### PR TITLE
Make all wasm instances share same linear memory

### DIFF
--- a/libraries/wasm-jit/Include/Runtime/Runtime.h
+++ b/libraries/wasm-jit/Include/Runtime/Runtime.h
@@ -217,6 +217,7 @@ namespace Runtime
 
 	RUNTIME_API void runInstanceStartFunc(ModuleInstance* moduleInstance);
 	RUNTIME_API void resetGlobalInstances(ModuleInstance* moduleInstance);
+	RUNTIME_API void resetMemory(MemoryInstance* memory, IR::MemoryType& newMemoryType);
 
 	// Gets an object exported by a ModuleInstance by name.
 	RUNTIME_API ObjectInstance* getInstanceExport(ModuleInstance* moduleInstance,const std::string& name);

--- a/libraries/wasm-jit/Source/Runtime/Memory.cpp
+++ b/libraries/wasm-jit/Source/Runtime/Memory.cpp
@@ -65,6 +65,8 @@ namespace Runtime
 		{
 			if(memories[memoryIndex] == this) { memories.erase(memories.begin() + memoryIndex); break; }
 		}
+
+		theMemoryInstance = nullptr;
 	}
 	
 	bool isAddressOwnedByMemory(U8* address)
@@ -85,6 +87,16 @@ namespace Runtime
 		assert(memory->type.size.max <= UINTPTR_MAX);
 		return Uptr(memory->type.size.max);
 	}
+
+	void resetMemory(MemoryInstance* memory, MemoryType& newMemoryType) {
+		memory->type.size.min = 1;
+		if(shrinkMemory(memory, memory->numPages - 1) == -1)
+			causeException(Exception::Cause::outOfMemory);
+		memset(memory->baseAddress, 0, 1<<IR::numBytesPerPageLog2);
+		memory->type = newMemoryType;
+		if(growMemory(memory, memory->type.size.min - 1) == -1)
+			causeException(Exception::Cause::outOfMemory);
+   }
 
 	Iptr growMemory(MemoryInstance* memory,Uptr numNewPages)
 	{

--- a/libraries/wasm-jit/Source/Runtime/ModuleInstance.cpp
+++ b/libraries/wasm-jit/Source/Runtime/ModuleInstance.cpp
@@ -28,6 +28,8 @@ namespace Runtime
 		};
 	}
 
+	MemoryInstance* MemoryInstance::theMemoryInstance = nullptr;
+
 	ModuleInstance* instantiateModule(const IR::Module& module,ImportBindings&& imports)
 	{
 		ModuleInstance* moduleInstance = new ModuleInstance(
@@ -72,9 +74,11 @@ namespace Runtime
 		}
 		for(const MemoryDef& memoryDef : module.memories.defs)
 		{
-			auto memory = createMemory(memoryDef.type);
-			if(!memory) { causeException(Exception::Cause::outOfMemory); }
-			moduleInstance->memories.push_back(memory);
+			if(!MemoryInstance::theMemoryInstance) {
+				MemoryInstance::theMemoryInstance = createMemory(memoryDef.type);
+				if(!MemoryInstance::theMemoryInstance) { causeException(Exception::Cause::outOfMemory); }
+			}
+			moduleInstance->memories.push_back(MemoryInstance::theMemoryInstance);
 		}
 
 		// Find the default memory and table for the module.
@@ -100,32 +104,10 @@ namespace Runtime
 			|| table->elements.size() - baseOffset < tableSegment.indices.size())
 			{ causeException(Exception::Cause::invalidSegmentOffset); }
 		}
-		for(auto& dataSegment : module.dataSegments)
-		{
-			MemoryInstance* memory = moduleInstance->memories[dataSegment.memoryIndex];
 
-			const Value baseOffsetValue = evaluateInitializer(moduleInstance,dataSegment.baseOffset);
-			errorUnless(baseOffsetValue.type == ValueType::i32);
-			const U32 baseOffset = baseOffsetValue.i32;
-			const Uptr numMemoryBytes = (memory->numPages << IR::numBytesPerPageLog2);
-			if(baseOffset > numMemoryBytes
-			|| numMemoryBytes - baseOffset < dataSegment.data.size())
-			{ causeException(Exception::Cause::invalidSegmentOffset); }
-		}
-
-		// Copy the module's data segments into the module's default memory.
-		for(const DataSegment& dataSegment : module.dataSegments)
-		{
-			MemoryInstance* memory = moduleInstance->memories[dataSegment.memoryIndex];
-
-			const Value baseOffsetValue = evaluateInitializer(moduleInstance,dataSegment.baseOffset);
-			errorUnless(baseOffsetValue.type == ValueType::i32);
-			const U32 baseOffset = baseOffsetValue.i32;
-
-			assert(baseOffset + dataSegment.data.size() <= (memory->numPages << IR::numBytesPerPageLog2));
-
-			memcpy(memory->baseAddress + baseOffset,dataSegment.data.data(),dataSegment.data.size());
-		}
+		//Previously, the module instantiation would write in to the memoryInstance here. Don't do that
+      //since the memoryInstance is shared across all moduleInstances and we could be compiling
+      //a new instance while another instance is running
 		
 		// Instantiate the module's global definitions.
 		for(const GlobalDef& globalDef : module.globals.defs)

--- a/libraries/wasm-jit/Source/Runtime/RuntimePrivate.h
+++ b/libraries/wasm-jit/Source/Runtime/RuntimePrivate.h
@@ -90,6 +90,8 @@ namespace Runtime
 
 		MemoryInstance(const MemoryType& inType): GCObject(ObjectKind::memory), type(inType), baseAddress(nullptr), numPages(0), endOffset(0), reservedBaseAddress(nullptr), reservedNumPlatformPages(0) {}
 		~MemoryInstance() override;
+
+      static MemoryInstance* theMemoryInstance;
 	};
 
 	// An instance of a WebAssembly global.


### PR DESCRIPTION
Previously, each wasm instance (smart contract instance) would allocate 12GB of virtual address space for it self. While not as dire as how table memory use to work, this still will exhaust virtual memory space at an alarmingly low number of contracts.

Since in this release execution is single threaded, for now just make every wasm instance share the same 12GB. In the future we can extend this to have a “thread pool of memories”.

Review notes: chain_test passes but I still feel a little queasy about the lack of extensive tests against this change. I think we still have a number of unit tests not merged for 3.0 changes though? So I was hesitant to work on making new unit tests that simply overlap with what we have non-merged anyways.