### PR TITLE
Add default install locations for WASM_LLVM_CONFIG and OPENSSL

### DIFF
--- a/CMakeModules/wasm.cmake
+++ b/CMakeModules/wasm.cmake
@@ -3,10 +3,15 @@ set(WASM_TOOLCHAIN FALSE)
 if(NOT DEFINED WASM_LLVM_CONFIG)
   if(NOT "$ENV{WASM_LLVM_CONFIG}" STREQUAL "")
     set(WASM_LLVM_CONFIG "$ENV{WASM_LLVM_CONFIG}" CACHE FILEPATH "Location of llvm-config compiled with WASM support.")
+  else()
+   find_file( WASM_LLVM_CONFIG
+              llvm-config
+              PATHS /usr/local/wasm/bin ${HOME}/opt/wasm/bin )
   endif()
 endif()
 
 if(WASM_LLVM_CONFIG)
+  message( STATUS "using ${WASM_LLVM_CONFIG}" )
   execute_process(
     COMMAND ${WASM_LLVM_CONFIG} --bindir
     RESULT_VARIABLE WASM_LLVM_CONFIG_OK

--- a/libraries/fc/CMakeLists.txt
+++ b/libraries/fc/CMakeLists.txt
@@ -47,6 +47,13 @@ IF(NOT "$ENV{OPENSSL_ROOT_DIR}" STREQUAL "")
   message(STATUS "Setting up OpenSSL root and include vars to ${OPENSSL_ROOT_DIR}, ${OPENSSL_INCLUDE_DIR}")
 ENDIF()
 
+IF( NOT OPENSSL_ROOT_DIR )
+   set( OPENSSL_ROOT_DIR /usr/local/opt/openssl CACHE FILEPATH "" )
+   set( OPENSSL_INCLUDE_DIR /usr/local/opt/openssl/include CACHE FILEPATH "location of Open SSL includes")
+ENDIF()
+
+message(STATUS "Setting up OpenSSL root and include vars to ${OPENSSL_ROOT_DIR}, ${OPENSSL_INCLUDE_DIR}")
+
 find_package(OpenSSL REQUIRED)
 
 set( CMAKE_FIND_LIBRARY_SUFFIXES ${ORIGINAL_LIB_SUFFIXES} )


### PR DESCRIPTION
Introduced NO_DEFAULT_PATH parameter to find_files(...) function call. This is used to point utility "llc" from /usr/local/wasm/bin location. 