### PR TITLE
Call wasm start func each time

### DIFF
--- a/libraries/chain/wasm_interface.cpp
+++ b/libraries/chain/wasm_interface.cpp
@@ -385,6 +385,7 @@ namespace eosio { namespace chain {
       FC_ASSERT( getFunctionType(call)->parameters.size() == args.size() );
 
       auto context_guard = scoped_context(current_context, code, context);
+      runInstanceStartFunc(code.instance);
       Runtime::invokeFunction(call,args);
    } catch( const Runtime::Exception& e ) {
       FC_THROW_EXCEPTION(wasm_execution_error,

--- a/libraries/wasm-jit/Include/Runtime/Runtime.h
+++ b/libraries/wasm-jit/Include/Runtime/Runtime.h
@@ -212,10 +212,10 @@ namespace Runtime
 
 	// Gets the default table/memory for a ModuleInstance.
 	RUNTIME_API MemoryInstance* getDefaultMemory(ModuleInstance* moduleInstance);
-   RUNTIME_API uint64_t getDefaultMemorySize(ModuleInstance* moduleInstance);
+	RUNTIME_API uint64_t getDefaultMemorySize(ModuleInstance* moduleInstance);
 	RUNTIME_API TableInstance* getDefaultTable(ModuleInstance* moduleInstance);
 
-   RUNTIME_API void runInstanceStartFunc(ModuleInstance* moduleInstance);
+	RUNTIME_API void runInstanceStartFunc(ModuleInstance* moduleInstance);
 
 	// Gets an object exported by a ModuleInstance by name.
 	RUNTIME_API ObjectInstance* getInstanceExport(ModuleInstance* moduleInstance,const std::string& name);

--- a/libraries/wasm-jit/Include/Runtime/Runtime.h
+++ b/libraries/wasm-jit/Include/Runtime/Runtime.h
@@ -215,6 +215,8 @@ namespace Runtime
    RUNTIME_API uint64_t getDefaultMemorySize(ModuleInstance* moduleInstance);
 	RUNTIME_API TableInstance* getDefaultTable(ModuleInstance* moduleInstance);
 
+   RUNTIME_API void runInstanceStartFunc(ModuleInstance* moduleInstance);
+
 	// Gets an object exported by a ModuleInstance by name.
 	RUNTIME_API ObjectInstance* getInstanceExport(ModuleInstance* moduleInstance,const std::string& name);
 }

--- a/libraries/wasm-jit/Source/Runtime/ModuleInstance.cpp
+++ b/libraries/wasm-jit/Source/Runtime/ModuleInstance.cpp
@@ -184,7 +184,7 @@ namespace Runtime
 		if(module.startFunctionIndex != UINTPTR_MAX)
 		{
 			assert(moduleInstance->functions[module.startFunctionIndex]->type == IR::FunctionType::get());
-			invokeFunction(moduleInstance->functions[module.startFunctionIndex],{});
+         moduleInstance->startFunctionIndex = module.startFunctionIndex;
 		}
 
 		moduleInstances.push_back(moduleInstance);
@@ -199,6 +199,11 @@ namespace Runtime
 	MemoryInstance* getDefaultMemory(ModuleInstance* moduleInstance) { return moduleInstance->defaultMemory; }
 	uint64_t getDefaultMemorySize(ModuleInstance* moduleInstance) { return moduleInstance->defaultMemory->numPages << IR::numBytesPerPageLog2; }
 	TableInstance* getDefaultTable(ModuleInstance* moduleInstance) { return moduleInstance->defaultTable; }
+
+   void runInstanceStartFunc(ModuleInstance* moduleInstance) {
+      if(moduleInstance->startFunctionIndex != UINTPTR_MAX)
+         invokeFunction(moduleInstance->functions[moduleInstance->startFunctionIndex],{});
+   }
 	
 	ObjectInstance* getInstanceExport(ModuleInstance* moduleInstance,const std::string& name)
 	{

--- a/libraries/wasm-jit/Source/Runtime/ModuleInstance.cpp
+++ b/libraries/wasm-jit/Source/Runtime/ModuleInstance.cpp
@@ -184,7 +184,7 @@ namespace Runtime
 		if(module.startFunctionIndex != UINTPTR_MAX)
 		{
 			assert(moduleInstance->functions[module.startFunctionIndex]->type == IR::FunctionType::get());
-         moduleInstance->startFunctionIndex = module.startFunctionIndex;
+			moduleInstance->startFunctionIndex = module.startFunctionIndex;
 		}
 
 		moduleInstances.push_back(moduleInstance);
@@ -200,10 +200,10 @@ namespace Runtime
 	uint64_t getDefaultMemorySize(ModuleInstance* moduleInstance) { return moduleInstance->defaultMemory->numPages << IR::numBytesPerPageLog2; }
 	TableInstance* getDefaultTable(ModuleInstance* moduleInstance) { return moduleInstance->defaultTable; }
 
-   void runInstanceStartFunc(ModuleInstance* moduleInstance) {
-      if(moduleInstance->startFunctionIndex != UINTPTR_MAX)
-         invokeFunction(moduleInstance->functions[moduleInstance->startFunctionIndex],{});
-   }
+	void runInstanceStartFunc(ModuleInstance* moduleInstance) {
+		if(moduleInstance->startFunctionIndex != UINTPTR_MAX)
+			invokeFunction(moduleInstance->functions[moduleInstance->startFunctionIndex],{});
+	}
 	
 	ObjectInstance* getInstanceExport(ModuleInstance* moduleInstance,const std::string& name)
 	{

--- a/libraries/wasm-jit/Source/Runtime/RuntimePrivate.h
+++ b/libraries/wasm-jit/Source/Runtime/RuntimePrivate.h
@@ -118,6 +118,8 @@ namespace Runtime
 
 		LLVMJIT::JITModuleBase* jitModule;
 
+      Uptr startFunctionIndex = UINTPTR_MAX;
+
 		ModuleInstance(
 			std::vector<FunctionInstance*>&& inFunctionImports,
 			std::vector<TableInstance*>&& inTableImports,

--- a/libraries/wasm-jit/Source/Runtime/RuntimePrivate.h
+++ b/libraries/wasm-jit/Source/Runtime/RuntimePrivate.h
@@ -118,7 +118,7 @@ namespace Runtime
 
 		LLVMJIT::JITModuleBase* jitModule;
 
-      Uptr startFunctionIndex = UINTPTR_MAX;
+		Uptr startFunctionIndex = UINTPTR_MAX;
 
 		ModuleInstance(
 			std::vector<FunctionInstance*>&& inFunctionImports,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,6 +37,7 @@ target_link_libraries( chain_test eosio_testing eosio_chain chainbase eos_utilit
 
 if(WASM_TOOLCHAIN)
   target_include_directories( chain_test PUBLIC ${CMAKE_BINARY_DIR}/contracts ${CMAKE_CURRENT_BINARY_DIR}/tests/contracts )
+  target_include_directories( chain_test PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/wasm_tests )
   add_dependencies(chain_test asserter test_api currency proxy)
 endif()
 

--- a/tests/wasm_tests/test_wasts.hpp
+++ b/tests/wasm_tests/test_wasts.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+// These are handcrafted or otherwise tricky to generate with our tool chain
+
+static const char entry_wast[] = R"=====(
+(module
+ (import "env" "assert" (func $assert (param i32 i32)))
+ (import "env" "now" (func $now (result i32)))
+ (table 0 anyfunc)
+ (memory $0 1)
+ (export "memory" (memory $0))
+ (export "entry" (func $entry))
+ (export "init" (func $init))
+ (export "apply" (func $apply))
+ (func $entry
+  (i32.store offset=4
+   (i32.const 0)
+   (call $now)
+  )
+ )
+ (func $init
+ )
+ (func $apply (param $0 i64) (param $1 i64)
+  (call $assert
+   (i32.eq
+    (i32.load offset=4
+     (i32.const 0)
+    )
+    (call $now)
+   )
+   (i32.const 0)
+  )
+ )
+ (start $entry)
+)
+)=====";

--- a/tests/wasm_tests/wasm_tests.cpp
+++ b/tests/wasm_tests/wasm_tests.cpp
@@ -523,7 +523,7 @@ BOOST_FIXTURE_TEST_CASE( test_deferred_failure, tester ) try {
 } FC_LOG_AND_RETHROW() /// test_currency
 
 /**
- * Make sure entry method is used correctly
+ * Make sure WASM "start" method is used correctly
  */
 BOOST_FIXTURE_TEST_CASE( check_entry_behavior, tester ) try {
    produce_blocks(2);

--- a/tests/wasm_tests/wasm_tests.cpp
+++ b/tests/wasm_tests/wasm_tests.cpp
@@ -16,6 +16,8 @@
 
 #include <fc/variant_object.hpp>
 
+#include "test_wasts.hpp"
+
 using namespace eosio;
 using namespace eosio::chain;
 using namespace eosio::chain::contracts;
@@ -519,6 +521,35 @@ BOOST_FIXTURE_TEST_CASE( test_deferred_failure, tester ) try {
    BOOST_REQUIRE_EQUAL(get_balance( N(bob)),   asset::from_string("0.0000 EOS").amount);
 
 } FC_LOG_AND_RETHROW() /// test_currency
+
+/**
+ * Make sure entry method is used correctly
+ */
+BOOST_FIXTURE_TEST_CASE( check_entry_behavior, tester ) try {
+   produce_blocks(2);
+
+   create_accounts( {N(entrycheck)}, asset::from_string("1000.0000 EOS") );
+   transfer( N(inita), N(entrycheck), "10.0000 EOS", "memo" );
+   produce_block();
+
+   set_code(N(entrycheck), entry_wast);
+   produce_blocks(10);
+
+   signed_transaction trx;
+   action act;
+   act.scope = N(entrycheck);
+   act.name = N();
+   act.authorization = vector<permission_level>{{N(entrycheck),config::active_name}};
+   trx.actions.push_back(act);
+
+   set_tapos(trx);
+   trx.sign(get_private_key( N(entrycheck), "active" ), chain_id_type());
+   control->push_transaction(trx);
+   produce_blocks(1);
+   BOOST_REQUIRE_EQUAL(true, chain_has_transaction(trx.id()));
+   const auto& receipt = get_transaction_receipt(trx.id());
+   BOOST_CHECK_EQUAL(transaction_receipt::executed, receipt.status);
+} FC_LOG_AND_RETHROW() /// prove_mem_reset
 
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Previously, the WASM "start" function would be called once right after compilation. This was problematic for two reasons. 1) It was called during a period of time not expected (not during any context), and 2) if the user was expecting the start function to be called for initialization it would not be called after the memory had been reset on subsequent apply() calls -- that could be a surprise.

Now call the WASM "start" function before each init() and apply().