### PR TITLE
Minor fix to exchange contract

### DIFF
--- a/contracts/exchange/exchange.cpp
+++ b/contracts/exchange/exchange.cpp
@@ -3,7 +3,7 @@
 extern "C" {
     /// The apply method implements the dispatch of events to this contract
     void apply( uint64_t code, uint64_t act ) {
-          typedef eosio::generic_currency< eosio::token<N(eosio.system),S(4,EOS)> > eos;
+          typedef eosio::generic_currency< eosio::token<N(eosio),S(4,EOS)> > eos;
           typedef eosio::generic_currency< eosio::token<N(currency),S(4,CUR)> >     cur;
 
           exchange<N(exchange), S(4,EXC), eos, cur>::apply( code, act );

--- a/contracts/exchange/exchange.hpp
+++ b/contracts/exchange/exchange.hpp
@@ -80,7 +80,7 @@ class exchange {
 
       account_index_type       _accounts;
       limit_base_quote_index   _base_quote_orders;
-      limit_base_quote_index   _quote_base_orders;
+      limit_quote_base_index   _quote_base_orders;
 
       exchange()
       :_accounts( ExchangeAccount, ExchangeAccount ),


### PR DESCRIPTION
Fix quote_base_orders type
Fix system account name for EOS token

Use the same as in eosio.system
https://github.com/EOSIO/eos/blob/317606da15730c3c413d9b7ed8507934c14ae320/contracts/eosio.system/eosio.system.cpp#L15