### PR TITLE
Add a find_package(Clang) for abi_generator

### DIFF
--- a/libraries/abi_generator/CMakeLists.txt
+++ b/libraries/abi_generator/CMakeLists.txt
@@ -1,5 +1,6 @@
 # Find an installed build of LLVM
 find_package(LLVM 4.0 REQUIRED CONFIG)
+find_package(Clang)
 set( CMAKE_CXX_STANDARD 14 )
 
 file(GLOB HEADERS "include/eosio/abi_generator/*.hpp")


### PR DESCRIPTION
abi_generator doesn't just use LLVM libraries, but Clang libraries too. Adding this declaration makes things work right when there are multiple clang libraries on a single system