### PR TITLE
 Make GELF logging optional and endpoint customizable in launcher.

### DIFF
--- a/programs/eosd/main.cpp
+++ b/programs/eosd/main.cpp
@@ -43,9 +43,7 @@ void initialize_logging()
 int main(int argc, char** argv)
 {
    try {
-      initialize_logging();
       app().set_version(eosio::eosd::config::version);
-      ilog("eosd version ${ver}", ("ver", eosio::eosd::config::itoh(static_cast<uint32_t>(app().version()))));
       app().register_plugin<net_api_plugin>();
       app().register_plugin<chain_api_plugin>();
       app().register_plugin<wallet_api_plugin>();
@@ -55,6 +53,8 @@ int main(int argc, char** argv)
       app().register_plugin<txn_test_gen_plugin>();
       if(!app().initialize<chain_plugin, http_plugin, net_plugin>(argc, argv))
          return -1;
+      initialize_logging();
+      ilog("eosd version ${ver}", ("ver", eosio::eosd::config::itoh(static_cast<uint32_t>(app().version()))));
       app().startup();
       app().exec();
    } catch (const fc::exception& e) {

--- a/programs/launcher/main.cpp
+++ b/programs/launcher/main.cpp
@@ -230,6 +230,7 @@ public:
   vector<string>  peers;
   vector<string>  producers;
   eosd_def*       instance;
+  string          gelf_endpoint;
 };
 
 void
@@ -268,6 +269,7 @@ struct remote_deploy {
 };
 
 struct testnet_def {
+  string name;
   remote_deploy ssh_helper;
   map <string,tn_node_def> nodes;
 };
@@ -333,12 +335,13 @@ struct launcher_def {
   bool skip_transaction_signatures = false;
   string eosd_extra_args;
   testnet_def network;
-  string alias_base;
+  string gelf_endpoint;
   vector <string> aliases;
   vector <host_def> bindings;
   int per_host = 0;
   last_run_def last_run;
   int start_delay = 0;
+  bool gelf_enabled;
   bool nogen;
   bool add_enable_stale_production = false;
   string launch_name;
@@ -388,6 +391,9 @@ launcher_def::set_options (bpo::options_description &cli) {
     ("host-map",bpo::value<bf::path>(&host_map_file)->default_value(""),"a file containing mapping specific nodes to hosts. Used to enhance the custom shape argument")
     ("servers",bpo::value<bf::path>(&server_ident_file)->default_value(""),"a file containing ip addresses and names of individual servers to deploy as producers or observers ")
     ("per-host",bpo::value<int>(&per_host)->default_value(0),"specifies how many eosd instances will run on a single host. Use 0 to indicate all on one.")
+    ("network-name",bpo::value<string>(&network.name)->default_value("testnet_"),"network name prefix used in GELF logging source")
+    ("enable-gelf-logging",bpo::value<bool>(&gelf_enabled)->default_value(true),"enable gelf logging appender in logging configuration file")
+    ("gelf-endpoint",bpo::value<string>(&gelf_endpoint)->default_value("10.160.11.21:12201"),"hostname:port or ip:port of GELF endpoint")
         ;
 }
 
@@ -452,7 +458,6 @@ launcher_def::initialize (const variables_map &vmap) {
 
   producers = 21;
   data_dir_base = "tn_data_";
-  alias_base = "testnet_";
   next_node = 0;
 
   load_servers ();
@@ -518,7 +523,7 @@ void
 launcher_def::assign_name (eosd_def &node) {
   string dex = next_node < 10 ? "0":"";
   dex += boost::lexical_cast<string,int>(next_node++);
-  node.name = alias_base + dex;
+  node.name = network.name + dex;
   node.data_dir = data_dir_base + dex;
 }
 
@@ -692,6 +697,7 @@ launcher_def::bind_nodes () {
             ext += prod_nodes;
           }
         }
+        node.gelf_endpoint = gelf_endpoint;
         network.nodes[node.name] = move(node);
         inst.node = &network.nodes[inst.name];
         i++;
@@ -718,7 +724,6 @@ launcher_def::find_host (const string &name)
 
 host_def *
 launcher_def::deploy_config_files (tn_node_def &node) {
-  bf::path filename;
   boost::system::error_code ec;
   eosd_def &instance = *node.instance;
   host_def *host = find_host (instance.host);
@@ -727,7 +732,6 @@ launcher_def::deploy_config_files (tn_node_def &node) {
   bf::path logging_source = stage / instance.data_dir / "logging.json";
   if (host->is_local()) {
     bf::path dd = bf::path(host->eos_root_dir) / instance.data_dir;
-    filename = dd / "config.ini";
     if (bf::exists (dd)) {
       int64_t count =  bf::remove_all (dd / "blocks", ec);
       if (ec.value() != 0) {
@@ -747,8 +751,8 @@ launcher_def::deploy_config_files (tn_node_def &node) {
            << " errno " << ec.value() << " " << strerror(ec.value()) << endl;
       exit (-1);
     }
-    bf::copy_file (logging_source, bf::path(host->eos_root_dir) / "logging.json", bf::copy_option::overwrite_if_exists);
-    bf::copy_file (source, filename, bf::copy_option::overwrite_if_exists);
+    bf::copy_file (logging_source, dd / "logging.json", bf::copy_option::overwrite_if_exists);
+    bf::copy_file (source, dd / "config.ini", bf::copy_option::overwrite_if_exists);
   }
   else {
     prep_remote_config_dir (instance, host);
@@ -764,7 +768,7 @@ launcher_def::deploy_config_files (tn_node_def &node) {
       exit(-1);
     }
 
-    dpath = bf::path (host->eos_root_dir) / "logging.json";
+    dpath = bf::path (host->eos_root_dir) / instance.data_dir / "logging.json";
 
     scp_cmd_line = compose_scp_command(*host, logging_source, dpath);
 
@@ -884,13 +888,15 @@ launcher_def::write_logging_config_file(tn_node_def &node) {
   }
 
   auto log_config = fc::logging_config::default_config();
-  log_config.appenders.push_back(
-        fc::appender_config( "net", "gelf",
-            fc::mutable_variant_object()
-                ( "endpoint", "10.160.11.21:12201" )
-                ( "host", instance.name )
-           ) );
-  log_config.loggers.front().appenders.push_back("net");
+  if(gelf_enabled) {
+    log_config.appenders.push_back(
+          fc::appender_config( "net", "gelf",
+              fc::mutable_variant_object()
+                  ( "endpoint", node.gelf_endpoint )
+                  ( "host", instance.name )
+             ) );
+    log_config.loggers.front().appenders.push_back("net");
+  }
 
   auto str = fc::json::to_pretty_string( log_config, fc::json::stringify_large_ints_and_doubles );
   cfg.write( str.c_str(), str.size() );


### PR DESCRIPTION
Also fix eosd order of initialization problem that prevented a custom log file location from being used.  Launcher now copies logging configuration to the data directory.  Also add network name command line option so networks can be distinguished in GELF log messages.