### PR TITLE
Fix for accidental abi change. #702

### DIFF
--- a/contracts/currency/currency.abi
+++ b/contracts/currency/currency.abi
@@ -16,7 +16,7 @@
       "name": "account",
       "base": "",
       "fields": {
-        "key": "uint64",
+        "account": "name",
         "balance": "uint64"
       }
     }

--- a/tests/eosd_run_test.sh
+++ b/tests/eosd_run_test.sh
@@ -409,6 +409,10 @@ count=`echo $INFO | grep -c "1000000000"`
 if [ $count == 0 ]; then
   error "FAILURE - get table currency account failed: $INFO"
 fi
+count=`echo $INFO | grep -c "account"`
+if [ $count == 0 ]; then
+  error "FAILURE - get table currency account failed: $INFO"
+fi
 
 # push message to currency contract
 INFO="$(programs/eosc/eosc --host $SERVER --port $PORT --wallet-port 8899 push message currency transfer '{"from":"currency","to":"inita","amount":50}' --scope currency,inita --permission currency@active)"


### PR DESCRIPTION
Resolves #702.

The currency.abi was accidentally modified during the coding style changes. Reverted back to the prior version, changing Name to name as the only change.

Added to eosd_run_test.sh script to verify "account" is returned from `./eosc get table currency currency account`