### PR TITLE
Make Jenkins only run one build's tests at a time.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,6 +37,9 @@ pipeline {
                             . $HOME/.bash_profile
                             export EOSLIB=$(pwd)/contracts
                             cd build
+                            printf "Waiting for testing to be available..."
+                            while /usr/bin/pgrep -x ctest > /dev/null; do sleep 1; done
+                            echo "OK!"
                             ctest --output-on-failure
                         '''
                     }


### PR DESCRIPTION
Due to port conflicts on our Jenkins machine while running tests, I have modified the Jenkinsfile to check if ctest is currently running, and then wait for it to complete before running a new test.