### PR TITLE
Resolve #152: Disable auth updates in pending transactions

### DIFF
--- a/libraries/chain/chain_controller.cpp
+++ b/libraries/chain/chain_controller.cpp
@@ -432,6 +432,9 @@ void chain_controller::apply_block(const signed_block& next_block, uint32_t skip
 
 void chain_controller::_apply_block(const signed_block& next_block)
 { try {
+   auto UnsetApplyingBlock = fc::make_scoped_exit([this] { _currently_applying_block = false; });
+   _currently_applying_block = true;
+
    uint32_t next_block_num = next_block.block_num();
    uint32_t skip = _skip_flags;
 
@@ -836,6 +839,10 @@ void chain_controller::initialize_indexes() {
 
 void chain_controller::initialize_chain(chain_initializer_interface& starter)
 { try {
+   // Behave as though we are applying a block during chain initialization (it's the genesis block!)
+   auto UnsetApplyingBlock = fc::make_scoped_exit([this] { _currently_applying_block = false; });
+   _currently_applying_block = true;
+
    if (!_db.find<global_property_object>()) {
       _db.with_write_lock([this, &starter] {
          auto initial_timestamp = starter.get_chain_start_time();

--- a/libraries/chain/include/eos/chain/chain_controller.hpp
+++ b/libraries/chain/include/eos/chain/chain_controller.hpp
@@ -260,6 +260,15 @@ namespace eos { namespace chain {
          void apply_block(const signed_block& next_block, uint32_t skip = skip_nothing);
          void _apply_block(const signed_block& next_block);
 
+         template<typename Function>
+         auto with_applying_block(Function&& f) -> decltype((*((Function*)nullptr))()) {
+            auto on_exit = fc::make_scoped_exit([this](){
+               _currently_applying_block = false;
+            });
+            _currently_applying_block = true;
+            return f();
+         }
+
          void check_transaction_authorization(const SignedTransaction& trx)const;
 
          ProcessedTransaction apply_transaction(const SignedTransaction& trx, uint32_t skip = skip_nothing);

--- a/libraries/chain/include/eos/chain/chain_controller.hpp
+++ b/libraries/chain/include/eos/chain/chain_controller.hpp
@@ -73,6 +73,11 @@ namespace eos { namespace chain {
           */
          signal<void(const SignedTransaction&)> on_pending_transaction;
 
+         /**
+          * @brief Check whether the controller is currently applying a block or not
+          * @return True if the controller is now applying a block; false otherwise
+          */
+         bool is_applying_block()const { return _currently_applying_block; }
 
          /**
           *  The controller can override any script endpoint with native code.
@@ -321,7 +326,7 @@ namespace eos { namespace chain {
          optional<database::session>      _pending_tx_session;
          deque<SignedTransaction>         _pending_transactions;
 
-         bool                             _pushing  = false;
+         bool                             _currently_applying_block = false;
          uint64_t                         _skip_flags = 0;
 
          flat_map<uint32_t,block_id_type> _checkpoints;


### PR DESCRIPTION
Affected contract methods:
 - newaccount
 - updateauth
 - deleteauth
 - linkauth
 - unlinkauth

Also, blockchain initialization (the genesis block) behaves like it is
applying a block, even though the genesis block isn't really a block.