### PR TITLE
Support proper spec compliant call_indirect wast syntax

### DIFF
--- a/tests/wasm_tests/test_wasts.hpp
+++ b/tests/wasm_tests/test_wasts.hpp
@@ -174,7 +174,7 @@ static const char memory_table_import[] = R"=====(
 
 static const char table_checker_wast[] = R"=====(
 (module
- (import "env" "assert" (func $assert (param i32 i32)))
+ (import "env" "eos_assert" (func $assert (param i32 i32)))
  (import "env" "printi" (func $printi (param i64)))
  (type $SIG$vj (func (param i64)))
  (table 1024 anyfunc)
@@ -214,16 +214,58 @@ static const char table_checker_wast[] = R"=====(
 )
 )=====";
 
+static const char table_checker_proper_syntax_wast[] = R"=====(
+(module
+ (import "env" "eos_assert" (func $assert (param i32 i32)))
+ (import "env" "printi" (func $printi (param i64)))
+ (type $SIG$vj (func (param i64)))
+ (table 1024 anyfunc)
+ (memory $0 1)
+ (export "apply" (func $apply))
+ (func $apply (param $0 i64) (param $1 i64)
+   (call_indirect (type $SIG$vj)
+     (i64.shr_u
+       (get_local $1)
+       (i64.const 32)
+     )
+     (i32.wrap/i64
+       (get_local $1)
+     )
+   )
+ )
+ (func $apple (type $SIG$vj) (param $0 i64)
+   (call $assert
+     (i64.eq
+       (get_local $0)
+       (i64.const 555)
+     )
+     (i32.const 0)
+   )
+ )
+ (func $bannna (type $SIG$vj) (param $0 i64)
+   (call $assert
+     (i64.eq
+       (get_local $0)
+       (i64.const 7777)
+     )
+     (i32.const 0)
+   )
+ )
+ (elem (i32.const 0) $apple)
+ (elem (i32.const 1022) $apple $bannna)
+)
+)=====";
+
 static const char table_checker_small_wast[] = R"=====(
 (module
- (import "env" "assert" (func $assert (param i32 i32)))
+ (import "env" "eos_assert" (func $assert (param i32 i32)))
  (import "env" "printi" (func $printi (param i64)))
  (type $SIG$vj (func (param i64)))
  (table 128 anyfunc)
  (memory $0 1)
  (export "apply" (func $apply))
  (func $apply (param $0 i64) (param $1 i64)
-   (call_indirect $SIG$vj
+   (call_indirect (type $SIG$vj)
      (i64.shr_u
        (get_local $1)
        (i64.const 32)

--- a/tests/wasm_tests/wasm_tests.cpp
+++ b/tests/wasm_tests/wasm_tests.cpp
@@ -677,8 +677,7 @@ BOOST_FIXTURE_TEST_CASE( test_table_key_validation, tester ) try {
 BOOST_FIXTURE_TEST_CASE( check_table_maximum, tester ) try {
    produce_blocks(2);
 
-   create_accounts( {N(tbl)}, asset::from_string("1000.0000 EOS") );
-   transfer( N(inita), N(tbl), "10.0000 EOS", "memo" );
+   create_accounts( {N(tbl)} );
    produce_block();
 
    set_code(N(tbl), table_checker_wast);
@@ -773,6 +772,36 @@ BOOST_FIXTURE_TEST_CASE( check_table_maximum, tester ) try {
    }
 
    produce_blocks(1);
+
+   //run a few tests with new, proper syntax, call_indirect
+   set_code(N(tbl), table_checker_proper_syntax_wast);
+   produce_blocks(1);
+
+   {
+   signed_transaction trx;
+   action act;
+   act.name = 555ULL<<32 | 1022ULL;       //top 32 is what we assert against, bottom 32 is indirect call index
+   act.account = N(tbl);
+   act.authorization = vector<permission_level>{{N(tbl),config::active_name}};
+   trx.actions.push_back(act);
+   set_tapos(trx);
+   trx.sign(get_private_key( N(tbl), "active" ), chain_id_type());
+   push_transaction(trx);
+   }
+
+   produce_blocks(1);
+
+   {
+   signed_transaction trx;
+   action act;
+   act.name = 7777ULL<<32 | 1023ULL;       //top 32 is what we assert against, bottom 32 is indirect call index
+   act.account = N(tbl);
+   act.authorization = vector<permission_level>{{N(tbl),config::active_name}};
+   trx.actions.push_back(act);
+   set_tapos(trx);
+   trx.sign(get_private_key( N(tbl), "active" ), chain_id_type());
+   push_transaction(trx);
+   }
 
    set_code(N(tbl), table_checker_small_wast);
    produce_blocks(1);


### PR DESCRIPTION
The wasm spec has a different definition for the call_indirect syntax in textual representation then what we currently support. Add code to support the spec’s syntax as newer binaryen (s2wasm) seems to use the spec’s syntax.

Be aware, this might still not be TECHNICALLY to spec — I think the spec may allow for defining the function prototype right at the call_indirect site. We only support usage of a type name or type index at the call_indirect site.

Fixes issue #1355