### PR TITLE
STAT 247 - Remove shadowed variable in launcher.

### DIFF
--- a/programs/launcher/main.cpp
+++ b/programs/launcher/main.cpp
@@ -458,8 +458,8 @@ launcher_def::initialize (const variables_map &vmap) {
   if (prod_nodes > total_nodes)
     total_nodes = prod_nodes;
 
-  char * erd = getenv ("EOS_ROOT_DIR");
-  if (erd == 0) {
+  erd = getenv ("EOS_ROOT_DIR");
+  if (erd.empty()) {
     erd = getenv ("PWD");
   }
   stage = bf::path(erd);

--- a/programs/launcher/main.cpp
+++ b/programs/launcher/main.cpp
@@ -420,7 +420,7 @@ launcher_def::initialize (const variables_map &vmap) {
   system_clock::time_point now = system_clock::now();
   std::time_t now_c = system_clock::to_time_t(now);
   ostringstream dstrm;
-  dstrm << std::put_time(std::localtime(&now_c), "%Y_%m_%d_%H_%M_%S") << ends;
+  dstrm << std::put_time(std::localtime(&now_c), "%Y_%m_%d_%H_%M_%S");
   launch_time = dstrm.str();
 
   if ( ! (shape.empty() ||

--- a/programs/launcher/main.cpp
+++ b/programs/launcher/main.cpp
@@ -458,10 +458,17 @@ launcher_def::initialize (const variables_map &vmap) {
   if (prod_nodes > total_nodes)
     total_nodes = prod_nodes;
 
-  erd = getenv ("EOS_ROOT_DIR");
-  if (erd.empty()) {
-    erd = getenv ("PWD");
+  char* erd_env_var = getenv ("EOS_ROOT_DIR");
+  if (erd_env_var == nullptr || std::string(erd_env_var).empty()) {
+     erd_env_var = getenv ("PWD");
   }
+
+  if (erd_env_var != nullptr) {
+     erd = erd_env_var;
+  } else {
+     erd.clear();
+  }
+
   stage = bf::path(erd);
   if (!bf::exists(stage)) {
     cerr << erd << " is not a valid path" << endl;


### PR DESCRIPTION
(Incorrectly tied to STAT 250, STAT 247 is the appropriate ticket)
Remove shadowed variable in launcher.
Remove end of string in stream that is causing nohup to not see the full command with & to put process in background.

Branch number is Jira ticket number.  No corresponding GH number.