### PR TITLE
Fixed issue 283 where node crashes if type are empty in Abi contract

### DIFF
--- a/libraries/types/AbiSerializer.cpp
+++ b/libraries/types/AbiSerializer.cpp
@@ -100,7 +100,10 @@ namespace eos { namespace types {
       tables.clear();
 
       for( const auto& td : abi.types )
+      {
+         FC_ASSERT( isType(td.type), "invalid type", ("type",td.type));
          typedefs[td.newTypeName] = td.type;
+      }
 
       for( const auto& st : abi.structs )
          structs[st.name] = st;


### PR DESCRIPTION
Added an assert statement in AbiSerializer::setAbi(const Abi& abi) method. Kindly review.