### PR TITLE
fix for corner condition of last irreversible block number 0

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -1597,7 +1597,7 @@ namespace eos {
     }
     bool accepted = false;
     // dlog ("last irrevesible block = ${lib}", ("lib", cc.last_irreversible_block_num()));
-    if( !syncing || num == cc.head_block_num()+1 ){ //  || num > cc.last_irreversible_block_num()) {
+    if( !syncing || num == cc.head_block_num()+1 ) {
       try {
         chain_plug->accept_block(msg, syncing);
         accepted = true;

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -616,7 +616,8 @@ namespace eos {
     uint32_t lib_num;
     try {
       lib_num = cc.last_irreversible_block_num();
-      lib_id = cc.get_block_id_for_num(lib_num);
+      if (lib_num > 0)
+        lib_id = cc.get_block_id_for_num(lib_num);
       head_id = cc.get_block_id_for_num (head_num);
     }
     catch (const assert_exception &ex) {
@@ -1219,7 +1220,7 @@ namespace eos {
       if( msg.last_irreversible_block_num  > head || sync_master->syncing() ) {
         sync_master->start_sync( c, peer_lib );
       }
-      else if( msg.head_id != head_id && msg.head_id != block_id_type( )) {
+      else if( msg.head_id != head_id ) { // && msg.head_id != block_id_type( )) {
         // dlog ("msg.head_id = ${m} our head = ${h}",("m",msg.head_id)("h",head_id));
 
         notice_message note;
@@ -1355,12 +1356,13 @@ namespace eos {
     }
 
     void net_plugin_impl::handle_message( connection_ptr c, const request_message &msg) {
-      // dlog ("got a request_message from ${p}", ("p",c->peer_name()));
       switch (msg.req_blocks.mode) {
       case id_list_modes::catch_up :
+        // dlog ("got a catch up request_message from ${p}", ("p",c->peer_name()));
         c->blk_send_branch( msg.req_trx.ids );
         break;
       case id_list_modes::normal :
+        // dlog ("got a normal request_message from ${p}", ("p",c->peer_name()));
         c->blk_send(msg.req_blocks.ids);
         break;
       default:;

--- a/programs/launcher/main.cpp
+++ b/programs/launcher/main.cpp
@@ -232,6 +232,7 @@ struct launcher_def {
   string alias_base;
   vector <string> aliases;
   last_run_def last_run;
+  int start_delay;
 
   void set_options (bpo::options_description &cli);
   void initialize (const variables_map &vmap);
@@ -261,6 +262,7 @@ launcher_def::set_options (bpo::options_description &cli) {
     ("output,o",bpo::value<bf::path>(),"save a copy of the generated topology in this file")
     ("skip-signature", bpo::bool_switch()->default_value(false), "EOSD does not require transaction signatures.")
     ("eosd", bpo::value<string>(), "forward eosd command line argument(s) to each instance of eosd, enclose arg in quotes")
+    ("delay,d",bpo::value<int>()->default_value(0),"seconds delay before starting each node after the first")
         ;
 }
 
@@ -280,6 +282,8 @@ launcher_def::initialize (const variables_map &vmap) {
     skip_transaction_signatures = vmap["skip-signature"].as<bool>();
   if (vmap.count("eosd"))
     eosd_extra_args = vmap["eosd"].as<string>();
+  if (vmap.count("delay"))
+    start_delay = vmap["delay"].as<int>();
 
   producers = 21;
   data_dir_base = "tn_data_";
@@ -707,6 +711,7 @@ launcher_def::start_all (string &gts, launch_modes mode) {
       }
     }
     launch (node.second, gts);
+    sleep (start_delay);
   }
   bf::path savefile = "last_run.json";
   bf::ofstream sf (savefile);

--- a/tests/p2p_tests/sync/test.sh
+++ b/tests/p2p_tests/sync/test.sh
@@ -3,7 +3,7 @@
 pnodes=10
 npnodes=0
 topo=star
-delay=1
+delay=0
 
 args=`getopt p:n:t:d: $*`
 if [ $? == 0 ]; then

--- a/tests/p2p_tests/sync/test.sh
+++ b/tests/p2p_tests/sync/test.sh
@@ -3,20 +3,43 @@
 pnodes=10
 npnodes=0
 topo=star
-if [ -n "$1" ]; then
-    pnodes=$1
-    if [ -n "$2" ]; then
-        topo=$2
-        if [ -n "$3" ]; then
-            npnodes=$3
+delay=1
+
+args=`getopt p:n:t:d: $*`
+if [ $? == 0 ]; then
+
+    set -- $args
+    for i; do
+        case "$i"
+        in
+            -p) pnodes=$2;
+                shift; shift;;
+            -n) nodes=$2;
+                shift; shift;;
+            -d) delay=$2;
+                shift; shift;;
+            -s) shape="$2";
+                shift; shift;;
+            --) shift;
+                break;;
+        esac
+    done
+else
+    echo "huh we got err $?"
+    if [ -n "$1" ]; then
+        pnodes=$1
+        if [ -n "$2" ]; then
+            topo=$2
+            if [ -n "$3" ]; then
+                npnodes=$3
+            fi
         fi
     fi
 fi
-
 total_nodes=`expr $pnodes + $npnodes`
 
 rm -rf tn_data_*
-programs/launcher/launcher -p $pnodes -n $total_nodes -s $topo
+programs/launcher/launcher -p $pnodes -n $total_nodes -s $topo -d $delay
 sleep 7
 echo "start" > test.out
 port=8888
@@ -62,4 +85,5 @@ if [ $lines -eq $total_nodes -a $prodsfound -eq 1 ]; then
     exit
 fi
 echo ERROR: $lines reports out of $total_nodes and prods = $prodsfound
+programs/launcher/launcher -k 15
 exit 1


### PR DESCRIPTION
Here's the fix for the sync stink. Turns out there were 2 errors related to the corner case of a new producer trying to synch while the last irreversible block is 0. First, when trying to initialize a "pending" block chain from LIB to current head, trying to fetch the block id for block 0, an exception was tossed, which caused a second lookup to be skipped. 

The other error was that when processing the handshake message, I was excluding a catch up step if the peer's head block was also 0,  fixing these make syncing work like butter.

I also added a startup delay argument to the launcher command line and refactored the p2p sync test to forward a value to that. 

As a final manual test I started 10 producers with empty block data directories and slowly started them in a random order that included a couple that had no direct connections between them. They all synched up just fine.