### PR TITLE
Fix for test broken by

### DIFF
--- a/tests/eosd_run_mongodb_test.sh
+++ b/tests/eosd_run_mongodb_test.sh
@@ -90,7 +90,7 @@ INITB_PRV_KEY="5KQwrPbwdL6PhXujxW37FSSQZ1JiwsST4cqQzDeyXtP79zkvFD3"
 LOG_FILE=eosd_run_test.log
 
 # eosd
-programs/launcher/launcher --eosd "--mongodb-uri $DB"
+programs/launcher/launcher --eosd "--plugin eosio::db_plugin --mongodb-uri $DB"
 verifyErrorCode "launcher"
 sleep 60
 count=`grep -c "generated block" tn_data_0/stderr.txt`


### PR DESCRIPTION
Launcher removed db_plugin needed by eosd_run_mongodb_test.sh. Added it back in via the command line.

#701 