### PR TITLE
added gettext as a dependency for darwin

### DIFF
--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -60,7 +60,7 @@ if [ $ARCH == "ubuntu" ]; then
 fi
 
 if [ $ARCH == "darwin" ]; then
-    DEPS="git automake libtool boost openssl llvm@4 gmp wget cmake"
+    DEPS="git automake libtool boost openssl llvm@4 gmp wget cmake gettext"
     brew update
     brew install --force $DEPS
     brew unlink $DEPS && brew link --force $DEPS


### PR DESCRIPTION
After localization changes for eosc the build script failed to work because we required gettext as a dependency.