### PR TITLE
Use eos for fake producer of Block 0. STAT-106

### DIFF
--- a/libraries/chain/chain_controller.cpp
+++ b/libraries/chain/chain_controller.cpp
@@ -1229,6 +1229,7 @@ void chain_controller::initialize_chain(chain_initializer_interface& starter)
 
          // create a dummy block and cycle for our dummy transactions to send to applied_irreversible_block below
          signed_block block{};
+         block.producer = config::EosContractName;
          block.cycles.emplace_back();
          block.cycles[0].emplace_back();
 

--- a/plugins/db_plugin/db_plugin.cpp
+++ b/plugins/db_plugin/db_plugin.cpp
@@ -273,7 +273,7 @@ void db_plugin_impl::_process_irreversible_block(const signed_block& block)
          FC_ASSERT(block_num < 2, "Expected start of block, instead received block_num: ${bn}", ("bn", block_num));
          // Currently we are creating a 'fake' block in chain_controller::initialize_chain() since initial accounts
          // and producers are not written to the block log. If this is the fake block, indicate it as block_num 0.
-         if (block_num == 1 && block.producer == AccountName{}) {
+         if (block_num == 1 && block.producer == config::EosContractName) {
             block_num = 0;
          }
       } else {


### PR DESCRIPTION
Use "eos" as the block.producer_account_id in mongodb since producer_account_id is marked as a required attribute.