### PR TITLE
Modify to_[u]int64, to_double to eval entire string #148

### DIFF
--- a/libraries/fc/src/string.cpp
+++ b/libraries/fc/src/string.cpp
@@ -93,7 +93,7 @@ namespace fc  {
   {
     try
     {
-      return boost::lexical_cast<int64_t>(i.c_str());
+      return boost::lexical_cast<int64_t>(i.c_str(), i.size());
     }
     catch( const boost::bad_lexical_cast& e )
     {
@@ -106,7 +106,7 @@ namespace fc  {
   { try {
     try
     {
-      return boost::lexical_cast<uint64_t>(i.c_str());
+      return boost::lexical_cast<uint64_t>(i.c_str(), i.size());
     }
     catch( const boost::bad_lexical_cast& e )
     {
@@ -119,7 +119,7 @@ namespace fc  {
   {
     try
     {
-      return boost::lexical_cast<double>(i.c_str());
+      return boost::lexical_cast<double>(i.c_str(), i.size());
     }
     catch( const boost::bad_lexical_cast& e )
     {


### PR DESCRIPTION
Resolves #148.

Modified the to_int64, to_uint64, to_double to evaluate the entire string instead of the default boost::lexical_cast which reads until it finds a non-number.

This fixes the issue of conversion of a sha256 into a number working for sha256 that start with a number. Now that conversion fails.