### PR TITLE
DAWN 646 - Fix problem where validation fails when creating new permission

### DIFF
--- a/libraries/chain/contracts/eosio_contract.cpp
+++ b/libraries/chain/contracts/eosio_contract.cpp
@@ -181,14 +181,15 @@ void apply_eosio_updateauth(apply_context& context) {
       if (act_auth.permission == config::owner_name || act_auth.permission == update.permission) {
          return true;
       }
+      const permission_object *current = db.find<permission_object, by_owner>(boost::make_tuple(update.account, update.permission));
+      // Permission doesn't exist yet
+      if (current == nullptr) return true;
 
-      auto current = db.get<permission_object, by_owner>(boost::make_tuple(update.account, update.permission));
-      while(current.name != config::owner_name) {
-         if (current.name == act_auth.permission) {
+      while(current->name != config::owner_name) {
+         if (current->name == act_auth.permission) {
             return true;
          }
-
-         current = db.get<permission_object>(current.parent);
+         current = &db.get<permission_object>(current->parent);
       }
 
       return false;

--- a/libraries/chain/contracts/eosio_contract.cpp
+++ b/libraries/chain/contracts/eosio_contract.cpp
@@ -182,8 +182,12 @@ void apply_eosio_updateauth(apply_context& context) {
          return true;
       }
       const permission_object *current = db.find<permission_object, by_owner>(boost::make_tuple(update.account, update.permission));
-      // Permission doesn't exist yet
-      if (current == nullptr) return true;
+      // Permission doesn't exist yet, check parent permission
+      if (current == nullptr) current = db.find<permission_object, by_owner>(boost::make_tuple(update.account, update.parent));
+      // Ensure either the permission or parent's permission exists
+      EOS_ASSERT(current != nullptr, permission_query_exception,
+                 "Fail to retrieve permission for: {\"actor\": \"${actor}\", \"permission\": \"${permission}\" }",
+                 ("actor", update.account)("permission", update.parent));
 
       while(current->name != config::owner_name) {
          if (current->name == act_auth.permission) {

--- a/libraries/chain/include/eosio/chain/exceptions.hpp
+++ b/libraries/chain/include/eosio/chain/exceptions.hpp
@@ -22,6 +22,8 @@ namespace eosio { namespace chain {
    FC_DECLARE_DERIVED_EXCEPTION( unknown_block_exception,           eosio::chain::chain_exception, 3110000, "unknown block" )
    FC_DECLARE_DERIVED_EXCEPTION( chain_type_exception,              eosio::chain::chain_exception, 3120000, "chain type exception" )
 
+   FC_DECLARE_DERIVED_EXCEPTION( permission_query_exception,        eosio::chain::database_query_exception, 3010001, "permission query exception" )
+
    FC_DECLARE_DERIVED_EXCEPTION( block_tx_output_exception,         eosio::chain::block_validate_exception, 3020001, "transaction outputs in block do not match transaction outputs from applying block" )
    FC_DECLARE_DERIVED_EXCEPTION( block_concurrency_exception,       eosio::chain::block_validate_exception, 3020002, "block does not guarantee concurrent exection without conflicts" )
    FC_DECLARE_DERIVED_EXCEPTION( block_lock_exception,              eosio::chain::block_validate_exception, 3020003, "shard locks in block are incorrect or mal-formed" )


### PR DESCRIPTION
Inside the current updateauth action handler, the code tries to retrieve existing permission inside database using db.get function. Since the given permission name doesn't exist yet in the blockchain, this function which will always throw an error. This causes user to be unable to create new permission using updateauth action