### PR TITLE
Change darwin build to use "openssl" instead of "openssl@1.1"

### DIFF
--- a/eosio_build.sh
+++ b/eosio_build.sh
@@ -91,8 +91,8 @@
 	fi
 
 	if [ $ARCH == "Darwin" ]; then
-		OPENSSL_ROOT_DIR=/usr/local/opt/openssl@1.1
-		OPENSSL_LIBRARIES=/usr/local/opt/openssl@1.1/lib
+		OPENSSL_ROOT_DIR=/usr/local/opt/openssl
+		OPENSSL_LIBRARIES=/usr/local/opt/openssl/lib
 		BINARYEN_BIN=/usr/local/binaryen/bin/
 		WASM_LLVM_CONFIG=/usr/local/wasm/bin/llvm-config
 		CXX_COMPILER=clang++


### PR DESCRIPTION
The eosio_build_darwin.sh script clearly executes a "brew install openssl" which gives openssl 1.0 installed to /usr/local/opt/openssl. Change eosio_build.sh to look in that directory since that appears to be the intention.

Known to fix one issue reported in #1361