### PR TITLE
fix the unused variable warning

### DIFF
--- a/plugins/chain_plugin/include/eos/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eos/chain_plugin/chain_plugin.hpp
@@ -219,7 +219,6 @@ public:
    
       vector<char> data;
    
-      auto start = fc::time_point::now();
       auto end   = fc::time_point::now() + fc::microseconds( 1000*10 ); /// 10ms max time
    
       int count = 0;


### PR DESCRIPTION
/eos/plugins/chain_plugin/include/eos/chain_plugin/chain_plugin.hpp:222:12: warning: unused variable 'start'
      [-Wunused-variable]
      auto start = fc::time_point::now();
           ^