### PR TITLE
Standard optimization Docker build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,5 +3,5 @@ image: docker:latest
 build:
   script:
       - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY
-      - docker build --rm -t $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA .
+      - docker build -t $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA -f Docker/Dockerfile .
       - docker push $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
   - cd $TRAVIS_BUILD_DIR/ext && git clone --depth=1 --single-branch git://github.com/oci-labs/clang-WebAssembly wasm-compiler
   - cd $TRAVIS_BUILD_DIR
 script:
-  - WASM_LLVM_CONFIG=$TRAVIS_BUILD_DIR/ext/wasm-compiler/bin/llvm-config ext/cmake-3.9.0-Linux-x86_64/bin/cmake -G Ninja -DCMAKE_CXX_COMPILER=clang++-4.0 -DCMAKE_C_COMPILER=clang-4.0 -DBOOST_ROOT=$TRAVIS_BUILD_DIR/ext -DSecp256k1_ROOT_DIR=$TRAVIS_BUILD_DIR/ext -DBINARYEN_ROOT=$TRAVIS_BUILD_DIR/ext/wasm-compiler/
+  - ext/cmake-3.9.0-Linux-x86_64/bin/cmake -G Ninja -DWASM_LLVM_CONFIG=$TRAVIS_BUILD_DIR/ext/wasm-compiler/bin/llvm-config -DCMAKE_CXX_COMPILER=clang++-4.0 -DCMAKE_C_COMPILER=clang-4.0 -DBOOST_ROOT=$TRAVIS_BUILD_DIR/ext -DSecp256k1_ROOT_DIR=$TRAVIS_BUILD_DIR/ext -DBINARYEN_ROOT=$TRAVIS_BUILD_DIR/ext/wasm-compiler/
   - ninja -j4
   - tests/eosd_run_test.sh
   - tests/chain_test

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,26 +1,28 @@
 FROM ubuntu:16.04
-LABEL authors="xiaobo (peterwillcn@gmail.com), toonsevrin (toonsevrin@gmail.com)"
+LABEL maintainer="xiaobo <peterwillcn@gmail.com>" version="0.1.1" \
+  description="This is eosio/eos image" website="https://eos.io" \
+  reviews="toonsevrin (toonsevrin@gmail.com), etc..."
 
 RUN echo 'APT::Install-Recommends 0;' >> /etc/apt/apt.conf.d/01norecommends \
- && echo 'APT::Install-Suggests 0;' >> /etc/apt/apt.conf.d/01norecommends \
- && apt-get update \
- && DEBIAN_FRONTEND=noninteractive apt-get install -y sudo wget net-tools ca-certificates unzip
+  && echo 'APT::Install-Suggests 0;' >> /etc/apt/apt.conf.d/01norecommends \
+  && apt-get update \
+  && DEBIAN_FRONTEND=noninteractive apt-get install -y sudo wget net-tools ca-certificates unzip
 
 RUN echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-4.0 main" >> /etc/apt/sources.list.d/llvm.list \
- && wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add - \
- && apt-get update \
- && DEBIAN_FRONTEND=noninteractive apt-get install -y git-core automake autoconf libtool build-essential pkg-config libtool \
-    mpi-default-dev libicu-dev python-dev python3-dev libbz2-dev zlib1g-dev libssl-dev libgmp-dev \
-    clang-4.0 lldb-4.0 lld-4.0 \
- && rm -rf /var/lib/apt/lists/*
+  && wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add - \
+  && apt-get update \
+  && DEBIAN_FRONTEND=noninteractive apt-get install -y git-core automake autoconf libtool build-essential pkg-config libtool \
+     mpi-default-dev libicu-dev python-dev python3-dev libbz2-dev zlib1g-dev libssl-dev libgmp-dev \
+     clang-4.0 lldb-4.0 lld-4.0 \
+  && rm -rf /var/lib/apt/lists/*
 
 RUN update-alternatives --install /usr/bin/clang clang /usr/lib/llvm-4.0/bin/clang 400 \
   && update-alternatives --install /usr/bin/clang++ clang++ /usr/lib/llvm-4.0/bin/clang++ 400
 
 RUN cd /tmp && wget https://cmake.org/files/v3.9/cmake-3.9.0-Linux-x86_64.sh \
-   && mkdir /opt/cmake && chmod +x /tmp/cmake-3.9.0-Linux-x86_64.sh \
-   && sh /tmp/cmake-3.9.0-Linux-x86_64.sh --prefix=/opt/cmake --skip-license \
-   && ln -s /opt/cmake/bin/cmake /usr/local/bin
+  && mkdir /opt/cmake && chmod +x /tmp/cmake-3.9.0-Linux-x86_64.sh \
+  && sh /tmp/cmake-3.9.0-Linux-x86_64.sh --prefix=/opt/cmake --skip-license \
+  && ln -s /opt/cmake/bin/cmake /usr/local/bin
 
 RUN cd /tmp && wget https://dl.bintray.com/boostorg/release/1.64.0/source/boost_1_64_0.tar.gz \
   && tar zxf boost_1_64_0.tar.gz \
@@ -42,17 +44,30 @@ RUN cd /tmp && mkdir wasm-compiler && cd wasm-compiler \
   && cmake -G "Unix Makefiles" -DCMAKE_INSTALL_PREFIX=/opt/wasm -DLLVM_TARGETS_TO_BUILD= -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=WebAssembly -DCMAKE_BUILD_TYPE=Release ../ \
   && make -j$(nproc) install && rm -rf /tmp/wasm-compiler
 
+RUN cd /tmp && wget https://github.com/WebAssembly/binaryen/archive/1.37.21.tar.gz && tar zxf 1.37.21.tar.gz \
+  && cd binaryen-1.37.21 && cmake . && make && mkdir /opt/binaryen && mv /tmp/binaryen-1.37.21/bin /opt/binaryen \
+  && ln -s /opt/binaryen/bin/* /usr/local && rm -rf /tmp/*
+
+# Following the official master branch code takes a long time to download, depending on the network speed.
+#RUN cd /tmp && git clone https://github.com/EOSIO/eos.git --recursive \
+#  && mkdir -p /opt/eos/bin/data-dir && cd eos && mkdir build && cd build \
+#  && cmake -DWASM_LLVM_CONFIG=/opt/wasm/bin/llvm-config -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -DCMAKE_INSTALL_PREFIX=/opt/eos ../ \
+#  && make -j$(nproc) && make install && mv ../contracts / \
+#  && ln -s /opt/eos/bin/eos* /usr/local/bin \
+#  && rm -rf /tmp/eos*
+#COPY config.ini genesis.json /
+#COPY entrypoint.sh /sbin
+
 RUN mkdir -p /opt/eos/bin/data-dir && mkdir -p /tmp/eos/build/
-
+# Using local code saves considerable time, but does't guarantee that your code stays up-to-date
 COPY . /tmp/eos/
-
 RUN cd /tmp/eos/build && cmake -DWASM_LLVM_CONFIG=/opt/wasm/bin/llvm-config -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -DCMAKE_INSTALL_PREFIX=/opt/eos ../ \
   && make -j$(nproc) && make install && mv ../contracts / \
   && ln -s /opt/eos/bin/eos* /usr/local/bin \
   && rm -rf /tmp/eos*
-
 COPY Docker/config.ini genesis.json /
 COPY Docker/entrypoint.sh /sbin
+
 RUN chmod +x /sbin/entrypoint.sh
 VOLUME /opt/eos/bin/data-dir
 EXPOSE 9876 8888

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:16.04
 LABEL maintainer="xiaobo <peterwillcn@gmail.com>" version="0.1.1" \
   description="This is eosio/eos image" website="https://eos.io" \
-  reviews="toonsevrin (toonsevrin@gmail.com), etc..."
+  reviewers="toonsevrin (toonsevrin@gmail.com), etc..."
 
 RUN echo 'APT::Install-Recommends 0;' >> /etc/apt/apt.conf.d/01norecommends \
   && echo 'APT::Install-Suggests 0;' >> /etc/apt/apt.conf.d/01norecommends \
@@ -48,26 +48,27 @@ RUN cd /tmp && wget https://github.com/WebAssembly/binaryen/archive/1.37.21.tar.
   && cd binaryen-1.37.21 && cmake . && make && mkdir /opt/binaryen && mv /tmp/binaryen-1.37.21/bin /opt/binaryen \
   && ln -s /opt/binaryen/bin/* /usr/local && rm -rf /tmp/*
 
-# Following the official master branch code takes a long time to download, depending on the network speed.
+# ** Following the official master branch code takes a long time to download, depending on the network speed.
+
 #RUN cd /tmp && git clone https://github.com/EOSIO/eos.git --recursive \
 #  && mkdir -p /opt/eos/bin/data-dir && cd eos && mkdir build && cd build \
 #  && cmake -DWASM_LLVM_CONFIG=/opt/wasm/bin/llvm-config -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -DCMAKE_INSTALL_PREFIX=/opt/eos ../ \
 #  && make -j$(nproc) && make install && mv ../contracts / \
 #  && ln -s /opt/eos/bin/eos* /usr/local/bin \
 #  && rm -rf /tmp/eos*
-#COPY config.ini genesis.json /
-#COPY entrypoint.sh /sbin
 
 RUN mkdir -p /opt/eos/bin/data-dir && mkdir -p /tmp/eos/build/
-# Using local code saves considerable time, but does't guarantee that your code stays up-to-date
+
+# ** Using local code saves considerable time, but does't guarantee that your code stays up-to-date
+
 COPY . /tmp/eos/
 RUN cd /tmp/eos/build && cmake -DWASM_LLVM_CONFIG=/opt/wasm/bin/llvm-config -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -DCMAKE_INSTALL_PREFIX=/opt/eos ../ \
   && make -j$(nproc) && make install && mv ../contracts / \
   && ln -s /opt/eos/bin/eos* /usr/local/bin \
   && rm -rf /tmp/eos*
+
 COPY Docker/config.ini genesis.json /
 COPY Docker/entrypoint.sh /sbin
-
 RUN chmod +x /sbin/entrypoint.sh
 VOLUME /opt/eos/bin/data-dir
 EXPOSE 9876 8888

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -1,16 +1,17 @@
 ### Run in docker
 
-So simple and fast operation EOS:
+Simple and fast setup of EOS on Docker is also available. Firstly, install dependencies:
  - [Docker](https://docs.docker.com)
  - [Docker-compose](https://github.com/docker/compose)
  - [Docker-volumes](https://github.com/cpuguy83/docker-volumes)
 
-Build eos images
+Build eos image
 
 ```
-cd eos/Docker
-cp ../genesis.json .
-docker build --rm -t eosio/eos .
+git clone https://github.com/EOSIO/eos.git --recursive
+cd eos
+cp genesis.json Docker 
+docker build -t eosio/eos -f Docker/Dockerfile .
 ```
 
 Start docker
@@ -18,17 +19,21 @@ Start docker
 ```
 sudo rm -rf /data/store/eos # options 
 sudo mkdir -p /data/store/eos
-docker-compose -f docker-compose.yml up
+docker-compose -f Docker/docker-compose.yml up
+```
+
+Get chain info
+
+```
+curl http://127.0.0.1:8888/v1/chain/get_info
 ```
 
 Run example contracts
 
+You can run the `eosc` commands via `docker exec` command. For example:
 ```
 cd /data/store/eos/contracts/exchange
-docker exec docker_eos_1 eosc setcode exchange contracts/exchange/exchange.wast contracts/exchange/exchange.abi
-
-cd /data/store/eos/contracts/currency 
-docker exec docker_eos_1 eosc setcode currency contracts/currency/currency.wast contracts/currency/currency.abi
+docker exec docker_eos_1 eosc contract exchange contracts/exchange/exchange.wast contracts/exchange/exchange.abi
 
 ```
 

--- a/Docker/config.ini
+++ b/Docker/config.ini
@@ -18,10 +18,10 @@ shared-file-dir = "blockchain"
 shared-file-size = 8192
 
 # The local IP and port to listen for incoming http connections.
-http-server-endpoint = 127.0.0.1:8888
+http-server-endpoint = 0.0.0.0:8888
 
 # The local IP address and port to listen for incoming connections.
-listen-endpoint = 127.0.0.1:9876
+listen-endpoint = 0.0.0.0:9876
 
 # The IP address and port of a remote peer to sync with.
 # remote-endpoint =

--- a/README.md
+++ b/README.md
@@ -138,6 +138,12 @@ If a repo is cloned without the `--recursive` flag, the submodules can be retrie
 The WASM_LLVM_CONFIG environment variable is used to find our recently built WASM compiler.
 This is needed to compile the example contracts inside eos/contracts folder and their respective tests.
 
+Also, to use the WASM compiler, eos has an external dependency on 
+ - [binaryen](https://github.com/WebAssembly/binaryen.git)
+   * need to checkout tag 1.37.21
+   * also need to run "make install"
+   * if installed in a location outside of PATH, need to set BINARYEN_ROOT to cmake
+
 #### On Ubuntu:
 
 ```commandline
@@ -268,7 +274,7 @@ cd ~/eos/build/programs/eosc/
 ./eosc contract exchange ../../../contracts/exchange/exchange.wast ../../../contracts/exchange/exchange.abi
 ```
 
-## Run in docker
+## Run eos in docker
 
 Simple and fast setup of EOS on Docker is also available. Firstly, install dependencies:
 
@@ -299,7 +305,7 @@ Get chain info
 curl http://127.0.0.1:8888/v1/chain/get_info
 ```
 
-### Docker run contract example
+### Run contract in docker example
 
 You can run the `eosc` commands via `docker exec` command. For example:
 ```

--- a/README.md
+++ b/README.md
@@ -278,41 +278,30 @@ Simple and fast setup of EOS on Docker is also available. Firstly, install depen
 
 Build eos image
 
-```commandline
-cd eos/Docker
-cp ../genesis.json .
-docker build --rm -t eosio/eos .
+```
+git clone https://github.com/EOSIO/eos.git --recursive
+cd eos
+cp genesis.json Docker 
+docker build -t eosio/eos -f Docker/Dockerfile .
 ```
 
-Start docker
+Starting the Docker this can be tested from container's host machine:
 
-```commandline
+```
 sudo rm -rf /data/store/eos # options 
 sudo mkdir -p /data/store/eos
-docker-compose -f docker-compose.yml up
+docker-compose -f Docker/docker-compose.yml up
 ```
 
-Also, to use the WASM compiler, eos has an external dependency on 
- - [binaryen](https://github.com/WebAssembly/binaryen.git)
-   * need to checkout tag 1.37.14
-   * also need to run "make install"
-   * if installed in a location outside of PATH, need to set BINARYEN_ROOT to cmake
-
-### Using the WASM compiler to perform a full build of the project
-
-For example:
+Get chain info
 
 ```
-# The local IP and port to listen for incoming http connections.
-http-server-endpoint = 0.0.0.0:8888
-```
-
-After starting the Docker this can be tested from container's host machine:
-```commandline
 curl http://127.0.0.1:8888/v1/chain/get_info
 ```
 
+### Docker run contract example
+
 You can run the `eosc` commands via `docker exec` command. For example:
-```commandline
+```
 docker exec docker_eos_1 eosc contract exchange contracts/exchange/exchange.wast contracts/exchange/exchange.abi
 ```

--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ machine:
 
 dependencies:
   override:
-    - cd ~/eos/Docker && docker build -t eosio/eos .
+    - cd ~/eos && docker build -t eosio/eos -f Docker/Dockerfile .
 
 test:
   pre:


### PR DESCRIPTION
1. Fix merge conflict and standard optimization docker build process.
2. Fix travis-ci cmake use -DWASM_LLVM_CONFIG.
3. Add binaryen for WASM compiler.
4. Use Local code copy build image, 
because clone code takes a lot of time, don't use clone repo. (@toonsevrin suggested)
5. Use **-f Docker/Dockerfile** fixed local code COPY problem.(ref: https://github.com/EOSIO/eos/issues/289)

**For example:**
 `docker build -t eosio/eos -f Docker/Dockerfile . `

So, Dockerfile will be restored from the root directory to the Docker directory, keep the code architecture clearer and less polluting.

