### PR TITLE
fixes for multi-node testing with the test.system contract

### DIFF
--- a/contracts/test.system/test.system.abi
+++ b/contracts/test.system/test.system.abi
@@ -19,15 +19,15 @@
       "name": "producer_key",
       "base": "",
       "fields": [
-        {"name":"account",    "type":"account_name"},
-        {"name":"public_key", "type":"string"}
+        {"name":"producer_name",      "type":"account_name"},
+        {"name":"signing_key",  "type":"public_key"}
       ]
     },{
       "name": "set_producers",
       "base": "",
       "fields": [
         {"name":"version",    "type":"uint32"},
-        {"name":"producer",   "type":"producer_key[]"}
+        {"name":"producers",   "type":"producer_key[]"}
       ]
     },{
       "name": "require_auth",

--- a/libraries/chain/chain_controller.cpp
+++ b/libraries/chain/chain_controller.cpp
@@ -1364,7 +1364,7 @@ account_name chain_controller::get_scheduled_producer(uint32_t slot_num)const
    uint64_t current_aslot = dpo.current_absolute_slot + slot_num;
    const auto& gpo = _db.get<global_property_object>();
    auto number_of_active_producers = gpo.active_producers.producers.size();
-   auto index = current_aslot % (number_of_active_producers);
+   auto index = current_aslot % (number_of_active_producers * config::producer_repititions);
    index /= config::producer_repititions;
    FC_ASSERT( gpo.active_producers.producers.size() > 0, "no producers defined" );
 

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2478,9 +2478,9 @@ namespace eosio {
    chain::public_key_type net_plugin_impl::get_authentication_key() const {
       if(!private_keys.empty())
          return private_keys.begin()->first;
-      producer_plugin* pp = app().find_plugin<producer_plugin>();
+      /*producer_plugin* pp = app().find_plugin<producer_plugin>();
       if(pp != nullptr && pp->get_state() == abstract_plugin::started)
-         return pp->first_producer_public_key();
+         return pp->first_producer_public_key();*/
       return chain::public_key_type();
    }
 


### PR DESCRIPTION
 * authentication keys were defaulting to the first producer key on a node if none was explicitly set however, the method of deriving this required that producer to be "active" creating a race condition for starting up a candidate producer node
 * `get_scheduled_producer` was not taking `config::producer_repititions` into account properly with its math, it is likely that we never had all of the producers working before
 * the ABI for `test.system` was not properly serializable for `setprods`