### PR TITLE
Fix memory issue with full message_buffer

### DIFF
--- a/plugins/net_plugin/include/eos/net_plugin/message_buffer.hpp
+++ b/plugins/net_plugin/include/eos/net_plugin/message_buffer.hpp
@@ -35,6 +35,13 @@ namespace eosio {
 
     message_buffer() : buffers{pool().malloc()}, read_ind{0,0}, write_ind{0,0} { }
 
+    ~message_buffer() {
+      while (buffers.size() > 0) {
+        pool().destroy(buffers.back());
+        buffers.pop_back();
+      }
+    }
+
     /*
      *  Returns the current read index referencing the byte in the buffer
      *  that is next to be read.
@@ -84,6 +91,19 @@ namespace eosio {
     }
 
     /*
+     *  Resets the message buffer to the initial state. Any unread data is
+     *  discarded.
+     */
+    void reset() {
+      read_ind = { 0, 0 };
+      write_ind = { 0, 0 };
+      while (buffers.size() > 1) {
+        pool().destroy(buffers.back());
+        buffers.pop_back();
+      }
+    }
+
+    /*
      *  Returns the current number of bytes remaining to be read.
      *  Logically, this is the different between where the read and write pointers are.
      */
@@ -119,12 +139,7 @@ namespace eosio {
     void advance_read_ptr(uint32_t bytes) {
       advance_index(read_ind, bytes);
       if (read_ind == write_ind) {
-        read_ind = { 0, 0 };
-        write_ind = { 0, 0 };
-        while (buffers.size() > 1) {
-          pool().destroy(buffers.back());
-          buffers.pop_back();
-        }
+        reset();
       } else if (read_ind.first > 0) {
         while (read_ind.first > 0) {
           pool().destroy(buffers.front());

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -599,6 +599,7 @@ namespace eosio {
       if (response_expected) {
         response_expected->cancel();
       }
+      pending_message_buffer.reset();
     }
 
   void connection::txn_send_pending (const vector<transaction_id_type> &ids) {
@@ -1228,44 +1229,48 @@ namespace eosio {
     }
 
     void net_plugin_impl::start_read_message( connection_ptr conn ) {
-      connection_wptr c( conn);
-      conn->socket->async_read_some(
-        conn->pending_message_buffer.get_buffer_sequence_for_boost_async_read(),
-        [this,c]( boost::system::error_code ec, std::size_t bytes_transferred ) {
-          if( !ec ) {
-            connection_ptr conn = c.lock();
-            if (!conn) {
-              return;
-            }
+      try {
+        connection_wptr c( conn);
+        conn->socket->async_read_some(
+          conn->pending_message_buffer.get_buffer_sequence_for_boost_async_read(),
+          [this,c]( boost::system::error_code ec, std::size_t bytes_transferred ) {
+            if( !ec ) {
+              connection_ptr conn = c.lock();
+              if (!conn) {
+                return;
+              }
 
-            FC_ASSERT(bytes_transferred <= conn->pending_message_buffer.bytes_to_write());
-            conn->pending_message_buffer.advance_write_ptr(bytes_transferred);
-            while (conn->pending_message_buffer.bytes_to_read() > 0) {
-              uint32_t bytes_in_buffer = conn->pending_message_buffer.bytes_to_read();
-              if (bytes_in_buffer < message_header_size) {
-                break;
-              } else {
-                uint32_t message_length;
-                auto index = conn->pending_message_buffer.read_index();
-                conn->pending_message_buffer.peek(&message_length, sizeof(message_length), index);
-                if (bytes_in_buffer >= message_length + message_header_size) {
-                  conn->pending_message_buffer.advance_read_ptr(message_header_size);
-                  if (!conn->process_next_message(*this, message_length)) {
-                    return;
-                  }
-                } else {
-                  conn->pending_message_buffer.add_space(message_length - bytes_in_buffer);
+              FC_ASSERT(bytes_transferred <= conn->pending_message_buffer.bytes_to_write());
+              conn->pending_message_buffer.advance_write_ptr(bytes_transferred);
+              while (conn->pending_message_buffer.bytes_to_read() > 0) {
+                uint32_t bytes_in_buffer = conn->pending_message_buffer.bytes_to_read();
+                if (bytes_in_buffer < message_header_size) {
                   break;
+                } else {
+                  uint32_t message_length;
+                  auto index = conn->pending_message_buffer.read_index();
+                  conn->pending_message_buffer.peek(&message_length, sizeof(message_length), index);
+                  if (bytes_in_buffer >= message_length + message_header_size) {
+                    conn->pending_message_buffer.advance_read_ptr(message_header_size);
+                    if (!conn->process_next_message(*this, message_length)) {
+                      return;
+                    }
+                  } else {
+                    conn->pending_message_buffer.add_space(message_length - bytes_in_buffer);
+                    break;
+                  }
                 }
               }
+              start_read_message(conn);
+            } else {
+              elog( "Error reading message from connection: ${m}",( "m", ec.message() ) );
+              close( c.lock() );
             }
-            start_read_message(conn);
-          } else {
-            elog( "Error reading message from connection: ${m}",( "m", ec.message() ) );
-            close( c.lock() );
           }
-        }
-      );
+        );
+      } catch (...) {
+        close(conn);
+      }
     }
 
   size_t net_plugin_impl::count_open_sockets () const


### PR DESCRIPTION
When the message_buffer's write index was advanced to the end of the buffer, the get_buffer_sequence_for_boost_async_read() function would return invalid pointers. An assert was added to that function to detect this, but the real problem was fixed in advance_write_ptr() to always assure that the write_ptr is pointing to allocated memory.