### PR TITLE
Make binaryen an external dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,6 +6,3 @@
 	path = libraries/appbase
 	url = https://github.com/eosio/appbase
         ignore = dirty
-[submodule "libraries/binaryen"]
-	path = libraries/binaryen
-	url = https://github.com/WebAssembly/binaryen.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
   - cd $TRAVIS_BUILD_DIR/ext && git clone --depth=1 --single-branch git://github.com/oci-labs/clang-WebAssembly wasm-compiler
   - cd $TRAVIS_BUILD_DIR
 script:
-  - WASM_LLVM_CONFIG=$TRAVIS_BUILD_DIR/ext/wasm-compiler/bin/llvm-config ext/cmake-3.9.0-Linux-x86_64/bin/cmake -G Ninja -DCMAKE_CXX_COMPILER=clang++-4.0 -DCMAKE_C_COMPILER=clang-4.0 -DBOOST_ROOT=$TRAVIS_BUILD_DIR/ext -DSecp256k1_ROOT_DIR=$TRAVIS_BUILD_DIR/ext
+  - WASM_LLVM_CONFIG=$TRAVIS_BUILD_DIR/ext/wasm-compiler/bin/llvm-config ext/cmake-3.9.0-Linux-x86_64/bin/cmake -G Ninja -DCMAKE_CXX_COMPILER=clang++-4.0 -DCMAKE_C_COMPILER=clang-4.0 -DBOOST_ROOT=$TRAVIS_BUILD_DIR/ext -DSecp256k1_ROOT_DIR=$TRAVIS_BUILD_DIR/ext -DBINARYEN_ROOT=$TRAVIS_BUILD_DIR/ext/wasm-compiler/
   - ninja -j4
   - tests/eosd_run_test.sh
   - tests/chain_test

--- a/CMakeModules/wasm.cmake
+++ b/CMakeModules/wasm.cmake
@@ -35,9 +35,7 @@ if( NOT ("${WASM_CLANG}" STREQUAL "" OR "${WASM_LLC}" STREQUAL "" OR "${WASM_LLV
 
     endif()
 
-  endif()
-
-  if (NOT BINARYEN_BIN)
+  else()
 
     message(STATUS "BINARYEN_BIN not defined looking in PATH")
     find_path(BINARYEN_BIN

--- a/CMakeModules/wasm.cmake
+++ b/CMakeModules/wasm.cmake
@@ -31,9 +31,7 @@ if( NOT ("${WASM_CLANG}" STREQUAL "" OR "${WASM_LLC}" STREQUAL "" OR "${WASM_LLV
 
     if(EXISTS "${BINARYEN_ROOT}/bin/s2wasm")
 
-      set(BINARYEN_BIN $ENV{BINARYEN_ROOT}/bin)
-
-      message(STATUS "BINARYEN_BIN => " ${BINARYEN_BIN})
+      set(BINARYEN_BIN ${BINARYEN_ROOT}/bin)
 
     endif()
 
@@ -41,7 +39,7 @@ if( NOT ("${WASM_CLANG}" STREQUAL "" OR "${WASM_LLC}" STREQUAL "" OR "${WASM_LLV
 
   if (NOT BINARYEN_BIN)
 
-    message(STATUS "BINARYEN_BIN not defined looking in PATH => " ${PATH})
+    message(STATUS "BINARYEN_BIN not defined looking in PATH")
     find_path(BINARYEN_BIN
               NAMES s2wasm
               ENV PATH )
@@ -50,9 +48,10 @@ if( NOT ("${WASM_CLANG}" STREQUAL "" OR "${WASM_LLC}" STREQUAL "" OR "${WASM_LLV
       unset(BINARYEN_BIN)
 
     endif()
-    message(STATUS "BINARYEN_BIN => " ${BINARYEN_BIN})
 
   endif()
+
+  message(STATUS "BINARYEN_BIN => " ${BINARYEN_BIN})
 
 endif()
 

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Also, to use the WASM compiler, eos has an external dependency on
  - [binaryen](https://github.com/WebAssembly/binaryen.git)
    * need to checkout tag 1.37.14
    * also need to run "make install"
+   * if installed in a location outside of PATH, need to set BINARYEN_ROOT to cmake
 
 ### Using the WASM compiler to perform a full build of the project
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ Eos has the following external dependencies, which must be installed on your sys
  - OpenSSL
  - LLVM 4.0 (Ubuntu users must install llvm-4.0 packages from https://apt.llvm.org/)
  - [secp256k1-zkp (Cryptonomex branch)](https://github.com/cryptonomex/secp256k1-zkp.git)
-
 ```
 git clone https://github.com/cryptonomex/secp256k1-zkp.git
 cd secp256k1-zkp
@@ -151,6 +150,11 @@ cd build
 cmake -G "Unix Makefiles" -DCMAKE_INSTALL_PREFIX=.. -DLLVM_TARGETS_TO_BUILD= -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=WebAssembly -DCMAKE_BUILD_TYPE=Release ../
 make -j4 install
 ```
+
+Also, to use the WASM compiler, eos has an external dependency on 
+ - [binaryen](https://github.com/WebAssembly/binaryen.git)
+   * need to checkout tag 1.37.14
+   * also need to run "make install"
 
 ### Using the WASM compiler to perform a full build of the project
 

--- a/contracts/eoslib/howto_build.dox
+++ b/contracts/eoslib/howto_build.dox
@@ -42,6 +42,12 @@ cmake -G "Unix Makefiles" -DCMAKE_INSTALL_PREFIX=.. -DLLVM_TARGETS_TO_BUILD= -DL
 make -j4 install
 ```
 
+Also, to use the WASM compiler, eos has an external dependency on
+ - [binaryen](https://github.com/WebAssembly/binaryen.git)
+   * need to checkout tag 1.37.14
+   * also need to run "make install"
+   * if installed in a location outside of PATH, need to set BINARYEN_ROOT to cmake
+
 ### Getting the code
 To download all of the code, download Eos and a recursion or two of submodules. The easiest way to get all of this is to do a recursive clone:
 

--- a/libraries/CMakeLists.txt
+++ b/libraries/CMakeLists.txt
@@ -2,10 +2,6 @@ add_subdirectory( fc )
 add_subdirectory( chainbase )
 add_subdirectory( wasm-jit )
 
-if(WASM_TOOLCHAIN)
-  add_subdirectory( binaryen )
-endif()
-
 add_subdirectory( types )
 add_subdirectory( chain )
 add_subdirectory( egenesis )


### PR DESCRIPTION
Removed the binaryen submodule, added instructions to compile and install binaryen, and changed cmake to find binaryen binaries using BINARYEN_ROOT var or else find them on path.