### PR TITLE
Eosio abi

### DIFF
--- a/contracts/eosio.system/eosio.system.abi
+++ b/contracts/eosio.system/eosio.system.abi
@@ -27,6 +27,7 @@
       "name": "nonce",
       "base": "",
       "fields": [
+        {"name":"from", "type":"account_name"},
         {"name":"value", "type":"string"}
       ]
     }

--- a/contracts/eosio.system/eosio.system.abi
+++ b/contracts/eosio.system/eosio.system.abi
@@ -1,9 +1,5 @@
 {
-  "types": [{
-      "new_type_name": "account_name",
-      "type": "name"
-    }
-  ],
+  "types": [],
   "structs": [{
       "name": "transfer",
       "base": "",

--- a/contracts/eosio.system/eosio.system.abi
+++ b/contracts/eosio.system/eosio.system.abi
@@ -27,7 +27,6 @@
       "name": "nonce",
       "base": "",
       "fields": [
-        {"name":"from", "type":"account_name"},
         {"name":"value", "type":"string"}
       ]
     }

--- a/contracts/eosio.system/eosio.system.cpp
+++ b/contracts/eosio.system/eosio.system.cpp
@@ -11,6 +11,6 @@ extern "C" {
 
     /// The apply method implements the dispatch of events to this contract
     void apply( uint64_t code, uint64_t act ) {
-       eosiosystem::contract<N(system_account)>::apply( code, act );
+       eosiosystem::contract<N(eosio)>::apply( code, act );
     }
 }

--- a/contracts/eosio.system/eosio.system.cpp
+++ b/contracts/eosio.system/eosio.system.cpp
@@ -11,6 +11,6 @@ extern "C" {
 
     /// The apply method implements the dispatch of events to this contract
     void apply( uint64_t code, uint64_t act ) {
-       eosiosystem::contract<N(eosio.system)>::apply( code, act );
+       eosiosystem::contract<N(system_account)>::apply( code, act );
     }
 }

--- a/contracts/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/eosio.system.hpp
@@ -77,10 +77,9 @@ namespace eosiosystem {
          };
 
          ACTION( SystemAccount, nonce ) {
-            account_name                    from;
             eosio::string                   value;
 
-            EOSLIB_SERIALIZE( nonce, (from)(value) );
+            EOSLIB_SERIALIZE( nonce, (value) );
          };
 
       static void on( const delnetbw& del ) {

--- a/contracts/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/eosio.system.hpp
@@ -17,7 +17,7 @@ namespace eosiosystem {
    template<account_name SystemAccount>
    class contract {
       public:
-         static const account_name system_account = N(eosio);
+         static const account_name system_account = SystemAccount;
          typedef eosio::generic_currency< eosio::token<system_account,S(4,EOS)> > currency;
 
          struct total_bandwidth {
@@ -77,9 +77,10 @@ namespace eosiosystem {
          };
 
          ACTION( SystemAccount, nonce ) {
+            account_name                    from;
             eosio::string                   value;
 
-            EOSLIB_SERIALIZE( nonce, (value) );
+            EOSLIB_SERIALIZE( nonce, (from)(value) );
          };
 
       static void on( const delnetbw& del ) {
@@ -103,7 +104,7 @@ namespace eosiosystem {
          static void apply( account_name code, action_name act ) {
             if( !eosio::dispatch<contract, regproducer, regproxy, nonce>( code, act) ) {
                if ( !eosio::dispatch<currency, typename currency::transfer, typename currency::issue>( code, act ) ) {
-                  eosio::print("Unexpected action: ", act, "\n");
+                  eosio::print("Unexpected action: ", eosio::name(act), "\n");
                   eos_assert( false, "received unexpected action");
                }
             }

--- a/contracts/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/eosio.system.hpp
@@ -17,7 +17,7 @@ namespace eosiosystem {
    template<account_name SystemAccount>
    class contract {
       public:
-         static const account_name system_account = N(eosio.system);
+         static const account_name system_account = N(eosio);
          typedef eosio::generic_currency< eosio::token<system_account,S(4,EOS)> > currency;
 
          struct total_bandwidth {

--- a/contracts/test.system/test.system.abi
+++ b/contracts/test.system/test.system.abi
@@ -1,9 +1,5 @@
 {
-  "types": [{
-    "new_type_name": "account_name",
-    "type": "name"
-  }
-  ],
+  "types": [],
   "structs": [{
       "name": "set_account_limits",
       "base": "",

--- a/libraries/chain/CMakeLists.txt
+++ b/libraries/chain/CMakeLists.txt
@@ -1,4 +1,4 @@
-file(GLOB HEADERS "include/eosio/chain/*.hpp")
+file(GLOB HEADERS "include/eosio/chain/*.hpp" "include/eosio/chain/contracts/*.hpp")
 
 ## SORT .cpp by most likely to change / break compile
 add_library( eosio_chain

--- a/libraries/chain/contracts/abi_serializer.cpp
+++ b/libraries/chain/contracts/abi_serializer.cpp
@@ -3,6 +3,7 @@
  *  @copyright defined in eos/LICENSE.txt
  */
 #include <eosio/chain/contracts/abi_serializer.hpp>
+#include <eosio/chain/contracts/chain_initializer.hpp>
 #include <eosio/chain/contracts/types.hpp>
 #include <eosio/chain/authority.hpp>
 #include <eosio/chain/chain_config.hpp>
@@ -129,6 +130,17 @@ namespace eosio { namespace chain { namespace contracts {
       FC_ASSERT( actions.size() == abi.actions.size() );
       FC_ASSERT( tables.size() == abi.tables.size() );
    }
+
+   void abi_serializer::append_system_abi(account_name account, abi_def& abi) {
+      if ( account == eosio::chain::config::system_account_name ) {
+         abi_def eos_abi = chain_initializer::eos_contract_abi();
+         abi.actions.insert(abi.actions.end(), eos_abi.actions.cbegin(), eos_abi.actions.cend());
+         abi.structs.insert(abi.structs.end(), eos_abi.structs.cbegin(), eos_abi.structs.cend());
+         abi.tables.insert(abi.tables.end(), eos_abi.tables.cbegin(), eos_abi.tables.cend());
+         abi.types.insert(abi.types.end(), eos_abi.types.cbegin(), eos_abi.types.cend());
+      }
+   }
+
    
    bool abi_serializer::is_builtin_type(const type_name& type)const {
       return built_in_types.find(type) != built_in_types.end();

--- a/libraries/chain/contracts/chain_initializer.cpp
+++ b/libraries/chain/contracts/chain_initializer.cpp
@@ -151,12 +151,6 @@ abi_def chain_initializer::eos_contract_abi()
    });
 
    // DATABASE RECORDS
-   eos_abi.structs.emplace_back( struct_def {
-      "account", "", {
-         {"key",     "name"},
-         {"balance", "uint64"},
-      }
-   });
 
    eos_abi.structs.emplace_back( struct_def {
       "pending_recovery", "", {

--- a/libraries/chain/include/eosio/chain/contracts/abi_serializer.hpp
+++ b/libraries/chain/include/eosio/chain/contracts/abi_serializer.hpp
@@ -72,11 +72,12 @@ struct abi_serializer {
    }
 
    template<typename Vec>
-   static bool to_abi(const Vec& abi_vec, abi_def& abi)
+   static bool to_abi(account_name account, const Vec& abi_vec, abi_def& abi)
    {
       if( !is_empty_abi(abi_vec) ) { /// 4 == packsize of empty Abi
          fc::datastream<const char*> ds( abi_vec.data(), abi_vec.size() );
          fc::raw::unpack( ds, abi );
+         append_system_abi(account, abi);
          return true;
       }
       return false;
@@ -84,6 +85,7 @@ struct abi_serializer {
 
    private:
    void binary_to_variant(const type_name& type, fc::datastream<const char*>& stream, fc::mutable_variant_object& obj)const;
+   static void append_system_abi(account_name account, abi_def& abi);
 };
 
 namespace impl {

--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -85,7 +85,7 @@ namespace eosio { namespace testing {
               try {
                  const auto &accnt = control->get_database().get<account_object, by_name>(name);
                  contracts::abi_def abi;
-                 if (contracts::abi_serializer::to_abi(accnt.abi, abi)) {
+                 if (contracts::abi_serializer::to_abi(accnt.name, accnt.abi, abi)) {
                     return contracts::abi_serializer(abi);
                  }
                  return optional<contracts::abi_serializer>();

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -174,7 +174,6 @@ namespace eosio { namespace testing {
                      ("permission", name(config::active_name))
                }))
                ("data", fc::mutable_variant_object()
-                  ("from", from)
                   ("value", v)
                )
             })

--- a/plugins/account_history_plugin/account_history_plugin.cpp
+++ b/plugins/account_history_plugin/account_history_plugin.cpp
@@ -413,7 +413,7 @@ fc::variant account_history_plugin_impl::transaction_to_variant(const packed_tra
       const auto* accnt = database.find<chain::account_object,chain::by_name>( name );
       if (accnt != nullptr) {
          abi_def abi;
-         if (abi_serializer::to_abi(accnt->abi, abi)) {
+         if (abi_serializer::to_abi(accnt->name, accnt->abi, abi)) {
             return abi_serializer(abi);
          }
       }

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -280,7 +280,7 @@ abi_def get_abi( const chain_controller& db, const name& account ) {
    const auto& code_accnt  = d.get<account_object,by_name>( account );
 
    abi_def abi;
-   abi_serializer::to_abi(code_accnt.abi, abi);
+   abi_serializer::to_abi(code_accnt.name, code_accnt.abi, abi);
    return abi;
 }
 
@@ -379,7 +379,7 @@ read_write::push_transaction_results read_write::push_transaction(const read_wri
       const auto* accnt  = db.get_database().find<account_object,by_name>( name );
       if (accnt != nullptr) {
          abi_def abi;
-         if (abi_serializer::to_abi(accnt->abi, abi)) {
+         if (abi_serializer::to_abi(accnt->name, accnt->abi, abi)) {
             return abi_serializer(abi);
          }
       }
@@ -423,7 +423,7 @@ read_only::get_code_results read_only::get_code( const get_code_params& params )
    }
 
    abi_def abi;
-   if( abi_serializer::to_abi(accnt.abi, abi) ) {
+   if( abi_serializer::to_abi(accnt.name, accnt.abi, abi) ) {
       result.abi = std::move(abi);
    }
 
@@ -465,7 +465,7 @@ read_only::abi_json_to_bin_result read_only::abi_json_to_bin( const read_only::a
    abi_json_to_bin_result result;
    const auto& code_account = db.get_database().get<account_object,by_name>( params.code );
    abi_def abi;
-   if( abi_serializer::to_abi(code_account.abi, abi) ) {
+   if( abi_serializer::to_abi(code_account.name, code_account.abi, abi) ) {
       abi_serializer abis( abi );
       result.binargs = abis.variant_to_binary( abis.get_action_type( params.action ), params.args );
    }
@@ -476,7 +476,7 @@ read_only::abi_bin_to_json_result read_only::abi_bin_to_json( const read_only::a
    abi_bin_to_json_result result;
    const auto& code_account = db.get_database().get<account_object,by_name>( params.code );
    abi_def abi;
-   if( abi_serializer::to_abi(code_account.abi, abi) ) {
+   if( abi_serializer::to_abi(code_account.name, code_account.abi, abi) ) {
       abi_serializer abis( abi );
       result.args = abis.binary_to_variant( abis.get_action_type( params.action ), params.binargs );
    }

--- a/programs/eosioc/main.cpp
+++ b/programs/eosioc/main.cpp
@@ -221,13 +221,16 @@ void add_standard_transaction_options(CLI::App* cmd) {
    cmd->add_flag("-f,--force-unique", tx_force_unique, localized("force the transaction to be unique. this will consume extra bandwidth and remove any protections against accidently issuing the same transaction multiple times"));
 }
 
-uint64_t generate_nonce_value() {
-   return fc::time_point::now().time_since_epoch().count();
+string generate_nonce_value() {
+   return fc::to_string(fc::time_point::now().time_since_epoch().count());
 }
 
-chain::action generate_nonce() {
+chain::action generate_nonce(account_name from) {
    auto v = generate_nonce_value();
-   return chain::action( {}, config::system_account_name, "nonce", fc::raw::pack(v));
+   variant nonce = fc::mutable_variant_object()
+         ("from", from)
+         ("value", v);
+   return chain::action( {}, config::system_account_name, "nonce", fc::raw::pack(nonce));
 }
 
 vector<chain::permission_level> get_account_permissions(const vector<string>& permissions) {
@@ -780,7 +783,7 @@ int main( int argc, char** argv ) {
                                config::system_account_name, "transfer", result.get_object()["binargs"].as<bytes>());
 
       if (tx_force_unique) {
-         actions.emplace_back( generate_nonce() );
+         actions.emplace_back( generate_nonce(name(sender)) );
       }
 
       send_actions(std::move(actions), skip_sign);
@@ -950,7 +953,7 @@ int main( int argc, char** argv ) {
       actions.emplace_back(accountPermissions, contract, action, result.get_object()["binargs"].as<bytes>());
 
       if (tx_force_unique) {
-         actions.emplace_back( generate_nonce() );
+         actions.emplace_back( generate_nonce(name(contract)) );
       }                                                      
 
       send_actions(std::move(actions), skip_sign);

--- a/programs/eosioc/main.cpp
+++ b/programs/eosioc/main.cpp
@@ -225,10 +225,9 @@ string generate_nonce_value() {
    return fc::to_string(fc::time_point::now().time_since_epoch().count());
 }
 
-chain::action generate_nonce(account_name from) {
+chain::action generate_nonce() {
    auto v = generate_nonce_value();
    variant nonce = fc::mutable_variant_object()
-         ("from", from)
          ("value", v);
    return chain::action( {}, config::system_account_name, "nonce", fc::raw::pack(nonce));
 }
@@ -783,7 +782,7 @@ int main( int argc, char** argv ) {
                                config::system_account_name, "transfer", result.get_object()["binargs"].as<bytes>());
 
       if (tx_force_unique) {
-         actions.emplace_back( generate_nonce(name(sender)) );
+         actions.emplace_back( generate_nonce() );
       }
 
       send_actions(std::move(actions), skip_sign);
@@ -953,7 +952,7 @@ int main( int argc, char** argv ) {
       actions.emplace_back(accountPermissions, contract, action, result.get_object()["binargs"].as<bytes>());
 
       if (tx_force_unique) {
-         actions.emplace_back( generate_nonce(name(contract)) );
+         actions.emplace_back( generate_nonce() );
       }                                                      
 
       send_actions(std::move(actions), skip_sign);

--- a/tests/wasm_tests/identity_tests.cpp
+++ b/tests/wasm_tests/identity_tests.cpp
@@ -38,12 +38,12 @@ public:
 
       const auto& accnt = control->get_database().get<account_object,by_name>( N(identity) );
       abi_def abi;
-      BOOST_REQUIRE_EQUAL(abi_serializer::to_abi(accnt.abi, abi), true);
+      BOOST_REQUIRE_EQUAL(abi_serializer::to_abi(accnt.name, accnt.abi, abi), true);
       abi_ser.set_abi(abi);
 
       const auto& acnt_test = control->get_database().get<account_object,by_name>( N(identitytest) );
       abi_def abi_test;
-      BOOST_REQUIRE_EQUAL(abi_serializer::to_abi(acnt_test.abi, abi_test), true);
+      BOOST_REQUIRE_EQUAL(abi_serializer::to_abi(accnt.name, acnt_test.abi, abi_test), true);
       abi_ser_test.set_abi(abi_test);
 
       const global_property_object &gpo = control->get_global_properties();

--- a/tests/wasm_tests/wasm_tests.cpp
+++ b/tests/wasm_tests/wasm_tests.cpp
@@ -13,10 +13,13 @@
 
 #include <noop/noop.wast.hpp>
 #include <noop/noop.abi.hpp>
+#include <eosio.system/eosio.system.wast.hpp>
+#include <eosio.system/eosio.system.abi.hpp>
 
 #include <Runtime/Runtime.h>
 
 #include <fc/variant_object.hpp>
+#include <fc/io/json.hpp>
 
 #include "test_wasts.hpp"
 
@@ -187,7 +190,7 @@ BOOST_FIXTURE_TEST_CASE( abi_from_variant, tester ) try {
       try {
          const auto& accnt  = this->control->get_database().get<account_object,by_name>( name );
          abi_def abi;
-         if (abi_serializer::to_abi(accnt.abi, abi)) {
+         if (abi_serializer::to_abi(accnt.name, accnt.abi, abi)) {
             return abi_serializer(abi);
          }
          return optional<abi_serializer>();
@@ -361,7 +364,7 @@ BOOST_FIXTURE_TEST_CASE( stl_test, tester ) try {
 
     const auto& accnt  = control->get_database().get<account_object,by_name>( N(stltest) );
     abi_def abi;
-    BOOST_REQUIRE_EQUAL(abi_serializer::to_abi(accnt.abi, abi), true);
+    BOOST_REQUIRE_EQUAL(abi_serializer::to_abi(accnt.name, accnt.abi, abi), true);
     abi_serializer abi_ser(abi);
 
     //send message
@@ -572,7 +575,7 @@ BOOST_FIXTURE_TEST_CASE(noop, tester) try {
    set_abi(N(noop), noop_abi);
    const auto& accnt  = control->get_database().get<account_object,by_name>(N(noop));
    abi_def abi;
-   BOOST_REQUIRE_EQUAL(abi_serializer::to_abi(accnt.abi, abi), true);
+   BOOST_REQUIRE_EQUAL(abi_serializer::to_abi(accnt.name, accnt.abi, abi), true);
    abi_serializer abi_ser(abi);
 
    {
@@ -624,6 +627,47 @@ BOOST_FIXTURE_TEST_CASE(noop, tester) try {
    }
 
  } FC_LOG_AND_RETHROW()
+
+// abi_serializer::to_variant failed because eosio_system_abi modified via set_abi.
+// This test also verifies that chain_initializer::eos_contract_abi() does not conflict
+// with eosio_system_abi as they are not allowed to contain duplicates.
+BOOST_FIXTURE_TEST_CASE(eosio_abi, tester) try {
+   produce_blocks(2);
+
+   set_code(config::system_account_name, eosio_system_wast);
+   set_abi(config::system_account_name, eosio_system_abi);
+   produce_block();
+
+   const auto& accnt  = control->get_database().get<account_object,by_name>(config::system_account_name);
+   abi_def abi;
+   BOOST_REQUIRE_EQUAL(abi_serializer::to_abi(accnt.name, accnt.abi, abi), true);
+   abi_serializer abi_ser(abi);
+   abi_ser.validate();
+
+   signed_transaction trx;
+   name a = N(alice);
+   authority owner_auth =  authority( get_public_key( a, "owner" ) );
+   trx.actions.emplace_back( vector<permission_level>{{config::system_account_name,config::active_name}},
+                             contracts::newaccount{
+                                   .creator  = config::system_account_name,
+                                   .name     = a,
+                                   .owner    = owner_auth,
+                                   .active   = authority( get_public_key( a, "active" ) ),
+                                   .recovery = authority( get_public_key( a, "recovery" ) ),
+                             });
+   set_tapos(trx);
+   trx.sign( get_private_key( config::system_account_name, "active" ), chain_id_type()  );
+   auto result = push_transaction( trx );
+
+   fc::variant pretty_output;
+   // verify to_variant works on eos native contract type: newaccount
+   // see abi_serializer::to_abi()
+   abi_serializer::to_variant(result, pretty_output, get_resolver());
+
+   BOOST_TEST(fc::json::to_string(pretty_output).find("newaccount") != std::string::npos);
+
+   produce_block();
+} FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( test_table_key_validation, tester ) try {
 } FC_LOG_AND_RETHROW()


### PR DESCRIPTION
abi_serializer::to_variant failed because the eosio_system_abi was overwritten when set_abi for the eosio.system was set.  Added chain_initializer::eos_contract_abi() to eosio account abi.

Also fixed nonce action in eosioc.