### PR TITLE
Added lookup of controlled accounts by controlling account name.

### DIFF
--- a/libraries/chain/include/eos/chain/types.hpp
+++ b/libraries/chain/include/eos/chain/types.hpp
@@ -174,6 +174,7 @@ namespace eos { namespace chain {
       generated_transaction_object_type,
       producer_object_type,
       chain_property_object_type,
+      account_control_history_object_type, ///< Defined by account_history_plugin
       account_transaction_history_object_type, ///< Defined by account_history_plugin
       transaction_history_object_type, ///< Defined by account_history_plugin
       public_key_history_object_type, ///< Defined by account_history_plugin
@@ -225,6 +226,7 @@ FC_REFLECT_ENUM(eos::chain::object_type,
                 (generated_transaction_object_type)
                 (producer_object_type)
                 (chain_property_object_type)
+                (account_control_history_object_type)
                 (account_transaction_history_object_type)
                 (transaction_history_object_type)
                 (public_key_history_object_type)

--- a/plugins/account_history_api_plugin/account_history_api_plugin.cpp
+++ b/plugins/account_history_api_plugin/account_history_api_plugin.cpp
@@ -41,7 +41,8 @@ void account_history_api_plugin::plugin_startup() {
    app().get_plugin<http_plugin>().add_api({
       CHAIN_RO_CALL(get_transaction),
       CHAIN_RO_CALL(get_transactions),
-      CHAIN_RO_CALL(get_key_accounts)
+      CHAIN_RO_CALL(get_key_accounts),
+      CHAIN_RO_CALL(get_controlled_accounts)
    });
 }
 

--- a/plugins/account_history_plugin/include/eos/account_history_plugin/account_control_history_object.hpp
+++ b/plugins/account_history_plugin/include/eos/account_history_plugin/account_control_history_object.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <chainbase/chainbase.hpp>
+#include <eos/chain/types.hpp>
+
+namespace eos {
+using chain::AccountName;
+using chain::PermissionName;
+using chain::shared_vector;
+using chain::transaction_id_type;
+using namespace boost::multi_index;
+
+class account_control_history_object : public chainbase::object<chain::account_control_history_object_type, account_control_history_object> {
+   OBJECT_CTOR(account_control_history_object)
+
+   id_type                            id;
+   AccountName                        controlled_account;
+   PermissionName                     controlled_permission;
+   AccountName                        controlling_account;
+};
+
+struct by_id;
+struct by_controlling;
+struct by_controlled_authority;
+using account_control_history_multi_index = chainbase::shared_multi_index_container<
+   account_control_history_object,
+   indexed_by<
+      ordered_unique<tag<by_id>, BOOST_MULTI_INDEX_MEMBER(account_control_history_object, account_control_history_object::id_type, id)>,
+      hashed_non_unique<tag<by_controlling>, BOOST_MULTI_INDEX_MEMBER(account_control_history_object, AccountName, controlling_account), std::hash<AccountName>>,
+      hashed_non_unique<tag<by_controlled_authority>,
+         composite_key< account_control_history_object,
+            member<account_control_history_object, AccountName, &account_control_history_object::controlled_account>,
+            member<account_control_history_object, PermissionName, &account_control_history_object::controlled_permission>
+         >,
+         composite_key_hash< std::hash<AccountName>, std::hash<PermissionName> >
+      >
+   >
+>;
+
+typedef chainbase::generic_index<account_control_history_multi_index> account_control_history_index;
+
+}
+
+CHAINBASE_SET_INDEX_TYPE( eos::account_control_history_object, eos::account_control_history_multi_index )
+
+FC_REFLECT( eos::account_control_history_object, (controlled_account)(controlled_permission)(controlling_account) )
+

--- a/plugins/account_history_plugin/include/eos/account_history_plugin/account_history_plugin.hpp
+++ b/plugins/account_history_plugin/include/eos/account_history_plugin/account_history_plugin.hpp
@@ -26,6 +26,7 @@ public:
    read_only(account_history_const_ptr&& account_history)
       : account_history(account_history) {}
 
+
    struct get_transaction_params {
       chain::transaction_id_type  transaction_id;
    };
@@ -34,6 +35,7 @@ public:
       fc::variant                 transaction;
    };
    get_transaction_results get_transaction(const get_transaction_params& params) const;
+
 
    struct get_transactions_params {
       chain::AccountName  account_name;
@@ -52,6 +54,7 @@ public:
 
    get_transactions_results get_transactions(const get_transactions_params& params) const;
 
+
    struct get_key_accounts_params {
       chain::public_key_type     public_key;
    };
@@ -59,6 +62,15 @@ public:
       vector<chain::AccountName> account_names;
    };
    get_key_accounts_results get_key_accounts(const get_key_accounts_params& params) const;
+
+
+   struct get_controlled_accounts_params {
+      chain::AccountName     controlling_account;
+   };
+   struct get_controlled_accounts_results {
+      vector<chain::AccountName> controlled_accounts;
+   };
+   get_controlled_accounts_results get_controlled_accounts(const get_controlled_accounts_params& params) const;
 };
 
 class read_write {
@@ -99,3 +111,5 @@ FC_REFLECT(eos::account_history_apis::read_only::ordered_transaction_results, (s
 FC_REFLECT(eos::account_history_apis::read_only::get_transactions_results, (transactions)(time_limit_exceeded_error) )
 FC_REFLECT(eos::account_history_apis::read_only::get_key_accounts_params, (public_key) )
 FC_REFLECT(eos::account_history_apis::read_only::get_key_accounts_results, (account_names) )
+FC_REFLECT(eos::account_history_apis::read_only::get_controlled_accounts_params, (controlling_account) )
+FC_REFLECT(eos::account_history_apis::read_only::get_controlled_accounts_results, (controlled_accounts) )

--- a/programs/eosc/main.cpp
+++ b/programs/eosc/main.cpp
@@ -41,6 +41,7 @@ const string account_history_func_base = "/v1/account_history";
 const string get_transaction_func = account_history_func_base + "/get_transaction";
 const string get_transactions_func = account_history_func_base + "/get_transactions";
 const string get_key_accounts_func = account_history_func_base + "/get_key_accounts";
+const string get_controlled_accounts_func = account_history_func_base + "/get_controlled_accounts";
 
 inline std::vector<Name> sort_names( std::vector<Name>&& names ) {
    std::sort( names.begin(), names.end() );
@@ -405,6 +406,15 @@ int send_command (const vector<string> &cmd_line)
      chain::public_key_type public_key(cmd_line[1]);
      auto arg = fc::mutable_variant_object( "public_key", public_key);
      std::cout << fc::json::to_pretty_string( call( get_key_accounts_func, arg) ) << std::endl;
+  } else if( command == "servants" ) {
+     if( cmd_line.size() != 2 )
+     {
+        std::cerr << "usage: " << program << " servants CONTROLLING_ACCOUNT_NAME\n";
+        return -1;
+     }
+     chain::AccountName controlling_account_name(cmd_line[1]);
+     auto arg = fc::mutable_variant_object( "controlling_account", controlling_account_name);
+     std::cout << fc::json::to_pretty_string( call( get_controlled_accounts_func, arg) ) << std::endl;
   }
   return 0;
 }


### PR DESCRIPTION
When get_controlled_accounts is called the passed in account name is used to retrieve all accounts that have provided an Authority that has given permissions to the passed in account .