### PR TITLE
Updated currency.abi

### DIFF
--- a/contracts/currency/currency.abi
+++ b/contracts/currency/currency.abi
@@ -1,23 +1,25 @@
 {
-  "types": [{
-      "new_type_name": "account_name",
-      "type": "name"
-    }
-  ],
+  "types": [],
   "structs": [{
+      "name": "currency_tokens",
+      "base": "",
+      "fields": {
+        "quantity": "uint64"
+      }
+    },{
       "name": "transfer",
       "base": "",
       "fields": {
         "from": "account_name",
         "to": "account_name",
-        "quantity": "uint64"
+        "quantity": "currency_tokens"
       }
     },{
       "name": "account",
       "base": "",
       "fields": {
-        "key": "name",
-        "balance": "uint64"
+        "key": "uint64",
+        "balance": "currency_tokens"
       }
     }
   ],
@@ -28,10 +30,14 @@
   ],
   "tables": [{
       "table_name": "account",
-      "type": "account",
       "index_type": "i64",
-      "key_names" : ["key"],
-      "key_types" : ["name"]
+      "key_names": [
+        "key"
+      ],
+      "key_types": [
+        "uint64"
+      ],
+      "type": "account"
     }
   ]
 }


### PR DESCRIPTION
This is the abi generated by the abigen.

It would be needed to update the examples / wiki:
old:
```
eosc push message currency transfer '{"from":"currency","to":"inita","quantity":50}' --scope currency,inita --permission currency@active
```
new:
```
eosc push message currency transfer '{"from":"currency","to":"inita","quantity": ''{"quantity":50}''}' --scope currency,inita --permission currency@active
```