### PR TITLE
Missing dependencies on identity test contract

### DIFF
--- a/contracts/identity/test/CMakeLists.txt
+++ b/contracts/identity/test/CMakeLists.txt
@@ -2,6 +2,6 @@ set(ABI_FILES "identity_test.abi")
 configure_file("${ABI_FILES}" "${CMAKE_CURRENT_BINARY_DIR}" COPYONLY)
 add_wast_executable(TARGET identity_test
   INCLUDE_FOLDERS "${STANDARD_INCLUDE_FOLDERS}"
-  LIBRARIES eosiolib
+  LIBRARIES libc++ libc eosiolib
   DESTINATION_FOLDER ${CMAKE_CURRENT_BINARY_DIR}
 )


### PR DESCRIPTION
libc/libcxx were not listed as dependencies on the identity test contract making highly parallel builds fail if it queued up that test before finishing the base contracts