### PR TITLE
assign tag to image in dockerfile

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM ubuntu:16.04
 MAINTAINER xiaobo (peterwillcn@gmail.com)
 
 RUN echo 'APT::Install-Recommends 0;' >> /etc/apt/apt.conf.d/01norecommends \


### PR DESCRIPTION
For users who pulled ubuntu image long ago, it will not update this image version.

And the commands in this dockerfile seems like only works in 16.04 or above.

By assign a tag to the docker image, every one will use the same version of ubuntu.