### PR TITLE
eosioc currency commands

### DIFF
--- a/contracts/currency/currency.abi
+++ b/contracts/currency/currency.abi
@@ -27,6 +27,13 @@
         {"name":"currency", "type":"uint64"},
         {"name":"balance", "type":"uint64"}
       ]
+    },{
+      "name": "currency_stats",
+      "base": "",
+      "fields": [
+        {"name":"currency", "type":"uint64"},
+        {"name":"supply", "type":"uint64"}
+      ]
     }
   ],
   "actions": [{
@@ -40,6 +47,12 @@
   "tables": [{
       "name": "account",
       "type": "account",
+      "index_type": "i64",
+      "key_names" : ["currency"],
+      "key_types" : ["uint64"]
+    },{
+      "name": "stat",
+      "type": "currency_stats",
       "index_type": "i64",
       "key_names" : ["currency"],
       "key_types" : ["uint64"]

--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -70,6 +70,8 @@ void chain_api_plugin::plugin_startup() {
       CHAIN_RO_CALL(get_account, 200),
       CHAIN_RO_CALL(get_code, 200),
       CHAIN_RO_CALL(get_table_rows, 200),
+      CHAIN_RO_CALL(get_currency_balance, 200),
+      CHAIN_RO_CALL(get_currency_stats, 200),
       CHAIN_RO_CALL(abi_json_to_bin, 200),
       CHAIN_RO_CALL(abi_bin_to_json, 200),
       CHAIN_RO_CALL(get_required_keys, 200),


### PR DESCRIPTION
Added 2x commands to `eosioc`

### `get currency balance <currency contract> <account> [<symbol>]`

This command queries a standardized currency balance from the blockchain and puts it into a prettier output format than raw database access would allow.  The optional `symbol` parameter can be used to pick a single currency since contracts can operate multiple:

```
$ ./eosioc get currency balance my.token alice
[
  "1000.0000 MYT"
]
$ ./eosioc get currency balance my.token alice MYT
"1000.0000 MYT"
```

### `get currency stats <currency contract> [<symbol>]`

This command queries the information about a currency.  Once again the optional `symbol` parameter is used to select a specific currency on a contract which operates multiple

```
$ ./eosioc get currency stats my.token
{
  "MYT": {
    "supply": "1000.0000 MYT"
  }
}
$ ./eosioc get currency stats my.token MYT
{
  "supply": "1000.0000 MYT"
}
```