### PR TITLE
Fix eoscpp eos install dir - For master branch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,6 +165,8 @@ else()
   message(STATUS "--------------------------------------------------------------------")
 endif()
 
+include(installer)
+
 add_subdirectory( libraries )
 add_subdirectory( programs )
 add_subdirectory( plugins )
@@ -174,7 +176,7 @@ add_subdirectory( tools )
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/genesis.json ${CMAKE_CURRENT_BINARY_DIR}/genesis.json COPYONLY)
 
-include(installer)
+
 include(doxygen)
 
 


### PR DESCRIPTION
For master branch
Reorder cmake, so eoscpp is able to retrieve the right CMAKE_INSTALL_PREFIX

Similar fix for DAWN-2.X branch is made as another pull request https://github.com/EOSIO/eos/pull/1234

DAWN-527