### PR TITLE
Compile wasm contracts that are part of eosio source with -O3, like t…

### DIFF
--- a/CMakeModules/wasm.cmake
+++ b/CMakeModules/wasm.cmake
@@ -91,7 +91,7 @@ macro(add_wast_target target INCLUDE_FOLDERS DESTINATION_FOLDER)
   
     add_custom_command(OUTPUT ${outfile}.bc
       DEPENDS ${infile}
-      COMMAND ${WASM_CLANG} -emit-llvm -O0 --std=c++14 --target=wasm32 -ffreestanding
+      COMMAND ${WASM_CLANG} -emit-llvm -O3 --std=c++14 --target=wasm32 -ffreestanding
               -nostdlib -fno-threadsafe-statics -fno-rtti -fno-exceptions -I ${INCLUDE_FOLDERS}
               -c ${infile} -o ${outfile}.bc 
       IMPLICIT_DEPENDS CXX ${infile}


### PR DESCRIPTION
…he eoscpp tool would

Reduces code size of currency contract to about 30% of that previously. Not seeing much difference in execution time but that's because it's so short I would need proper profiling to see it.