### PR TITLE
STAT-153(GH-682): Remove signed_transaction from transaction_object s…

### DIFF
--- a/libraries/chain/chain_controller.cpp
+++ b/libraries/chain/chain_controller.cpp
@@ -86,16 +86,6 @@ optional<signed_block> chain_controller::fetch_block_by_number(uint32_t num)cons
    return optional<signed_block>();
 }
 
-/*
-const signed_transaction& chain_controller::get_recent_transaction(const transaction_id_type& trx_id) const
-{
-   auto& index = _db.get_index<transaction_multi_index, by_trx_id>();
-   auto itr = index.find(trx_id);
-   FC_ASSERT(itr != index.end());
-   return itr->trx;
-}
-*/
-
 std::vector<block_id_type> chain_controller::get_block_ids_on_fork(block_id_type head_of_fork) const
 {
   pair<fork_database::branch_type, fork_database::branch_type> branches = _fork_db.fetch_branch_from(head_block_id(), head_of_fork);

--- a/libraries/chain/chain_controller.cpp
+++ b/libraries/chain/chain_controller.cpp
@@ -86,6 +86,7 @@ optional<signed_block> chain_controller::fetch_block_by_number(uint32_t num)cons
    return optional<signed_block>();
 }
 
+/*
 const signed_transaction& chain_controller::get_recent_transaction(const transaction_id_type& trx_id) const
 {
    auto& index = _db.get_index<transaction_multi_index, by_trx_id>();
@@ -93,6 +94,7 @@ const signed_transaction& chain_controller::get_recent_transaction(const transac
    FC_ASSERT(itr != index.end());
    return itr->trx;
 }
+*/
 
 std::vector<block_id_type> chain_controller::get_block_ids_on_fork(block_id_type head_of_fork) const
 {
@@ -127,7 +129,7 @@ const generated_transaction& chain_controller::get_generated_transaction( const 
  */
 bool chain_controller::push_block(const signed_block& new_block, uint32_t skip)
 { try {
-   return with_skip_flags( skip, [&](){ 
+   return with_skip_flags( skip, [&](){
       return without_pending_transactions( [&]() {
          return _db.with_write_lock( [&]() {
             return _push_block(new_block);
@@ -201,13 +203,13 @@ bool chain_controller::_push_block(const signed_block& new_block)
       if( (fc::time_point::now() - new_block.timestamp) < fc::seconds(60) )
       {
          auto exec_stop = std::chrono::high_resolution_clock::now();
-         auto exec_ms = std::chrono::duration_cast<std::chrono::milliseconds>(exec_stop - exec_start);      
+         auto exec_ms = std::chrono::duration_cast<std::chrono::milliseconds>(exec_stop - exec_start);
          size_t trxcount = 0;
          for (const auto& cycle : new_block.cycles)
             for (const auto& thread : cycle)
                trxcount += thread.user_input.size();
-         ilog( "${producer} #${num} @${time}  | ${trxcount} trx, ${pending} pending, exectime_ms=${extm}", 
-            ("producer", new_block.producer) 
+         ilog( "${producer} #${num} @${time}  | ${trxcount} trx, ${pending} pending, exectime_ms=${extm}",
+            ("producer", new_block.producer)
             ("time", new_block.timestamp)
             ("num", new_block.block_num())
             ("trxcount", trxcount)
@@ -260,7 +262,7 @@ processed_transaction chain_controller::_push_transaction(const signed_transacti
    temp_session.squash();
 
    // notify anyone listening to pending transactions
-   on_pending_transaction(trx); /// TODO move this to apply... ??? why... 
+   on_pending_transaction(trx); /// TODO move this to apply... ??? why...
 
    return pt;
 }
@@ -301,7 +303,7 @@ signed_block chain_controller::_generate_block(
    if( !(skip & skip_producer_signature) )
       FC_ASSERT( producer_obj.signing_key == block_signing_private_key.get_public_key() );
 
-  
+
    //
    // The following code throws away existing pending_tx_session and
    // rebuilds it by re-applying pending transactions.
@@ -325,7 +327,7 @@ signed_block chain_controller::_generate_block(
       const auto& gt = *iter;
       pending.emplace_back(std::reference_wrapper<const generated_transaction> {gt.trx});
    }
-   
+
    for(const auto& st: _pending_transactions) {
       pending.emplace_back(std::reference_wrapper<const signed_transaction> {st});
    }
@@ -363,7 +365,7 @@ signed_block chain_controller::_generate_block(
              } else {
                 FC_THROW_EXCEPTION(tx_scheduling_exception, "Unknown transaction type in block_schedule");
              }
-             
+
              temp_session.squash();
              valid_transaction_count++;
           }
@@ -377,7 +379,7 @@ signed_block chain_controller::_generate_block(
                 invalid_pending.emplace(t.id());
              } else if (trx.contains<std::reference_wrapper<const generated_transaction>>()) {
                 wlog( "The transaction was ${t}", ("t", trx.get<std::reference_wrapper<const generated_transaction>>().get()) );
-             } 
+             }
              invalid_transaction_count++;
           }
        }
@@ -393,7 +395,7 @@ signed_block chain_controller::_generate_block(
         pending_block.cycles.emplace_back(std::move(block_cycle));
      }
    }
-   
+
    size_t postponed_tx_count = pending.size() - valid_transaction_count - invalid_transaction_count;
    if( postponed_tx_count > 0 )
    {
@@ -499,24 +501,24 @@ struct path_cons_list {
    typedef static_variant<int, const char *> head_type;
    typedef const path_cons_list* tail_ref_type;
    typedef optional<tail_ref_type> tail_type;
-   
-   path_cons_list(int index, const path_cons_list &rest) 
+
+   path_cons_list(int index, const path_cons_list &rest)
       : head(head_type(index))
       , tail(tail_ref_type(&rest))
    { }
 
-   path_cons_list(const char *path, const path_cons_list &rest) 
+   path_cons_list(const char *path, const path_cons_list &rest)
       : head(head_type(path))
       , tail(tail_ref_type(&rest))
    { }
 
-   path_cons_list(const char *path) 
+   path_cons_list(const char *path)
       : head(head_type(path))
       , tail()
    { }
 
    //path_cons_list( path_cons_list && ) = delete;
-   
+
    const head_type head;
    tail_type tail;
 
@@ -550,7 +552,7 @@ string resolve_path_string(const path_cons_list& path) {
 template<typename T>
 void check_output(const T& expected, const T& actual, const path_cons_list& path) {
    try {
-      EOS_ASSERT((expected == actual), block_tx_output_exception, 
+      EOS_ASSERT((expected == actual), block_tx_output_exception,
          "expected: ${expected}, actual: ${actual}", ("expected", expected)("actual", actual));
    } FC_RETHROW_EXCEPTIONS(warn, "at: ${path}", ("path", resolve_path_string(path)));
 }
@@ -576,7 +578,7 @@ void check_output(const fc::optional<T>& expected, const fc::optional<T>& actual
 template<>
 void check_output(const types::bytes& expected, const types::bytes& actual, const path_cons_list& path) {
   check_output(expected.size(), actual.size(), path(".size()"));
-  
+
   auto cmp_result = std::memcmp(expected.data(), actual.data(), expected.size());
   check_output(cmp_result, 0, path("@memcmp()"));
 }
@@ -649,7 +651,7 @@ void chain_controller::_apply_block(const signed_block& next_block)
              ("calc",next_block.calculate_merkle_root())("next_block",next_block)("id",next_block.id()));
 
    const producer_object& signing_producer = validate_block_header(skip, next_block);
-   
+
    for (const auto& cycle : next_block.cycles)
       for (const auto& thread : cycle)
          for (const auto& trx : thread.user_input) {
@@ -701,7 +703,7 @@ void chain_controller::_apply_block(const signed_block& next_block)
    clear_expired_transactions();
 
    // notify observers that the block has been applied
-   // TODO: do this outside the write lock...? 
+   // TODO: do this outside the write lock...?
    applied_block( next_block ); //emit
    if (_currently_replaying_blocks)
      applied_irreversible_block(next_block);
@@ -827,7 +829,7 @@ void chain_controller::record_transaction(const signed_transaction& trx) {
    //Insert transaction into unique transactions database.
     _db.create<transaction_object>([&](transaction_object& transaction) {
         transaction.trx_id = trx.id(); /// TODO: consider caching ID
-        transaction.trx = trx;
+        transaction.expiration = trx.expiration;
     });
 }
 
@@ -835,7 +837,7 @@ void chain_controller::record_transaction(const generated_transaction& trx) {
    _db.modify( _db.get<generated_transaction_object,generated_transaction_object::by_trx_id>(trx.id), [&](generated_transaction_object& transaction) {
       transaction.status = generated_transaction_object::PROCESSED;
    });
-}     
+}
 
 
 
@@ -1239,7 +1241,7 @@ void chain_controller::initialize_chain(chain_initializer_interface& starter)
             processed_transaction trx; /// dummy transaction required for scope validation
             std::sort(trx.scope.begin(), trx.scope.end() );
             with_skip_flags(skip_scope_check | skip_transaction_signatures | skip_authority_check | received_block, [&](){
-               process_message(trx,m.code,m,output); 
+               process_message(trx,m.code,m,output);
             });
 
             trx.messages.push_back(m);
@@ -1477,7 +1479,7 @@ void chain_controller::clear_expired_transactions()
    //Transactions must have expired by at least two forking windows in order to be removed.
    auto& transaction_idx = _db.get_mutable_index<transaction_multi_index>();
    const auto& dedupe_index = transaction_idx.indices().get<by_expiration>();
-   while( (!dedupe_index.empty()) && (head_block_time() > dedupe_index.rbegin()->trx.expiration) )
+   while( (!dedupe_index.empty()) && (head_block_time() > dedupe_index.rbegin()->expiration) )
       transaction_idx.remove(*dedupe_index.rbegin());
 
    //Look for expired transactions in the pending generated list, and remove them.
@@ -1566,7 +1568,7 @@ processed_transaction chain_controller::transaction_from_variant( const fc::vari
             if( data.is_string() ) {
                GET_FIELD( vo, data, result.messages[i] );
             } else if ( data.is_object() ) {
-               result.messages[i].data = message_to_binary( result.messages[i].code, result.messages[i].type, data ); 
+               result.messages[i].data = message_to_binary( result.messages[i].code, result.messages[i].type, data );
                /*
                const auto& code_account = _db.get<account_object,by_name>( result.messages[i].code );
                eosio::types::abi code_abi;
@@ -1629,7 +1631,7 @@ fc::variant  chain_controller::transaction_to_variant( const processed_transacti
        const auto& code_account = _db.get<account_object,by_name>( msg.code );
        if( !types::abi_serializer::is_empty_abi(code_account.abi) ) {
           try {
-             msg_mvo( "data", message_from_binary( msg.code, msg.type, msg.data ) ); 
+             msg_mvo( "data", message_from_binary( msg.code, msg.type, msg.data ) );
              msg_mvo( "hex_data", msg.data );
           } catch ( ... ) {
             SET_FIELD( msg_mvo, msg, data );
@@ -1642,7 +1644,7 @@ fc::variant  chain_controller::transaction_to_variant( const processed_transacti
     }
     trx_mvo( "messages", std::move(msgsv) );
 
-    /* TODO: recursively process generated transactions 
+    /* TODO: recursively process generated transactions
     vector<fc::mutable_variant_object> outs( trx.messages.size() );
     for( uint32_t i = 0; i < trx.output.size(); ++i ) {
        auto& out_mvo = outs[i];

--- a/libraries/chain/include/eos/chain/chain_controller.hpp
+++ b/libraries/chain/include/eos/chain/chain_controller.hpp
@@ -121,7 +121,6 @@ namespace eosio { namespace chain {
          block_id_type               get_block_id_for_num( uint32_t block_num )const;
          optional<signed_block>      fetch_block_by_id( const block_id_type& id )const;
          optional<signed_block>      fetch_block_by_number( uint32_t num )const;
-         //const signed_transaction&    get_recent_transaction( const transaction_id_type& trx_id )const;
          std::vector<block_id_type>  get_block_ids_on_fork(block_id_type head_of_fork)const;
          const generated_transaction& get_generated_transaction( const generated_transaction_id_type& id ) const;
 

--- a/libraries/chain/include/eos/chain/chain_controller.hpp
+++ b/libraries/chain/include/eos/chain/chain_controller.hpp
@@ -121,7 +121,7 @@ namespace eosio { namespace chain {
          block_id_type               get_block_id_for_num( uint32_t block_num )const;
          optional<signed_block>      fetch_block_by_id( const block_id_type& id )const;
          optional<signed_block>      fetch_block_by_number( uint32_t num )const;
-         const signed_transaction&    get_recent_transaction( const transaction_id_type& trx_id )const;
+         //const signed_transaction&    get_recent_transaction( const transaction_id_type& trx_id )const;
          std::vector<block_id_type>  get_block_ids_on_fork(block_id_type head_of_fork)const;
          const generated_transaction& get_generated_transaction( const generated_transaction_id_type& id ) const;
 
@@ -134,7 +134,7 @@ namespace eosio { namespace chain {
 
          /**
           * This method will convert a signed transaction into a human-friendly variant that can be
-          * converted to JSON.  
+          * converted to JSON.
           */
          fc::variant       transaction_to_variant( const processed_transaction& trx )const;
 
@@ -189,7 +189,7 @@ namespace eosio { namespace chain {
 
 
          template<typename Function>
-         auto with_skip_flags( uint64_t flags, Function&& f ) -> decltype((*((Function*)nullptr))()) 
+         auto with_skip_flags( uint64_t flags, Function&& f ) -> decltype((*((Function*)nullptr))())
          {
             auto old_flags = _skip_flags;
             auto on_exit   = fc::make_scoped_exit( [&](){ _skip_flags = old_flags; } );
@@ -198,11 +198,11 @@ namespace eosio { namespace chain {
          }
 
          template<typename Function>
-         auto without_pending_transactions( Function&& f ) -> decltype((*((Function*)nullptr))()) 
+         auto without_pending_transactions( Function&& f ) -> decltype((*((Function*)nullptr))())
          {
             auto old_pending = std::move( _pending_transactions );
             _pending_tx_session.reset();
-            auto on_exit = fc::make_scoped_exit( [&](){ 
+            auto on_exit = fc::make_scoped_exit( [&](){
                for( const auto& t : old_pending ) {
                   try {
                      if (!is_known_transaction(t.id()))
@@ -268,7 +268,7 @@ namespace eosio { namespace chain {
  //  protected:
          const chainbase::database& get_database() const { return _db; }
          chainbase::database& get_mutable_database() { return _db; }
-         
+
          bool should_check_scope()const                      { return !(_skip_flags&skip_scope_check);            }
 
 
@@ -333,7 +333,7 @@ namespace eosio { namespace chain {
 
          template<typename T>
          typename T::processed apply_transaction(const T& trx);
-         
+
          template<typename T>
          typename T::processed process_transaction(const T& trx, int depth, const fc::time_point& start_time);
 
@@ -354,7 +354,7 @@ namespace eosio { namespace chain {
             validate_tapos(trx);
 
          } FC_CAPTURE_AND_RETHROW( (trx) ) }
-         
+
          /// Validate transaction helpers @{
          void validate_uniqueness(const signed_transaction& trx)const;
          void validate_uniqueness(const generated_transaction& trx)const;

--- a/libraries/chain/include/eos/chain/transaction_object.hpp
+++ b/libraries/chain/include/eos/chain/transaction_object.hpp
@@ -26,10 +26,10 @@ namespace eosio { namespace chain {
          OBJECT_CTOR(transaction_object)
 
          id_type             id;
-         signed_transaction  trx;
+         time_point_sec      expiration;
          transaction_id_type trx_id;
 
-         time_point_sec get_expiration()const { return trx.expiration; }
+         time_point_sec get_expiration()const { return expiration; }
    };
 
    struct by_expiration;
@@ -48,4 +48,4 @@ namespace eosio { namespace chain {
 
 CHAINBASE_SET_INDEX_TYPE(eosio::chain::transaction_object, eosio::chain::transaction_multi_index)
 
-FC_REFLECT( eosio::chain::transaction_object, (trx)(trx_id) )
+FC_REFLECT( eosio::chain::transaction_object, (expiration)(trx_id) )

--- a/libraries/types/include/eos/types/exceptions.hpp
+++ b/libraries/types/include/eos/types/exceptions.hpp
@@ -21,4 +21,4 @@ namespace eosio { namespace types {
    FC_DECLARE_DERIVED_EXCEPTION(invalid_schema_exception, type_exception,
                                 4050000, "Schema is invalid")
 
-} } // eosio::chain
+} } // eosio::types

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -1588,6 +1588,8 @@ namespace eosio {
               }
             }
             */
+            /* Commented out when signed_transaction removed from transaction_object.
+               This code needs to be re-evaluated when block summaries are reworked.
             for( auto &ut : cyc_thr_id.user_trx ) {
               // auto ltxn = local_txns.get<by_id>().find(ut);
 
@@ -1607,6 +1609,7 @@ namespace eosio {
                 break;
               }
             }
+            */
             if( fetch_error ){
               break;
             }

--- a/plugins/producer_plugin/include/eos/producer_plugin/producer_plugin.hpp
+++ b/plugins/producer_plugin/include/eos/producer_plugin/producer_plugin.hpp
@@ -50,4 +50,4 @@ private:
    std::unique_ptr<class producer_plugin_impl> my;
 };
 
-} //eos
+} //eosio


### PR DESCRIPTION
The transaction_object previously contained a signed_transaction which has various vector data members, making it unsuitable to store in shared memory. This change removes the signed_transaction and stores its id in the transaction_object. Various other locations were corrected to use this and one usage was commented out in handle_message(block_summary) as this is not currently supported.
Resolves #682 