### PR TITLE
Fix for stat 298. Configure eosd to load wallet plugin.

### DIFF
--- a/tests/trans_sync_across_mixed_cluster_test.sh
+++ b/tests/trans_sync_across_mixed_cluster_test.sh
@@ -112,8 +112,8 @@ cleanup
 
 # stand up eosd cluster
 launcherOpts="-p $pnodes -n $total_nodes -s $topo -d $delay"
-echo Launcher options: $launcherOpts
-programs/launcher/launcher $launcherOpts
+echo Launcher options: --eosd \"--plugin eosio::wallet_api_plugin\" $launcherOpts
+programs/launcher/launcher --eosd "--plugin eosio::wallet_api_plugin" $launcherOpts
 sleep 7
 
 startPort=8888


### PR DESCRIPTION
Resolves #964 

The launcher no longer adds wallet plugin automatically. Modified test to add it manually.