### PR TITLE
Embed git version in eosc/eosd/launcher.  Log in eosd.  Resolves #664

### DIFF
--- a/plugins/net_plugin/include/eos/net_plugin/protocol.hpp
+++ b/plugins/net_plugin/include/eos/net_plugin/protocol.hpp
@@ -1,3 +1,7 @@
+/**
+ *  @file
+ *  @copyright defined in eos/LICENSE.txt
+ */
 #pragma once
 #include <eos/chain/block.hpp>
 #include <eos/chain/types.hpp>
@@ -8,7 +12,7 @@ namespace eosio {
    using namespace fc;
 
   struct handshake_message {
-      int16_t         network_version = 0;
+      int16_t         network_version = 0; ///< derived from git commit hash, not sequential
       chain_id_type   chain_id; ///< used to identify chain
       fc::sha256      node_id; ///< used to identify peers and prevent self-connect
       string          p2p_address;

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -215,7 +215,6 @@ namespace eosio {
   constexpr auto     def_conn_retry_wait = std::chrono::seconds (30);
   constexpr auto     def_txn_expire_wait = std::chrono::seconds (3);
   constexpr auto     def_resp_expected_wait = std::chrono::seconds (1);
-  constexpr auto     def_network_version = 0;
   constexpr auto     def_sync_rec_span = 10;
   constexpr auto     def_max_just_send = 1300 * 3; // "mtu" * 3
   constexpr auto     def_send_whole_blocks = true;
@@ -2102,7 +2101,7 @@ namespace eosio {
       sync_manager::logger.set_log_level(logl);
     }
 
-    my->network_version = def_network_version;
+    my->network_version = (uint16_t)app().version_int();
     my->send_whole_blocks = def_send_whole_blocks;
 
     my->sync_master.reset( new sync_manager( def_sync_rec_span ) );

--- a/programs/eosc/CMakeLists.txt
+++ b/programs/eosc/CMakeLists.txt
@@ -5,8 +5,23 @@ endif()
 
 find_package( Gperftools QUIET )
 if( GPERFTOOLS_FOUND )
-    message( STATUS "Found gperftools; compiling steemd with TCMalloc")
+    message( STATUS "Found gperftools; compiling with TCMalloc")
     list( APPEND PLATFORM_SPECIFIC_LIBS tcmalloc )
+endif()
+
+if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/../../.git)
+  find_package(Git)
+  if(GIT_FOUND)
+    execute_process(
+      COMMAND ${GIT_EXECUTABLE} rev-parse --short HEAD
+      WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/../.."
+      OUTPUT_VARIABLE "eosc_BUILD_VERSION"
+      ERROR_QUIET
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+    message(STATUS "Git commit revision: ${eosc_BUILD_VERSION}")
+  else()
+    set(eosc_BUILD_VERSION 0)
+  endif()
 endif()
 
 find_package(Intl REQUIRED)

--- a/programs/eosc/config.hpp.in
+++ b/programs/eosc/config.hpp.in
@@ -1,6 +1,8 @@
 /** @file 
  *    @copyright defined in eos/LICENSE.txt 
- **/
+ *
+ * \warning This file is machine generated. DO NOT EDIT.  See config.hpp.in for changes.
+ */
 
 namespace eosio { namespace client { namespace config {
    constexpr char version_str[] = "${eosc_BUILD_VERSION}";

--- a/programs/eosc/config.hpp.in
+++ b/programs/eosc/config.hpp.in
@@ -3,6 +3,7 @@
  **/
 
 namespace eosio { namespace client { namespace config {
+   constexpr char version_str[] = "${eosc_BUILD_VERSION}";
    constexpr char locale_path[] = "${LOCALEDIR}";
    constexpr char locale_domain[] = "${LOCALEDOMAIN}";
-}}};
+}}}

--- a/programs/eosc/main.cpp
+++ b/programs/eosc/main.cpp
@@ -94,7 +94,7 @@ Options:
 #include "CLI11.hpp"
 #include "help_text.hpp"
 #include "localize.hpp"
-#include <config.hpp>
+#include "config.hpp"
 
 using namespace std;
 using namespace eosio;
@@ -455,7 +455,7 @@ int main( int argc, char** argv ) {
    bindtextdomain(locale_domain, locale_path);
    textdomain(locale_domain);
 
-   CLI::App app{"Command Line Interface to Eos Daemon"};
+   CLI::App app{"Command Line Interface to Eos Client"};
    app.require_subcommand();
    app.add_option( "-H,--host", host, localized("the host where eosd is running"), true );
    app.add_option( "-p,--port", port, localized("the port where eosd is running"), true );
@@ -464,6 +464,13 @@ int main( int argc, char** argv ) {
 
    bool verbose_errors = false;
    app.add_flag( "-v,--verbose", verbose_errors, localized("output verbose messages on error"));
+
+   auto version = app.add_subcommand("version", localized("Retrieve version information"), false);
+   version->require_subcommand();
+
+   version->add_subcommand("client", localized("Retrieve version information of the client"))->set_callback([] {
+     std::cout << localized("Build version: ${ver}", ("ver", eosio::client::config::version_str)) << std::endl;
+   });
 
    // Create subcommand
    auto create = app.add_subcommand("create", localized("Create various items, on and off the blockchain"), false);

--- a/programs/eosd/CMakeLists.txt
+++ b/programs/eosd/CMakeLists.txt
@@ -9,6 +9,25 @@ if( GPERFTOOLS_FOUND )
     list( APPEND PLATFORM_SPECIFIC_LIBS tcmalloc )
 endif()
 
+if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/../../.git)
+  find_package(Git)
+  if(GIT_FOUND)
+    execute_process(
+      COMMAND ${GIT_EXECUTABLE} rev-parse --short HEAD
+      WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/../.."
+      OUTPUT_VARIABLE "eosd_BUILD_VERSION"
+      ERROR_QUIET
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+    message(STATUS "Git commit revision: ${eosd_BUILD_VERSION}")
+  else()
+    set(eosd_BUILD_VERSION 0)
+  endif()
+endif()
+
+configure_file(config.hpp.in config.hpp ESCAPE_QUOTES)
+
+target_include_directories(eosd PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
+
 target_link_libraries( eosd
         PRIVATE appbase
         PRIVATE account_history_api_plugin account_history_plugin db_plugin

--- a/programs/eosd/config.hpp.in
+++ b/programs/eosd/config.hpp.in
@@ -1,0 +1,17 @@
+/**
+ *  @file
+ *  @copyright defined in eos/LICENSE.txt
+ *
+ * \warning This file is machine generated. DO NOT EDIT.  See config.hpp.in for changes.
+ */
+#pragma once
+
+#ifndef CONFIG_HPP_IN
+#define CONFIG_HPP_IN
+
+namespace eosio { namespace eosd { namespace config {
+  constexpr char version_str[] = "${eosd_BUILD_VERSION}";
+  constexpr uint64_t version_int = 0x${eosd_BUILD_VERSION};
+}}}
+
+#endif // CONFIG_HPP_IN

--- a/programs/eosd/main.cpp
+++ b/programs/eosd/main.cpp
@@ -19,12 +19,16 @@
 
 #include <boost/exception/diagnostic_information.hpp>
 
+#include "config.hpp"
+
 using namespace appbase;
 using namespace eosio;
 
 int main(int argc, char** argv)
 {
    try {
+      app().set_version(eosio::eosd::config::version_str);
+      ilog("eosd version ${ver}", ("ver", app().version()));
       app().register_plugin<net_plugin>();
       app().register_plugin<chain_api_plugin>();
       app().register_plugin<producer_plugin>();

--- a/programs/launcher/CMakeLists.txt
+++ b/programs/launcher/CMakeLists.txt
@@ -5,12 +5,31 @@ endif()
 
 find_package( Gperftools QUIET )
 if( GPERFTOOLS_FOUND )
-    message( STATUS "Found gperftools; compiling steemd with TCMalloc")
+    message( STATUS "Found gperftools; compiling with TCMalloc")
     list( APPEND PLATFORM_SPECIFIC_LIBS tcmalloc )
 endif()
 
-target_link_libraries( launcher
-                       PRIVATE fc ${CMAKE_DL_LIBS} ${PLATFORM_SPECIFIC_LIBS} )
+if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/../../.git)
+  find_package(Git)
+  if(GIT_FOUND)
+    execute_process(
+      COMMAND ${GIT_EXECUTABLE} rev-parse --short HEAD
+      WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/../.."
+      OUTPUT_VARIABLE "launcher_BUILD_VERSION"
+      ERROR_QUIET
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+    message(STATUS "Git commit revision: ${launcher_BUILD_VERSION}")
+  else()
+    set(launcher_BUILD_VERSION 0)
+  endif()
+endif()
+
+configure_file(config.hpp.in config.hpp ESCAPE_QUOTES)
+
+target_include_directories(launcher PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
+
+target_link_libraries(launcher
+                      PRIVATE fc ${CMAKE_DL_LIBS} ${PLATFORM_SPECIFIC_LIBS} )
 
 install( TARGETS
    launcher

--- a/programs/launcher/config.hpp.in
+++ b/programs/launcher/config.hpp.in
@@ -1,0 +1,16 @@
+/**
+ *  @file
+ *  @copyright defined in eos/LICENSE.txt
+ *
+ * \warning This file is machine generated. DO NOT EDIT.  See config.hpp.in for changes.
+ */
+#pragma once
+
+#ifndef CONFIG_HPP_IN
+#define CONFIG_HPP_IN
+
+namespace eosio { namespace launcher { namespace config {
+  constexpr char version_str[] = "${launcher_BUILD_VERSION}";
+}}}
+
+#endif // CONFIG_HPP_IN

--- a/programs/launcher/main.cpp
+++ b/programs/launcher/main.cpp
@@ -25,6 +25,8 @@
 #include <netinet/in.h>
 #include <net/if.h>
 
+#include "config.hpp"
+
 using namespace std;
 namespace bf = boost::filesystem;
 namespace bp = boost::process;
@@ -751,6 +753,7 @@ int main (int argc, char *argv[]) {
     ("timestamp,i",bpo::value<string>(),"set the timestamp for the first block. Use \"now\" to indicate the current time")
     ("launch,l",bpo::value<string>(), "select a subset of nodes to launch. Currently may be \"all\", \"none\", or \"local\". If not set, the default is to launch all unless an output file is named, in which case it starts none.")
     ("kill,k", bpo::value<string>(),"The launcher retrieves the previously started process ids and issue a kill signal to each.")
+    ("version,v", "print version information")
     ("help,h","print this list");
 
 
@@ -766,6 +769,10 @@ int main (int argc, char *argv[]) {
     }
     if (vmap.count("help") > 0) {
       opts.print(cerr);
+      return 0;
+    }
+    if (vmap.count("version") > 0) {
+      cout << eosio::launcher::config::version_str << endl;
       return 0;
     }
 


### PR DESCRIPTION
Not strictly necessary for launcher since it does not interact so directly with eosc/eosd, but included for the sake of completeness.  Launcher has been getting new features that correspond with new features in eosd, so being able to verify a version match could be useful.