### PR TITLE
Fix eoscpp eos install dir - For DAWN-2.X branch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,6 +165,8 @@ else()
   message(STATUS "--------------------------------------------------------------------")
 endif()
 
+include(installer)
+
 add_subdirectory( libraries )
 add_subdirectory( programs )
 add_subdirectory( plugins )
@@ -174,7 +176,7 @@ add_subdirectory( tools )
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/genesis.json ${CMAKE_CURRENT_BINARY_DIR}/genesis.json COPYONLY)
 
-include(installer)
+
 include(doxygen)
 
 


### PR DESCRIPTION
For DAWN-2.X branch
Reorder cmake, so eoscpp is able to retrieve the right CMAKE_INSTALL_PREFIX

Similar fix for master branch is made as another pull request https://github.com/EOSIO/eos/pull/1235

DAWN-527