### PR TITLE
Dawn 250 gh 1081 Add roll and bounce scripts and ability to call from launcher

### DIFF
--- a/programs/launcher/main.cpp
+++ b/programs/launcher/main.cpp
@@ -1218,7 +1218,7 @@ launcher_def::bounce (const string& node_numbers) {
    vector<string> nodes;
    boost::split(nodes, node_numbers, boost::is_any_of(","));
    for (string node_number: nodes) {
-      uint16_t node;
+      uint16_t node = -1;
       try {
          node = boost::lexical_cast<uint16_t,string>(node_number);
       }
@@ -1347,8 +1347,8 @@ int main (int argc, char *argv[]) {
     ("timestamp,i",bpo::value<string>(&gts),"set the timestamp for the first block. Use \"now\" to indicate the current time")
     ("launch,l",bpo::value<string>(), "select a subset of nodes to launch. Currently may be \"all\", \"none\", or \"local\". If not set, the default is to launch all unless an output file is named, in which case it starts none.")
     ("kill,k", bpo::value<string>(&kill_arg),"The launcher retrieves the previously started process ids and issue a kill to each.")
-    ("bounce", bpo::value<string>(&bounce_nodes),"comma-separated list of node numbers that will be restarted")
-    ("roll", bpo::value<string>(&roll_nodes),"comma-separated list of host names where the nodes should be rolled to a new version")
+    ("bounce", bpo::value<string>(&bounce_nodes),"comma-separated list of node numbers that will be restarted using the tn_bounce.sh script")
+    ("roll", bpo::value<string>(&roll_nodes),"comma-separated list of host names where the nodes should be rolled to a new version using the tn_roll.sh script")
     ("version,v", "print version information")
     ("help,h","print this list");
 

--- a/programs/launcher/main.cpp
+++ b/programs/launcher/main.cpp
@@ -358,6 +358,7 @@ struct launcher_def {
   void define_network ();
   void bind_nodes ();
   host_def *find_host (const string &name);
+  host_def *find_host_by_name_or_address (const string &name);
   host_def *deploy_config_files (tn_node_def &node);
   string compose_scp_command (const host_def &host, const bf::path &source,
                               const bf::path &destination);
@@ -373,6 +374,9 @@ struct launcher_def {
   void prep_remote_config_dir (eosd_def &node, host_def *host);
   void launch (eosd_def &node, string &gts);
   void kill (launch_modes mode, string sig_opt);
+  void bounce (const string& node_numbers);
+  bool bounce_node (uint16_t num);
+  void roll (const string& host_names);
   void start_all (string &gts, launch_modes mode);
 };
 
@@ -719,6 +723,23 @@ launcher_def::find_host (const string &name)
   }
   if (host == 0) {
     cerr << "could not find host for " << name << endl;
+    exit(-1);
+  }
+  return host;
+}
+
+host_def *
+launcher_def::find_host_by_name_or_address (const string &host_id)
+{
+  host_def *host = nullptr;
+  for (auto &h : bindings) {
+    if ((h.host_name == host_id) || (h.public_name == host_id)) {
+      host = &h;
+      break;
+    }
+  }
+  if (host == 0) {
+    cerr << "could not find host for " << host_id << endl;
     exit(-1);
   }
   return host;
@@ -1193,6 +1214,67 @@ launcher_def::kill (launch_modes mode, string sig_opt) {
 }
 
 void
+launcher_def::bounce (const string& node_numbers) {
+   vector<string> nodes;
+   boost::split(nodes, node_numbers, boost::is_any_of(","));
+   for (string node_number: nodes) {
+      uint16_t node;
+      try {
+         node = boost::lexical_cast<uint16_t,string>(node_number);
+      }
+      catch(boost::bad_lexical_cast &)
+      {
+         cerr << "Bad node number found in node number list for bounce: " << node_number << endl;
+         exit(-1);
+      }
+      if (!bounce_node(node)) {
+         cerr << "Node number not found: " << node << endl;
+      }
+   }
+}
+
+bool
+launcher_def::bounce_node (uint16_t num) {
+   string dex = num < 10 ? "0":"";
+   dex += boost::lexical_cast<string,uint16_t>(num);
+   string node_name = network.name + dex;
+   for (auto host: bindings) {
+      for (auto node: host.instances) {
+         if (node_name == node.name) {
+            string cmd = "cd " + host.eos_root_dir + "; "
+                       + "export EOSIO_HOME=" + host.eos_root_dir + "; "
+                       + "export EOSIO_TN_NODE=" + dex + "; "
+                       + "./scripts/tn_bounce.sh";
+            cout << "Bouncing " << node_name << endl;
+            if (!do_ssh(cmd, host.host_name)) {
+               cerr << "Unable to bounce " << node_name << endl;
+               exit (-1);
+            }
+            return true;
+         }
+      }
+   }
+   return false;
+}
+
+void
+launcher_def::roll (const string& host_names) {
+   vector<string> hosts;
+   boost::split(hosts, host_names, boost::is_any_of(","));
+   for (string host_name: hosts) {
+      cout << "Rolling " << host_name << endl;
+      auto host = find_host_by_name_or_address(host_name);
+      string cmd = "cd " + host->eos_root_dir + "; "
+                 + "export EOSIO_HOME=" + host->eos_root_dir + "; "
+                 + "./scripts/tn_roll.sh";
+      if (!do_ssh(cmd, host_name)) {
+         cerr << "Unable to roll " << host << endl;
+         exit (-1);
+      }
+   }
+}
+
+void
 launcher_def::start_all (string &gts, launch_modes mode) {
   switch (mode) {
   case LM_NONE:
@@ -1255,6 +1337,8 @@ int main (int argc, char *argv[]) {
   string gts;
   launch_modes mode;
   string kill_arg;
+  string bounce_nodes;
+  string roll_nodes;
 
   local_id.initialize();
   top.set_options(opts);
@@ -1263,6 +1347,8 @@ int main (int argc, char *argv[]) {
     ("timestamp,i",bpo::value<string>(&gts),"set the timestamp for the first block. Use \"now\" to indicate the current time")
     ("launch,l",bpo::value<string>(), "select a subset of nodes to launch. Currently may be \"all\", \"none\", or \"local\". If not set, the default is to launch all unless an output file is named, in which case it starts none.")
     ("kill,k", bpo::value<string>(&kill_arg),"The launcher retrieves the previously started process ids and issue a kill to each.")
+    ("bounce", bpo::value<string>(&bounce_nodes),"comma-separated list of node numbers that will be restarted")
+    ("roll", bpo::value<string>(&roll_nodes),"comma-separated list of host names where the nodes should be rolled to a new version")
     ("version,v", "print version information")
     ("help,h","print this list");
 
@@ -1309,6 +1395,12 @@ int main (int argc, char *argv[]) {
         kill_arg = "-" + kill_arg;
       }
       top.kill (mode, kill_arg);
+    }
+    else if (!bounce_nodes.empty()) {
+       top.bounce(bounce_nodes);
+    }
+    else if (!roll_nodes.empty()) {
+       top.roll(roll_nodes);
     }
     else {
       top.generate();

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -1,3 +1,9 @@
 add_subdirectory( testnet_np )
 
 configure_file(start_npnode.sh start_npnode.sh COPYONLY)
+configure_file(tn_bounce.sh tn_bounce.sh COPYONLY)
+configure_file(tn_down.sh tn_down.sh COPYONLY)
+configure_file(tn_gen_config.sh tn_gen_config.sh COPYONLY)
+configure_file(tn_roll.sh tn_roll.sh COPYONLY)
+configure_file(tn_start_all.sh tn_start_all.sh COPYONLY)
+configure_file(tn_up.sh tn_up.sh COPYONLY)

--- a/scripts/tn_down.sh
+++ b/scripts/tn_down.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+#
+# tn_bounce is used to restart a node that is acting badly or is down.
+# usage: tn_bounce.sh [arglist]
+# arglist will be passed to the node's command line. First with no modifiers
+# then with --replay and then a third time with --resync
+#
+# the data directory and log file are set by this script. Do not pass them on
+# the command line.
+#
+# in most cases, simply running ./tn_bounce.sh is sufficient.
+#
+
+
+prog=""
+RD=""
+for p in eosd eosiod; do
+    prog=$p
+    RD=$EOSIO_HOME/bin
+    if [ -f $RD/$prog ]; then
+        break;
+    else
+        RD=$EOSIO_HOME/programs/$prog
+        if [ -f $RD/$prog ]; then
+            break;
+        fi
+    fi
+    prog=""
+    RD=""
+done
+
+if [ \( -z "$prog" \) -o \( -z "RD" \) ]; then
+    echo unable to locate binary for eosd or eosiod
+    exit 1
+fi
+
+if [ -z "$EOSIO_TN_RESTART_DATA_DIR" ]; then
+    echo data directory not set
+    exit 1
+fi
+
+DD=$EOSIO_TN_RESTART_DATA_DIR;
+runtest=""
+if [ $DD = "all" ]; then
+    runtest=$prog
+else
+    runtest=`cat $DD/$prog.pid`
+fi
+echo runtest =  $runtest
+running=`ps -e | grep $runtest | grep -cv grep `
+
+if [ $running -ne 0 ]; then
+    echo killing $prog
+
+    if [ $runtest = $prog ]; then
+        kill -15 $runtest
+    else
+        pkill -15 $runtest
+    fi
+
+    for (( a = 10; $a; a = $(($a - 1)) )); do
+        echo waiting for safe termination, pass $((11 - $a))
+        sleep 2
+        running=`ps -e | grep $runtest | grep -cv grep`
+        echo running = $running
+        if [ $running -eq 0 ]; then
+            break;
+        fi
+    done
+fi
+
+if [ $running -ne 0 ]; then
+    echo killing $prog with SIGTERM failed, trying with SIGKILL
+    if [ $runtest = $prog ]; then
+        kill -9 $runtest
+    else
+        pkill -9 $runtest
+    fi
+fi

--- a/scripts/tn_down.sh
+++ b/scripts/tn_down.sh
@@ -1,26 +1,24 @@
 #!/bin/bash
 #
-# tn_bounce is used to restart a node that is acting badly or is down.
-# usage: tn_bounce.sh [arglist]
-# arglist will be passed to the node's command line. First with no modifiers
-# then with --replay and then a third time with --resync
-#
-# the data directory and log file are set by this script. Do not pass them on
-# the command line.
-#
-# in most cases, simply running ./tn_bounce.sh is sufficient.
+# tn_down.sh is used by the tn_bounce.sh and tn_roll.sh scripts. It is intended to terminate
+# specific EOS daemon processes.
 #
 
+
+if [ "$PWD" != "$EOSIO_HOME" ]; then
+    echo $0 must only be run from $EOSIO_HOME
+    exit -1
+fi
 
 prog=""
 RD=""
 for p in eosd eosiod; do
     prog=$p
-    RD=$EOSIO_HOME/bin
+    RD=bin
     if [ -f $RD/$prog ]; then
         break;
     else
-        RD=$EOSIO_HOME/programs/$prog
+        RD=programs/$prog
         if [ -f $RD/$prog ]; then
             break;
         fi
@@ -53,9 +51,9 @@ if [ $running -ne 0 ]; then
     echo killing $prog
 
     if [ $runtest = $prog ]; then
-        kill -15 $runtest
-    else
         pkill -15 $runtest
+    else
+        kill -15 $runtest
     fi
 
     for (( a = 10; $a; a = $(($a - 1)) )); do
@@ -72,8 +70,8 @@ fi
 if [ $running -ne 0 ]; then
     echo killing $prog with SIGTERM failed, trying with SIGKILL
     if [ $runtest = $prog ]; then
-        kill -9 $runtest
-    else
         pkill -9 $runtest
+    else
+        kill -9 $runtest
     fi
 fi

--- a/scripts/tn_roll.sh
+++ b/scripts/tn_roll.sh
@@ -58,15 +58,19 @@ if [ \( -z "$prog" \) -o \( -z "$RD" \) ]; then
 fi
 
 SDIR=staging/eos
+if [ ! -e $SDIR/$RD/$prog ]; then
+    echo $SDIR/$RD/$prog does not exist
+    exit 1
+fi
+
 if [ -e $RD/$prog ]; then
-    s1=`md5sum $RD/$prog`
-    s2=`md5sum $SDIR/$prog`
+    s1=`md5sum $RD/$prog | sed "s/ .*$//"`
+    s2=`md5sum $SDIR/$RD/$prog | sed "s/ .*$//"`
     if [ "$s1" == "$s2" ]; then
-        echo $HOSTNAME no update $SDIR/$prog
+        echo $HOSTNAME no update $SDIR/$RD/$prog
         exit 1;
     fi
 fi
-
 
 echo DD = $DD
 

--- a/scripts/tn_up.sh
+++ b/scripts/tn_up.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+#
+# tn_up is a helper script used to start a node that was previously stopped
+# usage: tn_bounce.sh [ [arglist]
+# arglist will be passed to the node's command line. First with no modifiers
+# then with --replay and then a third time with --resync
+#
+# the data directory and log file are set by this script. Do not pass them on
+# the command line.
+#
+# in most cases, simply running ./tn_bounce.sh is sufficient.
+#
+
+connected="0"
+
+relaunch() {
+    prog=$1; shift
+    DD=$1; shift
+    RD=$1; shift
+
+    now=`date +'%Y_%m_%d_%H_%M_%S'`
+    log=$DD/stderr.$now.txt
+
+    nohup $RD/$prog $* --data-dir $DD > $DD/stdout.txt  2> $log &
+    pid=$!
+    echo $pid > $DD/$prog.pid
+    for (( a = 10; $a; a = $(($a - 1)) )); do
+        echo checking viability pass $((11 - $a))
+        sleep 2
+        running=`ps -hp $pid`
+        if [ -z "$running" ]; then
+            break;
+        fi
+        connected=`grep -c "net_plugin.cpp:.*connection" $log`
+        if [ "$connected" -ne 0 ]; then
+            break;
+        fi
+    done
+}
+
+prog=""
+RD=""
+for p in eosd eosiod; do
+    prog=$p
+    RD=$EOSIO_HOME/bin
+    if [ -f $RD/$prog ]; then
+        break;
+    else
+        RD=$EOSIO_HOME/programs/$prog
+        if [ -f $RD/$prog ]; then
+            break;
+        fi
+    fi
+    prog=""
+    RD=""
+done
+
+if [ \( -z "$prog" \) -o \( -z "$RD" \) ]; then
+    echo unable to locate binary for eosd or eosiod
+    exit 1
+fi
+
+
+if [ -z "$EOSIO_TN_RESTART_DATA_DIR" ]; then
+    echo data directory not set
+    exit 1
+fi
+
+DD=$EOSIO_TN_RESTART_DATA_DIR;
+
+echo starting with no modifiers
+relaunch $prog $DD $RD $*
+if [ \( -z "$running" \) -o \( "$connected" -eq 0 \) ]; then
+    echo base relaunch failed, trying with replay
+    relaunch $prog $DD $RD $* --replay
+    if [ \( -z "$running" \) -o \( "$connected" -eq 0 \) ]; then
+        echo relaunch replay failed, trying with resync
+        relaunch $prog $DD $RD $* --resync
+    fi
+fi
+
+rm $DD/stderr.txt
+ln -s stderr.$now.txt $DD/stderr.txt

--- a/scripts/tn_up.sh
+++ b/scripts/tn_up.sh
@@ -1,15 +1,8 @@
 #!/bin/bash
 #
 # tn_up is a helper script used to start a node that was previously stopped
-# usage: tn_bounce.sh [ [arglist]
-# arglist will be passed to the node's command line. First with no modifiers
-# then with --replay and then a third time with --resync
-#
-# the data directory and log file are set by this script. Do not pass them on
-# the command line.
-#
-# in most cases, simply running ./tn_bounce.sh is sufficient.
-#
+# it is not intended to be run stand-alone, it is a companion to the tn_bounce.sh and
+# tn_roll.sh scripts.
 
 connected="0"
 
@@ -23,6 +16,7 @@ relaunch() {
 
     nohup $RD/$prog $* --data-dir $DD > $DD/stdout.txt  2> $log &
     pid=$!
+
     echo $pid > $DD/$prog.pid
     for (( a = 10; $a; a = $(($a - 1)) )); do
         echo checking viability pass $((11 - $a))
@@ -38,15 +32,20 @@ relaunch() {
     done
 }
 
+if [ "$PWD" != "$EOSIO_HOME" ]; then
+    echo $0 must only be run from $EOSIO_HOME
+    exit -1
+fi
+
 prog=""
 RD=""
 for p in eosd eosiod; do
     prog=$p
-    RD=$EOSIO_HOME/bin
+    RD=bin
     if [ -f $RD/$prog ]; then
         break;
     else
-        RD=$EOSIO_HOME/programs/$prog
+        RD=programs/$prog
         if [ -f $RD/$prog ]; then
             break;
         fi
@@ -59,7 +58,6 @@ if [ \( -z "$prog" \) -o \( -z "$RD" \) ]; then
     echo unable to locate binary for eosd or eosiod
     exit 1
 fi
-
 
 if [ -z "$EOSIO_TN_RESTART_DATA_DIR" ]; then
     echo data directory not set


### PR DESCRIPTION
This change adds new roll and bounce scripts which can be remotely invoked via the launcher. Using the --bounce and --roll options, you can now bounce all the nodes in a network or roll them to a new version.