### PR TITLE
fixes for wasm memory tests

### DIFF
--- a/libraries/chain/contracts/eosio_contract.cpp
+++ b/libraries/chain/contracts/eosio_contract.cpp
@@ -116,6 +116,10 @@ void apply_eosio_setcode(apply_context& context) {
 
    auto code_id = fc::sha256::hash( act.code.data(), act.code.size() );
 
+   // TODO: remove this compilation step in favor of validation without compilation
+   auto& code = context.mutable_controller.get_wasm_cache().checkout(code_id, act.code.data(), act.code.size());
+   context.mutable_controller.get_wasm_cache().checkin(code_id, code);
+
    const auto& account = db.get<account_object,by_name>(act.account);
 //   wlog( "set code: ${size}", ("size",act.code.size()));
    db.modify( account, [&]( auto& a ) {

--- a/libraries/wasm-jit/Source/WASM/WASMSerialization.cpp
+++ b/libraries/wasm-jit/Source/WASM/WASMSerialization.cpp
@@ -186,8 +186,10 @@ public:
    {}
 
 
-   void addCall(const Module& module, Serialization::OutputStream& inByteStream)
+   void addCall(Module& module, Serialization::OutputStream& inByteStream)
    {
+		// make sure the import is added
+		addImport(module);
       OpcodeAndImm<CallImm>* encodedOperator = (OpcodeAndImm<CallImm>*)inByteStream.advance(sizeof(OpcodeAndImm<CallImm>));
       encodedOperator->opcode = Opcode::call;
       // checktime will be the last defined import
@@ -217,11 +219,17 @@ public:
 
    void addImport(Module& module)
    {
-      const U32 functionTypeIndex = typeSlot;
-      module.functions.imports.push_back({{functionTypeIndex},std::move(u8"env"),std::move(u8"checktime")});
+		if (module.functions.imports.size() == 0 || module.functions.imports.back().exportName.compare(u8"checktime") != 0) {
+			if (typeSlot < 0) {
+				addTypeSlot(module);
+			}
+
+			const U32 functionTypeIndex = typeSlot;
+			module.functions.imports.push_back({{functionTypeIndex}, std::move(u8"env"), std::move(u8"checktime")});
+		}
    }
 
-   void conditionallyAddCall(Opcode opcode, const ControlStructureImm& imm, const Module& module, Serialization::OutputStream& inByteStream)
+   void conditionallyAddCall(Opcode opcode, const ControlStructureImm& imm, Module& module, Serialization::OutputStream& inByteStream)
    {
       switch(opcode)
       {
@@ -234,7 +242,7 @@ public:
    }
 
    template<typename Imm>
-   void conditionallyAddCall(Opcode , const Imm& , const Module& , Serialization::OutputStream& )
+   void conditionallyAddCall(Opcode , const Imm& , Module& , Serialization::OutputStream& )
    {
    }
 
@@ -270,12 +278,12 @@ private:
 
 struct NoOpInjection
 {
-   void addCall(const Module& , Serialization::OutputStream& ) {}
+   void addCall(Module& , Serialization::OutputStream& ) {}
    void setTypeSlot(const Module& , ResultType , const std::vector<ValueType>& ) {}
    void addTypeSlot(Module& ) {}
    void addImport(Module& ) {}
    template<typename Imm>
-   void conditionallyAddCall(Opcode , const Imm& , const Module& , Serialization::OutputStream& ) {}
+   void conditionallyAddCall(Opcode , const Imm& , Module& , Serialization::OutputStream& ) {}
    void adjustIfFunctionIndex(Uptr& , ObjectKind ) {}
    void adjustExportIndex(Module& ) {}
    template<typename Imm>

--- a/libraries/wasm-jit/Source/WASM/WASMSerialization.cpp
+++ b/libraries/wasm-jit/Source/WASM/WASMSerialization.cpp
@@ -188,8 +188,8 @@ public:
 
    void addCall(Module& module, Serialization::OutputStream& inByteStream)
    {
-		// make sure the import is added
-		addImport(module);
+      // make sure the import is added
+      addImport(module);
       OpcodeAndImm<CallImm>* encodedOperator = (OpcodeAndImm<CallImm>*)inByteStream.advance(sizeof(OpcodeAndImm<CallImm>));
       encodedOperator->opcode = Opcode::call;
       // checktime will be the last defined import
@@ -219,14 +219,14 @@ public:
 
    void addImport(Module& module)
    {
-		if (module.functions.imports.size() == 0 || module.functions.imports.back().exportName.compare(u8"checktime") != 0) {
-			if (typeSlot < 0) {
-				addTypeSlot(module);
-			}
+      if (module.functions.imports.size() == 0 || module.functions.imports.back().exportName.compare(u8"checktime") != 0) {
+         if (typeSlot < 0) {
+            addTypeSlot(module);
+         }
 
-			const U32 functionTypeIndex = typeSlot;
-			module.functions.imports.push_back({{functionTypeIndex}, std::move(u8"env"), std::move(u8"checktime")});
-		}
+         const U32 functionTypeIndex = typeSlot;
+         module.functions.imports.push_back({{functionTypeIndex}, std::move(u8"env"), std::move(u8"checktime")});
+      }
    }
 
    void conditionallyAddCall(Opcode opcode, const ControlStructureImm& imm, Module& module, Serialization::OutputStream& inByteStream)

--- a/tests/wasm_tests/wasm_tests.cpp
+++ b/tests/wasm_tests/wasm_tests.cpp
@@ -522,33 +522,9 @@ BOOST_FIXTURE_TEST_CASE( memory_operators, tester ) try {
 
    BOOST_CHECK_THROW(set_code(N(current_memory), current_memory_wast), eosio::chain::wasm_execution_error);
    produce_blocks(1);
-   {
-      signed_transaction trx;
-      action act;
-      act.account = N(current_memory);
-      act.authorization = vector<permission_level>{{N(current_memory),config::active_name}};
-      trx.actions.push_back(act);
-      set_tapos(trx);
-      trx.sign(get_private_key( N(current_memory), "active" ), chain_id_type());
 
-      BOOST_CHECK_THROW(push_transaction(trx), fc::unhandled_exception);
-   }
-
+   BOOST_CHECK_THROW(set_code(N(current_memory), grow_memory_wast), eosio::chain::wasm_execution_error);
    produce_blocks(1);
-   set_code(N(current_memory), grow_memory_wast);
-   produce_blocks(1);
-   {
-      signed_transaction trx;
-      action act;
-      act.account = N(current_memory);
-      act.authorization = vector<permission_level>{{N(current_memory),config::active_name}};
-      trx.actions.push_back(act);
-      set_tapos(trx);
-      trx.sign(get_private_key( N(current_memory), "active" ), chain_id_type());
-
-      BOOST_CHECK_THROW(push_transaction(trx), fc::unhandled_exception);
-      produce_blocks(1);
-   }
 
 } FC_LOG_AND_RETHROW()
 


### PR DESCRIPTION
the removal of `init` from `setcode` moved compilation AND validation of wasm to the first action.  We should do validation during `setcode` but doing this properly requires additional work.  This is a temporary fix

Additionally, the injector code was failing when hit with hand crafted wasm that had no types/import section(s)