### PR TITLE
Add Jenkinsfile, build dependencies with max jobs.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,38 @@
+pipeline {
+    agent any
+    stages {
+        stage('Build') {
+            parallel {
+                stage('Ubuntu') {
+                    steps {
+                        sh '''
+                            . $HOME/.bash_profile
+                            ./eosio_build.sh
+                        '''
+                    }
+                }
+                stage('MacOS') {
+                    steps {
+                        sh '''
+                            . $HOME/.bash_profile
+                            echo "Darwin build coming soon..."
+                        ''' 
+                    }
+                }
+                stage('Fedora') {
+                    steps {
+                        sh '''
+                            . $HOME/.bash_profile
+                            echo "Fedora build coming soon..."
+                        ''' 
+                    }
+                }
+            }
+        }
+    }
+    post { 
+        always { 
+            cleanWs()
+        }
+    }
+}

--- a/scripts/eosio_build_darwin.sh
+++ b/scripts/eosio_build_darwin.sh
@@ -165,13 +165,13 @@
 			exit;
 		fi
 		./configure
-		make
+		make -j${CPU_CORE}
 		if [ $? -ne 0 ]; then
 			printf "\tError compiling secp256k1-zkp.\n"
 			printf "\tExiting now.\n\n"
 			exit;
 		fi
-		sudo make install
+		sudo make -j${CPU_CORE} install
 		sudo rm -rf ${TEMP_DIR}/secp256k1-zkp
 	else
 		printf "\tsecp256k1 found at /usr/local/lib/\n"
@@ -183,7 +183,7 @@
 		git clone https://github.com/WebAssembly/binaryen
 		cd binaryen
 		git checkout tags/1.37.14
-		cmake . && make
+		cmake . && make -j${CPU_CORE}
 		if [ $? -ne 0 ]; then
 			printf "\tError compiling binaryen.\n"
 			printf "\tExiting now.\n\n"
@@ -217,7 +217,7 @@
 			printf "\tExiting now.\n\n"
 			exit;
 		fi
-		sudo make -j4 install
+		sudo make -j${CPU_CORE} install
 		sudo rm -rf ${TEMP_DIR}/wasm-compiler
 	else
 		printf "\tWASM found at /usr/local/wasm/bin/\n"

--- a/scripts/eosio_build_fedora.sh
+++ b/scripts/eosio_build_fedora.sh
@@ -112,7 +112,7 @@
 		tar xf boost_1.66.0.tar.bz2
 		cd boost_1_66_0/
 		./bootstrap.sh "--prefix=$BOOST_ROOT"
-		./b2 install
+		./b2 -j${CPU_CORE} install
 		rm -rf ${TEMP_DIR}/boost_1_66_0/
 		rm -f  ${TEMP_DIR}/boost_1.66.0.tar.bz2
 	else
@@ -133,13 +133,13 @@
 			exit;
 		fi
 		./configure
-		make
+		make -j${CPU_CORE}
 		if [ $? -ne 0 ]; then
 			printf "\tError compiling secp256k1-zkp.\n"
 			printf "\tExiting now.\n\n"
 			exit;
 		fi
-		sudo make install
+		sudo make -j${CPU_CORE} install
 		rm -rf cd ${TEMP_DIR}/secp256k1-zkp
 	else
 		printf "\tsecp256k1 found\n"
@@ -153,7 +153,7 @@
 		git clone https://github.com/WebAssembly/binaryen
 		cd binaryen
 		git checkout tags/1.37.14
-		cmake . && make
+		cmake . && make -j${CPU_CORE}
 		if [ $? -ne 0 ]; then
 			printf "\tError compiling binaryen.\n"
 			printf "\tExiting now.\n\n"
@@ -185,13 +185,13 @@
 			printf "\tExiting now.\n\n"
 			exit;
 		fi
-		make -j$(nproc)
+		make -j${CPU_CORE}
 		if [ $? -ne 0 ]; then
 			printf "\tError compiling LLVM and clang with EXPERIMENTAL WASM support.\n"
 			printf "\tExiting now.\n\n"
 			exit;
 		fi
-		make install
+		make -j${CPU_CORE} install
 		rm -rf ${TEMP_DIR}/llvm-compiler 2>/dev/null
 	else
 		printf "\tWASM found at ${HOME}/opt/wasm\n"

--- a/scripts/eosio_build_ubuntu.sh
+++ b/scripts/eosio_build_ubuntu.sh
@@ -94,7 +94,7 @@
 		tar xf boost_1.66.0.tar.bz2
 		cd boost_1_66_0/
 		./bootstrap.sh "--prefix=$BOOST_ROOT"
-		./b2 install
+		./b2 -j${CPU_CORE} install
 		rm -rf ${TEMP_DIR}/boost_1_66_0/
 		rm -f  ${TEMP_DIR}/boost_1.66.0.tar.bz2
 	else
@@ -115,13 +115,13 @@
 			exit;
 		fi
 		./configure
-		make
+		make -j${CPU_CORE}
 		if [ $? -ne 0 ]; then
 			printf "\tError compiling secp256k1-zkp.\n"
 			printf "\tExiting now.\n\n"
 			exit;
 		fi
-		sudo make install
+		sudo make -j${CPU_CORE} install
 		rm -rf cd ${TEMP_DIR}/secp256k1-zkp
 	else
 		printf "\tsecp256k1 found\n"
@@ -135,7 +135,7 @@
 		git clone https://github.com/WebAssembly/binaryen
 		cd binaryen
 		git checkout tags/1.37.14
-		cmake . && make
+		cmake . && make -j${CPU_CORE}
 		if [ $? -ne 0 ]; then
 			printf "\tError compiling binaryen.\n"
 			printf "\tExiting now.\n\n"
@@ -167,7 +167,7 @@
 			printf "\tExiting now.\n\n"
 			exit;
 		fi
-		make -j$(nproc)
+		make -j${CPU_CORE} install
 		if [ $? -ne 0 ]; then
 			printf "\tError compiling LLVM and clang with EXPERIMENTAL WASM support.\n"
 			printf "\tExiting now.\n\n"


### PR DESCRIPTION
This PR contains an initial Jenkinsfile to start doing our builds on Jenkins. Additionally, I made small modifications to the build scripts for each platform to build dependencies with the maximum number of jobs in order to speed up build time. Finally, the Ubuntu build script was only doing a make for the LLVM/WASM dependency, causing builds to fail. I updated this to do a make install, and the builds are now successful.