### PR TITLE
GELF logging

### DIFF
--- a/libraries/fc/CMakeLists.txt
+++ b/libraries/fc/CMakeLists.txt
@@ -73,6 +73,7 @@ set( fc_sources
      src/log/logger.cpp
      src/log/appender.cpp
      src/log/console_appender.cpp
+     src/log/gelf_appender.cpp
      src/log/logger_config.cpp
      src/crypto/_digest_common.cpp
      src/crypto/openssl.cpp
@@ -97,6 +98,8 @@ set( fc_sources
      src/crypto/elliptic_${ECC_IMPL}.cpp
      src/crypto/rand.cpp
      src/network/ip.cpp
+     src/network/resolve.cpp
+     src/network/udp_socket.cpp
      src/network/url.cpp
      src/compress/smaz.cpp
      src/compress/zlib.cpp

--- a/libraries/fc/include/fc/log/appender.hpp
+++ b/libraries/fc/include/fc/log/appender.hpp
@@ -1,6 +1,9 @@
 #pragma once
+#include <fc/any.hpp>
 #include <fc/shared_ptr.hpp>
 #include <fc/string.hpp>
+
+namespace boost { namespace asio { class io_service; } }
 
 namespace fc {
    class appender;
@@ -38,6 +41,7 @@ namespace fc {
          static appender::ptr get( const fc::string& name );
          static bool          register_appender( const fc::string& type, const appender_factory::ptr& f );
 
+         virtual void initialize( boost::asio::io_service& io_service ) = 0;
          virtual void log( const log_message& m ) = 0;
    };
 }

--- a/libraries/fc/include/fc/log/console_appender.hpp
+++ b/libraries/fc/include/fc/log/console_appender.hpp
@@ -52,6 +52,7 @@ namespace fc
             console_appender();
 
             ~console_appender();
+            void initialize( boost::asio::io_service& io_service ) {}
             virtual void log( const log_message& m );
             
             void print( const std::string& text_to_print, 

--- a/libraries/fc/include/fc/log/gelf_appender.hpp
+++ b/libraries/fc/include/fc/log/gelf_appender.hpp
@@ -4,6 +4,8 @@
 #include <fc/log/logger.hpp>
 #include <fc/time.hpp>
 
+namespace boost { namespace asio { class io_service; } }
+
 namespace fc 
 {
   // Log appender that sends log messages in JSON format over UDP
@@ -19,6 +21,14 @@ namespace fc
 
     gelf_appender(const variant& args);
     ~gelf_appender();
+    /** \brief Required for name resolution and socket initialization.
+     *
+     * \warning If this method is not called, this appender will log nothing.
+     *
+     * In a single-threaded world with a boost::io_service that's not owned
+     * by this library, ugly things are required.  Tough.
+     */
+    void initialize(boost::asio::io_service& io_service);
     virtual void log(const log_message& m) override;
 
   private:

--- a/libraries/fc/include/fc/log/logger_config.hpp
+++ b/libraries/fc/include/fc/log/logger_config.hpp
@@ -5,7 +5,7 @@ namespace fc {
    class path;
    struct appender_config {
       appender_config(const string& name = "",
-                      const string& type = "", 
+                      const string& type = "",
                       variant args = variant()) :
         name(name),
         type(type),
@@ -41,9 +41,6 @@ namespace fc {
 
    void configure_logging( const fc::path& log_config );
    bool configure_logging( const logging_config& l );
-
-   void set_thread_name( const string& name );
-   const string& get_thread_name();
 }
 
 #include <fc/reflect/reflect.hpp>

--- a/libraries/fc/include/fc/network/resolve.hpp
+++ b/libraries/fc/include/fc/network/resolve.hpp
@@ -1,0 +1,9 @@
+#pragma once
+#include <fc/vector.hpp>
+#include <fc/network/ip.hpp>
+
+namespace fc
+{
+  std::vector<boost::asio::ip::udp::endpoint> resolve(boost::asio::io_service& io_service,
+                                                      const std::string& host, uint16_t port);
+}

--- a/libraries/fc/include/fc/network/udp_socket.hpp
+++ b/libraries/fc/include/fc/network/udp_socket.hpp
@@ -1,0 +1,40 @@
+#pragma once
+#include <fc/utility.hpp>
+#include <fc/shared_ptr.hpp>
+#include <memory>
+
+#include <boost/asio.hpp>
+
+namespace fc {
+  namespace ip {
+    class endpoint;
+    class address;
+  }
+
+  /**
+   *  The udp_socket class has reference semantics, all copies will
+   *  refer to the same underlying socket.
+   */
+  class udp_socket {
+    public:
+      udp_socket();
+      udp_socket( const udp_socket& s );
+      ~udp_socket();
+
+      void initialize(boost::asio::io_service &);
+      void open();
+      void send_to(const char* b, size_t l, boost::asio::ip::udp::endpoint &to);
+      void send_to(const std::shared_ptr<const char>& b, size_t l, boost::asio::ip::udp::endpoint &to);
+      void close();
+
+      void set_reuse_address(bool);
+
+      void connect(const boost::asio::ip::udp::endpoint& e);
+      const boost::asio::ip::udp::endpoint local_endpoint() const;
+
+    private:
+      class                impl;
+      fc::shared_ptr<impl> my;
+  };
+
+}

--- a/libraries/fc/src/log/appender.cpp
+++ b/libraries/fc/src/log/appender.cpp
@@ -20,8 +20,6 @@ namespace fc {
      return lm;
    }
    appender::ptr appender::get( const fc::string& s ) {
-//     static fc::spin_lock appender_spinlock;
-//      scoped_lock<spin_lock> lock(appender_spinlock);
       return get_appender_map()[s];
    }
    bool  appender::register_appender( const fc::string& type, const appender_factory::ptr& f )
@@ -40,9 +38,9 @@ namespace fc {
       get_appender_map()[name] = ap;
       return ap;
    }
-   
+
    static bool reg_console_appender = appender::register_appender<console_appender>( "console" );
-//   static bool reg_file_appender = appender::register_appender<file_appender>( "file" );
-//  static bool reg_gelf_appender = appender::register_appender<gelf_appender>( "gelf" );
+   //static bool reg_file_appender = appender::register_appender<file_appender>( "file" );
+   static bool reg_gelf_appender = appender::register_appender<gelf_appender>( "gelf" );
 
 } // namespace fc

--- a/libraries/fc/src/log/console_appender.cpp
+++ b/libraries/fc/src/log/console_appender.cpp
@@ -12,7 +12,7 @@
 #include <fc/exception/exception.hpp>
 #include <iomanip>
 #include <sstream>
-#include <mutex>
+
 
 namespace fc {
 
@@ -25,7 +25,7 @@ namespace fc {
 #endif
    };
 
-   console_appender::console_appender( const variant& args ) 
+   console_appender::console_appender( const variant& args )
    :my(new impl)
    {
       configure( args.as<config>() );
@@ -64,7 +64,7 @@ namespace fc {
    #ifdef WIN32
    static WORD
    #else
-   static const char* 
+   static const char*
    #endif
    get_console_color(console_appender::color::type t ) {
       switch( t ) {
@@ -117,8 +117,6 @@ namespace fc {
       fc::string message = fc::format_string( m.get_format(), m.get_data() );
       line << message;//.c_str();
 
-      std::unique_lock<boost::mutex> lock(log_mutex());
-
       print( line.str(), my->lc[m.get_context().get_log_level()] );
 
       fprintf( out, "\n" );
@@ -138,7 +136,7 @@ namespace fc {
       #endif
 
       if( text.size() )
-         fprintf( out, "%s", text.c_str() ); //fmt_str.c_str() ); 
+         fprintf( out, "%s", text.c_str() ); //fmt_str.c_str() );
 
       #ifdef WIN32
       if (my->console_handle != INVALID_HANDLE_VALUE)

--- a/libraries/fc/src/log/gelf_appender.cpp
+++ b/libraries/fc/src/log/gelf_appender.cpp
@@ -4,7 +4,6 @@
 #include <fc/exception/exception.hpp>
 #include <fc/log/gelf_appender.hpp>
 #include <fc/reflect/variant.hpp>
-#include <fc/thread/thread.hpp>
 #include <fc/variant.hpp>
 #include <fc/io/json.hpp>
 #include <fc/crypto/city.hpp>
@@ -19,13 +18,20 @@
 
 namespace fc 
 {
+  namespace detail
+  {
+    boost::asio::ip::udp::endpoint to_asio_ep( const fc::ip::endpoint& e )
+    {
+      return boost::asio::ip::udp::endpoint(boost::asio::ip::address_v4(e.get_address()), e.port() );
+    }
+  }
 
   class gelf_appender::impl : public retainable
   {
   public:
-    config                     cfg;
-    optional<ip::endpoint>     gelf_endpoint;
-    udp_socket                 gelf_socket;
+    config                                    cfg;
+    optional<boost::asio::ip::udp::endpoint>  gelf_endpoint;
+    udp_socket                                gelf_socket;
 
     impl(const config& c) : 
       cfg(c)
@@ -40,12 +46,16 @@ namespace fc
   gelf_appender::gelf_appender(const variant& args) :
     my(new impl(args.as<config>()))
   {
+  }
+
+  void gelf_appender::initialize(boost::asio::io_service &io_service)
+  {
     try
     {
       try
       {
         // if it's a numeric address:port, this will parse it
-        my->gelf_endpoint = ip::endpoint::from_string(my->cfg.endpoint);
+        my->gelf_endpoint = detail::to_asio_ep(ip::endpoint::from_string(my->cfg.endpoint));
       }
       catch (...)
       {
@@ -60,9 +70,9 @@ namespace fc
           uint16_t port = boost::lexical_cast<uint16_t>(my->cfg.endpoint.substr(colon_pos + 1, my->cfg.endpoint.size()));
 
           string hostname = my->cfg.endpoint.substr( 0, colon_pos );
-          std::vector<ip::endpoint> endpoints = resolve(hostname, port);
+          auto endpoints = resolve(io_service, hostname, port);
           if (endpoints.empty())
-              FC_THROW_EXCEPTION(unknown_host_exception, "The host name can not be resolved: ${hostname}", 
+              FC_THROW_EXCEPTION(unknown_host_exception, "The logging destination host name can not be resolved: ${hostname}",
                                  ("hostname", hostname));
           my->gelf_endpoint = endpoints.back();
         }
@@ -73,11 +83,15 @@ namespace fc
       }
 
       if (my->gelf_endpoint)
+      {
+        my->gelf_socket.initialize(io_service);
         my->gelf_socket.open();
+        std::cerr << "opened GELF socket to endpoint " << my->cfg.endpoint << "\n";
+      }
     }
     catch (...)
     {
-      std::cerr << "error opening GELF socket to endpoint ${endpoint}" << my->cfg.endpoint << "\n";
+      std::cerr << "error opening GELF socket to endpoint " << my->cfg.endpoint << "\n";
     }
   }
 

--- a/libraries/fc/src/log/log_message.cpp
+++ b/libraries/fc/src/log/log_message.cpp
@@ -51,7 +51,7 @@ namespace fc
       my->line        = line;
       my->method      = method;
       my->timestamp   = time_point::now();
-      my->thread_name = fc::get_thread_name();
+      my->thread_name = std::string(); //fc::get_thread_name();
    }
 
    log_context::log_context( const variant& v )

--- a/libraries/fc/src/log/logger.cpp
+++ b/libraries/fc/src/log/logger.cpp
@@ -82,8 +82,6 @@ namespace fc {
     }
 
     logger logger::get( const fc::string& s ) {
-       //static fc::spin_lock logger_spinlock;
-       //scoped_lock<spin_lock> lock(logger_spinlock);
        return get_logger_map()[s];
     }
 
@@ -95,7 +93,7 @@ namespace fc {
 
     void logger::add_appender( const fc::shared_ptr<appender>& a )
     { my->_appenders.push_back(a); }
-    
+
 //    void logger::remove_appender( const fc::shared_ptr<appender>& a )
  //   { my->_appenders.erase(a); }
 

--- a/libraries/fc/src/network/udp_socket.cpp
+++ b/libraries/fc/src/network/udp_socket.cpp
@@ -1,6 +1,10 @@
+/**
+ *  @file
+ *  @copyright defined in eos/LICENSE.txt
+ */
 #include <fc/network/udp_socket.hpp>
 #include <fc/network/ip.hpp>
-#include <fc/fwd_impl.hpp>
+
 
 namespace fc
 {
@@ -47,8 +51,9 @@ namespace fc
         throw;
     }
 
-    my->_sock->async_send_to(boost::asio::buffer(buffer, length), to,
-                             [this](const boost::system::error_code& /*ec*/, std::size_t /*bytes_transferred*/)
+    auto send_buffer_ptr = std::make_shared<std::vector<char>>(buffer, buffer+length);
+    my->_sock->async_send_to(boost::asio::buffer(send_buffer_ptr.get(), length), to,
+                             [send_buffer_ptr](const boost::system::error_code& /*ec*/, std::size_t /*bytes_transferred*/)
     {
       // Swallow errors.  Currently only used for GELF logging, so depend on local
       // log to catch anything that doesn't make it across the network.
@@ -68,8 +73,9 @@ namespace fc
         throw;
     }
 
-    my->_sock->async_send_to(boost::asio::buffer(buffer.get(), length), to,
-                             [this](const boost::system::error_code& /*ec*/, std::size_t /*bytes_transferred*/)
+    auto preserved_buffer_ptr = buffer;
+    my->_sock->async_send_to(boost::asio::buffer(preserved_buffer_ptr.get(), length), to,
+                             [preserved_buffer_ptr](const boost::system::error_code& /*ec*/, std::size_t /*bytes_transferred*/)
     {
       // Swallow errors.  Currently only used for GELF logging, so depend on local
       // log to catch anything that doesn't make it across the network.

--- a/libraries/fc/src/network/udp_socket.cpp
+++ b/libraries/fc/src/network/udp_socket.cpp
@@ -1,166 +1,105 @@
 #include <fc/network/udp_socket.hpp>
 #include <fc/network/ip.hpp>
 #include <fc/fwd_impl.hpp>
-#include <fc/asio.hpp>
 
-
-namespace fc {
-  using boost::fibers::promise;
-  
-  class udp_socket::impl {
+namespace fc
+{
+  class udp_socket::impl : public fc::retainable
+  {
     public:
-      impl():_sock( fc::asio::default_io_service() ){}
-      ~impl(){ }
+      impl(){}
+      ~impl(){}
 
-      boost::asio::ip::udp::socket _sock;
+      std::shared_ptr<boost::asio::ip::udp::socket> _sock;
   };
 
-  boost::asio::ip::udp::endpoint to_asio_ep( const fc::ip::endpoint& e ) {
-    return boost::asio::ip::udp::endpoint(boost::asio::ip::address_v4(e.get_address()), e.port() );
-  }
-  fc::ip::endpoint to_fc_ep( const boost::asio::ip::udp::endpoint& e ) {
-    return fc::ip::endpoint( e.address().to_v4().to_ulong(), e.port() );
+  udp_socket::udp_socket()
+    : my(new impl())
+  {
   }
 
-  udp_socket::udp_socket()
-  :my( new impl() ) 
+  void udp_socket::initialize(boost::asio::io_service& service)
   {
+    my->_sock.reset(new boost::asio::ip::udp::socket(service));
   }
 
   udp_socket::~udp_socket() 
   {
     try 
     {
-      my->_sock.close(); //close boost socket to make any pending reads run their completion handler
+      if(my->_sock)
+        my->_sock->close(); //close boost socket to make any pending reads run their completion handler
     }
     catch (...) //avoid destructor throw and likely this is just happening because socket wasn't open.
     {
     }
   }
 
-  size_t udp_socket::send_to( const char* buffer, size_t length, const ip::endpoint& to ) 
+  void udp_socket::send_to(const char* buffer, size_t length, boost::asio::ip::udp::endpoint& to)
   {
     try 
     {
-      return my->_sock.send_to( boost::asio::buffer(buffer, length), to_asio_ep(to) );
+      my->_sock->send_to(boost::asio::buffer(buffer, length), to);
     } 
-    catch( const boost::system::system_error& e ) 
+    catch(const boost::system::system_error& e)
     {
-      if( e.code() != boost::asio::error::would_block )
+      if(e.code() != boost::asio::error::would_block)
         throw;
     }
 
-    auto completion_promise = std::make_shared<promise<size_t>>();
-    my->_sock.async_send_to( boost::asio::buffer(buffer, length), to_asio_ep(to), 
-                             asio::detail::read_write_handler(completion_promise) );
-
-    return completion_promise->get_future().get();
+    my->_sock->async_send_to(boost::asio::buffer(buffer, length), to,
+                             [this](const boost::system::error_code& /*ec*/, std::size_t /*bytes_transferred*/)
+    {
+      // Swallow errors.  Currently only used for GELF logging, so depend on local
+      // log to catch anything that doesn't make it across the network.
+    });
   }
 
-  size_t udp_socket::send_to( const std::shared_ptr<const char>& buffer, size_t length, 
-                              const fc::ip::endpoint& to )
+  void udp_socket::send_to(const std::shared_ptr<const char>& buffer, size_t length,
+                           boost::asio::ip::udp::endpoint& to)
   {
-    try 
+    try
     {
-      return my->_sock.send_to( boost::asio::buffer(buffer.get(), length), to_asio_ep(to) );
+      my->_sock->send_to(boost::asio::buffer(buffer.get(), length), to);
     } 
-    catch( const boost::system::system_error& e ) 
+    catch(const boost::system::system_error& e)
     {
-      if( e.code() != boost::asio::error::would_block )
+      if(e.code() != boost::asio::error::would_block)
         throw;
     }
 
-    auto completion_promise = std::make_shared<promise<size_t>>();
-    my->_sock.async_send_to( boost::asio::buffer(buffer.get(), length), to_asio_ep(to), 
-                             asio::detail::read_write_handler_with_buffer(completion_promise, buffer) );
-
-    return completion_promise->get_future().get();
-  }
-
-  void udp_socket::open() {
-    my->_sock.open( boost::asio::ip::udp::v4() );
-    my->_sock.non_blocking(true);
-  }
-  void udp_socket::set_receive_buffer_size( size_t s ) {
-    my->_sock.set_option(boost::asio::socket_base::receive_buffer_size(s) );
-  }
-  void udp_socket::bind( const fc::ip::endpoint& e ) {
-    my->_sock.bind( to_asio_ep(e) );
-  }
-
-  size_t udp_socket::receive_from( const std::shared_ptr<char>& receive_buffer, size_t receive_buffer_length, fc::ip::endpoint& from )
-  {
-    try 
+    my->_sock->async_send_to(boost::asio::buffer(buffer.get(), length), to,
+                             [this](const boost::system::error_code& /*ec*/, std::size_t /*bytes_transferred*/)
     {
-      boost::asio::ip::udp::endpoint boost_from_endpoint;
-      size_t bytes_read = my->_sock.receive_from( boost::asio::buffer(receive_buffer.get(), receive_buffer_length), 
-                                                  boost_from_endpoint );
-      from = to_fc_ep(boost_from_endpoint);
-      return bytes_read;
-    } 
-    catch( const boost::system::system_error& e ) 
-    {
-      if( e.code() != boost::asio::error::would_block ) 
-        throw;
-    }
-
-    boost::asio::ip::udp::endpoint boost_from_endpoint;
-    auto completion_promise = std::make_shared<promise<size_t>>();
-    my->_sock.async_receive_from( boost::asio::buffer(receive_buffer.get(), receive_buffer_length), 
-                                  boost_from_endpoint,
-                                  asio::detail::read_write_handler_with_buffer(completion_promise, receive_buffer) );
-    size_t bytes_read = completion_promise->get_future().get();
-    from = to_fc_ep(boost_from_endpoint);
-    return bytes_read;
+      // Swallow errors.  Currently only used for GELF logging, so depend on local
+      // log to catch anything that doesn't make it across the network.
+    });
   }
 
-  size_t udp_socket::receive_from( char* receive_buffer, size_t receive_buffer_length, fc::ip::endpoint& from ) 
+  void udp_socket::open()
   {
-    try 
-    {
-      boost::asio::ip::udp::endpoint boost_from_endpoint;
-      size_t bytes_read = my->_sock.receive_from( boost::asio::buffer(receive_buffer, receive_buffer_length), 
-                                                  boost_from_endpoint );
-      from = to_fc_ep(boost_from_endpoint);
-      return bytes_read;
-    } 
-    catch( const boost::system::system_error& e ) 
-    {
-      if( e.code() != boost::asio::error::would_block ) 
-        throw;
-    }
-
-    boost::asio::ip::udp::endpoint boost_from_endpoint;
-    auto completion_promise = std::make_shared<promise<size_t>>();
-    my->_sock.async_receive_from( boost::asio::buffer(receive_buffer, receive_buffer_length), boost_from_endpoint,
-                                  asio::detail::read_write_handler(completion_promise) );
-    size_t bytes_read = completion_promise->get_future().get();
-    from = to_fc_ep(boost_from_endpoint);
-    return bytes_read;
+    my->_sock->open(boost::asio::ip::udp::v4());
+    my->_sock->non_blocking(true);
   }
 
-  void   udp_socket::close() {
-    my->_sock.close();
-  }
-
-  fc::ip::endpoint udp_socket::local_endpoint()const {
-    return to_fc_ep( my->_sock.local_endpoint() );
-  }
-  void udp_socket::connect( const fc::ip::endpoint& e ) {
-     my->_sock.connect( to_asio_ep(e) );
-  }
-
-  void   udp_socket::set_multicast_enable_loopback( bool s )
+  void udp_socket::close()
   {
-    my->_sock.set_option( boost::asio::ip::multicast::enable_loopback(s) );
+    my->_sock->close();
   }
-  void   udp_socket::set_reuse_address( bool s )
+
+  const boost::asio::ip::udp::endpoint udp_socket::local_endpoint() const
   {
-    my->_sock.set_option( boost::asio::ip::udp::socket::reuse_address(s) );
+    return my->_sock->local_endpoint();
   }
-  void   udp_socket::join_multicast_group( const fc::ip::address& a )
+
+  void udp_socket::connect(const boost::asio::ip::udp::endpoint& e)
   {
-    my->_sock.set_option( boost::asio::ip::multicast::join_group( boost::asio::ip::address_v4(a) ) );
+    my->_sock->connect(e);
+  }
+
+  void udp_socket::set_reuse_address( bool s )
+  {
+    my->_sock->set_option( boost::asio::ip::udp::socket::reuse_address(s) );
   }
 
 }

--- a/programs/eosd/main.cpp
+++ b/programs/eosd/main.cpp
@@ -17,6 +17,7 @@
 #include <eosio/txn_test_gen_plugin/txn_test_gen_plugin.hpp>
 
 #include <fc/log/logger_config.hpp>
+#include <fc/log/appender.hpp>
 #include <fc/exception/exception.hpp>
 
 #include <boost/exception/diagnostic_information.hpp>
@@ -26,9 +27,23 @@
 using namespace appbase;
 using namespace eosio;
 
+namespace fc {
+   std::unordered_map<std::string,appender::ptr>& get_appender_map();
+}
+
+void initialize_logging()
+{
+  auto config_path = app().get_logging_conf();
+  if(fc::exists(config_path))
+    fc::configure_logging(config_path);
+  for(auto iter : fc::get_appender_map())
+    iter.second->initialize(app().get_io_service());
+}
+
 int main(int argc, char** argv)
 {
    try {
+      initialize_logging();
       app().set_version(eosio::eosd::config::version);
       ilog("eosd version ${ver}", ("ver", eosio::eosd::config::itoh(static_cast<uint32_t>(app().version()))));
       app().register_plugin<net_api_plugin>();


### PR DESCRIPTION
Updates fc library from steemit, plus significant changes to eliminate multithreading support.  The GELF log appender uses the `app()`'s `boost::io_service`.

Note some of the steemit updates ended up being whitespace only.

Resolves #724.