### PR TITLE
Dawn 548 - Docker fails to build because of install directory doesn't match

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -73,15 +73,14 @@ RUN git clone --depth 1 -b releases/stable git://github.com/mongodb/mongo-cxx-dr
 RUN git clone -b master --depth 1 https://github.com/EOSIO/eos.git --recursive \
     && cd eos \
     && cmake -H. -B"/tmp/build" -GNinja -DCMAKE_BUILD_TYPE=Release -DWASM_LLVM_CONFIG=/opt/wasm/bin/llvm-config -DCMAKE_CXX_COMPILER=clang++ \
-       -DCMAKE_C_COMPILER=clang -DCMAKE_INSTALL_PREFIX=/opt/eos  -DSecp256k1_ROOT_DIR=/usr/local \
+       -DCMAKE_C_COMPILER=clang -DSecp256k1_ROOT_DIR=/usr/local \
     && cmake --build /tmp/build --target install
-
 
 
 FROM ubuntu:16.04
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install openssl && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /usr/local/lib/* /usr/local/lib/
-COPY --from=builder /opt/eosio/bin /opt/eosio/bin
+COPY --from=builder /tmp/build/install/bin /opt/eosio/bin
 COPY --from=builder /tmp/build/contracts /contracts
 COPY --from=builder /eos/Docker/config.ini /eos/genesis.json /
 COPY start_eosiod.sh /opt/eosio/bin/start_eosiod.sh

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -2,18 +2,98 @@
 
 Simple and fast setup of EOS.IO on Docker is also available.
 
+- [Install Dependencies](#install-dependencies)
+- [Docker Requirement](#docker-requirement)
+- [Build eosio image](#build-eosio-image)
+- [Start both eosiod and walletd containers with docker-compose](#start-both-eosiod-and-walletd-containers-with-docker-compose)
+  - [Execute eosioc commands](#execute-eosioc-commands)
+  - [Making RPC API Call](#making-rpc-api-call)
+  - [Change eosiod default configuration](#change-eosiod-default-configuration)
+  - [Clear data-dir](#clear-data-dir)
+- [Start eosiod docker container only](#start-eosiod-docker-container-only)
+
 ## Install Dependencies
  - [Docker](https://docs.docker.com) Docker 17.05 or higher is required
 
 ## Docker Requirement
  - At least 8GB RAM (Docker -> Preferences -> Advanced -> Memory -> 8GB or above)
  
-## Build eos image
+## Build eosio image
 
 ```bash
 git clone https://github.com/EOSIO/eos.git --recursive
 cd eos/Docker
 docker build . -t eosio/eos
+```
+
+## Start both eosiod and walletd containers with docker-compose
+
+```bash
+docker-compose up
+```
+
+After `docker-compose up`, two services named eosiod and walletd will be started. eosiod service would expose ports 8888 and 9876 to the host. walletd service does not expose any port to the host, it is only accessible to eosioc when runing eosioc is running inside the walletd container as described in "Execute eosioc commands" section.
+
+
+
+### Execute eosioc commands
+
+You can run the `eosioc` commands via a bash alias.
+
+```bash
+alias eosioc='docker-compose exec walletd /opt/eosio/bin/eosioc -H eosiod'
+eosioc get info
+eosioc get account inita
+```
+
+Upload sample currency contract
+
+```bash
+eosioc wallet create
+eosioc wallet import 5KQwrPbwdL6PhXujxW37FSSQZ1JiwsST4cqQzDeyXtP79zkvFD3
+eosioc create account inita currency EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV
+eosioc set contract currency contracts/currency/currency.wast contracts/currency/currency.abi
+```
+
+If you don't need walletd afterwards, you can stop the walletd service using
+
+```bash
+docker-compose stop walletd
+```
+
+### Making RPC API Call
+
+Port 8888 of eosiod container is linked to port 8888 of host
+```bash
+curl http://127.0.0.1:8888/v1/chain/get_info
+```
+
+### Change eosiod default configuration
+
+You can use docker compose override file to change the default configurations. For example, create an alternate config file `config2.ini` and a `docker-compose.override.yml` with the following content.
+
+```yaml
+version: "2"
+
+services:
+  eosiod:
+    volumes:
+      - ./config2.ini:/opt/eosio/bin/data-dir/config.ini
+```
+
+Then restart your docker containers as follows:
+
+```bash
+docker-compose down
+docker-compose up
+```
+This will replace the `config.ini` inside your docker container with `config2.ini`
+
+### Clear data-dir
+The data volume created by docker-compose can be deleted as follows:
+
+```bash
+docker volume rm docker_eosiod-data-volume
 ```
 
 ## Start eosiod docker container only
@@ -31,69 +111,7 @@ $ docker volume rm fdc265730a4f697346fa8b078c176e315b959e79365fc9cbd11f090ea0cb5
 
 Alternately, you can directly mount host directory into the container
 ```bash
-docker run --name eosiod -v /path-to-data-dir:/opt/eosio/bin/data-dir -p 8888:8888 -p 9876:9876 -t eosio/eos start_eosiod.sh arg1 arg2
+docker run --name eosiod -v /absolute-path-to-data-dir:/opt/eosio/bin/data-dir -p 8888:8888 -p 9876:9876 -t eosio/eos start_eosiod.sh arg1 arg2
 ```
+The mounted host directory contains `config.ini` that is used by eosiod. After it is mounted, you can modify `config.ini` locally and restart your docker container to see the effect.
 
-## Get chain info
-
-```bash
-curl http://127.0.0.1:8888/v1/chain/get_info
-```
-
-## Start both eosiod and walletd containers
-
-```bash
-docker-compose up
-```
-
-After `docker-compose up`, two services named eosiod and walletd will be started. eosiod service would expose ports 8888 and 9876 to the host. walletd service does not expose any port to the host, it is only accessible to eosioc when runing eosioc is running inside the walletd container as described in "Execute eosioc commands" section.
-
-
-### Execute eosioc commands
-
-You can run the `eosioc` commands via a bash alias.
-
-```bash
-alias eosioc='docker-compose exec walletd /opt/eosio/bin/eosioc -H eosiod'
-eosioc get info
-eosioc get account inita
-```
-
-Upload sample exchange contract
-
-```bash
-eosioc set contract exchange contracts/exchange/exchange.wast contracts/exchange/exchange.abi
-```
-
-If you don't need walletd afterwards, you can stop the walletd service using
-
-```bash
-docker-compose stop walletd
-```
-### Change default configuration
-
-You can use docker compose override file to change the default configurations. For example, create an alternate config file `config2.ini` and a `docker-compose.override.yml` with the following content.
-
-```yaml
-version: "2"
-
-services:
-  eosiod:
-    volumes:
-      - eosiod-data-volume:/opt/eosio/bin/data-dir
-      - ./config2.ini:/opt/eosio/bin/data-dir/config.ini
-```
-
-Then restart your docker containers as follows:
-
-```bash
-docker-compose down
-docker-compose up
-```
-
-### Clear data-dir
-The data volume created by docker-compose can be deleted as follows:
-
-```bash
-docker volume rm docker_eosiod-data-volume
-```

--- a/Docker/config.ini
+++ b/Docker/config.ini
@@ -1,6 +1,14 @@
+# Track only transactions whose scopes involve the listed accounts. Default is to track all transactions.
+# filter_on_accounts = 
+
+# Limits the maximum time (in milliseconds) processing a single get_transactions call.
+get-transactions-time-limit = 3
+
 # File to read Genesis State from
-# genesis-json =
-genesis-json = "/opt/eos/bin/data-dir/genesis.json"
+genesis-json = "/opt/eosio/bin/data-dir/genesis.json"
+
+# override the initial timestamp in the Genesis State file
+# genesis-timestamp = 
 
 # the location of the block log (absolute path or relative to application data dir)
 block-log-dir = "blocks"
@@ -10,33 +18,75 @@ block-log-dir = "blocks"
 
 # open the database in read only mode
 readonly = 0
+# Limits the maximum time (in milliseconds) that is allowed a transaction's code to execute from a received block.
+rcvd-block-trans-execution-time = 72
+
+# Limits the maximum time (in milliseconds) that is allowed a pushed transaction's code to execute.
+trans-execution-time = 18
+
+# Limits the maximum time (in milliseconds) that is allowed a transaction's code to execute while creating a block.
+create-block-trans-execution-time = 18
 
 # the location of the chain shared memory files (absolute path or relative to application data dir)
 shared-file-dir = "blockchain"
+# Time to wait, in milliseconds, between creating next faucet created account.
+faucet-create-interval-ms = 1000
 
 # Minimum size MB of database shared memory file
 shared-file-size = 8192
+# Name to use as creator for faucet created accounts.
+faucet-name = faucet
+
+# [public key, WIF private key] for signing for faucet creator account
+faucet-private-key = ["EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV","5KQwrPbwdL6PhXujxW37FSSQZ1JiwsST4cqQzDeyXtP79zkvFD3"]
 
 # The local IP and port to listen for incoming http connections.
 http-server-address = 0.0.0.0:8888
 
-# The Access-Control-Allow-Origin http value
+# Specify the Access-Control-Allow-Origin to be returned on each request.
 # access-control-allow-origin = *
 
-# The Access-Control-Allow-Headers http value
+# Specify the Access-Control-Allow-Headers to be returned on each request.
 # access-control-allow-headers = Content-Type
 
-# true if Access-Control-Allow-Credentials: true should be specified in http response header
+# Specify if Access-Control-Allow-Credentials: true should be returned on each request.
 # access-control-allow-credentials = true
 
-# The local IP address and port to listen for incoming connections.
+# The actual host:port used to listen for incoming p2p connections.
 p2p-listen-endpoint = 0.0.0.0:9876
 
-# The IP address and port of a remote peer to sync with.
-# remote-endpoint =
-
-# The public IP address and port that should be advertized to peers.
+# An externally accessible host:port for identifying this node. Defaults to p2p-listen-endpoint.
 p2p-server-address = 0.0.0.0:9876
+
+# The public endpoint of a peer node to connect to. Use multiple p2p-peer-address options as needed to compose a network.
+# p2p-peer-address = 
+
+# The name supplied to identify this node amongst the peers.
+agent-name = "EOS Test Agent"
+
+# Can be 'any' or 'producers' or 'specified' or 'none'. If 'specified', peer-key must be specified at least once. If only 'producers', peer-key is not required. 'producers' and 'specified' may be combined.
+allowed-connection = any
+
+# Optional public key of peer allowed to connect.  May be used multiple times.
+# peer-key = 
+
+# Tuple of [PublicKey, WIF private key] (may specify multiple times)
+# peer-private-key = 
+
+# Log level: one of 'all', 'debug', 'info', 'warn', 'error', or 'off'
+log-level-net-plugin = info
+
+# Maximum number of clients from which connections are accepted, use 0 for no limit
+max-clients = 25
+
+# number of seconds to wait before cleaning up dead connections
+connection-cleanup-period = 30
+
+# True to require exact match of peer network version.
+network-version-match = 0
+
+# number of blocks to retrieve in a chunk from any individual peer during synchronization
+sync-fetch-span = 100
 
 # Enable block production, even if the chain is stale.
 enable-stale-production = true
@@ -44,8 +94,7 @@ enable-stale-production = true
 # Percent of producers (0-99) that must be participating in order to produce blocks
 required-participation = false
 
-# ID of producer controlled by this node (e.g. "inita", quotes are required, may specify multiple times)
-# producer-name =
+# ID of producer controlled by this node (e.g. inita; may specify multiple times)
 producer-name = inita
 producer-name = initb
 producer-name = initc
@@ -72,8 +121,6 @@ producer-name = initu
 private-key = ["EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV","5KQwrPbwdL6PhXujxW37FSSQZ1JiwsST4cqQzDeyXtP79zkvFD3"]
 
 # Plugin(s) to enable, may be specified multiple times
-# plugin =
-
 plugin = eosio::producer_plugin
 plugin = eosio::chain_api_plugin
 plugin = eosio::http_plugin


### PR DESCRIPTION
Since cmakelist gets refactored, CMAKE_INSTALL_PREFIX passed will always be replaced with CMAKE_BINARY_DIR/install

Also update the readme