### PR TITLE
Remove Boost unit test library linkage from chain_unit_test cmake

### DIFF
--- a/libraries/chain/test/CMakeLists.txt
+++ b/libraries/chain/test/CMakeLists.txt
@@ -9,6 +9,6 @@ add_executable(chain_unit_test
     )
 target_include_directories(chain_unit_test PRIVATE ${Boost_INCLUDE_DIRS})
 target_compile_definitions(chain_unit_test PRIVATE "BOOST_TEST_DYN_LINK=1")
-target_link_libraries(chain_unit_test ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} eosio_chain)
+target_link_libraries(chain_unit_test eosio_chain)
 
 add_test(chain_unit_test chain_unit_test)


### PR DESCRIPTION
Our root CMakeLists asks for several boost libraries to be linked, unit test being one of them. The additional request for boost unit test library in chain_unit_test can cause duplicate symbols at link time

Note -- I only encountered this problem when building with LLVM5. I double checked I could still build with LLVM4 after making this change.