### PR TITLE
Add nonce as native type for cleaner support. STAT-159 #677

### DIFF
--- a/libraries/native_contract/native_contract_chain_initializer.cpp
+++ b/libraries/native_contract/native_contract_chain_initializer.cpp
@@ -62,6 +62,7 @@ types::abi native_contract_chain_initializer::eos_contract_abi()
 //   eos_abi.types.push_back( types::type_def{"account_name","name"} );
    eos_abi.types.push_back( types::type_def{"share_type","int64"} );
    eos_abi.actions.push_back( types::action{name("transfer"), "transfer"} );
+   eos_abi.actions.push_back( types::action{name("nonce"), "nonce"} );
    eos_abi.actions.push_back( types::action{name("lock"), "lock"} );
    eos_abi.actions.push_back( types::action{name("unlock"), "unlock"} );
    eos_abi.actions.push_back( types::action{name("claim"), "claim"} );
@@ -75,6 +76,7 @@ types::abi native_contract_chain_initializer::eos_contract_abi()
    eos_abi.actions.push_back( types::action{name("deleteauth"), "deleteauth"} );
    eos_abi.actions.push_back( types::action{name("newaccount"), "newaccount"} );
    eos_abi.structs.push_back( eosio::types::get_struct<eosio::types::transfer>::type() );
+   eos_abi.structs.push_back( eosio::types::get_struct<eosio::types::nonce>::type() );
    eos_abi.structs.push_back( eosio::types::get_struct<eosio::types::lock>::type() );
    eos_abi.structs.push_back( eosio::types::get_struct<eosio::types::unlock>::type() );
    eos_abi.structs.push_back( eosio::types::get_struct<eosio::types::claim>::type() );

--- a/libraries/types/types.eos
+++ b/libraries/types/types.eos
@@ -81,6 +81,9 @@ struct transfer
    amount    uint64
    memo      string
 
+struct nonce         # used to make a transaction unique
+   value     string
+
 struct lock
    from      account_name
    to        account_name

--- a/programs/eosc/main.cpp
+++ b/programs/eosc/main.cpp
@@ -224,7 +224,7 @@ std::string generate_nonce_string() {
 }
 
 types::message generate_nonce() {
-   return message(N(eos),{}, N(nonce), generate_nonce_string());
+   return message(N(eos),{}, N(nonce), types::nonce{generate_nonce_string()});
 }
 
 vector<types::account_permission> get_account_permissions(const vector<string>& permissions) {

--- a/tests/eosd_run_mongodb_test.sh
+++ b/tests/eosd_run_mongodb_test.sh
@@ -222,7 +222,7 @@ if [ $count == 0 ]; then
 fi
 
 # transfer
-TRANSFER_INFO="$(programs/eosc/eosc --wallet-port 8899 transfer inita testera 975321 "test transfer")"
+TRANSFER_INFO="$(programs/eosc/eosc --wallet-port 8899 transfer -f inita testera 975321 "test transfer")"
 verifyErrorCode "eosc transfer"
 waitForNextTransaction
 
@@ -460,6 +460,12 @@ while [ "$NEXT_BLOCK_NUM" -le "$HEAD_BLOCK_NUM" ]; do
 
   NEXT_BLOCK_NUM=$((NEXT_BLOCK_NUM+1))
 done
+
+ASSERT_ERRORS="$(grep Assert tn_data_0/stderr.txt)"
+count=`grep -c Assert tn_data_0/stderr.txt`
+if [ $count != 0 ]; then
+  error "FAILURE - Assert in tn_data_0/stderr.txt"
+fi
 
 killAll
 cleanup


### PR DESCRIPTION
Resolves #677.

Added nonce which is used to create unique messages as a native type. This allows ABI to decode nonce when used.