### PR TITLE
Rename Table keytype to keytypes (plural)

### DIFF
--- a/libraries/types/types.eos
+++ b/libraries/types/types.eos
@@ -66,7 +66,7 @@ struct Table
    table      Name       # the name of the table
    indextype  TypeName   # the kind of index, i64, i128i128, etc
    keynames   TypeName[] # names for the keys defined by keytype
-   keytype    TypeName[] # the meaning / type of key parameters, how to convert binary key to json
+   keytypes   TypeName[] # the meaning / type of key parameters, how to convert binary key to json
    type       TypeName   # the meaning / type of the binary data stored in this table
 
 struct Abi


### PR DESCRIPTION
Fixes transaction error when loading Abi and contract.