### PR TITLE
DAWN-513 - Improve eosioc error message for 404 unknown endpoint

### DIFF
--- a/libraries/chain/include/eosio/chain/exceptions.hpp
+++ b/libraries/chain/include/eosio/chain/exceptions.hpp
@@ -21,6 +21,7 @@ namespace eosio { namespace chain {
    FC_DECLARE_DERIVED_EXCEPTION( black_swan_exception,              eosio::chain::chain_exception, 3100000, "black swan" )
    FC_DECLARE_DERIVED_EXCEPTION( unknown_block_exception,           eosio::chain::chain_exception, 3110000, "unknown block" )
    FC_DECLARE_DERIVED_EXCEPTION( chain_type_exception,              eosio::chain::chain_exception, 3120000, "chain type exception" )
+   FC_DECLARE_DERIVED_EXCEPTION( missing_plugin_exception,          eosio::chain::chain_exception, 3130000, "missing plugin exception" )
 
    FC_DECLARE_DERIVED_EXCEPTION( block_tx_output_exception,         eosio::chain::block_validate_exception, 3020001, "transaction outputs in block do not match transaction outputs from applying block" )
    FC_DECLARE_DERIVED_EXCEPTION( block_concurrency_exception,       eosio::chain::block_validate_exception, 3020002, "block does not guarantee concurrent exection without conflicts" )
@@ -59,6 +60,11 @@ namespace eosio { namespace chain {
    FC_DECLARE_DERIVED_EXCEPTION( action_type_exception,             eosio::chain::chain_type_exception, 3120004, "Invalid action" )
    FC_DECLARE_DERIVED_EXCEPTION( transaction_type_exception,        eosio::chain::chain_type_exception, 3120005, "Invalid transaction" )
    FC_DECLARE_DERIVED_EXCEPTION( abi_type_exception,                eosio::chain::chain_type_exception, 3120006, "Invalid ABI" )
+
+   FC_DECLARE_DERIVED_EXCEPTION( missing_chain_api_plugin_exception,                 eosio::chain::missing_plugin_exception, 3130001, "Missing Chain API Plugin" )
+   FC_DECLARE_DERIVED_EXCEPTION( missing_wallet_api_plugin_exception,                eosio::chain::missing_plugin_exception, 3130002, "Missing Wallet API Plugin" )
+   FC_DECLARE_DERIVED_EXCEPTION( missing_account_history_api_plugin_exception,       eosio::chain::missing_plugin_exception, 3130003, "Missing Account History API Plugin" )
+   FC_DECLARE_DERIVED_EXCEPTION( missing_net_api_plugin_exception,                   eosio::chain::missing_plugin_exception, 3130003, "Missing Net API Plugin" )
 
 
    #define EOS_RECODE_EXC( cause_type, effect_type ) \

--- a/programs/eosioc/help_text.cpp
+++ b/programs/eosioc/help_text.cpp
@@ -183,7 +183,13 @@ e.g.
   }]
 })=====";
 
-const char* error_advice_3030002 =  R"=====(Ensure that you have the related private keys inside your wallet)=====";
+const char* error_advice_3030002 =  "Ensure that you have the related private keys inside your wallet.";
+
+const char* error_advice_3130001 =  "Ensure that you have \033[2meosio::chain_api_plugin\033[0m\033[32m added to your node's configuration.";
+const char* error_advice_3130002 =  "Ensure that you have \033[2meosio::wallet_api_plugin\033[0m\033[32m added to your node's configuration.\n"\
+                                    "Otherwise specify your wallet location with \033[2m--wallet-host\033[0m\033[32m and \033[2m--wallet_port\033[0m\033[32m arguments.";
+const char* error_advice_3130003 =  "Ensure that you have \033[2meosio::account_history_api_plugin\033[0m\033[32m added to your node's configuration.";
+const char* error_advice_3130004 =  "Ensure that you have \033[2meosio::net_api_plugin\033[0m\033[32m added to your node's configuration";
 
 const std::map<int64_t, std::string> error_advice = {
    { 3120001, error_advice_3120001 },
@@ -192,6 +198,10 @@ const std::map<int64_t, std::string> error_advice = {
    { 3120004, error_advice_3120004 },
    { 3120005, error_advice_3120005 },
    { 3120006, error_advice_3120006 },
+   { 3130001, error_advice_3130001 },
+   { 3130002, error_advice_3130002 },
+   { 3130003, error_advice_3130003 },
+   { 3130004, error_advice_3130004 },
    { 3030002, error_advice_3030002 }
 };
 

--- a/programs/eosioc/httpc.cpp
+++ b/programs/eosioc/httpc.cpp
@@ -15,127 +15,135 @@
 #include <boost/asio.hpp>
 #include <fc/variant.hpp>
 #include <fc/io/json.hpp>
-#include <fc/exception/exception.hpp>
+#include <eosio/chain/exceptions.hpp>
 #include <eosio/http_plugin/http_plugin.hpp>
 #include <eosio/chain_plugin/chain_plugin.hpp>
+#include "httpc.hpp"
 
 using boost::asio::ip::tcp;
+namespace eosio { namespace client { namespace http {
+   fc::variant call( const std::string& server, uint16_t port,
+                     const std::string& path,
+                     const fc::variant& postdata ) {
+   try {
+      std::string postjson;
+      if( !postdata.is_null() )
+         postjson = fc::json::to_string( postdata );
 
-fc::variant call( const std::string& server, uint16_t port, 
-                  const std::string& path,
-                  const fc::variant& postdata ) 
-{ try {
-    std::string postjson;
-    if( !postdata.is_null() )
-       postjson = fc::json::to_string( postdata );
+      boost::asio::io_service io_service;
 
-    boost::asio::io_service io_service;
+      // Get a list of endpoints corresponding to the server name.
+      tcp::resolver resolver(io_service);
+      tcp::resolver::query query(server, std::to_string(port) );
+      tcp::resolver::iterator endpoint_iterator = resolver.resolve(query);
+      tcp::resolver::iterator end;
 
-    // Get a list of endpoints corresponding to the server name.
-    tcp::resolver resolver(io_service);
-    tcp::resolver::query query(server, std::to_string(port) );
-    tcp::resolver::iterator endpoint_iterator = resolver.resolve(query);
-    tcp::resolver::iterator end;
+      while( endpoint_iterator != end ) {
+         // Try each endpoint until we successfully establish a connection.
+         tcp::socket socket(io_service);
+         try {
+            boost::asio::connect(socket, endpoint_iterator);
+            endpoint_iterator = end;
+         } catch( std::exception& e ) {
+            ++endpoint_iterator;
+            if( endpoint_iterator != end )
+               continue;
+            else throw;
+         }
 
-    while( endpoint_iterator != end ) {
-       // Try each endpoint until we successfully establish a connection.
-       tcp::socket socket(io_service);
-       try {
-          boost::asio::connect(socket, endpoint_iterator);
-          endpoint_iterator = end;
-       } catch( std::exception& e ) {
-          ++endpoint_iterator;
-          if( endpoint_iterator != end )
-             continue;
-          else throw;
-       }
+         // Form the request. We specify the "Connection: close" header so that the
+         // server will close the socket after transmitting the response. This will
+         // allow us to treat all data up until the EOF as the content.
+         boost::asio::streambuf request;
+         std::ostream request_stream(&request);
+         request_stream << "POST " << path << " HTTP/1.0\r\n";
+         request_stream << "Host: " << server << "\r\n";
+         request_stream << "content-length: " << postjson.size() << "\r\n";
+         request_stream << "Accept: */*\r\n";
+         request_stream << "Connection: close\r\n\r\n";
+         request_stream << postjson;
 
-       // Form the request. We specify the "Connection: close" header so that the
-       // server will close the socket after transmitting the response. This will
-       // allow us to treat all data up until the EOF as the content.
-       boost::asio::streambuf request;
-       std::ostream request_stream(&request);
-       request_stream << "POST " << path << " HTTP/1.0\r\n";
-       request_stream << "Host: " << server << "\r\n";
-       request_stream << "content-length: " << postjson.size() << "\r\n";
-       request_stream << "Accept: */*\r\n";
-       request_stream << "Connection: close\r\n\r\n";
-       request_stream << postjson;
+         // Send the request.
+         boost::asio::write(socket, request);
 
-       // Send the request.
-       boost::asio::write(socket, request);
+         // Read the response status line. The response streambuf will automatically
+         // grow to accommodate the entire line. The growth may be limited by passing
+         // a maximum size to the streambuf constructor.
+         boost::asio::streambuf response;
+         boost::asio::read_until(socket, response, "\r\n");
 
-       // Read the response status line. The response streambuf will automatically
-       // grow to accommodate the entire line. The growth may be limited by passing
-       // a maximum size to the streambuf constructor.
-       boost::asio::streambuf response;
-       boost::asio::read_until(socket, response, "\r\n");
+         // Check that response is OK.
+         std::istream response_stream(&response);
+         std::string http_version;
+         response_stream >> http_version;
+         unsigned int status_code;
+         response_stream >> status_code;
+         std::string status_message;
+         std::getline(response_stream, status_message);
+         FC_ASSERT( !(!response_stream || http_version.substr(0, 5) != "HTTP/"), "Invalid Response" );
 
-       // Check that response is OK.
-       std::istream response_stream(&response);
-       std::string http_version;
-       response_stream >> http_version;
-       unsigned int status_code;
-       response_stream >> status_code;
-       std::string status_message;
-       std::getline(response_stream, status_message);
-       FC_ASSERT( !(!response_stream || http_version.substr(0, 5) != "HTTP/"), "Invalid Response" );
+         // Read the response headers, which are terminated by a blank line.
+         boost::asio::read_until(socket, response, "\r\n\r\n");
 
-       // Read the response headers, which are terminated by a blank line.
-       boost::asio::read_until(socket, response, "\r\n\r\n");
+         // Process the response headers.
+         std::string header;
+         while (std::getline(response_stream, header) && header != "\r")
+         {
+         //      std::cout << header << "\n";
+         }
+         //      std::cout << "\n";
 
-       // Process the response headers.
-       std::string header;
-       while (std::getline(response_stream, header) && header != "\r")
-       {
-//         std::cout << header << "\n";
-       }
- //      std::cout << "\n";
+         std::stringstream re;
+         // Write whatever content we already have to output.
+         if (response.size() > 0)
+            //   std::cout << &response;
+            re << &response;
 
-       std::stringstream re;
-       // Write whatever content we already have to output.
-       if (response.size() > 0)
-      //   std::cout << &response;
-         re << &response;
+         // Read until EOF, writing data to output as we go.
+         boost::system::error_code error;
+         while (boost::asio::read(socket, response,
+                                  boost::asio::transfer_at_least(1), error))
+            re << &response;
 
-       // Read until EOF, writing data to output as we go.
-       boost::system::error_code error;
-       while (boost::asio::read(socket, response,
-             boost::asio::transfer_at_least(1), error))
-          re << &response;
+         if (error != boost::asio::error::eof)
+            throw boost::system::system_error(error);
 
-       if (error != boost::asio::error::eof)
-         throw boost::system::system_error(error);
+         //  std::cout << re.str() <<"\n";
+         const auto response_result = fc::json::from_string(re.str());
+         if( status_code == 200 || status_code == 201 || status_code == 202 ) {
+            return response_result;
+         } else if( status_code == 404 ) {
+            // Unknown endpoint
+            if (path.compare(0, chain_func_base.size(), chain_func_base) == 0) {
+               throw chain::missing_chain_api_plugin_exception(FC_LOG_MESSAGE(error, "Chain API plugin is not enabled"));
+            } else if (path.compare(0, wallet_func_base.size(), wallet_func_base) == 0) {
+               throw chain::missing_wallet_api_plugin_exception(FC_LOG_MESSAGE(error, "Wallet is not available"));
+            } else if (path.compare(0, account_history_func_base.size(), account_history_func_base) == 0) {
+               throw chain::missing_account_history_api_plugin_exception(FC_LOG_MESSAGE(error, "Account History API plugin is not enabled"));
+            } else if (path.compare(0, net_func_base.size(), net_func_base) == 0) {
+               throw chain::missing_net_api_plugin_exception(FC_LOG_MESSAGE(error, "Net API plugin is not enabled"));
+            }
+         } else {
+            auto &&error = response_result.as<eosio::error_results>().error;
+            // Construct fc exception from error
+            const auto &stack_trace = error.stack_trace;
+            fc::exception new_exception(error.code, error.name, error.message);
+            if (stack_trace.empty()) {
+               new_exception.append_log(FC_LOG_MESSAGE(error, error.details));
+            } else {
+               for (auto itr = stack_trace.begin(); itr != stack_trace.end(); itr++) {
+                  const auto &error_message = itr == stack_trace.begin() ? error.details : std::string();
+                  new_exception.append_log(fc::log_message(*itr, error_message));
+               }
+            }
+            throw new_exception;
+         }
 
-     //  std::cout << re.str() <<"\n";
-       const auto response_result = fc::json::from_string(re.str());
-       if( status_code == 200 || status_code == 201 || status_code == 202 ) {
-          return response_result;
-       } else {
-          auto &&error = response_result.as<eosio::error_results>().error;
+         FC_ASSERT( status_code == 200, "Error code ${c}\n: ${msg}\n", ("c", status_code)("msg", re.str()) );
+      }
 
-          // eos recognized error code is from 3000000 to 3999999
-          // refer to libraries/chain/include/eosio/chain/exceptions.hpp
-          if (error.code >= 3000000 && error.code <= 3999999) {
-             // Construct fc exception from error
-             const auto &stack_trace = error.stack_trace;
-             fc::exception new_exception(error.code, error.name, error.message);
-             if (stack_trace.empty()) {
-                new_exception.append_log(FC_LOG_MESSAGE(error, error.details));
-             } else {
-                for (auto itr = stack_trace.begin(); itr != stack_trace.end(); itr++) {
-                   const auto &error_message = itr == stack_trace.begin() ? error.details : std::string();
-                   new_exception.append_log(fc::log_message(*itr, error_message));
-                }
-             }
-             throw new_exception;
-          }
-       }
-
-       FC_ASSERT( status_code == 200, "Error code ${c}\n: ${msg}\n", ("c", status_code)("msg", re.str()) );
-    }
-
-    FC_ASSERT( !"unable to connect" );
-  } FC_RETHROW_EXCEPTIONS( error, "Request Path: ${server}:${port}${path}, Request Post Data: ${postdata}" ,
-                           ("server", server)("port", port)("path", path)("postdata", postdata) )
-}
+      FC_ASSERT( !"unable to connect" );
+   } FC_RETHROW_EXCEPTIONS( error, "Request Path: ${server}:${port}${path}, Request Post Data: ${postdata}" ,
+                            ("server", server)("port", port)("path", path)("postdata", postdata) )
+   }
+}}}

--- a/programs/eosioc/httpc.hpp
+++ b/programs/eosioc/httpc.hpp
@@ -1,0 +1,49 @@
+/**
+ *  @file
+ *  @copyright defined in eos/LICENSE.txt
+ */
+#pragma once
+
+namespace eosio { namespace client { namespace http {
+   fc::variant call( const std::string& server, uint16_t port,
+                     const std::string& path,
+                     const fc::variant& postdata = fc::variant() );
+
+   const string chain_func_base = "/v1/chain";
+   const string get_info_func = chain_func_base + "/get_info";
+   const string push_txn_func = chain_func_base + "/push_transaction";
+   const string push_txns_func = chain_func_base + "/push_transactions";
+   const string json_to_bin_func = chain_func_base + "/abi_json_to_bin";
+   const string get_block_func = chain_func_base + "/get_block";
+   const string get_account_func = chain_func_base + "/get_account";
+   const string get_table_func = chain_func_base + "/get_table_rows";
+   const string get_code_func = chain_func_base + "/get_code";
+   const string get_currency_balance_func = chain_func_base + "/get_currency_balance";
+   const string get_currency_stats_func = chain_func_base + "/get_currency_stats";
+   const string get_required_keys = chain_func_base + "/get_required_keys";
+
+   const string account_history_func_base = "/v1/account_history";
+   const string get_transaction_func = account_history_func_base + "/get_transaction";
+   const string get_transactions_func = account_history_func_base + "/get_transactions";
+   const string get_key_accounts_func = account_history_func_base + "/get_key_accounts";
+   const string get_controlled_accounts_func = account_history_func_base + "/get_controlled_accounts";
+
+   const string net_func_base = "/v1/net";
+   const string net_connect = net_func_base + "/connect";
+   const string net_disconnect = net_func_base + "/disconnect";
+   const string net_status = net_func_base + "/status";
+   const string net_connections = net_func_base + "/connections";
+
+
+   const string wallet_func_base = "/v1/wallet";
+   const string wallet_create = wallet_func_base + "/create";
+   const string wallet_open = wallet_func_base + "/open";
+   const string wallet_list = wallet_func_base + "/list_wallets";
+   const string wallet_list_keys = wallet_func_base + "/list_keys";
+   const string wallet_public_keys = wallet_func_base + "/get_public_keys";
+   const string wallet_lock = wallet_func_base + "/lock";
+   const string wallet_lock_all = wallet_func_base + "/lock_all";
+   const string wallet_unlock = wallet_func_base + "/unlock";
+   const string wallet_import_key = wallet_func_base + "/import_key";
+   const string wallet_sign_trx = wallet_func_base + "/sign_transaction";
+ }}}

--- a/programs/eosioc/main.cpp
+++ b/programs/eosioc/main.cpp
@@ -95,12 +95,14 @@ Options:
 #include "help_text.hpp"
 #include "localize.hpp"
 #include "config.hpp"
+#include "httpc.hpp"
 
 using namespace std;
 using namespace eosio;
 using namespace eosio::chain;
 using namespace eosio::utilities;
 using namespace eosio::client::help;
+using namespace eosio::client::http;
 using namespace eosio::client::localize;
 using namespace eosio::client::config;
 using namespace boost::filesystem;
@@ -126,43 +128,6 @@ uint32_t port = 8888;
 string wallet_host = "localhost";
 uint32_t wallet_port = 8888;
 
-const string chain_func_base = "/v1/chain";
-const string get_info_func = chain_func_base + "/get_info";
-const string push_txn_func = chain_func_base + "/push_transaction";
-const string push_txns_func = chain_func_base + "/push_transactions";
-const string json_to_bin_func = chain_func_base + "/abi_json_to_bin";
-const string get_block_func = chain_func_base + "/get_block";
-const string get_account_func = chain_func_base + "/get_account";
-const string get_table_func = chain_func_base + "/get_table_rows";
-const string get_code_func = chain_func_base + "/get_code";
-const string get_currency_balance_func = chain_func_base + "/get_currency_balance";
-const string get_currency_stats_func = chain_func_base + "/get_currency_stats";
-const string get_required_keys = chain_func_base + "/get_required_keys";
-
-const string account_history_func_base = "/v1/account_history";
-const string get_transaction_func = account_history_func_base + "/get_transaction";
-const string get_transactions_func = account_history_func_base + "/get_transactions";
-const string get_key_accounts_func = account_history_func_base + "/get_key_accounts";
-const string get_controlled_accounts_func = account_history_func_base + "/get_controlled_accounts";
-
-const string net_func_base = "/v1/net";
-const string net_connect = net_func_base + "/connect";
-const string net_disconnect = net_func_base + "/disconnect";
-const string net_status = net_func_base + "/status";
-const string net_connections = net_func_base + "/connections";
-
-
-const string wallet_func_base = "/v1/wallet";
-const string wallet_create = wallet_func_base + "/create";
-const string wallet_open = wallet_func_base + "/open";
-const string wallet_list = wallet_func_base + "/list_wallets";
-const string wallet_list_keys = wallet_func_base + "/list_keys";
-const string wallet_public_keys = wallet_func_base + "/get_public_keys";
-const string wallet_lock = wallet_func_base + "/lock";
-const string wallet_lock_all = wallet_func_base + "/lock_all";
-const string wallet_unlock = wallet_func_base + "/unlock";
-const string wallet_import_key = wallet_func_base + "/import_key";
-const string wallet_sign_trx = wallet_func_base + "/sign_transaction";
 
 inline std::vector<name> sort_names( const std::vector<name>& names ) {
    auto results = std::vector<name>(names);
@@ -244,19 +209,14 @@ vector<chain::permission_level> get_account_permissions(const vector<string>& pe
    return accountPermissions;
 }
 
-fc::variant call( const std::string& server, uint16_t port,
-                  const std::string& path,
-                  const fc::variant& postdata = fc::variant() );
-
-
 template<typename T>
 fc::variant call( const std::string& server, uint16_t port,
                   const std::string& path,
-                  const T& v ) { return call( server, port, path, fc::variant(v) ); }
+                  const T& v ) { return eosio::client::http::call( server, port, path, fc::variant(v) ); }
 
 template<typename T>
 fc::variant call( const std::string& path,
-                  const T& v ) { return call( host, port, path, fc::variant(v) ); }
+                  const T& v ) { return eosio::client::http::call( host, port, path, fc::variant(v) ); }
 
 eosio::chain_apis::read_only::get_info_results get_info() {
   return call(host, port, get_info_func ).as<eosio::chain_apis::read_only::get_info_results>();


### PR DESCRIPTION
This is part of incremental pull request for DAWN-513 (3rd PR)

Improve eosioc error message for 404 unknown endpoint.
It now changes from 
<img width="915" alt="screen shot 2018-03-02 at 3 40 00 pm" src="https://user-images.githubusercontent.com/6541441/36888727-c4bc0e32-1e31-11e8-95b6-f3c58108aad5.png">
to
<img width="712" alt="screen shot 2018-03-02 at 3 51 18 pm" src="https://user-images.githubusercontent.com/6541441/36888732-caaf115e-1e31-11e8-8123-5ca3fad8b240.png">

Introduction of namespace causes changes in indentation. This PR also extracts RPC URLs out from main.cpp and move them to httpc.hpp so it can be referred by httpc.cpp.