### PR TITLE
Docker eosc convenience script

### DIFF
--- a/Docker/eosc.sh
+++ b/Docker/eosc.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+while :
+do
+read  -p "eosc " cmd
+docker exec docker_eos_1 eosc $cmd
+done

--- a/Docker/eosc.sh
+++ b/Docker/eosc.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+
+# Usage:
+# Go into cmd loop: sudo sh eosc.sh
+# Run single cmd:  sudo sh eosc.sh <eosc paramers>
+
 PREFIX="docker exec docker_eos_1 eosc"
 if [ -z $1 ] ; then
   while :

--- a/Docker/eosc.sh
+++ b/Docker/eosc.sh
@@ -8,7 +8,7 @@ PREFIX="docker exec docker_eos_1 eosc"
 if [ -z $1 ] ; then
   while :
   do
-  read  -p "eosc " cmd
+    read  -p "eosc " cmd
     $PREFIX $cmd
   done
 else

--- a/Docker/eosc.sh
+++ b/Docker/eosc.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
-while :
-do
-read  -p "eosc " cmd
-docker exec docker_eos_1 eosc $cmd
-done
+PREFIX="docker exec docker_eos_1 eosc"
+if [ -z $1 ] ; then
+  while :
+  do
+  read  -p "eosc " cmd
+    $PREFIX $cmd
+  done
+else
+  $PREFIX $@
+fi


### PR DESCRIPTION
A little convenience script so that we do not have to type the cumbersome prefix (`docker exec docker_eos_1 eosc`) that docker requires. Not sure if this is merge worthy but I like using it.