### PR TITLE
add build prefix to automated path

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ EOS comes with a number of programs you can find in `~/eos/build/programs`. They
 <a name="singlenode"></a>
 ### Creating and launching a single-node testnet 
 
-After successfully building the project, the `eosd` binary should be present in the `programs/eosd` directory. Go ahead and run `eosd` -- it will probably exit with an error, but if not, close it immediately with <kbd>Ctrl-C</kbd>. Note that `eosd` created a directory named `data-dir` containing the default configuration (`config.ini`) and some other internals. This default data storage path can be overridden by passing `--data-dir /path/to/data` to `eosd`.
+After successfully building the project, the `eosd` binary should be present in the `build/programs/eosd` directory. Go ahead and run `eosd` -- it will probably exit with an error, but if not, close it immediately with <kbd>Ctrl-C</kbd>. Note that `eosd` created a directory named `data-dir` containing the default configuration (`config.ini`) and some other internals. This default data storage path can be overridden by passing `--data-dir /path/to/data` to `eosd`.
 
 Edit the `config.ini` file, adding the following settings to the defaults already in place:
 


### PR DESCRIPTION
After building the eosd program is contained in build/programs/eosd not programs/eosd