### PR TITLE
Add string util to convert int to string

### DIFF
--- a/contracts/eoslib/string.h
+++ b/contracts/eoslib/string.h
@@ -5,12 +5,56 @@
  #pragma once
  #include <eoslib/types.h>
 
+   /**
+   *  @defgroup stringapi String API
+   *  @brief Defines string
+   *  @ingroup contractdev
+   */
+
  extern "C" {
 
+
+  /**
+   *  @defgroup stringcapi String C API
+   *  @brief Defines string 
+   *  @ingroup stringapi
+   *
+   *  @{
+   */
+
+    /**
+    * @brief Get number of digit for unsigned int
+    * 
+    * @param val - the number which digit to be counted
+    * @return uint32_t - length
+    */
     uint32_t uint_digit_len( uint64_t val);
+
+    /**
+    * @brief Get number of digit for signed int
+    * 
+    * @param val - the number which digit to be counted
+    * @return uint32_t - length
+    */
     uint32_t int_digit_len( int64_t val);
 
+    /**
+     * @brief Convert unsigned int to char array representation
+     * 
+     * @param input - number to be converted
+     * @param digit_len - len of number to be converted
+     * @param output - resulting char array representation
+     */
     void uint_to_char_arr( uint64_t input, uint32_t digit_len, char* output);
+
+    /**
+     * @brief Convert signed int to char array representation
+     * 
+     * @param input - number to be converted
+     * @param digit_len - len of number to be converted
+     * @param output - resulting char array representation
+     */
     void int_to_char_arr( int64_t input, uint32_t digit_len, char* output);
 
+    /// @}
 }

--- a/contracts/eoslib/string.h
+++ b/contracts/eoslib/string.h
@@ -1,0 +1,16 @@
+/**
+ + *  @file
+ + *  @copyright defined in eos/LICENSE.txt
+ + */
+ #pragma once
+ #include <eoslib/types.h>
+
+ extern "C" {
+
+    uint32_t uint_digit_len( uint64_t val);
+    uint32_t int_digit_len( int64_t val);
+
+    void uint_to_char_arr( uint64_t input, uint32_t digit_len, char* output);
+    void int_to_char_arr( int64_t input, uint32_t digit_len, char* output);
+
+}

--- a/contracts/eoslib/string.hpp
+++ b/contracts/eoslib/string.hpp
@@ -3,6 +3,7 @@
 #include <eoslib/system.h>
 #include <eoslib/memory.hpp>
 #include <eoslib/print.hpp>
+#include <eoslib/string.h>
 
 namespace eos {
 
@@ -229,5 +230,23 @@ namespace eos {
         prints_l(data, size);
       }
    }
+
+   static string to_string(uint64_t num) {
+     uint32_t digit_len = uint_digit_len(num);
+
+     char buff[digit_len];
+     uint_to_char_arr(num, digit_len, buff);
+
+     return string(buff, digit_len, true);
+   }
+
+   static string to_string(int64_t num) {
+    uint32_t digit_len = int_digit_len(num);
+
+    char buff[digit_len];
+    int_to_char_arr(num, digit_len, buff);
+
+    return string(buff, digit_len, true);
+  }
   };
 }

--- a/contracts/test_api/test_api.cpp
+++ b/contracts/test_api/test_api.cpp
@@ -109,6 +109,7 @@ extern "C" {
       WASM_TEST_HANDLER(test_string, print_null_terminated);
       WASM_TEST_HANDLER(test_string, print_non_null_terminated);
       WASM_TEST_HANDLER(test_string, print_unicode);
+      WASM_TEST_HANDLER(test_string, to_string);
 
       //unhandled test call
       WASM_TEST_ERROR_CODE = WASM_TEST_FAIL;

--- a/contracts/test_api/test_api.hpp
+++ b/contracts/test_api/test_api.hpp
@@ -147,4 +147,5 @@ struct test_string {
   static unsigned int print_null_terminated();
   static unsigned int print_non_null_terminated();
   static unsigned int print_unicode();
+  static unsigned int to_string();
 };

--- a/contracts/test_api/test_string.cpp
+++ b/contracts/test_api/test_string.cpp
@@ -290,3 +290,42 @@ unsigned int test_string::print_unicode() {
 
   return WASM_TEST_PASS;
 }
+
+unsigned int test_string::to_string() {
+  uint64_t num1 = 123456789;
+  char num1_char_array[] = {'1','2','3','4','5','6','7','8','9'};
+
+  int64_t num2 = -123456789;
+  char num2_char_array[] = {'-','1','2','3','4','5','6','7','8','9'};
+
+  uint32_t num1_digit_len = uint_digit_len(num1);
+  WASM_ASSERT( num1_digit_len == 9,  "num1_digit_len == 9" );
+
+  uint32_t num2_digit_len = int_digit_len(num2);
+  WASM_ASSERT( num2_digit_len == 10,  "num2_digit_len == 9" );
+
+  char buffer1[9];
+  uint_to_char_arr(num1,9,buffer1);
+  for (uint8_t i = 0; i < 9; i++) {
+    WASM_ASSERT( buffer1[i] == num1_char_array[i],  "buffer1[i] == num1_char_array[i]" );
+  }
+
+  char buffer2[10];
+  int_to_char_arr(num2,10,buffer2);
+  for (uint8_t i = 0; i < 10; i++) {
+    WASM_ASSERT( buffer2[i] == num2_char_array[i],  "buffer2[i] == num2_char_array[i]" );
+  }
+
+  eos::string str1 = eos::string::to_string(num1);
+  for (uint8_t i = 0; i < str1.get_size(); i++) {
+    WASM_ASSERT( str1[i] == num1_char_array[i],  "str1[i] == num1_char_array[i]" );
+  }
+
+  eos::string str2 = eos::string::to_string(num2);
+  for (uint8_t i = 0; i < str2.get_size(); i++) {
+    WASM_ASSERT( str2[i] == num2_char_array[i],  "str2[i] == num2_char_array[i]" );
+  }
+
+
+  return WASM_TEST_PASS;
+}

--- a/libraries/chain/wasm_interface.cpp
+++ b/libraries/chain/wasm_interface.cpp
@@ -252,6 +252,60 @@ DEFINE_INTRINSIC_FUNCTION7(env,upper_bound_str,upper_bound_str,i32,i64,scope,i64
   READ_RECORD_STR(upper_bound_record)
 }
 
+DEFINE_INTRINSIC_FUNCTION1(env,uint_digit_len,uint_digit_len,i32,i64,val) {
+  uint64_t num = uint64_t(val);
+  
+  if (num == 0) return 1;
+
+  uint32_t len = 0;
+  while (num > 0) {
+    num /= 10;
+    len++;
+  }
+  return len;
+}
+
+DEFINE_INTRINSIC_FUNCTION1(env,int_digit_len,int_digit_len,i32,i64,val) {
+  int64_t num = int64_t(val);
+ 
+  if (num == 0) return 1;
+  
+  uint32_t len = 0;
+  if (num < 0) {
+    len++;
+    num *= -1;
+  }
+  while (num > 0) {
+    num /= 10;
+    len++;
+  }
+  return len;
+}
+
+DEFINE_INTRINSIC_FUNCTION3(env,uint_to_char_arr,uint_to_char_arr,none,i64,input,i32,digit_len,i32,output) {
+  FC_ASSERT( digit_len > 0 );
+
+  auto& wasm  = wasm_interface::get();
+  auto  mem          = wasm.current_memory;
+
+  uint64_t num = uint64_t(input);
+  char* v = &memoryRef<char>( mem, output );
+  string res = std::to_string(num);
+  memcpy(v, res.data(), digit_len);
+}
+
+DEFINE_INTRINSIC_FUNCTION3(env,int_to_char_arr,int_to_char_arr,none,i64,input,i32,digit_len,i32,output) {
+  FC_ASSERT( digit_len > 0 );
+  
+  auto& wasm  = wasm_interface::get();
+  auto  mem          = wasm.current_memory;
+
+  int64_t num = int64_t(input);
+  char* v = &memoryRef<char>( mem, output );
+  string res = std::to_string(num);
+  memcpy(v, res.data(), digit_len);
+}
+
 DEFINE_INTRINSIC_FUNCTION3(env, assert_sha256,assert_sha256,none,i32,dataptr,i32,datalen,i32,hash) {
    FC_ASSERT( datalen > 0 );
 

--- a/tests/api_tests/api_tests.cpp
+++ b/tests/api_tests/api_tests.cpp
@@ -456,6 +456,7 @@ BOOST_FIXTURE_TEST_CASE(test_all, testing_fixture)
       CAPTURE(cerr, CALL_TEST_FUNCTION( TEST_METHOD("test_string", "print_unicode"), {}, {}) );
       BOOST_CHECK_EQUAL( capture.size() , 1);
       BOOST_CHECK_EQUAL( capture[0], "你好，世界！");
+      BOOST_CHECK_MESSAGE( CALL_TEST_FUNCTION( TEST_METHOD("test_string", "to_string"), {}, {} ) == WASM_TEST_PASS, "test_string::to_string()" );
 
 } FC_LOG_AND_RETHROW() }
 


### PR DESCRIPTION
Add utility function to convert int to string. One use case that will be useful for this is for hashing an integer in a contract (since sha256 takes string as input). 

STAT-112