### PR TITLE
Small print.hpp documentation update

### DIFF
--- a/contracts/eoslib/print.hpp
+++ b/contracts/eoslib/print.hpp
@@ -143,7 +143,7 @@ namespace eos {
     *
     *  Example:
     *  @code
-    *  char *s = "Hello World!";
+    *  char const *s = "Hello World!";
     *  uint64_t unsigned_64_bit_int = 1e+18;
     *  uint128_t unsigned_128_bit_int (87654323456);
     *  uint64_t string_as_unsigned_64_bit = N(abcde);


### PR DESCRIPTION
According to https://stackoverflow.com/questions/20944784/why-is-conversion-from-string-constant-to-char-valid-in-c-but-invalid-in-c. As I don't write a lot of cpp myself I'm not 100% sure why this is, but at least the code compiles with that.