### PR TITLE
Boost 1.66 compatibility, same as master.

### DIFF
--- a/libraries/fc/include/fc/log/appender.hpp
+++ b/libraries/fc/include/fc/log/appender.hpp
@@ -3,7 +3,11 @@
 #include <fc/shared_ptr.hpp>
 #include <fc/string.hpp>
 
+#if BOOST_VERSION >= 106600
+namespace boost { namespace asio { class io_context; typedef io_context io_service; } }
+#else
 namespace boost { namespace asio { class io_service; } }
+#endif
 
 namespace fc {
    class appender;

--- a/libraries/fc/include/fc/log/gelf_appender.hpp
+++ b/libraries/fc/include/fc/log/gelf_appender.hpp
@@ -4,7 +4,6 @@
 #include <fc/log/logger.hpp>
 #include <fc/time.hpp>
 
-namespace boost { namespace asio { class io_service; } }
 
 namespace fc 
 {


### PR DESCRIPTION
No changes to tests not present in the noon branch.