### PR TITLE
Fixes for GCC compiler errors

### DIFF
--- a/libraries/chain/chain_controller.cpp
+++ b/libraries/chain/chain_controller.cpp
@@ -1564,9 +1564,9 @@ processed_transaction chain_controller::transaction_from_variant( const fc::vari
                result.messages[i].data = message_to_binary( result.messages[i].code, result.messages[i].type, data ); 
                /*
                const auto& code_account = _db.get<account_object,by_name>( result.messages[i].code );
-               eosio::types::abi abi;
-               if( abi_serializer::to_abi(code_account.abi, abi) ) {
-                  types::abi_serializer abis( abi );
+               eosio::types::abi code_abi;
+               if( abi_serializer::to_abi(code_account.code_abi, code_abi) ) {
+                  types::abi_serializer abis( code_abi );
                   result.messages[i].data = abis.variant_to_binary( abis.get_action_type( result.messages[i].type ), data );
                }
                */

--- a/libraries/chain/chain_controller.cpp
+++ b/libraries/chain/chain_controller.cpp
@@ -629,8 +629,8 @@ void check_output(const generated_transaction& expected, const generated_transac
 template<>
 void check_output(const message_output& expected, const message_output& actual, const path_cons_list& path) {
    check_output(expected.notify, actual.notify, path(".notify"));
-   check_output(expected.inline_transaction, actual.inline_transaction, path(".inline_transaction"));
-   check_output(expected.deferred_transactions, actual.deferred_transactions, path(".deferred_transactions"));
+   check_output(expected.inline_trx, actual.inline_trx, path(".inline_trx"));
+   check_output(expected.deferred_trxs, actual.deferred_trxs, path(".deferred_trxs"));
 }
 
 template<typename T>
@@ -973,8 +973,8 @@ void chain_controller::process_message(const transaction& trx, account_name code
 
    // combine inline messages and process
    if (apply_ctx.inline_messages.size() > 0) {
-      output.inline_transaction = inline_transaction(trx);
-      (*output.inline_transaction).messages = std::move(apply_ctx.inline_messages);
+      output.inline_trx = inline_transaction(trx);
+      (*output.inline_trx).messages = std::move(apply_ctx.inline_messages);
    }
 
    for( auto& asynctrx : apply_ctx.deferred_transactions ) {
@@ -989,7 +989,7 @@ void chain_controller::process_message(const transaction& trx, account_name code
          transaction.status = generated_transaction_object::PENDING;
       });
 
-      output.deferred_transactions.emplace_back( gtrx );
+      output.deferred_trxs.emplace_back( gtrx );
    }
 
    // propagate used_authorizations up the context chain
@@ -1062,9 +1062,9 @@ typename T::processed chain_controller::process_transaction( const T& trx, int d
       auto& output = ptrx.output[i];
       rate_limit_message(trx.messages[i]);
       process_message(trx, trx.messages[i].code, trx.messages[i], output);
-      if (output.inline_transaction.valid() ) {
-         const transaction& trx = *output.inline_transaction;
-         output.inline_transaction = process_transaction(pending_inline_transaction(trx), depth + 1, start_time);
+      if (output.inline_trx.valid() ) {
+         const transaction& trx = *output.inline_trx;
+         output.inline_trx = process_transaction(pending_inline_transaction(trx), depth + 1, start_time);
       }
    }
 

--- a/libraries/chain/include/eos/chain/transaction.hpp
+++ b/libraries/chain/include/eos/chain/transaction.hpp
@@ -170,8 +170,8 @@ namespace eosio { namespace chain {
     */
    struct message_output {
       vector<notify_output>             notify; ///< accounts to notify, may only be notified once
-      fc::optional<inline_transaction>  inline_transaction; ///< transactions generated and applied after notify
-      vector<generated_transaction>     deferred_transactions; ///< transactions generated but not applied
+      fc::optional<inline_transaction>  inline_trx; ///< transactions generated and applied after notify
+      vector<generated_transaction>     deferred_trxs; ///< transactions generated but not applied
    };
 
    struct notify_output {
@@ -200,7 +200,7 @@ namespace eosio { namespace chain {
 
 FC_REFLECT(eosio::chain::generated_transaction, (id))
 FC_REFLECT_DERIVED(eosio::chain::signed_transaction, (eosio::types::signed_transaction), )
-FC_REFLECT(eosio::chain::message_output, (notify)(inline_transaction)(deferred_transactions) )
+FC_REFLECT(eosio::chain::message_output, (notify)(inline_trx)(deferred_trxs) )
 FC_REFLECT_DERIVED(eosio::chain::processed_transaction, (eosio::types::signed_transaction), (output) )
 FC_REFLECT_DERIVED(eosio::chain::pending_inline_transaction, (eosio::types::transaction), )
 FC_REFLECT_DERIVED(eosio::chain::inline_transaction, (eosio::types::transaction), (output) )

--- a/libraries/types/abi_serializer.cpp
+++ b/libraries/types/abi_serializer.cpp
@@ -39,7 +39,7 @@ namespace eosio { namespace types {
 
    abi_serializer::abi_serializer( const abi& abi ) {
       configure_built_in_types();
-      setAbi(abi);
+      set_abi(abi);
    }
 
    void abi_serializer::configure_built_in_types() {
@@ -98,7 +98,7 @@ namespace eosio { namespace types {
       built_in_types.emplace("abi",                     packUnpack<abi>());
    }
 
-   void abi_serializer::setAbi( const abi& abi ) {
+   void abi_serializer::set_abi(const abi& abi) {
       typedefs.clear();
       structs.clear();
       actions.clear();

--- a/libraries/types/include/eos/types/abi_serializer.hpp
+++ b/libraries/types/include/eos/types/abi_serializer.hpp
@@ -19,7 +19,7 @@ using std::pair;
 struct abi_serializer {
    abi_serializer(){ configure_built_in_types(); }
    abi_serializer( const abi& abi );
-   void setAbi( const abi& abi );
+   void set_abi(const abi& abi);
 
    map<type_name, type_name> typedefs;
    map<type_name, struct_t>  structs;

--- a/libraries/types/types.eos
+++ b/libraries/types/types.eos
@@ -104,10 +104,10 @@ struct newaccount
 
 struct setcode
    account         account_name # the account that is handling the message
-   vm_type          uint8        # the virtual machine type
-   vm_version       uint8        # the virtual machine version
+   vm_type         uint8        # the virtual machine type
+   vm_version      uint8        # the virtual machine version
    code            bytes        # the apply
-   abi             abi          # the interface description of the code
+   code_abi        abi          # the interface description of the code
 
 
 struct setproducer
@@ -130,7 +130,7 @@ struct updateauth
    account     account_name
    permission  permission_name
    parent      permission_name
-   authority   authority
+   new_authority   authority
 
 struct deleteauth
    account account_name

--- a/plugins/account_history_plugin/account_history_plugin.cpp
+++ b/plugins/account_history_plugin/account_history_plugin.cpp
@@ -266,7 +266,7 @@ vector<account_name> account_history_plugin_impl::get_key_accounts(const public_
       auto range = pub_key_idx.equal_range( public_key );
       for (auto obj = range.first; obj != range.second; ++obj)
       {
-         accounts.insert(obj->account_name);
+         accounts.insert(obj->name);
       }
    } );
    return vector<account_name>(accounts.begin(), accounts.end());
@@ -352,13 +352,13 @@ void account_history_plugin_impl::applied_block(const signed_block& block)
    }
 }
 
-void account_history_plugin_impl::add(chainbase::database& db, const vector<types::key_permission_weight>& keys, const account_name& account_name, const permission_name& permission)
+void account_history_plugin_impl::add(chainbase::database& db, const vector<types::key_permission_weight>& keys, const account_name& name, const permission_name& permission)
 {
    for (auto pub_key_weight : keys )
    {
       db.create<public_key_history_object>([&](public_key_history_object& obj) {
          obj.public_key = pub_key_weight.key;
-         obj.account_name = account_name;
+         obj.name = name;
          obj.permission = permission;
       });
    }

--- a/plugins/account_history_plugin/account_history_plugin.cpp
+++ b/plugins/account_history_plugin/account_history_plugin.cpp
@@ -333,10 +333,10 @@ void account_history_plugin_impl::applied_block(const signed_block& block)
                   {
                      const auto update = msg.as<types::updateauth>();
                      remove<public_key_history_multi_index, by_account_permission>(db, update.account, update.permission);
-                     add(db, update.authority.keys, update.account, update.permission);
+                     add(db, update.new_authority.keys, update.account, update.permission);
 
                      remove<account_control_history_multi_index, by_controlled_authority>(db, update.account, update.permission);
-                     add(db, update.authority.accounts, update.account, update.permission);
+                     add(db, update.new_authority.accounts, update.account, update.permission);
                   }
                   else if (msg.type == DELETE_AUTH)
                   {

--- a/plugins/account_history_plugin/account_history_plugin.cpp
+++ b/plugins/account_history_plugin/account_history_plugin.cpp
@@ -309,7 +309,7 @@ void account_history_plugin_impl::applied_block(const signed_block& block)
             for (const auto& account_name : trx.scope)
             {
                db.create<account_transaction_history_object>([&trx,&account_name](account_transaction_history_object& account_transaction_history) {
-                  account_transaction_history.account_name = account_name;
+                  account_transaction_history.name = account_name;
                   account_transaction_history.transaction_id = trx.id();
                });
             }

--- a/plugins/account_history_plugin/include/eos/account_history_plugin/account_history_plugin.hpp
+++ b/plugins/account_history_plugin/include/eos/account_history_plugin/account_history_plugin.hpp
@@ -42,7 +42,7 @@ public:
 
 
    struct get_transactions_params {
-      chain::account_name account_name;
+      name                account_name;
       optional<uint32_t>  skip_seq;
       optional<uint32_t>  num_seq;
    };
@@ -63,16 +63,16 @@ public:
       chain::public_key_type     public_key;
    };
    struct get_key_accounts_results {
-      vector<chain::account_name> account_names;
+      vector<name> account_names;
    };
    get_key_accounts_results get_key_accounts(const get_key_accounts_params& params) const;
 
 
    struct get_controlled_accounts_params {
-      chain::account_name     controlling_account;
+      name     controlling_account;
    };
    struct get_controlled_accounts_results {
-      vector<chain::account_name> controlled_accounts;
+      vector<name> controlled_accounts;
    };
    get_controlled_accounts_results get_controlled_accounts(const get_controlled_accounts_params& params) const;
 };

--- a/plugins/account_history_plugin/include/eos/account_history_plugin/account_transaction_history_object.hpp
+++ b/plugins/account_history_plugin/include/eos/account_history_plugin/account_transaction_history_object.hpp
@@ -29,7 +29,7 @@ class account_transaction_history_object : public chainbase::object<chain::accou
    OBJECT_CTOR(account_transaction_history_object)
 
    id_type                            id;
-   account_name                       account_name;
+   account_name                       name;
    transaction_id_type                transaction_id;
 };
 
@@ -40,10 +40,10 @@ using account_transaction_history_multi_index = chainbase::shared_multi_index_co
    account_transaction_history_object,
    indexed_by<
       ordered_unique<tag<by_id>, BOOST_MULTI_INDEX_MEMBER(account_transaction_history_object, account_transaction_history_object::id_type, id)>,
-      hashed_non_unique<tag<by_account_name>, BOOST_MULTI_INDEX_MEMBER(account_transaction_history_object, account_name, account_name), std::hash<account_name>>,
+      hashed_non_unique<tag<by_account_name>, BOOST_MULTI_INDEX_MEMBER(account_transaction_history_object, account_name, name), std::hash<account_name>>,
       hashed_unique<tag<by_account_name_trx_id>,
          composite_key< account_transaction_history_object,
-            member<account_transaction_history_object, account_name, &account_transaction_history_object::account_name>,
+            member<account_transaction_history_object, account_name, &account_transaction_history_object::name>,
             member<account_transaction_history_object, transaction_id_type, &account_transaction_history_object::transaction_id>
          >,
          composite_key_hash< std::hash<account_name>, std::hash<transaction_id_type> >
@@ -57,5 +57,5 @@ typedef chainbase::generic_index<account_transaction_history_multi_index> accoun
 
 CHAINBASE_SET_INDEX_TYPE( eosio::account_transaction_history_object, eosio::account_transaction_history_multi_index )
 
-FC_REFLECT( eosio::account_transaction_history_object, (account_name)(transaction_id) )
+FC_REFLECT( eosio::account_transaction_history_object, (name)(transaction_id) )
 

--- a/plugins/account_history_plugin/include/eos/account_history_plugin/public_key_history_object.hpp
+++ b/plugins/account_history_plugin/include/eos/account_history_plugin/public_key_history_object.hpp
@@ -31,8 +31,8 @@ class public_key_history_object : public chainbase::object<chain::public_key_his
 
    id_type           id;
    public_key_type   public_key;
-   account_name      account_name;
-   permission_name    permission;
+   account_name      name;
+   permission_name   permission;
 };
 
 struct by_id;
@@ -45,7 +45,7 @@ using public_key_history_multi_index = chainbase::shared_multi_index_container<
       hashed_non_unique<tag<by_pub_key>, BOOST_MULTI_INDEX_MEMBER(public_key_history_object, public_key_type, public_key), std::hash<public_key_type> >,
       hashed_non_unique<tag<by_account_permission>,
          composite_key< public_key_history_object,
-            member<public_key_history_object, account_name,     &public_key_history_object::account_name>,
+            member<public_key_history_object, account_name,     &public_key_history_object::name>,
             member<public_key_history_object, permission_name,  &public_key_history_object::permission>
          >,
          composite_key_hash<
@@ -62,5 +62,5 @@ typedef chainbase::generic_index<public_key_history_multi_index> public_key_hist
 
 CHAINBASE_SET_INDEX_TYPE( eosio::public_key_history_object, eosio::public_key_history_multi_index )
 
-FC_REFLECT( eosio::public_key_history_object, (public_key)(account_name)(permission) )
+FC_REFLECT( eosio::public_key_history_object, (public_key)(name)(permission) )
 

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -338,7 +338,7 @@ read_only::get_table_rows_result read_only::get_table_rows( const read_only::get
       if( table_key == TERTIARY )
          return get_table_rows_ex<chain::key64x64x64_value_index, chain::by_scope_tertiary>(p,abi);
    }
-   FC_ASSERT( false, "invalid table type/key ${type}/${key}", ("type",table_type)("key",table_key)("abi",abi));
+   FC_ASSERT( false, "invalid table type/key ${type}/${key}", ("type",table_type)("key",table_key)("code_abi",abi));
 }
 
 read_only::get_block_results read_only::get_block(const read_only::get_block_params& params) const {
@@ -385,9 +385,9 @@ read_write::push_transactions_results read_write::push_transactions(const read_w
 
 read_only::get_code_results read_only::get_code( const get_code_params& params )const {
    get_code_results result;
-   result.name = params.name;
+   result.account_name = params.account_name;
    const auto& d = db.get_database();
-   const auto& accnt  = d.get<account_object,by_name>( params.name );
+   const auto& accnt  = d.get<account_object,by_name>( params.account_name );
 
    if( accnt.code.size() ) {
       result.wast = chain::wasm_to_wast( (const uint8_t*)accnt.code.data(), accnt.code.size() );
@@ -404,11 +404,11 @@ read_only::get_account_results read_only::get_account( const get_account_params&
    using namespace native::eosio;
 
    get_account_results result;
-   result.name = params.name;
+   result.account_name = params.account_name;
 
    const auto& d = db.get_database();
-   const auto& balance        = d.get<balance_object,by_owner_name>( params.name );
-   const auto& staked_balance = d.get<staked_balance_object,by_owner_name>( params.name );
+   const auto& balance        = d.get<balance_object,by_owner_name>( params.account_name );
+   const auto& staked_balance = d.get<staked_balance_object,by_owner_name>( params.account_name );
 
    result.eos_balance          = asset(balance.balance, EOS_SYMBOL);
    result.staked_balance       = asset(staked_balance.staked_balance);
@@ -416,8 +416,8 @@ read_only::get_account_results read_only::get_account( const get_account_params&
    result.last_unstaking_time  = staked_balance.last_unstaking_time;
 
    const auto& permissions = d.get_index<permission_index,by_owner>();
-   auto perm = permissions.lower_bound( boost::make_tuple( params.name ) );
-   while( perm != permissions.end() && perm->owner == params.name ) {
+   auto perm = permissions.lower_bound( boost::make_tuple( params.account_name ) );
+   while( perm != permissions.end() && perm->owner == params.account_name ) {
       /// TODO: lookup perm->parent name 
       name parent;
 

--- a/plugins/chain_plugin/include/eos/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eos/chain_plugin/chain_plugin.hpp
@@ -64,12 +64,12 @@ public:
    get_info_results get_info(const get_info_params&) const;
 
    struct producer_info {
-      name                       name;
+      name                       producer_name;
    };
 
 
    struct get_account_results {
-      name                       name;
+      name                       account_name;
       asset                      eos_balance = asset(0,EOS_SYMBOL);
       asset                      staked_balance;
       asset                      unstaking_balance;
@@ -78,20 +78,20 @@ public:
       optional<producer_info>    producer;
    };
    struct get_account_params {
-      name name;
+      name account_name;
    };
    get_account_results get_account( const get_account_params& params )const;
 
 
    struct get_code_results {
-      name                   name;
+      name                   account_name;
       string                 wast;
       fc::sha256             code_hash;
       optional<types::abi>   abi;
    };
 
    struct get_code_params {
-      name name;
+      name                   account_name;
    };
    get_code_results get_code( const get_code_params& params )const;
 
@@ -209,7 +209,7 @@ public:
       const auto& d = db.get_database();
    
       types::abi_serializer abis;
-      abis.setAbi(abi);
+      abis.set_abi(abi);
    
       const auto& idx = d.get_index<IndexType, Scope>();
       auto lower = idx.lower_bound( boost::make_tuple(p.scope, p.code, p.table   ) );
@@ -321,11 +321,11 @@ FC_REFLECT( eosio::chain_apis::read_write::push_transaction_results, (transactio
 FC_REFLECT( eosio::chain_apis::read_only::get_table_rows_params, (json)(table_key)(scope)(code)(table)(lower_bound)(upper_bound)(limit) )
 FC_REFLECT( eosio::chain_apis::read_only::get_table_rows_result, (rows)(more) );
 
-FC_REFLECT( eosio::chain_apis::read_only::get_account_results, (name)(eos_balance)(staked_balance)(unstaking_balance)(last_unstaking_time)(permissions)(producer) )
-FC_REFLECT( eosio::chain_apis::read_only::get_code_results, (name)(code_hash)(wast)(abi) )
-FC_REFLECT( eosio::chain_apis::read_only::get_account_params, (name) )
-FC_REFLECT( eosio::chain_apis::read_only::get_code_params, (name) )
-FC_REFLECT( eosio::chain_apis::read_only::producer_info, (name) )
+FC_REFLECT( eosio::chain_apis::read_only::get_account_results, (account_name)(eos_balance)(staked_balance)(unstaking_balance)(last_unstaking_time)(permissions)(producer) )
+FC_REFLECT( eosio::chain_apis::read_only::get_code_results, (account_name)(code_hash)(wast)(abi) )
+FC_REFLECT( eosio::chain_apis::read_only::get_account_params, (account_name) )
+FC_REFLECT( eosio::chain_apis::read_only::get_code_params, (account_name) )
+FC_REFLECT( eosio::chain_apis::read_only::producer_info, (producer_name) )
 FC_REFLECT( eosio::chain_apis::read_only::abi_json_to_bin_params, (code)(action)(args) )
 FC_REFLECT( eosio::chain_apis::read_only::abi_json_to_bin_result, (binargs)(required_scope)(required_auth) )
 FC_REFLECT( eosio::chain_apis::read_only::abi_bin_to_json_params, (code)(action)(binargs) )

--- a/plugins/db_plugin/db_plugin.cpp
+++ b/plugins/db_plugin/db_plugin.cpp
@@ -190,11 +190,11 @@ namespace {
      try {
         types::abi_serializer abis;
         if (msg.code == config::eos_contract_name) {
-           abis.setAbi(db_plugin_impl::eos_abi);
+           abis.set_abi(db_plugin_impl::eos_abi);
         } else {
            auto from_account = find_account(accounts, msg.code);
            auto abi = fc::json::from_string(bsoncxx::to_json(from_account.view()["abi"].get_document())).as<types::abi>();
-           abis.setAbi(abi);
+           abis.set_abi(abi);
         }
         auto v = abis.binary_to_variant(abis.get_action_type(msg.type), msg.data);
         auto json = fc::json::to_string(v);
@@ -208,6 +208,10 @@ namespace {
         }
      } catch (fc::exception& e) {
         elog("Unable to convert message.data to ABI type: ${t}, what: ${e}", ("t", msg.type)("e", e.to_string()));
+     } catch (std::exception& e) {
+        elog("Unable to convert message.data to ABI type: ${t}, std what: ${e}", ("t", msg.type)("e", e.what()));
+     } catch (...) {
+        elog("Unable to convert message.data to ABI type: ${t}", ("t", msg.type));
      }
      // if anything went wrong just store raw hex_data
      msg_doc.append(kvp("hex_data", fc::variant(msg.data).as_string()));
@@ -552,7 +556,7 @@ void db_plugin_impl::update_account(const chain::message& msg) {
 
       document update_from{};
       update_from << "$set" << open_document
-                  << "abi" << bsoncxx::from_json(fc::json::to_string(setcode.abi))
+                  << "abi" << bsoncxx::from_json(fc::json::to_string(setcode.code_abi))
                   << "updatedAt" << b_date{now}
                   << close_document;
 

--- a/programs/eosc/main.cpp
+++ b/programs/eosc/main.cpp
@@ -387,7 +387,7 @@ struct set_account_permission_subcommand {
             name parent;
             if (parentStr.size() == 0) {
                // see if we can auto-determine the proper parent
-               const auto account_result = call(get_account_func, fc::mutable_variant_object("name", accountStr));
+               const auto account_result = call(get_account_func, fc::mutable_variant_object("account_name", accountStr));
                const auto& existing_permissions = account_result.get_object()["permissions"].get_array();
                auto permissionPredicate = [this](const auto& perm) { 
                   return perm.is_object() && 
@@ -540,7 +540,7 @@ int main( int argc, char** argv ) {
    getAccount->add_option("name", accountName, localized("The name of the account to retrieve"))->required();
    getAccount->set_callback([&] {
       std::cout << fc::json::to_pretty_string(call(get_account_func,
-                                                   fc::mutable_variant_object("name", accountName)))
+                                                   fc::mutable_variant_object("account_name", accountName)))
                 << std::endl;
    });
 
@@ -552,7 +552,7 @@ int main( int argc, char** argv ) {
    getCode->add_option("-c,--code",codeFilename, localized("The name of the file to save the contract .wast to") );
    getCode->add_option("-a,--abi",abiFilename, localized("The name of the file to save the contract .abi to") );
    getCode->set_callback([&] {
-      auto result = call(get_code_func, fc::mutable_variant_object("name", accountName));
+      auto result = call(get_code_func, fc::mutable_variant_object("account_name", accountName));
 
       std::cout << localized("code hash: ${code_hash}", ("code_hash", result["code_hash"].as_string())) << std::endl;
 
@@ -686,7 +686,7 @@ int main( int argc, char** argv ) {
       handler.account = account;
       handler.code.assign(wasm.begin(), wasm.end());
       if (abi->count())
-         handler.abi = fc::json::from_file(abiPath).as<types::abi>();
+         handler.code_abi = fc::json::from_file(abiPath).as<types::abi>();
 
       signed_transaction trx;
       trx.scope = sort_names({config::eos_contract_name, account});

--- a/tests/api_tests/api_tests.cpp
+++ b/tests/api_tests/api_tests.cpp
@@ -526,7 +526,7 @@ BOOST_FIXTURE_TEST_CASE(test_case_name, testing_fixture)                        
 
 #define RUN_CODE_ABI_WITH_TRANSFER(account_name, test_wast, test_abi)                                      \
       types::setcode handler;                                                                              \
-      handler.abi = fc::json::from_string(test_abi).as<types::abi>();                                      \
+      handler.code_abi = fc::json::from_string(test_abi).as<types::abi>();                                 \
       RUN_CODE_HANDLER_WITH_TRANSFER(account_name, test_wast)
 
 #define TEST_CASE_RUN_CODE_ABI_W_XFER(test_case_name, account_name, test_wast, test_abi)                   \

--- a/tests/tests/abi_tests.cpp
+++ b/tests/tests/abi_tests.cpp
@@ -446,7 +446,7 @@ BOOST_FIXTURE_TEST_CASE(abi_cycle, testing_fixture)
    BOOST_CHECK_EXCEPTION( abis.validate(), fc::assert_exception, is_assert_exception );
 
    abi = fc::json::from_string(struct_cycle_abi).as<types::abi>();
-   abis.setAbi(abi);
+      abis.set_abi(abi);
    BOOST_CHECK_EXCEPTION( abis.validate(), fc::assert_exception, is_assert_exception );
 
 } FC_LOG_AND_RETHROW() }
@@ -751,7 +751,7 @@ BOOST_FIXTURE_TEST_CASE(updateauth, testing_fixture)
      "account" : "updauth.acct",
      "permission" : "updauth.prm",
      "parent" : "updauth.prnt",
-     "authority" : {
+     "new_authority" : {
         "threshold" : "2147483145",
         "keys" : [ {"key" : "EOS65rXebLhtk2aTTzP4e9x1AQZs7c5NNXJp89W8R3HyaA6Zyd4im", "weight" : 57005},
                    {"key" : "EOS5eVr9TVnqwnUBNwf9kwMTbrHvX5aPyyEG97dz2b2TNeqWRzbJf", "weight" : 57605} ],
@@ -767,21 +767,21 @@ BOOST_FIXTURE_TEST_CASE(updateauth, testing_fixture)
    BOOST_CHECK_EQUAL("updauth.acct", updateauth.account);
    BOOST_CHECK_EQUAL("updauth.prm", updateauth.permission);
    BOOST_CHECK_EQUAL("updauth.prnt", updateauth.parent);
-   BOOST_CHECK_EQUAL(2147483145u, updateauth.authority.threshold);
+   BOOST_CHECK_EQUAL(2147483145u, updateauth.new_authority.threshold);
 
-   BOOST_REQUIRE_EQUAL(2, updateauth.authority.keys.size());
-   BOOST_CHECK_EQUAL("EOS65rXebLhtk2aTTzP4e9x1AQZs7c5NNXJp89W8R3HyaA6Zyd4im", (std::string)updateauth.authority.keys[0].key);
-   BOOST_CHECK_EQUAL(57005u, updateauth.authority.keys[0].weight);
-   BOOST_CHECK_EQUAL("EOS5eVr9TVnqwnUBNwf9kwMTbrHvX5aPyyEG97dz2b2TNeqWRzbJf", (std::string)updateauth.authority.keys[1].key);
-   BOOST_CHECK_EQUAL(57605u, updateauth.authority.keys[1].weight);
+   BOOST_REQUIRE_EQUAL(2, updateauth.new_authority.keys.size());
+   BOOST_CHECK_EQUAL("EOS65rXebLhtk2aTTzP4e9x1AQZs7c5NNXJp89W8R3HyaA6Zyd4im", (std::string)updateauth.new_authority.keys[0].key);
+   BOOST_CHECK_EQUAL(57005u, updateauth.new_authority.keys[0].weight);
+   BOOST_CHECK_EQUAL("EOS5eVr9TVnqwnUBNwf9kwMTbrHvX5aPyyEG97dz2b2TNeqWRzbJf", (std::string)updateauth.new_authority.keys[1].key);
+   BOOST_CHECK_EQUAL(57605u, updateauth.new_authority.keys[1].weight);
 
-   BOOST_REQUIRE_EQUAL(2, updateauth.authority.accounts.size());
-   BOOST_CHECK_EQUAL("prm.acct1", updateauth.authority.accounts[0].permission.account);
-   BOOST_CHECK_EQUAL("prm.prm1", updateauth.authority.accounts[0].permission.permission);
-   BOOST_CHECK_EQUAL(53005u, updateauth.authority.accounts[0].weight);
-   BOOST_CHECK_EQUAL("prm.acct2", updateauth.authority.accounts[1].permission.account);
-   BOOST_CHECK_EQUAL("prm.prm2", updateauth.authority.accounts[1].permission.permission);
-   BOOST_CHECK_EQUAL(53405u, updateauth.authority.accounts[1].weight);
+   BOOST_REQUIRE_EQUAL(2, updateauth.new_authority.accounts.size());
+   BOOST_CHECK_EQUAL("prm.acct1", updateauth.new_authority.accounts[0].permission.account);
+   BOOST_CHECK_EQUAL("prm.prm1", updateauth.new_authority.accounts[0].permission.permission);
+   BOOST_CHECK_EQUAL(53005u, updateauth.new_authority.accounts[0].weight);
+   BOOST_CHECK_EQUAL("prm.acct2", updateauth.new_authority.accounts[1].permission.account);
+   BOOST_CHECK_EQUAL("prm.prm2", updateauth.new_authority.accounts[1].permission.permission);
+   BOOST_CHECK_EQUAL(53405u, updateauth.new_authority.accounts[1].weight);
 
    auto var2 = verify_round_trip_conversion( abis, "updateauth", var );
    auto updateauth2 = var2.as<eosio::types::updateauth>();
@@ -789,21 +789,21 @@ BOOST_FIXTURE_TEST_CASE(updateauth, testing_fixture)
    BOOST_CHECK_EQUAL(updateauth.permission, updateauth2.permission);
    BOOST_CHECK_EQUAL(updateauth.parent, updateauth2.parent);
 
-   BOOST_CHECK_EQUAL(updateauth.authority.threshold, updateauth2.authority.threshold);
+   BOOST_CHECK_EQUAL(updateauth.new_authority.threshold, updateauth2.new_authority.threshold);
 
-   BOOST_REQUIRE_EQUAL(updateauth.authority.keys.size(), updateauth2.authority.keys.size());
-   BOOST_CHECK_EQUAL(updateauth.authority.keys[0].key, updateauth2.authority.keys[0].key);
-   BOOST_CHECK_EQUAL(updateauth.authority.keys[0].weight, updateauth2.authority.keys[0].weight);
-   BOOST_CHECK_EQUAL(updateauth.authority.keys[1].key, updateauth2.authority.keys[1].key);
-   BOOST_CHECK_EQUAL(updateauth.authority.keys[1].weight, updateauth2.authority.keys[1].weight);
+   BOOST_REQUIRE_EQUAL(updateauth.new_authority.keys.size(), updateauth2.new_authority.keys.size());
+   BOOST_CHECK_EQUAL(updateauth.new_authority.keys[0].key, updateauth2.new_authority.keys[0].key);
+   BOOST_CHECK_EQUAL(updateauth.new_authority.keys[0].weight, updateauth2.new_authority.keys[0].weight);
+   BOOST_CHECK_EQUAL(updateauth.new_authority.keys[1].key, updateauth2.new_authority.keys[1].key);
+   BOOST_CHECK_EQUAL(updateauth.new_authority.keys[1].weight, updateauth2.new_authority.keys[1].weight);
 
-   BOOST_REQUIRE_EQUAL(updateauth.authority.accounts.size(), updateauth2.authority.accounts.size());
-   BOOST_CHECK_EQUAL(updateauth.authority.accounts[0].permission.account, updateauth2.authority.accounts[0].permission.account);
-   BOOST_CHECK_EQUAL(updateauth.authority.accounts[0].permission.permission, updateauth2.authority.accounts[0].permission.permission);
-   BOOST_CHECK_EQUAL(updateauth.authority.accounts[0].weight, updateauth2.authority.accounts[0].weight);
-   BOOST_CHECK_EQUAL(updateauth.authority.accounts[1].permission.account, updateauth2.authority.accounts[1].permission.account);
-   BOOST_CHECK_EQUAL(updateauth.authority.accounts[1].permission.permission, updateauth2.authority.accounts[1].permission.permission);
-   BOOST_CHECK_EQUAL(updateauth.authority.accounts[1].weight, updateauth2.authority.accounts[1].weight);
+   BOOST_REQUIRE_EQUAL(updateauth.new_authority.accounts.size(), updateauth2.new_authority.accounts.size());
+   BOOST_CHECK_EQUAL(updateauth.new_authority.accounts[0].permission.account, updateauth2.new_authority.accounts[0].permission.account);
+   BOOST_CHECK_EQUAL(updateauth.new_authority.accounts[0].permission.permission, updateauth2.new_authority.accounts[0].permission.permission);
+   BOOST_CHECK_EQUAL(updateauth.new_authority.accounts[0].weight, updateauth2.new_authority.accounts[0].weight);
+   BOOST_CHECK_EQUAL(updateauth.new_authority.accounts[1].permission.account, updateauth2.new_authority.accounts[1].permission.account);
+   BOOST_CHECK_EQUAL(updateauth.new_authority.accounts[1].permission.permission, updateauth2.new_authority.accounts[1].permission.permission);
+   BOOST_CHECK_EQUAL(updateauth.new_authority.accounts[1].weight, updateauth2.new_authority.accounts[1].weight);
 
 } FC_LOG_AND_RETHROW() }
 


### PR DESCRIPTION
Resolve #665 
STAT-152
GCC does not like using name of type as variable name.
