### PR TITLE
Make irrelevant sigs a soft check

### DIFF
--- a/libraries/chain/chain_controller.cpp
+++ b/libraries/chain/chain_controller.cpp
@@ -326,6 +326,7 @@ signed_block chain_controller::_generate_block(
       if( new_total_size >= maximum_block_size )
       {
          postponed_tx_count++;
+         ++itr;
          continue;
       }
 

--- a/libraries/chain/include/eos/chain/chain_controller.hpp
+++ b/libraries/chain/include/eos/chain/chain_controller.hpp
@@ -269,7 +269,7 @@ namespace eos { namespace chain {
             return f();
          }
 
-         void check_transaction_authorization(const SignedTransaction& trx)const;
+         void check_transaction_authorization(const SignedTransaction& trx, bool allow_unused_signatures = false)const;
 
          ProcessedTransaction apply_transaction(const SignedTransaction& trx, uint32_t skip = skip_nothing);
          ProcessedTransaction _apply_transaction(const SignedTransaction& trx);

--- a/tests/common/database_fixture.cpp
+++ b/tests/common/database_fixture.cpp
@@ -116,7 +116,8 @@ void testing_blockchain::produce_blocks(uint32_t count, uint32_t blocks_to_miss)
       auto slot = blocks_to_miss + 1;
       auto producer = get_producer(get_scheduled_producer(slot));
       auto private_key = fixture.get_private_key(producer.signing_key);
-      generate_block(get_slot_time(slot), producer.owner, private_key, chain_controller::skip_transaction_signatures);
+      generate_block(get_slot_time(slot), producer.owner, private_key,
+                     skip_trx_sigs? chain_controller::skip_transaction_signatures : 0);
    }
 }
 

--- a/tests/tests/native_contract_tests.cpp
+++ b/tests/tests/native_contract_tests.cpp
@@ -508,6 +508,7 @@ BOOST_FIXTURE_TEST_CASE(auth_links, testing_fixture) { try {
    }
 
    Transfer_Asset(chain, inita, alice, Asset(1000));
+   chain.produce_blocks();
    // Take off the training wheels, we're gonna fully validate transactions now
    chain.set_auto_sign_transactions(false);
    chain.set_skip_transaction_signature_checking(false);


### PR DESCRIPTION
Previously, irrelevant signatures were always rejected. Now, they're always rejected unless we're processing a block which includes a transaction with irrelevant signatures.

Question: Should we instead allow irrelevant sigs for pending transactions as well as when applying a block, but only reject them when generating a block? If we do, then these transactions will move through the P2P network, but never get added to a block unless a producer ignores the soft check. It is likely that these transactions would circulate in nodes' pending state until they expire.

To prevent this, I opted to make pending transactions apply the soft checks as well.