### PR TITLE
Temporary reduction of wasm memory to 2MB

### DIFF
--- a/libraries/chain/include/eosio/chain/wasm_eosio_constraints.hpp
+++ b/libraries/chain/include/eosio/chain/wasm_eosio_constraints.hpp
@@ -7,7 +7,7 @@ namespace IR {
 namespace eosio { namespace chain {
 
 namespace wasm_constraints {
-   constexpr unsigned maximum_linear_memory      = 33*1024*1024;//bytes
+   constexpr unsigned maximum_linear_memory      = 2*1024*1024;//bytes
    constexpr unsigned maximum_mutable_globals    = 1024;        //bytes
    constexpr unsigned maximum_table_elements     = 1024;        //elements
    constexpr unsigned maximum_linear_memory_init = 64*1024;     //bytes


### PR DESCRIPTION
I need this for #1452. The interpreter implementation is doing really spooky things when memory is much more than 2MB. I will have to refactor quite a bit of code to work around this issue and I'd like to do the work off small branches from trunk vs let #1452 continue on for another week or so.