### PR TITLE
Fix failing MacOS build

### DIFF
--- a/scripts/eosio_build_darwin.sh
+++ b/scripts/eosio_build_darwin.sh
@@ -193,9 +193,10 @@
 			printf "\tExiting now.\n\n"
 			exit;
 		fi
+		[ -d /usr/local/binaryen ] && sudo rm -r /usr/local/binaryen
 		sudo mkdir /usr/local/binaryen
 		sudo mv ${TEMP_DIR}/binaryen/bin /usr/local/binaryen
-		sudo ln -s /usr/local/binaryen/bin/* /usr/local
+		sudo ln -sf /usr/local/binaryen/bin/* /usr/local/bin
 		sudo rm -rf ${TEMP_DIR}/binaryen
 	else
 		printf "\tBinaryen found at /usr/local/binaryen/bin/\n"


### PR DESCRIPTION
This is already proposed by PR #871

> 3. deleting /usr/local/binaryen before copy, so that the script runs idempotently
> 4. link files under /usr/local/binaryen/bin to /usr/local/bin, instead of /usr/local (assuming that was a mistake)

However, this file contains the same error.

I found those who are experiencing the same problem in Issue #895.