### PR TITLE
Remove many useless cmake installs

### DIFF
--- a/libraries/abi_generator/CMakeLists.txt
+++ b/libraries/abi_generator/CMakeLists.txt
@@ -62,13 +62,3 @@ if (USE_PCH)
   set_target_properties(abi_generator PROPERTIES COTIRE_ADD_UNITY_BUILD FALSE)
   cotire(eos_utilities)
 endif(USE_PCH)
-
-install( TARGETS
-   abi_generator
-   RUNTIME DESTINATION bin
-   LIBRARY DESTINATION lib
-   ARCHIVE DESTINATION lib
-)
-
-install( FILES ${HEADERS} DESTINATION "include/eosio/abi_generator" )
-

--- a/libraries/chain/CMakeLists.txt
+++ b/libraries/chain/CMakeLists.txt
@@ -41,15 +41,6 @@ if(MSVC)
   set_source_files_properties( db_init.cpp db_block.cpp database.cpp block_log.cpp PROPERTIES COMPILE_FLAGS "/bigobj" )
 endif(MSVC)
 
-INSTALL( TARGETS
-   eosio_chain
-
-   RUNTIME DESTINATION bin
-   LIBRARY DESTINATION lib
-   ARCHIVE DESTINATION lib
-)
-INSTALL( FILES ${HEADERS} DESTINATION "include/eosio/chain" )
-
 add_subdirectory(test)
 
 #add_executable( test test.cpp )

--- a/libraries/egenesis/CMakeLists.txt
+++ b/libraries/egenesis/CMakeLists.txt
@@ -49,11 +49,3 @@ target_include_directories( eos_egenesis_brief
    PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" )
 target_include_directories( eos_egenesis_full
    PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" )
-
-INSTALL( TARGETS
-   embed_genesis eos_egenesis_none eos_egenesis_brief eos_egenesis_full
-
-   RUNTIME DESTINATION bin
-   LIBRARY DESTINATION lib
-   ARCHIVE DESTINATION lib
-)

--- a/libraries/testing/CMakeLists.txt
+++ b/libraries/testing/CMakeLists.txt
@@ -18,12 +18,3 @@ add_dependencies( eosio_testing test.system )
 if(MSVC)
   set_source_files_properties( db_init.cpp db_block.cpp database.cpp block_log.cpp PROPERTIES COMPILE_FLAGS "/bigobj" )
 endif(MSVC)
-
-INSTALL( TARGETS
-   eosio_testing
-
-   RUNTIME DESTINATION bin
-   LIBRARY DESTINATION lib
-   ARCHIVE DESTINATION lib
-)
-INSTALL( FILES ${HEADERS} DESTINATION "include/eos/chain" )

--- a/libraries/utilities/CMakeLists.txt
+++ b/libraries/utilities/CMakeLists.txt
@@ -30,12 +30,3 @@ if (USE_PCH)
   set_target_properties(eos_utilities PROPERTIES COTIRE_ADD_UNITY_BUILD FALSE)
   cotire(eos_utilities)
 endif(USE_PCH)
-
-install( TARGETS
-   eos_utilities
-
-   RUNTIME DESTINATION bin
-   LIBRARY DESTINATION lib
-   ARCHIVE DESTINATION lib
-)
-install( FILES ${HEADERS} DESTINATION "include/eos/utilities" )

--- a/plugins/account_history_api_plugin/CMakeLists.txt
+++ b/plugins/account_history_api_plugin/CMakeLists.txt
@@ -5,12 +5,3 @@ add_library( account_history_api_plugin
 
 target_link_libraries( account_history_api_plugin account_history_plugin chain_plugin http_plugin appbase )
 target_include_directories( account_history_api_plugin PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" )
-
-install( TARGETS
-   account_history_api_plugin
-
-   RUNTIME DESTINATION bin
-   LIBRARY DESTINATION lib
-   ARCHIVE DESTINATION lib
-)
-install( FILES ${HEADERS} DESTINATION "include/eos/account_history_api_plugin" )

--- a/plugins/account_history_plugin/CMakeLists.txt
+++ b/plugins/account_history_plugin/CMakeLists.txt
@@ -5,12 +5,3 @@ add_library( account_history_plugin
 
 target_link_libraries( account_history_plugin chain_plugin eosio_chain appbase )
 target_include_directories( account_history_plugin PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" )
-
-install( TARGETS
-   account_history_plugin
-
-   RUNTIME DESTINATION bin
-   LIBRARY DESTINATION lib
-   ARCHIVE DESTINATION lib
-)
-install( FILES ${HEADERS} DESTINATION "include/eos/account_history_plugin" )

--- a/plugins/chain_api_plugin/CMakeLists.txt
+++ b/plugins/chain_api_plugin/CMakeLists.txt
@@ -5,12 +5,3 @@ add_library( chain_api_plugin
 
 target_link_libraries( chain_api_plugin chain_plugin http_plugin appbase )
 target_include_directories( chain_api_plugin PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" )
-
-install( TARGETS
-   chain_api_plugin
-
-   RUNTIME DESTINATION bin
-   LIBRARY DESTINATION lib
-   ARCHIVE DESTINATION lib
-)
-install( FILES ${HEADERS} DESTINATION "include/eos/chain_api_plugin" )

--- a/plugins/chain_plugin/CMakeLists.txt
+++ b/plugins/chain_plugin/CMakeLists.txt
@@ -5,12 +5,3 @@ add_library( chain_plugin
 
 target_link_libraries( chain_plugin eosio_chain appbase )
 target_include_directories( chain_plugin PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" )
-
-install( TARGETS
-   chain_plugin
-
-   RUNTIME DESTINATION bin
-   LIBRARY DESTINATION lib
-   ARCHIVE DESTINATION lib
-)
-install( FILES ${HEADERS} DESTINATION "include/eos/chain_plugin" )

--- a/plugins/faucet_testnet_plugin/CMakeLists.txt
+++ b/plugins/faucet_testnet_plugin/CMakeLists.txt
@@ -5,12 +5,3 @@ add_library( faucet_testnet_plugin
 
 target_link_libraries( faucet_testnet_plugin appbase fc http_plugin chain_plugin )
 target_include_directories( faucet_testnet_plugin PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" )
-
-install( TARGETS
-   faucet_testnet_plugin
-
-   RUNTIME DESTINATION bin
-   LIBRARY DESTINATION lib
-   ARCHIVE DESTINATION lib
-)
-install( FILES ${HEADERS} DESTINATION "include/eosio/faucet_testnet_plugin" )

--- a/plugins/http_plugin/CMakeLists.txt
+++ b/plugins/http_plugin/CMakeLists.txt
@@ -5,12 +5,3 @@ add_library( http_plugin
 
 target_link_libraries( http_plugin appbase fc )
 target_include_directories( http_plugin PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" )
-
-install( TARGETS
-   http_plugin
-
-   RUNTIME DESTINATION bin
-   LIBRARY DESTINATION lib
-   ARCHIVE DESTINATION lib
-)
-install( FILES ${HEADERS} DESTINATION "include/eos/http_plugin" )

--- a/plugins/mongo_db_plugin/CMakeLists.txt
+++ b/plugins/mongo_db_plugin/CMakeLists.txt
@@ -63,15 +63,6 @@ if(BUILD_MONGO_DB_PLUGIN)
           PUBLIC chain_plugin eosio_chain appbase
           ${EOS_LIBMONGOCXX} ${EOS_LIBBSONCXX}
           )
-
-  install( TARGETS
-     mongo_db_plugin
-
-     RUNTIME DESTINATION bin
-     LIBRARY DESTINATION lib
-     ARCHIVE DESTINATION lib
-  )
-  install( FILES ${HEADERS} DESTINATION "include/eosio/mongo_db_plugin" )
 else()
   message("mongo_db_plugin not selected and will be omitted.")
 endif()

--- a/plugins/net_api_plugin/CMakeLists.txt
+++ b/plugins/net_api_plugin/CMakeLists.txt
@@ -5,12 +5,3 @@ add_library( net_api_plugin
 
 target_link_libraries( net_api_plugin net_plugin http_plugin appbase )
 target_include_directories( net_api_plugin PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" )
-
-install( TARGETS
-   net_api_plugin
-
-   RUNTIME DESTINATION bin
-   LIBRARY DESTINATION lib
-   ARCHIVE DESTINATION lib
-)
-install( FILES ${HEADERS} DESTINATION "include/eosio/net_api_plugin" )

--- a/plugins/net_plugin/CMakeLists.txt
+++ b/plugins/net_plugin/CMakeLists.txt
@@ -5,12 +5,3 @@ add_library( net_plugin
 
 target_link_libraries( net_plugin chain_plugin producer_plugin appbase fc )
 target_include_directories( net_plugin PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" )
-
-install( TARGETS
-   net_plugin
-
-   RUNTIME DESTINATION bin
-   LIBRARY DESTINATION lib
-   ARCHIVE DESTINATION lib
-)
-install( FILES ${HEADERS} DESTINATION "include/eosio/net_plugin" )

--- a/plugins/producer_plugin/CMakeLists.txt
+++ b/plugins/producer_plugin/CMakeLists.txt
@@ -8,11 +8,3 @@ add_library( producer_plugin
 target_link_libraries( producer_plugin chain_plugin appbase eosio_chain eos_utilities net_plugin )
 target_include_directories( producer_plugin
                             PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" )
-
-install( TARGETS
-   producer_plugin
-
-   RUNTIME DESTINATION bin
-   LIBRARY DESTINATION lib
-   ARCHIVE DESTINATION lib
-)

--- a/plugins/template_plugin/CMakeLists.txt
+++ b/plugins/template_plugin/CMakeLists.txt
@@ -5,12 +5,3 @@ add_library( template_plugin
 
 target_link_libraries( template_plugin appbase fc )
 target_include_directories( template_plugin PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" )
-
-install( TARGETS
-   template_plugin
-
-   RUNTIME DESTINATION bin
-   LIBRARY DESTINATION lib
-   ARCHIVE DESTINATION lib
-)
-install( FILES ${HEADERS} DESTINATION "include/eosio/template_plugin" )

--- a/plugins/txn_test_gen_plugin/CMakeLists.txt
+++ b/plugins/txn_test_gen_plugin/CMakeLists.txt
@@ -8,15 +8,4 @@ target_link_libraries( txn_test_gen_plugin appbase fc http_plugin chain_plugin )
 target_include_directories( txn_test_gen_plugin PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" )
 target_include_directories( txn_test_gen_plugin PUBLIC ${CMAKE_BINARY_DIR}/contracts )
 
-add_dependencies( txn_test_gen_plugin currency)
-
-install( TARGETS
-   txn_test_gen_plugin
-
-   RUNTIME DESTINATION bin
-   LIBRARY DESTINATION lib
-   ARCHIVE DESTINATION lib
-)
-install( FILES ${HEADERS} DESTINATION "include/eosio/txn_test_gen_plugin" )
-
 endif()

--- a/plugins/wallet_api_plugin/CMakeLists.txt
+++ b/plugins/wallet_api_plugin/CMakeLists.txt
@@ -5,12 +5,3 @@ add_library( wallet_api_plugin
 
 target_link_libraries( wallet_api_plugin wallet_plugin http_plugin appbase )
 target_include_directories( wallet_api_plugin PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" )
-
-install( TARGETS
-   wallet_api_plugin
-
-   RUNTIME DESTINATION bin
-   LIBRARY DESTINATION lib
-   ARCHIVE DESTINATION lib
-)
-install( FILES ${HEADERS} DESTINATION "include/eos/wallet_api_plugin" )

--- a/plugins/wallet_plugin/CMakeLists.txt
+++ b/plugins/wallet_plugin/CMakeLists.txt
@@ -7,12 +7,3 @@ add_library( wallet_plugin
 
 target_link_libraries( wallet_plugin eosio_chain appbase )
 target_include_directories( wallet_plugin PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" )
-
-install( TARGETS
-   wallet_plugin
-
-   RUNTIME DESTINATION bin
-   LIBRARY DESTINATION lib
-   ARCHIVE DESTINATION lib
-)
-install( FILES ${HEADERS} DESTINATION "include/eos/wallet_plugin" )


### PR DESCRIPTION
There are a bunch of files that get installed (via something like make install) that make absolutely no sense. No one can do anything useful with the static library to the net_plugin, for example. Removing all of the obvious offenders. I left stuff that still doesn't feel appropriate to me like fc and appbase. Technically those can be used standalone outside of eosio. Save those for a separate PR one day since it could be more contentious.