### PR TITLE
Add optional cmd "sudo make install"

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ cd eos
 ./build.sh darwin
 ```
 
+Optional: copy binaries to system `/usr/local/folder` make convenient for `eoscpp`
+```
+sudo install make
+```
 Now you can proceed to the next step - [Creating and launching a single-node testnet](#singlenode)
 
 <a name="runanode"></a>


### PR DESCRIPTION
`eoscpp` is the main problems in Developer Group, people normally encounter this issue after they copy executable `eoscpp` to `/usr/local/bin`
![image](https://user-images.githubusercontent.com/16319106/33803412-72b2315e-ddca-11e7-83cc-3b638ad4286c.png)
Above message shows cannot access `/usr/local/share/skeleton`


Thanks @elmato for clarification:
Since `eoscpp` use `EOSIO_INSTALL_DIR` which is under root system, ![image](https://user-images.githubusercontent.com/16319106/33803449-6c887d50-ddcb-11e7-9b37-1b2621b1da23.png)
, so `sudo install make` will make convenient for developers to use `eoscpp` and future command line tools

Reference: 
[make vs make install StackoverFlows](https://stackoverflow.com/questions/10961439/why-always-configure-make-make-install-as-3-separate-steps)