### PR TITLE
P2p send block summaries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,4 +30,4 @@ script:
   - tests/chain_test
   - tests/slow_test
   - tests/api_test
-  - tests/p2p-test/sync/test.sh
+  - tests/p2p_test/sync/test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,3 +30,4 @@ script:
   - tests/chain_test
   - tests/slow_test
   - tests/api_test
+  - tests/p2p-test/sync/test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,4 +30,4 @@ script:
   - tests/chain_test
   - tests/slow_test
   - tests/api_test
-  - tests/p2p_test/sync/test.sh
+  - tests/p2p_tests/sync/test.sh

--- a/plugins/net_plugin/include/eos/net_plugin/protocol.hpp
+++ b/plugins/net_plugin/include/eos/net_plugin/protocol.hpp
@@ -32,20 +32,27 @@ namespace eos {
       mutable tstamp  dst;       //!< destination timestamp
    };
 
+  using ordered_txn_ids = vector<transaction_id_type>;
+  using ordered_blk_ids = vector<block_id_type>;
    struct notice_message {
-      vector<transaction_id_type> known_trx;
-      vector<block_id_type>       known_blocks;
+      ordered_txn_ids known_trx;
+      ordered_blk_ids known_blocks;
    };
-
 
    struct request_message {
-      vector<transaction_id_type> req_trx;
-      vector<block_id_type>       req_blocks;
+      ordered_txn_ids req_trx;
+      ordered_blk_ids req_blocks;
    };
 
+  struct thread_ids {
+    ordered_txn_ids gen_trx; // is this necessary to send?
+    ordered_txn_ids user_trx;
+  };
+
+  using cycle_ids = vector<thread_ids>;
    struct block_summary_message {
-      signed_block                block;
-      vector<transaction_id_type> trx_ids;
+      signed_block_header         block_header;
+      vector<cycle_ids>           trx_ids;
    };
 
    struct sync_request_message {
@@ -73,7 +80,8 @@ FC_REFLECT( eos::handshake_message,
             (os)(agent) )
 
 FC_REFLECT( eos::time_message, (org)(rec)(xmt)(dst) )
-FC_REFLECT( eos::block_summary_message, (block)(trx_ids) )
+FC_REFLECT( eos::thread_ids, (gen_trx)(user_trx) );
+FC_REFLECT( eos::block_summary_message, (block_header)(trx_ids) )
 FC_REFLECT( eos::notice_message, (known_trx)(known_blocks) )
 FC_REFLECT( eos::request_message, (req_trx)(req_blocks) )
 FC_REFLECT( eos::sync_request_message, (start_block)(end_block) )

--- a/plugins/net_plugin/include/eos/net_plugin/protocol.hpp
+++ b/plugins/net_plugin/include/eos/net_plugin/protocol.hpp
@@ -34,7 +34,8 @@ namespace eos {
 
   using ordered_txn_ids = vector<transaction_id_type>;
   using ordered_blk_ids = vector<block_id_type>;
-   struct notice_message {
+
+  struct notice_message {
       ordered_txn_ids known_trx;
       ordered_blk_ids known_blocks;
    };

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -45,7 +45,7 @@ namespace eos {
     transaction_id_type id;
     fc::time_point      received;
     fc::time_point_sec  expires;
-    // vector<char>        packed_transaction; //just for the moment
+    vector<char>        packed_transaction; //just for the moment
     uint32_t            block_num = -1; /// block transaction was included in
     bool                validated = false; /// whether or not our node has validated it
   };
@@ -234,7 +234,7 @@ namespace eos {
     > block_state_index;
 
   /**
-   * Index by start_block
+   * Index by start_block_num
    */
   struct sync_state {
     sync_state(uint32_t start = 0, uint32_t end = 0, uint32_t last_acted = 0)
@@ -245,7 +245,7 @@ namespace eos {
     uint32_t     end_block;
     uint32_t     last; ///< last sent or received
     time_point   start_time; ///< time request made or received
-    deque< vector<char> > block_cache;
+    deque<vector<char> > block_cache;
   };
 
   using sync_state_ptr = shared_ptr< sync_state >;
@@ -272,6 +272,16 @@ namespace eos {
     sync_state_ptr          sync_requested;  // this peer is requesting info from us
     socket_ptr              socket;
 
+#warning ("TODO: Rework Message Caching for efficiency")
+    // WHat I mean here is that incoming data should be read in chunks that are as
+    // large as possible. We can query the recv buffer size. When using async_read_some(),
+    // we will frequently end a read in the middle of a message. That could happen with
+    // small messages, in which a simple "normalize" call could reset the buffer and allow a
+    // subsequent read to pick up the rest. In the case of very large messages, we should allow
+    // for the creation of a secondary buffer big enough to hold the entire message. Better
+    // still would be to have a mempool class that has a series of fixed size blocks that can
+    // be used scatter-gather style.
+
     uint32_t                pending_message_size;
     vector<char>            pending_message_buffer;
     uint32_t                send_message_size;
@@ -286,6 +296,7 @@ namespace eos {
     bool                    syncing;
     string                  peer_addr;
     unique_ptr<boost::asio::steady_timer> response_expected;
+    optional<request_message> pending_fetch;
 
     /** \name Peer Timestamps
      *  Time message handling
@@ -338,10 +349,10 @@ namespace eos {
 
     void enqueue( const net_message &msg );
     void enqueue_sync_block ();
-
     void send_next_message();
 
     void sync_wait ();
+    void fetch_wait ();
     void sync_timeout (boost::system::error_code ec);
     void fetch_timeout (boost::system::error_code ec);
   };
@@ -352,8 +363,9 @@ namespace eos {
     uint32_t            sync_req_head;
     uint32_t            sync_req_span;
 
-    deque< sync_state_ptr > full_chunks;
-    deque< sync_state_ptr > partial_chunks;
+    deque<sync_state_ptr> full_chunks;
+    deque<sync_state_ptr> partial_chunks;
+    deque<block_id_type> _blocks;
     chain_plugin * chain_plug;
 
   public:
@@ -364,6 +376,9 @@ namespace eos {
     void take_chunk (connection_ptr c);
     void start_sync (connection_ptr c, uint32_t target);
 
+    void set_blocks_to_fetch (vector<block_id_type>);
+    void assign_fectch (connection_ptr c);
+    void reassign_fetch (connection_ptr c);
   };
 
   //---------------------------------------------------------------------------
@@ -385,7 +400,8 @@ namespace eos {
         connecting (false),
         syncing (false),
         peer_addr (endpoint),
-        response_expected ()
+        response_expected (),
+        pending_fetch ()
     {
       wlog( "created connection to ${n}", ("n", endpoint) );
       initialize();
@@ -408,7 +424,8 @@ namespace eos {
         connecting (false),
         syncing (false),
         peer_addr (),
-        response_expected ()
+        response_expected (),
+        pending_fetch()
     {
       wlog( "accepted network connection" );
       initialize ();
@@ -493,42 +510,44 @@ namespace eos {
   }
 
   void connection::send_next_message() {
-      if( !out_queue.size() ) {
-        if (sync_requested ) {
-          enqueue_sync_block();
-        }
-        return;
+    if( !out_queue.size() ) {
+      if( sync_requested ) {
+        enqueue_sync_block( );
       }
-
-      auto& m = out_queue.front();
-      if (m.contains<sync_request_message>()) {
-        sync_wait( );
-      }
-      send_message_size = fc::raw::pack_size( m );
-      fc::datastream<char*> ds( send_buffer.data(), send_message_size + sizeof(send_message_size) );
-      ds.write( (char*)&send_message_size, sizeof(send_message_size) );
-      fc::raw::pack( ds, m );
-
-      boost::asio::async_write( *socket, boost::asio::buffer( send_buffer, send_message_size + sizeof(send_message_size) ),
-                   [this]( boost::system::error_code ec, std::size_t /*bytes_transferred*/ ) {
-                     if( ec ) {
-                       elog( "Error sending message: ${msg}", ("msg",ec.message() ) );
-                     } else  {
-                       if (!out_queue.size()) {
-                         elog ("out_queue underflow!");
-                       } else {
-                         out_queue.pop_front();
-                       }
-                       send_next_message();
-                     }
-                   });
+      return;
     }
+
+    auto& m = out_queue.front();
+    if (m.contains<sync_request_message>()) {
+      sync_wait( );
+    } else if (m.contains<request_message>()) {
+      pending_fetch = m.get<request_message>();
+      fetch_wait( );
+    }
+    send_message_size = fc::raw::pack_size( m );
+    fc::datastream<char*> ds( send_buffer.data(), send_message_size + sizeof(send_message_size) );
+    ds.write( (char*)&send_message_size, sizeof(send_message_size) );
+    fc::raw::pack( ds, m );
+
+    boost::asio::async_write( *socket, boost::asio::buffer( send_buffer, send_message_size + sizeof(send_message_size) ),
+                              [this]( boost::system::error_code ec, std::size_t /*bytes_transferred*/ ) {
+                                if( ec ) {
+                                  elog( "Error sending message: ${msg}", ("msg",ec.message() ) );
+                                } else  {
+                                  if (!out_queue.size()) {
+                                    elog ("out_queue underflow!");
+                                  } else {
+                                    out_queue.pop_front();
+                                  }
+                                  send_next_message();
+                                }
+                              });
+  }
 
   void connection::enqueue_sync_block ( ) {
     chain_controller& cc = app().find_plugin<chain_plugin>()->chain();
     uint32_t num = ++sync_requested->last;
 
-    ilog ("num = ${num} end = ${end}",("num",num)("end",sync_requested->end_block));
     if (num == sync_requested->end_block) {
       sync_requested.reset();
     }
@@ -545,6 +564,12 @@ namespace eos {
   void connection::sync_wait( ) {
     response_expected->expires_from_now( my_impl->resp_expected_period);
     response_expected->async_wait( boost::bind(&connection::sync_timeout,
+                                               this, boost::asio::placeholders::error));
+  }
+
+  void connection::fetch_wait( ) {
+    response_expected->expires_from_now( my_impl->resp_expected_period);
+    response_expected->async_wait( boost::bind(&connection::fetch_timeout,
                                                this, boost::asio::placeholders::error));
   }
 
@@ -568,52 +593,60 @@ namespace eos {
   void connection::fetch_timeout( boost::system::error_code ec ) {
     if( !ec ) {
       dlog ("fetch timeout occurred");
-    }
-    else if( ec == boost::asio::error::operation_aborted) {
-      if( !connected()) {
-        dlog ("fetch timeout was cancelled due to dead connection");
+      if( !( pending_fetch->req_trx.empty( ) || pending_fetch->req_blocks.empty( ) ) ) {
+        enqueue( ( request_message ) {vector<transaction_id_type>( ), vector<block_id_type>( )} );
+        my_impl->sync_master->reassign_fetch( shared_from_this( ) );
       }
+    }
+    else if( ec == boost::asio::error::operation_aborted ) {
+      if( !connected( ) ) {
+        dlog ("fetch timeout was cancelled due to dead connection");
+        my_impl->sync_master->reassign_fetch( shared_from_this( ) );
+      }
+    }
+    else {
+      elog( "setting timer for fetch request got error ${ec}", ("ec", ec.message( ) ) );
     }
   }
   //-----------------------------------------------------------
 
-  sync_manager::sync_manager (uint32_t span)
-    :sync_head (0)
-    ,sync_req_head (0)
-    ,sync_req_span (span)
+  sync_manager::sync_manager( uint32_t span )
+    :sync_head( 0 )
+    ,sync_req_head( 0 )
+    ,sync_req_span( span )
   {
-    chain_plug = app().find_plugin<chain_plugin>();
+    chain_plug = app( ).find_plugin<chain_plugin>( );
   }
 
-  bool sync_manager::syncing () {
-    return (sync_req_head != sync_head ||
-            chain_plug->chain().head_block_num() < sync_req_head);
+  bool sync_manager::syncing( ) {
+    return( sync_req_head != sync_head ||
+            chain_plug->chain( ).head_block_num( ) < sync_req_head );
   }
 
-  void sync_manager::assign_chunk (connection_ptr c) {
+  void sync_manager::assign_chunk( connection_ptr c ) {
     uint32_t start = 0;
     uint32_t end = 0;
 
-    if( !partial_chunks.empty() ) {
-      c->sync_receiving = partial_chunks.front();
-      partial_chunks.pop_front();
+    if( !partial_chunks.empty( ) ) {
+      c->sync_receiving = partial_chunks.front( );
+      partial_chunks.pop_front( );
       start = c->sync_receiving->last + 1;
       end = c->sync_receiving->end_block;
     }
     else if( sync_req_head != sync_head ) {
       start = sync_req_head + 1;
-      end = (start + sync_req_span -1);
-      if (end > sync_head)
+      end = ( start + sync_req_span - 1 );
+      if( end > sync_head )
         end = sync_head;
-      if( end > 0 && end >= start) {
-        c->sync_receiving.reset(new sync_state (start, end, sync_req_head));
+      if( end > 0 && end >= start ) {
+        c->sync_receiving.reset(new sync_state( start, end, sync_req_head ) );
       }
     }
     else {
-      c->sync_receiving.reset();
+      c->sync_receiving.reset ( );
     }
-    if (end > 0 && end >= start) {
-      c->enqueue((sync_request_message){start, end});
+    if( end > 0 && end >= start ) {
+      c->enqueue( (sync_request_message){start, end} );
       sync_req_head = end;
     }
   }
@@ -622,12 +655,12 @@ namespace eos {
       chain_plugin * chain_plug;
       postcache (chain_plugin *cp) : chain_plug (cp) {}
 
-      void operator()(const signed_block &block) const
+      void operator( )(const signed_block &block) const
       {
         try {
-          chain_plug->accept_block (block,true);
-        } catch (const unlinkable_block_exception &ex) {
-          elog ("unlinkable_block_exception accept block #${n}",("n",block.block_num()));
+          chain_plug->accept_block( block,true );
+        } catch( const unlinkable_block_exception &ex ) {
+          elog( "unlinkable_block_exception accept block #${n}",("n",block.block_num()));
           //close (c);
         } catch (const assert_exception &ex) {
           elog ("unable to accept block on assert exception ${n}",("n",ex.what()));
@@ -641,47 +674,47 @@ namespace eos {
       template <typename T> void operator()(const T &msg) const { /* no-op */ }
     };
 
-    void sync_manager::apply_chunk (sync_state_ptr ss) {
+    void sync_manager::apply_chunk( sync_state_ptr ss) {
       postcache pc(chain_plug);
-      for (auto & blk : ss->block_cache) {
+      for( auto & blk : ss->block_cache) {
         auto block = fc::raw::unpack<net_message>( blk );
-        block.visit (pc);
+        block.visit( pc);
       }
     }
 
-    void sync_manager::take_chunk (connection_ptr c) {
-      if (!c->sync_receiving) {
-        elog ("take_chunk called, but sync_receiving is empty");
+    void sync_manager::take_chunk( connection_ptr c) {
+      if( !c->sync_receiving) {
+        elog( "take_chunk called, but sync_receiving is empty");
         return;
       }
       sync_state_ptr ss;
       c->sync_receiving.swap(ss);
-      if (!ss->block_cache.empty()) {
-        if (ss->last < ss->end_block) {
+      if( !ss->block_cache.empty()) {
+        if( ss->last < ss->end_block) {
           partial_chunks.push_back( ss );
           return;
         }
 
-        if (ss->start_block != chain_plug->chain().last_irreversible_block_num() + 1) {
+        if( ss->start_block != chain_plug->chain().last_irreversible_block_num() + 1) {
           bool found = false;
-          for (auto pos = full_chunks.begin(); !found && pos != full_chunks.end(); ++pos) {
-            if (ss->end_block < (*pos)->start_block) {
-              full_chunks.insert (pos,ss);
+          for( auto pos = full_chunks.begin(); !found && pos != full_chunks.end(); ++pos) {
+            if( ss->end_block <( *pos)->start_block) {
+              full_chunks.insert( pos,ss);
               found = true;
             }
           }
-          if (!found) {
-            full_chunks.push_back (ss); //either full chunks is empty or pos ran off the end
+          if( !found) {
+            full_chunks.push_back( ss); //either full chunks is empty or pos ran off the end
           }
         }
         else {
-          apply_chunk (ss);
+          apply_chunk( ss);
         }
       }
-      while (!full_chunks.empty()) {
+      while( !full_chunks.empty()) {
         auto chunk = full_chunks.front();
-        if (chunk->start_block == chain_plug->chain().head_block_num() + 1) {
-          apply_chunk (chunk);
+        if( chunk->start_block == chain_plug->chain().head_block_num() + 1) {
+          apply_chunk( chunk);
           if( chunk->last == chunk->end_block ) {
             full_chunks.pop_front();
           }
@@ -694,32 +727,37 @@ namespace eos {
           break;
       }
 
-      if ( chain_plug->chain().head_block_num() == sync_head ) {
+      if(  chain_plug->chain().head_block_num() == sync_head ) {
+
         handshake_message hello;
         handshake_initializer::populate(hello);
-        my_impl->send_all (hello, [](connection_ptr /* no arg */) -> bool  {
+        my_impl->send_all( hello, [](connection_ptr /* no arg */) -> bool  {
           return true;
         });
     }
-      if (c->connected()) {
-        assign_chunk (c);
+      if( c->connected()) {
+        assign_chunk( c);
       }
     }
 
-    void sync_manager::start_sync (connection_ptr c, uint32_t target) {
-      ilog ("Catching up with chain, our head is ${cc}, theirs is ${t}",
-            ("cc",sync_req_head)("t",target));
-      if (!syncing()) {
+    void sync_manager::start_sync( connection_ptr c, uint32_t target) {
+      ilog( "Catching up with chain, our head is ${cc}, theirs is ${t}",
+           ( "cc",sync_req_head)("t",target));
+      if( !syncing()) {
         sync_req_head = chain_plug->chain().head_block_num();
       }
-      if (target > sync_head) {
+      if( target > sync_head) {
         sync_head = target;
       }
-      if (c->sync_receiving && c->sync_receiving->end_block > 0) {
+      if( c->sync_receiving && c->sync_receiving->end_block > 0) {
         return;
       }
-      assign_chunk (c);
+      assign_chunk( c);
     }
+
+  void sync_manager::reassign_fetch( connection_ptr c) {
+#warning( "TODO: migrate remaining fetch requests to other peers");
+  }
 
   //------------------------------------------------------------------------
 
@@ -738,7 +776,7 @@ namespace eos {
                                    connect( c, endpoint_itr );
                                  } else {
                                    elog( "Unable to resolve ${peer_addr}: ${error}",
-                                         ( "peer_addr", c->peer_addr )("error", err.message() ) );
+                                        (  "peer_addr", c->peer_addr )("error", err.message() ) );
                                  }
                                });
     }
@@ -749,7 +787,7 @@ namespace eos {
       c->connecting = true;
       c->socket->async_connect( current_endpoint,
                            [c, endpoint_itr, this]
-                           ( const boost::system::error_code& err ) {
+                          (  const boost::system::error_code& err ) {
                              if( !err ) {
                                start_session( c );
                              } else {
@@ -758,8 +796,8 @@ namespace eos {
                                  connect( c, endpoint_itr );
                                }
                                else {
-                                 elog ("connection failed to ${peer}: ${error}",
-                                       ("peer", c->peer_addr)("error",err.message()));
+                                 elog( "connection failed to ${peer}: ${error}",
+                                      ( "peer", c->peer_addr)("error",err.message()));
                                  c->connecting = false;
                                  c->close();
                                }
@@ -790,19 +828,19 @@ namespace eos {
               start_session( c );
             } else {
               elog( "Error max_client_count ${m} exceeded",
-                    ("m", max_client_count) );
+                   ( "m", max_client_count) );
               socket->close( );
             }
             start_listen_loop();
           } else {
-            elog( "Error accepting connection: ${m}", ("m", ec.message() ) );
+            elog( "Error accepting connection: ${m}",( "m", ec.message() ) );
           }
         });
     }
 
     void net_plugin_impl::start_read_message( connection_ptr conn ) {
       conn->pending_message_size = 0;
-      connection_wptr c (conn);
+      connection_wptr c( conn);
       uint32_t *buff = &(conn.get()->pending_message_size);
 
       boost::asio::async_read( *conn->socket,
@@ -818,7 +856,7 @@ namespace eos {
                                      elog( "Received a message that was too big" );
                                    }
                                  } else {
-                                   elog( "Error reading message from connection: ${m}", ("m", ec.message() ) );
+                                   elog( "Error reading message from connection: ${m}",( "m", ec.message() ) );
                                  }
                                  close( c.lock() );
                                }
@@ -827,74 +865,80 @@ namespace eos {
 
     template<typename VerifierFunc>
     void net_plugin_impl::send_all( const net_message &msg, VerifierFunc verify) {
-      for (auto &c : connections) {
-        if (c->current() && verify (c)) {
+      for( auto &c : connections) {
+        if( c->current() && verify( c)) {
           c->enqueue( msg );
         }
       }
     }
 
-    void net_plugin_impl::handle_message (connection_ptr c, const handshake_message &msg) {
+    void net_plugin_impl::handle_message( connection_ptr c, const handshake_message &msg) {
       c->connecting = false;
 
-      if (msg.node_id == node_id) {
-        elog ("Self connection detected. Closing connection");
+      if( msg.node_id == node_id) {
+        elog( "Self connection detected. Closing connection");
         close( c );
         return;
       }
-      if (msg.chain_id != chain_id) {
-        elog ("Peer on a different chain. Closing connection");
-        close (c);
+      if( msg.chain_id != chain_id) {
+        elog( "Peer on a different chain. Closing connection");
+        close( c);
         return;
       }
-      if (msg.network_version != network_version) {
-        elog ("Peer network version does not match expected ${nv} but got ${mnv}",
-              ("nv", network_version)("mnv",msg.network_version));
-        close (c);
+      if( msg.network_version != network_version) {
+        elog( "Peer network version does not match expected ${nv} but got ${mnv}",
+             ( "nv", network_version)("mnv",msg.network_version));
+        close( c);
         return;
       }
 
       chain_controller& cc = chain_plug->chain();
-      uint32_t lib_num = cc.last_irreversible_block_num ();
+      uint32_t lib_num = cc.last_irreversible_block_num( );
       uint32_t peer_lib = msg.last_irreversible_block_num;
       bool on_fork = false;
-      if (peer_lib <= lib_num && peer_lib > 0) {
+      if( peer_lib <= lib_num && peer_lib > 0) {
         try {
-          block_id_type peer_lib_id =  cc.get_block_id_for_num (peer_lib);
-          on_fork = (msg.last_irreversible_block_id != peer_lib_id);
+          block_id_type peer_lib_id =  cc.get_block_id_for_num( peer_lib);
+          on_fork =( msg.last_irreversible_block_id != peer_lib_id);
         }
-        catch (...) {
-          wlog ("caught an exception getting block id for ${pl}",("pl",peer_lib));
+        catch( ...) {
+          wlog( "caught an exception getting block id for ${pl}",("pl",peer_lib));
           on_fork = true;
         }
-        if (on_fork) {
-          elog ("Peer chain is forked");
-          close (c);
+        if( on_fork) {
+          elog( "Peer chain is forked");
+          close( c);
           return;
         }
       }
 
-      if ( c->remote_node_id != msg.node_id) {
+      if(  c->remote_node_id != msg.node_id) {
         //        c->reset();
         c->remote_node_id = msg.node_id;
       }
 
       c->syncing = false;
 
-      uint32_t head = cc.head_block_num ();
-      if ( msg.last_irreversible_block_num  >  head || sync_master->syncing() ) {
+      uint32_t head = cc.head_block_num( );
+      block_id_type head_id = cc.head_block_id();
+
+      if(  msg.last_irreversible_block_num  >  head || sync_master->syncing() ) {
         dlog("calling start_sync, myhead = ${h} their last_irreversible = ${mhn}",
-             ("h",head)("mhn",peer_lib));
-        sync_master->start_sync (c, peer_lib);
+            ( "h",head)("mhn",peer_lib));
+        sync_master->start_sync( c, peer_lib);
       }
-      else if( msg.head_num < cc.head_block_num()) {
+      else if( msg.head_id != head_id && head_id != block_id_type( )) {
         dlog("peer doesn't need to sync but does need to fetch blocks/trans");
         if( msg.head_num >= lib_num ) {
-#warning ("TODO: construct notice message for blocks and transactions");
+          notice_message msg;
+          msg.known_blocks = cc.get_block_ids_on_fork(cc.head_block_id());
+          dlog("known_blks size is ${s}",("s",msg.known_blocks.size()));
+#warning("TODO: get a list of known, unblocked transactions");
+          //   msg.known_trx = cc.get_pending_transaction_ids();
+          c->enqueue( msg);
         }
         c->syncing = true;
       }
-
 
       c->last_handshake = msg;
     }
@@ -935,24 +979,39 @@ namespace eos {
       notice_message fwd;
       request_message req;
 
-      for (const auto& t : msg.known_trx) {
-        const auto &tx = c->trx_state.find(t);
-        if (tx == c->trx_state.end()) {
+      for( const auto& t : msg.known_trx) {
+
+        const auto &tx = my_impl->local_txns.find(t);
+        if( tx == my_impl->local_txns.end()) {
           c->trx_state.insert((transaction_state){t,true,true,(uint32_t)-1,
                 fc::time_point(),fc::time_point()});
+
           fwd.known_trx.push_back(t);
           req.req_trx.push_back(t);
         }
       }
-      if (fwd.known_trx.size() > 0) {
-        send_all (fwd, [c,fwd](connection_ptr cptr) -> bool {
+      for( const auto& t : msg.known_blocks) {
+        const auto &tx = c->trx_state.find(t);
+        if( tx == c->trx_state.end()) {
+          c->trx_state.insert((transaction_state){t,true,true,(uint32_t)-1,
+                fc::time_point(),fc::time_point()});
+
+          fwd.known_trx.push_back(t);
+          req.req_trx.push_back(t);
+        }
+      }
+
+
+      if( fwd.known_trx.size() > 0) {
+        send_all( fwd, [c,fwd](connection_ptr cptr) -> bool {
+
             return cptr != c;
           });
         c->enqueue(req);
       }
     }
 
-    void net_plugin_impl::handle_message (connection_ptr c, const request_message &msg) {
+    void net_plugin_impl::handle_message( connection_ptr c, const request_message &msg) {
         // collect a list of transactions that were found.
         // collect a second list of transaction ids that were not found but are otherwise known by some peers
         // finally, what remains are future(?) transactions
@@ -960,9 +1019,9 @@ namespace eos {
       vector< SignedTransaction > send_now;
       map <connection_ptr, vector < transaction_id_type > > forward_to;
       auto conn_ndx = connections.begin();
-      for (auto t: msg.req_trx) {
+      for( auto t: msg.req_trx) {
         auto txn = local_txns.get<by_id>().find(t);
-        if (txn != local_txns.end()) {
+        if( txn != local_txns.end()) {
           chain_controller &cc = chain_plug->chain();
           try {
             send_now.push_back(cc.get_recent_transaction(t));
@@ -973,21 +1032,21 @@ namespace eos {
         else {
           int cycle_count = 2;
           auto loop_start = conn_ndx++;
-          while (conn_ndx != loop_start) {
-            if (conn_ndx == connections.end()) {
-              if (--cycle_count == 0) {
+          while( conn_ndx != loop_start) {
+            if( conn_ndx == connections.end()) {
+              if( --cycle_count == 0) {
                 elog("loop cycled twice, something is wrong");
                 break;
               }
               conn_ndx = connections.begin();
               continue;
             }
-            if (conn_ndx->get() == c.get()) {
+            if( conn_ndx->get() == c.get()) {
               ++conn_ndx;
               continue;
             }
             auto txn = conn_ndx->get()->trx_state.get<by_id>().find(t);
-            if (txn != conn_ndx->get()->trx_state.end()) {
+            if( txn != conn_ndx->get()->trx_state.end()) {
 
               //forward_to[conn_ndx]->push_back(t);
               break;
@@ -997,71 +1056,122 @@ namespace eos {
         }
       }
 
-      if (!send_now.empty()) {
-        for (auto &t : send_now) {
-          c->enqueue (t);
+      if( !send_now.empty()) {
+        for( auto &t : send_now) {
+          c->enqueue( t);
         }
       }
     }
 
-    void net_plugin_impl::handle_message (connection_ptr c, const sync_request_message &msg) {
-      if (msg.end_block == 0) {
+    void net_plugin_impl::handle_message( connection_ptr c, const sync_request_message &msg) {
+      if( msg.end_block == 0) {
         c->sync_requested.reset();
       } else {
-        c->sync_requested.reset(new sync_state (msg.start_block,msg.end_block,msg.start_block-1));
+        c->sync_requested.reset(new sync_state( msg.start_block,msg.end_block,msg.start_block-1));
         c->enqueue_sync_block();
       }
     }
 
-    void net_plugin_impl::handle_message (connection_ptr c, const block_summary_message &msg) {
+    void net_plugin_impl::handle_message( connection_ptr c, const block_summary_message &msg) {
       const auto& itr = c->block_state.get<by_id>();
-      auto bs = itr.find(msg.block.id());
-      if (bs == c->block_state.end()) {
-        c->block_state.insert ((block_state){msg.block.id(),true,true,fc::time_point()});
-        send_all (msg, [c](connection_ptr cptr) -> bool {
+      auto bs = itr.find(msg.block_header.id());
+      if( bs == c->block_state.end()) {
+        c->block_state.insert( (block_state){msg.block_header.id(),true,true,fc::time_point()});
+        send_all( msg, [c](connection_ptr cptr) -> bool {
             return cptr != c;
           });
       } else {
-        if (!bs->is_known) {
+        if( !bs->is_known) {
           block_state value = *bs;
           value.is_known= true;
-          c->block_state.insert (std::move(value));
-          send_all (msg, [c](connection_ptr cptr) -> bool {
+          c->block_state.insert( std::move(value));
+          send_all( msg, [c](connection_ptr cptr) -> bool {
               return cptr != c;
             });
         }
       }
-#warning ("TODO: reconstruct actual block from cached transactions")
+
       signed_block sb;
+      bool fetch_error = false;
       chain_controller &cc = chain_plug->chain();
-      if (!cc.is_known_block(msg.block.id()) ) {
+      if( !cc.is_known_block(msg.block_header.id()) ) {
+        (signed_block_header)sb = msg.block_header;
+        for( auto &cyc : msg.trx_ids ) {
+          eos::chain::cycle sbcycle;
+          for( auto &cyc_thr_id : cyc ) {
+            eos::chain::thread cyc_thr;
+            for( auto &gt : cyc_thr_id.gen_trx ) {
+              try {
+                auto gen = cc.get_generated_transaction( gt );
+                cyc_thr.generated_input.push_back( ProcessedGeneratedTransaction( gen ) );
+              } catch ( const exception &ex) {
+                fetch_error = true;
+                elog( "unable to retieve generated transaction, caught {ex}", ("ex",ex) );
+                break;
+              } catch ( ... ) {
+                fetch_error = true;
+                elog( "unable to retieve generated transaction" );
+                break;
+              }
+            }
+            for( auto &ut : cyc_thr_id.user_trx ) {
+              try {
+                cyc_thr.user_input.push_back( ProcessedTransaction( cc.get_recent_transaction( ut ) ) );
+              } catch ( const exception &ex) {
+                fetch_error = true;
+                elog( "unable to retieve user transaction, caught {ex}", ("ex",ex) );
+                break;
+              } catch ( ... ) {
+                fetch_error = true;
+                elog( "unable to retieve user transaction" );
+                break;
+              }
+            }
+            if( !fetch_error ){
+              sbcycle.push_back( cyc_thr );
+            }
+            else {
+              break;
+            }
+          }
+          if( !fetch_error ){
+            sb.cycles.push_back( sbcycle );
+          }
+          else {
+            break;
+          }
+        }
+
         try {
-          chain_plug->accept_block(sb, false);
-        } catch (const unlinkable_block_exception &ex) {
-          elog ("   caught unlinkable block exception #${n}",("n",sb.block_num()));
-           close (c);
-        } catch (const assert_exception &ex) {
-          // received a block due to out of sequence
-          elog ("  caught assertion #${n}",("n",sb.block_num()));
+          if( !fetch_error )
+            chain_plug->accept_block(sb, false);
+        } catch( const unlinkable_block_exception &ex) {
+          elog( "   caught unlinkable block exception #${n}",("n",sb.block_num()));
+          close( c);
+        } catch( const assert_exception &ex) {
+            // received a block due to out of sequence
+          elog( "  caught assertion #${n}",("n",sb.block_num()));
+        } catch( ... ) {
+          elog( "unable to accept block, reason unknown" );
         }
       }
     }
 
-    void net_plugin_impl::handle_message (connection_ptr c, const SignedTransaction &msg) {
+    void net_plugin_impl::handle_message( connection_ptr c, const SignedTransaction &msg) {
       transaction_id_type txnid = msg.id();
-      if( local_txns.get<by_id>().find( txnid ) != local_txns.end () ) { //found
+      if( local_txns.get<by_id>().find( txnid ) != local_txns.end( ) ) { //found
         return;
       }
 
       auto tx = c->trx_state.find(txnid);
-      if (tx == c->trx_state.end()) {
+      if( tx == c->trx_state.end()) {
         c->trx_state.insert((transaction_state){txnid,true,true,(uint32_t)msg.refBlockNum,
               fc::time_point(),fc::time_point()});
       } else {
         struct trx_mod {
           UInt16 block;
           trx_mod( UInt16 bn) : block(bn) {}
-          void operator () (transaction_state &t) {
+          void operator( )( transaction_state &t) {
             t.is_known_by_peer = true;
             t.block_num = static_cast<uint32_t>(block);
           }
@@ -1070,85 +1180,85 @@ namespace eos {
       }
 
       try {
-        chain_plug->accept_transaction (msg);
-      } catch (const fc::exception &ex) {
+        chain_plug->accept_transaction( msg);
+      } catch( const fc::exception &ex) {
         // received a block due to out of sequence
-        elog ("accept txn threw  ${m}",("m",ex.what()));
+        elog( "accept txn threw  ${m}",("m",ex.what()));
       }
-      catch (...) {
-        elog (" caught something attempting to accept transaction");
+      catch( ...) {
+        elog( " caught something attempting to accept transaction");
       }
 
     }
 
-    void net_plugin_impl::handle_message (connection_ptr c, const signed_block &msg) {
+    void net_plugin_impl::handle_message( connection_ptr c, const signed_block &msg) {
       chain_controller &cc = chain_plug->chain();
       try {
-        if (cc.is_known_block(msg.id())) {
+        if( cc.is_known_block(msg.id())) {
           return;
         }
-      } catch (...) {
+      } catch( ...) {
       }
-      if (cc.head_block_num() >= msg.block_num()) {
-        elog ("received a full block we know about #${n}", ("n",msg.block_num()));
+      if( cc.head_block_num() >= msg.block_num()) {
+        elog( "received a full block we know about #${n}",( "n",msg.block_num()));
       }
 
       bool has_chunk = false;
       uint32_t num = msg.block_num();
       bool syncing = sync_master->syncing();
       if( syncing ) {
-        has_chunk = (c->sync_receiving && c->sync_receiving->end_block > 0);
+        has_chunk =( c->sync_receiving && c->sync_receiving->end_block > 0);
 
-        if (!has_chunk) {
+        if( !has_chunk) {
           elog("got a block while syncing but no sync_receiving set #${n}",
-               ("n",num));
+              ( "n",num));
         }
         else {
           if( c->sync_receiving->last + 1 != num) {
-            elog ("expected block ${next} but got ${num}",("next",c->sync_receiving->last+1)("num",num));
+            elog( "expected block ${next} but got ${num}",("next",c->sync_receiving->last+1)("num",num));
           }
           c->sync_receiving->last = num;
         }
       }
       bool accepted = false;
-      if (!syncing || num == cc.head_block_num()+1) {
+      if( !syncing || num == cc.head_block_num()+1) {
         try {
           chain_plug->accept_block(msg, syncing);
           accepted = true;
-        } catch (const unlinkable_block_exception &ex) {
-          elog ("unlinkable_block_exception accept block #${n} syncing",("n",num));
-          close (c);
-        } catch (const assert_exception &ex) {
-          elog ("unable to accept block on assert exception ${n}",("n",ex.what()));
-        } catch (const fc::exception &ex) {
-          elog ("accept_block threw a non-assert exception ${x}", ("x",ex.what()));
-        } catch (...) {
-          elog ("handle sync block caught something else");
+        } catch( const unlinkable_block_exception &ex) {
+          elog( "unlinkable_block_exception accept block #${n} syncing",("n",num));
+          close( c);
+        } catch( const assert_exception &ex) {
+          elog( "unable to accept block on assert exception ${n}",("n",ex.what()));
+        } catch( const fc::exception &ex) {
+          elog( "accept_block threw a non-assert exception ${x}",( "x",ex.what()));
+        } catch( ...) {
+          elog( "handle sync block caught something else");
         }
       }
 
-      if (has_chunk) {
-        if (!accepted) {
+      if( has_chunk) {
+        if( !accepted) {
           c->sync_receiving->block_cache.emplace_back(std::move(c->blk_buffer));
         }
 
-        if (num == c->sync_receiving->end_block) {
-          sync_master->take_chunk (c);
+        if( num == c->sync_receiving->end_block) {
+          sync_master->take_chunk( c);
         } else {
           c->sync_wait( );
         }
       }
       else {
-#warning ("TODO: only send if not requested, and if the size is less than the just send it size otherwise send a notice");
-        send_all (msg, [c](connection_ptr conn) -> bool {
-            return (c != conn);
+#warning( "TODO: only send if not requested, and if the size is less than the just send it size otherwise send a notice");
+        send_all( msg, [c](connection_ptr conn) -> bool {
+            return( c != conn);
           });
        }
     }
 
     struct precache : public fc::visitor<void> {
       connection_ptr c;
-      precache (connection_ptr conn) : c(conn) {}
+      precache( connection_ptr conn) : c(conn) {}
 
       void operator()(const signed_block &msg) const
       {
@@ -1167,12 +1277,12 @@ namespace eos {
     struct msgHandler : public fc::visitor<void> {
       net_plugin_impl &impl;
       connection_ptr c;
-      msgHandler (net_plugin_impl &imp, connection_ptr conn) : impl(imp), c(conn) {}
+      msgHandler( net_plugin_impl &imp, connection_ptr conn) : impl(imp), c(conn) {}
 
       template <typename T>
       void operator()(const T &msg) const
       {
-        impl.handle_message (c, msg);
+        impl.handle_message( c, msg);
       }
     };
 
@@ -1186,44 +1296,44 @@ namespace eos {
                 c->message_size = bytes_transferred;
                 auto msg = fc::raw::unpack<net_message>( c->pending_message_buffer );
                 precache pc( c );
-                msg.visit (pc);
+                msg.visit( pc);
                 start_read_message( c );
 
                 msgHandler m(*this, c);
                 msg.visit(m);
                 return;
-              } catch ( const fc::exception& e ) {
+              } catch(  const fc::exception& e ) {
                 edump((e.to_detail_string() ));
               }
             } else {
-              elog( "Error reading message from connection: ${m}", ("m", ec.message() ) );
+              elog( "Error reading message from connection: ${m}",( "m", ec.message() ) );
             }
             close( c );
           });
     }
 
-    void net_plugin_impl::start_conn_timer () {
-      connector_check->expires_from_now (connector_period);
-      connector_check->async_wait ([&](boost::system::error_code ec) {
-          if (!ec) {
-            connection_monitor ();
+    void net_plugin_impl::start_conn_timer( ) {
+      connector_check->expires_from_now( connector_period);
+      connector_check->async_wait( [&](boost::system::error_code ec) {
+          if( !ec) {
+            connection_monitor( );
           }
           else {
-            elog ("Error from connection check monitor: ${m}", ("m", ec.message()));
-            start_conn_timer ();
+            elog( "Error from connection check monitor: ${m}",( "m", ec.message()));
+            start_conn_timer( );
           }
         });
     }
 
-    void net_plugin_impl::start_txn_timer () {
-      transaction_check->expires_from_now (txn_exp_period);
-      transaction_check->async_wait ([&](boost::system::error_code ec) {
-          if (!ec) {
-            expire_txns ();
+    void net_plugin_impl::start_txn_timer( ) {
+      transaction_check->expires_from_now( txn_exp_period);
+      transaction_check->async_wait( [&](boost::system::error_code ec) {
+          if( !ec) {
+            expire_txns( );
           }
           else {
-            elog ("Error from connection check monitor: ${m}", ("m", ec.message()));
-            start_txn_timer ();
+            elog( "Error from connection check monitor: ${m}",( "m", ec.message()));
+            start_txn_timer( );
           }
         });
     }
@@ -1250,42 +1360,42 @@ namespace eos {
       start_txn_timer();
     }
 
-    void net_plugin_impl::expire_txns () {
-      start_txn_timer ();
+    void net_plugin_impl::expire_txns( ) {
+      start_txn_timer( );
       auto &old = local_txns.get<by_expiry>();
-      auto ex_up = old.upper_bound (time_point::now());
-      auto ex_lo = old.lower_bound (fc::time_point_sec (0));
-      old.erase (ex_lo, ex_up);
+      auto ex_up = old.upper_bound( time_point::now());
+      auto ex_lo = old.lower_bound( fc::time_point_sec( 0));
+      old.erase( ex_lo, ex_up);
       auto &stale = local_txns.get<by_block_num>();
       chain_controller &cc = chain_plug->chain();
       uint32_t bn = cc.last_irreversible_block_num();
       auto bn_up = stale.upper_bound(bn);
       auto bn_lo = stale.lower_bound(0);
-      stale.erase (bn_lo, bn_up);
+      stale.erase( bn_lo, bn_up);
     }
 
-    void net_plugin_impl::connection_monitor () {
+    void net_plugin_impl::connection_monitor( ) {
       start_conn_timer();
       vector <connection_ptr> discards;
       num_clients = 0;
-      for (auto &c : connections ) {
-        if (!c->socket->is_open() && !c->connecting) {
-          if (c->peer_addr.length() > 0) {
-            connect (c);
+      for( auto &c : connections ) {
+        if( !c->socket->is_open() && !c->connecting) {
+          if( c->peer_addr.length() > 0) {
+            connect( c);
           }
           else {
-            discards.push_back (c);
+            discards.push_back( c);
           }
         } else {
-          if (c->peer_addr.empty()) {
+          if( c->peer_addr.empty()) {
             num_clients++;
           }
         }
       }
-      if (discards.size () ) {
-        for (auto &c : discards) {
+      if( discards.size( ) ) {
+        for( auto &c : discards) {
           connections.erase( c );
-          c.reset ();
+          c.reset( );
         }
       }
     }
@@ -1294,40 +1404,43 @@ namespace eos {
       if( c->peer_addr.empty( ) ) {
         --num_clients;
       }
-      if (c->sync_receiving)
-        sync_master->take_chunk (c);
+      if( c->sync_receiving)
+        sync_master->take_chunk( c);
       c->close();
     }
 
-    void net_plugin_impl::send_all_txn (const SignedTransaction& txn) {
+    void net_plugin_impl::send_all_txn( const SignedTransaction& txn) {
       transaction_id_type txnid = txn.id();
-      if( local_txns.get<by_id>().find( txnid ) != local_txns.end () ) { //found
+      if( local_txns.get<by_id>().find( txnid ) != local_txns.end( ) ) { //found
         return;
       }
+      size_t bufsiz = fc::raw::pack_size(txn);
+      vector<char> buff(bufsiz);
 
       uint16_t bn = static_cast<uint16_t>(txn.refBlockNum);
       node_transaction_state nts = {txnid,time_point::now(),
                                     txn.expiration,
+                                    buff,
                                     bn, true};
       local_txns.insert(nts);
 
-      if (fc::raw::pack_size(txn) <= just_send_it_max) {
-        send_all (txn, [txn, txnid](connection_ptr c) -> bool {
+      if( fc::raw::pack_size(txn) <= just_send_it_max) {
+        send_all( txn, [txn, txnid](connection_ptr c) -> bool {
             const auto& bs = c->trx_state.find(txnid);
             bool unknown = bs == c->trx_state.end();
-            if (unknown)
+            if( unknown)
               c->trx_state.insert(transaction_state({txnid,true,true,(uint32_t)-1,
                       fc::time_point(),fc::time_point() }));
             return unknown;
           });
       }
       else {
-        pending_notify.push_back (txnid);
+        pending_notify.push_back( txnid);
         notice_message nm = {pending_notify};
-        send_all (nm, [txn, txnid](connection_ptr c) -> bool {
+        send_all( nm, [txn, txnid](connection_ptr c) -> bool {
             const auto& bs = c->trx_state.find(txnid);
             bool unknown = bs == c->trx_state.end();
-            if (unknown)
+            if( unknown)
               c->trx_state.insert(transaction_state({txnid,false,true,(uint32_t)-1,
                       fc::time_point(),fc::time_point() }));
             return unknown;
@@ -1339,48 +1452,56 @@ namespace eos {
     /**
      * This one is necessary to hook into the boost notifier api
      **/
-    void net_plugin_impl::transaction_ready (const SignedTransaction& txn) {
-      my_impl->send_all_txn (txn);
+    void net_plugin_impl::transaction_ready( const SignedTransaction& txn) {
+      my_impl->send_all_txn( txn);
     }
 
-    void net_plugin_impl::broadcast_block_impl (const chain::signed_block &sb) {
-      if (send_whole_blocks) {
-        send_all (sb,[](connection_ptr c) -> bool { return true; });
+    void net_plugin_impl::broadcast_block_impl( const chain::signed_block &sb) {
+      if( send_whole_blocks) {
+        send_all( sb,[](connection_ptr c) -> bool { return true; });
       }
       chain_controller &cc = chain_plug->chain();
 
-      vector<transaction_id_type> trxs;
-      if (!sb.cycles.empty()) {
-        for (const auto& cyc : sb.cycles) {
-          for (const auto& thr : cyc) {
-            for (auto ui : thr.user_input) {
-              auto &txn = cc.get_recent_transaction (ui.id());
-              auto &id_iter = local_txns.get<by_id>();
-              auto lt = id_iter.find(ui.id());
-              if (lt != local_txns.end()) {
-                id_iter.modify (lt, update_block_num(txn.refBlockNum));
-              } else {
-                transaction_id_type txnid = txn.id();
-                if( local_txns.get<by_id>().find( txnid ) == local_txns.end () ) { //not found
-                  uint16_t bn = static_cast<uint16_t>(txn.refBlockNum);
-                  node_transaction_state nts = {txnid,time_point::now(),
-                                                txn.expiration, bn, true};
-                  local_txns.insert(nts);
-                }
+      vector<cycle_ids> trxs;
+      if( !sb.cycles.empty()) {
+        for( const auto& cyc : sb.cycles) {
+          if( !cyc.empty() ) {
+            thread_ids thd_ids;
+            for( const auto& thr : cyc) {
+              for( auto gi : thr.generated_input ) {
+                thd_ids.gen_trx.push_back( gi.id );
               }
-              trxs.push_back (ui.id());
+              for( auto ui : thr.user_input) {
+                auto &txn = cc.get_recent_transaction( ui.id( ) );
+                auto &id_iter = local_txns.get<by_id>();
+                auto lt = id_iter.find( ui.id( ) );
+                if( lt != local_txns.end()) {
+                  id_iter.modify( lt, update_block_num(txn.refBlockNum));
+                } else {
+                  transaction_id_type txnid = txn.id();
+                  if( local_txns.get<by_id>().find( txnid ) == local_txns.end( ) ) { //not found
+                    uint16_t bn = static_cast<uint16_t>(txn.refBlockNum);
+                    node_transaction_state nts = {txnid,time_point::now(),
+                                                  txn.expiration,
+                                                  vector<char>(),
+                                                  bn, true};
+                    local_txns.insert(nts);
+                  }
+                }
+                thd_ids.user_trx.push_back( ui.id( ) );
+              }
             }
           }
         }
       }
 
-      if (!send_whole_blocks) {
+      if( !send_whole_blocks) {
         block_summary_message bsm = {sb, trxs};
-        send_all (bsm,[sb](connection_ptr c) -> bool {
+        send_all( bsm,[sb](connection_ptr c) -> bool {
             return true;
             const auto& bs = c->block_state.find(sb.id());
-            if (bs == c->block_state.end()) {
-              c->block_state.insert ((block_state){sb.id(),true,true,fc::time_point()});
+            if( bs == c->block_state.end()) {
+              c->block_state.insert( (block_state){sb.id(),true,true,fc::time_point()});
               return true;
             }
             return false;
@@ -1389,7 +1510,7 @@ namespace eos {
     }
 
   void
-  handshake_initializer::populate (handshake_message &hello) {
+  handshake_initializer::populate( handshake_message &hello) {
     hello.network_version = my_impl->network_version;
     hello.chain_id = my_impl->chain_id;
     hello.node_id = my_impl->node_id;
@@ -1409,17 +1530,17 @@ namespace eos {
     chain_controller& cc = my_impl->chain_plug->chain();
     try {
       hello.last_irreversible_block_id = cc.get_block_id_for_num
-        (hello.last_irreversible_block_num = cc.last_irreversible_block_num());
+       ( hello.last_irreversible_block_num = cc.last_irreversible_block_num());
     }
-    catch (const unknown_block_exception &ex) {
+    catch( const unknown_block_exception &ex) {
       hello.last_irreversible_block_id = fc::sha256::hash(0);
       hello.last_irreversible_block_num = 0;
     }
     try {
       hello.head_id = cc.get_block_id_for_num
-        (hello.head_num = cc.head_block_num());
+       ( hello.head_num = cc.head_block_num());
     }
-    catch (const unknown_block_exception &ex) {
+    catch( const unknown_block_exception &ex) {
       hello.head_id = fc::sha256::hash(0);
       hello.head_num = 0;
     }
@@ -1437,10 +1558,10 @@ namespace eos {
   void net_plugin::set_program_options( options_description& cli, options_description& cfg )
   {
     cfg.add_options()
-      ("listen-endpoint", bpo::value<string>()->default_value( "0.0.0.0:9876" ), "The local IP address and port to listen for incoming connections.")
-      ("remote-endpoint", bpo::value< vector<string> >()->composing(), "The IP address and port of a remote peer to sync with.")
-      ("public-endpoint", bpo::value<string>(), "Overrides the advertised listen endpointlisten ip address.")
-      ("agent-name", bpo::value<string>()->default_value("EOS Test Agent"), "The name supplied to identify this node amongst the peers.")
+     ( "listen-endpoint", bpo::value<string>()->default_value( "0.0.0.0:9876" ), "The local IP address and port to listen for incoming connections.")
+     ( "remote-endpoint", bpo::value< vector<string> >()->composing(), "The IP address and port of a remote peer to sync with.")
+     ( "public-endpoint", bpo::value<string>(), "Overrides the advertised listen endpointlisten ip address.")
+     ( "agent-name", bpo::value<string>()->default_value("EOS Test Agent"), "The name supplied to identify this node amongst the peers.")
       ;
   }
 
@@ -1472,20 +1593,20 @@ namespace eos {
 
       my->acceptor.reset( new tcp::acceptor( app().get_io_service() ) );
     }
-    if (options.count ("public-endpoint") ) {
+    if( options.count( "public-endpoint") ) {
       my->p2p_address = options.at("public-endpoint").as< string >();
     }
     else {
-      if (my->listen_endpoint.address().to_v4() == address_v4::any()) {
+      if( my->listen_endpoint.address().to_v4() == address_v4::any()) {
         boost::system::error_code ec;
         auto host = host_name(ec);
-        if (ec.value() != boost::system::errc::success) {
+        if( ec.value() != boost::system::errc::success) {
 
-          FC_THROW_EXCEPTION (fc::invalid_arg_exception,
-                              "Unable to retrieve host_name. ${msg}", ("msg",ec.message()));
+          FC_THROW_EXCEPTION( fc::invalid_arg_exception,
+                              "Unable to retrieve host_name. ${msg}",( "msg",ec.message()));
 
         }
-        auto port = my->p2p_address.substr (my->p2p_address.find(':'), my->p2p_address.size());
+        auto port = my->p2p_address.substr( my->p2p_address.find(':'), my->p2p_address.size());
         my->p2p_address = host + port;
       }
     }
@@ -1493,8 +1614,8 @@ namespace eos {
     if( options.count( "remote-endpoint" ) ) {
       my->supplied_peers = options.at( "remote-endpoint" ).as< vector<string> >();
     }
-    if (options.count("agent-name")) {
-      my->user_agent_name = options.at ("agent-name").as< string > ();
+    if( options.count("agent-name")) {
+      my->user_agent_name = options.at( "agent-name").as< string >( );
     }
     my->chain_plug = app().find_plugin<chain_plugin>();
     my->chain_plug->get_chain_id(my->chain_id);
@@ -1513,12 +1634,12 @@ namespace eos {
       my->start_listen_loop();
     }
 
-    my->chain_plug->chain().on_pending_transaction.connect (&net_plugin_impl::transaction_ready);
+    my->chain_plug->chain().on_pending_transaction.connect( &net_plugin_impl::transaction_ready);
     my->start_monitors();
 
     for( auto seed_node : my->supplied_peers ) {
       connection_ptr c = std::make_shared<connection>(seed_node);
-      my->connections.insert (c);
+      my->connections.insert( c);
       my->connect( c );
     }
   }
@@ -1531,11 +1652,11 @@ namespace eos {
         ilog( "close acceptor" );
         my->acceptor->close();
 
-        ilog( "close ${s} connections", ("s",my->connections.size()) );
+        ilog( "close ${s} connections",( "s",my->connections.size()) );
         auto cons = my->connections;
         for( auto con : cons ) {
           con->socket->close();
-          my->close (con);
+          my->close( con);
         }
 
         my->acceptor.reset(nullptr);
@@ -1543,7 +1664,7 @@ namespace eos {
       ilog( "exit shutdown" );
     } FC_CAPTURE_AND_RETHROW() }
 
-    void net_plugin::broadcast_block (const chain::signed_block &sb) {
-      my->broadcast_block_impl (sb);
+    void net_plugin::broadcast_block( const chain::signed_block &sb) {
+      my->broadcast_block_impl( sb);
     }
 }

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -289,7 +289,7 @@ namespace eos {
     vector<char>            blk_buffer;
     size_t                  message_size;
 
-    fc::sha256              remote_node_id;
+    fc::sha256              node_id;
     handshake_message       last_handshake;
     deque<net_message>      out_queue;
     bool                    connecting;
@@ -394,7 +394,7 @@ namespace eos {
         pending_message_size(0),
         pending_message_buffer(recv_buf_size),
         send_buffer(send_buf_size),
-        remote_node_id(),
+        node_id(),
         last_handshake(),
         out_queue(),
         connecting (false),
@@ -418,7 +418,7 @@ namespace eos {
         pending_message_size(0),
         pending_message_buffer(recv_buf_size),
         send_buffer(send_buf_size),
-        remote_node_id(),
+        node_id(),
         last_handshake(),
         out_queue(),
         connecting (false),
@@ -439,7 +439,7 @@ namespace eos {
     }
 
   void connection::initialize () {
-      auto *rnd = remote_node_id.data();
+      auto *rnd = node_id.data();
       rnd[0] = 0;
       response_expected.reset(new boost::asio::steady_timer (app().get_io_service()));
     }
@@ -592,7 +592,7 @@ namespace eos {
 
   void connection::fetch_timeout( boost::system::error_code ec ) {
     if( !ec ) {
-      dlog ("fetch timeout occurred");
+      //      dlog ("fetch timeout occurred");
       if( !( pending_fetch->req_trx.empty( ) || pending_fetch->req_blocks.empty( ) ) ) {
         enqueue( ( request_message ) {vector<transaction_id_type>( ), vector<block_id_type>( )} );
         my_impl->sync_master->reassign_fetch( shared_from_this( ) );
@@ -600,7 +600,7 @@ namespace eos {
     }
     else if( ec == boost::asio::error::operation_aborted ) {
       if( !connected( ) ) {
-        dlog ("fetch timeout was cancelled due to dead connection");
+        //        dlog ("fetch timeout was cancelled due to dead connection");
         my_impl->sync_master->reassign_fetch( shared_from_this( ) );
       }
     }
@@ -912,9 +912,9 @@ namespace eos {
         }
       }
 
-      if(  c->remote_node_id != msg.node_id) {
+      if(  c->node_id != msg.node_id) {
         //        c->reset();
-        c->remote_node_id = msg.node_id;
+        c->node_id = msg.node_id;
       }
 
       c->syncing = false;
@@ -923,16 +923,12 @@ namespace eos {
       block_id_type head_id = cc.head_block_id();
 
       if(  msg.last_irreversible_block_num  >  head || sync_master->syncing() ) {
-        dlog("calling start_sync, myhead = ${h} their last_irreversible = ${mhn}",
-            ( "h",head)("mhn",peer_lib));
         sync_master->start_sync( c, peer_lib);
       }
       else if( msg.head_id != head_id && head_id != block_id_type( )) {
-        dlog("peer doesn't need to sync but does need to fetch blocks/trans");
         if( msg.head_num >= lib_num ) {
           notice_message msg;
           msg.known_blocks = cc.get_block_ids_on_fork(cc.head_block_id());
-          dlog("known_blks size is ${s}",("s",msg.known_blocks.size()));
 #warning("TODO: get a list of known, unblocked transactions");
           //   msg.known_trx = cc.get_pending_transaction_ids();
           c->enqueue( msg);
@@ -967,9 +963,9 @@ namespace eos {
       }
 
       c->offset = (double(c->rec - c->org) + double(msg.xmt - c->dst)) / 2;
-      double NsecPerUsec{1000};
+      //  double NsecPerUsec{1000};
       //
-      dlog("Clock offset is ${o}ns (${us}us)", ("o", c->offset)("us", c->offset/NsecPerUsec));
+      //  dlog("Clock offset is ${o}ns (${us}us)", ("o", c->offset)("us", c->offset/NsecPerUsec));
       c->org = 0;
       c->rec = 0;
     }
@@ -1176,7 +1172,8 @@ namespace eos {
 
     }
 
-    void net_plugin_impl::handle_message( connection_ptr c, const signed_block &msg) {
+  void net_plugin_impl::handle_message( connection_ptr c, const signed_block &msg) {
+    //    dlog ("got block #${num}, from ${id}",("num",msg.block_num())("id",c->node_id));
       chain_controller &cc = chain_plug->chain();
       try {
         if( cc.is_known_block(msg.id())) {
@@ -1206,7 +1203,8 @@ namespace eos {
         }
       }
       bool accepted = false;
-      if( !syncing || num == cc.head_block_num()+1) {
+      //      dlog ("last irrevesible block = ${lib}", ("lib", cc.last_irreversible_block_num()));
+      if( !syncing || num == cc.head_block_num()+1  || num > cc.last_irreversible_block_num()) {
         try {
           chain_plug->accept_block(msg, syncing);
           accepted = true;
@@ -1234,8 +1232,10 @@ namespace eos {
         }
       }
       else {
-#warning( "TODO: only send if not requested, and if the size is less than the just send it size otherwise send a notice");
+        //        dlog ("forwarding the signed block");
+        if (fc::raw::pack_size(msg) < just_send_it_max)
         send_all( msg, [c](connection_ptr conn) -> bool {
+            //            dlog( "sending to ${c}",("c", conn->peer_addr));
             return( c != conn);
           });
        }
@@ -1549,6 +1549,7 @@ namespace eos {
      ( "remote-endpoint", bpo::value< vector<string> >()->composing(), "The IP address and port of a remote peer to sync with.")
      ( "public-endpoint", bpo::value<string>(), "Overrides the advertised listen endpointlisten ip address.")
      ( "agent-name", bpo::value<string>()->default_value("EOS Test Agent"), "The name supplied to identify this node amongst the peers.")
+      ( "send-whole-blocks", bpo::value<bool>()->default_value(def_send_whole_blocks), "True to always send full blocks, false to send block summaries" )
       ;
   }
 
@@ -1604,9 +1605,14 @@ namespace eos {
     if( options.count("agent-name")) {
       my->user_agent_name = options.at( "agent-name").as< string >( );
     }
+    if( options.count( "send-whole-blocks")) {
+      my->send_whole_blocks = options.at( "send-whole-blocks" ).as<bool>();
+    }
+
     my->chain_plug = app().find_plugin<chain_plugin>();
     my->chain_plug->get_chain_id(my->chain_id);
     fc::rand_pseudo_bytes(my->node_id.data(), my->node_id.data_size());
+    ilog ("my node_id is $id",("id",my->node_id));
 
     my->keepalive_timer.reset(new boost::asio::steady_timer (app().get_io_service()));
     my->ticker();
@@ -1652,6 +1658,7 @@ namespace eos {
     } FC_CAPTURE_AND_RETHROW() }
 
     void net_plugin::broadcast_block( const chain::signed_block &sb) {
+      //      dlog( "broadcasting block #${num}",("num",sb.block_num()) );
       my->broadcast_block_impl( sb);
     }
 }

--- a/programs/launcher/main.cpp
+++ b/programs/launcher/main.cpp
@@ -450,7 +450,6 @@ launcher_def::make_star () {
     links = (size_t)sqrt(total_nodes);
   }
   size_t gap = total_nodes > 6 ? 4 : total_nodes - links;
-
   // use to prevent duplicates since all connections are bidirectional
   std::map <string, std::set<string>> peers_to_from;
   for (size_t i = 0; i < total_nodes; i++) {
@@ -461,13 +460,21 @@ launcher_def::make_star () {
       size_t ndx = (i + l * gap) % total_nodes;
       if (i == ndx) {
         ++ndx;
+        if (ndx == total_nodes) {
+          ndx = 0;
+        }
       }
       auto &peer = aliases[ndx];
       for (bool found = true; found; ) {
         found = false;
         for (auto &p : current.peers) {
           if (p == peer) {
-            peer = aliases[++ndx];
+            ++ndx;
+            if (ndx == total_nodes) {
+              ndx = 0;
+            }
+            peer = aliases[ndx];
+
             found = true;
             break;
           }

--- a/programs/launcher/main.cpp
+++ b/programs/launcher/main.cpp
@@ -44,11 +44,9 @@ struct localIdentity {
       cerr << "unable to retrieve host name: " << ec.message() << endl;
     }
     else {
-      cerr << "adding hostname " << hn << endl;
       names.push_back (hn);
       if (hn.find ('.') != string::npos) {
         names.push_back (hn.substr (0,hn.find('.')));
-        cerr << "adding hostname " << hn.substr (0,hn.find('.')) << endl;
       }
     }
 
@@ -64,7 +62,6 @@ struct localIdentity {
           if (in_addr != 0) {
             fc::ip::address ifa(in_addr);
             addrs.push_back (ifa);
-            cout << "found interface " << (string)ifa << endl;
           }
         }
       }
@@ -146,7 +143,7 @@ struct eosd_def {
 
  const string &dot_alias (const string &name) {
     if (dot_alias_str.empty()) {
-      dot_alias_str = name + "\nprod=";
+      dot_alias_str = name + "\\nprod=";
       if (producers.empty()) {
         dot_alias_str += "<none>";
       }
@@ -326,13 +323,13 @@ launcher_def::generate () {
 void
 launcher_def::write_dot_file () {
   bf::ofstream df ("testnet.dot");
-  df << "digraph G\n{\n";
+  df << "digraph G\n{\nlayout=\"circo\";";
   for (auto &node : network.nodes) {
     for (const auto &p : node.second.peers) {
       string pname=network.nodes.find(p)->second.dot_alias(p);
       df << "\"" << node.second.dot_alias (node.first)
          << "\"->\"" << pname
-         << "\" [dir=\"both\"]" << std::endl;
+         << "\" [dir=\"forward\"];" << std::endl;
     }
   }
   df << "}\n";
@@ -490,7 +487,10 @@ launcher_def::make_star () {
   if (total_nodes > 12) {
     links = (size_t)sqrt(total_nodes);
   }
-  size_t gap = total_nodes > 6 ? 4 : total_nodes - links;
+  size_t gap = total_nodes > 6 ? 3 : (total_nodes - links)/2 +1;
+  while (total_nodes % gap == 0) {
+    ++gap;
+  }
   // use to prevent duplicates since all connections are bidirectional
   std::map <string, std::set<string>> peers_to_from;
   for (size_t i = 0; i < total_nodes; i++) {
@@ -514,6 +514,8 @@ launcher_def::make_star () {
             if (ndx == total_nodes) {
               ndx = 0;
             }
+
+
             peer = aliases[ndx];
 
             found = true;
@@ -659,7 +661,7 @@ launcher_def::launch (eosd_def &node, string &gts) {
     info.kill_cmd = "";
 
     if(!c.running()) {
-      cout << "child not running after spawn " << eosdcmd << endl;
+      cerr << "child not running after spawn " << eosdcmd << endl;
       for (int i = 0; i > 0; i++) {
         if (c.running () ) break;
       }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,3 +27,4 @@ if(WASM_TOOLCHAIN)
 endif()
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/eosd_run_test.sh ${CMAKE_CURRENT_BINARY_DIR}/eosd_run_test.sh COPYONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/p2p_test/sync/test.sh ${CMAKE_CURRENT_BINARY_DIR}/p2p_test/sync/test.sh COPYONLY)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,4 +27,4 @@ if(WASM_TOOLCHAIN)
 endif()
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/eosd_run_test.sh ${CMAKE_CURRENT_BINARY_DIR}/eosd_run_test.sh COPYONLY)
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/p2p_test/sync/test.sh ${CMAKE_CURRENT_BINARY_DIR}/p2p_test/sync/test.sh COPYONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/p2p_tests/sync/test.sh ${CMAKE_CURRENT_BINARY_DIR}/p2p_tests/sync/test.sh COPYONLY)

--- a/tests/p2p_tests/initial_sync_test.sh
+++ b/tests/p2p_tests/initial_sync_test.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+cd ../..
+count=5
+topo=star
+if [ -n "$1" ]; then
+    count=$1
+    if [ -n "$2" ]; then
+        topo=$2
+    fi
+fi
+
+total_nodes=`expr $count + 2`
+
+rm -rf tn_data_*
+programs/launcher/launcher -p $count -n $total_nodes -s $topo
+sleep 7
+echo "start" > test.out
+port=8888
+endport=`expr $port + $count`
+echo endport = $endport
+while [ $port  -ne $endport ]; do
+    programs/eosc/eosc --port $port get block 1 >> test.out 2>&1;
+    port=`expr $port + 1`
+done
+
+grep 'producer"' test.out | tee summary | sort -u -k2 | tee unique
+prods=`wc -l < unique`
+lines=`wc -l < summary`
+if [ $lines -eq $count -a $prods -eq 1 ]; then
+    echo all synced
+    programs/launcher/launcher -k 15
+    cd -
+    exit
+fi
+echo lines = $lines and prods = $prods
+sleep 18
+programs/eosc/eosc --port 8888 get block 5
+sleep 18
+programs/eosc/eosc --port 8888 get block 10
+sleep 16
+programs/eosc/eosc --port 8888 get block 15
+sleep 16
+programs/eosc/eosc --port 8888 get block 20
+sleep 16
+echo "pass 2" > test.out
+port=8888
+while [ $port  -ne $endport ]; do
+    programs/eosc/eosc --port $port get block 1 >> test.out 2>&1;
+    port=`expr $port + 1`
+done
+
+grep 'producer"' test.out
+
+programs/launcher/launcher -k 9
+cd -

--- a/tests/p2p_tests/sync/test.sh
+++ b/tests/p2p_tests/sync/test.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-cd ../../..
 pnodes=10
 npnodes=0
 topo=star
@@ -34,7 +33,6 @@ lines=`wc -l < summary`
 if [ $lines -eq $total_nodes -a $prodsfound -eq 1 ]; then
     echo all synced
     programs/launcher/launcher -k 15
-    cd -
     exit
 fi
 echo $lines reports out of $total_nodes and prods = $prodsfound
@@ -61,9 +59,7 @@ lines=`wc -l < summary`
 if [ $lines -eq $total_nodes -a $prodsfound -eq 1 ]; then
     echo all synced
     programs/launcher/launcher -k 15
-    cd -
     exit
 fi
 echo ERROR: $lines reports out of $total_nodes and prods = $prodsfound
-cd -
 exit 1


### PR DESCRIPTION
This PR addresses the lion's share of #515, apart from initial bulk transfer of unblocked signed transactions necessary for the receiving node to be able to construct a block based on its summary.

Second, this PR resolves #421 and adds a test script, tests/p2p-tests/sync/test.sh
