### PR TITLE
fix for corner condition of last irreversible block number 0 #651

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,4 +37,5 @@ script:
   - tests/slow_test
   - tests/api_test
   - tests/p2p_tests/sync/test.sh
+  - tests/p2p_tests/sync/test.sh -p 2 -d 10
   - tests/eosd_run_mongodb_test.sh

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -411,7 +411,7 @@ namespace eosio {
      *
      * This method is called to adjust the size of the
      * pending_message_buffer when there is a partial message
-     * in the buffer of message_length. There may be 
+     * in the buffer of message_length. There may be
      * additional messages earlier in the buffer that
      * can be removed
      */
@@ -423,7 +423,7 @@ namespace eosio {
      * message_length is the already determined length of the data
      * part of the message and impl in the net plugin implementation
      * that will handle the message.
-     * Returns true is successful. Returns false if an error was 
+     * Returns true is successful. Returns false if an error was
      * encountered unpacking or processing the message.
      */
     bool process_next_message(net_plugin_impl& impl, uint32_t message_length);
@@ -688,7 +688,8 @@ namespace eosio {
     uint32_t lib_num;
     try {
       lib_num = cc.last_irreversible_block_num();
-      lib_id = cc.get_block_id_for_num(lib_num);
+      if( lib_num != 0 )
+        lib_id = cc.get_block_id_for_num(lib_num);
       head_id = cc.get_block_id_for_num (head_num);
     }
     catch (const assert_exception &ex) {
@@ -935,9 +936,9 @@ namespace eosio {
 
   void connection::adjust_buffer_size(uint32_t message_length) {
     uint32_t current_buffer_size = pending_message_buffer.size();
-    if (current_buffer_size - pending_message_read_index + 1 < message_length) 
+    if (current_buffer_size - pending_message_read_index + 1 < message_length)
 
-      // Not enough room in the buffer, grow the buffer, first move remaining 
+      // Not enough room in the buffer, grow the buffer, first move remaining
       // unprocessed data to the beginning of the buffer
       if (pending_message_read_index != 0) {
         memmove(&pending_message_buffer[0],
@@ -1235,7 +1236,7 @@ namespace eosio {
             connection_ptr conn = c.lock();
             if (!conn) {
               return;
-            } 
+            }
             conn->pending_message_write_index += bytes_transferred;
             while (conn->pending_message_read_index < conn->pending_message_write_index) {
               uint32_t bytes_in_buffer = conn->pending_message_write_index - conn->pending_message_read_index;
@@ -1357,7 +1358,7 @@ namespace eosio {
       if( msg.last_irreversible_block_num  > head || sync_master->syncing() ) {
         sync_master->start_sync( c, peer_lib );
       }
-      else if( msg.head_id != head_id && msg.head_id != block_id_type( )) {
+      else if( msg.head_id != head_id ) {
         fc_dlog(logger, "msg.head_id = ${m} our head = ${h}",("m",msg.head_id)("h",head_id));
 
         notice_message note;
@@ -1494,12 +1495,13 @@ namespace eosio {
     }
 
     void net_plugin_impl::handle_message( connection_ptr c, const request_message &msg) {
-      fc_dlog(logger, "got a request_message from ${p}", ("p",c->peer_name()));
       switch (msg.req_blocks.mode) {
       case id_list_modes::catch_up :
+        fc_dlog(logger, "got a catch_up request_message from ${p}", ("p",c->peer_name()));
         c->blk_send_branch( msg.req_trx.ids );
         break;
       case id_list_modes::normal :
+        fc_dlog(logger, "got a normal request_message from ${p}", ("p",c->peer_name()));
         c->blk_send(msg.req_blocks.ids);
         break;
       default:;

--- a/programs/launcher/main.cpp
+++ b/programs/launcher/main.cpp
@@ -232,6 +232,7 @@ struct launcher_def {
   string alias_base;
   vector <string> aliases;
   last_run_def last_run;
+  int start_delay;
 
   void set_options (bpo::options_description &cli);
   void initialize (const variables_map &vmap);
@@ -261,6 +262,7 @@ launcher_def::set_options (bpo::options_description &cli) {
     ("output,o",bpo::value<bf::path>(),"save a copy of the generated topology in this file")
     ("skip-signature", bpo::bool_switch()->default_value(false), "EOSD does not require transaction signatures.")
     ("eosd", bpo::value<string>(), "forward eosd command line argument(s) to each instance of eosd, enclose arg in quotes")
+    ("delay,d",bpo::value<int>()->default_value(0),"seconds delay before starting each node after the first")
         ;
 }
 
@@ -280,6 +282,8 @@ launcher_def::initialize (const variables_map &vmap) {
     skip_transaction_signatures = vmap["skip-signature"].as<bool>();
   if (vmap.count("eosd"))
     eosd_extra_args = vmap["eosd"].as<string>();
+  if (vmap.count("delay"))
+    start_delay = vmap["delay"].as<int>();
 
   producers = 21;
   data_dir_base = "tn_data_";
@@ -708,6 +712,7 @@ launcher_def::start_all (string &gts, launch_modes mode) {
       }
     }
     launch (node.second, gts);
+    sleep (start_delay);
   }
   bf::path savefile = "last_run.json";
   bf::ofstream sf (savefile);

--- a/tests/p2p_tests/sync/test.sh
+++ b/tests/p2p_tests/sync/test.sh
@@ -3,20 +3,43 @@
 pnodes=10
 npnodes=0
 topo=star
-if [ -n "$1" ]; then
-    pnodes=$1
-    if [ -n "$2" ]; then
-        topo=$2
-        if [ -n "$3" ]; then
-            npnodes=$3
+delay=0
+
+args=`getopt p:n:t:d: $*`
+if [ $? == 0 ]; then
+
+    set -- $args
+    for i; do
+        case "$i"
+        in
+            -p) pnodes=$2;
+                shift; shift;;
+            -n) nodes=$2;
+                shift; shift;;
+            -d) delay=$2;
+                shift; shift;;
+            -s) shape="$2";
+                shift; shift;;
+            --) shift;
+                break;;
+        esac
+    done
+else
+    echo "huh we got err $?"
+    if [ -n "$1" ]; then
+        pnodes=$1
+        if [ -n "$2" ]; then
+            topo=$2
+            if [ -n "$3" ]; then
+                npnodes=$3
+            fi
         fi
     fi
 fi
-
 total_nodes=`expr $pnodes + $npnodes`
 
 rm -rf tn_data_*
-programs/launcher/launcher -p $pnodes -n $total_nodes -s $topo
+programs/launcher/launcher -p $pnodes -n $total_nodes -s $topo -d $delay
 sleep 7
 echo "start" > test.out
 port=8888
@@ -62,4 +85,5 @@ if [ $lines -eq $total_nodes -a $prodsfound -eq 1 ]; then
     exit
 fi
 echo ERROR: $lines reports out of $total_nodes and prods = $prodsfound
+programs/launcher/launcher -k 15
 exit 1


### PR DESCRIPTION
This is the same change as #650 but applied to the current master so as to avoid a massive rebase effort. Here's the original comment, which still applies.

Here's the fix for the sync stink. Turns out there were 2 errors related to the corner case of a new producer trying to synch while the last irreversible block is 0. First, when trying to initialize a "pending" block chain from LIB to current head, trying to fetch the block id for block 0, an exception was tossed, which caused a second lookup to be skipped.

The other error was that when processing the handshake message, I was excluding a catch up step if the peer's head block was also 0, fixing these make syncing work like butter.

I also added a startup delay argument to the launcher command line and refactored the p2p sync test to forward a value to that.

As a final manual test I started 10 producers with empty block data directories and slowly started them in a random order that included a couple that had no direct connections between them. They all synched up just fine.