### PR TITLE
DAWN 513 : Fix error message is not displayed at all when it’s not recognized and verbose_errors option is not used

### DIFF
--- a/programs/eosioc/help_text.cpp
+++ b/programs/eosioc/help_text.cpp
@@ -197,7 +197,7 @@ const std::map<int64_t, std::string> error_advice = {
 
 
 namespace eosio { namespace client { namespace help {
-bool print_recognized_error_code(const fc::exception& e, const bool verbose_errors) {
+bool print_recognized_errors(const fc::exception& e, const bool verbose_errors) {
    // eos recognized error code is from 3000000 to 3999999
    // refer to libraries/chain/include/eosio/chain/exceptions.hpp
    if (e.code() >= 3000000 && e.code() <= 3999999) {
@@ -239,9 +239,7 @@ bool print_recognized_error_code(const fc::exception& e, const bool verbose_erro
    return false;
 }
 
-bool print_help_text(const fc::exception& e, const bool verbose_errors) {
-   // Check if the exception has recognized error code
-   if (print_recognized_error_code(e, verbose_errors)) return true;
+bool print_help_text(const fc::exception& e) {
    bool result = false;
    // Large input strings to std::regex can cause SIGSEGV, this is a known bug in libstdc++.
    // See https://stackoverflow.com/questions/36304204/%D0%A1-regex-segfault-on-long-sequences

--- a/programs/eosioc/help_text.hpp
+++ b/programs/eosioc/help_text.hpp
@@ -6,5 +6,6 @@
 #include <fc/exception/exception.hpp>
 
 namespace eosio { namespace client { namespace help {
-   bool print_help_text(const fc::exception& e, const bool verbose_errors);
+   bool print_recognized_errors(const fc::exception& e, const bool verbose_errors);
+   bool print_help_text(const fc::exception& e);
 }}}

--- a/programs/eosioc/httpc.cpp
+++ b/programs/eosioc/httpc.cpp
@@ -136,6 +136,6 @@ fc::variant call( const std::string& server, uint16_t port,
     }
 
     FC_ASSERT( !"unable to connect" );
-  } FC_RETHROW_EXCEPTIONS( error, "Request Path: ${server}:${port}${path}\n  Request Post Data: ${postdata}}" ,
+  } FC_RETHROW_EXCEPTIONS( error, "Request Path: ${server}:${port}${path}, Request Post Data: ${postdata}" ,
                            ("server", server)("port", port)("path", path)("postdata", postdata) )
 }

--- a/programs/eosioc/main.cpp
+++ b/programs/eosioc/main.cpp
@@ -1006,8 +1006,11 @@ int main( int argc, char** argv ) {
          }
       } else {
          // attempt to extract the error code if one is present
-         if (!print_help_text(e, verbose_errors) && verbose_errors) {
-            elog("Failed with error: ${e}", ("e", verbose_errors ? e.to_detail_string() : e.to_string()));
+         if (!print_recognized_errors(e, verbose_errors)) {
+            // Error is not recognized
+            if (!print_help_text(e) || verbose_errors) {
+               elog("Failed with error: ${e}", ("e", verbose_errors ? e.to_detail_string() : e.to_string()));
+            }
          }
       }
       return 1;


### PR DESCRIPTION
The improvement made in PR 1477 doesn't take into account the case where error is not recognized by `print_help_text` function and -v (verbose errors option) is not used

Second PR for DAWN-513