### PR TITLE
STAT-156, GH#683: Fix test failure

### DIFF
--- a/tests/slow_tests/deferred_tests.cpp
+++ b/tests/slow_tests/deferred_tests.cpp
@@ -64,7 +64,14 @@ BOOST_FIXTURE_TEST_CASE(opaque_proxy, testing_fixture)
       Set_Proxy_Owner(chain, "proxy", "newguy");
       chain.produce_blocks(7);
       
-      Transfer_Asset(chain, inita, proxy, asset(100));
+      try {
+        Transfer_Asset(chain, inita, proxy, asset(100));
+      } catch (eosio::chain::api_not_supported) {
+        // transfer_send is not functional in STAT, exception expected.
+        return;
+      }
+      BOOST_FAIL("transfer_send is not functional in STAT, exception expected.");
+
       chain.produce_blocks(1);
       BOOST_CHECK_EQUAL(chain.get_liquid_balance("newguy"), asset(0));
       BOOST_CHECK_EQUAL(chain.get_liquid_balance("inita"), asset(100000-300));


### PR DESCRIPTION
Fix test failure in deferred_tests. Proxy will throw an exception due to lack of support for generated transactions.