### PR TITLE
Restore fc thread logging

### DIFF
--- a/libraries/fc/include/fc/log/logger_config.hpp
+++ b/libraries/fc/include/fc/log/logger_config.hpp
@@ -41,6 +41,9 @@ namespace fc {
 
    void configure_logging( const fc::path& log_config );
    bool configure_logging( const logging_config& l );
+
+   void set_thread_name( const string& name );
+   const string& get_thread_name();
 }
 
 #include <fc/reflect/reflect.hpp>

--- a/libraries/fc/src/log/appender.cpp
+++ b/libraries/fc/src/log/appender.cpp
@@ -6,6 +6,7 @@
 #include <fc/log/file_appender.hpp>
 #include <fc/log/gelf_appender.hpp>
 #include <fc/variant.hpp>
+#include <mutex>
 #include "console_defines.h"
 
 
@@ -20,6 +21,8 @@ namespace fc {
      return lm;
    }
    appender::ptr appender::get( const fc::string& s ) {
+      static std::mutex appender_mutex;
+      std::lock_guard<std::mutex> lock(appender_mutex);
       return get_appender_map()[s];
    }
    bool  appender::register_appender( const fc::string& type, const appender_factory::ptr& f )

--- a/libraries/fc/src/log/console_appender.cpp
+++ b/libraries/fc/src/log/console_appender.cpp
@@ -117,6 +117,8 @@ namespace fc {
       fc::string message = fc::format_string( m.get_format(), m.get_data() );
       line << message;//.c_str();
 
+      std::unique_lock<boost::mutex> lock(log_mutex());
+
       print( line.str(), my->lc[m.get_context().get_log_level()] );
 
       fprintf( out, "\n" );

--- a/libraries/fc/src/log/gelf_appender.cpp
+++ b/libraries/fc/src/log/gelf_appender.cpp
@@ -15,6 +15,7 @@
 #include <queue>
 #include <sstream>
 #include <iostream>
+#include <boost/thread/mutex.hpp>
 
 namespace fc 
 {
@@ -98,6 +99,10 @@ namespace fc
   gelf_appender::~gelf_appender()
   {}
 
+  boost::mutex& gelf_log_mutex() {
+     static boost::mutex m; return m;
+  }
+
   void gelf_appender::log(const log_message& message)
   {
     if (!my->gelf_endpoint)
@@ -155,6 +160,8 @@ namespace fc
         gelf_message_as_string[1] == (char)0xda)
       gelf_message_as_string[1] = (char)0x9c;
     assert(gelf_message_as_string[1] == (char)0x9c);
+
+    std::unique_lock<boost::mutex> lock(gelf_log_mutex());
 
     // packets are sent by UDP, and they tend to disappear if they
     // get too large.  It's hard to find any solid numbers on how

--- a/libraries/fc/src/log/log_message.cpp
+++ b/libraries/fc/src/log/log_message.cpp
@@ -51,7 +51,7 @@ namespace fc
       my->line        = line;
       my->method      = method;
       my->timestamp   = time_point::now();
-      my->thread_name = std::string(); //fc::get_thread_name();
+      my->thread_name = fc::get_thread_name();
    }
 
    log_context::log_context( const variant& v )

--- a/libraries/fc/src/log/logger_config.cpp
+++ b/libraries/fc/src/log/logger_config.cpp
@@ -91,7 +91,7 @@ namespace fc {
    }
    const string& get_thread_name() {
       static int thread_count = 0;
-      if( thread_name == string() )
+      if( thread_name.empty() )
          thread_name = string("thread-")+fc::to_string(thread_count++);
       return thread_name;
    }

--- a/libraries/fc/src/log/logger_config.cpp
+++ b/libraries/fc/src/log/logger_config.cpp
@@ -84,4 +84,15 @@ namespace fc {
       cfg.loggers.push_back( dlc );
       return cfg;
    }
+
+   static thread_local std::string thread_name;
+   void set_thread_name( const string& name ) {
+      thread_name = name;
+   }
+   const string& get_thread_name() {
+      static int thread_count = 0;
+      if( thread_name == string() )
+         thread_name = string("thread-")+fc::to_string(thread_count++);
+      return thread_name;
+   }
 }


### PR DESCRIPTION
Some thread constructs in fc's logging were removed on master. Restore them.