### PR TITLE
allow passing binary WASM to eosioc set contract (in addtion to WAST)

### DIFF
--- a/programs/eosioc/main.cpp
+++ b/programs/eosioc/main.cpp
@@ -684,8 +684,11 @@ int main( int argc, char** argv ) {
       fc::read_file_contents(wastPath, wast);
 
       vector<uint8_t> wasm;
-      if(wast.compare(0, 4, "\x00\x61\x73\x6d"))
+      const string binary_wasm_header = "\x00\x61\x73\x6d";
+      if(wast.compare(0, 4, binary_wasm_header)) {
+         std::cout << localized("Using already assembled WASM...") << std::endl;
          wasm = vector<uint8_t>(wast.begin(), wast.end());
+      }
       else {
          std::cout << localized("Assembling WASM...") << std::endl;
          wasm = assemble_wast(wast);

--- a/programs/eosioc/main.cpp
+++ b/programs/eosioc/main.cpp
@@ -672,7 +672,7 @@ int main( int argc, char** argv ) {
    string abiPath;
    auto contractSubcommand = setSubcommand->add_subcommand("contract", localized("Create or update the contract on an account"));
    contractSubcommand->add_option("account", account, localized("The account to publish a contract for"))->required();
-   contractSubcommand->add_option("wast-file", wastPath, localized("The file containing the contract WAST"))->required()
+   contractSubcommand->add_option("wast-file", wastPath, localized("The file containing the contract WAST or WASM"))->required()
          ->check(CLI::ExistingFile);
    auto abi = contractSubcommand->add_option("abi-file,-a,--abi", abiPath, localized("The ABI for the contract"))
               ->check(CLI::ExistingFile);
@@ -682,8 +682,14 @@ int main( int argc, char** argv ) {
       std::string wast;
       std::cout << localized("Reading WAST...") << std::endl;
       fc::read_file_contents(wastPath, wast);
-      std::cout << localized("Assembling WASM...") << std::endl;
-      auto wasm = assemble_wast(wast);
+
+      vector<uint8_t> wasm;
+      if(wast.compare(0, 4, "\x00\x61\x73\x6d"))
+         wasm = vector<uint8_t>(wast.begin(), wast.end());
+      else {
+         std::cout << localized("Assembling WASM...") << std::endl;
+         wasm = assemble_wast(wast);
+      }
 
       contracts::setcode handler;
       handler.account = account;


### PR DESCRIPTION
Some toolchains output binary WASM directly; it's nice to not need WASM->WAST translation before setting the contract via eosioc

I know this is a little kludgy since I left in the "reading WAST..." print which isn't always correct now. But this keep the changeset very minimal