### PR TITLE
P2p sync improvement

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -220,9 +220,7 @@ namespace eos {
       fc::datastream<char*> ds( buffer.data(), buffer.size() );
       ds.write( (char*)&size, sizeof(size) );
       fc::raw::pack( ds, m );
-      dlog ("send_next_message called, buffer size = ${s}", ("s",buffer.size()));
-
-
+      boost::asio::buffer abuff( buffer.data(), buffer.size());
       boost::asio::async_write( *socket, boost::asio::buffer( buffer.data(), buffer.size() ),
                    [this,buf=std::move(buffer)]( boost::system::error_code ec, std::size_t bytes_transferred ) {
                      if( ec ) {
@@ -233,9 +231,6 @@ namespace eos {
                        } else {
                          out_queue.pop_front();
                        }
-                       dlog ("after write, bytes_transferred = ${bt} buf.size = ${bs}",
-                             ("bt",bytes_transferred)("bs",buf.size()));
-
                        send_next_message();
                      }
                    });
@@ -393,7 +388,6 @@ namespace eos {
         just_send_it_max = mtu;
       }
       start_read_message( con );
-      dlog ("calling send_handshake");
       con->send_handshake( );
 
       // for now, we can just use the application main loop.
@@ -471,7 +465,6 @@ namespace eos {
       sync_state req =  {low, high, sync_req_head, time_point::now(), vector<signed_block>() };
       c->in_sync_state.push_back (req);
       sync_request_message srm = {req.start_block, req.end_block };
-      dlog ("sending srm, from ${s} to ${e}", ("s", req.start_block)("e", req.end_block));
       c->send (srm);
       sync_req_head = high;
       return (sync_req_head == sync_head);
@@ -567,7 +560,6 @@ namespace eos {
       }
 
       uint32_t head = cc.head_block_num ();
-      dlog ("msg.head_num = ${m} head = ${h}", ("m", msg.head_num)("h",head));
       if ( msg.head_num  >  head) {
         set_sync_head(msg.head_num);
       }


### PR DESCRIPTION
This PR is associated with issue #344.

Background for this PR. Dan wrote the following as a recipe for cahing up a new node with the rest of the chain.

    if my head block < the LIB of a peer and my head block age > block interval * round_size/2 then
    enter sync mode...
        divide the block numbers you need to fetch among peers and send fetch request
        if peer does not respond to request in a timely manner then make request to another peer
        ensure that there is a constant queue of requests in flight and everytime a request is filled
        send of another request.

     Once you have caught up to all peers, notify all peers of your head block so they know that you
     know the LIB and will start sending you real time tranasctions

Early on I created a niave version of this model, but it failed when there was more than one peer to draw from.

What I have here is a revision to that model that more closely resembles what was described above. A major difference is that rather that requesting individual blocks in sequential order, I have the requester request groups of blocks. The blocks in these groups are then send in sequential order, but with two or more peers available to query, some blocks have to be cached so they can be applied in sequence.

As always, the handshake message carries the head block number and last irreversable block number. However I have a much simpler algorithm for dropping into sync mode - is my head block less than my peer's head block?

If it is, then the list of needed blocks gets devided amongst the peers, but not all at once. Each peer is given an assignment, and when that assignment is filled, the peer receives a new assinment. This is repeated as many times as neccesary. Since blocks are sequential within a chunk, once a given chunk is found to contain the next required block, all of the blocks in that chunk are rapidly processed into the chain as are any subsequent chunk provided by any peer.

One thing that might strike someone as weird is that I'm acutally caching the received byte array in the unmarshaled format. Then when it is due to be applied I the conversion to the block and apply the result. I replicate the visitor pattern for cache pre/post processing. Every short cut I tried ended in a core file.
