### PR TITLE
Enhance string class

### DIFF
--- a/contracts/eoslib/string.hpp
+++ b/contracts/eoslib/string.hpp
@@ -12,8 +12,8 @@ namespace eosio {
    * Otherwise it will not give the right length
    * @param cstr - null terminated string
    */
-  inline uint32_t cstrlen(const char* cstr) {
-    uint32_t len = 0;
+  inline size_t cstrlen(const char* cstr) {
+    size_t len = 0;
     while(*cstr != '\0') {
       len++;
       cstr++;
@@ -24,7 +24,7 @@ namespace eosio {
   class string {
 
   private:
-    uint32_t size; // size of the string
+    size_t size; // size of the string
     char* data; // underlying data
     bool own_memory; // true if the object is responsible to clean the memory
     uint32_t* refcount; // shared reference count to the underlying data
@@ -50,7 +50,7 @@ namespace eosio {
      * Constructor to create string with reserved space
      * @param s size to be reserved (in number o)
      */
-    string(uint32_t s) : size(s), own_memory(true) {
+    string(size_t s) : size(s), own_memory(true) {
       data = (char *)malloc(s * sizeof(char));
       refcount = (uint32_t*)malloc(sizeof(uint32_t));
       *refcount = 1;
@@ -62,7 +62,7 @@ namespace eosio {
      * @param s    size of the string (in number of bytes)
      * @param copy true to have the data copied and owned by the object
      */
-    string(char* d, uint32_t s, bool copy) {
+    string(char* d, size_t s, bool copy) {
       assign(d, s, copy);
     }
 
@@ -98,7 +98,7 @@ namespace eosio {
     }
 
     // Get size of the string (in number of bytes)
-    const uint32_t get_size() const {
+    const size_t get_size() const {
       return size;
     }
 
@@ -124,7 +124,7 @@ namespace eosio {
      * @param  copy true to have the data copied and owned by the object
      * @return      the current string
      */
-    string& assign(char* d, uint32_t s, bool copy) {
+    string& assign(char* d, size_t s, bool copy) {
       release_data_if_needed();
 
       if (copy) {
@@ -150,12 +150,12 @@ namespace eosio {
      * @param  copy        true to have the data copied and owned by the object
      * @return             substring of the current string
      */
-    string substr(uint32_t offset, uint32_t substr_size, bool copy) {
+    string substr(size_t offset, size_t substr_size, bool copy) {
       assert((offset < size) && (offset + substr_size < size), "out of bound");
       return string(data + offset, substr_size, copy);
     }
 
-    char operator [] (const uint32_t index) {
+    char operator [] (const size_t index) {
       assert(index < size, "index out of bound");
       return *(data + index);
     }
@@ -194,7 +194,7 @@ namespace eosio {
       assert((size + str.size > size) && (size + str.size > str.size), "overflow");
 
       char* new_data;
-      uint32_t new_size;
+      size_t new_size;
       if (size > 0 && *(data + size - 1) == '\0') {
         // Null terminated string, remove the \0 when concatenates
         new_size = size - 1 + str.size;

--- a/contracts/eoslib/string.hpp
+++ b/contracts/eoslib/string.hpp
@@ -50,10 +50,17 @@ namespace eosio {
      * Constructor to create string with reserved space
      * @param s size to be reserved (in number o)
      */
-    string(size_t s) : size(s), own_memory(true) {
-      data = (char *)malloc(s * sizeof(char));
-      refcount = (uint32_t*)malloc(sizeof(uint32_t));
-      *refcount = 1;
+    string(size_t s) : size(s) {
+      if (s == 0) {
+        data = nullptr;
+        own_memory = false;
+        refcount = nullptr;
+      } else {
+        data = (char *)malloc(s * sizeof(char));
+        own_memory = true;
+        refcount = (uint32_t*)malloc(sizeof(uint32_t));
+        *refcount = 1;
+      }
     }
 
     /**
@@ -125,22 +132,36 @@ namespace eosio {
      * @return      the current string
      */
     string& assign(char* d, size_t s, bool copy) {
-      release_data_if_needed();
-
-      if (copy) {
-        data = (char *)malloc(s * sizeof(char));
-        memcpy(data, d, s * sizeof(char));
-        own_memory = true;
-        refcount = (uint32_t*)malloc(sizeof(uint32_t));
-        *refcount = 1;
+      if (s == 0) {
+        clear();
       } else {
-        data = d;
-        own_memory = false;
-        refcount = nullptr;
+        release_data_if_needed();
+        if (copy) {
+          data = (char *)malloc(s * sizeof(char));
+          memcpy(data, d, s * sizeof(char));
+          own_memory = true;
+          refcount = (uint32_t*)malloc(sizeof(uint32_t));
+          *refcount = 1;
+        } else {
+          data = d;
+          own_memory = false;
+          refcount = nullptr;
+        }
+        size = s;
       }
-      size = s;
 
       return *this;
+    }
+    
+    /**
+     * Clear the content of the string
+     */
+    void clear() {
+      release_data_if_needed();
+      data = nullptr;
+      size = 0;
+      own_memory = false;
+      refcount = nullptr;
     }
 
     /**

--- a/contracts/eoslib/string.hpp
+++ b/contracts/eoslib/string.hpp
@@ -6,7 +6,21 @@
 #include <eoslib/print.hpp>
 
 namespace eosio {
-
+  /**
+   * @brief Count the length of null terminated string (excluding the null terminated symbol)
+   * Non-null terminated string need to be passed here, 
+   * Otherwise it will not give the right length
+   * @param cstr - null terminated string
+   */
+  inline uint32_t cstrlen(const char* cstr) {
+    uint32_t len = 0;
+    while(*cstr != '\0') {
+      len++;
+      cstr++;
+    }
+    return len;
+  }
+    
   class string {
 
   private:
@@ -61,6 +75,21 @@ namespace eosio {
         refcount = obj.refcount;
         if (refcount != nullptr) (*refcount)++;
       }
+    }
+
+    /**
+     * @brief Constructor for string literal
+     * Non-null terminated string need to be passed here, 
+     * Otherwise it will have extraneous data
+     * @param cstr - null terminated string
+     */
+    string(const char* cstr) {
+      size = cstrlen(cstr) + 1;
+      data = (char *)malloc(size * sizeof(char));
+      memcpy(data, cstr, size * sizeof(char));
+      own_memory = true;
+      refcount = (uint32_t*)malloc(sizeof(uint32_t));
+      *refcount = 1;
     }
 
     // Destructor
@@ -131,6 +160,7 @@ namespace eosio {
       return *(data + index);
     }
 
+    // Assignment operator
     string& operator = (const string& obj) {
       if (this != &obj) {
         release_data_if_needed();
@@ -141,6 +171,23 @@ namespace eosio {
         if (refcount != nullptr) (*refcount)++;
       }
       return *this;
+    }
+
+    /**
+     * @brief Assignment operator for string literal
+     * Non-null terminated string need to be passed here, 
+     * Otherwise it will have extraneous data
+     * @param cstr - null terminated string
+     */
+    string& operator = (const char* cstr) {
+        release_data_if_needed();
+        size = cstrlen(cstr) + 1;
+        data = (char *)malloc(size * sizeof(char));
+        memcpy(data, cstr, size * sizeof(char));
+        own_memory = true;
+        refcount = (uint32_t*)malloc(sizeof(uint32_t));
+        *refcount = 1;
+        return *this;
     }
 
     string& operator += (const string& str){

--- a/contracts/test_api/test_api.cpp
+++ b/contracts/test_api/test_api.cpp
@@ -111,6 +111,7 @@ extern "C" {
       WASM_TEST_HANDLER(test_string, print_unicode);
       WASM_TEST_HANDLER(test_string, valid_utf8);
       WASM_TEST_HANDLER(test_string, invalid_utf8);
+      WASM_TEST_HANDLER(test_string, string_literal);
 
       //unhandled test call
       WASM_TEST_ERROR_CODE = WASM_TEST_FAIL;

--- a/contracts/test_api/test_api.hpp
+++ b/contracts/test_api/test_api.hpp
@@ -149,4 +149,5 @@ struct test_string {
   static unsigned int print_unicode();
   static unsigned int valid_utf8();
   static unsigned int invalid_utf8();
+  static unsigned int string_literal();
 };

--- a/contracts/test_api/test_string.cpp
+++ b/contracts/test_api/test_string.cpp
@@ -12,7 +12,7 @@ unsigned int test_string::construct_with_size() {
    WASM_ASSERT( str1.is_own_memory() == true,  "str1.is_own_memory() == true" );
 
    size_t size2 = 0;
-   eos::string str2(size2);
+   eosio::string str2(size2);
 
    WASM_ASSERT( str2.get_size() == size2,  "str2.get_size() == size2" );
    WASM_ASSERT( str2.get_data() == nullptr,  "str2.get_data() == nullptr" );
@@ -32,7 +32,7 @@ unsigned int test_string::construct_with_data() {
   WASM_ASSERT( str1.get_data() == data,  "str1.get_data() == data" );
   WASM_ASSERT( str1.is_own_memory() == false,  "str1.is_own_memory() == false" );
 
-  eos::string str2(data, 0, false);
+  eosio::string str2(data, 0, false);
 
   WASM_ASSERT( str2.get_size() == 0,  "str2.get_size() == 0" );
   WASM_ASSERT( str2.get_data() == nullptr,  "str2.get_data() == nullptr" );
@@ -71,7 +71,7 @@ unsigned int test_string::construct_with_data_copied() {
   }
   WASM_ASSERT( str1.is_own_memory() == true,  "str.is_own_memory() == true" );
 
-  eos::string str2(data, 0, true);
+  eosio::string str2(data, 0, true);
   
   WASM_ASSERT( str2.get_size() == 0,  "str2.get_size() == 0" );
   WASM_ASSERT( str2.get_data() == nullptr,  "str2.get_data() == nullptr" );
@@ -367,7 +367,7 @@ unsigned int test_string::string_literal() {
   char data1[] = "abcdefghij";
   char data2[] = "klmnopqrstuvwxyz";
 
-  eos::string str = "abcdefghij";
+  eosio::string str = "abcdefghij";
 
   WASM_ASSERT( str.get_size() == 11,  "data1 str.get_size() == 11" );
   for (uint8_t i = 0; i < 11; i++) {

--- a/contracts/test_api/test_string.cpp
+++ b/contracts/test_api/test_string.cpp
@@ -5,10 +5,18 @@
 
 unsigned int test_string::construct_with_size() {
 
-   size_t size = 100;
-   eosio::string str(size);
+   size_t size1 = 100;
+   eosio::string str1(size1);
 
-   WASM_ASSERT( str.get_size() == size,  "str.get_size() == size" );
+   WASM_ASSERT( str1.get_size() == size1,  "str1.get_size() == size1" );
+   WASM_ASSERT( str1.is_own_memory() == true,  "str1.is_own_memory() == true" );
+
+   size_t size2 = 0;
+   eos::string str2(size2);
+
+   WASM_ASSERT( str2.get_size() == size2,  "str2.get_size() == size2" );
+   WASM_ASSERT( str2.get_data() == nullptr,  "str2.get_data() == nullptr" );
+   WASM_ASSERT( str2.is_own_memory() == false,  "str2.is_own_memory() == false" );
 
    return WASM_TEST_PASS;
 }
@@ -18,11 +26,17 @@ unsigned int test_string::construct_with_data() {
   char data[] = "abcdefghij";
   size_t size = sizeof(data)/sizeof(char);
 
-  eosio::string str(data, size, false);
+  eosio::string str1(data, size, false);
 
-  WASM_ASSERT( str.get_size() == size,  "str.get_size() == size" );
-  WASM_ASSERT( str.get_data() == data,  "str.get_data() == data" );
-  WASM_ASSERT( str.is_own_memory() == false,  "str.is_own_memory() == false" );
+  WASM_ASSERT( str1.get_size() == size,  "str1.get_size() == size" );
+  WASM_ASSERT( str1.get_data() == data,  "str1.get_data() == data" );
+  WASM_ASSERT( str1.is_own_memory() == false,  "str1.is_own_memory() == false" );
+
+  eos::string str2(data, 0, false);
+
+  WASM_ASSERT( str2.get_size() == 0,  "str2.get_size() == 0" );
+  WASM_ASSERT( str2.get_data() == nullptr,  "str2.get_data() == nullptr" );
+  WASM_ASSERT( str2.is_own_memory() == false,  "str2.is_own_memory() == false" );
 
   return WASM_TEST_PASS;
 }
@@ -48,14 +62,20 @@ unsigned int test_string::construct_with_data_copied() {
   char data[] = "abcdefghij";
   size_t size = sizeof(data)/sizeof(char);
 
-  eosio::string str(data, size, true);
+  eosio::string str1(data, size, true);
 
-  WASM_ASSERT( str.get_size() == size,  "str.get_size() == size" );
-  WASM_ASSERT( str.get_data() != data,  "str.get_data() != data" );
+  WASM_ASSERT( str1.get_size() == size,  "str1.get_size() == size" );
+  WASM_ASSERT( str1.get_data() != data,  "str1.get_data() != data" );
   for (uint8_t i = 0; i < size; i++) {
-    WASM_ASSERT( str[i] == data[i],  "str[i] == data[i]" );
+    WASM_ASSERT( str1[i] == data[i],  "str1[i] == data[i]" );
   }
-  WASM_ASSERT( str.is_own_memory() == true,  "str.is_own_memory() == true" );
+  WASM_ASSERT( str1.is_own_memory() == true,  "str.is_own_memory() == true" );
+
+  eos::string str2(data, 0, true);
+  
+  WASM_ASSERT( str2.get_size() == 0,  "str2.get_size() == 0" );
+  WASM_ASSERT( str2.get_data() == nullptr,  "str2.get_data() == nullptr" );
+  WASM_ASSERT( str2.is_own_memory() == false,  "str2.is_own_memory() == false" );
 
   return WASM_TEST_PASS;
 }
@@ -212,6 +232,12 @@ unsigned int test_string::assign() {
     WASM_ASSERT( str[i] == data[i],  "str[i] == data[i]" );
   }
   WASM_ASSERT( str.is_own_memory() == true,  "str.is_own_memory() == true" );
+
+  str.assign(data, 0, true);
+
+  WASM_ASSERT( str.get_size() == 0,  "str.get_size() == 0" );
+  WASM_ASSERT( str.get_data() == nullptr,  "str.get_data() == nullptr" );
+  WASM_ASSERT( str.is_own_memory() == false,  "str.is_own_memory() == false" );
 
   return WASM_TEST_PASS;
 }

--- a/contracts/test_api/test_string.cpp
+++ b/contracts/test_api/test_string.cpp
@@ -291,7 +291,6 @@ unsigned int test_string::print_unicode() {
   return WASM_TEST_PASS;
 }
 
-
 unsigned int test_string::valid_utf8() {
   // Roman alphabet is 1 byte UTF-8
   char data[] = "abcdefghij";
@@ -327,6 +326,31 @@ unsigned int test_string::invalid_utf8() {
   // If it is not multiple of 3, then it is invalid
   eosio::string invalid_chinese_str(chinese_str_data, 5, false);
   assert_is_utf8(invalid_chinese_str.get_data(), invalid_chinese_str.get_size(), "the string should be a valid utf8 string");
+
+  return WASM_TEST_PASS;
+}
+
+
+unsigned int test_string::string_literal() {
+  // Construct
+  char data1[] = "abcdefghij";
+  char data2[] = "klmnopqrstuvwxyz";
+
+  eos::string str = "abcdefghij";
+
+  WASM_ASSERT( str.get_size() == 11,  "data1 str.get_size() == 11" );
+  for (uint8_t i = 0; i < 11; i++) {
+    WASM_ASSERT( str[i] == data1[i],  "data1 str[i] == data1[i]" );
+  }
+  WASM_ASSERT( str.is_own_memory() == true,  "data1 str.is_own_memory() == true" );
+
+  str = "klmnopqrstuvwxyz";
+  
+  WASM_ASSERT( str.get_size() == 17,  "data2 str.get_size() == 17" );
+  for (uint8_t i = 0; i < 17; i++) {
+    WASM_ASSERT( str[i] == data2[i],  "data2 str[i] == data2[i]" );
+  }
+  WASM_ASSERT( str.is_own_memory() == true,  "data2 str.is_own_memory() == true" );
 
   return WASM_TEST_PASS;
 }

--- a/contracts/test_api/test_string.cpp
+++ b/contracts/test_api/test_string.cpp
@@ -5,7 +5,7 @@
 
 unsigned int test_string::construct_with_size() {
 
-   uint32_t size = 100;
+   size_t size = 100;
    eosio::string str(size);
 
    WASM_ASSERT( str.get_size() == size,  "str.get_size() == size" );
@@ -16,7 +16,7 @@ unsigned int test_string::construct_with_size() {
 
 unsigned int test_string::construct_with_data() {
   char data[] = "abcdefghij";
-  uint32_t size = sizeof(data)/sizeof(char);
+  size_t size = sizeof(data)/sizeof(char);
 
   eosio::string str(data, size, false);
 
@@ -29,8 +29,8 @@ unsigned int test_string::construct_with_data() {
 
 unsigned int test_string::construct_with_data_partially() {
   char data[] = "abcdefghij";
-  uint32_t substr_size = 5;
-  uint32_t offset = 2;
+  size_t substr_size = 5;
+  size_t offset = 2;
 
   eosio::string str(data + offset, substr_size, false);
 
@@ -46,7 +46,7 @@ unsigned int test_string::construct_with_data_partially() {
 
 unsigned int test_string::construct_with_data_copied() {
   char data[] = "abcdefghij";
-  uint32_t size = sizeof(data)/sizeof(char);
+  size_t size = sizeof(data)/sizeof(char);
 
   eosio::string str(data, size, true);
 
@@ -62,7 +62,7 @@ unsigned int test_string::construct_with_data_copied() {
 
 unsigned int test_string::copy_constructor() {
   char data[] = "abcdefghij";
-  uint32_t size = sizeof(data)/sizeof(char);
+  size_t size = sizeof(data)/sizeof(char);
 
   eosio::string str1(data, size, true);
 
@@ -79,7 +79,7 @@ unsigned int test_string::copy_constructor() {
 
 unsigned int test_string::assignment_operator() {
   char data[] = "abcdefghij";
-  uint32_t size = sizeof(data)/sizeof(char);
+  size_t size = sizeof(data)/sizeof(char);
 
   eosio::string str1(data, size, true);
 
@@ -97,7 +97,7 @@ unsigned int test_string::assignment_operator() {
 
 unsigned int test_string::index_operator() {
   char data[] = "abcdefghij";
-  uint32_t size = sizeof(data)/sizeof(char);
+  size_t size = sizeof(data)/sizeof(char);
 
   eosio::string str(data, size, false);
 
@@ -110,7 +110,7 @@ unsigned int test_string::index_operator() {
 
 unsigned int test_string::index_out_of_bound() {
   char data[] = "abcdefghij";
-  uint32_t size = sizeof(data)/sizeof(char);
+  size_t size = sizeof(data)/sizeof(char);
 
   eosio::string str(data, size, false);
   char c = str[size];
@@ -120,12 +120,12 @@ unsigned int test_string::index_out_of_bound() {
 
 unsigned int test_string::substring() {
   char data[] = "abcdefghij";
-  uint32_t size = sizeof(data)/sizeof(char);
+  size_t size = sizeof(data)/sizeof(char);
 
   eosio::string str(data, size, false);
 
-  uint32_t substr_size = 5;
-  uint32_t offset = 2;
+  size_t substr_size = 5;
+  size_t offset = 2;
   eosio::string substr = str.substr(offset, substr_size, false);
 
   WASM_ASSERT( substr.get_size() == substr_size,  "str.get_size() == substr_size" );
@@ -140,12 +140,12 @@ unsigned int test_string::substring() {
 
 unsigned int test_string::substring_out_of_bound() {
   char data[] = "abcdefghij";
-  uint32_t size = sizeof(data)/sizeof(char);
+  size_t size = sizeof(data)/sizeof(char);
 
   eosio::string str(data, size, false);
 
-  uint32_t substr_size = size;
-  uint32_t offset = 1;
+  size_t substr_size = size;
+  size_t offset = 1;
   eosio::string substr = str.substr(offset, substr_size, false);
 
   return WASM_TEST_PASS;
@@ -153,11 +153,12 @@ unsigned int test_string::substring_out_of_bound() {
 
 unsigned int test_string::concatenation_null_terminated() {
   char data1[] = "abcdefghij";
-  uint32_t size1 = sizeof(data1)/sizeof(char);
+
+  size_t size1 = sizeof(data1)/sizeof(char);
   eosio::string str1(data1, size1, false);
 
   char data2[] = "klmnoppqrst";
-  uint32_t size2 = sizeof(data2)/sizeof(char);
+  size_t size2 = sizeof(data2)/sizeof(char);
   eosio::string str2(data2, size2, false);
 
   str1 += str2;
@@ -176,11 +177,12 @@ unsigned int test_string::concatenation_null_terminated() {
 
 unsigned int test_string::concatenation_non_null_terminated() {
   char data1[] = {'a','b','c','d','e','f','g','h','i','j'};
-  uint32_t size1 = sizeof(data1)/sizeof(char);
+
+  size_t size1 = sizeof(data1)/sizeof(char);
   eosio::string str1(data1, size1, false);
 
   char data2[] = {'k','l','m','n','o','p','q','r','s','t'};
-  uint32_t size2 = sizeof(data2)/sizeof(char);
+  size_t size2 = sizeof(data2)/sizeof(char);
   eosio::string str2(data2, size2, false);
 
   str1 += str2;
@@ -199,7 +201,7 @@ unsigned int test_string::concatenation_non_null_terminated() {
 
 unsigned int test_string::assign() {
   char data[] = "abcdefghij";
-  uint32_t size = sizeof(data)/sizeof(char);
+  size_t size = sizeof(data)/sizeof(char);
 
   eosio::string str(100);
   str.assign(data, size, true);
@@ -217,35 +219,35 @@ unsigned int test_string::assign() {
 
 unsigned int test_string::comparison_operator() {
   char data1[] = "abcdefghij";
-  uint32_t size1 = sizeof(data1)/sizeof(char);
+  size_t size1 = sizeof(data1)/sizeof(char);
   eosio::string str1(data1, size1, false);
 
   char data2[] = "abcdefghij";
-  uint32_t size2 = sizeof(data2)/sizeof(char);
+  size_t size2 = sizeof(data2)/sizeof(char);
   eosio::string str2(data2, size2, false);
 
   char data3[] = "klmno";
-  uint32_t size3 = sizeof(data3)/sizeof(char);
+  size_t size3 = sizeof(data3)/sizeof(char);
   eosio::string str3(data3, size3, false);
 
   char data4[] = "aaaaaaaaaaaaaaa";
-  uint32_t size4 = sizeof(data4)/sizeof(char);
+  size_t size4 = sizeof(data4)/sizeof(char);
   eosio::string str4(data4, size4, false);
 
   char data5[] = "你好";
-  uint32_t size5 = sizeof(data5)/sizeof(char);
+  size_t size5 = sizeof(data5)/sizeof(char);
   eosio::string str5(data5, size5, false);
 
   char data6[] = "你好嗎？";
-  uint32_t size6 = sizeof(data6)/sizeof(char);
+  size_t size6 = sizeof(data6)/sizeof(char);
   eosio::string str6(data6, size6, false);
 
   char data7[] = {'a', 'b', 'c', 'd', 'e'};
-  uint32_t size7 = sizeof(data7)/sizeof(char);
+  size_t size7 = sizeof(data7)/sizeof(char);
   eosio::string str7(data7, size7, false);
 
   char data8[] = {'a', 'b', 'c'};
-  uint32_t size8 = sizeof(data8)/sizeof(char);
+  size_t size8 = sizeof(data8)/sizeof(char);
   eosio::string str8(data8, size8, false);
 
   WASM_ASSERT( str1 == str2,  "str1 == str2" );
@@ -263,7 +265,8 @@ unsigned int test_string::comparison_operator() {
 
 unsigned int test_string::print_null_terminated() {
   char data[] = "Hello World!";
-  uint32_t size = sizeof(data)/sizeof(char);
+
+  size_t size = sizeof(data)/sizeof(char);
   eosio::string str(data, size, false);
 
   eosio::print(str);
@@ -273,7 +276,8 @@ unsigned int test_string::print_null_terminated() {
 
 unsigned int test_string::print_non_null_terminated() {
   char data[] = {'H', 'e', 'l', 'l', 'o', ' ', 'W', 'o', 'r', 'l', 'd', '!'};
-  uint32_t size = sizeof(data)/sizeof(char);
+
+  size_t size = sizeof(data)/sizeof(char);
   eosio::string str(data, size, false);
 
   eosio::print(str);
@@ -283,7 +287,8 @@ unsigned int test_string::print_non_null_terminated() {
 
 unsigned int test_string::print_unicode() {
   char data[] = "你好，世界！";
-  uint32_t size = sizeof(data)/sizeof(char);
+
+  size_t size = sizeof(data)/sizeof(char);
   eosio::string str(data, size, false);
 
   eosio::print(str);

--- a/tests/api_tests/api_tests.cpp
+++ b/tests/api_tests/api_tests.cpp
@@ -458,7 +458,8 @@ BOOST_FIXTURE_TEST_CASE(test_all, testing_fixture)
       BOOST_CHECK_EQUAL( capture[0], "你好，世界！");
       BOOST_CHECK_MESSAGE( CALL_TEST_FUNCTION( TEST_METHOD("test_string", "valid_utf8"), {}, {} ) == WASM_TEST_PASS, "test_string::valid_utf8()" );
       BOOST_CHECK_EXCEPTION( CALL_TEST_FUNCTION( TEST_METHOD("test_string", "invalid_utf8"), {}, {} ), fc::assert_exception, is_assert_exception );
-      
+      BOOST_CHECK_MESSAGE( CALL_TEST_FUNCTION( TEST_METHOD("test_string", "string_literal"), {}, {} ) == WASM_TEST_PASS, "test_string::string_literal()" );
+
 } FC_LOG_AND_RETHROW() }
 
 #define RUN_CODE_HANDLER_WITH_TRANSFER(account_name, test_wast)                                            \


### PR DESCRIPTION
While writing smart contract, I find the following things to be improved for the string class

1. It is inconvenient to use the string class without support for string literal, i.e.
```
char[] data = "Hello World!";
uint32_t size = sizeof(data)/sizeof(char);
eos::string str(data, size, true);

vs

eos::string str = "Hello World!";
```
So support for string literal is added here

2. Add support for string with size 0. Previously, passing size 0 to the string constructor/ assign will throw an exception which cause problem when unpacking empty string. 

3. Use size_t instead of uint32_t for string's size to match datastream's `inline bool write( const char* d, size_t s )` function. Otherwise, there will be problem in packing when size of string is bigger than size_t.

STAT-112
STAT-120
