### PR TITLE
Remove memset on malloc heap init

### DIFF
--- a/contracts/eosiolib/eosiolib.cpp
+++ b/contracts/eosiolib/eosiolib.cpp
@@ -202,7 +202,6 @@ namespace eosio {
          {
             _heap_size = size;
             _heap = mem_heap;
-            memset(_heap, 0, _heap_size);
          }
 
          uint32_t is_init() const


### PR DESCRIPTION
The wasm runtime guarantees that fresh pages are zero filled. Not seeing any reason to do a memset on heap init since that memory will be zeroed already anyways.