### PR TITLE
Fix failing docker build

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -76,8 +76,8 @@ RUN git clone -b master --depth 1 https://github.com/EOSIO/eos.git --recursive \
     && cd eos \
     && cmake -H. -B"/tmp/build" -GNinja -DCMAKE_BUILD_TYPE=Release -DWASM_LLVM_CONFIG=/opt/wasm/bin/llvm-config -DCMAKE_CXX_COMPILER=clang++ \
        -DCMAKE_C_COMPILER=clang -DCMAKE_INSTALL_PREFIX=/opt/eos  -DSecp256k1_ROOT_DIR=/usr/local \
-    && cmake --build /tmp/build --target install
-
+    && cmake --build /tmp/build --target install \
+    && cd /tmp/build && cmake -DCMAKE_INSTALL_PREFIX=/opt/eos -P cmake_install.cmake
 
 
 FROM ubuntu:16.04


### PR DESCRIPTION
Fix install path for eos that is causing the Docker build to fail. This is a quick hack but will unblock some people that is trying to build this docker image.

This closes #1143 and #1146