### PR TITLE
Modified benchmark to take only 40 transactions at a time

### DIFF
--- a/programs/eosc/main.cpp
+++ b/programs/eosc/main.cpp
@@ -1060,10 +1060,11 @@ int main( int argc, char** argv ) {
 
             sign_transaction(trx);
             batch.emplace_back(trx);
-            if( batch.size() == 600 ) {
+            if( batch.size() == 40 ) {
                auto result = call( push_txns_func, batch );
                std::cout << fc::json::to_pretty_string(result) << std::endl;
                batch.resize(0);
+	       info = get_info();
             }
          }
          if( !loop ) break;


### PR DESCRIPTION
updated benchmark to 40 transaction batches and updated transaction time to block header.