### PR TITLE
initalize sbrk_bytes based on initial memory size of wasm memory

### DIFF
--- a/libraries/chain/include/eosio/chain/wasm_interface_private.hpp
+++ b/libraries/chain/include/eosio/chain/wasm_interface_private.hpp
@@ -28,8 +28,8 @@ struct wasm_cache::entry {
 struct wasm_context {
    wasm_context(wasm_cache::entry &code, apply_context& ctx) : code(code), context(ctx)
    {
-      //initialize to minimum bytes and limit this to 32 bit space
-      sbrk_bytes = (1 << IR::numBytesPerPageLog2) > UINT32_MAX ? UINT32_MAX : 1 << IR::numBytesPerPageLog2;
+      MemoryInstance* default_mem = Runtime::getDefaultMemory(code.instance);
+      sbrk_bytes = default_mem ? Runtime::getMemoryNumPages(default_mem) << IR::numBytesPerPageLog2 : 0;
    }
    wasm_cache::entry& code;
    apply_context& context;


### PR DESCRIPTION
sbrk_bytes needs to be initialized to the end of initial memory. Hardcoding it to 64KB means it'll stomp on any initial memory above 64KB.

Found via unit tests that I'm not committing yet due to state of master