### PR TITLE
Social smart-contract: vote power calculation fix

### DIFF
--- a/contracts/social/social.cpp
+++ b/contracts/social/social.cpp
@@ -93,7 +93,7 @@ void apply_social_vote() {
       static Account account;
       Db::get( "account", account );
       auto abs_vote = abs(vote.vote_power);
-      account.vote_power = max( account.social_power, 
+      account.vote_power = min( account.social_power, 
                                 account.vote_power + (account.social_power * (now()-last_vote)) / days(7));
       assert( abs_vote <= account.vote_power, "insufficient vote power" );
       post.votes += vote.vote_power;


### PR DESCRIPTION
Vote power should be equal to last vote power plus regenerated from latest vote, but not to exceed account social power. That's why we should take **min** but not **max**