### PR TITLE
Progress on #7, upgrades to testing framework

### DIFF
--- a/libraries/chain/chain_controller.cpp
+++ b/libraries/chain/chain_controller.cpp
@@ -246,6 +246,7 @@ ProcessedTransaction chain_controller::_push_transaction(const SignedTransaction
       _pending_tx_session = _db.start_undo_session(true);
 
    auto temp_session = _db.start_undo_session(true);
+   validate_referenced_accounts(trx);
    check_transaction_authorization(trx);
    auto pt = _apply_transaction(trx);
    _pending_transactions.push_back(trx);
@@ -331,6 +332,7 @@ signed_block chain_controller::_generate_block(
       try
       {
          auto temp_session = _db.start_undo_session(true);
+         validate_referenced_accounts(tx);
          check_transaction_authorization(tx);
          _apply_transaction(tx);
          temp_session.squash();
@@ -441,8 +443,10 @@ void chain_controller::_apply_block(const signed_block& next_block)
    
    for (const auto& cycle : next_block.cycles)
       for (const auto& thread : cycle)
-         for (const auto& trx : thread.user_input)
+         for (const auto& trx : thread.user_input) {
+            validate_referenced_accounts(trx);
             check_transaction_authorization(trx);
+         }
 
    /* We do not need to push the undo state for each transaction
     * because they either all apply and are valid or the
@@ -524,7 +528,6 @@ try {
    validate_expiration(trx);
    validate_uniqueness(trx);
    validate_tapos(trx);
-   validate_referenced_accounts(trx);
 
 } FC_CAPTURE_AND_RETHROW( (trx) ) }
 

--- a/libraries/chain/chain_controller.cpp
+++ b/libraries/chain/chain_controller.cpp
@@ -32,6 +32,7 @@
 #include <eos/chain/transaction_object.hpp>
 #include <eos/chain/producer_object.hpp>
 #include <eos/chain/permission_link_object.hpp>
+#include <eos/chain/authority_checker.hpp>
 
 #include <eos/chain/wasm_interface.hpp>
 
@@ -505,6 +506,9 @@ void chain_controller::check_transaction_authorization(const SignedTransaction& 
                        ("auth", declaredAuthority));
          }
       }
+
+   EOS_ASSERT(checker.all_keys_used(), tx_irrelevant_sig,
+              "Transaction bears irrelevant signatures from these keys: ${keys}", ("keys", checker.unused_keys()));
 }
 
 ProcessedTransaction chain_controller::apply_transaction(const SignedTransaction& trx, uint32_t skip)

--- a/libraries/chain/include/eos/chain/authority.hpp
+++ b/libraries/chain/include/eos/chain/authority.hpp
@@ -30,55 +30,8 @@ struct shared_authority {
    shared_vector<types::KeyPermissionWeight>     keys;
 };
 
-/**
- * @brief This class determines whether a set of signing keys are sufficient to satisfy an authority or not
- *
- * To determine whether an authority is satisfied or not, we first determine which keys have approved of a message, and
- * then determine whether that list of keys is sufficient to satisfy the authority. This class takes a list of keys and
- * provides the @ref satisfied method to determine whether that list of keys satisfies a provided authority.
- *
- * @tparam F A callable which takes a single argument of type @ref AccountPermission and returns the corresponding
- * authority
- */
-template<typename F>
-class AuthorityChecker {
-   F PermissionToAuthority;
-   flat_set<public_key_type> signingKeys;
-
-public:
-   AuthorityChecker(F PermissionToAuthority, const flat_set<public_key_type>& signingKeys)
-      : PermissionToAuthority(PermissionToAuthority), signingKeys(signingKeys) {}
-
-   bool satisfied(const types::AccountPermission& permission) const {
-      return satisfied(PermissionToAuthority(permission));
-   }
-   template<typename AuthorityType>
-   bool satisfied(const AuthorityType& authority) const {
-      UInt32 weight = 0;
-      for (const auto& kpw : authority.keys) {
-         if (signingKeys.count(kpw.key)) {
-            weight += kpw.weight;
-            if (weight >= authority.threshold)
-               return true;
-         }
-      }
-      for (const auto& apw : authority.accounts)
-//#warning TODO: Recursion limit? Yes: implement as producer-configurable parameter 
-         if (satisfied(apw.permission)) {
-            weight += apw.weight;
-            if (weight >= authority.threshold)
-               return true;
-         }
-      return false;
-   }
-};
-
-inline bool operator < ( const types::AccountPermission& a, const types::AccountPermission& b ) {
-   return std::tie( a.account, a.permission ) < std::tie( b.account, b.permission );
-}
-template<typename F>
-AuthorityChecker<F> MakeAuthorityChecker(F&& pta, const flat_set<public_key_type>& signingKeys) {
-   return AuthorityChecker<F>(std::forward<F>(pta), signingKeys);
+inline bool operator< (const types::AccountPermission& a, const types::AccountPermission& b) {
+   return std::tie(a.account, a.permission) < std::tie(b.account, b.permission);
 }
 
 /**

--- a/libraries/chain/include/eos/chain/authority.hpp
+++ b/libraries/chain/include/eos/chain/authority.hpp
@@ -38,7 +38,7 @@ inline bool operator< (const types::AccountPermission& a, const types::AccountPe
  * Makes sure all keys are unique and sorted and all account permissions are unique and sorted and that authority can
  * be satisfied
  */
-inline bool validate( types::Authority& auth ) {
+inline bool validate(const types::Authority& auth) {
    const types::KeyPermissionWeight* prev = nullptr;
    decltype(auth.threshold) totalWeight = 0;
 

--- a/libraries/chain/include/eos/chain/authority_checker.hpp
+++ b/libraries/chain/include/eos/chain/authority_checker.hpp
@@ -1,0 +1,127 @@
+#pragma once
+
+#include <eos/chain/types.hpp>
+#include <eos/types/generated.hpp>
+
+#include <eos/utilities/parallel_markers.hpp>
+
+#include <fc/scoped_exit.hpp>
+
+#include <boost/range/algorithm/find.hpp>
+#include <boost/algorithm/cxx11/all_of.hpp>
+
+namespace eos { namespace chain {
+
+namespace detail {
+using MetaPermission = static_variant<types::KeyPermissionWeight, types::AccountPermissionWeight>;
+
+struct GetWeightVisitor {
+   using result_type = UInt32;
+
+   template<typename Permission>
+   UInt32 operator()(const Permission& permission) { return permission.weight; }
+};
+
+// Orders permissions descending by weight, and breaks ties with Key permissions being less than Account permissions
+struct MetaPermissionComparator {
+   bool operator()(const MetaPermission& a, const MetaPermission& b) const {
+      GetWeightVisitor scale;
+      if (a.visit(scale) > b.visit(scale)) return true;
+      return a.contains<types::KeyPermissionWeight>() && !b.contains<types::KeyPermissionWeight>();
+   }
+};
+
+using MetaPermissionSet = boost::container::flat_multiset<MetaPermission, MetaPermissionComparator>;
+}
+
+/**
+ * @brief This class determines whether a set of signing keys are sufficient to satisfy an authority or not
+ *
+ * To determine whether an authority is satisfied or not, we first determine which keys have approved of a message, and
+ * then determine whether that list of keys is sufficient to satisfy the authority. This class takes a list of keys and
+ * provides the @ref satisfied method to determine whether that list of keys satisfies a provided authority.
+ *
+ * @tparam F A callable which takes a single argument of type @ref AccountPermission and returns the corresponding
+ * authority
+ */
+template<typename F>
+class AuthorityChecker {
+   F PermissionToAuthority;
+   vector<public_key_type> signingKeys;
+   vector<bool> usedKeys;
+
+   struct WeightTallyVisitor {
+      using result_type = UInt32;
+
+      AuthorityChecker& checker;
+      UInt32 totalWeight = 0;
+
+      WeightTallyVisitor(AuthorityChecker& checker)
+         : checker(checker) {}
+
+      UInt32 operator()(const types::KeyPermissionWeight& permission) {
+         auto itr = boost::find(checker.signingKeys, permission.key);
+         if (itr != checker.signingKeys.end()) {
+            checker.usedKeys[itr - checker.signingKeys.begin()] = true;
+            totalWeight += permission.weight;
+         }
+         return totalWeight;
+      }
+      UInt32 operator()(const types::AccountPermissionWeight& permission) {
+         //TODO: Recursion limit? Yes: implement as producer-configurable parameter
+         if (checker.satisfied(permission.permission))
+            totalWeight += permission.weight;
+         return totalWeight;
+      }
+   };
+
+public:
+   AuthorityChecker(F PermissionToAuthority, const flat_set<public_key_type>& signingKeys)
+      : PermissionToAuthority(PermissionToAuthority),
+        signingKeys(signingKeys.begin(), signingKeys.end()),
+        usedKeys(signingKeys.size(), false)
+   {}
+
+   bool satisfied(const types::AccountPermission& permission) {
+      return satisfied(PermissionToAuthority(permission));
+   }
+   template<typename AuthorityType>
+   bool satisfied(const AuthorityType& authority) {
+      // Save the current used keys; if we do not satisfy this authority, the newly used keys aren't actually used
+      auto KeyReverter = fc::make_scoped_exit([this, keys = usedKeys] () mutable {
+         usedKeys = keys;
+      });
+
+      // Sort key permissions and account permissions together into a single set of MetaPermissions
+      detail::MetaPermissionSet permissions;
+      permissions.insert(authority.keys.begin(), authority.keys.end());
+      permissions.insert(authority.accounts.begin(), authority.accounts.end());
+
+      // Check all permissions, from highest weight to lowest, seeing if signingKeys satisfies them or not
+      WeightTallyVisitor visitor(*this);
+      for (const auto& permission : permissions)
+         // If we've got enough weight, to satisfy the authority, return!
+         if (permission.visit(visitor) >= authority.threshold) {
+            KeyReverter.cancel();
+            return true;
+         }
+      return false;
+   }
+
+   bool all_keys_used() const { return boost::algorithm::all_of_equal(usedKeys, true); }
+   flat_set<public_key_type> used_keys() const {
+      auto range = utilities::FilterDataByMarker(signingKeys, usedKeys, true);
+      return {range.begin(), range.end()};
+   }
+   flat_set<public_key_type> unused_keys() const {
+      auto range = utilities::FilterDataByMarker(signingKeys, usedKeys, false);
+      return {range.begin(), range.end()};
+   }
+};
+
+template<typename F>
+AuthorityChecker<F> MakeAuthorityChecker(F&& pta, const flat_set<public_key_type>& signingKeys) {
+   return AuthorityChecker<F>(std::forward<F>(pta), signingKeys);
+}
+
+}} // namespace eos::chain

--- a/libraries/chain/message_handling_contexts.cpp
+++ b/libraries/chain/message_handling_contexts.cpp
@@ -4,11 +4,10 @@
 #include <eos/chain/key_value_object.hpp>
 #include <eos/chain/chain_controller.hpp>
 
+#include <eos/utilities/parallel_markers.hpp>
+
 #include <boost/algorithm/cxx11/all_of.hpp>
 #include <boost/range/algorithm/find_if.hpp>
-#include <boost/range/combine.hpp>
-#include <boost/range/adaptor/filtered.hpp>
-#include <boost/range/adaptor/transformed.hpp>
 
 namespace eos { namespace chain {
 
@@ -48,15 +47,7 @@ bool apply_context::all_authorizations_used() const {
 }
 
 vector<types::AccountPermission> apply_context::unused_authorizations() const {
-   auto RemoveUsed = boost::adaptors::filtered([](const auto& tuple) {
-      return !boost::get<0>(tuple);
-   });
-   auto ToPermission = boost::adaptors::transformed([](const auto& tuple) {
-      return boost::get<1>(tuple);
-   });
-
-   // zip the parallel arrays, filter out the used authorizations, and return just the permissions that are left
-   auto range = boost::combine(used_authorizations, msg.authorization) | RemoveUsed | ToPermission;
+   auto range = utilities::FilterDataByMarker(msg.authorization, used_authorizations, false);
    return {range.begin(), range.end()};
 }
 

--- a/libraries/fc/include/fc/scoped_exit.hpp
+++ b/libraries/fc/include/fc/scoped_exit.hpp
@@ -9,12 +9,15 @@ namespace fc {
          scoped_exit( C&& c ):callback( std::forward<C>(c) ){}
          scoped_exit( scoped_exit&& mv ):callback( std::move( mv.callback ) ){}
 
+         void cancel() { canceled = true; }
+
          ~scoped_exit() {
-            try { callback(); } catch( ... ) {}
+            if (!canceled)
+               try { callback(); } catch( ... ) {}
          }
 
          scoped_exit& operator = ( scoped_exit&& mv ) {
-            callback = std::move(mv);
+            callback = std::move(mv.callback);
             return *this;
          }
       private:
@@ -22,6 +25,7 @@ namespace fc {
          scoped_exit& operator=( const scoped_exit& );
 
          Callback callback;
+         bool canceled = false;
    };
 
    template<typename Callback>

--- a/libraries/utilities/include/eos/utilities/parallel_markers.hpp
+++ b/libraries/utilities/include/eos/utilities/parallel_markers.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <boost/range/combine.hpp>
+#include <boost/range/adaptor/filtered.hpp>
+#include <boost/range/adaptor/transformed.hpp>
+
+namespace eos { namespace utilities {
+
+/**
+ * @brief Return values in DataRange corresponding to matching Markers
+ *
+ * Takes two parallel ranges, a Data range containing data values, and a Marker range containing markers on the
+ * corresponding data values. Returns a new Data range containing only the values corresponding to markers which match
+ * markerValue
+ *
+ * For example:
+ * @code{.cpp}
+ * vector<char> data = {'A', 'B', 'C'};
+ * vector<bool> markers = {true, false, true};
+ * auto markedData = FilterDataByMarker(data, markers, true);
+ * // markedData contains {'A', 'C'}
+ * @endcode
+ */
+template<typename DataRange, typename MarkerRange, typename Marker>
+DataRange FilterDataByMarker(DataRange data, MarkerRange markers, const Marker& markerValue) {
+   auto RemoveMismatchedMarkers = boost::adaptors::filtered([&markerValue](const auto& tuple) {
+      return boost::get<0>(tuple) == markerValue;
+   });
+   auto ToData = boost::adaptors::transformed([](const auto& tuple) {
+      return boost::get<1>(tuple);
+   });
+
+   // Zip the ranges together, filter out data with markers that don't match, and return the data without the markers
+   auto range = boost::combine(markers, data) | RemoveMismatchedMarkers | ToData;
+   return {range.begin(), range.end()};
+}
+
+}} // namespace eos::utilities
+

--- a/tests/common/database_fixture.hpp
+++ b/tests/common/database_fixture.hpp
@@ -119,6 +119,7 @@ public:
 
    void store_private_key(const private_key_type& key);
    private_key_type get_private_key(const public_key_type& public_key) const;
+   flat_set<public_key_type> available_keys() const;
 
 protected:
    std::vector<fc::temp_directory> anonymous_temp_dirs;
@@ -178,8 +179,27 @@ public:
    /// @brief Get the specified block producer's signing key
    PublicKey get_block_signing_key(const AccountName& producerName);
 
+   /// @brief Attempt to sign the provided transaction using the keys available to the testing_fixture
+   void sign_transaction(SignedTransaction& trx);
+
+   /// @brief Override push_transaction to apply testing policies
+   ProcessedTransaction push_transaction(SignedTransaction trx, uint32_t skip_flags = 0);
+
+   /// @brief Set whether testing_blockchain::push_transaction checks signatures by default
+   /// @param skip_sigs If true, push_transaction will skip signature checks; otherwise, no changes will be made
+   void set_skip_transaction_signature_checking(bool skip_sigs) {
+      skip_trx_sigs = skip_sigs;
+   }
+   /// @brief Set whether testing_blockchain::push_transaction attempts to sign transactions or not
+   void set_auto_sign_transactions(bool auto_sign) {
+      auto_sign_trxs = auto_sign;
+   }
+
 protected:
+   chainbase::database& db;
    testing_fixture& fixture;
+   bool skip_trx_sigs = true;
+   bool auto_sign_trxs = false;
 };
 
 using boost::signals2::scoped_connection;

--- a/tests/common/macro_support.hpp
+++ b/tests/common/macro_support.hpp
@@ -51,7 +51,7 @@ inline std::vector<Name> sort_names( std::vector<Name>&& names ) {
                          "newaccount", types::newaccount{#creator, #name, owner, active, recovery, deposit}); \
       trx.expiration = chain.head_block_time() + 100; \
       trx.set_reference_block(chain.head_block_id()); \
-      chain.push_transaction(trx, chain_controller::skip_transaction_signatures); \
+      chain.push_transaction(trx); \
       BOOST_TEST_CHECKPOINT("Created account " << #name); \
    }
 #define MKACCT2(chain, name) \
@@ -83,7 +83,7 @@ inline std::vector<Name> sort_names( std::vector<Name>&& names ) {
                          "updateauth", types::updateauth{#account, authname, parentname, auth}); \
       trx.expiration = chain.head_block_time() + 100; \
       trx.set_reference_block(chain.head_block_id()); \
-      chain.push_transaction(trx, chain_controller::skip_transaction_signatures); \
+      chain.push_transaction(trx); \
       BOOST_TEST_CHECKPOINT("Set " << #account << "'s " << authname << " authority."); \
    }
 
@@ -96,7 +96,7 @@ inline std::vector<Name> sort_names( std::vector<Name>&& names ) {
                          "deleteauth", types::deleteauth{#account, authname}); \
       trx.expiration = chain.head_block_time() + 100; \
       trx.set_reference_block(chain.head_block_id()); \
-      chain.push_transaction(trx, chain_controller::skip_transaction_signatures); \
+      chain.push_transaction(trx); \
       BOOST_TEST_CHECKPOINT("Deleted " << #account << "'s " << authname << " authority."); \
    }
 
@@ -109,7 +109,7 @@ inline std::vector<Name> sort_names( std::vector<Name>&& names ) {
                          "linkauth", types::linkauth{#account, #codeacct, messagetype, authname}); \
       trx.expiration = chain.head_block_time() + 100; \
       trx.set_reference_block(chain.head_block_id()); \
-      chain.push_transaction(trx, chain_controller::skip_transaction_signatures); \
+      chain.push_transaction(trx); \
       BOOST_TEST_CHECKPOINT("Link " << #codeacct << "::" << messagetype << " to " << #account \
                             << "'s " << authname << " authority."); \
    }
@@ -124,7 +124,7 @@ inline std::vector<Name> sort_names( std::vector<Name>&& names ) {
                          "unlinkauth", types::unlinkauth{#account, #codeacct, messagetype}); \
       trx.expiration = chain.head_block_time() + 100; \
       trx.set_reference_block(chain.head_block_id()); \
-      chain.push_transaction(trx, chain_controller::skip_transaction_signatures); \
+      chain.push_transaction(trx); \
       BOOST_TEST_CHECKPOINT("Unlink " << #codeacct << "::" << messagetype << " from " << #account); \
    }
 #define LINKAUTH3(chain, account, codeacct) LINKAUTH5(chain, account, codeacct, "")
@@ -138,7 +138,7 @@ inline std::vector<Name> sort_names( std::vector<Name>&& names ) {
                          "transfer", types::transfer{#sender, #recipient, Amount.amount}); \
       trx.expiration = chain.head_block_time() + 100; \
       trx.set_reference_block(chain.head_block_id()); \
-      chain.push_transaction(trx, chain_controller::skip_transaction_signatures); \
+      chain.push_transaction(trx); \
       BOOST_TEST_CHECKPOINT("Transfered " << Amount << " from " << #sender << " to " << #recipient); \
    }
 #define XFER4(chain, sender, recipient, amount) XFER5(chain, sender, recipient, amount, "")
@@ -151,7 +151,7 @@ inline std::vector<Name> sort_names( std::vector<Name>&& names ) {
                         "lock", types::lock{#sender, #recipient, amount}); \
       trx.expiration = chain.head_block_time() + 100; \
       trx.set_reference_block(chain.head_block_id()); \
-      chain.push_transaction(trx, chain_controller::skip_transaction_signatures); \
+      chain.push_transaction(trx); \
       BOOST_TEST_CHECKPOINT("Staked " << amount << " to " << #recipient); \
    }
 #define STAKE3(chain, account, amount) STAKE4(chain, account, account, amount)
@@ -165,7 +165,7 @@ inline std::vector<Name> sort_names( std::vector<Name>&& names ) {
                          "unlock", types::unlock{#account, amount}); \
       trx.expiration = chain.head_block_time() + 100; \
       trx.set_reference_block(chain.head_block_id()); \
-      chain.push_transaction(trx, chain_controller::skip_transaction_signatures); \
+      chain.push_transaction(trx); \
       BOOST_TEST_CHECKPOINT("Begin unstake " << amount << " to " << #account); \
    }
 
@@ -177,7 +177,7 @@ inline std::vector<Name> sort_names( std::vector<Name>&& names ) {
                          "claim", types::claim{#account, amount}); \
       trx.expiration = chain.head_block_time() + 100; \
       trx.set_reference_block(chain.head_block_id()); \
-      chain.push_transaction(trx, chain_controller::skip_transaction_signatures); \
+      chain.push_transaction(trx); \
       BOOST_TEST_CHECKPOINT("Finish unstake " << amount << " to " << #account); \
    }
 
@@ -190,7 +190,7 @@ inline std::vector<Name> sort_names( std::vector<Name>&& names ) {
                          "setproducer", types::setproducer{#owner, key, cfg}); \
       trx.expiration = chain.head_block_time() + 100; \
       trx.set_reference_block(chain.head_block_id()); \
-      chain.push_transaction(trx, chain_controller::skip_transaction_signatures); \
+      chain.push_transaction(trx); \
       BOOST_TEST_CHECKPOINT("Create producer " << #owner); \
    }
 #define MKPDCR3(chain, owner, key) MKPDCR4(chain, owner, key, BlockchainConfiguration{});
@@ -207,7 +207,7 @@ inline std::vector<Name> sort_names( std::vector<Name>&& names ) {
                          "okproducer", types::okproducer{#voter, #producer, approved? 1 : 0}); \
       trx.expiration = chain.head_block_time() + 100; \
       trx.set_reference_block(chain.head_block_id()); \
-      chain.push_transaction(trx, chain_controller::skip_transaction_signatures); \
+      chain.push_transaction(trx); \
       BOOST_TEST_CHECKPOINT("Set producer approval from " << #voter << " for " << #producer << " to " << approved); \
    }
 
@@ -220,7 +220,7 @@ inline std::vector<Name> sort_names( std::vector<Name>&& names ) {
                          "setproducer", types::setproducer{owner, key, cfg}); \
       trx.expiration = chain.head_block_time() + 100; \
       trx.set_reference_block(chain.head_block_id()); \
-      chain.push_transaction(trx, chain_controller::skip_transaction_signatures); \
+      chain.push_transaction(trx); \
       BOOST_TEST_CHECKPOINT("Update producer " << owner); \
    }
 #define UPPDCR3(chain, owner, key) UPPDCR4(chain, owner, key, chain.get_producer(owner).configuration)

--- a/tests/tests/native_contract_tests.cpp
+++ b/tests/tests/native_contract_tests.cpp
@@ -34,6 +34,7 @@ BOOST_FIXTURE_TEST_CASE(create_account, testing_fixture)
       BOOST_CHECK_EQUAL(chain.get_liquid_balance("inita"), Asset(100000));
 
       Make_Account(chain, joe, inita, Asset(1000));
+      chain.produce_blocks();
       Transfer_Asset(chain, inita, joe, Asset(1000));
 
       { // test in the pending state

--- a/tests/tests/native_contract_tests.cpp
+++ b/tests/tests/native_contract_tests.cpp
@@ -5,6 +5,7 @@
 #include <eos/chain/permission_object.hpp>
 #include <eos/chain/permission_link_object.hpp>
 #include <eos/chain/key_value_object.hpp>
+#include <eos/chain/authority_checker.hpp>
 
 #include <eos/native_contract/producer_objects.hpp>
 


### PR DESCRIPTION
We now check that transactions don't have any unnecessary signatures.

Upgrade AuthorityChecker to support tracking which keys were used. This makes it possible to check for irrelevant sigs, and also makes it possible to automatically sign transactions by taking a list of available keys and determining which ones are necessary to authorize the transaction.

Upgrade testing framework to support automatically signing transactions (not yet working as of 7eb2013)