### PR TITLE
Testing #123: Permission links

### DIFF
--- a/libraries/chain/chain_controller.cpp
+++ b/libraries/chain/chain_controller.cpp
@@ -518,8 +518,9 @@ void chain_controller::check_transaction_authorization(const SignedTransaction& 
          }
       }
 
-   EOS_ASSERT(checker.all_keys_used(), tx_irrelevant_sig,
-              "Transaction bears irrelevant signatures from these keys: ${keys}", ("keys", checker.unused_keys()));
+   if ((_skip_flags & skip_transaction_signatures) == false)
+      EOS_ASSERT(checker.all_keys_used(), tx_irrelevant_sig,
+                 "Transaction bears irrelevant signatures from these keys: ${keys}", ("keys", checker.unused_keys()));
 }
 
 ProcessedTransaction chain_controller::apply_transaction(const SignedTransaction& trx, uint32_t skip)

--- a/libraries/chain/chain_controller.cpp
+++ b/libraries/chain/chain_controller.cpp
@@ -509,7 +509,8 @@ void chain_controller::check_transaction_authorization(const SignedTransaction& 
          if ((_skip_flags & skip_authority_check) == false) {
             const auto& index = _db.get_index<permission_index>().indices();
             EOS_ASSERT(getPermission(declaredAuthority).satisfies(minimumPermission, index), tx_irrelevant_auth,
-                       "Message declares irrelevant authority '${auth}'", ("auth", declaredAuthority));
+                       "Message declares irrelevant authority '${auth}'; minimum authority is ${min}",
+                       ("auth", declaredAuthority)("min", minimumPermission.name));
          }
          if ((_skip_flags & skip_transaction_signatures) == false) {
             EOS_ASSERT(checker.satisfied(declaredAuthority), tx_missing_sigs,

--- a/libraries/native_contract/eos_contract.cpp
+++ b/libraries/native_contract/eos_contract.cpp
@@ -161,6 +161,8 @@ void apply_eos_lock(apply_context& context) {
    context.require_scope(lock.from);
    context.require_scope(config::EosContractName);
 
+   context.require_authorization(lock.from);
+
    context.require_recipient(lock.to);
    context.require_recipient(lock.from);
 

--- a/tests/common/database_fixture.cpp
+++ b/tests/common/database_fixture.cpp
@@ -166,7 +166,7 @@ types::PublicKey testing_blockchain::get_block_signing_key(const types::AccountN
    return get_database().get<producer_object, by_owner>(producerName).signing_key;
 }
 
-void testing_blockchain::sign_transaction(SignedTransaction& trx) {
+void testing_blockchain::sign_transaction(SignedTransaction& trx) const {
    auto GetAuthority = [this](const types::AccountPermission& permission) {
       auto key = boost::make_tuple(permission.account, permission.permission);
       return db.get<permission_object, by_owner>(key).auth;

--- a/tests/common/database_fixture.cpp
+++ b/tests/common/database_fixture.cpp
@@ -184,7 +184,7 @@ void testing_blockchain::sign_transaction(SignedTransaction& trx) {
       trx.sign(fixture.get_private_key(key), chain_id_type{});
 }
 
-ProcessedTransaction testing_blockchain::push_transaction(SignedTransaction trx, uint32_t skip_flags) {
+fc::optional<ProcessedTransaction> testing_blockchain::push_transaction(SignedTransaction trx, uint32_t skip_flags) {
    if (skip_trx_sigs)
       skip_flags |= chain_controller::skip_transaction_signatures;
 
@@ -192,6 +192,10 @@ ProcessedTransaction testing_blockchain::push_transaction(SignedTransaction trx,
       sign_transaction(trx);
    }
 
+   if (hold_for_review) {
+      review_storage = std::make_pair(trx, skip_flags);
+      return {};
+   }
    return chain_controller::push_transaction(trx, skip_flags);
 }
 

--- a/tests/common/database_fixture.hpp
+++ b/tests/common/database_fixture.hpp
@@ -180,7 +180,7 @@ public:
    PublicKey get_block_signing_key(const AccountName& producerName);
 
    /// @brief Attempt to sign the provided transaction using the keys available to the testing_fixture
-   void sign_transaction(SignedTransaction& trx);
+   void sign_transaction(SignedTransaction& trx) const;
 
    /// @brief Override push_transaction to apply testing policies
    /// If transactions are being held for review, transaction will be held after testing policies are applied


### PR DESCRIPTION
 - Add more tests for permission links
 - Update test framework to support reviewing transactions it generates prior to pushing them
 - Bug fixes in chain_controller

This pull should resolve #123 