### PR TITLE
restore the call to `record_transaction` 

### DIFF
--- a/libraries/chain/chain_controller.cpp
+++ b/libraries/chain/chain_controller.cpp
@@ -1385,6 +1385,7 @@ transaction_trace chain_controller::__apply_transaction( transaction_metadata& m
    }
 
    update_usage(meta, act_usage);
+   record_transaction(meta.trx);
    return result;
 }
 


### PR DESCRIPTION
accidentally removed from `chain_controller::_apply_transaction` in 35f98e09d