### PR TITLE
Contract integration test

### DIFF
--- a/programs/eosc/main.cpp
+++ b/programs/eosc/main.cpp
@@ -729,7 +729,7 @@ int main( int argc, char** argv ) {
          for( const auto& s : subscopes )
          trx.scope.emplace_back(s);
       }
-      ilog("Transaction result:\n${r}", ("r", fc::json::to_pretty_string(push_transaction(trx, !skip_sign ))));
+      std::cout << fc::json::to_pretty_string(push_transaction(trx, !skip_sign )) << std::endl;
    });
 
    // push transaction

--- a/tests/eosd_run_test.sh
+++ b/tests/eosd_run_test.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# prevent bc from adding \ at end of large hex values
+export BC_LINE_LENGTH=9999
+
+# $1 - error message
 error()
 {
   (>&2 echo $1)
@@ -11,7 +15,7 @@ verifyErrorCode()
 {
   rc=$?
   if [[ $rc != 0 ]]; then
-    error "$1 returned error code $rc"
+    error "FAILURE - $1 returned error code $rc"
   fi
 }
 
@@ -25,6 +29,16 @@ cleanup()
 {
   rm -rf tn_data_0
   rm -rf test_wallet_0
+}
+
+# $1 - string that contains "transaction_id": "<trans id>", in it
+# result <trans id> stored in TRANS_ID
+getTransactionId()
+{
+  TRANS_ID="$(echo "$1" | awk '/transaction_id/ {print $2}')"
+  # remove leading/trailing quotes
+  TRANS_ID=${TRANS_ID#\"}
+  TRANS_ID=${TRANS_ID%\",}
 }
 
 # result stored in HEAD_BLOCK_NUM
@@ -83,6 +97,10 @@ PUB_KEY3="$(echo "$KEYS" | awk '/Public/ {print $3}')"
 if [ -z "$PRV_KEY1" ] || [ -z "$PRV_KEY2" ] || [ -z "$PRV_KEY3" ] || [ -z "$PUB_KEY1" ] || [ -z "$PUB_KEY2" ] || [ -z "$PUB_KEY3" ]; then
   error "FAILURE - create keys"
 fi
+
+#
+# Wallet Tests
+#
 
 # walletd
 programs/eos-walletd/eos-walletd --data-dir test_wallet_0 --http-server-endpoint=127.0.0.1:8899 > test_walletd_output.log 2>&1 &
@@ -165,6 +183,10 @@ if [[ $count == 0 ]]; then
   error "FAILURE - wallet keys did not include $INITA_PRV_KEY"
 fi
 
+#
+# Account and Transfer Tests
+#
+
 # create new account
 ACCOUNT_INFO="$(programs/eosc/eosc --wallet-port 8899 create account inita testera $PUB_KEY1 $PUB_KEY3)"
 verifyErrorCode "eosc create account"
@@ -190,13 +212,11 @@ if [ $count == 0 ]; then
 fi
 
 # create another new account via initb
-ACCOUNT_INFO="$(programs/eosc/eosc --wallet-port 8899 create account initb testerb $PUB_KEY2 $PUB_KEY3)"
+ACCOUNT_INFO="$(programs/eosc/eosc --wallet-port 8899 create account initb currency $PUB_KEY2 $PUB_KEY3)"
 verifyErrorCode "eosc create account"
 waitForNextBlock
 
-#
-# now transfer from testera to testerb using keys from testera
-#
+## now transfer from testera to currency using keys from testera
 
 # lock via lock_all
 programs/eosc/eosc --wallet-port 8899 wallet lock_all
@@ -207,18 +227,14 @@ echo $PASSWORD | programs/eosc/eosc --wallet-port 8899 wallet unlock --name test
 verifyErrorCode "eosc wallet unlock"
 
 # transfer
-TRANSFER_INFO="$(programs/eosc/eosc --wallet-port 8899 transfer testera testerb 975311 "test transfer a->b")"
+TRANSFER_INFO="$(programs/eosc/eosc --wallet-port 8899 transfer testera currency 975311 "test transfer a->b")"
 verifyErrorCode "eosc transfer"
-TRANS_ID="$(echo "$TRANSFER_INFO" | awk '/transaction_id/ {print $2}')"
 waitForNextBlock
-
-# remove leading/trailing quotes
-TRANS_ID=${TRANS_ID#\"}
-TRANS_ID=${TRANS_ID%\",}
+getTransactionId "$TRANSFER_INFO"
 
 # verify transfer
-ACCOUNT_INFO="$(programs/eosc/eosc --wallet-port 8899 get account testerb)"
-verifyErrorCode "eosc get account testerb"
+ACCOUNT_INFO="$(programs/eosc/eosc --wallet-port 8899 get account currency)"
+verifyErrorCode "eosc get account currency"
 count=`echo $ACCOUNT_INFO | grep -c "97.5311"`
 if [ $count == 0 ]; then
   error "FAILURE - transfer failed: $ACCOUNT_INFO"
@@ -231,7 +247,7 @@ count=`echo $ACCOUNT_INFO | grep -c "testera"`
 if [ $count == 0 ]; then
   error "FAILURE - get accounts failed: $ACCOUNT_INFO"
 fi
-count=`echo $ACCOUNT_INFO | grep -c "testerb"`
+count=`echo $ACCOUNT_INFO | grep -c "currency"`
 if [ $count == 0 ]; then
   error "FAILURE - get accounts failed: $ACCOUNT_INFO"
 fi
@@ -241,7 +257,7 @@ count=`echo $ACCOUNT_INFO | grep -c "testera"`
 if [ $count == 0 ]; then
   error "FAILURE - get accounts failed: $ACCOUNT_INFO"
 fi
-count=`echo $ACCOUNT_INFO | grep -c "testerb"`
+count=`echo $ACCOUNT_INFO | grep -c "currency"`
 if [ $count != 0 ]; then
   error "FAILURE - get accounts failed: $ACCOUNT_INFO"
 fi
@@ -253,7 +269,7 @@ count=`echo $ACCOUNT_INFO | grep -c "testera"`
 if [ $count == 0 ]; then
   error "FAILURE - get servants failed: $ACCOUNT_INFO"
 fi
-count=`echo $ACCOUNT_INFO | grep -c "testerb"`
+count=`echo $ACCOUNT_INFO | grep -c "currency"`
 if [ $count != 0 ]; then
   error "FAILURE - get servants failed: $ACCOUNT_INFO"
 fi
@@ -266,7 +282,7 @@ fi
 
 # get transaction
 TRANS_INFO="$(programs/eosc/eosc --wallet-port 8899 get transaction $TRANS_ID)"
-verifyErrorCode "eosc get transaction trans_id"
+verifyErrorCode "eosc get transaction trans_id of $TRANS_INFO"
 count=`echo $TRANS_INFO | grep -c "transfer"`
 if [ $count == 0 ]; then
   error "FAILURE - get transaction trans_id failed: $TRANS_INFO"
@@ -282,6 +298,79 @@ verifyErrorCode "eosc get transactions testera"
 count=`echo $TRANS_INFO | grep -c "$TRANS_ID"`
 if [ $count == 0 ]; then
   error "FAILURE - get transactions testera failed: $TRANS_INFO"
+fi
+
+#
+# Currency Contract Tests
+#
+
+# verify no contract in place
+CODE_INFO="$(programs/eosc/eosc --wallet-port 8899 get code currency)"
+verifyErrorCode "eosc get code currency"
+# convert to num
+CODE_HASH="$(echo "$CODE_INFO" | awk '/code hash/ {print $3}')"
+CODE_HASH="$(echo $CODE_HASH | awk '{print toupper($0)}')"
+CODE_HASH="$(echo "ibase=16; $CODE_HASH" | bc)"
+if [ $CODE_HASH != 0 ]; then
+  error "FAILURE - get code currency failed: $CODE_INFO"
+fi
+
+# upload a contract
+INFO="$(programs/eosc/eosc --wallet-port 8899 set contract currency contracts/currency/currency.wast contracts/currency/currency.abi)"
+verifyErrorCode "eosc set contract testera"
+count=`echo $INFO | grep -c "processed"`
+if [ $count == 0 ]; then
+  error "FAILURE - set contract failed: $INFO"
+fi
+getTransactionId "$INFO"
+
+waitForNextBlock
+# verify transaction exists
+TRANS_INFO="$(programs/eosc/eosc --wallet-port 8899 get transaction $TRANS_ID)"
+verifyErrorCode "eosc get transaction trans_id of $TRANS_INFO"
+
+# verify code is set
+CODE_INFO="$(programs/eosc/eosc --wallet-port 8899 get code currency)"
+verifyErrorCode "eosc get code currency"
+# convert to num
+CODE_HASH="$(echo "$CODE_INFO" | awk '/code hash/ {print $3}')"
+CODE_HASH="$(echo $CODE_HASH | awk '{print toupper($0)}')"
+CODE_HASH="$(echo "ibase=16; $CODE_HASH" | bc)"
+if [ $CODE_HASH == 0 ]; then
+  error "FAILURE - get code currency failed: $CODE_INFO"
+fi
+
+# verify currency contract has proper initial balance
+INFO="$(programs/eosc/eosc --wallet-port 8899 get table currency currency account)"
+verifyErrorCode "eosc get table currency account"
+count=`echo $INFO | grep -c "1000000000"`
+if [ $count == 0 ]; then
+  error "FAILURE - get table currency account failed: $INFO"
+fi
+
+# push message to currency contract
+INFO="$(programs/eosc/eosc --wallet-port 8899 push message currency transfer '{"from":"currency","to":"inita","amount":50}' --scope currency,inita --permission currency@active)"
+verifyErrorCode "eosc push message currency transfer"
+getTransactionId "$INFO"
+
+# verify transaction exists
+waitForNextBlock
+TRANS_INFO="$(programs/eosc/eosc --wallet-port 8899 get transaction $TRANS_ID)"
+verifyErrorCode "eosc get transaction trans_id of $TRANS_INFO"
+
+# read current contract balance
+ACCOUNT_INFO="$(programs/eosc/eosc --wallet-port 8899 get table inita currency account)"
+verifyErrorCode "eosc get table currency account"
+count=`echo $ACCOUNT_INFO | grep "balance" | grep -c "50"`
+if [ $count == 0 ]; then
+  error "FAILURE - get table inita account failed: $ACCOUNT_INFO"
+fi
+
+ACCOUNT_INFO="$(programs/eosc/eosc --wallet-port 8899 get table currency currency account)"
+verifyErrorCode "eosc get table currency account"
+count=`echo $ACCOUNT_INFO | grep "balance" | grep -c "999999950"`
+if [ $count == 0 ]; then
+  error "FAILURE - get table currency account failed: $ACCOUNT_INFO"
 fi
 
 


### PR DESCRIPTION
Issue #372 

The integration test eosd_run_test.sh now exercises everything called out in README.md.

Changed eosc main.cpp one location where it was using ilog instead of cout.