### PR TITLE
Issue #1495, fix for TB capacity drives

### DIFF
--- a/scripts/eosio_build_darwin.sh
+++ b/scripts/eosio_build_darwin.sh
@@ -8,8 +8,12 @@
 	CPU_SPEED=`bc <<< "scale=2; ($(sysctl -in hw.cpufrequency) / 100000000) / 10"`
 	CPU_CORE=$( sysctl -in machdep.cpu.core_count )
 
-	DISK_TOTAL=`df -H $PWD | grep /dev | tr -s ' ' | cut -d\  -f2 | sed 's/[^0-9]//'`
-	DISK_AVAIL=`df -H $PWD | grep /dev | tr -s ' ' | cut -d\  -f4 | sed 's/[^0-9]//'`
+	blksize=`df . | head -1 | awk '{print $2}' | cut -d- -f1`
+	gbfactor=$(( 1073741824 / $blksize ))
+	total_blks=`df . | tail -1 | awk '{print $2}'`
+	avail_blks=`df . | tail -1 | awk '{print $4}'`
+	DISK_TOTAL=$(($total_blks / $gbfactor ))
+	DISK_AVAIL=$(($avail_blks / $gbfactor ))
 
 	printf "\n\tOS name: $ARCH\n"
 	printf "\tOS Version: ${OS_VER}\n"


### PR DESCRIPTION
compute the disk capacity based on block sizes and counts so that terabyte capacity drives do not break the script. This only addresses macos builds.