### PR TITLE
Reload logging.json on receipt of SIGHUP.

### DIFF
--- a/programs/eosiod/main.cpp
+++ b/programs/eosiod/main.cpp
@@ -31,6 +31,38 @@ namespace fc {
    std::unordered_map<std::string,appender::ptr>& get_appender_map();
 }
 
+void logging_conf_loop()
+{
+  std::shared_ptr<boost::asio::signal_set> sighup_set(new boost::asio::signal_set(app().get_io_service(), SIGHUP));
+  sighup_set->async_wait([sighup_set](const boost::system::error_code& err, int /*num*/) {
+    if(!err)
+    {
+      ilog("Received HUP.  Reloading logging configuration.");
+      auto config_path = app().get_logging_conf();
+      if(fc::exists(config_path))
+      {
+        try {
+          fc::configure_logging(config_path);
+        } catch (const fc::exception& e) {
+          elog("Error reloading logging.json");
+          elog("${e}", ("e",e.to_detail_string()));
+        } catch (const boost::exception& e) {
+          elog("Error reloading logging.json");
+          elog("${e}", ("e",boost::diagnostic_information(e)));
+        } catch (const std::exception& e) {
+          elog("Error reloading logging.json");
+          elog("${e}", ("e",e.what()));
+        } catch (...) {
+          elog("Error reloading logging.json");
+        }
+      }
+      for(auto iter : fc::get_appender_map())
+        iter.second->initialize(app().get_io_service());
+      logging_conf_loop();
+    }
+  });
+}
+
 void initialize_logging()
 {
   auto config_path = app().get_logging_conf();
@@ -38,6 +70,8 @@ void initialize_logging()
     fc::configure_logging(config_path);
   for(auto iter : fc::get_appender_map())
     iter.second->initialize(app().get_io_service());
+
+  logging_conf_loop();
 }
 
 int main(int argc, char** argv)


### PR DESCRIPTION
logging_conf_loop() duplicates everything initialize_logging() does but
with error handling intentionally omitted from initialize_logging().
Startup requires a good logging.json, but reload tolerates a bad one.
Good daemons always keep running as best they can once started, but can
insist on a good startup environment.