### PR TITLE
Compatibility fixes for boost 1.66.

### DIFF
--- a/libraries/fc/include/fc/log/appender.hpp
+++ b/libraries/fc/include/fc/log/appender.hpp
@@ -3,7 +3,11 @@
 #include <fc/shared_ptr.hpp>
 #include <fc/string.hpp>
 
+#if BOOST_VERSION >= 106600
+namespace boost { namespace asio { class io_context; typedef io_context io_service; } }
+#else
 namespace boost { namespace asio { class io_service; } }
+#endif
 
 namespace fc {
    class appender;

--- a/libraries/fc/include/fc/log/gelf_appender.hpp
+++ b/libraries/fc/include/fc/log/gelf_appender.hpp
@@ -4,8 +4,6 @@
 #include <fc/log/logger.hpp>
 #include <fc/time.hpp>
 
-namespace boost { namespace asio { class io_service; } }
-
 namespace fc 
 {
   // Log appender that sends log messages in JSON format over UDP

--- a/tests/api_tests/api_tests.cpp
+++ b/tests/api_tests/api_tests.cpp
@@ -46,6 +46,8 @@
 #include <eos/chain/staked_balance_objects.hpp>
 #include <eos/chain/balance_object.hpp>
 
+#include <eos/chain_plugin/chain_plugin.hpp>
+
 FC_REFLECT( dummy_message, (a)(b)(c) );
 FC_REFLECT( u128_msg, (values) );
 

--- a/tests/common/database_fixture.hpp
+++ b/tests/common/database_fixture.hpp
@@ -7,7 +7,6 @@
 #include <eos/chain/chain_controller.hpp>
 #include <eos/chain/producer_object.hpp>
 #include <eos/chain/exceptions.hpp>
-#include <eos/chain_plugin/chain_plugin.hpp>
 
 #include <eos/native_contract/native_contract_chain_initializer.hpp>
 #include <eos/native_contract/native_contract_chain_administrator.hpp>

--- a/tests/slow_tests/slow_tests.cpp
+++ b/tests/slow_tests/slow_tests.cpp
@@ -14,6 +14,8 @@
 
 #include <eos/utilities/tempdir.hpp>
 
+#include <eos/chain_plugin/chain_plugin.hpp>
+
 #include <fc/crypto/digest.hpp>
 
 #include "../common/database_fixture.hpp"

--- a/tests/tests/message_buffer_tests.cpp
+++ b/tests/tests/message_buffer_tests.cpp
@@ -7,6 +7,29 @@
 #include <boost/test/unit_test.hpp>
 #include <iostream>
 
+#if BOOST_VERSION >= 106600
+namespace boost
+{
+  namespace asio
+  {
+    namespace detail
+    {
+      inline void* buffer_cast_helper(const mutable_buffer& b)
+      {
+      #if defined(BOOST_ASIO_ENABLE_BUFFER_DEBUGGING)
+        if (b.size() && b.get_debug_check())
+          b.get_debug_check()();
+      #endif // BOOST_ASIO_ENABLE_BUFFER_DEBUGGING
+        return b.data();
+      }
+      inline size_t buffer_size_helper(const mutable_buffer& b)
+      {
+        return b.size();
+      }
+    }
+  }
+}
+#endif
 
 namespace eosio {
 using namespace std;


### PR DESCRIPTION
Shuffle of #includes in tests is necessary to avoid a template error deep in boost asio.  Resolves #984.