### PR TITLE
Fix template specialization issue

### DIFF
--- a/libraries/fc/include/fc/reflect/typename.hpp
+++ b/libraries/fc/include/fc/reflect/typename.hpp
@@ -15,7 +15,7 @@ namespace fc {
   class exception;
   namespace ip { class address; }
 
-  template<typename T> class get_typename{};
+  template<typename... T> struct get_typename;
   template<> struct get_typename<int32_t>  { static const char* name()  { return "int32_t";  } };
   template<> struct get_typename<int64_t>  { static const char* name()  { return "int64_t";  } };
   template<> struct get_typename<int16_t>  { static const char* name()  { return "int16_t";  } };

--- a/libraries/fc/include/fc/static_variant.hpp
+++ b/libraries/fc/include/fc/static_variant.hpp
@@ -385,5 +385,5 @@ struct visitor {
       s.visit( to_static_variant(ar[1]) );
    }
 
-  template<typename... T> struct get_typename<T...>  { static const char* name()   { return typeid(static_variant<T...>).name();   } };
+  template<typename... T> struct get_typename { static const char* name()   { return typeid(static_variant<T...>).name();   } };
 } // namespace fc


### PR DESCRIPTION
According to C++14 template specialization has to be more specialized than
the primary template. get_typename defined in static_variant.hpp was less
specialized than the primary template in typename.hpp.
Because of that build was failing on GCC 7.1.1. Fixes #140