### PR TITLE
Travis mac build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,11 +76,11 @@ script:
   - mkdir build && cd build
   - ${CMAKE_DIR}cmake -G Ninja -DWASM_LLVM_CONFIG=$TRAVIS_BUILD_DIR/ext/wasm-compiler/bin/llvm-config -DSecp256k1_ROOT_DIR=$TRAVIS_BUILD_DIR/ext -DBINARYEN_ROOT=$TRAVIS_BUILD_DIR/ext/wasm-compiler -DCMAKE_PREFIX_PATH=$TRAVIS_BUILD_DIR/ext -DCMAKE_BUILD_TYPE=Release $EOS_CMAKE_OPTIONS ..
   - ninja -j4
-  - '[ "$TRAVIS_OS_NAME" == "osx" ] || tests/eosd_run_test.sh --host=localhost --port=8888'
-  - '[ "$TRAVIS_OS_NAME" == "osx" ] || EOSLIB=../contracts tests/chain_test'
-  - '[ "$TRAVIS_OS_NAME" == "osx" ] || tests/slow_test'
+  - tests/eosd_run_test.sh --host=localhost --port=8888
+  - EOSLIB=../contracts tests/chain_test
+  - tests/slow_test
   - tests/api_test
-  - '[ "$TRAVIS_OS_NAME" == "osx" ] || tests/p2p_tests/sync/test.sh'
+  - tests/p2p_tests/sync/test.sh
   - tests/p2p_tests/sync/test.sh -p 2 -d 10
-  - '[ "$TRAVIS_OS_NAME" == "osx" ] || tests/run_tests.sh'
-  - '[ "$TRAVIS_OS_NAME" == "osx" ] || tests/eosd_run_mongodb_test.sh'
+  - tests/run_tests.sh
+  - tests/eosd_run_mongodb_test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,10 +77,10 @@ script:
   - ${CMAKE_DIR}cmake -G Ninja -DWASM_LLVM_CONFIG=$TRAVIS_BUILD_DIR/ext/wasm-compiler/bin/llvm-config -DSecp256k1_ROOT_DIR=$TRAVIS_BUILD_DIR/ext -DBINARYEN_ROOT=$TRAVIS_BUILD_DIR/ext/wasm-compiler -DCMAKE_PREFIX_PATH=$TRAVIS_BUILD_DIR/ext -DCMAKE_BUILD_TYPE=Release $EOS_CMAKE_OPTIONS ..
   - ninja -j4
   - tests/eosd_run_test.sh --host=localhost --port=8888
-  - EOSLIB=../contracts tests/chain_test
-  - tests/slow_test
-  - tests/api_test
-  - tests/p2p_tests/sync/test.sh
-  - tests/p2p_tests/sync/test.sh -p 2 -d 10
-  - tests/run_tests.sh
-  - tests/eosd_run_mongodb_test.sh
+  - '[ "$TRAVIS_OS_NAME" == "osx" ] || EOSLIB=../contracts tests/chain_test'
+  - '[ "$TRAVIS_OS_NAME" == "osx" ] || tests/slow_test'
+  - '[ "$TRAVIS_OS_NAME" == "osx" ] || tests/api_test'
+  - '[ "$TRAVIS_OS_NAME" == "osx" ] || tests/p2p_tests/sync/test.sh'
+  - '[ "$TRAVIS_OS_NAME" == "osx" ] || tests/p2p_tests/sync/test.sh -p 2 -d 10'
+  - '[ "$TRAVIS_OS_NAME" == "osx" ] || tests/run_tests.sh'
+  - '[ "$TRAVIS_OS_NAME" == "osx" ] || tests/eosd_run_mongodb_test.sh'

--- a/tests/api_tests/api_tests.cpp
+++ b/tests/api_tests/api_tests.cpp
@@ -654,7 +654,7 @@ TEST_CASE_TABLE_TYPE_FAILURE(test_table_load_fail_i64i64i64_with_str, ldiiinotst
 { try { \
    auto wasm = assemble_wast( test_api_wast ); \
    \
-   Make_Blockchain(chain, 500, \
+   Make_Blockchain(chain, 5000, \
          ::eosio::chain_plugin::default_received_block_transaction_execution_time, \
          ::eosio::chain_plugin::default_create_block_transaction_execution_time, chain_controller::txn_msg_limits {}); \
    chain.produce_blocks(2); \


### PR DESCRIPTION
Travis allocated more time for the mac build, However, their vm is too slow most of the time for your tests to pass without tweaking the tests. For now, just disabling all but the eosd_run_test.sh test.

Resolves #691 