### PR TITLE
Prevent R/Wable "code" section from WASM (????)

### DIFF
--- a/libraries/wasm-jit/Source/Runtime/LLVMJIT.cpp
+++ b/libraries/wasm-jit/Source/Runtime/LLVMJIT.cpp
@@ -123,6 +123,8 @@ namespace LLVMJIT
 		virtual bool needsToReserveAllocationSpace() override { return true; }
 		virtual void reserveAllocationSpace(uintptr_t numCodeBytes,U32 codeAlignment,uintptr_t numReadOnlyBytes,U32 readOnlyAlignment,uintptr_t numReadWriteBytes,U32 readWriteAlignment) override
 		{
+			if(numReadWriteBytes)
+				 Runtime::causeException(Exception::Cause::outOfMemory);
 			// Calculate the number of pages to be used by each section.
 			codeSection.numPages = shrAndRoundUp(numCodeBytes,Platform::getPageSizeLog2());
 			readOnlySection.numPages = shrAndRoundUp(numReadOnlyBytes,Platform::getPageSizeLog2());


### PR DESCRIPTION
When the WASM code is compiled we end up needing memory for the generated x86_64 code. We end up with..
1) An executable section, for the code. Makes sense.
2) A readonly section, for exception unwinding. Okay, that makes sense too.
3) Potentially a readwrite section????

I've never seen numReadWriteBytes be anything other than 0. I'm not sure what kind of code would require RW section nor what that section could actually be used for. But if we did end up with RW sections here it would cause lots of problems. So, protect against it.