### PR TITLE
fix build.sh and install_dependencies.sh on macos

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -17,6 +17,9 @@ TEMP_DIR=/tmp
 ARCH=$1
 TARGET_ARCHS="ubuntu darwin"
 
+# Stop script on error
+set -e
+
 # Check ARCH
 if [[ $# > 2 ]]; then
   echo ""

--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -60,7 +60,7 @@ if [ $ARCH == "ubuntu" ]; then
 fi
 
 if [ $ARCH == "darwin" ]; then
-    DEPS="git automake libtool boost openssl llvm@4 gmp wget cmake gettext"
+    DEPS="git cmake automake libtool boost openssl llvm@4 gmp wget cmake gettext libmongoc mongo-cxx-driver doxygen"
     brew update
     brew install --force $DEPS
     brew unlink $DEPS && brew link --force $DEPS
@@ -82,9 +82,10 @@ if [ $ARCH == "darwin" ]; then
     cd binaryen
     git checkout tags/1.37.14
     cmake . && make
+    [ -d /usr/local/binaryen ] && sudo rm -r /usr/local/binaryen
     sudo mkdir /usr/local/binaryen
     sudo mv ${TEMP_DIR}/binaryen/bin /usr/local/binaryen
-    sudo ln -s /usr/local/binaryen/bin/* /usr/local
+    sudo ln -sf /usr/local/binaryen/bin/* /usr/local/bin
     sudo rm -rf ${TEMP_DIR}/binaryen
     BINARYEN_BIN=/usr/local/binaryen/bin/
 


### PR DESCRIPTION
1) set stop on error, so that the script won't continue to run when error happens
2) added missing dependencies for mac: cmake libmongoc mongo-cxx-driver doxygen
3) deleting /usr/local/binaryen before copy, so that the script runs idempotently
4) link files under /usr/local/binaryen/bin to /usr/local/bin, instead of /usr/local (assuming that was a mistake)