### PR TITLE
Destroy chain_controller during chain_plugin shutdown STAT-218

### DIFF
--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -257,6 +257,7 @@ void chain_plugin::plugin_startup()
 } FC_CAPTURE_AND_RETHROW( (my->genesis_file.generic_string()) ) }
 
 void chain_plugin::plugin_shutdown() {
+   my->chain.reset();
 }
 
 chain_apis::read_write chain_plugin::get_read_write_api() {


### PR DESCRIPTION
When running a node sending hundreds of transactions a second, Ctrl-Cing it will typically crash. Destroy the chain_controller during chain_plugin::plugin_shutdown() to ensure better cleanup.