### PR TITLE
disable implicit conversion from number to asset structure

### DIFF
--- a/contracts/eoslib/asset.hpp
+++ b/contracts/eoslib/asset.hpp
@@ -27,7 +27,7 @@ namespace eosio {
       uint64_t     amount = 0;
       symbol_name  symbol = S(4,EOS);
 
-      asset( uint64_t a = 0, uint64_t s = S(4,EOS))
+      explicit asset( uint64_t a = 0, uint64_t s = S(4,EOS))
       :amount(a),symbol(s){}
 
 


### PR DESCRIPTION
As I understand it correctly conversion from asset -> token and token -> asset is allowed provided it's done for the same symbol ( see assert )
However current constructor of asset with 2 default parameters allows implicit conversion from number to asset structure. Below please find my tests. 

```
   using token = eosio::token<N(currency),S(4,CUR)> ;
   token t(a); //OK
   eosio::asset a1 (10, S(4,CUR)); //OK
   eosio::asset a2 = 123; //should ERROR 
   a1 = 123; //should ERROR
   eosio::asset a3(a); //OK
   eosio::asset a4(t); //OK
```