### PR TITLE
Compatibility fixes for clang lib linking.

### DIFF
--- a/programs/abi_gen/CMakeLists.txt
+++ b/programs/abi_gen/CMakeLists.txt
@@ -1,4 +1,7 @@
 set(SOURCES main.cpp)
+find_package(LLVM 4.0 REQUIRED CONFIG)
+
+link_directories(${LLVM_LIBRARY_DIR})
 
 add_executable(abi_gen ${SOURCES})
 
@@ -10,7 +13,7 @@ endif()
 
 find_package( Gperftools QUIET )
 if( GPERFTOOLS_FOUND )
-    message( STATUS "Found gperftools; compiling steemd with TCMalloc")
+    message( STATUS "Found gperftools; compiling with TCMalloc")
     list( APPEND PLATFORM_SPECIFIC_LIBS tcmalloc )
 endif()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,6 +6,10 @@ if( GPERFTOOLS_FOUND )
     list( APPEND PLATFORM_SPECIFIC_LIBS tcmalloc )
 endif()
 
+find_package(LLVM 4.0 REQUIRED CONFIG)
+
+link_directories(${LLVM_LIBRARY_DIR})
+
 set( CMAKE_CXX_STANDARD 14 )
 
 file(GLOB UNIT_TESTS "tests/*.cpp")


### PR DESCRIPTION
On some platforms, statically linked libraries of libraries are still
relinked in executables.  Add search path to enable builds.