### PR TITLE
STAT-306 #970 Replay causes assertion

### DIFF
--- a/libraries/chain/include/eos/chain/account_object.hpp
+++ b/libraries/chain/include/eos/chain/account_object.hpp
@@ -23,6 +23,8 @@ namespace eosio { namespace chain {
       shared_vector<char> abi;
 
       void set_abi( const eosio::types::abi& _abi ) {
+         // Added resize(0) here to avoid bug in boost vector container
+         abi.resize( 0 );
          abi.resize( fc::raw::pack_size( _abi ) );
          fc::datastream<char*> ds( abi.data(), abi.size() );
          fc::raw::pack( ds, _abi );

--- a/libraries/native_contract/eos_contract.cpp
+++ b/libraries/native_contract/eos_contract.cpp
@@ -206,6 +206,8 @@ void apply_eos_setcode(apply_context& context) {
       /** TODO: consider whether a microsecond level local timestamp is sufficient to detect code version changes*/
       #warning TODO: update setcode message to include the hash, then validate it in validate 
       a.code_version = fc::sha256::hash( msg.code.data(), msg.code.size() );
+      // Added resize(0) here to avoid bug in boost vector container
+      a.code.resize( 0 );
       a.code.resize( msg.code.size() );
       memcpy( a.code.data(), msg.code.data(), msg.code.size() );
 


### PR DESCRIPTION
Add a workaround of resize(0) to avoid issues with boost::container::vector where it is resizing to a larger buffer and trying to move data. This is most likely a bug in boost::container.