### PR TITLE
fix the s2wasm cannot find issue

### DIFF
--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -34,7 +34,7 @@ if [ $ARCH == "ubuntu" ]; then
 
     # install binaryen
     cd ${TEMP_DIR}
-    git clone https://github.com/WebAssembly/binaryen
+    git clone https://github.com/WebAssembly/binaryen.git
     cd binaryen
     git checkout tags/1.37.14
     cmake . && make

--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -77,6 +77,26 @@ if [ $ARCH == "darwin" ]; then
     sudo rm -rf ${TEMP_DIR}/secp256k1-zkp
 
     # Install binaryen v1.37.14:
+    
+    # In case user encounter s2wasm not found, uncomment the six lines below to remove the existing binaryen.
+    # sudo rm -rf /usr/local/binaryen.js /usr/local/empty.txt /usr/local/wasm.js 
+    # echo "remove existing binary.js, empty.txt, and wasm.js under /usr/local/"
+    # sudo rm -rf /usr/local/binaryen  
+    # echo "remove existing binaryen folder under /usr/local/"
+    # sudo rm -rf ${TEMP_DIR}/binaryren 
+    # echo "remove existing binaryen folder under \${TEMP_DIR}"
+
+    cd ${TEMP_DIR}
+    git clone https://github.com/WebAssembly/binaryen.git
+    cd binaryen
+    git checkout tags/1.37.14
+    cmake . && make
+    sudo mkdir /usr/local/binaryen
+    sudo mv ${TEMP_DIR}/binaryen/bin /usr/local/binaryen
+    sudo ln -s /usr/local/binaryen/bin/* /usr/local
+    sudo rm -rf ${TEMP_DIR}/binaryen
+    BINARYEN_BIN=/usr/local/binaryen/bin/
+
     cd ${TEMP_DIR}
     git clone https://github.com/WebAssembly/binaryen.git
     cd binaryen

--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -78,7 +78,7 @@ if [ $ARCH == "darwin" ]; then
 
     # Install binaryen v1.37.14:
     cd ${TEMP_DIR}
-    git clone https://github.com/WebAssembly/binaryen
+    git clone https://github.com/WebAssembly/binaryen.git
     cd binaryen
     git checkout tags/1.37.14
     cmake . && make

--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -84,7 +84,7 @@ if [ $ARCH == "darwin" ]; then
     # sudo rm -rf /usr/local/binaryen  
     # echo "remove existing binaryen folder under /usr/local/"
     # sudo rm -rf ${TEMP_DIR}/binaryren 
-    # echo "remove existing binaryen folder under \${TEMP_DIR}"
+    # echo "remove existing binaryen folder under ${TEMP_DIR}"
 
     cd ${TEMP_DIR}
     git clone https://github.com/WebAssembly/binaryen.git

--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -97,17 +97,6 @@ if [ $ARCH == "darwin" ]; then
     sudo rm -rf ${TEMP_DIR}/binaryen
     BINARYEN_BIN=/usr/local/binaryen/bin/
 
-    cd ${TEMP_DIR}
-    git clone https://github.com/WebAssembly/binaryen.git
-    cd binaryen
-    git checkout tags/1.37.14
-    cmake . && make
-    sudo mkdir /usr/local/binaryen
-    sudo mv ${TEMP_DIR}/binaryen/bin /usr/local/binaryen
-    sudo ln -s /usr/local/binaryen/bin/* /usr/local
-    sudo rm -rf ${TEMP_DIR}/binaryen
-    BINARYEN_BIN=/usr/local/binaryen/bin/
-
     # Build LLVM and clang for WASM:
     cd ${TEMP_DIR}
     mkdir wasm-compiler


### PR DESCRIPTION
add .`git` of the git clone of `binaryen`
This typo will lead to unsuccessful build: cannot find`s2wasm` 
This is a common issue in the Developer group.
![image](https://user-images.githubusercontent.com/16319106/32876683-efd47bc4-cad8-11e7-86d2-9a93f7ec6bee.png)
