### PR TITLE
fix for push_block with multiple transactions

### DIFF
--- a/libraries/chain/chain_controller.cpp
+++ b/libraries/chain/chain_controller.cpp
@@ -604,10 +604,11 @@ void chain_controller::__apply_block(const signed_block& next_block)
    /// cache the input tranasction ids so that they can be looked up when executing the
    /// summary
    vector<transaction_metadata> input_metas;
-   map<transaction_id_type,transaction_metadata*> trx_index;
+   input_metas.reserve(next_block.input_transactions.size());
+   map<transaction_id_type,size_t> trx_index;
    for( const auto& t : next_block.input_transactions ) {
       input_metas.emplace_back(t, chain_id_type(), next_block.timestamp);
-      trx_index[input_metas.back().id] =  &input_metas.back();
+      trx_index[input_metas.back().id] =  input_metas.size() - 1;
    }
 
    block_trace next_block_trace(next_block);
@@ -660,7 +661,7 @@ void chain_controller::__apply_block(const signed_block& next_block)
                 auto make_metadata = [&]() -> transaction_metadata* {
                   auto itr = trx_index.find(receipt.id);
                   if( itr != trx_index.end() ) {
-                     return itr->second;
+                     return &input_metas.at(itr->second);
                   } else {
                      const auto& gtrx = _db.get<generated_transaction_object,by_trx_id>(receipt.id);
                      auto trx = fc::raw::unpack<deferred_transaction>(gtrx.packed_trx.data(), gtrx.packed_trx.size());


### PR DESCRIPTION
fixed bugs that were only apparent when pushing a block with enough transactions to resize the `vector<transaction_metadata>` that we create out of the `input_transactions`

