### PR TITLE
STAT-188: GH-743: Fix eosd restart issues

### DIFF
--- a/plugins/account_history_plugin/account_history_plugin.cpp
+++ b/plugins/account_history_plugin/account_history_plugin.cpp
@@ -301,17 +301,23 @@ void account_history_plugin_impl::applied_block(const signed_block& block)
             if (check_relevance && !is_scope_relevant(trx.scope))
                continue;
 
-            db.create<transaction_history_object>([&block_id,&trx](transaction_history_object& transaction_history) {
-               transaction_history.block_id = block_id;
-               transaction_history.transaction_id = trx.id();
-            });
+            // TODO: Find a better way of avoiding duplicates on restart. For now swallow exception.
+            try {
+              db.create<transaction_history_object>([&block_id,&trx](transaction_history_object& transaction_history) {
+                 transaction_history.block_id = block_id;
+                 transaction_history.transaction_id = trx.id();
+              });
+            } catch (std::logic_error&) { }
 
             for (const auto& account_name : trx.scope)
             {
-               db.create<account_transaction_history_object>([&trx,&account_name](account_transaction_history_object& account_transaction_history) {
+              // TODO: Find a better way of avoiding duplicates on restart. For now swallow exception.
+              try {
+                db.create<account_transaction_history_object>([&trx,&account_name](account_transaction_history_object& account_transaction_history) {
                   account_transaction_history.name = account_name;
                   account_transaction_history.transaction_id = trx.id();
-               });
+                });
+              } catch (std::logic_error&) { }
             }
 
             for (const chain::message& msg : trx.messages)

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -81,12 +81,13 @@ namespace eosio {
     void operator() (node_transaction_state& nts) {
       nts.received = fc::time_point::now();
       nts.validated = true;
-      size_t packsiz = fc::raw::pack_size(txn);
-      size_t bufsiz = packsiz + sizeof(packsiz);
+      net_message msg(txn);
+      uint32_t packsiz = fc::raw::pack_size(msg);
+      uint32_t bufsiz = packsiz + sizeof(packsiz);
       nts.packed_transaction.resize(bufsiz);
       fc::datastream<char*> ds( nts.packed_transaction.data(), bufsiz );
       ds.write( reinterpret_cast<char*>(&packsiz), sizeof(packsiz) );
-      fc::raw::pack( ds, txn );
+      fc::raw::pack( ds, msg );
     }
   };
 
@@ -999,10 +1000,16 @@ namespace eosio {
     try {
       // If it is a signed_block, then save the raw message for the cache
       // This must be done before we unpack the message.
-      unsigned_int which;
+      // This code is copied from fc::io::unpack(..., unsigned_int)
       auto index = pending_message_buffer.read_index();
-      pending_message_buffer.peek(&which, sizeof(unsigned_int), index);
-      if(which == uint32_t(net_message::tag<signed_block>::value)) {
+      uint64_t which = 0; char b = 0; uint8_t by = 0;
+      do {
+        pending_message_buffer.peek(&b, 1, index);
+        which |= uint32_t(uint8_t(b) & 0x7f) << by;
+        by += 7;
+      } while( uint8_t(b) & 0x80 );
+
+      if (which == uint64_t(net_message::tag<signed_block>::value)) {
         blk_buffer.resize(message_length);
         auto index = pending_message_buffer.read_index();
         pending_message_buffer.peek(blk_buffer.data(), message_length, index);
@@ -1983,13 +1990,14 @@ namespace eosio {
 
   size_t net_plugin_impl::cache_txn(const transaction_id_type txnid,
                                      const signed_transaction& txn ) {
-      size_t packsiz = fc::raw::pack_size(txn);
-      size_t bufsiz = packsiz + sizeof(packsiz);
+      net_message msg(txn);
+      uint32_t packsiz = fc::raw::pack_size(msg);
+      uint32_t bufsiz = packsiz + sizeof(packsiz);
       vector<char> buff(bufsiz);
       fc::datastream<char*> ds( buff.data(), bufsiz);
       ds.write( reinterpret_cast<char*>(&packsiz), sizeof(packsiz) );
 
-      fc::raw::pack( ds, txn );
+      fc::raw::pack( ds, msg );
 
       uint16_t bn = static_cast<uint16_t>(txn.ref_block_num);
       node_transaction_state nts = {txnid,time_point::now(),


### PR DESCRIPTION
Fix multiple problems that were preventing restart of eosd without --resync:
- transaction_history_object and account_transaction_history_object were both trying to create duplicates for transactions in reversible blocks. For now, we simply ignore the exceptions and keep the objects in shared memory
- fix multiple problems with signed_transaction marshalling
- correct handling of signed_blocks