### PR TITLE
Added help messages for various errors induced while testing currency contract

### DIFF
--- a/programs/eosc/help_text.cpp
+++ b/programs/eosc/help_text.cpp
@@ -40,6 +40,15 @@ issue:
     Please note, this will consume more bandwidth than the base transaction 
 )text";
 
+const char* missing_perms_help_text = 1 + R"text(
+The transaction requires permissions that were not granted by the transaction.
+Missing permission from:
+  - ${1}
+
+Please use the `-p,--permissions` option to add the missing accounts!
+Note: you will need an unlocked wallet that can authorized these permissions.  
+)text";
+
 const char* missing_sigs_help_text = 1 + R"text(
 The transaction requires permissions that could not be authorized by the wallet.
 Missing authrizations:
@@ -48,8 +57,20 @@ Missing authrizations:
 Please make sure the proper keys are imported into an unlocked wallet and try again!    
 )text";
 
-const char* unknown_account_help_text = 1 + R"text(
+const char* missing_scope_help_text = 1 + R"text(
+The transaction requires scopes that were not listed by the transaction.
+Missing scope(s):
+  - ${1}
+
+Please use the `-S,--scope` option to add the missing accounts!
+)text";
+
+
+const char* tx_unknown_account_help_text = 1 + R"text(
 The transaction references an account which does not exist.
+)text";
+
+const char* unknown_account_help_text = 1 + R"text(
 Unknown accounts:
   - ${1}
 
@@ -76,15 +97,31 @@ const char* locked_wallet_help_text = 1 + R"text(
 The wallet named "${1}" is locked.  Please unlock it and try again.
 )text";
 
+const char* duplicate_key_import_help_text = 1 + R"text(
+This key is already imported into the wallet named "${1}".
+)text";
+
+const char* unknown_abi_table_help_text = 1 + R"text(
+The ABI for the code on account "${1}" does not specify table "${2}".
+
+Please check the account and table name, and verify that the account has the expected code using:
+  eosc get code ${1}
+)text";
+
 const std::vector<std::pair<const char*, std::vector<const char *>>> error_help_text {
    {"Error\n: 3030011", {transaction_help_text_header, duplicate_transaction_help_text}},
+   {"Error\n: 3030001[^\\x00]*\\{\"acct\":\"([^\"]*)\"\\}", {transaction_help_text_header, missing_perms_help_text}},
    {"Error\n: 3030002[^\\x00]*Transaction declares authority.*account\":\"([^\"]*)\",\"permission\":\"([^\"]*)\"", {transaction_help_text_header, missing_sigs_help_text}},
-   {"Account not found: ([\\S]*)", {transaction_help_text_header, unknown_account_help_text}},
+   {"Error\n: 3030008[^\\x00]*\\{\"scope\":\"([^\"]*)\"\\}", {transaction_help_text_header, missing_scope_help_text}},
+   {"Account not found: ([\\S]*)", {transaction_help_text_header, tx_unknown_account_help_text, unknown_account_help_text}},
    {"Error\n: 303", {transaction_help_text_header}},
    {"unknown key[^\\x00]*abi_json_to_bin.*code\":\"([^\"]*)\".*action\":\"([^\"]*)\"", {missing_abi_help_text}},
+   {"unknown key[^\\x00]*chain/get_code.*name\":\"([^\"]*)\"", {unknown_account_help_text}},
    {"Unable to open file[^\\x00]*wallet/open.*postdata\":\"([^\"]*)\"", {unknown_wallet_help_text}},
    {"AES error[^\\x00]*wallet/unlock.*postdata\":\\[\"([^\"]*)\"", {bad_wallet_password_help_text}},
    {"Wallet is locked: ([\\S]*)", {locked_wallet_help_text}},
+   {"Key already in wallet[^\\x00]*wallet/import_key.*postdata\":\\[\"([^\"]*)\"", {duplicate_key_import_help_text}},
+   {"Abi does not define table[^\\x00]*get_table_rows.*code\":\"([^\"]*)\",\"table\":\"([^\"]*)\"", {unknown_abi_table_help_text}}
 };
 
 auto smatch_to_variant(const std::smatch& smatch) {


### PR DESCRIPTION
closes #431

added error messages for:
- importing a key to a wallet that is already in the wallet
- getting the code hash for an unknown account name
- getting a table that is not specified by the ABI
- sending a message that doesn't list the required permissions (#431)
- sending a message that doesn't list the required scopes