### PR TITLE
Eosc crash

### DIFF
--- a/programs/eosc/CMakeLists.txt
+++ b/programs/eosc/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable( eosc main.cpp httpc.cpp help_text.cpp )
+add_executable( eosc main.cpp httpc.cpp help_text.cpp localize.hpp config.hpp CLI11.hpp)
 if( UNIX AND NOT APPLE )
   set(rt_library rt )
 endif()

--- a/programs/eosc/help_text.cpp
+++ b/programs/eosc/help_text.cpp
@@ -100,7 +100,11 @@ namespace eosio { namespace client { namespace help {
 
 bool print_help_text(const fc::exception& e) {
    bool result = false;
+   // Large input strings to std::regex can cause SIGSEGV, this is a known bug in libstdc++.
+   // See https://stackoverflow.com/questions/36304204/%D0%A1-regex-segfault-on-long-sequences
    auto detail_str = e.to_detail_string();
+   // 2048 nice round number. Picked for no particular reason. Bug above was reported for 22K+ strings.
+   if (detail_str.size() > 2048) return result;
    try {
       for (const auto& candidate : error_help_text) {
          auto expr = std::regex {candidate.first};

--- a/programs/eosc/localize.hpp
+++ b/programs/eosc/localize.hpp
@@ -15,6 +15,13 @@ namespace eosio { namespace client { namespace localize {
    #define localized(str, ...) localized_with_variant((str), fc::mutable_variant_object() __VA_ARGS__ )
 
    inline auto localized_with_variant( const char* raw_fmt, const fc::variant_object& args) {
-      return fc::format_string(::gettext(raw_fmt), args);
+      if (raw_fmt != nullptr) {
+         try {
+            return fc::format_string(::gettext(raw_fmt), args);
+         } catch (...) {
+         }
+         return std::string(raw_fmt);
+      }
+      return std::string();
    }
 }}}

--- a/programs/eosc/main.cpp
+++ b/programs/eosc/main.cpp
@@ -1162,7 +1162,7 @@ int main( int argc, char** argv ) {
          }
       } else {
          // attempt to extract the error code if one is present
-         if (!print_help_text(e) || verbose_errors) {
+         if (verbose_errors || !print_help_text(e)) {
             elog("Failed with error: ${e}", ("e", verbose_errors ? e.to_detail_string() : e.to_string()));
          }
       }

--- a/tests/eosd_run_test.sh
+++ b/tests/eosd_run_test.sh
@@ -460,6 +460,16 @@ if [ $count == 0 ]; then
 fi
 getTransactionId "$INFO"
 
+#
+# Setting simpledb contract without simpledb account was causing core dump in eosc.
+# Verify eosc generates an error, but does not core dump.
+#
+
+INFO="$( { programs/eosc/eosc --host $SERVER --port $PORT --wallet-port 8899 set contract simpledb contracts/simpledb/simpledb.wast contracts/simpledb/simpledb.abi ; } 2>&1 )"
+rc=$?
+if [ $rc -eq 0 ] || [ $rc -eq 139 ]; then # 139 SIGSEGV
+  error "FAILURE - $1 returned error code $rc, should have failed to execute."
+fi
 
 #
 # Producer


### PR DESCRIPTION
STAT-261 - GH-#876 ⁃ Investigate and solve reported activity that causes EOSC to crash

`std::regex` has known bug of SIGSEGV when input string is too large. Avoided the bug by only trying to localize strings less than 2048 characters.

Resolves #876 