### PR TITLE
fix abi tests

### DIFF
--- a/contracts/eosiolib/string.hpp
+++ b/contracts/eosiolib/string.hpp
@@ -4,6 +4,7 @@
 #include <eosiolib/system.h>
 #include <eosiolib/memory.hpp>
 #include <eosiolib/print.hpp>
+#include <eosiolib/varint.hpp>
 
 namespace eosio {
   /**

--- a/tests/tests/abi_tests.cpp
+++ b/tests/tests/abi_tests.cpp
@@ -414,6 +414,8 @@ BOOST_AUTO_TEST_CASE(generator)
    const char* all_types = R"=====(
     #include <eosiolib/types.hpp>
     #include <eosiolib/string.hpp>
+    #include <eosiolib/asset.hpp>
+    #include <eosiolib/vector.hpp>
 
     typedef int field;
     typedef int struct_def;
@@ -442,7 +444,7 @@ BOOST_AUTO_TEST_CASE(generator)
       fixed_string32          field6;
       fixed_string16          field7;
       type_name               field8;
-      bytes                   field9;
+      eosio::bytes            field9;
       uint8_t                 field10;
       uint16_t                field11;
       uint32_t                field12;
@@ -473,9 +475,8 @@ BOOST_AUTO_TEST_CASE(generator)
       action_def              field37;
       table_def               field38;
       abi_def                 field39;
-      nonce                   field40;
       public_key              field41;
-      asset                   field42;
+      eosio::asset            field42;
    };
    )=====";
 
@@ -602,9 +603,6 @@ BOOST_AUTO_TEST_CASE(generator)
           },{
              "name": "field39",
              "type": "abi_def"
-          },{
-             "name": "field40",
-             "type": "nonce"
           },{
              "name": "field41",
              "type": "public_key"

--- a/tests/tests/abi_tests.cpp
+++ b/tests/tests/abi_tests.cpp
@@ -475,8 +475,8 @@ BOOST_AUTO_TEST_CASE(generator)
       action_def              field37;
       table_def               field38;
       abi_def                 field39;
-      public_key              field41;
-      eosio::asset            field42;
+      public_key              field40;
+      eosio::asset            field41;
    };
    )=====";
 
@@ -604,10 +604,10 @@ BOOST_AUTO_TEST_CASE(generator)
              "name": "field39",
              "type": "abi_def"
           },{
-             "name": "field41",
+             "name": "field40",
              "type": "public_key"
           },{
-             "name": "field42",
+             "name": "field41",
              "type": "asset"
           }]
            }],


### PR DESCRIPTION
there were a few missing headers in contract side and `nonce` is no longer a built-in type.