### PR TITLE
Fix deployment of compiled smart contracts to /build directory rather than sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ code hash: 0000000000000000000000000000000000000000000000000000000000000000
 With an account for a contract created, you can upload a sample contract:
 
 ```commandline
-./eosc set contract currency ../../../contracts/currency/currency.wast ../../../contracts/currency/currency.abi
+./eosc set contract currency ../../contracts/currency/currency.wast ../../contracts/currency/currency.abi
 ```
 
 As a response you should get a json with a `transaction_id` field. Your contract was successfully uploaded!
@@ -508,5 +508,5 @@ curl http://127.0.0.1:8888/v1/chain/get_info
 You can run the `eosc` commands via `docker exec` command. For example:
 
 ```
-docker exec docker_eos_1 eosc contract exchange contracts/exchange/exchange.wast contracts/exchange/exchange.abi
+docker exec docker_eos_1 eosc contract exchange build/contracts/exchange/exchange.wast build/contracts/exchange/exchange.abi
 ```

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ source ~/.bash_profile
 ## Building and running a node
 
 ### Getting the code
+
 To download all of the code, download Eos and a recursion or two of submodules. The easiest way to get all of this is to do a recursive clone:
 
 `git clone https://github.com/eosio/eos --recursive`

--- a/contracts/currency/CMakeLists.txt
+++ b/contracts/currency/CMakeLists.txt
@@ -1,2 +1,4 @@
 file(GLOB SOURCE_FILES "*.cpp")
-add_wast_target(currency "${SOURCE_FILES}" "${CMAKE_SOURCE_DIR}/contracts" ${CMAKE_CURRENT_SOURCE_DIR})
+file(GLOB ABI_FILES "*.abi")
+add_wast_target(currency "${SOURCE_FILES}" "${CMAKE_SOURCE_DIR}/contracts" ${CMAKE_CURRENT_BINARY_DIR})
+configure_file("${ABI_FILES}" "${CMAKE_CURRENT_BINARY_DIR}" COPYONLY)

--- a/contracts/exchange/CMakeLists.txt
+++ b/contracts/exchange/CMakeLists.txt
@@ -1,3 +1,5 @@
 file(GLOB SOURCE_FILES "*.cpp")
-add_wast_target(exchange "${SOURCE_FILES}" "${CMAKE_SOURCE_DIR}/contracts" ${CMAKE_CURRENT_SOURCE_DIR})
+file(GLOB ABI_FILES "*.abi")
+add_wast_target(exchange "${SOURCE_FILES}" "${CMAKE_SOURCE_DIR}/contracts" ${CMAKE_CURRENT_BINARY_DIR})
+configure_file("${ABI_FILES}" "${CMAKE_CURRENT_BINARY_DIR}" COPYONLY)
 add_dependencies( exchange currency )

--- a/contracts/infinite/CMakeLists.txt
+++ b/contracts/infinite/CMakeLists.txt
@@ -1,2 +1,2 @@
 file(GLOB SOURCE_FILES "*.cpp")
-add_wast_target(infinite "${SOURCE_FILES}" "${CMAKE_SOURCE_DIR}/contracts" ${CMAKE_CURRENT_SOURCE_DIR})
+add_wast_target(infinite "${SOURCE_FILES}" "${CMAKE_SOURCE_DIR}/contracts" ${CMAKE_CURRENT_BINARY_DIR})

--- a/contracts/simpledb/CMakeLists.txt
+++ b/contracts/simpledb/CMakeLists.txt
@@ -1,2 +1,4 @@
 file(GLOB SOURCE_FILES "*.cpp")
-add_wast_target(simpledb "${SOURCE_FILES}" "${CMAKE_SOURCE_DIR}/contracts" ${CMAKE_CURRENT_SOURCE_DIR})
+file(GLOB ABI_FILES "*.abi")
+add_wast_target(simpledb "${SOURCE_FILES}" "${CMAKE_SOURCE_DIR}/contracts" ${CMAKE_CURRENT_BINARY_DIR})
+configure_file("${ABI_FILES}" "${CMAKE_CURRENT_BINARY_DIR}" COPYONLY)

--- a/contracts/social/CMakeLists.txt
+++ b/contracts/social/CMakeLists.txt
@@ -1,2 +1,2 @@
 file(GLOB SOURCE_FILES "*.cpp")
-add_wast_target(social "${SOURCE_FILES}" "${CMAKE_SOURCE_DIR}/contracts" ${CMAKE_CURRENT_SOURCE_DIR})
+add_wast_target(social "${SOURCE_FILES}" "${CMAKE_SOURCE_DIR}/contracts" ${CMAKE_CURRENT_BINARY_DIR})

--- a/contracts/test_api/CMakeLists.txt
+++ b/contracts/test_api/CMakeLists.txt
@@ -1,2 +1,2 @@
 file(GLOB SOURCE_FILES "*.cpp")
-add_wast_target(test_api "${SOURCE_FILES}" "${CMAKE_SOURCE_DIR}/contracts" ${CMAKE_CURRENT_SOURCE_DIR})
+add_wast_target(test_api "${SOURCE_FILES}" "${CMAKE_SOURCE_DIR}/contracts" ${CMAKE_CURRENT_BINARY_DIR})


### PR DESCRIPTION
* Fix deployment of compiled smart contracts to /build directory rather than sources
* Copy .abi files to build folder for smart contracts
* Update README.md to reflect the change