### PR TITLE
P2p sync slow peers #291

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -231,18 +231,6 @@ namespace eos {
 
   class connection : public std::enable_shared_from_this<connection> {
   public:
-#if 0
-    enum status_t {
-      disconnected_server,
-      disconnected_client,
-      connecting,
-      awaiting_handshake,
-      catchup_via_sync,
-      catchup_via_request,
-      ready
-    };
-#endif
-
     connection( string endpoint,
                 size_t send_buf_size = def_buffer_size,
                 size_t recv_buf_size = def_buffer_size );


### PR DESCRIPTION
Summary of changes: 
* Added timeout handler to connections in order to check for slow peers. 
* Broke the classes net_plugin_impl, connections, and sync_manager into separate declaration and definition sections to clean up some cross references between these classes. Since the net_plugin.cpp file is getting rather long, this change also enables splitting that into separate header and implementation files if desired.
* Added several more TODO warnings to identify remaining  sections of code to be implemented to complete p2p.
* Renamed send() to enqueue() since that is more accurate to what the function does. Same with write_block_backlog() to enqueue_sync_block()
* Refactored the new sync_manager class to enable the reassignment of pending block requests. as needed.
* Sync based on block number stops with the last irrefutable block. subsequent blocks are to be requested by block id. 

Questions:
1. I'm not sure how to handle requesting blocks newer than the last irreversible block. In that it is possible different peers may represent different forks. I suppose that different the chain controller will hold different forks until consensus dictates which is correct.
2. what is the best way to find all of the unblocked transactions, since those will be needed for the next block?