### PR TITLE
Adjust docker memory requirements

### DIFF
--- a/Docker/README.md
+++ b/Docker/README.md
@@ -6,7 +6,7 @@ Simple and fast setup of EOS on Docker is also available.
  - [Docker](https://docs.docker.com) Docker 17.05 or higher is required
 
 ## Docker Requirement
- - At least 8GB RAM (Docker -> Preferences -> Advanced -> Memory -> 8GB or above)
+ - At least 3GB RAM (Docker -> Preferences -> Advanced -> Memory -> 3GB or above.  Alternatively, append `--memory 3GB` to `docker build` command)
  
 ## Build eos image
 


### PR DESCRIPTION
Docker build works OK with 3GB memory (MacOS Sierra 10.12.6, Docker 17.09.1-ce), 8GB seems unnecessarily high.  

Also, specify alternate means of setting memory available to docker build versus setting global preferences.