### PR TITLE
The default setting for build.sh is to install dependencies

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -57,7 +57,7 @@ if [ $ARCH == "darwin" ]; then
 fi
 
 # Debug flags
-INSTALL_DEPS=0
+INSTALL_DEPS=1
 COMPILE_EOS=1
 COMPILE_CONTRACTS=1
 


### PR DESCRIPTION
Changed default value of INSTALL_DEPS to 1 from 0.