### PR TITLE
STAT-281: Fix runaway memory usage in the p2p

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -1382,7 +1382,7 @@ namespace eosio {
                         return;
                       }
                     } else {
-                      conn->pending_message_buffer.add_space(message_length - bytes_in_buffer);
+                      conn->pending_message_buffer.add_space(message_length + message_header_size - bytes_in_buffer);
                       break;
                     }
                   }


### PR DESCRIPTION
This call could previously end up with a negative number (passed as unsigned).