### PR TITLE
fix invalid action names #149

### DIFF
--- a/contracts/exchange/exchange.abi
+++ b/contracts/exchange/exchange.abi
@@ -55,10 +55,10 @@
       "action": "sell",
       "type": "SellOrder"
     },{
-      "action": "cancel_buy",
+      "action": "cancelbuy",
       "type": "OrderID"
     },{
-      "action": "cancel_sell",
+      "action": "cancelsell",
       "type": "OrderID"
     }
   ],

--- a/contracts/exchange/exchange.cpp
+++ b/contracts/exchange/exchange.cpp
@@ -307,10 +307,10 @@ extern "C" {
             case N(sell):
                apply_exchange_sell( currentMessage<exchange::SellOrder>() );
                break;
-            case N(cancel_buy):
+            case N(cancelbuy):
                apply_exchange_cancel_buy( currentMessage<exchange::OrderID>() );
                break;
-            case N(cancel_sell):
+            case N(cancelsell):
                apply_exchange_cancel_sell( currentMessage<exchange::OrderID>() );
                break;
             default:


### PR DESCRIPTION
The exchange contract was using invalid method names ('_') is not valid.  By fixing issue #149 this error was now detected and now throws.

