### PR TITLE
Improve interactions with eosc

### DIFF
--- a/contracts/eoslib/contracts.dox
+++ b/contracts/eoslib/contracts.dox
@@ -30,7 +30,7 @@
   }
   ```
 
-  `main` is give the arguments `code` and `action` which uniquely identify every event in
+  `apply` is give the arguments `code` and `action` which uniquely identify every event in
   the system. For example, `code` could be a *currency* contract and `action` could be *transfer*.  This event (code,action)
   may be passed to several contracts including the `sender` and `receiver`.  It is up to your application to figure
   out what to do in response to such an event.

--- a/libraries/fc/CMakeLists.txt
+++ b/libraries/fc/CMakeLists.txt
@@ -65,6 +65,7 @@ set( fc_sources
      src/io/json.cpp
      src/io/varint.cpp
      src/io/fstream.cpp
+     src/io/console.cpp
      src/filesystem.cpp
      src/interprocess/file_mapping.cpp
      src/interprocess/mmap_struct.cpp

--- a/plugins/wallet_plugin/wallet.cpp
+++ b/plugins/wallet_plugin/wallet.cpp
@@ -142,8 +142,12 @@ public:
          FC_THROW("Invalid private key");
       eos::chain::public_key_type wif_pub_key = optional_private_key->get_public_key();
 
-      _keys[wif_pub_key] = wif_key;
-      return true;
+      auto itr = _keys.find(wif_pub_key);
+      if( itr == _keys.end() ) {
+         _keys[wif_pub_key] = wif_key;
+         return true;
+      }
+      FC_ASSERT( !"Key already in wallet" );
    }
 
    bool load_wallet_file(string wallet_filename = "")

--- a/plugins/wallet_plugin/wallet_manager.cpp
+++ b/plugins/wallet_plugin/wallet_manager.cpp
@@ -33,8 +33,9 @@ std::string wallet_manager::create(const std::string& name) {
    std::string password = gen_password();
 
    auto wallet_filename = dir / (name + file_ext);
-   if (fc::exists( dir / wallet_filename)) {
-      FC_THROW("Wallet with name: ${n} already exists.", ("n", name));
+
+   if (fc::exists( wallet_filename)) {
+      FC_THROW("Wallet with name: '${n}' already exists at ${path}", ("n", name)("path",fc::path(wallet_filename)));
    }
 
    wallet_data d;

--- a/programs/eosd/CMakeLists.txt
+++ b/programs/eosd/CMakeLists.txt
@@ -12,7 +12,7 @@ endif()
 target_link_libraries( eosd
         PRIVATE appbase
         PRIVATE account_history_api_plugin account_history_plugin
-        PRIVATE chain_api_plugin producer_plugin chain_plugin
+        PRIVATE chain_api_plugin producer_plugin chain_plugin wallet_api_plugin
         PRIVATE net_plugin http_plugin
         PRIVATE eos_chain fc ${CMAKE_DL_LIBS} ${PLATFORM_SPECIFIC_LIBS} )
 

--- a/programs/eosd/main.cpp
+++ b/programs/eosd/main.cpp
@@ -7,6 +7,7 @@
 #include <eos/net_plugin/net_plugin.hpp>
 #include <eos/account_history_plugin/account_history_plugin.hpp>
 #include <eos/account_history_api_plugin/account_history_api_plugin.hpp>
+#include <eos/wallet_api_plugin/wallet_api_plugin.hpp>
 
 #include <fc/log/logger_config.hpp>
 #include <fc/exception/exception.hpp>
@@ -21,11 +22,9 @@ int main(int argc, char** argv)
    try {
       app().register_plugin<net_plugin>();
       app().register_plugin<chain_api_plugin>();
-      app().register_plugin<http_plugin>();
       app().register_plugin<producer_plugin>();
-      app().register_plugin<chain_plugin>();
-      app().register_plugin<account_history_plugin>();
       app().register_plugin<account_history_api_plugin>();
+      app().register_plugin<wallet_api_plugin>();
       if(!app().initialize<chain_plugin, http_plugin, net_plugin>(argc, argv))
          return -1;
       app().startup();


### PR DESCRIPTION
- wallet no longer overwrites when re-creating
- adding password prompt so it isn't logged in history #315
- fix type-o in contract dox
- provide feedback on successful wallet commands
- added default "wallet name" to wallet args so it can be skipped
- adding args to change wallet host/port as well as eosd host
- adding ability to run wallet_api_plugin to eosd
- started pretty printing of account history
- adding missing fc/src/io/console.cpp to CMakeList