### PR TITLE
remove init() contract ABI call from setcode

### DIFF
--- a/contracts/exchange/exchange.cpp
+++ b/contracts/exchange/exchange.cpp
@@ -285,14 +285,6 @@ void apply_exchange_cancel_sell( order_id order ) {
 } // namespace exchange
 
 extern "C" {
-   void init() {
-      /*
-      setAuthority( "currencya", "transfer", "anyone" );
-      setAuthority( "currencyb", "transfer", "anyone" );
-      registerHandler( "apply", "currencya", "transfer" );
-      registerHandler( "apply", "currencyb", "transfer" );
-      */
-   }
 
 //   void validate( uint64_t code, uint64_t action ) { }
 //   void precondition( uint64_t code, uint64_t action ) { }

--- a/contracts/infinite/infinite.cpp
+++ b/contracts/infinite/infinite.cpp
@@ -40,9 +40,6 @@ namespace infinite {
 using namespace infinite;
 
 extern "C" {
-    void init()  {
-       store_account( N(currency), account( currency_tokens(1000ll*1000ll*1000ll) ) );
-    }
 
     /// The apply method implements the dispatch of events to this contract
     void apply( uint64_t code, uint64_t action ) {

--- a/contracts/proxy/proxy.cpp
+++ b/contracts/proxy/proxy.cpp
@@ -60,8 +60,6 @@ using namespace proxy;
 using namespace eosio;
 
 extern "C" {
-    void init()  {
-    }
 
     /// The apply method implements the dispatch of events to this contract
     void apply( uint64_t code, uint64_t action ) {

--- a/contracts/simpledb/simpledb.cpp
+++ b/contracts/simpledb/simpledb.cpp
@@ -10,9 +10,6 @@
 #include <eoslib/raw.hpp>
 
 extern "C" {
-   void init()  {
-
-   }
    
    void apply( uint64_t code, uint64_t action ) {
       if( code == N(simpledb) ) {

--- a/contracts/skeleton/skeleton.cpp
+++ b/contracts/skeleton/skeleton.cpp
@@ -10,13 +10,6 @@
  */
 extern "C" {
 
-    /**
-     *  This method is called once when the contract is published or updated.
-     */
-    void init()  {
-       eosio::print( "Init World!\n" );
-    }
-
     /// The apply method implements the dispatch of events to this contract
     void apply( uint64_t code, uint64_t action ) {
        eosio::print( "Hello World: ", eosio::name(code), "->", eosio::name(action), "\n" );

--- a/contracts/storage/storage.cpp
+++ b/contracts/storage/storage.cpp
@@ -100,10 +100,6 @@ namespace TOKEN_NAME {
 using namespace TOKEN_NAME;
 
 extern "C" {
-    void init()  {
-       // How do we initialize the storage capacity? By how much here?
-       accounts::store( account( storage_tokens(1000ll*1000ll*1000ll) ), N(storage) );
-    }
 
     /// The apply method implements the dispatch of events to this contract
     void apply( uint64_t code, uint64_t action ) {

--- a/contracts/tic_tac_toe/tic_tac_toe.cpp
+++ b/contracts/tic_tac_toe/tic_tac_toe.cpp
@@ -182,12 +182,6 @@ namespace tic_tac_toe {
 */
 extern "C" {
 
-  /**
-  *  This method is called once when the contract is published or updated.
-  */
-  void init()  {
-  }
-
   /// The apply method implements the dispatch of events to this contract
   void apply( uint64_t code, uint64_t action ) {
     if (code == N(tic.tac.toe)) {

--- a/libraries/chain/contracts/eosio_contract.cpp
+++ b/libraries/chain/contracts/eosio_contract.cpp
@@ -238,12 +238,11 @@ void apply_eosio_setcode(apply_context& context) {
       // Added resize(0) here to avoid bug in boost vector container
       a.code.resize( 0 );
       a.code.resize( act.code.size() );
+      a.last_code_update = context.controller.head_block_time();
       memcpy( a.code.data(), act.code.data(), act.code.size() );
 
    });
 
-   // make sure the code gets a chance to initialize itself
-   context.require_recipient(act.account);
 }
 
 void apply_eosio_setabi(apply_context& context) {

--- a/libraries/chain/include/eosio/chain/account_object.hpp
+++ b/libraries/chain/include/eosio/chain/account_object.hpp
@@ -19,6 +19,7 @@ namespace eosio { namespace chain {
       account_name         name;
       uint8_t              vm_type      = 0;
       uint8_t              vm_version   = 0;
+      time_point_sec       last_code_update;
       digest_type          code_version;
       block_timestamp_type creation_date;
 

--- a/libraries/chain/wasm_interface.cpp
+++ b/libraries/chain/wasm_interface.cpp
@@ -413,13 +413,9 @@ namespace eosio { namespace chain {
    }
 
    void wasm_interface::apply( wasm_cache::entry& code, apply_context& context ) {
-      if (context.act.account == config::system_account_name && context.act.name == N(setcode)) {
-         my->call("init", {}, code, context);
-      } else {
-         vector<Value> args = {Value(uint64_t(context.act.account)),
-                               Value(uint64_t(context.act.name))};
-         my->call("apply", args, code, context);
-      }
+      vector<Value> args = {Value(uint64_t(context.act.account)),
+                            Value(uint64_t(context.act.name))};
+      my->call("apply", args, code, context);
    }
 
    void wasm_interface::error( wasm_cache::entry& code, apply_context& context ) {

--- a/tests/wasm_tests/test_wasts.hpp
+++ b/tests/wasm_tests/test_wasts.hpp
@@ -10,15 +10,12 @@ static const char entry_wast[] = R"=====(
  (memory $0 1)
  (export "memory" (memory $0))
  (export "entry" (func $entry))
- (export "init" (func $init))
  (export "apply" (func $apply))
  (func $entry
   (i32.store offset=4
    (i32.const 0)
    (call $now)
   )
- )
- (func $init
  )
  (func $apply (param $0 i64) (param $1 i64)
   (call $assert
@@ -39,10 +36,7 @@ static const char simple_no_memory_wast[] = R"=====(
 (module
  (import "env" "memcpy" (func $memcpy (param i32 i32 i32) (result i32)))
  (table 0 anyfunc)
- (export "init" (func $init))
  (export "apply" (func $apply))
- (func $init
- )
  (func $apply (param $0 i64) (param $1 i64)
     (drop
        (call $memcpy
@@ -61,23 +55,16 @@ static const char mutable_global_wast[] = R"=====(
  (table 0 anyfunc)
  (memory $0 1)
  (export "memory" (memory $0))
- (export "init" (func $init))
  (export "apply" (func $apply))
- (func $init
-   (set_global $g0
-     (i32.const 444)
-   )
- )
  (func $apply (param $0 i64) (param $1 i64)
-  (call $assert
-   (i32.eq
-    (get_global $g0)
-    (i32.const 2)
-   )
-   (i32.const 0)
+  (if (i64.eq (get_local $1) (i64.const 0))
+    (set_global $g0 (i64.const 444))
+  )
+  (if (i64.eq (get_local $1) (i64.const 1))
+    (call $assert (i64.eq (get_global $g0) (i64.const 2)) (i32.const 0))
   )
  )
- (global $g0 (mut i32) (i32.const 2))
+ (global $g0 (mut i64) (i64.const 2))
 )
 )=====";
 
@@ -86,14 +73,11 @@ static const char current_memory_wast[] = R"=====(
  (table 0 anyfunc)
  (memory $0 1)
  (export "memory" (memory $0))
- (export "init" (func $init))
  (export "apply" (func $apply))
- (func $init
+ (func $apply (param $0 i64) (param $1 i64)
    (drop
      (current_memory)
    )
- )
- (func $apply (param $0 i64) (param $1 i64)
  )
 )
 )=====";
@@ -103,16 +87,13 @@ static const char grow_memory_wast[] = R"=====(
  (table 0 anyfunc)
  (memory $0 1)
  (export "memory" (memory $0))
- (export "init" (func $init))
  (export "apply" (func $apply))
- (func $init
+ (func $apply (param $0 i64) (param $1 i64)
    (drop
      (grow_memory
        (i32.const 20)
      )
    )
- )
- (func $apply (param $0 i64) (param $1 i64)
  )
 )
 )=====";

--- a/tests/wasm_tests/wasm_tests.cpp
+++ b/tests/wasm_tests/wasm_tests.cpp
@@ -484,11 +484,20 @@ BOOST_FIXTURE_TEST_CASE( check_global_reset, tester ) try {
    produce_blocks(1);
 
    signed_transaction trx;
+   {
    action act;
    act.account = N(globalreset);
-   act.name = N();
+   act.name = 0ULL;
    act.authorization = vector<permission_level>{{N(globalreset),config::active_name}};
    trx.actions.push_back(act);
+   }
+   {
+   action act;
+   act.account = N(globalreset);
+   act.name = 1ULL;
+   act.authorization = vector<permission_level>{{N(globalreset),config::active_name}};
+   trx.actions.push_back(act);
+   }
 
    set_tapos(trx);
    trx.sign(get_private_key( N(globalreset), "active" ), chain_id_type());
@@ -507,10 +516,35 @@ BOOST_FIXTURE_TEST_CASE( memory_operators, tester ) try {
    transfer( N(inita), N(current_memory), "10.0000 EOS", "memo" );
    produce_block();
 
-   BOOST_CHECK_THROW(set_code(N(current_memory), current_memory_wast), fc::unhandled_exception);
+   set_code(N(current_memory), current_memory_wast);
    produce_blocks(1);
+   {
+      signed_transaction trx;
+      action act;
+      act.account = N(current_memory);
+      act.authorization = vector<permission_level>{{N(current_memory),config::active_name}};
+      trx.actions.push_back(act);
+      set_tapos(trx);
+      trx.sign(get_private_key( N(current_memory), "active" ), chain_id_type());
 
-   BOOST_CHECK_THROW(set_code(N(current_memory), grow_memory_wast), fc::unhandled_exception);
+      BOOST_CHECK_THROW(control->push_transaction(trx), fc::unhandled_exception);
+   }
+
+   produce_blocks(1);
+   set_code(N(current_memory), grow_memory_wast);
+   produce_blocks(1);
+   {
+      signed_transaction trx;
+      action act;
+      act.account = N(current_memory);
+      act.authorization = vector<permission_level>{{N(current_memory),config::active_name}};
+      trx.actions.push_back(act);
+      set_tapos(trx);
+      trx.sign(get_private_key( N(current_memory), "active" ), chain_id_type());
+
+      BOOST_CHECK_THROW(control->push_transaction(trx), fc::unhandled_exception);
+      produce_blocks(1);
+   }
 
 } FC_LOG_AND_RETHROW()
 


### PR DESCRIPTION
We no longer have the init() entry point for smart contracts, instead everything flows through apply().

We also no longer want to execute code within 30 seconds of an update to the code to give the node a chance to compile/cache the contract.

This update does not enforce the 30 second delay, but does remove the instant call to init() via inline notice of setcode.

