### PR TITLE
DAWN 515 - Improving EOSIOC: error that is received from RPC API Call

### DIFF
--- a/libraries/chain/name.cpp
+++ b/libraries/chain/name.cpp
@@ -7,12 +7,13 @@
 namespace eosio { namespace chain { 
 
    void name::set( const char* str ) {
-   try {
-      const auto len = strnlen(str,14);
-      EOS_ASSERT( len <= 13, name_type_exception, "Name is longer than 13 characters (${name}) ", ("name",string(str)) );
+      const auto len = strnlen(str, 14);
+      EOS_ASSERT(len <= 13, name_type_exception, "Name is longer than 13 characters (${name}) ", ("name", string(str)));
       value = string_to_name(str);
-      EOS_ASSERT( to_string() == string(str), name_type_exception, "Name not properly normalized (name: ${name}, normalized: ${normalized}) ", ("name",string(str))("normalized",to_string())  );
-   }FC_CAPTURE_AND_RETHROW( (str) ) }
+      EOS_ASSERT(to_string() == string(str), name_type_exception,
+                 "Name not properly normalized (name: ${name}, normalized: ${normalized}) ",
+                 ("name", string(str))("normalized", to_string()));
+   }
 
    name::operator string()const {
      static const char* charmap = ".12345abcdefghijklmnopqrstuvwxyz";

--- a/plugins/account_history_api_plugin/account_history_api_plugin.cpp
+++ b/plugins/account_history_api_plugin/account_history_api_plugin.cpp
@@ -28,11 +28,11 @@ void account_history_api_plugin::plugin_initialize(const variables_map&) {}
              auto result = api_handle.call_name(fc::json::from_string(body).as<api_namespace::call_name ## _params>()); \
              cb(200, fc::json::to_string(result)); \
           } catch (fc::eof_exception& e) { \
-             error_results results{400, "Bad Request", e.to_string()}; \
+             error_results results{400, "Bad Request", e}; \
              cb(400, fc::json::to_string(results)); \
              elog("Unable to parse arguments: ${args}", ("args", body)); \
           } catch (fc::exception& e) { \
-             error_results results{500, "Internal Service Error", e.to_detail_string()}; \
+             error_results results{500, "Internal Service Error", e}; \
              cb(500, fc::json::to_string(results)); \
              elog("Exception encountered while processing ${call}: ${e}", ("call", #api_name "." #call_name)("e", e)); \
           } \

--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -36,20 +36,20 @@ void chain_api_plugin::plugin_initialize(const variables_map&) {}
              auto result = api_handle.call_name(fc::json::from_string(body).as<api_namespace::call_name ## _params>()); \
              cb(http_response_code, fc::json::to_string(result)); \
           } catch (chain::tx_missing_sigs& e) { \
-             error_results results{401, "UnAuthorized", e.to_string()}; \
+             error_results results{401, "UnAuthorized", e}; \
              cb(401, fc::json::to_string(results)); \
           } catch (chain::tx_duplicate& e) { \
-             error_results results{409, "Conflict", e.to_string()}; \
+             error_results results{409, "Conflict", e}; \
              cb(409, fc::json::to_string(results)); \
           } catch (chain::transaction_exception& e) { \
-             error_results results{400, "Bad Request", e.to_string()}; \
+             error_results results{400, "Bad Request", e}; \
              cb(400, fc::json::to_string(results)); \
           } catch (fc::eof_exception& e) { \
-             error_results results{400, "Bad Request", e.to_string()}; \
+             error_results results{400, "Bad Request", e}; \
              cb(400, fc::json::to_string(results)); \
              elog("Unable to parse arguments: ${args}", ("args", body)); \
           } catch (fc::exception& e) { \
-             error_results results{500, "Internal Service Error", e.to_detail_string()}; \
+             error_results results{500, "Internal Service Error", e}; \
              cb(500, fc::json::to_string(results)); \
              elog("Exception encountered while processing ${call}: ${e}", ("call", #api_name "." #call_name)("e", e)); \
           } \

--- a/plugins/faucet_testnet_plugin/faucet_testnet_plugin.cpp
+++ b/plugins/faucet_testnet_plugin/faucet_testnet_plugin.cpp
@@ -63,11 +63,11 @@ using results_pair = std::pair<uint32_t,fc::variant>;
              const auto result = api_handle->invoke_cb(body); \
              response_cb(result.first, fc::json::to_string(result.second)); \
           } catch (fc::eof_exception& e) { \
-             error_results results{400, "Bad Request", e.to_string()}; \
+             error_results results{400, "Bad Request", e}; \
              response_cb(400, fc::json::to_string(results)); \
              elog("Unable to parse arguments: ${args}", ("args", body)); \
           } catch (fc::exception& e) { \
-             error_results results{500, "Internal Service Error", e.to_detail_string()}; \
+             error_results results{500, "Internal Service Error", e}; \
              response_cb(500, fc::json::to_string(results)); \
              elog("Exception encountered while processing ${call}: ${e}", ("call", #api_name "." #call_name)("e", e)); \
           } \

--- a/plugins/http_plugin/http_plugin.cpp
+++ b/plugins/http_plugin/http_plugin.cpp
@@ -186,7 +186,7 @@ namespace eosio {
                      } else {
                         wlog("404 - not found: ${ep}", ("ep",resource));
                         error_results results{websocketpp::http::status_code::not_found,
-                                              "Not Found", fc::exception(fc::log_message(fc::log_context(), "Unknown Endpoint"))};
+                                              "Not Found", fc::exception(FC_LOG_MESSAGE(error, "Unknown Endpoint"))};
                         con->set_body(fc::json::to_string(results));
                         con->set_status(websocketpp::http::status_code::not_found);
                      }
@@ -199,12 +199,12 @@ namespace eosio {
                   } catch( const std::exception& e ) {
                      elog( "http: ${e}", ("e",e.what()));
                      error_results results{websocketpp::http::status_code::internal_server_error,
-                                           "Internal Service Error", fc::exception(fc::log_message(fc::log_context(), e.what()))};
+                                           "Internal Service Error", fc::exception(FC_LOG_MESSAGE(error, e.what()))};
                      con->set_body(fc::json::to_string(results));
                      con->set_status(websocketpp::http::status_code::internal_server_error);
                   } catch( ... ) {
                      error_results results{websocketpp::http::status_code::internal_server_error,
-                                           "Internal Service Error", fc::exception(fc::log_message(fc::log_context(), "Unknown Exception"))};
+                                           "Internal Service Error", fc::exception(FC_LOG_MESSAGE(error, "Unknown Exception"))};
                      con->set_body(fc::json::to_string(results));
                      con->set_status(websocketpp::http::status_code::internal_server_error);
                   }

--- a/plugins/http_plugin/http_plugin.cpp
+++ b/plugins/http_plugin/http_plugin.cpp
@@ -186,25 +186,25 @@ namespace eosio {
                      } else {
                         wlog("404 - not found: ${ep}", ("ep",resource));
                         error_results results{websocketpp::http::status_code::not_found,
-                                              "Not Found", "Unknown Endpoint"};
+                                              "Not Found", fc::exception(fc::log_message(fc::log_context(), "Unknown Endpoint"))};
                         con->set_body(fc::json::to_string(results));
                         con->set_status(websocketpp::http::status_code::not_found);
                      }
                   } catch( const fc::exception& e ) {
                      elog( "http: ${e}", ("e",e.to_detail_string()));
                      error_results results{websocketpp::http::status_code::internal_server_error,
-                                           "Internal Service Error", e.to_detail_string()};
+                                           "Internal Service Error", e};
                      con->set_body(fc::json::to_string(results));
                      con->set_status(websocketpp::http::status_code::internal_server_error);
                   } catch( const std::exception& e ) {
                      elog( "http: ${e}", ("e",e.what()));
                      error_results results{websocketpp::http::status_code::internal_server_error,
-                                           "Internal Service Error", e.what()};
+                                           "Internal Service Error", fc::exception(fc::log_message(fc::log_context(), e.what()))};
                      con->set_body(fc::json::to_string(results));
                      con->set_status(websocketpp::http::status_code::internal_server_error);
                   } catch( ... ) {
                      error_results results{websocketpp::http::status_code::internal_server_error,
-                                           "Internal Service Error", "unknown exception"};
+                                           "Internal Service Error", fc::exception(fc::log_message(fc::log_context(), "Unknown Exception"))};
                      con->set_body(fc::json::to_string(results));
                      con->set_status(websocketpp::http::status_code::internal_server_error);
                   }

--- a/plugins/net_api_plugin/net_api_plugin.cpp
+++ b/plugins/net_api_plugin/net_api_plugin.cpp
@@ -31,11 +31,11 @@ using namespace eosio;
              INVOKE \
              cb(http_response_code, fc::json::to_string(result)); \
           } catch (fc::eof_exception& e) { \
-             error_results results{400, "Bad Request", e.to_string()}; \
+             error_results results{400, "Bad Request", e}; \
              cb(400, fc::json::to_string(results)); \
              elog("Unable to parse arguments: ${args}", ("args", body)); \
           } catch (fc::exception& e) { \
-             error_results results{500, "Internal Service Error", e.to_detail_string()}; \
+             error_results results{500, "Internal Service Error", e}; \
              cb(500, fc::json::to_string(results)); \
              elog("Exception encountered while processing ${call}: ${e}", ("call", #api_name "." #call_name)("e", e)); \
           } \

--- a/plugins/txn_test_gen_plugin/txn_test_gen_plugin.cpp
+++ b/plugins/txn_test_gen_plugin/txn_test_gen_plugin.cpp
@@ -46,11 +46,11 @@ using namespace eosio::chain;
              INVOKE \
              cb(http_response_code, fc::json::to_string(result)); \
           } catch (fc::eof_exception& e) { \
-             error_results results{400, "Bad Request", e.to_string()}; \
+             error_results results{400, "Bad Request", e}; \
              cb(400, fc::json::to_string(results)); \
              elog("Unable to parse arguments: ${args}", ("args", body)); \
           } catch (fc::exception& e) { \
-             error_results results{500, "Internal Service Error", e.to_detail_string()}; \
+             error_results results{500, "Internal Service Error", e}; \
              cb(500, fc::json::to_string(results)); \
              elog("Exception encountered while processing ${call}: ${e}", ("call", #api_name "." #call_name)("e", e)); \
           } \

--- a/plugins/wallet_api_plugin/wallet_api_plugin.cpp
+++ b/plugins/wallet_api_plugin/wallet_api_plugin.cpp
@@ -32,11 +32,11 @@ using namespace eosio;
              INVOKE \
              cb(http_response_code, fc::json::to_string(result)); \
           } catch (fc::eof_exception& e) { \
-             error_results results{400, "Bad Request", e.to_string()}; \
+             error_results results{400, "Bad Request", e}; \
              cb(400, fc::json::to_string(results)); \
              elog("Unable to parse arguments: ${args}", ("args", body)); \
           } catch (fc::exception& e) { \
-             error_results results{500, "Internal Service Error", e.to_detail_string()}; \
+             error_results results{500, "Internal Service Error", e}; \
              cb(500, fc::json::to_string(results)); \
              elog("Exception encountered while processing ${call}: ${e}", ("call", #api_name "." #call_name)("e", e)); \
           } \

--- a/programs/eosioc/help_text.cpp
+++ b/programs/eosioc/help_text.cpp
@@ -5,6 +5,7 @@
 #include "help_text.hpp"
 #include "localize.hpp"
 #include <regex>
+#include <fc/io/json.hpp>
 
 using namespace eosio::client::localize;
 
@@ -196,7 +197,7 @@ const std::map<int64_t, std::string> error_advice = {
 
 
 namespace eosio { namespace client { namespace help {
-bool print_recognized_error_code(const fc::exception& e, const bool show_error_trace) {
+bool print_recognized_error_code(const fc::exception& e, const bool verbose_errors) {
    // eos recognized error code is from 3000000 to 3999999
    // refer to libraries/chain/include/eosio/chain/exceptions.hpp
    if (e.code() >= 3000000 && e.code() <= 3999999) {
@@ -212,9 +213,12 @@ bool print_recognized_error_code(const fc::exception& e, const bool show_error_t
          if (!log.get_format().empty()) {
             // Localize the message as needed
             explanation += "\n  " + localized_with_variant(log.get_format().data(), log.get_data());
+         } else if (log.get_data().size() > 0 && verbose_errors) {
+            // Show data-only log only if verbose_errors option is enabled
+            explanation += "\n  " + fc::json::to_string(log.get_data());
          }
          // Check if there's stack trace to be added
-         if (!log.get_context().get_method().empty() && show_error_trace) {
+         if (!log.get_context().get_method().empty() && verbose_errors) {
             stack_trace += "\n  " +
                            log.get_context().get_file() +  ":" +
                            fc::to_string(log.get_context().get_line_number())  + " " +
@@ -235,9 +239,9 @@ bool print_recognized_error_code(const fc::exception& e, const bool show_error_t
    return false;
 }
 
-bool print_help_text(const fc::exception& e, const bool show_error_trace) {
+bool print_help_text(const fc::exception& e, const bool verbose_errors) {
    // Check if the exception has recognized error code
-   if (print_recognized_error_code(e, show_error_trace)) return true;
+   if (print_recognized_error_code(e, verbose_errors)) return true;
    bool result = false;
    // Large input strings to std::regex can cause SIGSEGV, this is a known bug in libstdc++.
    // See https://stackoverflow.com/questions/36304204/%D0%A1-regex-segfault-on-long-sequences

--- a/programs/eosioc/help_text.cpp
+++ b/programs/eosioc/help_text.cpp
@@ -182,22 +182,25 @@ e.g.
   }]
 })=====";
 
+const char* error_advice_3030002 =  R"=====(Ensure that you have the related private keys inside your wallet)=====";
+
 const std::map<int64_t, std::string> error_advice = {
    { 3120001, error_advice_3120001 },
    { 3120002, error_advice_3120002 },
    { 3120003, error_advice_3120003 },
    { 3120004, error_advice_3120004 },
    { 3120005, error_advice_3120005 },
-   { 3120006, error_advice_3120006 }
+   { 3120006, error_advice_3120006 },
+   { 3030002, error_advice_3030002 }
 };
 
 
 namespace eosio { namespace client { namespace help {
-bool print_recognized_error_code(const fc::exception& e) {
+bool print_recognized_error_code(const fc::exception& e, const bool show_error_trace) {
    // eos recognized error code is from 3000000 to 3999999
    // refer to libraries/chain/include/eosio/chain/exceptions.hpp
    if (e.code() >= 3000000 && e.code() <= 3999999) {
-      std::string advice, explanation;
+      std::string advice, explanation, stack_trace;
 
       // Get advice, if any
       const auto advice_itr = error_advice.find(e.code());
@@ -210,20 +213,31 @@ bool print_recognized_error_code(const fc::exception& e) {
             // Localize the message as needed
             explanation += "\n  " + localized_with_variant(log.get_format().data(), log.get_data());
          }
+         // Check if there's stack trace to be added
+         if (!log.get_context().get_method().empty() && show_error_trace) {
+            stack_trace += "\n  " +
+                           log.get_context().get_file() +  ":" +
+                           fc::to_string(log.get_context().get_line_number())  + " " +
+                           log.get_context().get_method();
+         }
       }
+      // Append header
       if (!explanation.empty()) explanation = std::string("Error Details:") + explanation;
+      if (!stack_trace.empty()) stack_trace = std::string("Stack Trace:") + stack_trace;
 
       std::cerr << "\033[31m" << "Error " << e.code() << ": " << e.what() << "\033[0m";
       if (!advice.empty()) std::cerr << "\n" << "\033[32m" << advice << "\033[0m";
-      if (!explanation.empty()) std::cerr  << "\n" << "\033[33m" << explanation << "\033[0m" << std::endl;
+      if (!explanation.empty()) std::cerr  << "\n" << "\033[33m" << explanation << "\033[0m";
+      if (!stack_trace.empty()) std::cerr  << "\n" << stack_trace;
+      std::cerr << std::endl;
       return true;
    }
    return false;
 }
 
-bool print_help_text(const fc::exception& e) {
+bool print_help_text(const fc::exception& e, const bool show_error_trace) {
    // Check if the exception has recognized error code
-   if (print_recognized_error_code(e)) return true;
+   if (print_recognized_error_code(e, show_error_trace)) return true;
    bool result = false;
    // Large input strings to std::regex can cause SIGSEGV, this is a known bug in libstdc++.
    // See https://stackoverflow.com/questions/36304204/%D0%A1-regex-segfault-on-long-sequences

--- a/programs/eosioc/help_text.hpp
+++ b/programs/eosioc/help_text.hpp
@@ -6,5 +6,5 @@
 #include <fc/exception/exception.hpp>
 
 namespace eosio { namespace client { namespace help {
-   bool print_help_text(const fc::exception& e);
+   bool print_help_text(const fc::exception& e, const bool show_error_trace);
 }}}

--- a/programs/eosioc/help_text.hpp
+++ b/programs/eosioc/help_text.hpp
@@ -6,5 +6,5 @@
 #include <fc/exception/exception.hpp>
 
 namespace eosio { namespace client { namespace help {
-   bool print_help_text(const fc::exception& e, const bool show_error_trace);
+   bool print_help_text(const fc::exception& e, const bool verbose_errors);
 }}}

--- a/programs/eosioc/main.cpp
+++ b/programs/eosioc/main.cpp
@@ -459,6 +459,8 @@ int main( int argc, char** argv ) {
 
    bool verbose_errors = false;
    app.add_flag( "-v,--verbose", verbose_errors, localized("output verbose actions on error"));
+   bool show_error_trace = false;
+   app.add_flag( "-t,--error-trace", show_error_trace, localized("output error stack trace"));
 
    auto version = app.add_subcommand("version", localized("Retrieve version information"), false);
    version->require_subcommand();
@@ -1006,7 +1008,7 @@ int main( int argc, char** argv ) {
          }
       } else {
          // attempt to extract the error code if one is present
-         if (verbose_errors || !print_help_text(e)) {
+         if (verbose_errors || !print_help_text(e, show_error_trace)) {
             elog("Failed with error: ${e}", ("e", verbose_errors ? e.to_detail_string() : e.to_string()));
          }
       }

--- a/programs/eosioc/main.cpp
+++ b/programs/eosioc/main.cpp
@@ -459,8 +459,6 @@ int main( int argc, char** argv ) {
 
    bool verbose_errors = false;
    app.add_flag( "-v,--verbose", verbose_errors, localized("output verbose actions on error"));
-   bool show_error_trace = false;
-   app.add_flag( "-t,--error-trace", show_error_trace, localized("output error stack trace"));
 
    auto version = app.add_subcommand("version", localized("Retrieve version information"), false);
    version->require_subcommand();
@@ -1008,7 +1006,7 @@ int main( int argc, char** argv ) {
          }
       } else {
          // attempt to extract the error code if one is present
-         if (verbose_errors || !print_help_text(e, show_error_trace)) {
+         if (!print_help_text(e, verbose_errors) && verbose_errors) {
             elog("Failed with error: ${e}", ("e", verbose_errors ? e.to_detail_string() : e.to_string()));
          }
       }


### PR DESCRIPTION
This is the first attempt of improving error that EOSIOC receives from RPC API call to be more verbose and meaningful.

This pull request changes the error sent by RPC API call from:
```
{
  "code": 500,
  "message": "Internal Service Error",
  "details": "3040000 action_validate_exception: message validation exception\nCannot create account named eosio, as that name is already taken\n    {\"name\":\"eosio\"}\n    thread-0  eosio_contract.cpp:79 apply_eosio_newaccount\n\n    {\"create\":{\"creator\":\"eosio\",\"name\":\"eosio\",\"owner\":{\"threshold\":1,\"accounts\":[],\"keys\":[{\"key\":\"EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV\",\"weight\":1}]},\"active\":{\"threshold\":1,\"accounts\":[],\"keys\":[{\"key\":\"EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV\",\"weight\":1}]},\"recovery\":{\"threshold\":1,\"accounts\":[{\"permission\":{\"actor\":\"eosio\",\"permission\":\"active\"},\"weight\":1}],\"keys\":[]}}}\n    thread-0  eosio_contract.cpp:104 apply_eosio_newaccount\n\n    {\"_pending_console_output.str()\":\"\"}\n    thread-0  apply_context.cpp:32 exec_one\n\n    {\"trx\":{\"signatures\":[\"EOSJuWLunf2SvsSppwNQLNRRvBWTuqUPbjiZwU46f2p1ByW1A5KSVHBYvBe129uZ3WjuynoxXewbp3iHnTzRRXvistMugaAa5\"],\"compression\":\"none\",\"data\":\"99d9935a0000ed0000b4ed210000000000010000000000ea305500409e9a2264b89a010000000000ea305500000000a8ed32327c0000000000ea30550000000000ea30550100000000010002c0ded2bc1f1305fb0faac5e6c03ee3a1924234985427b6167ca569d13df435cf01000100000000010002c0ded2bc1f1305fb0faac5e6c03ee3a1924234985427b6167ca569d13df435cf010001000000010000000000ea305500000000a8ed3232010000\"}}\n    thread-0  chain_controller.cpp:256 push_transaction"
}
```

to:
```
{
  "code": 500,
  "message": "Internal Service Error",
  "error": {
    "code": 3040000,
    "name": "action_validate_exception",
    "message": "message validation exception",
    "details": "Cannot create account named eosio, as that name is already taken",
    "stack_trace": [
      {
        "level": "error",
        "file": "eosio_contract.cpp",
        "line": 79,
        "method": "apply_eosio_newaccount",
        "hostname": "",
        "thread_name": "thread-0",
        "timestamp": "2018-02-26T10:06:26.728"
      },
      {
        "level": "warn",
        "file": "eosio_contract.cpp",
        "line": 104,
        "method": "apply_eosio_newaccount",
        "hostname": "",
        "thread_name": "thread-0",
        "timestamp": "2018-02-26T10:06:26.728"
      },
      {
        "level": "warn",
        "file": "apply_context.cpp",
        "line": 32,
        "method": "exec_one",
        "hostname": "",
        "thread_name": "thread-0",
        "timestamp": "2018-02-26T10:06:26.728"
      },
      {
        "level": "warn",
        "file": "chain_controller.cpp",
        "line": 256,
        "method": "push_transaction",
        "hostname": "",
        "thread_name": "thread-0",
        "timestamp": "2018-02-26T10:06:26.729"
      }
    ]
  }
}
```
(stack trace is limited to 10)

And change the eosioc displayed error message from:
![screen shot 2018-02-26 at 5 56 44 pm](https://user-images.githubusercontent.com/6541441/36664741-956d2da0-1b20-11e8-9ae7-35d0e066506e.png)
to:
![screen shot 2018-02-26 at 6 04 27 pm](https://user-images.githubusercontent.com/6541441/36664734-8e1cf382-1b20-11e8-9923-7c38e3942f73.png)

This PR currently only improves one error message returned by RPC API call. If there is no problem with this PR and it gets merged, another PR will be made to improve the remaining error messages in the list https://docs.google.com/spreadsheets/d/1ccnjnDbImkLaEG4qjD6VdjTJjwd5RRZPaGBp04rRqII/edit#gid=83425241. 
