### PR TITLE
 Check wasm->native pointer validity based on active pages

### DIFF
--- a/libraries/wasm-jit/Source/Runtime/Memory.cpp
+++ b/libraries/wasm-jit/Source/Runtime/Memory.cpp
@@ -134,11 +134,10 @@ namespace Runtime
 	
 	U8* getValidatedMemoryOffsetRange(MemoryInstance* memory,Uptr offset,Uptr numBytes)
 	{
-		if(!memory)
-			causeException(Exception::Cause::accessViolation);
 		// Validate that the range [offset..offset+numBytes) is contained by the memory's reserved pages.
 		U8* address = memory->baseAddress + offset;
-		if(	address < memory->reservedBaseAddress
+		if(	!memory
+		||	address < memory->reservedBaseAddress
 		||	address + numBytes < address
 		||	address + numBytes >= memory->reservedBaseAddress + (memory->reservedNumPlatformPages << Platform::getPageSizeLog2()))
 		{


### PR DESCRIPTION
Previously the wasm->native invoke wrapper would validate wasm pointers based on their validity in the mapped memory pages. This only means the pointer lied within the 4/8/12GB virtual memory map. So it was trivial to hand off a pointer from wasm->native that would segv when native code accessed it. This is caught (and handled) but preference is for there to be no way to segv inside of native code to prevent any oddities from longjmping.

Now, check that the pointer lies within the "active" memory pages -- pages that are R/Wable

Extra review note: There are a few places that can still pass pointers than can segv native code. I'd like to get those cleaned up in the future.