### PR TITLE
missing sync mode STAT-209

### DIFF
--- a/plugins/net_plugin/include/eos/net_plugin/protocol.hpp
+++ b/plugins/net_plugin/include/eos/net_plugin/protocol.hpp
@@ -78,6 +78,7 @@ namespace eosio {
   enum id_list_modes {
     none,
     catch_up,
+    last_irr_catch_up,
     normal
   };
 
@@ -85,6 +86,7 @@ namespace eosio {
     switch( m ) {
     case none : return "none";
     case catch_up : return "catch up";
+    case last_irr_catch_up : return "last irreversible";
     case normal : return "normal";
     default: return "undefined mode";
     }


### PR DESCRIPTION
fix for the case when a peer is notified that it needs to continue catching up to the last irreversible block STAT-209, #794
