### PR TITLE
Use Checksum type instead of uint256 for sha256

### DIFF
--- a/contracts/eoslib/crypto.h
+++ b/contracts/eoslib/crypto.h
@@ -14,10 +14,10 @@ extern "C" {
  *
  *  This method is optimized to a NO-OP when in fast evaluation mode
  */
-void assert_sha256( char* data, uint32_t length, const Checksum* hash );
+void assert_sha256( char* data, uint32_t length, const checksum* hash );
 
 /**
  *  Calculates sha256( data,length) and stores result in memory pointed to by hash 
  */
-void sha256( char* data, uint32_t length, Checksum* hash );
+void sha256( char* data, uint32_t length, checksum* hash );
 }

--- a/contracts/eoslib/crypto.h
+++ b/contracts/eoslib/crypto.h
@@ -8,7 +8,7 @@ extern "C" {
 /**
  *  This method is implemented as:
  *
- *  Checksum calc_hash;
+ *  checksum calc_hash;
  *  sha256( data, length, &calc_hash );
  *  assert( calc_hash == hash, "invalid hash" );
  *

--- a/contracts/eoslib/crypto.h
+++ b/contracts/eoslib/crypto.h
@@ -8,16 +8,16 @@ extern "C" {
 /**
  *  This method is implemented as:
  *
- *  uint256 calc_hash;
+ *  Checksum calc_hash;
  *  sha256( data, length, &calc_hash );
  *  assert( calc_hash == hash, "invalid hash" );
  *
  *  This method is optimized to a NO-OP when in fast evaluation mode
  */
-void assert_sha256( char* data, uint32_t length, const uint256* hash );
+void assert_sha256( char* data, uint32_t length, const Checksum* hash );
 
 /**
  *  Calculates sha256( data,length) and stores result in memory pointed to by hash 
  */
-void sha256( char* data, uint32_t length, uint256* hash );
+void sha256( char* data, uint32_t length, Checksum* hash );
 }

--- a/contracts/test_api/test_crypto.cpp
+++ b/contracts/test_api/test_crypto.cpp
@@ -70,36 +70,36 @@ extern "C" {
 
 unsigned int test_crypto::test_sha256() {
 
-  Checksum tmp;
+  checksum tmp;
 
   sha256( (char *)test1, my_strlen(test1), &tmp );
-  WASM_ASSERT( my_memcmp((void *)test1_ok, &tmp, sizeof(Checksum)), "sha256 test1" );
+  WASM_ASSERT( my_memcmp((void *)test1_ok, &tmp, sizeof(checksum)), "sha256 test1" );
 
   sha256( (char *)test3, my_strlen(test3), &tmp );
-  WASM_ASSERT( my_memcmp((void *)test3_ok, &tmp, sizeof(Checksum)), "sha256 test3" );
+  WASM_ASSERT( my_memcmp((void *)test3_ok, &tmp, sizeof(checksum)), "sha256 test3" );
 
   sha256( (char *)test4, my_strlen(test4), &tmp );
-  WASM_ASSERT( my_memcmp((void *)test4_ok, &tmp, sizeof(Checksum)), "sha256 test4" );
+  WASM_ASSERT( my_memcmp((void *)test4_ok, &tmp, sizeof(checksum)), "sha256 test4" );
 
   sha256( (char *)test5, my_strlen(test5), &tmp );
-  WASM_ASSERT( my_memcmp((void *)test5_ok, &tmp, sizeof(Checksum)), "sha256 test5" );
+  WASM_ASSERT( my_memcmp((void *)test5_ok, &tmp, sizeof(checksum)), "sha256 test5" );
 
   return WASM_TEST_PASS;
 }
 
 unsigned int test_crypto::sha256_no_data() {
 
-  Checksum tmp;
+  checksum tmp;
 
   sha256( (char *)test2, my_strlen(test2), &tmp );
-  WASM_ASSERT( my_memcmp((void *)test2_ok, &tmp, sizeof(Checksum)), "sha256 test2" );
+  WASM_ASSERT( my_memcmp((void *)test2_ok, &tmp, sizeof(checksum)), "sha256 test2" );
 
   return WASM_TEST_PASS;
 }
 
 unsigned int test_crypto::asert_sha256_false() {
   
-  Checksum tmp;
+  checksum tmp;
 
   sha256( (char *)test1, my_strlen(test1), &tmp );
   tmp.hash[0] ^= (uint64_t)(-1);
@@ -110,7 +110,7 @@ unsigned int test_crypto::asert_sha256_false() {
 
 unsigned int test_crypto::asert_sha256_true() {
   
-  Checksum tmp;
+  checksum tmp;
 
   sha256( (char *)test1, my_strlen(test1), &tmp );
   assert_sha256( (char *)test1, my_strlen(test1), &tmp);
@@ -129,7 +129,7 @@ unsigned int test_crypto::asert_sha256_true() {
 
 unsigned int test_crypto::asert_no_data() {
   
-  Checksum *tmp = (Checksum*)test2_ok;
+  checksum *tmp = (checksum*)test2_ok;
   assert_sha256( (char *)test2, my_strlen(test2), tmp);
 
   return WASM_TEST_FAIL;

--- a/contracts/test_api/test_crypto.cpp
+++ b/contracts/test_api/test_crypto.cpp
@@ -70,39 +70,39 @@ extern "C" {
 
 unsigned int test_crypto::test_sha256() {
 
-  uint256 tmp;
+  Checksum tmp;
 
   sha256( (char *)test1, my_strlen(test1), &tmp );
-  WASM_ASSERT( my_memcmp((void *)test1_ok, &tmp, sizeof(uint256)), "sha256 test1" );
+  WASM_ASSERT( my_memcmp((void *)test1_ok, &tmp, sizeof(Checksum)), "sha256 test1" );
 
   sha256( (char *)test3, my_strlen(test3), &tmp );
-  WASM_ASSERT( my_memcmp((void *)test3_ok, &tmp, sizeof(uint256)), "sha256 test3" );
+  WASM_ASSERT( my_memcmp((void *)test3_ok, &tmp, sizeof(Checksum)), "sha256 test3" );
 
   sha256( (char *)test4, my_strlen(test4), &tmp );
-  WASM_ASSERT( my_memcmp((void *)test4_ok, &tmp, sizeof(uint256)), "sha256 test4" );
+  WASM_ASSERT( my_memcmp((void *)test4_ok, &tmp, sizeof(Checksum)), "sha256 test4" );
 
   sha256( (char *)test5, my_strlen(test5), &tmp );
-  WASM_ASSERT( my_memcmp((void *)test5_ok, &tmp, sizeof(uint256)), "sha256 test5" );
+  WASM_ASSERT( my_memcmp((void *)test5_ok, &tmp, sizeof(Checksum)), "sha256 test5" );
 
   return WASM_TEST_PASS;
 }
 
 unsigned int test_crypto::sha256_no_data() {
 
-  uint256 tmp;
+  Checksum tmp;
 
   sha256( (char *)test2, my_strlen(test2), &tmp );
-  WASM_ASSERT( my_memcmp((void *)test2_ok, &tmp, sizeof(uint256)), "sha256 test2" );
+  WASM_ASSERT( my_memcmp((void *)test2_ok, &tmp, sizeof(Checksum)), "sha256 test2" );
 
   return WASM_TEST_PASS;
 }
 
 unsigned int test_crypto::asert_sha256_false() {
   
-  uint256 tmp;
+  Checksum tmp;
 
   sha256( (char *)test1, my_strlen(test1), &tmp );
-  tmp.words[0] ^= (uint64_t)(-1);
+  tmp.hash[0] ^= (uint64_t)(-1);
   assert_sha256( (char *)test1, my_strlen(test1), &tmp);
   
   return WASM_TEST_FAIL;
@@ -110,7 +110,7 @@ unsigned int test_crypto::asert_sha256_false() {
 
 unsigned int test_crypto::asert_sha256_true() {
   
-  uint256 tmp;
+  Checksum tmp;
 
   sha256( (char *)test1, my_strlen(test1), &tmp );
   assert_sha256( (char *)test1, my_strlen(test1), &tmp);
@@ -129,7 +129,7 @@ unsigned int test_crypto::asert_sha256_true() {
 
 unsigned int test_crypto::asert_no_data() {
   
-  uint256 *tmp = (uint256*)test2_ok;
+  Checksum *tmp = (Checksum*)test2_ok;
   assert_sha256( (char *)test2, my_strlen(test2), tmp);
 
   return WASM_TEST_FAIL;


### PR DESCRIPTION
Since https://github.com/EOSIO/eos/pull/605 is already merged, we can use Checksum object now. Checksum should be used instead of uint256 to handle sha256 in the contract because of the way it is being packed and unpacked.