### PR TITLE
Validate "string pointers" for wasm are entirely in active pages

### DIFF
--- a/libraries/chain/include/eosio/chain/wasm_interface_private.hpp
+++ b/libraries/chain/include/eosio/chain/wasm_interface_private.hpp
@@ -439,7 +439,7 @@ struct intrinsic_invoker_impl<Ret, std::tuple<null_terminated_ptr, Inputs...>, s
       char *base          = (char*)(getMemoryBaseAddress(mem) + ptr);
       char *p             = base;
       char *top_of_memory = (char*)(getMemoryBaseAddress(mem) + IR::numBytesPerPage*Runtime::getMemoryNumPages(mem));
-      while(p != top_of_memory)
+      while(p < top_of_memory)
          if(*p++ == '\0')
             return Then(wasm, null_terminated_ptr{base}, rest..., translated...);
       Runtime::causeException(Exception::Cause::accessViolation);

--- a/libraries/chain/wasm_interface.cpp
+++ b/libraries/chain/wasm_interface.cpp
@@ -642,7 +642,7 @@ class system_api : public context_aware_api {
    public:
       using context_aware_api::context_aware_api;
 
-      void assert(bool condition, const char* str) {
+      void assert(bool condition, null_terminated_ptr str) {
          std::string message( str );
          if( !condition ) edump((message));
          FC_ASSERT( condition, "assertion failed: ${s}", ("s",message));
@@ -689,8 +689,8 @@ class console_api : public context_aware_api {
    public:
       using context_aware_api::context_aware_api;
 
-      void prints(const char *str) {
-         context.console_append(str);
+      void prints(null_terminated_ptr str) {
+         context.console_append((const char*)str);
       }
 
       void prints_l(array_ptr<const char> str, size_t str_len ) {

--- a/libraries/chain/wasm_interface.cpp
+++ b/libraries/chain/wasm_interface.cpp
@@ -690,7 +690,7 @@ class console_api : public context_aware_api {
       using context_aware_api::context_aware_api;
 
       void prints(null_terminated_ptr str) {
-         context.console_append((const char*)str);
+         context.console_append<const char*>(str);
       }
 
       void prints_l(array_ptr<const char> str, size_t str_len ) {


### PR DESCRIPTION
There are a couple native methods callable from WASM where the methods expect a NULL terminated char array (a string). Validate that the string lives entirely within active pages before dispatching it. Otherwise native code could segv if given a non-null-terminated string on the end of active pages.