### PR TITLE
compressed transactions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,8 @@ FIND_PACKAGE(Boost 1.64 REQUIRED COMPONENTS
     chrono
     unit_test_framework
     context
-    locale)
+    locale
+    iostreams)
 
 if( WIN32 )
 

--- a/libraries/chain/CMakeLists.txt
+++ b/libraries/chain/CMakeLists.txt
@@ -30,7 +30,7 @@ add_library( eosio_chain
 
 
              ${HEADERS}
-        )
+        transaction_metadata.cpp)
 
 target_link_libraries( eosio_chain eos_utilities fc chainbase Logging IR WAST WASM Runtime )
 target_include_directories( eosio_chain

--- a/libraries/chain/block.cpp
+++ b/libraries/chain/block.cpp
@@ -52,7 +52,7 @@ namespace eosio { namespace chain {
       ids.reserve(input_transactions.size());
 
       for( const auto& t : input_transactions ) 
-         ids.emplace_back( t.id() );
+         ids.emplace_back( t.get_transaction().id() );
 
       return merkle( std::move(ids) );
    }

--- a/libraries/chain/chain_controller.cpp
+++ b/libraries/chain/chain_controller.cpp
@@ -124,16 +124,6 @@ optional<signed_block> chain_controller::fetch_block_by_number(uint32_t num)cons
    return optional<signed_block>();
 }
 
-/*
-const signed_transaction& chain_controller::get_recent_transaction(const transaction_id_type& trx_id) const
-{
-   auto& index = _db.get_index<transaction_multi_index, by_trx_id>();
-   auto itr = index.find(trx_id);
-   FC_ASSERT(itr != index.end());
-   return itr->trx;
-}
-*/
-
 std::vector<block_id_type> chain_controller::get_block_ids_on_fork(block_id_type head_of_fork) const
 {
   pair<fork_database::branch_type, fork_database::branch_type> branches = _fork_db.fetch_branch_from(head_block_id(), head_of_fork);
@@ -250,7 +240,7 @@ bool chain_controller::_push_block(const signed_block& new_block)
  * queues full as well, it will be kept in the queue to be propagated later when a new block flushes out the pending
  * queues.
  */
-transaction_trace chain_controller::push_transaction(const signed_transaction& trx, uint32_t skip)
+transaction_trace chain_controller::push_transaction(const packed_transaction& trx, uint32_t skip)
 { try {
    return with_skip_flags(skip, [&]() {
       return _db.with_write_lock([&]() {
@@ -259,16 +249,16 @@ transaction_trace chain_controller::push_transaction(const signed_transaction& t
    });
 } FC_CAPTURE_AND_RETHROW((trx)) }
 
-transaction_trace chain_controller::_push_transaction(const signed_transaction& trx) {
-   check_transaction_authorization(trx);
+transaction_trace chain_controller::_push_transaction(const packed_transaction& trx) {
    transaction_metadata   mtrx( trx, get_chain_id(), head_block_time());
+   check_transaction_authorization(mtrx.trx, trx.signatures);
 
-   auto result = _push_transaction(mtrx);
-
-   _pending_block->input_transactions.push_back(trx);
+   auto result = _push_transaction(std::move(mtrx));
 
    // notify anyone listening to pending transactions
    on_pending_transaction(trx);
+
+   _pending_block->input_transactions.emplace_back(trx);
 
    return result;
 
@@ -286,7 +276,7 @@ static void record_locks_for_data_access(const vector<action_trace>& action_trac
    }
 }
 
-transaction_trace chain_controller::_push_transaction( transaction_metadata& data )
+transaction_trace chain_controller::_push_transaction( transaction_metadata&& data )
 {
    const transaction& trx = data.trx;
    // If this is the first transaction pushed after applying a block, start a new undo session.
@@ -325,6 +315,8 @@ transaction_trace chain_controller::_push_transaction( transaction_metadata& dat
 
    // The transaction applied successfully. Merge its changes into the pending block session.
    temp_session.squash();
+
+   _pending_transaction_metas.emplace_back(std::forward<transaction_metadata>(data));
 
    return result;
 }
@@ -483,7 +475,7 @@ signed_block chain_controller::_generate_block( block_timestamp_type when,
       _pending_block->producer    = producer_obj.owner;
       _pending_block->previous    = head_block_id();
       _pending_block->block_mroot = get_dynamic_global_properties().block_merkle_root.get_root();
-      _pending_block->transaction_mroot = _pending_block->calculate_transaction_merkle_root();
+      _pending_block->transaction_mroot = transaction_metadata::calculate_transaction_merkle_root( _pending_transaction_metas );
       _pending_block->action_mroot = _pending_block_trace->calculate_action_merkle_root();
 
 
@@ -588,9 +580,11 @@ void chain_controller::__apply_block(const signed_block& next_block)
 
    /// cache the input tranasction ids so that they can be looked up when executing the
    /// summary
-   map<transaction_id_type,const signed_transaction*> trx_index;
+   vector<transaction_metadata> input_metas;
+   map<transaction_id_type,transaction_metadata*> trx_index;
    for( const auto& t : next_block.input_transactions ) {
-      trx_index[t.get_transaction().id()] = &t;
+      input_metas.emplace_back(t, chain_id_type(), next_block.timestamp);
+      trx_index[input_metas.back().id] =  &input_metas.back();
    }
 
    block_trace next_block_trace(next_block);
@@ -639,25 +633,27 @@ void chain_controller::__apply_block(const signed_block& next_block)
 
             shard_trace s_trace;
             for (const auto& receipt : shard.transactions) {
-                auto make_metadata = [&](){
+                optional<transaction_metadata> _temp;
+                auto make_metadata = [&]() -> transaction_metadata* {
                   auto itr = trx_index.find(receipt.id);
                   if( itr != trx_index.end() ) {
-                     return transaction_metadata( *itr->second, get_chain_id(), next_block.timestamp );
+                     return itr->second;
                   } else {
                      const auto& gtrx = _db.get<generated_transaction_object,by_trx_id>(receipt.id);
                      auto trx = fc::raw::unpack<deferred_transaction>(gtrx.packed_trx.data(), gtrx.packed_trx.size());
-                     return transaction_metadata(trx, gtrx.published, trx.sender, trx.sender_id, gtrx.packed_trx.data(), gtrx.packed_trx.size() );
+                     _temp.emplace(trx, gtrx.published, trx.sender, trx.sender_id, gtrx.packed_trx.data(), gtrx.packed_trx.size() );
+                     return &*_temp;
                   }
                };
 
-               auto mtrx = make_metadata();
-               mtrx.region_id = r.region;
-               mtrx.cycle_index = cycle_index;
-               mtrx.shard_index = shard_index;
-               mtrx.allowed_read_locks.emplace(&shard.read_locks);
-               mtrx.allowed_write_locks.emplace(&shard.write_locks);
+               auto *mtrx = make_metadata();
+               mtrx->region_id = r.region;
+               mtrx->cycle_index = cycle_index;
+               mtrx->shard_index = shard_index;
+               mtrx->allowed_read_locks.emplace(&shard.read_locks);
+               mtrx->allowed_write_locks.emplace(&shard.write_locks);
 
-               s_trace.transaction_traces.emplace_back(_apply_transaction(mtrx));
+               s_trace.transaction_traces.emplace_back(_apply_transaction(*mtrx));
                record_locks_for_data_access(s_trace.transaction_traces.back().action_traces, used_read_locks, used_write_locks);
 
                FC_ASSERT(receipt.status == s_trace.transaction_traces.back().status);
@@ -690,19 +686,19 @@ void chain_controller::__apply_block(const signed_block& next_block)
    } /// for each region
 
    FC_ASSERT(next_block.action_mroot == next_block_trace.calculate_action_merkle_root());
+   FC_ASSERT( transaction_metadata::calculate_transaction_merkle_root(input_metas) == next_block.transaction_mroot, "merkle root does not match" );
 
-   _finalize_block( next_block_trace );
+      _finalize_block( next_block_trace );
 } FC_CAPTURE_AND_RETHROW( (next_block.block_num()) )  }
 
-flat_set<public_key_type> chain_controller::get_required_keys(const signed_transaction& trx,
-                                                              const flat_set<public_key_type>& candidate_keys)const 
+flat_set<public_key_type> chain_controller::get_required_keys(const transaction& trx,
+                                                              const flat_set<public_key_type>& candidate_keys)const
 {
    auto checker = make_auth_checker( [&](const permission_level& p){ return get_permission(p).auth; },
                                      get_global_properties().configuration.max_authority_depth,
                                      candidate_keys);
 
-   const auto decompressed = trx.get_transaction();
-   for (const auto& act : decompressed.actions ) {
+   for (const auto& act : trx.actions ) {
       for (const auto& declared_auth : act.authorization) {
          if (!checker.satisfied(declared_auth)) {
             EOS_ASSERT(checker.satisfied(declared_auth), tx_missing_sigs,
@@ -756,11 +752,11 @@ void chain_controller::check_authorization( const vector<action>& actions,
                  ("keys", checker.unused_keys()));
 }
 
-void chain_controller::check_transaction_authorization(const signed_transaction& trx, 
+void chain_controller::check_transaction_authorization(const transaction& trx,
+                                                       const vector<signature_type>& signatures,
                                                        bool allow_unused_signatures)const 
 {
-   auto decompressed = trx.get_transaction();
-   check_authorization( decompressed.actions, trx.get_signature_keys( chain_id_type{} ), allow_unused_signatures );
+   check_authorization( trx.actions, trx.get_signature_keys( signatures, chain_id_type{} ), allow_unused_signatures );
 }
 
 optional<permission_name> chain_controller::lookup_minimum_permission(account_name authorizer_account,
@@ -790,10 +786,10 @@ optional<permission_name> chain_controller::lookup_minimum_permission(account_na
    } FC_CAPTURE_AND_RETHROW((authorizer_account)(scope)(act_name))
 }
 
-void chain_controller::validate_uniqueness( const signed_transaction& trx )const {
+void chain_controller::validate_uniqueness( const transaction& trx )const {
    if( !should_check_for_duplicate_transactions() ) return;
 
-   auto transaction = _db.find<transaction_object, by_trx_id>(trx.get_transaction().id());
+   auto transaction = _db.find<transaction_object, by_trx_id>(trx.id());
    EOS_ASSERT(transaction == nullptr, tx_duplicate, "transaction is not unique");
 }
 
@@ -885,8 +881,6 @@ const producer_object& chain_controller::validate_block_header(uint32_t skip, co
    }
 
    
-   FC_ASSERT( next_block.calculate_transaction_merkle_root() == next_block.transaction_mroot, "merkle root does not match" );
-
    return producer;
 }
 
@@ -1082,14 +1076,14 @@ void chain_controller::_initialize_chain(contracts::chain_initializer& starter)
          ctrace.shard_traces.emplace_back();
          auto& strace = ctrace.shard_traces.back();
 
-         transaction genesis_setup_transaction; // not actually signed, signature checking is skipped
+         signed_transaction genesis_setup_transaction; // not actually signed, signature checking is skipped
          genesis_setup_transaction.actions = move(acts);
-         block.input_transactions.emplace_back(genesis_setup_transaction, signed_transaction::zlib);
+         block.input_transactions.emplace_back(genesis_setup_transaction);
 
          ilog( "applying genesis transaction" );
          with_skip_flags(skip_scope_check | skip_transaction_signatures | skip_authority_check | received_block | genesis_setup, 
          [&](){ 
-            transaction_metadata tmeta( genesis_setup_transaction );
+            transaction_metadata tmeta( packed_transaction(genesis_setup_transaction), chain_id_type(),  initial_timestamp );
             transaction_trace ttrace = __apply_transaction( tmeta );
             strace.append(ttrace);
          });
@@ -1452,7 +1446,7 @@ transaction_trace chain_controller::_apply_error( transaction_metadata& meta ) {
 
    transaction etrx;
    etrx.actions.emplace_back(vector<permission_level>{{meta.sender_id,config::active_name}},
-                             contracts::onerror(meta.generated_data, meta.generated_data + meta.generated_size) );
+                             contracts::onerror(meta.raw_data, meta.raw_data + meta.raw_size) );
 
    try {
       auto temp_session = _db.start_undo_session(true);
@@ -1524,7 +1518,7 @@ void chain_controller::push_deferred_transactions( bool flush )
          try {
             auto trx = fc::raw::unpack<deferred_transaction>(trx_p->packed_trx.data(), trx_p->packed_trx.size());
             transaction_metadata mtrx (trx, trx_p->published, trx.sender, trx.sender_id, trx_p->packed_trx.data(), trx_p->packed_trx.size());
-            _push_transaction(mtrx);
+            _push_transaction(std::move(mtrx));
             generated_transaction_idx.remove(*trx_p);
          } FC_CAPTURE_AND_LOG((trx_p->trx_id)(trx_p->sender));
       } else {

--- a/libraries/chain/include/eosio/chain/block.hpp
+++ b/libraries/chain/include/eosio/chain/block.hpp
@@ -113,7 +113,7 @@ namespace eosio { namespace chain {
     */
    struct signed_block : public signed_block_summary {
       digest_type                  calculate_transaction_merkle_root()const;
-      vector<signed_transaction>   input_transactions; /// this is loaded and indexed into map<id,trx> that is referenced by summary
+      vector<packed_transaction>   input_transactions; /// this is loaded and indexed into map<id,trx> that is referenced by summary
    };
 
    struct shard_trace {

--- a/libraries/chain/include/eosio/chain/chain_controller.hpp
+++ b/libraries/chain/include/eosio/chain/chain_controller.hpp
@@ -210,7 +210,7 @@ namespace eosio { namespace chain {
             auto on_exit = fc::make_scoped_exit( [&](){ 
                for( const auto& t : old_input ) {
                   try {
-                     if (!is_known_transaction(t.id()))
+                     if (!is_known_transaction(t.get_transaction().id()))
                         push_transaction( t );
                   } catch ( ... ){}
                }

--- a/libraries/chain/include/eosio/chain/exceptions.hpp
+++ b/libraries/chain/include/eosio/chain/exceptions.hpp
@@ -44,6 +44,7 @@ namespace eosio { namespace chain {
    FC_DECLARE_DERIVED_EXCEPTION( tx_msgs_auth_exceeded,             eosio::chain::transaction_exception, 3030018, "Number of transaction messages per authorized account has been exceeded" )
    FC_DECLARE_DERIVED_EXCEPTION( tx_msgs_code_exceeded,             eosio::chain::transaction_exception, 3030019, "Number of transaction messages per code account has been exceeded" )
    FC_DECLARE_DERIVED_EXCEPTION( wasm_execution_error,              eosio::chain::transaction_exception, 3030020, "Runtime Error Processing WASM" )
+   FC_DECLARE_DERIVED_EXCEPTION( tx_decompression_error,            eosio::chain::transaction_exception, 3030020, "Error decompressing transaction" )
 
    FC_DECLARE_DERIVED_EXCEPTION( account_name_exists_exception,     eosio::chain::action_validate_exception, 3040001, "account name already exists" )
    FC_DECLARE_DERIVED_EXCEPTION( invalid_pts_address,               eosio::chain::utility_exception, 3060001, "invalid pts address" )

--- a/libraries/chain/include/eosio/chain/transaction.hpp
+++ b/libraries/chain/include/eosio/chain/transaction.hpp
@@ -138,12 +138,28 @@ namespace eosio { namespace chain {
       digest_type         sig_digest( const chain_id_type& chain_id )const;
    };
 
-   struct signed_transaction : public transaction {
-      vector<signature_type> signatures;
+   struct signed_transaction {
+      enum compression_type {
+         none,
+         zlib,
+
+      };
+
+      signed_transaction() = default;
+
+      signed_transaction(const transaction& t, signed_transaction::compression_type _compression) {
+         set_transaction(t, _compression);
+      }
+
+      vector<signature_type>    signatures;
+      compression_type          compression;
+      bytes                     data;
 
       const signature_type&     sign(const private_key_type& key, const chain_id_type& chain_id);
       signature_type            sign(const private_key_type& key, const chain_id_type& chain_id)const;
       flat_set<public_key_type> get_signature_keys( const chain_id_type& chain_id )const;
+      transaction               get_transaction()const;
+      void                      set_transaction(const transaction& t, signed_transaction::compression_type _compression);
    };
 
 
@@ -206,7 +222,8 @@ FC_REFLECT( eosio::chain::permission_level, (actor)(permission) )
 FC_REFLECT( eosio::chain::action, (account)(name)(authorization)(data) )
 FC_REFLECT( eosio::chain::transaction_header, (expiration)(region)(ref_block_num)(ref_block_prefix) )
 FC_REFLECT_DERIVED( eosio::chain::transaction, (eosio::chain::transaction_header), (actions) )
-FC_REFLECT_DERIVED( eosio::chain::signed_transaction, (eosio::chain::transaction), (signatures) )
+FC_REFLECT_ENUM( eosio::chain::signed_transaction::compression_type, (none)(zlib))
+FC_REFLECT( eosio::chain::signed_transaction, (signatures)(compression)(data) )
 FC_REFLECT_DERIVED( eosio::chain::deferred_transaction, (eosio::chain::transaction), (sender_id)(sender)(execute_after) )
 FC_REFLECT_ENUM( eosio::chain::data_access_info::access_type, (read)(write))
 FC_REFLECT( eosio::chain::data_access_info, (type)(code)(scope)(sequence))

--- a/libraries/chain/include/eosio/chain/transaction.hpp
+++ b/libraries/chain/include/eosio/chain/transaction.hpp
@@ -134,20 +134,52 @@ namespace eosio { namespace chain {
    struct transaction : public transaction_header {
       vector<action>         actions;
 
-      transaction_id_type id()const;
-      digest_type         sig_digest( const chain_id_type& chain_id )const;
+      transaction_id_type        id()const;
+      digest_type                sig_digest( const chain_id_type& chain_id )const;
+      flat_set<public_key_type>  get_signature_keys( const vector<signature_type>& signatures, const chain_id_type& chain_id )const;
+
    };
 
-   struct signed_transaction {
+   struct signed_transaction : public transaction
+   {
+      signed_transaction() = default;
+//      signed_transaction( const signed_transaction& ) = default;
+//      signed_transaction( signed_transaction&& ) = default;
+      signed_transaction( transaction&& trx, const vector<signature_type>& signatures)
+      : transaction(std::forward<transaction>(trx))
+      , signatures(signatures)
+      {
+      }
+
+      vector<signature_type>    signatures;
+
+      const signature_type&     sign(const private_key_type& key, const chain_id_type& chain_id);
+      signature_type            sign(const private_key_type& key, const chain_id_type& chain_id)const;
+      flat_set<public_key_type> get_signature_keys( const chain_id_type& chain_id )const;
+   };
+
+   struct packed_transaction {
       enum compression_type {
          none,
          zlib,
-
       };
 
-      signed_transaction() = default;
+      packed_transaction() = default;
 
-      signed_transaction(const transaction& t, signed_transaction::compression_type _compression) {
+      explicit packed_transaction(const transaction& t, compression_type _compression = none)
+      {
+         set_transaction(t, _compression);
+      }
+
+      explicit packed_transaction(const signed_transaction& t, compression_type _compression = none)
+      :signatures(t.signatures)
+      {
+         set_transaction(t, _compression);
+      }
+
+      explicit packed_transaction(signed_transaction&& t, compression_type _compression = none)
+      :signatures(std::move(t.signatures))
+      {
          set_transaction(t, _compression);
       }
 
@@ -155,11 +187,11 @@ namespace eosio { namespace chain {
       compression_type          compression;
       bytes                     data;
 
-      const signature_type&     sign(const private_key_type& key, const chain_id_type& chain_id);
-      signature_type            sign(const private_key_type& key, const chain_id_type& chain_id)const;
-      flat_set<public_key_type> get_signature_keys( const chain_id_type& chain_id )const;
+      bytes                     get_raw_transaction()const;
       transaction               get_transaction()const;
-      void                      set_transaction(const transaction& t, signed_transaction::compression_type _compression);
+      signed_transaction        get_signed_transaction()const;
+      void                      set_transaction(const transaction& t, compression_type _compression = none);
+
    };
 
 
@@ -222,8 +254,9 @@ FC_REFLECT( eosio::chain::permission_level, (actor)(permission) )
 FC_REFLECT( eosio::chain::action, (account)(name)(authorization)(data) )
 FC_REFLECT( eosio::chain::transaction_header, (expiration)(region)(ref_block_num)(ref_block_prefix) )
 FC_REFLECT_DERIVED( eosio::chain::transaction, (eosio::chain::transaction_header), (actions) )
-FC_REFLECT_ENUM( eosio::chain::signed_transaction::compression_type, (none)(zlib))
-FC_REFLECT( eosio::chain::signed_transaction, (signatures)(compression)(data) )
+FC_REFLECT_DERIVED( eosio::chain::signed_transaction, (eosio::chain::transaction), (signatures) )
+FC_REFLECT_ENUM( eosio::chain::packed_transaction::compression_type, (none)(zlib))
+FC_REFLECT( eosio::chain::packed_transaction, (signatures)(compression)(data) )
 FC_REFLECT_DERIVED( eosio::chain::deferred_transaction, (eosio::chain::transaction), (sender_id)(sender)(execute_after) )
 FC_REFLECT_ENUM( eosio::chain::data_access_info::access_type, (read)(write))
 FC_REFLECT( eosio::chain::data_access_info, (type)(code)(scope)(sequence))

--- a/libraries/chain/include/eosio/chain/transaction_metadata.hpp
+++ b/libraries/chain/include/eosio/chain/transaction_metadata.hpp
@@ -21,15 +21,21 @@ struct transaction_metadata {
    {}
 
    transaction_metadata( const signed_transaction& t, chain_id_type chainid, const time_point& published )
-      :trx(t)
+      :decompressed_trx(t.get_transaction())
+      ,trx(*decompressed_trx)
       ,id(trx.id())
-      ,bandwidth_usage( fc::raw::pack_size(t) )
+      ,bandwidth_usage( (uint32_t)fc::raw::pack_size(t) )
       ,published(published)
    { }
 
+
+   // things for signed_transactions
+   optional<transaction>                 decompressed_trx;
+   optional<flat_set<public_key_type>>   signing_keys;
+
    const transaction&                    trx;
    transaction_id_type                   id;
-   optional<flat_set<public_key_type>>   signing_keys;
+
    uint32_t                              region_id       = 0;
    uint32_t                              cycle_index     = 0;
    uint32_t                              shard_index     = 0;

--- a/libraries/chain/include/eosio/chain/transaction_metadata.hpp
+++ b/libraries/chain/include/eosio/chain/transaction_metadata.hpp
@@ -9,28 +9,27 @@
 namespace eosio { namespace chain {
 
 struct transaction_metadata {
-   transaction_metadata( const transaction& t )
-      :trx(t)
-      ,id(trx.id()) {}
+//   transaction_metadata( const transaction& t )
+//      :trx(t)
+//      ,id(trx.id()) {}
 
-   transaction_metadata( const transaction& t, const time_point& published, const account_name& sender, uint32_t sender_id, const char* generated_data, size_t generated_size )
+   transaction_metadata( const transaction& t, const time_point& published, const account_name& sender, uint32_t sender_id, const char* raw_data, size_t raw_size )
       :trx(t)
       ,id(trx.id())
       ,published(published)
-      ,sender(sender),sender_id(sender_id),generated_data(generated_data),generated_size(generated_size)
+      ,sender(sender),sender_id(sender_id),raw_data(raw_data),raw_size(raw_size)
    {}
 
-   transaction_metadata( const signed_transaction& t, chain_id_type chainid, const time_point& published )
-      :decompressed_trx(t.get_transaction())
-      ,trx(*decompressed_trx)
-      ,id(trx.id())
-      ,bandwidth_usage( (uint32_t)fc::raw::pack_size(t) )
-      ,published(published)
-   { }
+   transaction_metadata( const packed_transaction& t, chain_id_type chainid, const time_point& published );
 
+   transaction_metadata( transaction_metadata && ) = default;
+   transaction_metadata& operator= (transaction_metadata &&) = default;
 
-   // things for signed_transactions
+   // things for packed_transaction
+   optional<bytes>                       raw_trx;
    optional<transaction>                 decompressed_trx;
+
+   // things for signed/packed transactions
    optional<flat_set<public_key_type>>   signing_keys;
 
    const transaction&                    trx;
@@ -45,12 +44,16 @@ struct transaction_metadata {
    // things for processing deferred transactions
    optional<account_name>                sender;
    uint32_t                              sender_id = 0;
-   const char*                           generated_data = nullptr;
-   size_t                                generated_size = 0;
+
+   // packed form to pass to contracts if needed
+   const char*                           raw_data = nullptr;
+   size_t                                raw_size = 0;
 
    // scopes available to this transaction if we are applying a block
    optional<const vector<shard_lock>*>   allowed_read_locks;
    optional<const vector<shard_lock>*>   allowed_write_locks;
+
+   static digest_type calculate_transaction_merkle_root( const vector<transaction_metadata>& metas );
 };
 
 } } // eosio::chain

--- a/libraries/chain/test/CMakeLists.txt
+++ b/libraries/chain/test/CMakeLists.txt
@@ -6,7 +6,7 @@ add_executable(chain_unit_test
     test.cpp
     block_test.cpp
     name_test.cpp
-    )
+    transaction_test.cpp)
 target_include_directories(chain_unit_test PRIVATE ${Boost_INCLUDE_DIRS})
 target_compile_definitions(chain_unit_test PRIVATE "BOOST_TEST_DYN_LINK=1")
 target_link_libraries(chain_unit_test eosio_chain)

--- a/libraries/chain/test/transaction_test.cpp
+++ b/libraries/chain/test/transaction_test.cpp
@@ -37,8 +37,8 @@ BOOST_AUTO_TEST_SUITE(transaction_test)
          trx.actions.emplace_back(vector<permission_level>{{N(decomp), config::active_name}},
                                   test_action {"random data here"});
 
-         signed_transaction t;
-         t.set_transaction(trx, signed_transaction::zlib);
+         packed_transaction t;
+         t.set_transaction(trx, packed_transaction::zlib);
 
          auto actual = fc::to_hex(t.data);
          BOOST_CHECK_EQUAL(expected, actual);
@@ -58,10 +58,10 @@ BOOST_AUTO_TEST_SUITE(transaction_test)
 
          char compressed_tx_raw[] = "78da63606060d8bf7ff5eab2198ace8c13962fe3909cb0f114835aa9248866044a3284784ef402d12bde1a19090a1425e6a5e4e72aa42496242a64a416a50200a9d114bb";
 
-         signed_transaction t;
+         packed_transaction t;
          t.data.resize((sizeof(compressed_tx_raw) - 1) / 2);
          fc::from_hex(compressed_tx_raw, t.data.data(), t.data.size());
-         t.compression= signed_transaction::zlib;
+         t.compression= packed_transaction::zlib;
 
          auto actual = t.get_transaction();
          BOOST_CHECK_EQUAL(expected.region, actual.region);

--- a/libraries/chain/test/transaction_test.cpp
+++ b/libraries/chain/test/transaction_test.cpp
@@ -1,0 +1,82 @@
+#include <boost/test/unit_test.hpp>
+
+#include <eosio/chain/transaction.hpp>
+#include <eosio/chain/contracts/types.hpp>
+
+#include <fc/io/raw.hpp>
+
+using namespace eosio::chain;
+using namespace std;
+
+struct test_action {
+   string value;
+
+   static account_name get_account() {
+      return N(test.account);
+   }
+
+   static action_name get_name() {
+      return N(test.action);
+   }
+};
+
+FC_REFLECT(test_action, (value));
+
+BOOST_AUTO_TEST_SUITE(transaction_test)
+
+   BOOST_AUTO_TEST_CASE(compress_transaction)
+   {
+      try {
+
+         std::string expected = "78da63606060d8bf7ff5eab2198ace8c13962fe3909cb0f114835aa9248866044a3284784ef402d12bde1a19090a1425e6a5e4e72aa42496242a64a416a50200a9d114bb";
+
+         transaction trx;
+         trx.region = 0xBFBFU;
+         trx.ref_block_num = 0xABABU;
+         trx.ref_block_prefix = 0x43219876UL;
+         trx.actions.emplace_back(vector<permission_level>{{N(decomp), config::active_name}},
+                                  test_action {"random data here"});
+
+         signed_transaction t;
+         t.set_transaction(trx, signed_transaction::zlib);
+
+         auto actual = fc::to_hex(t.data);
+         BOOST_CHECK_EQUAL(expected, actual);
+      } FC_LOG_AND_RETHROW();
+
+   }
+
+   BOOST_AUTO_TEST_CASE(decompress_transaction)
+   {
+      try {
+         transaction expected;
+         expected.region = 0xBFBFU;
+         expected.ref_block_num = 0xABABU;
+         expected.ref_block_prefix = 0x43219876UL;
+         expected.actions.emplace_back(vector<permission_level>{{N(decomp), config::active_name}},
+                                       test_action {"random data here"});
+
+         char compressed_tx_raw[] = "78da63606060d8bf7ff5eab2198ace8c13962fe3909cb0f114835aa9248866044a3284784ef402d12bde1a19090a1425e6a5e4e72aa42496242a64a416a50200a9d114bb";
+
+         signed_transaction t;
+         t.data.resize((sizeof(compressed_tx_raw) - 1) / 2);
+         fc::from_hex(compressed_tx_raw, t.data.data(), t.data.size());
+         t.compression= signed_transaction::zlib;
+
+         auto actual = t.get_transaction();
+         BOOST_CHECK_EQUAL(expected.region, actual.region);
+         BOOST_CHECK_EQUAL(expected.ref_block_num, actual.ref_block_num);
+         BOOST_CHECK_EQUAL(expected.ref_block_prefix, actual.ref_block_prefix);
+         BOOST_REQUIRE_EQUAL(expected.actions.size(), actual.actions.size());
+         BOOST_CHECK_EQUAL((string)expected.actions[0].name, (string)actual.actions[0].name);
+         BOOST_CHECK_EQUAL((string)expected.actions[0].account, (string)actual.actions[0].account);
+         BOOST_REQUIRE_EQUAL(expected.actions[0].authorization.size(), actual.actions[0].authorization.size());
+         BOOST_CHECK_EQUAL((string)expected.actions[0].authorization[0].actor, (string)actual.actions[0].authorization[0].actor);
+         BOOST_CHECK_EQUAL((string)expected.actions[0].authorization[0].permission, (string)actual.actions[0].authorization[0].permission);
+         BOOST_REQUIRE_EQUAL(fc::to_hex(expected.actions[0].data), fc::to_hex(actual.actions[0].data));
+
+      } FC_LOG_AND_RETHROW();
+
+   }
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/libraries/chain/transaction.cpp
+++ b/libraries/chain/transaction.cpp
@@ -13,6 +13,10 @@
 #include <boost/multi_index/sequenced_index.hpp>
 #include <boost/multi_index/hashed_index.hpp>
 #include <boost/multi_index/member.hpp>
+#include <boost/iostreams/filtering_stream.hpp>
+#include <boost/iostreams/device/back_inserter.hpp>
+#include <boost/iostreams/filter/zlib.hpp>
+
 
 namespace eosio { namespace chain {
 
@@ -68,12 +72,12 @@ digest_type transaction::sig_digest( const chain_id_type& chain_id )const {
 }
 
 const signature_type& signed_transaction::sign(const private_key_type& key, const chain_id_type& chain_id) {
-   signatures.push_back(key.sign(sig_digest(chain_id)));
+   signatures.push_back(key.sign(get_transaction().sig_digest(chain_id)));
    return signatures.back();
 }
 
 signature_type signed_transaction::sign(const private_key_type& key, const chain_id_type& chain_id)const {
-   return key.sign(sig_digest(chain_id));
+   return key.sign(get_transaction().sig_digest(chain_id));
 }
 
 flat_set<public_key_type> signed_transaction::get_signature_keys( const chain_id_type& chain_id )const
@@ -82,15 +86,16 @@ flat_set<public_key_type> signed_transaction::get_signature_keys( const chain_id
 
    constexpr size_t recovery_cache_size = 100000;
    static recovery_cache_type recovery_cache;
-   const digest_type digest = sig_digest(chain_id);
+   const auto trx = get_transaction();
+   const digest_type digest = trx.sig_digest(chain_id);
 
    flat_set<public_key_type> recovered_pub_keys;
    for(const signature_type& sig : signatures) {
       recovery_cache_type::index<by_sig>::type::iterator it = recovery_cache.get<by_sig>().find(sig);
 
-      if(it == recovery_cache.get<by_sig>().end() || it->trx_id != id()) {
+      if(it == recovery_cache.get<by_sig>().end() || it->trx_id != trx.id()) {
          public_key_type recov = public_key_type(sig, digest);
-         recovery_cache.emplace_back( cached_pub_key{id(), recov, sig} ); //could fail on dup signatures; not a problem
+         recovery_cache.emplace_back( cached_pub_key{trx.id(), recov, sig} ); //could fail on dup signatures; not a problem
          recovered_pub_keys.insert(recov);
          continue;
       }
@@ -102,6 +107,93 @@ flat_set<public_key_type> signed_transaction::get_signature_keys( const chain_id
 
    return recovered_pub_keys;
 } FC_CAPTURE_AND_RETHROW() }
+
+namespace bio = boost::iostreams;
+
+template<size_t Limit>
+struct read_limiter {
+   using char_type = char;
+   using category = bio::multichar_output_filter_tag;
+
+   template<typename Sink>
+   size_t write(Sink &sink, const char* s, size_t count)
+   {
+      EOS_ASSERT(_total + count <= Limit, tx_decompression_error, "Exceeded maximum decopressed transaction size");
+      _total += count;
+      return bio::write(sink, s, count);
+   }
+
+   size_t _total = 0;
+};
+
+static transaction unpack_transaction(const bytes& data) {
+   return fc::raw::unpack<transaction>(data);
+}
+
+
+static transaction zlib_decompress_transaction(const bytes& data) {
+   try {
+      bytes out;
+      bio::filtering_ostream decomp;
+      decomp.push(bio::zlib_decompressor());
+      decomp.push(read_limiter<10*1024*1024>()); // limit to 10 megs decompressed for zip bomb protections
+      decomp.push(bio::back_inserter(out));
+      bio::write(decomp, data.data(), data.size());
+      bio::close(decomp);
+      return unpack_transaction(out);
+   } catch( fc::exception& er ) {
+      throw;
+   } catch( ... ) {
+      fc::unhandled_exception er( FC_LOG_MESSAGE( warn, "internal decompression error"), std::current_exception() );
+      throw er;
+   }
+}
+
+static bytes pack_transaction(const transaction& t) {
+   return fc::raw::pack(t);
+}
+
+static bytes zlib_compress_transaction(const transaction& t) {
+   bytes in = pack_transaction(t);
+   bytes out;
+   bio::filtering_ostream comp;
+   comp.push(bio::zlib_compressor(bio::zlib::best_compression));
+   comp.push(bio::back_inserter(out));
+   bio::write(comp, in.data(), in.size());
+   bio::close(comp);
+   return out;
+}
+
+transaction signed_transaction::get_transaction()const
+{
+   try {
+      switch(compression) {
+         case none:
+            return unpack_transaction(data);
+         case zlib:
+            return zlib_decompress_transaction(data);
+         default:
+            FC_THROW("Unknown transaction compression algorithm");
+      }
+   } FC_CAPTURE_AND_RETHROW((compression)(data))
+}
+
+void signed_transaction::set_transaction(const transaction& t, signed_transaction::compression_type _compression)
+{
+   try {
+      switch(_compression) {
+         case none:
+            data = pack_transaction(t);
+            break;
+         case zlib:
+            data = zlib_compress_transaction(t);
+            break;
+         default:
+            FC_THROW("Unknown transaction compression algorithm");
+      }
+   } FC_CAPTURE_AND_RETHROW((_compression)(t))
+   compression = _compression;
+}
 
 
 } } // eosio::chain

--- a/libraries/chain/transaction_metadata.cpp
+++ b/libraries/chain/transaction_metadata.cpp
@@ -1,0 +1,28 @@
+#include <eosio/chain/transaction_metadata.hpp>
+#include <eosio/chain/merkle.hpp>
+#include <fc/io/raw.hpp>
+
+namespace eosio { namespace chain {
+
+transaction_metadata::transaction_metadata( const packed_transaction& t, chain_id_type chainid, const time_point& published )
+   :raw_trx(t.get_raw_transaction())
+   ,decompressed_trx(fc::raw::unpack<transaction>(*raw_trx))
+   ,trx(*decompressed_trx)
+   ,id(decompressed_trx->id())
+   ,bandwidth_usage( (uint32_t)fc::raw::pack_size(t) )
+   ,published(published)
+   ,raw_data(raw_trx->data())
+   ,raw_size(raw_trx->size())
+{ }
+
+digest_type transaction_metadata::calculate_transaction_merkle_root( const vector<transaction_metadata>& metas ) {
+   vector<digest_type> ids;
+   ids.reserve(metas.size());
+
+   for( const auto& t : metas )
+      ids.emplace_back( t.id );
+
+   return merkle( std::move(ids) );
+}
+
+} } // eosio::chain

--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -22,6 +22,7 @@ namespace eosio { namespace testing {
          signed_block      produce_block( fc::microseconds skip_time = fc::milliseconds(config::block_interval_ms) );
          void              produce_blocks( uint32_t n = 1 );
 
+         transaction_trace push_transaction( packed_transaction& trx );
          transaction_trace push_transaction( signed_transaction& trx );
          void              set_tapos( signed_transaction& trx ) const;
 

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -113,14 +113,18 @@ namespace eosio { namespace testing {
                                    .deposit  = initial_balance
                                 });
 
-      trx.sign( get_private_key( creator, "active" ), chain_id_type()  ); 
+      set_tapos(trx);
+      trx.sign( get_private_key( creator, "active" ), chain_id_type()  );
+      push_transaction( trx );
+   }
 
-      control->push_transaction( trx );
+   transaction_trace tester::push_transaction( packed_transaction& trx ) {
+      return control->push_transaction( trx );
    }
 
    transaction_trace tester::push_transaction( signed_transaction& trx ) {
-      set_tapos(trx);
-      return control->push_transaction( trx );
+      auto ptrx = packed_transaction(trx);
+      return push_transaction( ptrx );
    }
 
    void tester::create_account( account_name a, string initial_balance, account_name creator, bool multisig  ) {
@@ -141,8 +145,9 @@ namespace eosio { namespace testing {
                                    .memo   = memo
                                 } );
 
-      trx.sign( get_private_key( from, "active" ), chain_id_type()  ); 
-      return control->push_transaction( trx );
+      set_tapos(trx);
+      trx.sign( get_private_key( from, "active" ), chain_id_type()  );
+      return push_transaction( trx );
    }
 
    void tester::set_authority( account_name account,
@@ -160,7 +165,7 @@ namespace eosio { namespace testing {
 
       set_tapos( trx );
       trx.sign( get_private_key( account, "active" ), chain_id_type()  ); 
-      control->push_transaction( trx );
+      push_transaction( trx );
    } FC_CAPTURE_AND_RETHROW( (account)(perm)(auth)(parent) ) }
 
    void tester::set_code( account_name account, const char* wast ) try {
@@ -218,7 +223,7 @@ namespace eosio { namespace testing {
 
       set_tapos( trx );
       trx.sign( get_private_key( account, "active" ), chain_id_type()  );
-      control->push_transaction( trx );
+      push_transaction( trx );
    } FC_CAPTURE_AND_RETHROW( (account)(wast) )
 
    void tester::set_abi( account_name account, const char* abi_json) {
@@ -232,7 +237,7 @@ namespace eosio { namespace testing {
 
       set_tapos( trx );
       trx.sign( get_private_key( account, "active" ), chain_id_type()  );
-      control->push_transaction( trx );
+      push_transaction( trx );
    }
 
    bool tester::chain_has_transaction( const transaction_id_type& txid ) const {

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -504,9 +504,9 @@ read_only::abi_bin_to_json_result read_only::abi_bin_to_json( const read_only::a
 }
 
 read_only::get_required_keys_result read_only::get_required_keys( const get_required_keys_params& params )const {
-   packed_transaction pretty_input;
+   transaction pretty_input;
    from_variant(params.transaction, pretty_input);
-   auto required_keys_set = db.get_required_keys(pretty_input.get_transaction(), params.available_keys);
+   auto required_keys_set = db.get_required_keys(pretty_input, params.available_keys);
    get_required_keys_result result;
    result.required_keys = required_keys_set;
    return result;

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -230,7 +230,7 @@ bool chain_plugin::accept_block(const signed_block& block, bool currently_syncin
    return true;
 }
 
-void chain_plugin::accept_transaction(const signed_transaction& trx) {
+void chain_plugin::accept_transaction(const packed_transaction& trx) {
    chain().push_transaction(trx, my->skip_flags);
 }
 
@@ -387,7 +387,7 @@ read_write::push_block_results read_write::push_block(const read_write::push_blo
 }
 
 read_write::push_transaction_results read_write::push_transaction(const read_write::push_transaction_params& params) {
-   signed_transaction pretty_input;
+   packed_transaction pretty_input;
    auto resolver = [&,this]( const account_name& name ) -> optional<abi_serializer> {
       const auto* accnt  = db.get_database().find<account_object,by_name>( name );
       if (accnt != nullptr) {
@@ -405,7 +405,7 @@ read_write::push_transaction_results read_write::push_transaction(const read_wri
 #warning TODO: get transaction results asynchronously
    fc::variant pretty_output;
    abi_serializer::to_variant(result, pretty_output, resolver);
-   return read_write::push_transaction_results{ pretty_input.id(), pretty_output };
+   return read_write::push_transaction_results{ result.id, pretty_output };
 }
 
 read_write::push_transactions_results read_write::push_transactions(const read_write::push_transactions_params& params) {
@@ -504,9 +504,9 @@ read_only::abi_bin_to_json_result read_only::abi_bin_to_json( const read_only::a
 }
 
 read_only::get_required_keys_result read_only::get_required_keys( const get_required_keys_params& params )const {
-   signed_transaction pretty_input;
+   packed_transaction pretty_input;
    from_variant(params.transaction, pretty_input);
-   auto required_keys_set = db.get_required_keys(pretty_input, params.available_keys);
+   auto required_keys_set = db.get_required_keys(pretty_input.get_transaction(), params.available_keys);
    get_required_keys_result result;
    result.required_keys = required_keys_set;
    return result;

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -340,7 +340,7 @@ public:
    chain_apis::read_write get_read_write_api();
 
    bool accept_block(const chain::signed_block& block, bool currently_syncing);
-   void accept_transaction(const chain::signed_transaction& trx);
+   void accept_transaction(const chain::packed_transaction& trx);
 
    bool block_is_on_preferred_chain(const chain::block_id_type& block_id);
 

--- a/plugins/faucet_testnet_plugin/faucet_testnet_plugin.cpp
+++ b/plugins/faucet_testnet_plugin/faucet_testnet_plugin.cpp
@@ -240,7 +240,7 @@ struct faucet_testnet_plugin_impl {
       trx.sign(_create_account_private_key, chainid);
 
       try {
-         cc.push_transaction(trx);
+         cc.push_transaction(packed_transaction(trx));
       } catch (const account_name_exists_exception& ) {
          // another transaction ended up adding the account, so look for alternates
          return find_alternates(new_account_name);

--- a/plugins/txn_test_gen_plugin/txn_test_gen_plugin.cpp
+++ b/plugins/txn_test_gen_plugin/txn_test_gen_plugin.cpp
@@ -93,7 +93,7 @@ struct txn_test_gen_plugin_impl {
       trx.actions.emplace_back(vector<chain::permission_level>{{creator,"active"}}, contracts::newaccount{creator, newaccountB, owner_auth, active_auth, recovery_auth, stake});
       }
       trx.sign(creator_priv_key, chainid);
-      cc.push_transaction(trx);
+      cc.push_transaction(packed_transaction(trx));
 
       //now, transfer some balance to new accounts
       {
@@ -104,7 +104,7 @@ struct txn_test_gen_plugin_impl {
       trx.expiration = cc.head_block_time() + fc::seconds(30);
       trx.set_reference_block(cc.head_block_id());
       trx.sign(creator_priv_key, chainid);
-      cc.push_transaction(trx);
+      cc.push_transaction(packed_transaction(trx));
       }
    }
 
@@ -156,7 +156,7 @@ struct txn_test_gen_plugin_impl {
 
       fc::crypto::private_key creator_priv_key = fc::crypto::private_key::regenerate(fc::sha256(std::string(64, 'a')));
       trx.sign(creator_priv_key, chainid);
-      cc.push_transaction(trx);
+      cc.push_transaction(packed_transaction(trx));
       }
 
       //make transaction b->a
@@ -168,7 +168,7 @@ struct txn_test_gen_plugin_impl {
 
       fc::crypto::private_key b_priv_key = fc::crypto::private_key::regenerate(fc::sha256(std::string(64, 'b')));
       trx.sign(b_priv_key, chainid);
-      cc.push_transaction(trx);
+      cc.push_transaction(packed_transaction(trx));
       }
    }
 

--- a/tests/chain_tests/transfer_tests.cpp
+++ b/tests/chain_tests/transfer_tests.cpp
@@ -69,9 +69,9 @@ BOOST_AUTO_TEST_CASE( transfer_test ) { try {
                                 } );
 
       test.set_tapos( trx );
-      BOOST_REQUIRE_THROW( test.control->push_transaction( trx ), tx_missing_sigs );
+      BOOST_REQUIRE_THROW( test.push_transaction( trx ), tx_missing_sigs );
       trx.sign( test.get_private_key( from, "active" ), chain_id_type()  ); 
-      test.control->push_transaction( trx );
+      test.push_transaction( trx );
   }
 
   {
@@ -90,7 +90,7 @@ BOOST_AUTO_TEST_CASE( transfer_test ) { try {
       test.set_tapos( trx );
       trx.sign( test.get_private_key( to, "active" ), chain_id_type()  ); 
       /// action not provided from authority
-      BOOST_REQUIRE_THROW( test.control->push_transaction( trx ), tx_missing_auth);
+      BOOST_REQUIRE_THROW( test.push_transaction( trx ), tx_missing_auth);
   }
 
 } FC_LOG_AND_RETHROW() } /// transfer_test
@@ -143,7 +143,7 @@ BOOST_AUTO_TEST_CASE( transfer_delegation ) { try {
       wdump((fc::raw::pack_size(trx)));
 
       /// action not provided from authority
-      test.control->push_transaction( trx );
+      test.push_transaction( trx );
   }
 
 } FC_LOG_AND_RETHROW() }

--- a/tests/wasm_tests/currency_tests.cpp
+++ b/tests/wasm_tests/currency_tests.cpp
@@ -89,7 +89,7 @@ BOOST_FIXTURE_TEST_CASE( test_currency, tester ) try {
 
       set_tapos(trx);
       trx.sign(get_private_key(N(currency), "active"), chain_id_type());
-      control->push_transaction(trx);
+      push_transaction(trx);
       produce_block();
 
       BOOST_REQUIRE_EQUAL(true, chain_has_transaction(trx.id()));
@@ -113,7 +113,7 @@ BOOST_FIXTURE_TEST_CASE( test_currency, tester ) try {
 
       set_tapos(trx);
       trx.sign(get_private_key(N(currency), "active"), chain_id_type());
-      control->push_transaction(trx);
+      push_transaction(trx);
       produce_block();
 
       BOOST_REQUIRE_EQUAL(true, chain_has_transaction(trx.id()));
@@ -137,7 +137,7 @@ BOOST_FIXTURE_TEST_CASE( test_currency, tester ) try {
 
       set_tapos(trx);
       trx.sign(get_private_key(N(alice), "active"), chain_id_type());
-      BOOST_CHECK_EXCEPTION(control->push_transaction(trx), fc::assert_exception, assert_message_is("integer underflow subtracting token balance"));
+      BOOST_CHECK_EXCEPTION(push_transaction(trx), fc::assert_exception, assert_message_is("integer underflow subtracting token balance"));
       produce_block();
 
       BOOST_REQUIRE_EQUAL(false, chain_has_transaction(trx.id()));
@@ -162,7 +162,7 @@ BOOST_FIXTURE_TEST_CASE( test_currency, tester ) try {
 
       set_tapos(trx);
       trx.sign(get_private_key(N(alice), "active"), chain_id_type());
-      control->push_transaction(trx);
+      push_transaction(trx);
       produce_block();
 
       BOOST_REQUIRE_EQUAL(true, chain_has_transaction(trx.id()));

--- a/tests/wasm_tests/wasm_tests.cpp
+++ b/tests/wasm_tests/wasm_tests.cpp
@@ -98,7 +98,7 @@ BOOST_FIXTURE_TEST_CASE( basic_test, tester ) try {
 
       set_tapos( trx );
       trx.sign( get_private_key( N(asserter), "active" ), chain_id_type() );
-      auto result = control->push_transaction( trx );
+      auto result = push_transaction( trx );
       BOOST_CHECK_EQUAL(result.status, transaction_receipt::executed);
       BOOST_CHECK_EQUAL(result.action_traces.size(), 1);
       BOOST_CHECK_EQUAL(result.action_traces.at(0).receiver.to_string(),  name(N(asserter)).to_string() );
@@ -126,7 +126,7 @@ BOOST_FIXTURE_TEST_CASE( basic_test, tester ) try {
       trx.sign( get_private_key( N(asserter), "active" ), chain_id_type() );
       yes_assert_id = trx.id();
 
-      BOOST_CHECK_THROW(control->push_transaction( trx ), fc::assert_exception);
+      BOOST_CHECK_THROW(push_transaction( trx ), fc::assert_exception);
    }
 
    produce_blocks(1);
@@ -158,7 +158,7 @@ BOOST_FIXTURE_TEST_CASE( prove_mem_reset, tester ) try {
 
       set_tapos( trx );
       trx.sign( get_private_key( N(asserter), "active" ), chain_id_type() );
-      control->push_transaction( trx );
+      push_transaction( trx );
       produce_blocks(1);
       BOOST_REQUIRE_EQUAL(true, chain_has_transaction(trx.id()));
       const auto& receipt = get_transaction_receipt(trx.id());
@@ -213,7 +213,7 @@ BOOST_FIXTURE_TEST_CASE( abi_from_variant, tester ) try {
    abi_serializer::from_variant(pretty_trx, trx, resolver);
    set_tapos( trx );
    trx.sign( get_private_key( N(asserter), "active" ), chain_id_type() );
-   control->push_transaction( trx );
+   push_transaction( trx );
    produce_blocks(1);
    BOOST_REQUIRE_EQUAL(true, chain_has_transaction(trx.id()));
    const auto& receipt = get_transaction_receipt(trx.id());
@@ -239,7 +239,7 @@ BOOST_FIXTURE_TEST_CASE( test_api_bootstrap, tester ) try {
 
       set_tapos(trx);
       trx.sign(get_private_key(N(tester), "active"), chain_id_type());
-      BOOST_CHECK_EXCEPTION(control->push_transaction(trx), fc::assert_exception, assert_message_is("test_action::assert_false"));
+      BOOST_CHECK_EXCEPTION(push_transaction(trx), fc::assert_exception, assert_message_is("test_action::assert_false"));
       produce_block();
 
       BOOST_REQUIRE_EQUAL(false, chain_has_transaction(trx.id()));
@@ -252,7 +252,7 @@ BOOST_FIXTURE_TEST_CASE( test_api_bootstrap, tester ) try {
 
       set_tapos(trx);
       trx.sign(get_private_key(N(tester), "active"), chain_id_type());
-      control->push_transaction(trx);
+      push_transaction(trx);
       produce_block();
 
       BOOST_REQUIRE_EQUAL(true, chain_has_transaction(trx.id()));
@@ -294,7 +294,7 @@ BOOST_FIXTURE_TEST_CASE( test_proxy, tester ) try {
 
       set_tapos(trx);
       trx.sign(get_private_key(N(proxy), "active"), chain_id_type());
-      control->push_transaction(trx);
+      push_transaction(trx);
       produce_block();
       BOOST_REQUIRE_EQUAL(true, chain_has_transaction(trx.id()));
    }
@@ -351,7 +351,7 @@ BOOST_FIXTURE_TEST_CASE( test_deferred_failure, tester ) try {
 
       set_tapos(trx);
       trx.sign(get_private_key(N(proxy), "active"), chain_id_type());
-      control->push_transaction(trx);
+      push_transaction(trx);
       produce_block();
       BOOST_REQUIRE_EQUAL(true, chain_has_transaction(trx.id()));
    }
@@ -392,7 +392,7 @@ BOOST_FIXTURE_TEST_CASE( test_deferred_failure, tester ) try {
 
       set_tapos(trx);
       trx.sign(get_private_key(N(bob), "active"), chain_id_type());
-      control->push_transaction(trx);
+      push_transaction(trx);
       produce_block();
       BOOST_REQUIRE_EQUAL(true, chain_has_transaction(trx.id()));
    }
@@ -440,7 +440,7 @@ BOOST_FIXTURE_TEST_CASE( check_entry_behavior, tester ) try {
 
    set_tapos(trx);
    trx.sign(get_private_key( N(entrycheck), "active" ), chain_id_type());
-   control->push_transaction(trx);
+   push_transaction(trx);
    produce_blocks(1);
    BOOST_REQUIRE_EQUAL(true, chain_has_transaction(trx.id()));
    const auto& receipt = get_transaction_receipt(trx.id());
@@ -469,7 +469,7 @@ BOOST_FIXTURE_TEST_CASE( simple_no_memory_check, tester ) try {
    trx.actions.push_back(act);
 
    trx.sign(get_private_key( N(nomem), "active" ), chain_id_type());
-   BOOST_CHECK_THROW(control->push_transaction( trx ), wasm_execution_error);
+   BOOST_CHECK_THROW(push_transaction( trx ), wasm_execution_error);
 } FC_LOG_AND_RETHROW()
 
 //Make sure globals are all reset to their inital values
@@ -492,7 +492,7 @@ BOOST_FIXTURE_TEST_CASE( check_global_reset, tester ) try {
 
    set_tapos(trx);
    trx.sign(get_private_key( N(globalreset), "active" ), chain_id_type());
-   control->push_transaction(trx);
+   push_transaction(trx);
    produce_blocks(1);
    BOOST_REQUIRE_EQUAL(true, chain_has_transaction(trx.id()));
    const auto& receipt = get_transaction_receipt(trx.id());

--- a/tests/wasm_tests/wasm_tests.cpp
+++ b/tests/wasm_tests/wasm_tests.cpp
@@ -527,7 +527,7 @@ BOOST_FIXTURE_TEST_CASE( memory_operators, tester ) try {
       set_tapos(trx);
       trx.sign(get_private_key( N(current_memory), "active" ), chain_id_type());
 
-      BOOST_CHECK_THROW(control->push_transaction(trx), fc::unhandled_exception);
+      BOOST_CHECK_THROW(push_transaction(trx), fc::unhandled_exception);
    }
 
    produce_blocks(1);
@@ -542,7 +542,7 @@ BOOST_FIXTURE_TEST_CASE( memory_operators, tester ) try {
       set_tapos(trx);
       trx.sign(get_private_key( N(current_memory), "active" ), chain_id_type());
 
-      BOOST_CHECK_THROW(control->push_transaction(trx), fc::unhandled_exception);
+      BOOST_CHECK_THROW(push_transaction(trx), fc::unhandled_exception);
       produce_blocks(1);
    }
 


### PR DESCRIPTION
closes #1255

This enables compressed transaction support.

For now, the only compression schemes available are "none" and "zlib" aka deflate. 

ABI serializer is updated to decompress `packed_transaction` following the precedence set up with `action` which is that `data` will display uncompressed and pretty printed, and `hex_data` will contain the real `data` member's bytes. 

Most of the APIs now take `packed_transaction` where they used to take `signed_transaction` . For convenience, the `tester` has an API endpoint that still takes a `signed_transaction` and will pack it for you.

`eosioc` will automatically compress `setcode` and `setabi` actions.  All other actions are considered uncompressed.   `eosioc push transaction` and `eosioc push transactions` now expect JSONified `packed_transaction` as input.   For convenience, when given a JSON/variant `packed_transaction` it will respect `data` as a string of hex bytes OR a fully exploded pretty `transaction`.  This means that even a non ABI-aware JSONifiy of a `packed_transaction` is still loadable.

Added a few unit tests to make sure that inflate/deflate from known hex data (encoded via command line) works as well as our limiter which protects us from deflate bombs.

NOTE: as this potentially makes some operations like `id()` more expensive on a `packed_transaction` some of the core code was changed to cache values in proper places.  There are still opportunities for this. 
