### PR TITLE
Add Access-Control-Allow options

### DIFF
--- a/Docker/config.ini
+++ b/Docker/config.ini
@@ -23,6 +23,12 @@ http-server-endpoint = 0.0.0.0:8888
 # The Access-Control-Allow-Origin http value
 # access-control-allow-origin = *
 
+# The Access-Control-Allow-Headers http value
+# access-control-allow-headers = Content-Type
+
+# true if Access-Control-Allow-Credentials: true should be specified in http response header
+# access-control-allow-credentials = true
+
 # The local IP address and port to listen for incoming connections.
 listen-endpoint = 0.0.0.0:9876
 


### PR DESCRIPTION
Issue #374.

To host eosd behind ssl, some additional Access-Control-Allow options where required. This adds:
* Access-Control-Allow-Headers
* Access-Control-Allow-Credentials

Added as options to the config.ini
