### PR TITLE
fc: make Secp256k1 var names consistent

### DIFF
--- a/libraries/fc/CMakeLists.txt
+++ b/libraries/fc/CMakeLists.txt
@@ -10,15 +10,15 @@ SET( BUILD_SHARED_LIBS NO )
 SET( ECC_IMPL secp256k1 CACHE STRING "secp256k1 or openssl or mixed" )
 
 
-IF(NOT "$ENV{SECP256K1_ROOT_DIR}" STREQUAL "")
-  set(SECP256K1_ROOT_DIR $ENV{SECP256K1_ROOT_DIR} )
-  set(SECP256K1_INCLUDE_DIR ${SECP256K1_ROOT_DIR}/include)
+IF(NOT "$ENV{Secp256k1_ROOT_DIR}" STREQUAL "")
+  set(Secp256k1_ROOT_DIR $ENV{Secp256k1_ROOT_DIR} )
+  set(Secp256k1_INCLUDE_DIR ${Secp256k1_ROOT_DIR}/include)
 ELSE()
-  SET( SECP256K1_INCLUDE_DIR /usr/local/include )
-  SET( SECP256K1_ROOT_DIR /usr/local )
+  SET( Secp256k1_INCLUDE_DIR /usr/local/include )
+  SET( Secp256k1_ROOT_DIR /usr/local )
 ENDIF()
 
-message(STATUS "Setting up SECP256K1 root and include vars to ${SECP256K1_ROOT_DIR}, ${SECP256K1_INCLUDE_DIR}")
+message(STATUS "Setting up Secp256k1 root and include vars to ${Secp256k1_ROOT_DIR}, ${Secp256k1_INCLUDE_DIR}")
 
 set(platformBitness 32)
 if(CMAKE_SIZEOF_VOID_P EQUAL 8)
@@ -158,7 +158,7 @@ target_include_directories(fc
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
     ${Boost_INCLUDE_DIR}
     ${OPENSSL_INCLUDE_DIR}
-    ${SECP256K1_INCLUDE_DIR}
+    ${Secp256k1_INCLUDE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/vendor/websocketpp
 
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}


### PR DESCRIPTION
When trying to use a custom build of libsecp256k1 (from cryptonomex), without overwriting the system lib, through

export Secp256k1_ROOT_DIR=/custom/path

it would still use /usr/lib/libsecp256k1.so