### PR TITLE
STAT-118 (GH-618): Use Scatter/Gather for reads

### DIFF
--- a/plugins/net_plugin/include/eos/net_plugin/message_buffer.hpp
+++ b/plugins/net_plugin/include/eos/net_plugin/message_buffer.hpp
@@ -1,8 +1,11 @@
+/**
+ *  @file
+ *  @copyright defined in eos/LICENSE.txt
+ */
 #pragma once
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/pool/object_pool.hpp>
 #include <fc/io/raw.hpp>
-#include <iostream>
 #include <deque>
 #include <array>
 
@@ -138,17 +141,6 @@ namespace eosio {
      */
     void advance_write_ptr(uint32_t bytes) {
       advance_index(write_ind, bytes);
-    }
-
-    /*
-     *  Debug function that will print the state of the message buffer
-     *  to standard out.
-     */
-    void show_state() const {
-      std::cout << "Number of buffers = " << buffers.size() << "\n"
-                << "Size of buffers   = " << buffer_len << "\n"
-                << "Write Index       = " << write_ind.first << ", " << write_ind.second << "\n"
-                << "Read Index        = " << read_ind.first << ", " << read_ind.second << std::endl;
     }
 
     /*

--- a/plugins/net_plugin/include/eos/net_plugin/message_buffer.hpp
+++ b/plugins/net_plugin/include/eos/net_plugin/message_buffer.hpp
@@ -1,0 +1,278 @@
+#pragma once
+#include <boost/asio/ip/tcp.hpp>
+#include <boost/pool/object_pool.hpp>
+#include <fc/io/raw.hpp>
+#include <iostream>
+#include <deque>
+#include <array>
+
+namespace eosio {
+
+  template <uint32_t buffer_len>
+  class mb_datastream;
+
+  /**
+   *  @brief abstraction for a message buffer that spans a chain of physical buffers
+   *
+   *  This message buffer abstraction will allocate individual character arrays
+   *  of size buffer_len from a boost::object_pool.  It supports creation of a
+   *  vector of boost::mutable_buffer for use with async_read() and async_read_some().
+   *  It also supports use with the fc unpack() functionality via a datastream
+   *  helper class.
+   */
+  template <uint32_t buffer_len>
+  class message_buffer {
+  public:
+    /*
+     *  index abstraction that references a point in the chain of buffers.
+     *  first refers to the buffer's index in the deque.
+     *  second refers to the byte in the character buffer.
+     */
+    typedef std::pair<uint32_t, uint32_t> index_t;
+
+    message_buffer() : buffers{pool().malloc()}, read_ind{0,0}, write_ind{0,0} { }
+
+    /*
+     *  Returns the current read index referencing the byte in the buffer
+     *  that is next to be read.
+     */
+    index_t read_index() const { return read_ind; }
+
+    /*
+     *  Returns the current write index referencing the byte in the buffer
+     *  that is next to be written to.
+     */
+    index_t write_index() const { return write_ind; }
+
+    /*
+     *  Returns the current read pointer pointing to the memory location
+     *  of the next byte to be read.
+     */
+    char* read_ptr() {
+      return &buffers[read_ind.first]->at(read_ind.second);
+    }
+
+    /*
+     *  Returns the current write pointer pointing to the memory location
+     *  of the next byte to be written to.
+     */
+    char* write_ptr() {
+      return &buffers[write_ind.first]->at(write_ind.second);
+    }
+
+    /*
+     *  Adds an additional buffer of buffer_len to the chain of buffers.
+     *  Does not affect the read or write pointer.
+     */
+    void add_buffer_to_chain() {
+      buffers.push_back(pool().malloc());
+    }
+
+    /*
+     *  Adds additional buffers of length buffer_len to the chain of buffers
+     *  in order to add at least bytes to the space available.
+     *  Does not affect the read or write pointer.
+     */
+    void add_space(uint32_t bytes) {
+      int buffers_to_add = bytes / buffer_len + 1;
+      for (int i = 0; i < buffers_to_add; i++) {
+        buffers.push_back(pool().malloc());
+      }
+    }
+
+    /*
+     *  Returns the current number of bytes remaining to be read.
+     *  Logically, this is the different between where the read and write pointers are.
+     */
+    uint32_t bytes_to_read() const {
+      return (write_ind.first - read_ind.first) * buffer_len + write_ind.second - read_ind.second;
+    }
+
+    /*
+     *  Returns the current number of bytes available to be written.
+     *  Logically, this is the different between the write pointer and the
+     *  end of the buffer.  If this is not enough room, call either
+     *  add_buffer_to_chain() or add_room() to create more space.
+     */
+    uint32_t bytes_to_write() const {
+      return total_bytes() - write_ind.first * buffer_len - write_ind.second;
+    }
+
+    /*
+     *  Returns the total number of bytes in the buffer chain.
+     */
+    uint32_t total_bytes() const {
+      return buffer_len * buffers.size();
+    }
+
+    /*
+     *  Advances the read pointer/index the supplied number of bytes along
+     *  the buffer chain.  Any buffers that the read pointer moves beyond
+     *  will be removed from the buffer chain.  If the read pointer becomes
+     *  equal to the write pointer, the message buffer will be reset to
+     *  its initial state (one buffer with read and write pointers at the
+     *  start).
+     */
+    void advance_read_ptr(uint32_t bytes) {
+      advance_index(read_ind, bytes);
+      if (read_ind == write_ind) {
+        read_ind = { 0, 0 };
+        write_ind = { 0, 0 };
+        while (buffers.size() > 1) {
+          pool().destroy(buffers.back());
+          buffers.pop_back();
+        }
+      } else if (read_ind.first > 0) {
+        while (read_ind.first > 0) {
+          pool().destroy(buffers.front());
+          buffers.pop_front();
+          read_ind.first--;
+          write_ind.first--;
+        }
+      }
+    }
+
+    /*
+     *  Advances the write pointer/index the supplied number of bytes along
+     *  the buffer chain.
+     */
+    void advance_write_ptr(uint32_t bytes) {
+      advance_index(write_ind, bytes);
+    }
+
+    /*
+     *  Debug function that will print the state of the message buffer
+     *  to standard out.
+     */
+    void show_state() const {
+      std::cout << "Number of buffers = " << buffers.size() << "\n"
+                << "Size of buffers   = " << buffer_len << "\n"
+                << "Write Index       = " << write_ind.first << ", " << write_ind.second << "\n"
+                << "Read Index        = " << read_ind.first << ", " << read_ind.second << std::endl;
+    }
+
+    /*
+     *  Creates and returns a vector of boost mutable_buffers that can
+     *  be passed to boost async_read() and async_read_some() functions.
+     *  The beginning of the vector will be the write pointer, which
+     *  should be advanced the number of bytes read after the read returns.
+     */
+    std::vector<boost::asio::mutable_buffer> get_buffer_sequence_for_boost_async_read() {
+      std::vector<boost::asio::mutable_buffer> seq;
+      seq.push_back(boost::asio::buffer(&buffers[write_ind.first]->at(write_ind.second),
+                                                buffer_len - write_ind.second));
+      for (std::size_t i = write_ind.first + 1; i < buffers.size(); i++) {
+        seq.push_back(boost::asio::buffer(&buffers[i]->at(0), buffer_len));
+      }
+      return seq;
+    }
+
+    /*
+     *  Reads size bytes from the buffer chain starting at the read pointer.
+     *  The read pointer is advanced size bytes.
+     */
+    bool read(void* s, uint32_t size) {
+      if (bytes_to_read() < size) {
+        return false;
+      }
+      if (read_ind.second + size < buffer_len) {
+        memcpy(s, read_ptr(), size);
+        advance_read_ptr(size);
+      } else {
+        uint32_t num_in_buffer = buffer_len - read_ind.second;
+        memcpy(s, read_ptr(), num_in_buffer);
+        advance_read_ptr(num_in_buffer);
+        read((char*)s + num_in_buffer, size - num_in_buffer);
+      }
+      return true;
+    }
+
+    /*
+     *  Reads size bytes from the buffer chain starting at the supplied index.
+     *  The read pointer is not advanced.
+     */
+    bool peek(void* s, uint32_t size, index_t index) {
+      if (bytes_to_read() < size) {
+        return false;
+      }
+      if (index.second + size < buffer_len) {
+        memcpy(s, get_ptr(index), size);
+        advance_index(index, size);
+      } else {
+        uint32_t num_in_buffer = buffer_len - index.second;
+        memcpy(s, get_ptr(index), num_in_buffer);
+        advance_index(index, num_in_buffer);
+        peek((char*)s + num_in_buffer, size - num_in_buffer, index);
+      }
+      return true;
+    }
+
+    /*
+     *  Creates an mb_datastream object that can be used with the
+     *  fc library's unpack functionality.
+     */
+    mb_datastream<buffer_len> create_datastream();
+
+  private:
+    static boost::object_pool<std::array<char, buffer_len> >& pool() {
+      static boost::object_pool<std::array<char, buffer_len> > pool;
+      return pool;
+    }
+
+    /*
+     *  Advances the supplied index along the buffer chain the specified
+     *  number of bytes.
+     */
+    static void advance_index(index_t& index, uint32_t bytes) {
+      index.first += (bytes + index.second) / buffer_len;
+      index.second = (bytes + index.second) % buffer_len;
+    }
+
+    /*
+     *  Returns the character pointer associated with the supplied index.
+     */
+    char* get_ptr(index_t index) {
+      return &buffers[index.first]->at(index.second);
+    }
+
+    std::deque<std::array<char, buffer_len>* > buffers;
+    index_t read_ind;
+    index_t write_ind;
+  };
+
+
+
+  /*
+   *  @brief datastream adapter that adapts message_buffer for use with fc unpack
+   *
+   *  This class supports unpack functionality but not pack.
+   */
+  // Stream adapter for use with the fc unpack functionality
+  template <uint32_t buffer_len>
+  class mb_datastream {
+     public:
+        mb_datastream( message_buffer<buffer_len>& m ) : mb(m) {}
+
+        inline void skip( size_t s ) { mb.advance_read_ptr(s); }
+        inline bool read( char* d, size_t s ) {
+          if (mb.bytes_to_read() >= s) {
+            mb.read(d, s);
+            return true;
+          }
+          fc::detail::throw_datastream_range_error( "read", mb.bytes_to_read(), s - mb.bytes_to_read());
+        }
+
+        inline bool   get( unsigned char& c ) { return mb.read(&c, 1); }
+        inline bool   get( char& c ) { return mb.read(&c, 1); }
+
+      private:
+        message_buffer<buffer_len>& mb;
+  };
+
+  template <uint32_t buffer_len>
+  inline mb_datastream<buffer_len> message_buffer<buffer_len>::create_datastream() {
+    return mb_datastream<buffer_len>(*this);
+  }
+
+} // namespace eosio
+

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -209,8 +209,8 @@ namespace eosio {
   /**
    * default value initializers
    */
-  constexpr auto     def_buffer_size_mb = 4;
-  constexpr auto     def_buffer_size = 1024*1024*def_buffer_size_mb;
+  constexpr auto     def_send_buffer_size_mb = 4;
+  constexpr auto     def_send_buffer_size = 1024*1024*def_send_buffer_size_mb;
   constexpr auto     def_max_clients = 20; // 0 for unlimited clients
   constexpr auto     def_conn_retry_wait = std::chrono::seconds (30);
   constexpr auto     def_txn_expire_wait = std::chrono::seconds (3);
@@ -293,10 +293,10 @@ namespace eosio {
   class connection : public std::enable_shared_from_this<connection> {
   public:
     connection( string endpoint,
-                size_t send_buf_size = def_buffer_size );
+                size_t send_buf_size = def_send_buffer_size );
 
     connection( socket_ptr s,
-                size_t send_buf_size = def_buffer_size );
+                size_t send_buf_size = def_send_buffer_size );
     ~connection();
     void initialize ();
 
@@ -306,7 +306,7 @@ namespace eosio {
     sync_state_ptr          sync_requested;  // this peer is requesting info from us
     socket_ptr              socket;
 
-    message_buffer<def_buffer_size>  pending_message_buffer;
+    message_buffer<4096>    pending_message_buffer;
     vector<char>            send_buffer;
     vector<char>            blk_buffer;
 

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -6,6 +6,7 @@
 
 #include <eos/net_plugin/net_plugin.hpp>
 #include <eos/net_plugin/protocol.hpp>
+#include <eos/net_plugin/message_buffer.hpp>
 #include <eos/chain/chain_controller.hpp>
 #include <eos/chain/exceptions.hpp>
 #include <eos/chain/block.hpp>
@@ -292,12 +293,10 @@ namespace eosio {
   class connection : public std::enable_shared_from_this<connection> {
   public:
     connection( string endpoint,
-                size_t send_buf_size = def_buffer_size,
-                size_t recv_buf_size = def_buffer_size );
+                size_t send_buf_size = def_buffer_size );
 
     connection( socket_ptr s,
-                size_t send_buf_size = def_buffer_size,
-                size_t recv_buf_size = def_buffer_size );
+                size_t send_buf_size = def_buffer_size );
     ~connection();
     void initialize ();
 
@@ -307,19 +306,7 @@ namespace eosio {
     sync_state_ptr          sync_requested;  // this peer is requesting info from us
     socket_ptr              socket;
 
-    //#warning ("TODO: Rework Message Caching for efficiency")
-    // WHat I mean here is that incoming data should be read in chunks that are as
-    // large as possible. We can query the recv buffer size. When using async_read_some(),
-    // we will frequently end a read in the middle of a message. That could happen with
-    // small messages, in which a simple "normalize" call could reset the buffer and allow a
-    // subsequent read to pick up the rest. In the case of very large messages, we should allow
-    // for the creation of a secondary buffer big enough to hold the entire message. Better
-    // still would be to have a mempool class that has a series of fixed size blocks that can
-    // be used scatter-gather style.
-
-    vector<char>            pending_message_buffer;
-    uint32_t                pending_message_write_index;
-    uint32_t                pending_message_read_index;
+    message_buffer<def_buffer_size>  pending_message_buffer;
     vector<char>            send_buffer;
     vector<char>            blk_buffer;
 
@@ -407,16 +394,6 @@ namespace eosio {
     void sync_timeout (boost::system::error_code ec);
     void fetch_timeout (boost::system::error_code ec);
 
-    /** \brief Adjust the pending message buffer
-     *
-     * This method is called to adjust the size of the
-     * pending_message_buffer when there is a partial message
-     * in the buffer of message_length. There may be
-     * additional messages earlier in the buffer that
-     * can be removed
-     */
-    void adjust_buffer_size(uint32_t message_length);
-
     /** \brief Process the next message from the pending message buffer
      *
      * Process the next message from the pending_message_buffer.
@@ -434,26 +411,6 @@ namespace eosio {
 
   const fc::string connection::logger_name("connection");
   fc::logger connection::logger(connection::logger_name);
-
-  struct precache : public fc::visitor<void> {
-    connection_ptr c;
-    size_t message_size;
-    precache( connection_ptr conn, size_t msg_size) : c(conn), message_size(msg_size) {}
-
-    void operator()(const signed_block &msg) const
-    {
-      c->blk_buffer.resize(message_size);
-      memcpy(c->blk_buffer.data(),
-             &c->pending_message_buffer[c->pending_message_read_index+message_header_size],
-             message_size);
-    }
-
-    template <typename T>
-    void operator()(const T &msg) const
-    {
-      //no-op
-    }
-  };
 
   struct msgHandler : public fc::visitor<void> {
     net_plugin_impl &impl;
@@ -499,16 +456,12 @@ namespace eosio {
   //---------------------------------------------------------------------------
 
   connection::connection( string endpoint,
-                          size_t send_buf_size,
-                          size_t recv_buf_size )
+                          size_t send_buf_size )
       : block_state(),
         trx_state(),
         sync_receiving(),
         sync_requested(),
         socket( std::make_shared<tcp::socket>( std::ref( app().get_io_service() ))),
-        pending_message_buffer(recv_buf_size),
-        pending_message_write_index(0),
-        pending_message_read_index(0),
         send_buffer(send_buf_size),
         node_id(),
         last_handshake(),
@@ -526,16 +479,12 @@ namespace eosio {
     }
 
   connection::connection( socket_ptr s,
-                          size_t send_buf_size,
-                          size_t recv_buf_size )
+                          size_t send_buf_size )
       : block_state(),
         trx_state(),
         sync_receiving(),
         sync_requested(),
         socket( s ),
-        pending_message_buffer(recv_buf_size),
-        pending_message_write_index(0),
-        pending_message_read_index(0),
         send_buffer(send_buf_size),
         node_id(),
         last_handshake(),
@@ -934,41 +883,21 @@ namespace eosio {
     }
   }
 
-  void connection::adjust_buffer_size(uint32_t message_length) {
-    uint32_t current_buffer_size = pending_message_buffer.size();
-    if (current_buffer_size - pending_message_read_index + 1 < message_length)
-
-      // Not enough room in the buffer, grow the buffer, first move remaining
-      // unprocessed data to the beginning of the buffer
-      if (pending_message_read_index != 0) {
-        memmove(&pending_message_buffer[0],
-                &pending_message_buffer[pending_message_read_index],
-                pending_message_write_index - pending_message_read_index);
-        pending_message_write_index -= pending_message_read_index;
-        pending_message_read_index = 0;
-      }
-
-
-      // See if we need to grow the buffer or if there is enough space now.
-      uint32_t bytes_needed = message_length - current_buffer_size - pending_message_read_index + 1;
-      if (bytes_needed > 0) {
-        // Grow the buffer by some multiplier of the current size.
-        // Note that the buffer size will never shrink in the current implementation.
-        // The eventual solution will be to use a chain of buffers using scatter/gather
-        uint32_t multiplier = (bytes_needed / current_buffer_size) + 2;
-        uint32_t new_size = current_buffer_size * multiplier;
-        pending_message_buffer.resize(new_size);
-      }
-    }
-
   bool connection::process_next_message(net_plugin_impl& impl, uint32_t message_length) {
     try {
-      fc::datastream<const char*> ds(&pending_message_buffer[pending_message_read_index + message_header_size],
-                                     message_length);
+      // If it is a signed_block, then save the raw message for the cache
+      // This must be done before we unpack the message.
+      unsigned_int which;
+      auto index = pending_message_buffer.read_index();
+      pending_message_buffer.peek(&which, sizeof(unsigned_int), index);
+      if (which == uint32_t(net_message::tag<signed_block>::value)) {
+        blk_buffer.resize(message_length);
+        auto index = pending_message_buffer.read_index();
+        pending_message_buffer.peek(blk_buffer.data(), message_length, index);
+      }
+      auto ds = pending_message_buffer.create_datastream();
       net_message msg;
       fc::raw::unpack(ds, msg);
-      precache pc( shared_from_this(), message_length );
-      msg.visit( pc);
       msgHandler m(impl, shared_from_this() );
       msg.visit(m);
     } catch(  const fc::exception& e ) {
@@ -976,7 +905,6 @@ namespace eosio {
       impl.close( shared_from_this() );
       return false;
     }
-    pending_message_read_index += message_header_size + message_length;
     return true;
   }
 
@@ -1229,37 +1157,32 @@ namespace eosio {
     void net_plugin_impl::start_read_message( connection_ptr conn ) {
       connection_wptr c( conn);
       conn->socket->async_read_some(
-        boost::asio::buffer(&conn->pending_message_buffer[conn->pending_message_write_index],
-                            conn->pending_message_buffer.size() - conn->pending_message_write_index),
+        conn->pending_message_buffer.get_buffer_sequence_for_boost_async_read(),
         [this,c]( boost::system::error_code ec, std::size_t bytes_transferred ) {
           if( !ec ) {
             connection_ptr conn = c.lock();
             if (!conn) {
               return;
             }
-            conn->pending_message_write_index += bytes_transferred;
-            while (conn->pending_message_read_index < conn->pending_message_write_index) {
-              uint32_t bytes_in_buffer = conn->pending_message_write_index - conn->pending_message_read_index;
+            conn->pending_message_buffer.advance_write_ptr(bytes_transferred);
+            while (conn->pending_message_buffer.bytes_to_read() > 0) {
+              uint32_t bytes_in_buffer = conn->pending_message_buffer.bytes_to_read();
               if (bytes_in_buffer < message_header_size) {
                 break;
               } else {
-                // Ignore byte-ordering concerns
                 uint32_t message_length;
-                memcpy(&message_length, &conn->pending_message_buffer[conn->pending_message_read_index], sizeof(message_length));
-                if (bytes_in_buffer >= message_header_size + message_length) {
+                auto index = conn->pending_message_buffer.read_index();
+                conn->pending_message_buffer.peek(&message_length, sizeof(message_length), index);
+                if (bytes_in_buffer >= message_length + message_header_size) {
+                  conn->pending_message_buffer.advance_read_ptr(message_header_size);
                   if (!conn->process_next_message(*this, message_length)) {
                     return;
                   }
                 } else {
-                  conn->adjust_buffer_size(message_length);
+                  conn->pending_message_buffer.add_space(message_length - bytes_in_buffer);
                   break;
                 }
               }
-            }
-            if (conn->pending_message_read_index == conn->pending_message_write_index) {
-              // Buffer is empty, reset indices
-              conn->pending_message_read_index = 0;
-              conn->pending_message_write_index = 0;
             }
             start_read_message(conn);
           } else {

--- a/tests/tests/message_buffer_tests.cpp
+++ b/tests/tests/message_buffer_tests.cpp
@@ -1,3 +1,7 @@
+/**
+ *  @file
+ *  @copyright defined in eos/LICENSE.txt
+ */
 
 #include <eos/net_plugin/message_buffer.hpp>
 #include <boost/test/unit_test.hpp>

--- a/tests/tests/message_buffer_tests.cpp
+++ b/tests/tests/message_buffer_tests.cpp
@@ -1,0 +1,195 @@
+
+#include <eos/net_plugin/message_buffer.hpp>
+#include <boost/test/unit_test.hpp>
+#include <iostream>
+
+
+namespace eosio {
+using namespace std;
+
+BOOST_AUTO_TEST_SUITE(message_buffer_tests)
+
+constexpr auto     def_buffer_size_mb = 4;
+constexpr auto     def_buffer_size = 1024*1024*def_buffer_size_mb;
+
+/// Test default construction and buffer sequence generation
+BOOST_AUTO_TEST_CASE(message_buffer_construction)
+{
+  try {
+    eosio::message_buffer<def_buffer_size> mb;
+    BOOST_CHECK_EQUAL(mb.total_bytes(), def_buffer_size);
+    BOOST_CHECK_EQUAL(mb.bytes_to_write(), def_buffer_size);
+    BOOST_CHECK_EQUAL(mb.bytes_to_read(), 0);
+    BOOST_CHECK_EQUAL(mb.read_ptr(), mb.write_ptr());
+
+    auto mbs = mb.get_buffer_sequence_for_boost_async_read();
+    auto mbsi = mbs.begin();
+    BOOST_CHECK_EQUAL(boost::asio::detail::buffer_size_helper(*mbsi), def_buffer_size);
+    BOOST_CHECK_EQUAL(boost::asio::detail::buffer_cast_helper(*mbsi), mb.write_ptr());
+    mbsi++;
+    BOOST_CHECK(mbsi == mbs.end());
+  }
+  FC_LOG_AND_RETHROW()
+}
+
+/// Test buffer growth and shrinking
+BOOST_AUTO_TEST_CASE(message_buffer_growth)
+{
+  try {
+    eosio::message_buffer<def_buffer_size> mb;
+    mb.add_buffer_to_chain();
+    BOOST_CHECK_EQUAL(mb.total_bytes(), 2 * def_buffer_size);
+    BOOST_CHECK_EQUAL(mb.bytes_to_write(), 2 * def_buffer_size);
+    BOOST_CHECK_EQUAL(mb.bytes_to_read(), 0);
+    BOOST_CHECK_EQUAL(mb.read_ptr(), mb.write_ptr());
+
+    {
+      auto mbs = mb.get_buffer_sequence_for_boost_async_read();
+      auto mbsi = mbs.begin();
+      BOOST_CHECK_EQUAL(boost::asio::detail::buffer_size_helper(*mbsi), def_buffer_size);
+      BOOST_CHECK_EQUAL(boost::asio::detail::buffer_cast_helper(*mbsi), mb.write_ptr());
+      mbsi++;
+      BOOST_CHECK(mbsi != mbs.end());
+      BOOST_CHECK_EQUAL(boost::asio::detail::buffer_size_helper(*mbsi), def_buffer_size);
+      BOOST_CHECK_NE(boost::asio::detail::buffer_cast_helper(*mbsi), nullptr);
+      mbsi++;
+      BOOST_CHECK(mbsi == mbs.end());
+    }
+
+    mb.advance_write_ptr(100);
+    BOOST_CHECK_EQUAL(mb.total_bytes(), 2 * def_buffer_size);
+    BOOST_CHECK_EQUAL(mb.bytes_to_write(), 2 * def_buffer_size - 100);
+    BOOST_CHECK_EQUAL(mb.bytes_to_read(), 100);
+    BOOST_CHECK_NE(mb.read_ptr(), nullptr);
+    BOOST_CHECK_NE(mb.write_ptr(), nullptr);
+    BOOST_CHECK_EQUAL((mb.read_ptr() + 100), mb.write_ptr());
+
+    {
+      auto mbs = mb.get_buffer_sequence_for_boost_async_read();
+      auto mbsi = mbs.begin();
+      BOOST_CHECK_EQUAL(boost::asio::detail::buffer_size_helper(*mbsi), def_buffer_size - 100);
+      BOOST_CHECK_EQUAL(boost::asio::detail::buffer_cast_helper(*mbsi), mb.write_ptr());
+      mbsi++;
+      BOOST_CHECK(mbsi != mbs.end());
+      BOOST_CHECK_EQUAL(boost::asio::detail::buffer_size_helper(*mbsi), def_buffer_size);
+      BOOST_CHECK_NE(boost::asio::detail::buffer_cast_helper(*mbsi), nullptr);
+      mbsi++;
+      BOOST_CHECK(mbsi == mbs.end());
+    }
+
+    mb.advance_read_ptr(50);
+    BOOST_CHECK_EQUAL(mb.total_bytes(), 2 * def_buffer_size);
+    BOOST_CHECK_EQUAL(mb.bytes_to_write(), 2 * def_buffer_size - 100);
+    BOOST_CHECK_EQUAL(mb.bytes_to_read(), 50);
+
+    mb.advance_write_ptr(def_buffer_size);
+    BOOST_CHECK_EQUAL(mb.total_bytes(), 2 * def_buffer_size);
+    BOOST_CHECK_EQUAL(mb.bytes_to_write(), def_buffer_size - 100);
+    BOOST_CHECK_EQUAL(mb.bytes_to_read(), 50 + def_buffer_size);
+
+    // Moving read_ptr into second block should reset second block to first
+    mb.advance_read_ptr(def_buffer_size);
+    BOOST_CHECK_EQUAL(mb.total_bytes(), def_buffer_size);
+    BOOST_CHECK_EQUAL(mb.bytes_to_write(), def_buffer_size - 100);
+    BOOST_CHECK_EQUAL(mb.bytes_to_read(), 50);
+
+    // Moving read_ptr to write_ptr should shrink chain and reset ptrs
+    mb.advance_read_ptr(50);
+    BOOST_CHECK_EQUAL(mb.total_bytes(), def_buffer_size);
+    BOOST_CHECK_EQUAL(mb.bytes_to_write(), def_buffer_size);
+    BOOST_CHECK_EQUAL(mb.bytes_to_read(), 0);
+
+    mb.add_buffer_to_chain();
+    BOOST_CHECK_EQUAL(mb.total_bytes(), 2 * def_buffer_size);
+    BOOST_CHECK_EQUAL(mb.bytes_to_write(), 2 * def_buffer_size);
+    BOOST_CHECK_EQUAL(mb.bytes_to_read(), 0);
+
+    mb.advance_write_ptr(50);
+    BOOST_CHECK_EQUAL(mb.total_bytes(), 2 * def_buffer_size);
+    BOOST_CHECK_EQUAL(mb.bytes_to_write(), 2 * def_buffer_size - 50);
+    BOOST_CHECK_EQUAL(mb.bytes_to_read(), 50);
+
+    // Moving read_ptr to write_ptr should shrink chain and reset ptrs
+    mb.advance_read_ptr(50);
+    BOOST_CHECK_EQUAL(mb.total_bytes(), def_buffer_size);
+    BOOST_CHECK_EQUAL(mb.bytes_to_write(), def_buffer_size);
+    BOOST_CHECK_EQUAL(mb.bytes_to_read(), 0);
+  }
+  FC_LOG_AND_RETHROW()
+}
+
+/// Test peek and read across multiple buffers
+BOOST_AUTO_TEST_CASE(message_buffer_peek_read)
+{
+  try {
+    {
+      const uint32_t small = 32;
+      eosio::message_buffer<small> mb;
+      BOOST_CHECK_EQUAL(mb.total_bytes(), small);
+      BOOST_CHECK_EQUAL(mb.bytes_to_write(), small);
+      BOOST_CHECK_EQUAL(mb.bytes_to_read(), 0);
+      BOOST_CHECK_EQUAL(mb.read_ptr(), mb.write_ptr());
+      BOOST_CHECK_EQUAL(mb.read_index().first, 0);
+      BOOST_CHECK_EQUAL(mb.read_index().second, 0);
+      BOOST_CHECK_EQUAL(mb.write_index().first, 0);
+      BOOST_CHECK_EQUAL(mb.write_index().second, 0);
+
+      mb.add_space(100 - small);
+      BOOST_CHECK_EQUAL(mb.total_bytes(), 4 * small);
+      BOOST_CHECK_EQUAL(mb.bytes_to_write(), 4 * small);
+      BOOST_CHECK_EQUAL(mb.bytes_to_read(), 0);
+      BOOST_CHECK_EQUAL(mb.read_ptr(), mb.write_ptr());
+
+      char* write_ptr = mb.write_ptr();
+      for (char ind = 0; ind < 100; ) {
+        *write_ptr = ind;
+        ind++;
+        if (ind % small == 0) {
+          mb.advance_write_ptr(small);
+          write_ptr = mb.write_ptr();
+        } else {
+          write_ptr++;
+        }
+      }
+      mb.advance_write_ptr(100 % small);
+
+      BOOST_CHECK_EQUAL(mb.total_bytes(), 4 * small);
+      BOOST_CHECK_EQUAL(mb.bytes_to_write(), 4 * small - 100);
+      BOOST_CHECK_EQUAL(mb.bytes_to_read(), 100);
+      BOOST_CHECK_NE((void*) mb.read_ptr(), (void*) mb.write_ptr());
+      BOOST_CHECK_EQUAL(mb.read_index().first, 0);
+      BOOST_CHECK_EQUAL(mb.read_index().second, 0);
+      BOOST_CHECK_EQUAL(mb.write_index().first, 3);
+      BOOST_CHECK_EQUAL(mb.write_index().second, 4);
+
+      char buffer[100];
+      auto index = mb.read_index();
+      mb.peek(buffer, 100, index);
+      for (int i=0; i < 100; i++) {
+        BOOST_CHECK_EQUAL(i, buffer[i]);
+      }
+
+      BOOST_CHECK_EQUAL(mb.total_bytes(), 4 * small);
+      BOOST_CHECK_EQUAL(mb.bytes_to_write(), 4 * small - 100);
+      BOOST_CHECK_EQUAL(mb.bytes_to_read(), 100);
+      BOOST_CHECK_NE((void*) mb.read_ptr(), (void*) mb.write_ptr());
+
+      char buffer2[100];
+      mb.read(buffer2, 100);
+      for (int i=0; i < 100; i++) {
+        BOOST_CHECK_EQUAL(i, buffer2[i]);
+      }
+
+      BOOST_CHECK_EQUAL(mb.total_bytes(), small);
+      BOOST_CHECK_EQUAL(mb.bytes_to_write(), small);
+      BOOST_CHECK_EQUAL(mb.bytes_to_read(), 0);
+      BOOST_CHECK_EQUAL(mb.read_ptr(), mb.write_ptr());
+    }
+  }
+  FC_LOG_AND_RETHROW()
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+} // namespace eosio
+


### PR DESCRIPTION
This changes the P2P code to use scatter/gather reads to and a sequence of buffers in place of one small buffer. It uses boost object_pool to manage the individual buffers.