### PR TITLE
WASM Add Memory Pages

### DIFF
--- a/contracts/eoslib/memory.h
+++ b/contracts/eoslib/memory.h
@@ -18,23 +18,22 @@ extern "C" {
    */
 
  /**
-   * Allocate or remove a page of memory to accommodate the
+   * Allocate page(s) of memory to accommodate the
    * requested number of bytes.
-   * @brief Allocate or remove a page of memory
-   * @param num_bytes  Number of bytes to add or remove.
+   * @brief Allocate page memory
+   * @param num_bytes  Number of bytes to add.
    *
    * @return void pointer to the previous end of allocated bytes
    *
    * Example:
    * @code
    * // allocate a whole new page, the returned offset is the pointer to the
-   * // newly allocated page (if passing in negative num_bytes, then offset
-   * // will be the end of the page that was removed
+   * // newly allocated page
    * char* new_page = static_cast<char*>(sbrk(65536));
    * memset(new_page, 0, 65536);
    * @endcode
    */
-  void* sbrk( int32_t num_bytes );
+  void* sbrk( uint32_t num_bytes );
 
  /**
   * Copy a block of memory from source to destination.

--- a/contracts/eoslib/memory.h
+++ b/contracts/eoslib/memory.h
@@ -18,6 +18,25 @@ extern "C" {
    */
 
  /**
+   * Allocate or remove a page of memory to accommodate the
+   * requested number of bytes.
+   * @brief Allocate or remove a page of memory
+   * @param num_bytes  Number of bytes to add or remove.
+   *
+   * @return void pointer to the previous end of allocated bytes
+   *
+   * Example:
+   * @code
+   * // allocate a whole new page, the returned offset is the pointer to the
+   * // newly allocated page (if passing in negative num_bytes, then offset
+   * // will be the end of the page that was removed
+   * char* new_page = static_cast<char*>(sbrk(65536));
+   * memset(new_page, 0, 65536);
+   * @endcode
+   */
+  void* sbrk( int32_t num_bytes );
+
+ /**
   * Copy a block of memory from source to destination.
   * @brief Copy a block of memory from source to destination.
   * @param destination  Pointer to the destination to copy to.

--- a/libraries/chain/include/eos/chain/exceptions.hpp
+++ b/libraries/chain/include/eos/chain/exceptions.hpp
@@ -59,6 +59,7 @@ namespace eos { namespace chain {
    FC_DECLARE_DERIVED_EXCEPTION( tx_scheduling_exception,           eos::chain::transaction_exception, 3030013, "transaction failed during sheduling" )
    FC_DECLARE_DERIVED_EXCEPTION( tx_unknown_argument,               eos::chain::transaction_exception, 3030014, "transaction provided an unknown value to a system call" )
    FC_DECLARE_DERIVED_EXCEPTION( tx_resource_exhausted,             eos::chain::transaction_exception, 3030015, "transaction exhausted allowed resources" )
+   FC_DECLARE_DERIVED_EXCEPTION( page_memory_error,                 eos::chain::transaction_exception, 3030016, "error in WASM page memory" )
 
    FC_DECLARE_DERIVED_EXCEPTION( invalid_pts_address,               eos::chain::utility_exception, 3060001, "invalid pts address" )
    FC_DECLARE_DERIVED_EXCEPTION( insufficient_feeds,                eos::chain::chain_exception, 37006, "insufficient feeds" )

--- a/libraries/chain/include/eos/chain/wasm_interface.hpp
+++ b/libraries/chain/include/eos/chain/wasm_interface.hpp
@@ -7,7 +7,7 @@
 
 namespace eos { namespace chain {
 
-class  chain_controller;
+class chain_controller;
 class wasm_memory;
 
 /**

--- a/libraries/chain/include/eos/chain/wasm_interface.hpp
+++ b/libraries/chain/include/eos/chain/wasm_interface.hpp
@@ -8,6 +8,8 @@
 namespace eos { namespace chain {
 
 class  chain_controller;
+class wasm_memory;
+
 /**
  * @class wasm_interface
  *
@@ -43,6 +45,8 @@ class wasm_interface {
       Runtime::MemoryInstance*   current_memory  = nullptr;
       Runtime::ModuleInstance*   current_module  = nullptr;
       ModuleState*               current_state   = nullptr;
+      wasm_memory*               current_memory_management = nullptr;
+
 
    private:
       void load( const AccountName& name, const chainbase::database& db );

--- a/libraries/chain/wasm_interface.cpp
+++ b/libraries/chain/wasm_interface.cpp
@@ -22,7 +22,9 @@ namespace eos { namespace chain {
    class wasm_memory
    {
    public:
-      wasm_memory(wasm_interface& interface);
+      explicit wasm_memory(wasm_interface& interface);
+      wasm_memory(const wasm_memory&) = delete;
+      wasm_memory(wasm_memory&&) = delete;
       ~wasm_memory();
       U32 sbrk(I32 num_bytes);
    private:
@@ -583,7 +585,7 @@ DEFINE_INTRINSIC_FUNCTION1(env,free,free,none,i32,ptr) {
 
    void  wasm_interface::vm_call( const char* name ) {
    try {
-      std::unique_ptr<wasm_memory> wasm_memory_mgmt(new wasm_memory(*this));
+      std::unique_ptr<wasm_memory> wasm_memory_mgmt;
       try {
          /*
          name += "_" + std::string( current_validate_context->msg.code ) + "_";
@@ -609,6 +611,7 @@ DEFINE_INTRINSIC_FUNCTION1(env,free,free,none,i32,ptr) {
          memcpy( memstart, state.init_memory.data(), state.mem_end);
 
          checktimeStart = fc::time_point::now();
+         wasm_memory_mgmt.reset(new wasm_memory(*this));
 
          Runtime::invokeFunction(call,args);
          wasm_memory_mgmt.reset();

--- a/tests/api_tests/api_tests.cpp
+++ b/tests/api_tests/api_tests.cpp
@@ -489,7 +489,7 @@ BOOST_FIXTURE_TEST_CASE(test_memcpy_overlap_start, testing_fixture)
 {
    try {
       MEMORY_TEST_RUN(testolstart, memory_test_wast);
-      BOOST_FAIL("memcpy should have thrown assert acception");
+      BOOST_FAIL("memcpy should have thrown assert exception");
    }
    catch(fc::assert_exception& ex)
    {
@@ -502,7 +502,7 @@ BOOST_FIXTURE_TEST_CASE(test_memcpy_overlap_end, testing_fixture)
 {
    try {
       MEMORY_TEST_RUN(testolend, memory_test_wast);
-      BOOST_FAIL("memcpy should have thrown assert acception");
+      BOOST_FAIL("memcpy should have thrown assert exception");
    }
    catch(fc::assert_exception& ex)
    {
@@ -510,7 +510,36 @@ BOOST_FIXTURE_TEST_CASE(test_memcpy_overlap_end, testing_fixture)
    }
 }
 
-//Test intrinsic provided memset and memcpy
+//Test logic for memory.hpp adding extra pages of memory
 MEMORY_TEST_CASE(test_extended_memory, testextmem, extended_memory_test_wast)
+
+//Test logic for extra pages of memory
+MEMORY_TEST_CASE(test_page_memory, testpagemem, extended_memory_test_wast)
+
+//Test logic for exceeding extra pages of memory
+BOOST_FIXTURE_TEST_CASE(test_page_memory_exceeded, testing_fixture)
+{
+   try {
+      MEMORY_TEST_RUN(testmemexc, extended_memory_test_wast);
+      BOOST_FAIL("sbrk should have thrown exception");
+   }
+   catch (eos::chain::page_memory_error& )
+   {
+      // expected behavior
+   }
+}
+
+//Test logic for preventing reducing page memory
+BOOST_FIXTURE_TEST_CASE(test_page_memory_negative_bytes, testing_fixture)
+{
+   try {
+      MEMORY_TEST_RUN(testnegbytes, extended_memory_test_wast);
+      BOOST_FAIL("sbrk should have thrown exception");
+   }
+   catch (fc::assert_exception& ex)
+   {
+      BOOST_REQUIRE(ex.to_detail_string().find("not reduce") != std::string::npos);
+   }
+}
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
#504 
Added sbrk to intrinsic functions to allow new page memory to be added in WASM.  All pages added during execution of WASM will be removed when WASM execution is completed.