### PR TITLE
Add Page Memory to malloc/realloc and add free logic

### DIFF
--- a/contracts/eoslib/memory.hpp
+++ b/contracts/eoslib/memory.hpp
@@ -34,6 +34,12 @@ namespace eos {
    private:
       void* malloc(uint32_t size)
       {
+         if (size == 0)
+            return nullptr;
+
+         eos::print("malloc ", size, "\n");
+         adjust_to_mem_block(size);
+
          // first pass of loop never has to initialize the slot in _available_heap
          uint32_t needs_init = 0;
          char* buffer = nullptr;
@@ -46,14 +52,13 @@ namespace eos {
                char* new_heap = nullptr;
                if (current_heap == 0)
                {
-                  memset(_initial_heap, 0, sizeof(_initial_heap));
                   current.init(_initial_heap, INITIAL_HEAP_SIZE);
                }
                else
                {
                   // REMOVE logic, just using to test out multiple heap logic till memory can be allocated
                   char* const new_heap = &_initial_heap[INITIAL_HEAP_SIZE + NEW_HEAP_SIZE * (current_heap - 1)];
-                  _available_heaps[current_heap].init(new_heap, NEW_HEAP_SIZE);
+                  current.init(new_heap, NEW_HEAP_SIZE);
                }
             }
             buffer = current.malloc(size);
@@ -61,17 +66,33 @@ namespace eos {
                break;
          }
 
-         // only update the current_heap if memory was allocated
+         // only update the _current_heap if memory was allocated
          if (buffer != nullptr)
          {
-            _current_heap = current_heap;
+            // make sure skipped heap memory is handled
+            for (;_current_heap < current_heap; ++_current_heap)
+            {
+               _available_heaps[_current_heap].cleanup_remaining();
+            }
          }
 
+         eos::print("malloc done\n");
          return buffer;
       }
 
       void* realloc(void* ptr, uint32_t size)
       {
+         if (size == 0)
+         {
+            free(ptr);
+            return nullptr;
+         }
+
+         eos::print("realloc ", size, "\n");
+         const uint32_t REMOVE = size;
+         adjust_to_mem_block(size);
+         eos::print("allocating ", size, "(", REMOVE, ")\n");
+
          char* realloc_ptr = nullptr;
          uint32_t orig_ptr_size = 0;
          if (ptr != nullptr)
@@ -84,7 +105,10 @@ namespace eos {
                   realloc_ptr = realloc_heap->realloc_in_place(char_ptr, size, &orig_ptr_size);
 
                   if (realloc_ptr != nullptr)
+                  {
+                     eos::print("realloc (in_place) done\n");
                      return realloc_ptr;
+                  }
                   else
                      break;
                }
@@ -100,12 +124,35 @@ namespace eos {
             free (ptr);
          }
 
+         eos::print("realloc (copy) done\n");
          return new_alloc;
       }
 
-      void free(void* )
+      void free(void* ptr)
       {
-         // currently no-op
+         if (ptr == nullptr)
+            return;
+
+         char* const char_ptr = static_cast<char*>(ptr);
+         for (memory* free_heap = _available_heaps; free_heap < _available_heaps + HEAPS_SIZE && free_heap->is_init(); ++free_heap)
+         {
+            if (free_heap->is_in_heap(char_ptr))
+            {
+               free_heap->free(char_ptr);
+               break;
+            }
+         }
+      }
+
+      void adjust_to_mem_block(uint32_t& size)
+      {
+         const uint32_t remainder = (size + SIZE_MARKER) & REM_MEM_BLOCK_MASK;
+         eos::print("adjust_to_mem_block ", size, " + ", SIZE_MARKER, " remainder=", remainder, "\n");
+         if (remainder > 0)
+         {
+            size += MEM_BLOCK - remainder;
+            eos::print("adjust_to_mem_block ", size, "\n");
+         }
       }
 
       class memory
@@ -145,13 +192,15 @@ namespace eos {
 
          char* malloc(uint32_t size)
          {
-            if (_offset + size + SIZE_MARKER > _heap_size || size == 0)
+            uint32_t used_up_size = _offset + size + SIZE_MARKER;
+            if (used_up_size > _heap_size)
             {
                return nullptr;
             }
 
-            buffer_ptr new_buff(&_heap[_offset + SIZE_MARKER], size);
+            buffer_ptr new_buff(&_heap[_offset + SIZE_MARKER], size, _heap + _heap_size);
             _offset += size + SIZE_MARKER;
+            new_buff.mark_alloc();
             return new_buff.ptr();
          }
 
@@ -159,7 +208,7 @@ namespace eos {
          {
             const char* const END_OF_BUFFER = _heap + _heap_size;
 
-            buffer_ptr orig_buffer(ptr);
+            buffer_ptr orig_buffer(ptr, END_OF_BUFFER);
             *orig_ptr_size = orig_buffer.size();
             // is the passed in pointer valid
             char* const orig_buffer_end = orig_buffer.end();
@@ -178,13 +227,10 @@ namespace eos {
             const int32_t diff = size - *orig_ptr_size;
             if (diff < 0)
             {
-               memset(orig_buffer_end + diff, 0, -diff);
-               // if ptr was the last allocated buffer, we can contract
-               if (orig_buffer_end == &_heap[_offset])
-               {
-                  _offset += diff;
-               }
-               // else current implementation doesn't worry about freeing excess memory
+               // use a buffer_ptr to allocate the memory to free
+               char* const new_ptr = ptr + size + SIZE_MARKER;
+               buffer_ptr excess_to_free(new_ptr, -diff, _heap + _heap_size);
+               excess_to_free.mark_free();
 
                return ptr;
             }
@@ -196,39 +242,50 @@ namespace eos {
 
                return ptr;
             }
-            else if (diff == 0)
-            {
+            if (-diff == 0)
                return ptr;
-            }
 
-            // could not resize in place
-            return nullptr;
+            if (!orig_buffer.merge_contiguous_if_available(size))
+               // could not resize in place
+               return nullptr;
+
+            return ptr;
          }
 
-         void free(char* )
+         void free(char* ptr)
          {
-            // currently no-op
+            buffer_ptr to_free(ptr, _heap + _heap_size);
+            to_free.mark_free();
+         }
+
+         void cleanup_remaining()
+         {
+            if (_offset == _heap_size)
+               return;
+
+            // take the remaining memory and act like it was allocated
+            const uint32_t size = _heap_size - _offset - SIZE_MARKER;
+            buffer_ptr new_buff(&_heap[_offset + SIZE_MARKER], size, _heap + _heap_size);
+            _offset = _heap_size;
+            new_buff.mark_free();
          }
 
       private:
          class buffer_ptr
          {
          public:
-            buffer_ptr(void* ptr)
+            buffer_ptr(void* ptr, const char* const heap_end)
             : _ptr(static_cast<char*>(ptr))
-            , _size(*(uint32_t*)(static_cast<char*>(ptr) - SIZE_MARKER))
+            , _size(*reinterpret_cast<uint32_t*>(static_cast<char*>(ptr) - SIZE_MARKER) & ~ALLOC_MEMORY_MASK)
+            , _heap_end(heap_end)
             {
             }
 
-            buffer_ptr(void* ptr, uint32_t buff_size)
+            buffer_ptr(void* ptr, uint32_t buff_size, const char* const heap_end)
             : _ptr(static_cast<char*>(ptr))
+            , _heap_end(heap_end)
             {
                size(buff_size);
-            }
-
-            const void* size_ptr()
-            {
-               return _ptr - SIZE_MARKER;
             }
 
             uint32_t size()
@@ -238,7 +295,9 @@ namespace eos {
 
             void size(uint32_t val)
             {
-               *reinterpret_cast<uint32_t*>(_ptr - SIZE_MARKER) = val;
+               // keep the same state (allocated or free) as was set before
+               const uint32_t memory_state = *reinterpret_cast<uint32_t*>(_ptr - SIZE_MARKER) & ALLOC_MEMORY_MASK;
+               *reinterpret_cast<uint32_t*>(_ptr - SIZE_MARKER) = val | memory_state;
                _size = val;
             }
 
@@ -251,10 +310,70 @@ namespace eos {
             {
                return _ptr;
             }
-         private:
 
-            char* const _ptr;
+            void mark_alloc()
+            {
+               *reinterpret_cast<uint32_t*>(_ptr - SIZE_MARKER) |= ALLOC_MEMORY_MASK;
+            }
+
+            void mark_free()
+            {
+               eos::print("mark_free ptr=", (uint64_t)_ptr, "\n");
+               *reinterpret_cast<uint32_t*>(_ptr - SIZE_MARKER) &= ~ALLOC_MEMORY_MASK;
+            }
+
+            bool is_alloc() const
+            {
+               return *reinterpret_cast<const uint32_t*>(_ptr - SIZE_MARKER) | ALLOC_MEMORY_MASK;
+            }
+
+            char* merge_contiguous_if_available(uint32_t needed_size)
+            {
+               return merge_contiguous(needed_size, true);
+            }
+
+            char* merge_contiguous(uint32_t needed_size)
+            {
+               return merge_contiguous(needed_size, false);
+            }
+         private:
+            char* merge_contiguous(uint32_t needed_size, bool all_or_nothing)
+            {
+               // do not bother if there isn't contiguious space to allocate
+               if (all_or_nothing && _heap_end - _ptr < needed_size)
+                  return nullptr;
+
+               uint32_t possible_size = _size;
+               while (possible_size < needed_size  && (_ptr + possible_size < _heap_end))
+               {
+                  const uint32_t next_mem_flag_size = *reinterpret_cast<const uint32_t*>(_ptr + possible_size);
+                  // if ALLOCed then done with contiguous free memory
+                  if (next_mem_flag_size | ALLOC_MEMORY_MASK)
+                     break;
+
+                  possible_size += (next_mem_flag_size & ~ALLOC_MEMORY_MASK) + SIZE_MARKER;
+               }
+
+               if (all_or_nothing && possible_size < needed_size)
+                  return nullptr;
+
+               // combine
+               const uint32_t new_size = possible_size < needed_size ? possible_size : needed_size;
+               size(new_size);
+
+               if (possible_size > needed_size)
+               {
+                  const uint32_t freed_size = possible_size - needed_size - SIZE_MARKER;
+                  buffer_ptr freed_remainder(_ptr + needed_size + SIZE_MARKER, freed_size, _heap_end);
+                  freed_remainder.mark_free();
+               }
+
+               return new_size == needed_size ? _ptr : nullptr;
+            }
+
+            char* _ptr;
             uint32_t _size;
+            const char* const _heap_end;
          };
 
          uint32_t _heap_size;
@@ -263,6 +382,9 @@ namespace eos {
       };
 
       static const uint32_t SIZE_MARKER = sizeof(uint32_t);
+      // allocate memory in 8 char blocks
+      static const uint32_t MEM_BLOCK = 8;
+      static const uint32_t REM_MEM_BLOCK_MASK = MEM_BLOCK - 1;
       static const uint32_t INITIAL_HEAP_SIZE = 8192;//32768;
       static const uint32_t NEW_HEAP_SIZE = 1024; // should be 65536
       static const uint32_t HEAPS_SIZE = 4; // _initial_heap plus 3 pages (64K each)
@@ -270,6 +392,7 @@ namespace eos {
       char _initial_heap[INITIAL_HEAP_SIZE + NEW_HEAP_SIZE * (HEAPS_SIZE - 1)];
       memory _available_heaps[HEAPS_SIZE];
       uint32_t _current_heap;
+      static const uint32_t ALLOC_MEMORY_MASK = 1 << 31;
    } memory_heap;
 
   /**

--- a/tests/api_tests/api_tests.cpp
+++ b/tests/api_tests/api_tests.cpp
@@ -509,8 +509,14 @@ MEMORY_TEST_CASE(test_memory, testmemory, memory_test_wast)
 //Test memcmp
 MEMORY_TEST_CASE(test_memcmp, testmemcmp, memory_test_wast)
 
-//Test wasm memory allocation at boundaries
-MEMORY_TEST_CASE(test_memory_bounds, testbounds, memory_test_wast)
+//Test wasm memory allocation of one large hunk
+MEMORY_TEST_CASE(test_memory_hunk, testmemhunk, memory_test_wast)
+
+//Test wasm memory allocation of many medium hunks in contiguous 2nd heap
+MEMORY_TEST_CASE(test_memory_hunks, testmemhunks, memory_test_wast)
+
+//Test wasm memory allocation of many medium hunks with disjoint heaps
+MEMORY_TEST_CASE(test_memory_hunks_disjoint, testdisjoint, memory_test_wast)
 
 //Test intrinsic provided memset and memcpy
 MEMORY_TEST_CASE(test_memset_memcpy, testmemset, memory_test_wast)

--- a/tests/api_tests/extended_memory_test/extended_memory_test.cpp
+++ b/tests/api_tests/extended_memory_test/extended_memory_test.cpp
@@ -34,9 +34,9 @@ extern "C" {
     {
        // initial buffer will be exhausted at 8192
 
-       // 8178 left (10 + ptr header)
-       char* ptr1 = (char*)eos::malloc(10);
-       assert(ptr1 != nullptr, "should have allocated 10 char buf");
+       // 8176 left (12 + ptr header)
+       char* ptr1 = (char*)eos::malloc(12);
+       assert(ptr1 != nullptr, "should have allocated 12 char buf");
        // leave a little space at end of 1st buffer
        char* ptr2 = (char*)eos::malloc(8159);
        assert(ptr2 != nullptr, "should have allocated 8159 char buf");
@@ -46,8 +46,8 @@ extern "C" {
        assert(ptr3 != nullptr, "should have allocated a 20 char buf");
        verify(ptr3, 0, 20);
        // re-sized in 1st memory heap
-       char* ptr2_realloc = (char*)eos::realloc(ptr2, 8174);
-       assert(ptr2_realloc != nullptr, "should have returned a 8174 char buf");
+       char* ptr2_realloc = (char*)eos::realloc(ptr2, 8172);
+       assert(ptr2_realloc != nullptr, "should have returned a 8172 char buf");
        assert(ptr2_realloc == ptr2, "should have enlarged the 8159 char buf");
 
        // re-sized in 1st memory heap
@@ -66,9 +66,9 @@ extern "C" {
        assert(ptr1_realloc == ptr1, "should have enlarged the 5 char buf");
 
        // re-size into 2nd memory heap
-       ptr1_realloc = (char*)eos::realloc(ptr1, 11);
-       assert(ptr1_realloc != nullptr, "should have returned a 11 char buf");
-       assert(ptr1_realloc != ptr1, "should have reallocated the 10 char buf");
+       ptr1_realloc = (char*)eos::realloc(ptr1, 13);
+       assert(ptr1_realloc != nullptr, "should have returned a 13 char buf");
+       assert(ptr1_realloc != ptr1, "should have reallocated the 12 char buf");
        assert(ptr4 + 20 < ptr1_realloc, "11 char buf should have been created after ptr4"); // test specific to implementation (can remove for refactor)
 
        // allocate rest of 2nd memory heap (1024 chars total)
@@ -86,28 +86,6 @@ extern "C" {
        char* ptr6 = (char*)eos::malloc(996);
        assert(ptr6 != nullptr, "should have allocated a 996 char buf");
        assert(ptr5 + 1020 < ptr6, "1020 char buf should have been created after ptr5"); // test specific to implementation (can remove for refactor)
-
-       // 21 char buffer exceeds inital buffer of 1024 (WILL CHANGE WHEN ACTUALLY ALLOCATING PAGE MEMORY)
-       char* ptr7 = (char*)eos::malloc(21);
-       assert(ptr7 == nullptr, "should not have allocated a 21 char buf");
-
-       // allocated to 4 less than end (1020 chars)
-       char* ptr8 = (char*)eos::malloc(16);
-       assert(ptr8 != nullptr, "should have allocated a 16 char buf");
-       assert(ptr7 + 20 < ptr8, "16 char buf should have been created after ptr7"); // test specific to implementation (can remove for refactor)
-
-       // at 1020, not enough space to allocated any memory besides the ptr header
-       char* ptr9 = (char*)eos::malloc(1);
-       assert(ptr9 == nullptr, "should not have allocated a 1 char buf");
-
-       // at 1020, reallocate the last 4 chars
-       char* ptr8_realloc = (char*)eos::realloc(ptr8, 20);
-       assert(ptr8_realloc != nullptr, "should have returned a 20 char buf");
-       assert(ptr8_realloc == ptr8, "should have enlarged the 16 char buf");
-
-       // at 1024, no memory remains
-       char* ptr10 = (char*)eos::malloc(10);
-       assert(ptr10 == nullptr, "should not have allocated a 10 char buf");
     }
 
     void test_page_memory()


### PR DESCRIPTION
#129 
Refactored to add 64K page memory as new heaps for allocating.  If new page memory is adjacent to an existing heap, then the heap is expanded to limit fragmentation of the memory.

Free logic was also added.  Free memory is just tracked by using the highest bit in the ptr header.  So free processing costs very little at time of calling free at the cost of searching when the freed memory is required (after 1M of memory has been allocated).  Also, this implementation helps to not have reserve extra memory to maintain a separate list and the logic to manage those list (like allocating it at the end of a heap and growing backwards and preventing memory collisions).