### PR TITLE
Remove redundant namespace aliases that confuse gcc.

### DIFF
--- a/libraries/chain/include/eos/chain/balance_object.hpp
+++ b/libraries/chain/include/eos/chain/balance_object.hpp
@@ -13,8 +13,7 @@
 
 namespace eosio {
 namespace chain {
-namespace types = ::eosio::types;
-namespace config = ::eosio::config;
+
 
 /**
  * @brief The balance_object class tracks the EOS balance for accounts

--- a/libraries/chain/include/eos/chain/producer_objects.hpp
+++ b/libraries/chain/include/eos/chain/producer_objects.hpp
@@ -18,8 +18,6 @@
 namespace eosio {
 namespace chain {
 
-namespace config = ::eosio::config;
-namespace types = ::eosio::types;
 
 FC_DECLARE_EXCEPTION(producer_race_overflow_exception, 10000000, "Producer Virtual Race time has overflowed");
 

--- a/libraries/chain/include/eos/chain/staked_balance_objects.hpp
+++ b/libraries/chain/include/eos/chain/staked_balance_objects.hpp
@@ -16,8 +16,6 @@
 namespace eosio {
 namespace chain {
 
-namespace config = ::eosio::config;
-namespace types = ::eosio::types;
 
 /**
  * @brief The producer_slate struct stores a list of producers voted on by an account


### PR DESCRIPTION
Introduced by #748 
Fixes gcc build.