### PR TITLE
Add curl to dependency list

### DIFF
--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -8,7 +8,7 @@ if [ $ARCH == "ubuntu" ]; then
                          libbz2-dev libssl-dev libgmp3-dev \
                          autotools-dev build-essential \
                          libbz2-dev libicu-dev python-dev \
-                         autoconf libtool git
+                         autoconf libtool git curl
     OPENSSL_ROOT_DIR=/usr/local/opt/openssl
     OPENSSL_LIBRARIES=/usr/local/opt/openssl/lib
 


### PR DESCRIPTION
Xenial (Ubuntu 16.04) image that is downloaded from the official ubuntu website doesn't have curl installed by default