### PR TITLE
Add install CMake Command Line

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,7 +517,7 @@ You can find up to date information about EOS Docker in the [Docker Readme](http
 
 If you prefer to manually build dependencies, follow the steps below.
 
-This project is written primarily in C++14 and uses CMake as its build system. An up-to-date Clang and the latest version of CMake is recommended.
+This project is written primarily in C++14 and uses CMake as its build system. An up-to-date Clang and the latest version of CMake is recommended, and do make sure you have CMake installed for Command Line Use.
 
 Dependencies:
 


### PR DESCRIPTION
`CMake command not found` is a very common issues for Mac User. Installing CMake App does not include install CMake Command Line Tools, this simple line will remind developers to install requisite Command Line of CMake.
![image](https://user-images.githubusercontent.com/16319106/35679577-8ebc45a0-0792-11e8-80f4-dfb1c4499351.png)
![image](https://user-images.githubusercontent.com/16319106/35679555-8114f8f2-0792-11e8-9d16-fcc9a3216a9f.png)
![image](https://user-images.githubusercontent.com/16319106/35679565-899d5924-0792-11e8-81a3-4a58b2d3f455.png)
