### PR TITLE
GH-796: Remove block summary support

### DIFF
--- a/plugins/net_plugin/include/eos/net_plugin/protocol.hpp
+++ b/plugins/net_plugin/include/eos/net_plugin/protocol.hpp
@@ -113,22 +113,6 @@ namespace eosio {
     ordered_blk_ids req_blocks;
   };
 
-  struct processed_trans_summary {
-    transaction_id_type id;
-    vector<message_output> outmsgs;
-  };
-
-  struct thread_ids {
-    vector<transaction_id_type> gen_trx; // is this necessary to send?
-    vector<processed_trans_summary> user_trx;
-  };
-
-  using cycle_ids = vector<thread_ids>;
-   struct block_summary_message {
-      signed_block_header         block_header;
-      vector<cycle_ids>           trx_ids;
-   };
-
    struct sync_request_message {
       uint32_t start_block;
       uint32_t end_block;
@@ -140,7 +124,6 @@ namespace eosio {
                                       notice_message,
                                       request_message,
                                       sync_request_message,
-                                      block_summary_message,
                                       signed_transaction,
                                       signed_block>;
 
@@ -155,9 +138,6 @@ FC_REFLECT( eosio::handshake_message,
             (os)(agent)(generation) )
 FC_REFLECT( eosio::go_away_message, (reason)(node_id) )
 FC_REFLECT( eosio::time_message, (org)(rec)(xmt)(dst) )
-FC_REFLECT( eosio::processed_trans_summary, (id)(outmsgs) )
-FC_REFLECT( eosio::thread_ids, (gen_trx)(user_trx) )
-FC_REFLECT( eosio::block_summary_message, (block_header)(trx_ids) )
 FC_REFLECT( eosio::notice_message, (known_trx)(known_blocks) )
 FC_REFLECT( eosio::request_message, (req_trx)(req_blocks) )
 FC_REFLECT( eosio::sync_request_message, (start_block)(end_block) )

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -1864,7 +1864,6 @@ namespace eosio {
 
     void net_plugin_impl::broadcast_block_impl( const chain::signed_block &sb) {
       send_all( sb,[](connection_ptr c) -> bool { return true; });
-      return;
     }
 
     bool net_plugin_impl::authenticate_peer(const handshake_message& msg) const {

--- a/programs/launcher/main.cpp
+++ b/programs/launcher/main.cpp
@@ -769,7 +769,6 @@ launcher_def::write_config_file (tn_node_def &node) {
   cfg << "genesis-json = " << host->genesis << "\n"
       << "block-log-dir = blocks\n"
       << "readonly = 0\n"
-      << "send-whole-blocks = true\n"
       << "shared-file-dir = blockchain\n"
       << "shared-file-size = " << instance.file_size << "\n"
       << "http-server-endpoint = " << host->host_name << ":" << instance.http_port << "\n"


### PR DESCRIPTION
Remove the P2P support for block summary as it is not supported in STAT. Also removes the send-whole-blocks option from the launcher.