### PR TITLE
Modify .gitignore for executable files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,8 +43,8 @@ programs/js_operation_serializer/js_operation_serializer
 programs/witness_node/witness_node
 programs/data-dir
 programs/eos-walletd/eos-walletd
-programs/eosd/eosd
-programs/eosc/eosc
+programs/eosiod/eosiod
+programs/eosioc/eosioc
 programs/launcher/launcher
 
 tests/app_test


### PR DESCRIPTION
This patch change .gitignore for executable files. Because recently executable files are changed.
eosd/eosd => eosiod/eosiod
eosc/eosc => eosioc/eosioc