### PR TITLE
#1381 backwards compatibility and related updates.

### DIFF
--- a/libraries/chain/chain_controller.cpp
+++ b/libraries/chain/chain_controller.cpp
@@ -904,7 +904,7 @@ void chain_controller::process_message(const transaction& trx, account_name code
    auto us_duration = (fc::time_point::now() - start_time).count();
    if( is_producing() ) {
       EOS_ASSERT(us_duration < chain_configuration.max_trx_runtime, checktime_exceeded,
-                  "Transaction message exceeded maximum total transaction time of ${limit}ms, took ${duration}ms", ("limit", chain_configuration.max_trx_runtime/1000)("dur",us_duration/1000));
+                  "Transaction message exceeded maximum total transaction time of ${limit}ms, took ${dur}ms", ("limit", chain_configuration.max_trx_runtime/1000)("dur",us_duration/1000));
    }
    EOS_ASSERT(depth < chain_configuration.in_depth_limit, msg_resource_exhausted,
      "Message processing exceeded maximum inline recursion depth of ${limit}", ("limit", chain_configuration.in_depth_limit));

--- a/scripts/tn_up.sh
+++ b/scripts/tn_up.sh
@@ -17,9 +17,15 @@ relaunch() {
     nohup $RD/$prog $* --data-dir $DD > $DD/stdout.txt  2> $log &
     pid=$!
 
+    prevsize=0
     echo $pid > $DD/$prog.pid
     for (( a = 10; $a; a = $(($a - 1)) )); do
-        echo checking viability pass $((11 - $a))
+        cursize=`wc -l $log | awk '{print $1}'`
+        if [ "$cursize" -gt "$prevsize" ]; then
+            a=10
+            prevsize=$cursize;
+        fi
+        echo checking viability pass $((11 - $a)) logsize $prevsize
         sleep 2
         running=`ps -hp $pid`
         if [ -z "$running" ]; then


### PR DESCRIPTION
The synchronization of nodes changed a bit with respect to the fetching of blocks since the last irreversible block. This patch only affects a newer eosd catching up to an older one and not vice-versa since there won't ever be the need for an older node to catch up to a newer one.

I'm also including some related odds and ends, a change to the tn_up.sh helper script to make it wait for a replay to complete before moving on.

Finally, I am including a fix to a log message in the chain controller.