### PR TITLE
fix the typo in storage.abi

### DIFF
--- a/contracts/storage/storage.abi
+++ b/contracts/storage/storage.abi
@@ -18,7 +18,7 @@
         "fields": {
             "account": "AccountName",
             "tokbalance": "UInt64",
-            "quotausage: "UInt64"
+            "quotausage": "UInt64"
         }
     },{ 
         "name": "Link",
@@ -30,7 +30,7 @@
             "size"  : "UInt32",
             "store" : "UInt8",
             "accept": "UInt8",
-            "stake: : "UInt64",
+            "stake" : "UInt64",
             "producer": "AccountName"
         }
     }


### PR DESCRIPTION
fix the typo in the storage contract abi file.
