### PR TITLE
P2p liveness checking #395

### DIFF
--- a/plugins/net_plugin/include/eos/net_plugin/protocol.hpp
+++ b/plugins/net_plugin/include/eos/net_plugin/protocol.hpp
@@ -26,7 +26,6 @@ namespace eos {
    static_assert(sizeof(std::chrono::system_clock::duration::rep) >= 8, "system_clock is expected to be at least 64 bits");
 
    struct time_message {
-              uint8_t precision; //!< precision
               tstamp  org;       //!< origin timestamp
               tstamp  rec;       //!< receive timestamp
               tstamp  xmt;       //!< transmit timestamp
@@ -73,9 +72,7 @@ FC_REFLECT( eos::handshake_message,
             (head_num)(head_id)
             (os)(agent) )
 
-FC_REFLECT( eos::time_message,
-            (precision)(org)(rec)(xmt)(dst) )
-
+FC_REFLECT( eos::time_message, (org)(rec)(xmt)(dst) )
 FC_REFLECT( eos::block_summary_message, (block)(trx_ids) )
 FC_REFLECT( eos::notice_message, (known_trx)(known_blocks) )
 FC_REFLECT( eos::request_message, (req_trx)(req_blocks) )

--- a/plugins/net_plugin/include/eos/net_plugin/protocol.hpp
+++ b/plugins/net_plugin/include/eos/net_plugin/protocol.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <eos/chain/block.hpp>
 #include <eos/chain/types.hpp>
+#include <chrono>
 
 namespace eos {
    using namespace chain;
@@ -17,6 +18,19 @@ namespace eos {
       block_id_type   head_id;
       string          os;
       string          agent;
+   };
+
+   typedef std::chrono::system_clock::duration::rep tstamp;
+   typedef int32_t                                  tdist;
+
+   static_assert(sizeof(std::chrono::system_clock::duration::rep) >= 8, "system_clock is expected to be at least 64 bits");
+
+   struct time_message {
+              uint8_t precision; //!< precision
+              tstamp  org;       //!< origin timestamp
+              tstamp  rec;       //!< receive timestamp
+              tstamp  xmt;       //!< transmit timestamp
+      mutable tstamp  dst;       //!< destination timestamp
    };
 
    struct notice_message {
@@ -41,6 +55,7 @@ namespace eos {
    };
 
    using net_message = static_variant<handshake_message,
+                                      time_message,
                                       notice_message,
                                       request_message,
                                       sync_request_message,
@@ -57,6 +72,9 @@ FC_REFLECT( eos::handshake_message,
             (last_irreversible_block_num)(last_irreversible_block_id)
             (head_num)(head_id)
             (os)(agent) )
+
+FC_REFLECT( eos::time_message,
+            (precision)(org)(rec)(xmt)(dst) )
 
 FC_REFLECT( eos::block_summary_message, (block)(trx_ids) )
 FC_REFLECT( eos::notice_message, (known_trx)(known_blocks) )

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -121,21 +121,6 @@ namespace eos {
 
     shared_ptr<tcp::resolver>     resolver;
 
-    /** \name Peer Timestamps
-     *  Time message handling
-     *  @{
-     */
-    const tstamp DUSECS{1000000};
-    const tstamp HUSECS{1024*1024};
-    const int MINSTEP{5}; //!< Minimum change in clock value
-    const int MAXSTEP{20000}; //!< Maximum clock increment
-    const size_t MINLOOPS{5}; //!< Minimum number of clock samples
-    const double PHI{15e-6}; //!< Frequency tolerance (15 ppm)
-    uint8_t                       precision;  //!< precision
-    double                        rootdelay;  //!< root delay
-    double                        rootdisp;   //!< root dispersion
-    /** @} */
-
     void connect( connection_ptr c );
     void connect( connection_ptr c, tcp::resolver::iterator endpoint_itr );
     void start_session( connection_ptr c );
@@ -166,12 +151,6 @@ namespace eos {
      * to floating double.  All further processing is in
      * floating-double arithmetic with rounding done by the hardware.
      * This is necessary in order to avoid overflow and preserve precision.
-     *
-     * The delay calculation is a special case.  In cases where the
-     * server and client clocks are running at different rates and
-     * with very fast networks, the delay can appear negative.  In
-     * order to avoid violating the Principle of Least Astonishment,
-     * the delay is clamped to not less than the system precision.
      */
     void handle_message( connection_ptr c, const time_message &msg);
     /** @} */
@@ -192,9 +171,6 @@ namespace eos {
      *  Time message handling
      *  @{
      */
-    /** \brief Determine local clock precision
-     */
-    void determine_clock_precision();
     /** \brief 1 second ticker, for peer heartbeat
      */
     void ticker();
@@ -328,21 +304,13 @@ namespace eos {
      *  @{
      */
     // Members set from network data
-    tstamp                         reftime;         //!< reference time
-    uint8_t                        precision;       //!< Peer's own assessment of its clock precision
-    double                         rootdelay;       //!< Total round-trip delay to the reference clock
-    double                         rootdisp;        //!< Total dispersion to the reference clock
     tstamp                         org{0};          //!< originate timestamp
     tstamp                         rec{0};          //!< receive timestamp
     tstamp                         dst{0};          //!< destination timestamp
     tstamp                         xmt{0};          //!< transmit timestamp
 
     // Computed data
-    double                         update_time{0};  //!< update time
     double                         offset{0};       //!< peer offset
-    double                         delay{0};        //!< peer delay
-    double                         disp{0};         //!< peer dispersion
-    double                         jitter{0};       //!< RMS jitter
 
     char                           ts[32];          //!< working buffer for making human readable timestamps
     /** @} */
@@ -512,30 +480,20 @@ namespace eos {
   }
 
   void connection::send_time () {
-    dlog("Sending time message");
     time_message xpkt;
-    xpkt.precision = my_impl->precision;
     xpkt.org = rec;
     xpkt.rec = dst;
     xpkt.xmt = get_time();
     org = xpkt.xmt;
     enqueue(xpkt);
-    dlog("Outgoing rec is ${rec} (${ts})", ("rec", rec)("ts", convert_tstamp(rec)));
-    dlog("Outgoing dst is ${dst} (${ts})", ("dst", dst)("ts", convert_tstamp(dst)));
-    dlog("Outgoing org (which is xmt) is ${org} (${ts})", ("org", org)("ts", convert_tstamp(org)));
   }
 
   void connection::send_time (const time_message& msg) {
-    dlog("Sending time message");
     time_message xpkt;
-    xpkt.precision = my_impl->precision;
     xpkt.org = msg.xmt;
     xpkt.rec = msg.dst;
     xpkt.xmt = get_time();
     enqueue(xpkt);
-    dlog("Outgoing rec is ${rec} (${ts})", ("rec", xpkt.rec)("ts", convert_tstamp(rec)));
-    dlog("Outgoing org is ${org} (${ts})", ("org", xpkt.org)("ts", convert_tstamp(org)));
-    dlog("Outgoing xmt is ${xmt} (${ts})", ("xmt", xpkt.xmt)("ts", convert_tstamp(xmt)));
   }
 
   void connection::enqueue( const net_message &m ) {
@@ -958,12 +916,6 @@ namespace eos {
        */
       msg.dst = c->get_time();
 
-      dlog("Processing time message");
-
-      auto log2d = [](uint8_t logbasetwo) {
-        return logbasetwo < 0 ? 1. / (1L << -logbasetwo) : 1L << logbasetwo;
-      };
-
       // If the transmit timestamp is zero, the peer is horribly broken.
       if(msg.xmt == 0)
         return;                 /* invalid timestamp */
@@ -981,21 +933,9 @@ namespace eos {
         return;  // We don't have enough data to perform the calculation yet.
       }
 
-      c->precision = msg.precision;
-
-      dlog("Calculation rec is ${rec} (${ts})", ("rec", msg.rec)("ts", c->convert_tstamp(msg.rec)));
-      dlog("Calculation org is ${org} (${ts})", ("org", c->org)("ts", c->convert_tstamp(c->org)));
-      dlog("Calculation xmt is ${xmt} (${ts})", ("xmt", msg.xmt)("ts", c->convert_tstamp(msg.xmt)));
-      dlog("Calculation dst is ${dst} (${ts})", ("dst", c->dst)("ts", c->convert_tstamp(c->dst)));
       c->offset = (double(c->rec - c->org) + double(msg.xmt - c->dst)) / 2;
-      c->delay = std::max(double(c->rec - c->org) - double(msg.xmt - c->dst),
-                          log2d(precision));
-      c->disp = log2d(msg.precision) + log2d(precision) + PHI *
-                    double(msg.dst - c->org);
       double NsecPerUsec{1000};
       dlog("Clock offset is ${o}ns (${us}us)", ("o", c->offset)("us", c->offset/NsecPerUsec));
-      dlog("Delay to client is ${d} (${us}us)", ("d", c->delay)("us", c->delay/NsecPerUsec));
-      dlog("Dispersion is ${d}", ("d", c->disp));
       c->org = 0;
       c->rec = 0;
     }
@@ -1459,40 +1399,6 @@ namespace eos {
       }
     }
 
-    void net_plugin_impl::determine_clock_precision () {
-      tstamp last = std::chrono::system_clock::now().time_since_epoch().count();
-      long diff;
-      long val{my_impl->MAXSTEP};
-      long usec{0};
-      size_t i{0};
-      for( ; i < my_impl->MINLOOPS && usec < my_impl->HUSECS; )
-      {
-        tstamp t = std::chrono::system_clock::now().time_since_epoch().count();
-        diff = t - last;
-        last = t;
-        if(diff < 0)
-          diff += my_impl->DUSECS;
-        usec += diff;
-        if(diff > my_impl->MINSTEP)
-        {
-          ++i;
-          if(diff < val)
-            val = diff;
-        }
-      }
-      ilog("Local clock precision is ${precision} nsec after ${i} loop${suffix}", ("precision", val)("i", i)("suffix", i == 1 ? "" : "s"));
-
-      // Find the nearest power of two.
-      val--;
-      val |= val >> 1;
-      val |= val >> 2;
-      val |= val >> 4;
-      val |= val >> 8;
-      val |= val >> 16;
-      val++;
-      my_impl->precision = uint8_t(val);
-    }
-
   void
   handshake_initializer::populate (handshake_message &hello) {
     hello.network_version = my_impl->network_version;
@@ -1606,7 +1512,6 @@ namespace eos {
     fc::rand_pseudo_bytes(my->node_id.data(), my->node_id.data_size());
 
     my->second_timer.reset(new boost::asio::steady_timer (app().get_io_service()));
-    my->determine_clock_precision();
     my->ticker();
   }
 


### PR DESCRIPTION
Resolves Issue #395.  Add a time_message used to check peer connection status and clock offset.  Offset is calculated, logged, and stored, but not yet actively used to take any actions.  Check interval is also subject to design decision.