### PR TITLE
Hash unique 826

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,9 @@ libraries/wasm-jit/Source/Programs/Disassemble
 libraries/wasm-jit/Source/Programs/Test
 libraries/wasm-jit/Source/Programs/wavm
 
+programs/abi_gen/abi_gen
 programs/cli_wallet/cli_wallet
+programs/codegen/codegen
 programs/js_operation_serializer/js_operation_serializer
 programs/witness_node/witness_node
 programs/data-dir
@@ -49,10 +51,16 @@ programs/eosc/eosc
 programs/launcher/launcher
 
 tests/app_test
+tests/api_test
 tests/chain_bench
 tests/chain_test
+tests/slow_test
 tests/intense_test
 tests/performance_test
+tests/stress_test/node_modules/*
+tests/stress_test/stress_test_result_*.txt
+
+tools/eoscpp
 
 doxygen
 
@@ -68,6 +76,9 @@ object_database/*
 *.pyc
 *.pyo
 
+build.ninja
+.ninja_*
+*.ninja
 build/*
 build-debug/*
 
@@ -75,5 +86,3 @@ tn_data_*
 .vscode
 .DS_Store
 
-tests/stress_test/node_modules/*
-tests/stress_test/stress_test_result_*.txt

--- a/libraries/chain/include/eos/chain/generated_transaction_object.hpp
+++ b/libraries/chain/include/eos/chain/generated_transaction_object.hpp
@@ -8,7 +8,6 @@
 #include <eos/chain/transaction.hpp>
 #include <fc/uint128.hpp>
 
-#include <boost/multi_index/hashed_index.hpp>
 #include <boost/multi_index/mem_fun.hpp>
 
 #include "multi_index_includes.hpp"
@@ -48,7 +47,7 @@ namespace eosio { namespace chain {
       generated_transaction_object,
       indexed_by<
          ordered_unique<tag<by_id>, BOOST_MULTI_INDEX_MEMBER(generated_transaction_object, generated_transaction_object::id_type, id)>,
-         hashed_unique<tag<generated_transaction_object::by_trx_id>, const_mem_fun<generated_transaction_object, generated_transaction_id_type, &generated_transaction_object::get_id>>,
+         ordered_unique<tag<generated_transaction_object::by_trx_id>, const_mem_fun<generated_transaction_object, generated_transaction_id_type, &generated_transaction_object::get_id>>,
          ordered_non_unique<tag<generated_transaction_object::by_expiration>, const_mem_fun<generated_transaction_object, time_point_sec, &generated_transaction_object::get_expiration>>,
          ordered_non_unique<tag<generated_transaction_object::by_status>, BOOST_MULTI_INDEX_MEMBER(generated_transaction_object, generated_transaction_object::status_type, status)>
       >

--- a/libraries/chain/include/eos/chain/transaction_object.hpp
+++ b/libraries/chain/include/eos/chain/transaction_object.hpp
@@ -8,7 +8,6 @@
 #include <eos/chain/transaction.hpp>
 #include <fc/uint128.hpp>
 
-#include <boost/multi_index/hashed_index.hpp>
 #include <boost/multi_index/mem_fun.hpp>
 
 #include "multi_index_includes.hpp"
@@ -38,7 +37,7 @@ namespace eosio { namespace chain {
       transaction_object,
       indexed_by<
          ordered_unique<tag<by_id>, BOOST_MULTI_INDEX_MEMBER(transaction_object, transaction_object::id_type, id)>,
-         hashed_unique<tag<by_trx_id>, BOOST_MULTI_INDEX_MEMBER(transaction_object, transaction_id_type, trx_id), std::hash<transaction_id_type>>,
+         ordered_unique<tag<by_trx_id>, BOOST_MULTI_INDEX_MEMBER(transaction_object, transaction_id_type, trx_id)>,
          ordered_non_unique<tag<by_expiration>, const_mem_fun<transaction_object, time_point_sec, &transaction_object::get_expiration>>
       >
    >;

--- a/plugins/account_history_plugin/include/eos/account_history_plugin/account_control_history_object.hpp
+++ b/plugins/account_history_plugin/include/eos/account_history_plugin/account_control_history_object.hpp
@@ -30,13 +30,12 @@ using account_control_history_multi_index = chainbase::shared_multi_index_contai
    account_control_history_object,
    indexed_by<
       ordered_unique<tag<by_id>, BOOST_MULTI_INDEX_MEMBER(account_control_history_object, account_control_history_object::id_type, id)>,
-      hashed_non_unique<tag<by_controlling>, BOOST_MULTI_INDEX_MEMBER(account_control_history_object, account_name, controlling_account), std::hash<account_name>>,
-      hashed_non_unique<tag<by_controlled_authority>,
+      ordered_non_unique<tag<by_controlling>, BOOST_MULTI_INDEX_MEMBER(account_control_history_object, account_name, controlling_account)>,
+      ordered_non_unique<tag<by_controlled_authority>,
          composite_key< account_control_history_object,
             member<account_control_history_object, account_name, &account_control_history_object::controlled_account>,
             member<account_control_history_object, permission_name, &account_control_history_object::controlled_permission>
-         >,
-         composite_key_hash< std::hash<account_name>, std::hash<permission_name> >
+         >
       >
    >
 >;

--- a/plugins/account_history_plugin/include/eos/account_history_plugin/account_transaction_history_object.hpp
+++ b/plugins/account_history_plugin/include/eos/account_history_plugin/account_transaction_history_object.hpp
@@ -40,13 +40,12 @@ using account_transaction_history_multi_index = chainbase::shared_multi_index_co
    account_transaction_history_object,
    indexed_by<
       ordered_unique<tag<by_id>, BOOST_MULTI_INDEX_MEMBER(account_transaction_history_object, account_transaction_history_object::id_type, id)>,
-      hashed_non_unique<tag<by_account_name>, BOOST_MULTI_INDEX_MEMBER(account_transaction_history_object, account_name, name), std::hash<account_name>>,
-      hashed_unique<tag<by_account_name_trx_id>,
+      ordered_non_unique<tag<by_account_name>, BOOST_MULTI_INDEX_MEMBER(account_transaction_history_object, account_name, name)>,
+      ordered_unique<tag<by_account_name_trx_id>,
          composite_key< account_transaction_history_object,
             member<account_transaction_history_object, account_name, &account_transaction_history_object::name>,
             member<account_transaction_history_object, transaction_id_type, &account_transaction_history_object::transaction_id>
-         >,
-         composite_key_hash< std::hash<account_name>, std::hash<transaction_id_type> >
+         >
       >
    >
 >;

--- a/plugins/account_history_plugin/include/eos/account_history_plugin/public_key_history_object.hpp
+++ b/plugins/account_history_plugin/include/eos/account_history_plugin/public_key_history_object.hpp
@@ -42,15 +42,11 @@ using public_key_history_multi_index = chainbase::shared_multi_index_container<
    public_key_history_object,
    indexed_by<
       ordered_unique<tag<by_id>, BOOST_MULTI_INDEX_MEMBER(public_key_history_object, public_key_history_object::id_type, id)>,
-      hashed_non_unique<tag<by_pub_key>, BOOST_MULTI_INDEX_MEMBER(public_key_history_object, public_key_type, public_key), std::hash<public_key_type> >,
-      hashed_non_unique<tag<by_account_permission>,
+      ordered_non_unique<tag<by_pub_key>, BOOST_MULTI_INDEX_MEMBER(public_key_history_object, public_key_type, public_key)>,
+      ordered_non_unique<tag<by_account_permission>,
          composite_key< public_key_history_object,
             member<public_key_history_object, account_name,     &public_key_history_object::name>,
             member<public_key_history_object, permission_name,  &public_key_history_object::permission>
-         >,
-         composite_key_hash<
-            std::hash<account_name>,
-            std::hash<permission_name>
          >
       >
    >

--- a/plugins/account_history_plugin/include/eos/account_history_plugin/transaction_history_object.hpp
+++ b/plugins/account_history_plugin/include/eos/account_history_plugin/transaction_history_object.hpp
@@ -25,7 +25,7 @@ using transaction_history_multi_index = chainbase::shared_multi_index_container<
    transaction_history_object,
    indexed_by<
       ordered_unique<tag<by_id>, BOOST_MULTI_INDEX_MEMBER(transaction_history_object, transaction_history_object::id_type, id)>,
-      hashed_unique<tag<by_trx_id>, BOOST_MULTI_INDEX_MEMBER(transaction_history_object, transaction_id_type, transaction_id), std::hash<transaction_id_type>>
+      ordered_unique<tag<by_trx_id>, BOOST_MULTI_INDEX_MEMBER(transaction_history_object, transaction_id_type, transaction_id)>
    >
 >;
 

--- a/tests/eosd_run_test.sh
+++ b/tests/eosd_run_test.sh
@@ -70,7 +70,9 @@ killAll()
 
 cleanup()
 {
-  rm -rf tn_data_00
+  if [ "$SERVER" == "localhost" ]; then
+    rm -rf tn_data_00
+  fi
   rm -rf test_wallet_0
 }
 


### PR DESCRIPTION
Resolves #826 

* Removed uses of hashed unique in chainbase shared memory.
* Includes small fix for eosd_run_test.sh script so it does not rm directory if it didn't create it.
* Includes some addition .gitignores