### PR TITLE
Improve eosioc error message for get, set, wallet, push subcommand

### DIFF
--- a/libraries/chain/chain_controller.cpp
+++ b/libraries/chain/chain_controller.cpp
@@ -1090,7 +1090,7 @@ const producer_object& chain_controller::get_producer(const account_name& owner_
 const permission_object&   chain_controller::get_permission( const permission_level& level )const
 { try {
    return _db.get<permission_object, by_owner>( boost::make_tuple(level.actor,level.permission) );
-} FC_CAPTURE_AND_RETHROW( (level) ) }
+} EOS_CAPTURE_AND_RETHROW( chain::permission_query_exception, "Fail to retrieve permission: ${level}", ("level", level) ) }
 
 uint32_t chain_controller::last_irreversible_block_num() const {
    return get_dynamic_global_properties().last_irreversible_block_num;

--- a/libraries/chain/contracts/abi_serializer.cpp
+++ b/libraries/chain/contracts/abi_serializer.cpp
@@ -294,7 +294,7 @@ namespace eosio { namespace chain { namespace contracts {
             }
             else {
                /// TODO: default construct field and write it out
-               FC_ASSERT( !"missing field in variant object", "Missing '${f}' in variant object", ("f",field.name) );
+               FC_THROW( "Missing '${f}' in variant object", ("f",field.name) );
             }
          }
       }

--- a/libraries/chain/contracts/eosio_contract.cpp
+++ b/libraries/chain/contracts/eosio_contract.cpp
@@ -246,9 +246,15 @@ void apply_eosio_linkauth(apply_context& context) {
    context.require_authorization(requirement.account);
    
    auto& db = context.mutable_db;
-   db.get<account_object, by_name>(requirement.account);
-   db.get<account_object, by_name>(requirement.code);
-   db.get<permission_object, by_name>(requirement.requirement);
+   const auto *account = db.find<account_object, by_name>(requirement.account);
+   EOS_ASSERT(account != nullptr, account_query_exception,
+              "Fail to retrieve account: ${account}", ("account", requirement.account));
+   const auto *code = db.find<account_object, by_name>(requirement.code);
+   EOS_ASSERT(code != nullptr, account_query_exception,
+              "Fail to retrieve code for account: ${account}", ("account", requirement.code));
+   const auto *permission = db.find<permission_object, by_name>(requirement.requirement);
+   EOS_ASSERT(permission != nullptr, permission_query_exception,
+              "Fail to retrieve permission: ${permission}", ("permission", requirement.requirement));
    
    auto link_key = boost::make_tuple(requirement.account, requirement.code, requirement.type);
    auto link = db.find<permission_link_object, by_action_name>(link_key);

--- a/libraries/chain/include/eosio/chain/contracts/abi_serializer.hpp
+++ b/libraries/chain/include/eosio/chain/contracts/abi_serializer.hpp
@@ -6,7 +6,7 @@
 #include <eosio/chain/contracts/types.hpp>
 #include <eosio/chain/transaction.hpp>
 #include <eosio/chain/block.hpp>
-
+#include <eosio/chain/exceptions.hpp>
 #include <fc/variant_object.hpp>
 
 namespace eosio { namespace chain { namespace contracts {
@@ -303,8 +303,8 @@ namespace impl {
       static void extract( const variant& v, action& act, Resolver resolver )
       {
          const variant_object& vo = v.get_object();
-         FC_ASSERT(vo.contains("account"));
-         FC_ASSERT(vo.contains("name"));
+         EOS_ASSERT(vo.contains("account"), packed_transaction_type_exception, "Missing account");
+         EOS_ASSERT(vo.contains("name"), packed_transaction_type_exception, "Missing name");
          from_variant(vo["account"], act.account);
          from_variant(vo["name"], act.name);
 
@@ -334,14 +334,15 @@ namespace impl {
             }
          }
 
-         FC_ASSERT(!act.data.empty(), "Failed to deserialize data for ${account}:${name}", ("account", act.account)("name", act.name));
+         EOS_ASSERT(!act.data.empty(), packed_transaction_type_exception,
+                    "Failed to deserialize data for ${account}:${name}", ("account", act.account)("name", act.name));
       }
 
       template<typename Resolver>
       static void extract( const variant& v, packed_transaction& ptrx, Resolver resolver ) {
          const variant_object& vo = v.get_object();
-         FC_ASSERT(vo.contains("signatures"));
-         FC_ASSERT(vo.contains("compression"));
+         EOS_ASSERT(vo.contains("signatures"), packed_transaction_type_exception, "Missing signatures");
+         EOS_ASSERT(vo.contains("compression"), packed_transaction_type_exception, "Missing compression");
          from_variant(vo["signatures"], ptrx.signatures);
          if ( vo.contains("context_free_data")) {
             from_variant(vo["context_free_data"], ptrx.context_free_data);
@@ -351,7 +352,7 @@ namespace impl {
          if (vo.contains("hex_data") && vo["hex_data"].is_string() && !vo["hex_data"].as_string().empty()) {
             from_variant(vo["hex_data"], ptrx.data);
          } else {
-            FC_ASSERT(vo.contains("data"));
+            EOS_ASSERT(vo.contains("data"), packed_transaction_type_exception, "Missing data");
             if (vo["data"].is_string()) {
                from_variant(vo["data"], ptrx.data);
             } else {

--- a/libraries/chain/include/eosio/chain/exceptions.hpp
+++ b/libraries/chain/include/eosio/chain/exceptions.hpp
@@ -27,6 +27,7 @@ namespace eosio { namespace chain {
    FC_DECLARE_DERIVED_EXCEPTION( permission_query_exception,        eosio::chain::database_query_exception, 3010001, "Permission Query Exception" )
    FC_DECLARE_DERIVED_EXCEPTION( account_query_exception,           eosio::chain::database_query_exception, 3010002, "Account Query Exception" )
    FC_DECLARE_DERIVED_EXCEPTION( contract_table_query_exception,    eosio::chain::database_query_exception, 3010003, "Contract Table Query Exception" )
+   FC_DECLARE_DERIVED_EXCEPTION( contract_query_exception,          eosio::chain::database_query_exception, 3010004, "Contract Query Exception" )
 
    FC_DECLARE_DERIVED_EXCEPTION( block_tx_output_exception,         eosio::chain::block_validate_exception, 3020001, "transaction outputs in block do not match transaction outputs from applying block" )
    FC_DECLARE_DERIVED_EXCEPTION( block_concurrency_exception,       eosio::chain::block_validate_exception, 3020002, "block does not guarantee concurrent exection without conflicts" )
@@ -51,9 +52,14 @@ namespace eosio { namespace chain {
    FC_DECLARE_DERIVED_EXCEPTION( tx_msgs_auth_exceeded,             eosio::chain::transaction_exception, 3030018, "Number of transaction messages per authorized account has been exceeded" )
    FC_DECLARE_DERIVED_EXCEPTION( tx_msgs_code_exceeded,             eosio::chain::transaction_exception, 3030019, "Number of transaction messages per code account has been exceeded" )
    FC_DECLARE_DERIVED_EXCEPTION( wasm_execution_error,              eosio::chain::transaction_exception, 3030020, "Runtime Error Processing WASM" )
-   FC_DECLARE_DERIVED_EXCEPTION( tx_decompression_error,            eosio::chain::transaction_exception, 3030020, "Error decompressing transaction" )
+   FC_DECLARE_DERIVED_EXCEPTION( tx_decompression_error,            eosio::chain::transaction_exception, 3030021, "Error decompressing transaction" )
+   FC_DECLARE_DERIVED_EXCEPTION( expired_tx_exception,              eosio::chain::transaction_exception, 3030022, "Expired Transaction" )
+   FC_DECLARE_DERIVED_EXCEPTION( tx_exp_too_far_exception,          eosio::chain::transaction_exception, 3030023, "Transaction Expiration Too Far" )
+   FC_DECLARE_DERIVED_EXCEPTION( invalid_ref_block_exception,       eosio::chain::transaction_exception, 3030024, "Invalid Reference Block" )
+   FC_DECLARE_DERIVED_EXCEPTION( tx_apply_exception,                eosio::chain::transaction_exception, 3030025, "Transaction Apply Exception" )
 
    FC_DECLARE_DERIVED_EXCEPTION( account_name_exists_exception,     eosio::chain::action_validate_exception, 3040001, "account name already exists" )
+   FC_DECLARE_DERIVED_EXCEPTION( invalid_action_args_exception,       eosio::chain::action_validate_exception, 3040002, "Invalid Action Arguments" )
    FC_DECLARE_DERIVED_EXCEPTION( invalid_pts_address,               eosio::chain::utility_exception, 3060001, "invalid pts address" )
    FC_DECLARE_DERIVED_EXCEPTION( insufficient_feeds,                eosio::chain::chain_exception, 37006, "insufficient feeds" )
 
@@ -68,6 +74,7 @@ namespace eosio { namespace chain {
    FC_DECLARE_DERIVED_EXCEPTION( abi_type_exception,                eosio::chain::chain_type_exception, 3120007, "Invalid ABI" )
    FC_DECLARE_DERIVED_EXCEPTION( block_id_type_exception,           eosio::chain::chain_type_exception, 3120008, "Invalid block ID" )
    FC_DECLARE_DERIVED_EXCEPTION( transaction_id_type_exception,     eosio::chain::chain_type_exception, 3120009, "Invalid transaction ID" )
+   FC_DECLARE_DERIVED_EXCEPTION( packed_transaction_type_exception, eosio::chain::chain_type_exception, 3120010, "Invalid packed transaction" )
 
    FC_DECLARE_DERIVED_EXCEPTION( asset_type_exception,     eosio::chain::chain_type_exception, 3120011, "Invalid asset" )
 

--- a/libraries/chain/include/eosio/chain/exceptions.hpp
+++ b/libraries/chain/include/eosio/chain/exceptions.hpp
@@ -75,8 +75,7 @@ namespace eosio { namespace chain {
    FC_DECLARE_DERIVED_EXCEPTION( block_id_type_exception,           eosio::chain::chain_type_exception, 3120008, "Invalid block ID" )
    FC_DECLARE_DERIVED_EXCEPTION( transaction_id_type_exception,     eosio::chain::chain_type_exception, 3120009, "Invalid transaction ID" )
    FC_DECLARE_DERIVED_EXCEPTION( packed_transaction_type_exception, eosio::chain::chain_type_exception, 3120010, "Invalid packed transaction" )
-
-   FC_DECLARE_DERIVED_EXCEPTION( asset_type_exception,     eosio::chain::chain_type_exception, 3120011, "Invalid asset" )
+   FC_DECLARE_DERIVED_EXCEPTION( asset_type_exception,              eosio::chain::chain_type_exception, 3120011, "Invalid asset" )
 
    FC_DECLARE_DERIVED_EXCEPTION( missing_chain_api_plugin_exception,                 eosio::chain::missing_plugin_exception, 3130001, "Missing Chain API Plugin" )
    FC_DECLARE_DERIVED_EXCEPTION( missing_wallet_api_plugin_exception,                eosio::chain::missing_plugin_exception, 3130002, "Missing Wallet API Plugin" )

--- a/libraries/chain/include/eosio/chain/exceptions.hpp
+++ b/libraries/chain/include/eosio/chain/exceptions.hpp
@@ -22,8 +22,11 @@ namespace eosio { namespace chain {
    FC_DECLARE_DERIVED_EXCEPTION( unknown_block_exception,           eosio::chain::chain_exception, 3110000, "unknown block" )
    FC_DECLARE_DERIVED_EXCEPTION( chain_type_exception,              eosio::chain::chain_exception, 3120000, "chain type exception" )
    FC_DECLARE_DERIVED_EXCEPTION( missing_plugin_exception,          eosio::chain::chain_exception, 3130000, "missing plugin exception" )
+   FC_DECLARE_DERIVED_EXCEPTION( wallet_exception,                  eosio::chain::chain_exception, 3140000, "wallet exception" )
 
-   FC_DECLARE_DERIVED_EXCEPTION( permission_query_exception,        eosio::chain::database_query_exception, 3010001, "permission query exception" )
+   FC_DECLARE_DERIVED_EXCEPTION( permission_query_exception,        eosio::chain::database_query_exception, 3010001, "Permission Query Exception" )
+   FC_DECLARE_DERIVED_EXCEPTION( account_query_exception,           eosio::chain::database_query_exception, 3010002, "Account Query Exception" )
+   FC_DECLARE_DERIVED_EXCEPTION( contract_table_query_exception,    eosio::chain::database_query_exception, 3010003, "Contract Table Query Exception" )
 
    FC_DECLARE_DERIVED_EXCEPTION( block_tx_output_exception,         eosio::chain::block_validate_exception, 3020001, "transaction outputs in block do not match transaction outputs from applying block" )
    FC_DECLARE_DERIVED_EXCEPTION( block_concurrency_exception,       eosio::chain::block_validate_exception, 3020002, "block does not guarantee concurrent exection without conflicts" )
@@ -58,16 +61,26 @@ namespace eosio { namespace chain {
 
    FC_DECLARE_DERIVED_EXCEPTION( name_type_exception,               eosio::chain::chain_type_exception, 3120001, "Invalid name" )
    FC_DECLARE_DERIVED_EXCEPTION( public_key_type_exception,         eosio::chain::chain_type_exception, 3120002, "Invalid public key" )
-   FC_DECLARE_DERIVED_EXCEPTION( authority_type_exception,          eosio::chain::chain_type_exception, 3120003, "Invalid authority" )
-   FC_DECLARE_DERIVED_EXCEPTION( action_type_exception,             eosio::chain::chain_type_exception, 3120004, "Invalid action" )
-   FC_DECLARE_DERIVED_EXCEPTION( transaction_type_exception,        eosio::chain::chain_type_exception, 3120005, "Invalid transaction" )
-   FC_DECLARE_DERIVED_EXCEPTION( abi_type_exception,                eosio::chain::chain_type_exception, 3120006, "Invalid ABI" )
-   FC_DECLARE_DERIVED_EXCEPTION( asset_type_exception,              eosio::chain::chain_type_exception, 3120007, "Invalid asset" )
+   FC_DECLARE_DERIVED_EXCEPTION( private_key_type_exception,        eosio::chain::chain_type_exception, 3120003, "Invalid private key" )
+   FC_DECLARE_DERIVED_EXCEPTION( authority_type_exception,          eosio::chain::chain_type_exception, 3120004, "Invalid authority" )
+   FC_DECLARE_DERIVED_EXCEPTION( action_type_exception,             eosio::chain::chain_type_exception, 3120005, "Invalid action" )
+   FC_DECLARE_DERIVED_EXCEPTION( transaction_type_exception,        eosio::chain::chain_type_exception, 3120006, "Invalid transaction" )
+   FC_DECLARE_DERIVED_EXCEPTION( abi_type_exception,                eosio::chain::chain_type_exception, 3120007, "Invalid ABI" )
+   FC_DECLARE_DERIVED_EXCEPTION( block_id_type_exception,           eosio::chain::chain_type_exception, 3120008, "Invalid block ID" )
+   FC_DECLARE_DERIVED_EXCEPTION( transaction_id_type_exception,     eosio::chain::chain_type_exception, 3120009, "Invalid transaction ID" )
+
+   FC_DECLARE_DERIVED_EXCEPTION( asset_type_exception,     eosio::chain::chain_type_exception, 3120011, "Invalid asset" )
 
    FC_DECLARE_DERIVED_EXCEPTION( missing_chain_api_plugin_exception,                 eosio::chain::missing_plugin_exception, 3130001, "Missing Chain API Plugin" )
    FC_DECLARE_DERIVED_EXCEPTION( missing_wallet_api_plugin_exception,                eosio::chain::missing_plugin_exception, 3130002, "Missing Wallet API Plugin" )
    FC_DECLARE_DERIVED_EXCEPTION( missing_account_history_api_plugin_exception,       eosio::chain::missing_plugin_exception, 3130003, "Missing Account History API Plugin" )
-   FC_DECLARE_DERIVED_EXCEPTION( missing_net_api_plugin_exception,                   eosio::chain::missing_plugin_exception, 3130003, "Missing Net API Plugin" )
+   FC_DECLARE_DERIVED_EXCEPTION( missing_net_api_plugin_exception,                   eosio::chain::missing_plugin_exception, 3130004, "Missing Net API Plugin" )
+
+   FC_DECLARE_DERIVED_EXCEPTION( wallet_exist_exception,            eosio::chain::wallet_exception, 3140001, "Wallet already exists" )
+   FC_DECLARE_DERIVED_EXCEPTION( wallet_nonexistent_exception,      eosio::chain::wallet_exception, 3140002, "Nonexistent wallet" )
+   FC_DECLARE_DERIVED_EXCEPTION( wallet_locked_exception,           eosio::chain::wallet_exception, 3140003, "Locked wallet" )
+   FC_DECLARE_DERIVED_EXCEPTION( wallet_missing_pub_key_exception,  eosio::chain::wallet_exception, 3140004, "Missing public key" )
+   FC_DECLARE_DERIVED_EXCEPTION( wallet_invalid_password_exception, eosio::chain::wallet_exception, 3140005, "Invalid wallet password" )
 
 
    #define EOS_RECODE_EXC( cause_type, effect_type ) \

--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -191,7 +191,7 @@ namespace eosio { namespace testing {
          :expected(expected)
       {}
 
-      bool operator()( const fc::assert_exception& ex ) {
+      bool operator()( const fc::exception& ex ) {
          auto message = ex.get_log().at(0).get_message();
          return boost::algorithm::ends_with(message, expected);
       }

--- a/libraries/utilities/include/eosio/utilities/exception_macros.hpp
+++ b/libraries/utilities/include/eosio/utilities/exception_macros.hpp
@@ -8,6 +8,9 @@
       FC_THROW_EXCEPTION( exc_type, FORMAT, __VA_ARGS__ );            \
    FC_MULTILINE_MACRO_END
 
+#define EOS_THROW( exc_type, FORMAT, ... ) \
+    throw exc_type( FC_LOG_MESSAGE( error, FORMAT, __VA_ARGS__ ) );
+
 #define EOS_CAPTURE_AND_RETHROW(exc_type, FORMAT, ... ) \
    catch (fc::exception& e) { \
       exc_type new_exception(FC_LOG_MESSAGE( error, FORMAT, __VA_ARGS__ )); \
@@ -15,7 +18,14 @@
          new_exception.append_log(log); \
       } \
       throw new_exception; \
-   } 
+   } catch( const std::exception& e ) {  \
+      exc_type fce(FC_LOG_MESSAGE( warn, FORMAT" (${what})" ,__VA_ARGS__("what",e.what()))); \
+      throw fce;\
+   } catch( ... ) {  \
+      throw fc::unhandled_exception( \
+                FC_LOG_MESSAGE( warn, FORMAT,__VA_ARGS__), \
+                std::current_exception() ); \
+   }
 
 
 #define EOS_DECLARE_OP_BASE_EXCEPTIONS( op_name )                \

--- a/libraries/utilities/include/eosio/utilities/exception_macros.hpp
+++ b/libraries/utilities/include/eosio/utilities/exception_macros.hpp
@@ -11,15 +11,22 @@
 #define EOS_THROW( exc_type, FORMAT, ... ) \
     throw exc_type( FC_LOG_MESSAGE( error, FORMAT, __VA_ARGS__ ) );
 
-#define EOS_CAPTURE_AND_RETHROW(exc_type, FORMAT, ... ) \
-   catch (fc::exception& e) { \
-      exc_type new_exception(FC_LOG_MESSAGE( error, FORMAT, __VA_ARGS__ )); \
+/**
+ * Macro inspired from FC_RETHROW_EXCEPTIONS
+ * The main difference here is that if the exception caught isn't of type "eosio::chain::chain_exception"
+ * This macro will rethrow the exception as the specified "exception_type"
+ */
+#define EOS_RETHROW_EXCEPTIONS(exception_type, FORMAT, ... ) \
+   catch (eosio::chain::chain_exception& e) { \
+      FC_RETHROW_EXCEPTION( e, warn, FORMAT, __VA_ARGS__ ); \
+   } catch (fc::exception& e) { \
+      exception_type new_exception(FC_LOG_MESSAGE( warn, FORMAT, __VA_ARGS__ )); \
       for (const auto& log: e.get_log()) { \
          new_exception.append_log(log); \
       } \
       throw new_exception; \
    } catch( const std::exception& e ) {  \
-      exc_type fce(FC_LOG_MESSAGE( warn, FORMAT" (${what})" ,__VA_ARGS__("what",e.what()))); \
+      exception_type fce(FC_LOG_MESSAGE( warn, FORMAT" (${what})" ,__VA_ARGS__("what",e.what()))); \
       throw fce;\
    } catch( ... ) {  \
       throw fc::unhandled_exception( \
@@ -27,6 +34,28 @@
                 std::current_exception() ); \
    }
 
+/**
+ * Macro inspired from FC_CAPTURE_AND_RETHROW
+ * The main difference here is that if the exception caught isn't of type "eosio::chain::chain_exception"
+ * This macro will rethrow the exception as the specified "exception_type"
+ */
+#define EOS_CAPTURE_AND_RETHROW( exception_type, ... ) \
+   catch (eosio::chain::chain_exception& e) { \
+      FC_RETHROW_EXCEPTION( e, warn, "", FC_FORMAT_ARG_PARAMS(__VA_ARGS__) ); \
+   } catch (fc::exception& e) { \
+      exception_type new_exception(e.get_log()); \
+      throw new_exception; \
+   } catch( const std::exception& e ) {  \
+      exception_type fce( \
+                FC_LOG_MESSAGE( warn, "${what}: ",FC_FORMAT_ARG_PARAMS(__VA_ARGS__)("what",e.what())), \
+                fc::std_exception_code,\
+                BOOST_CORE_TYPEID(decltype(e)).name(), \
+                e.what() ) ; throw fce;\
+   } catch( ... ) {  \
+      throw fc::unhandled_exception( \
+                FC_LOG_MESSAGE( warn, "",FC_FORMAT_ARG_PARAMS(__VA_ARGS__)), \
+                std::current_exception() ); \
+   }
 
 #define EOS_DECLARE_OP_BASE_EXCEPTIONS( op_name )                \
    FC_DECLARE_DERIVED_EXCEPTION(                                      \

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -381,7 +381,7 @@ fc::variant read_only::get_block(const read_only::get_block_params& params) cons
          block = db.fetch_block_by_number(fc::to_uint64(params.block_num_or_id));
       }
 
-   } EOS_CAPTURE_AND_RETHROW(chain::block_id_type_exception, "Invalid block ID: ${block_num_or_id}", ("block_num_or_id", params.block_num_or_id))
+   } EOS_RETHROW_EXCEPTIONS(chain::block_id_type_exception, "Invalid block ID: ${block_num_or_id}", ("block_num_or_id", params.block_num_or_id))
 
    if (!block)
       FC_THROW_EXCEPTION(unknown_block_exception,
@@ -408,7 +408,7 @@ read_write::push_transaction_results read_write::push_transaction(const read_wri
    auto resolver = make_resolver(this);
    try {
       abi_serializer::from_variant(params, pretty_input, resolver);
-   } EOS_CAPTURE_AND_RETHROW(chain::packed_transaction_type_exception, "Invalid packed transaction")
+   } EOS_RETHROW_EXCEPTIONS(chain::packed_transaction_type_exception, "Invalid packed transaction")
 
    auto result = db.push_transaction(pretty_input, skip_flags);
 #warning TODO: get transaction results asynchronously
@@ -493,7 +493,7 @@ read_only::abi_json_to_bin_result read_only::abi_json_to_bin( const read_only::a
       abi_serializer abis( abi );
       try {
          result.binargs = abis.variant_to_binary(abis.get_action_type(params.action), params.args);
-      } EOS_CAPTURE_AND_RETHROW(chain::invalid_action_args_exception,
+      } EOS_RETHROW_EXCEPTIONS(chain::invalid_action_args_exception,
                                 "'${args}' is invalid args for action '${action}' code '${code}'",
                                 ("args", params.args)("action", params.action)("code", params.code))
    }

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -288,11 +288,8 @@ read_only::get_info_results read_only::get_info(const read_only::get_info_params
 
 abi_def get_abi( const chain_controller& db, const name& account ) {
    const auto &d = db.get_database();
-   const account_object *code_accnt = nullptr;
-   try {
-      code_accnt = &d.get<account_object, by_name>(account);
-      FC_ASSERT(code_accnt != nullptr);
-   } EOS_CAPTURE_AND_RETHROW( chain::account_query_exception, "Fail to retrive account for ${account}", ("account", account) )
+   const account_object *code_accnt = d.find<account_object, by_name>(account);
+   EOS_ASSERT(code_accnt != nullptr, chain::account_query_exception, "Fail to retrieve account for ${account}", ("account", account) );
    abi_def abi;
    abi_serializer::to_abi(code_accnt->abi, abi);
    return abi;

--- a/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
@@ -81,36 +81,48 @@ namespace eosio {
     * @brief Structure used to create JSON error responses
     */
    struct error_results {
-      struct error_detail {
+      uint16_t code;
+      string message;
+
+      struct error_info {
          int64_t code;
          string name;
-         string message;
-         string details;
-         vector<fc::log_context> stack_trace;
+         string what;
 
-         static const uint8_t stack_trace_limit = 10;
+         struct error_detail {
+            string message;
+            string file;
+            uint64_t line_number;
+            string method;
+         };
 
-         error_detail() {};
+         vector<error_detail> details;
 
-         error_detail(const fc::exception& exc) {
+         static const uint8_t details_limit = 10;
+
+         error_info() {};
+
+         error_info(const fc::exception& exc) {
             code = exc.code();
             name = exc.name();
-            message = exc.what();
-            details = exc.top_message();
+            what = exc.what();
             for (auto itr = exc.get_log().begin(); itr != exc.get_log().end(); ++itr) {
                // Prevent sending trace that are too big
-               if (stack_trace.size() >= stack_trace_limit) break;
-               // Append context
-               stack_trace.emplace_back(itr->get_context());
+               if (details.size() >= details_limit) break;
+               // Append error
+               error_detail detail = {
+                       itr->get_message(), itr->get_context().get_file(),
+                       itr->get_context().get_line_number(), itr->get_context().get_method()
+               };
+               details.emplace_back(detail);
             }
          }
       };
 
-      uint16_t code;
-      string message;
-      error_detail error;
+      error_info error;
    };
 }
 
-FC_REFLECT(eosio::error_results::error_detail, (code)(name)(message)(details)(stack_trace))
+FC_REFLECT(eosio::error_results::error_info::error_detail, (message)(file)(line_number)(method))
+FC_REFLECT(eosio::error_results::error_info, (code)(name)(what)(details))
 FC_REFLECT(eosio::error_results, (code)(message)(error))

--- a/plugins/wallet_plugin/wallet.cpp
+++ b/plugins/wallet_plugin/wallet.cpp
@@ -24,6 +24,8 @@
 #ifndef WIN32
 # include <sys/types.h>
 # include <sys/stat.h>
+#include <eosio/chain/exceptions.hpp>
+
 #endif
 
 namespace eosio { namespace wallet {
@@ -295,7 +297,8 @@ void wallet_api::unlock(string password)
    FC_ASSERT(pk.checksum == pw);
    my->_keys = std::move(pk.keys);
    my->_checksum = pk.checksum;
-} FC_CAPTURE_AND_RETHROW() }
+} EOS_CAPTURE_AND_RETHROW(chain::wallet_invalid_password_exception,
+                          "Invalid password for wallet: \"${wallet_name}\"", ("wallet_name", get_wallet_filename())) }
 
 void wallet_api::set_password( string password )
 {

--- a/plugins/wallet_plugin/wallet.cpp
+++ b/plugins/wallet_plugin/wallet.cpp
@@ -297,7 +297,7 @@ void wallet_api::unlock(string password)
    FC_ASSERT(pk.checksum == pw);
    my->_keys = std::move(pk.keys);
    my->_checksum = pk.checksum;
-} EOS_CAPTURE_AND_RETHROW(chain::wallet_invalid_password_exception,
+} EOS_RETHROW_EXCEPTIONS(chain::wallet_invalid_password_exception,
                           "Invalid password for wallet: \"${wallet_name}\"", ("wallet_name", get_wallet_filename())) }
 
 void wallet_api::set_password( string password )

--- a/plugins/wallet_plugin/wallet_manager.cpp
+++ b/plugins/wallet_plugin/wallet_manager.cpp
@@ -3,7 +3,7 @@
  *  @copyright defined in eos/LICENSE.txt
  */
 #include <eosio/wallet_plugin/wallet_manager.hpp>
-
+#include <eosio/chain/exceptions.hpp>
 namespace eosio {
 namespace wallet {
 
@@ -38,7 +38,7 @@ std::string wallet_manager::create(const std::string& name) {
    auto wallet_filename = dir / (name + file_ext);
 
    if (fc::exists(wallet_filename)) {
-      FC_THROW("Wallet with name: '${n}' already exists at ${path}", ("n", name)("path",fc::path(wallet_filename)));
+      EOS_THROW(chain::wallet_exist_exception, "Wallet with name: '${n}' already exists at ${path}", ("n", name)("path",fc::path(wallet_filename)));
    }
 
    wallet_data d;
@@ -68,7 +68,7 @@ void wallet_manager::open(const std::string& name) {
    auto wallet_filename = dir / (name + file_ext);
    wallet->set_wallet_filename(wallet_filename.string());
    if (!wallet->load_wallet_file()) {
-      FC_THROW("Unable to open file: ${f}", ("f", wallet_filename.string()));
+      EOS_THROW(chain::wallet_nonexistent_exception, "Unable to open file: ${f}", ("f", wallet_filename.string()));
    }
 
    // If we have name in our map then remove it since we want the emplace below to replace.
@@ -134,7 +134,7 @@ void wallet_manager::lock_all() {
 void wallet_manager::lock(const std::string& name) {
    check_timeout();
    if (wallets.count(name) == 0) {
-      FC_THROW("Wallet not found: ${w}", ("w", name));
+      EOS_THROW(chain::wallet_nonexistent_exception, "Wallet not found: ${w}", ("w", name));
    }
    auto& w = wallets.at(name);
    if (w->is_locked()) {
@@ -158,11 +158,11 @@ void wallet_manager::unlock(const std::string& name, const std::string& password
 void wallet_manager::import_key(const std::string& name, const std::string& wif_key) {
    check_timeout();
    if (wallets.count(name) == 0) {
-      FC_THROW("Wallet not found: ${w}", ("w", name));
+      EOS_THROW(chain::wallet_nonexistent_exception, "Wallet not found: ${w}", ("w", name));
    }
    auto& w = wallets.at(name);
    if (w->is_locked()) {
-      FC_THROW("Wallet is locked: ${w}", ("w", name));
+      EOS_THROW(chain::wallet_locked_exception, "Wallet is locked: ${w}", ("w", name));
    }
    w->import_key(wif_key);
 }
@@ -185,7 +185,7 @@ wallet_manager::sign_transaction(const chain::signed_transaction& txn, const fla
          }
       }
       if (!found) {
-         FC_THROW("Public key not found in unlocked wallets ${k}", ("k", pk));
+         EOS_THROW(chain::wallet_missing_pub_key_exception, "Public key not found in unlocked wallets ${k}", ("k", pk));
       }
    }
 

--- a/programs/cleos/help_text.cpp
+++ b/programs/cleos/help_text.cpp
@@ -97,11 +97,16 @@ auto smatch_to_variant(const std::smatch& smatch) {
    return result;
 };
 
+const char* error_advice_3010001 =  "Most likely, the given account/ permission doesn't exist in the blockchain.";
+const char* error_advice_3010002 =  "Most likely, the given account doesn't exist in the blockchain.";
+const char* error_advice_3010003 =  "Most likely, the given table doesnt' exist in the blockchain.";
+
+const char* error_advice_3030002 =  "Ensure that you have the related private keys inside your wallet and you wallet is unlocked.";
+
 const char* error_advice_3120001 = R"=====(Name should be less than 13 characters and only contains the following symbol .12345abcdefghijklmnopqrstuvwxyz)=====";
-
 const char* error_advice_3120002 = R"=====(Public key should be encoded in base58 and starts with EOS prefix)=====";
-
-const char* error_advice_3120003 = R"=====(Ensure that your authority JSON follows the following format!
+const char* error_advice_3120003 = R"=====(Private key should be encoded in base58 WIF)=====";
+const char* error_advice_3120004 = R"=====(Ensure that your authority JSON follows the following format!
 {
   "threshold":"uint32_t",
   "keys":[{ "key":"public_key", "weight":"uint16_t" }],
@@ -119,10 +124,8 @@ e.g.
     "weight":"1
   }]
 })=====";
-
-const char* error_advice_3120004 = R"=====(Ensure that your action JSON follows the contract's abi!)=====";
-
-const char* error_advice_3120005 = R"=====(Ensure that your transaction JSON follows the following format!\n"
+const char* error_advice_3120005 = R"=====(Ensure that your action JSON follows the contract's abi!)=====";
+const char* error_advice_3120006 = R"=====(Ensure that your transaction JSON follows the following format!\n"
 {
   "ref_block_num":"uint16_t",
   "ref_block_prefix":"uint32_t",
@@ -152,8 +155,7 @@ e.g.
     "data":"000000008093dd74000000000094dd74e80300000000000000"
   }]
 })=====";
-
-const char* error_advice_3120006 =  R"=====(Ensure that your abi JSON follows the following format!
+const char* error_advice_3120007 =  R"=====(Ensure that your abi JSON follows the following format!
 {
   "types" : [{ "new_type_name":"type_name", "type":"type_name" }],
   "structs" : [{ "name":"type_name", "base":"type_name", "fields": [{ "name":"field_name", "type": "type_name" }] }],
@@ -182,27 +184,49 @@ e.g.
     "type":"foobar" "
   }]
 })=====";
+const char* error_advice_3120008 =  "Ensure that the block ID is a SHA-256 hexadecimal string!";
+const char* error_advice_3120009 =  "Ensure that the transaction ID is a SHA-256 hexadecimal string!";
 
-const char* error_advice_3030002 =  "Ensure that you have the related private keys inside your wallet.";
+const char* error_advice_3130001 =  "Ensure that you have \033[2meosio::chain_api_plugin\033[0m\033[32m added to your node's configuration!";
+const char* error_advice_3130002 =  "Ensure that you have \033[2meosio::wallet_api_plugin\033[0m\033[32m added to your node's configuration!\n"\
+                                    "Otherwise specify your wallet location with \033[2m--wallet-host\033[0m\033[32m and \033[2m--wallet_port\033[0m\033[32m arguments!";
+const char* error_advice_3130003 =  "Ensure that you have \033[2meosio::account_history_api_plugin\033[0m\033[32m added to your node's configuration!";
+const char* error_advice_3130004 =  "Ensure that you have \033[2meosio::net_api_plugin\033[0m\033[32m added to your node's configuration!";
 
-const char* error_advice_3130001 =  "Ensure that you have \033[2meosio::chain_api_plugin\033[0m\033[32m added to your node's configuration.";
-const char* error_advice_3130002 =  "Ensure that you have \033[2meosio::wallet_api_plugin\033[0m\033[32m added to your node's configuration.\n"\
-                                    "Otherwise specify your wallet location with \033[2m--wallet-host\033[0m\033[32m and \033[2m--wallet_port\033[0m\033[32m arguments.";
-const char* error_advice_3130003 =  "Ensure that you have \033[2meosio::account_history_api_plugin\033[0m\033[32m added to your node's configuration.";
-const char* error_advice_3130004 =  "Ensure that you have \033[2meosio::net_api_plugin\033[0m\033[32m added to your node's configuration";
+const char* error_advice_3140001 =  "Try to use different wallet name.";
+const char* error_advice_3140002 =  "Are you sure you typed the name correctly?";
+const char* error_advice_3140003 =  "Ensure that your wallet is unlocked before using it!";
+const char* error_advice_3140004 =  "Ensure that you have the relevant private key imported!";
+const char* error_advice_3140005 =  "Are you sure you are using the right password?";
+
 
 const std::map<int64_t, std::string> error_advice = {
+   { 3010001, error_advice_3010001 },
+   { 3010002, error_advice_3010002 },
+   { 3010003, error_advice_3010003 },
+
+   { 3030002, error_advice_3030002 },
+
    { 3120001, error_advice_3120001 },
    { 3120002, error_advice_3120002 },
    { 3120003, error_advice_3120003 },
    { 3120004, error_advice_3120004 },
    { 3120005, error_advice_3120005 },
    { 3120006, error_advice_3120006 },
+   { 3120007, error_advice_3120007 },
+   { 3120008, error_advice_3120008 },
+   { 3120009, error_advice_3120008 },
+
    { 3130001, error_advice_3130001 },
    { 3130002, error_advice_3130002 },
    { 3130003, error_advice_3130003 },
    { 3130004, error_advice_3130004 },
-   { 3030002, error_advice_3030002 }
+
+   { 3140001, error_advice_3140001 },
+   { 3140002, error_advice_3140002 },
+   { 3140003, error_advice_3140003 },
+   { 3140004, error_advice_3140004 },
+   { 3140005, error_advice_3140005 }
 };
 
 

--- a/programs/cleos/help_text.cpp
+++ b/programs/cleos/help_text.cpp
@@ -102,9 +102,9 @@ const char* error_advice_3010002 =  "Most likely, the given account doesn't exis
 const char* error_advice_3010003 =  "Most likely, the given table doesnt' exist in the blockchain.";
 const char* error_advice_3010004 =  "Most likely, the given contract doesnt' exist in the blockchain.";
 
+const char* error_advice_3030000 =  "Ensure that your transaction satisfy the contract's constraint!";
 const char* error_advice_3030001 =  R"=====(Ensure that you have the related authority inside your transaction!;
-If you are currently using 'eosioc push action' command, try to add the relevant authority using -p option.)=====";
-
+If you are currently using 'cleos push action' command, try to add the relevant authority using -p option.)=====";
 const char* error_advice_3030002 =  "Ensure that you have the related private keys inside your wallet and you wallet is unlocked.";
 const char* error_advice_3030003 =  "Please remove the unnecessary authority from your action!";
 const char* error_advice_3030004 =  "Please remove the unnecessary signature from your transaction!";
@@ -112,10 +112,9 @@ const char* error_advice_3030011 =  "You can try embedding eosio nonce action in
 const char* error_advice_3030022 =  "Please increase the expiration time of your transaction!";
 const char* error_advice_3030023 =  "Please decrease the expiration time of your transaction!";
 const char* error_advice_3030024 =  "Ensure that the reference block exist in the blockchain!";
-const char* error_advice_3030025 =  "Ensure that your transaction satisfy the contract's constraint!";
 
 const char* error_advice_3040002 = R"=====(Ensure that your arguments follow the contract abi!
-You can check the contract's abi by using 'eosioc get code' command.)=====";
+You can check the contract's abi by using 'cleos get code' command.)=====";
 
 const char* error_advice_3120001 = R"=====(Name should be less than 13 characters and only contains the following symbol .12345abcdefghijklmnopqrstuvwxyz)=====";
 const char* error_advice_3120002 = R"=====(Public key should be encoded in base58 and starts with EOS prefix)=====";
@@ -232,6 +231,7 @@ const std::map<int64_t, std::string> error_advice = {
    { 3010003, error_advice_3010003 },
    { 3010004, error_advice_3010004 },
 
+   { 3030000, error_advice_3030000 },
    { 3030001, error_advice_3030001 },
    { 3030002, error_advice_3030002 },
    { 3030003, error_advice_3030003 },
@@ -240,7 +240,7 @@ const std::map<int64_t, std::string> error_advice = {
    { 3030022, error_advice_3030022 },
    { 3030023, error_advice_3030023 },
    { 3030024, error_advice_3030024 },
-   { 3030025, error_advice_3030025 },
+
 
    { 3040002, error_advice_3040002 },
 

--- a/programs/cleos/help_text.cpp
+++ b/programs/cleos/help_text.cpp
@@ -100,8 +100,22 @@ auto smatch_to_variant(const std::smatch& smatch) {
 const char* error_advice_3010001 =  "Most likely, the given account/ permission doesn't exist in the blockchain.";
 const char* error_advice_3010002 =  "Most likely, the given account doesn't exist in the blockchain.";
 const char* error_advice_3010003 =  "Most likely, the given table doesnt' exist in the blockchain.";
+const char* error_advice_3010004 =  "Most likely, the given contract doesnt' exist in the blockchain.";
+
+const char* error_advice_3030001 =  R"=====(Ensure that you have the related authority inside your transaction!;
+If you are currently using 'eosioc push action' command, try to add the relevant authority using -p option.)=====";
 
 const char* error_advice_3030002 =  "Ensure that you have the related private keys inside your wallet and you wallet is unlocked.";
+const char* error_advice_3030003 =  "Please remove the unnecessary authority from your action!";
+const char* error_advice_3030004 =  "Please remove the unnecessary signature from your transaction!";
+const char* error_advice_3030011 =  "You can try embedding eosio nonce action inside your transaction to ensure uniqueness.";
+const char* error_advice_3030022 =  "Please increase the expiration time of your transaction!";
+const char* error_advice_3030023 =  "Please decrease the expiration time of your transaction!";
+const char* error_advice_3030024 =  "Ensure that the reference block exist in the blockchain!";
+const char* error_advice_3030025 =  "Ensure that your transaction satisfy the contract's constraint!";
+
+const char* error_advice_3040002 = R"=====(Ensure that your arguments follow the contract abi!
+You can check the contract's abi by using 'eosioc get code' command.)=====";
 
 const char* error_advice_3120001 = R"=====(Name should be less than 13 characters and only contains the following symbol .12345abcdefghijklmnopqrstuvwxyz)=====";
 const char* error_advice_3120002 = R"=====(Public key should be encoded in base58 and starts with EOS prefix)=====";
@@ -186,6 +200,18 @@ e.g.
 })=====";
 const char* error_advice_3120008 =  "Ensure that the block ID is a SHA-256 hexadecimal string!";
 const char* error_advice_3120009 =  "Ensure that the transaction ID is a SHA-256 hexadecimal string!";
+const char* error_advice_3120010 =  R"=====(Ensure that your packed transaction JSON follows the following format!
+{
+  "signatures" : [ "signature" ],
+  "compression" : enum("none", "zlib"),
+  "data" : "bytes"
+}
+e.g.
+{
+  "signatures" : [ "EOSJze4m1ZHQ4UjuHpBcX6uHPN4Xyggv52raQMTBZJghzDLepaPcSGCNYTxaP2NiaF4yRF5RaYwqsQYAwBwFtfuTJr34Z5GJX" ],
+  "compression" : "none",
+  "data" : "6c36a25a00002602626c5e7f0000000000010000001e4d75af460000000000a53176010000000000ea305500000000a8ed3232180000001e4d75af4680969800000000000443555200000000"
+})=====";
 
 const char* error_advice_3130001 =  "Ensure that you have \033[2meosio::chain_api_plugin\033[0m\033[32m added to your node's configuration!";
 const char* error_advice_3130002 =  "Ensure that you have \033[2meosio::wallet_api_plugin\033[0m\033[32m added to your node's configuration!\n"\
@@ -204,8 +230,19 @@ const std::map<int64_t, std::string> error_advice = {
    { 3010001, error_advice_3010001 },
    { 3010002, error_advice_3010002 },
    { 3010003, error_advice_3010003 },
+   { 3010004, error_advice_3010004 },
 
+   { 3030001, error_advice_3030001 },
    { 3030002, error_advice_3030002 },
+   { 3030003, error_advice_3030003 },
+   { 3030004, error_advice_3030004 },
+   { 3030011, error_advice_3030011 },
+   { 3030022, error_advice_3030022 },
+   { 3030023, error_advice_3030023 },
+   { 3030024, error_advice_3030024 },
+   { 3030025, error_advice_3030025 },
+
+   { 3040002, error_advice_3040002 },
 
    { 3120001, error_advice_3120001 },
    { 3120002, error_advice_3120002 },
@@ -215,7 +252,8 @@ const std::map<int64_t, std::string> error_advice = {
    { 3120006, error_advice_3120006 },
    { 3120007, error_advice_3120007 },
    { 3120008, error_advice_3120008 },
-   { 3120009, error_advice_3120008 },
+   { 3120009, error_advice_3120009 },
+   { 3120010, error_advice_3120010 },
 
    { 3130001, error_advice_3130001 },
    { 3130002, error_advice_3130002 },
@@ -246,14 +284,14 @@ bool print_recognized_errors(const fc::exception& e, const bool verbose_errors) 
          // Check if there's a log to display
          if (!log.get_format().empty()) {
             // Localize the message as needed
-            explanation += "\n  " + localized_with_variant(log.get_format().data(), log.get_data());
+            explanation += "\n" + localized_with_variant(log.get_format().data(), log.get_data());
          } else if (log.get_data().size() > 0 && verbose_errors) {
             // Show data-only log only if verbose_errors option is enabled
-            explanation += "\n  " + fc::json::to_string(log.get_data());
+            explanation += "\n" + fc::json::to_string(log.get_data());
          }
          // Check if there's stack trace to be added
          if (!log.get_context().get_method().empty() && verbose_errors) {
-            stack_trace += "\n  " +
+            stack_trace += "\n" +
                            log.get_context().get_file() +  ":" +
                            fc::to_string(log.get_context().get_line_number())  + " " +
                            log.get_context().get_method();

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -344,7 +344,7 @@ struct set_account_permission_subcommand {
             if (boost::istarts_with(authorityJsonOrFile, "EOS")) {
                try {
                   auth = authority(public_key_type(authorityJsonOrFile));
-               } EOS_CAPTURE_AND_RETHROW(public_key_type_exception, "Invalid public key: ${public_key}", ("public_key", authorityJsonOrFile))
+               } EOS_RETHROW_EXCEPTIONS(public_key_type_exception, "Invalid public key: ${public_key}", ("public_key", authorityJsonOrFile))
             } else {
                fc::variant parsedAuthority;
                try {
@@ -354,8 +354,8 @@ struct set_account_permission_subcommand {
                      parsedAuthority = fc::json::from_file(authorityJsonOrFile);
                   }
                   auth = parsedAuthority.as<authority>();
-               } EOS_CAPTURE_AND_RETHROW(authority_type_exception, "Fail to parse Authority JSON")
-
+               } EOS_RETHROW_EXCEPTIONS(authority_type_exception, "Fail to parse Authority JSON")
+                 
             }
 
             name parent;
@@ -475,10 +475,10 @@ int main( int argc, char** argv ) {
       public_key_type owner_key, active_key;
       try {
          owner_key = public_key_type(owner_key_str);
-      } EOS_CAPTURE_AND_RETHROW(public_key_type_exception, "Invalid owner public key: ${public_key}", ("public_key", owner_key_str))
+      } EOS_RETHROW_EXCEPTIONS(public_key_type_exception, "Invalid owner public key: ${public_key}", ("public_key", owner_key_str))
       try {
          active_key = public_key_type(active_key_str);
-      } EOS_CAPTURE_AND_RETHROW(public_key_type_exception, "Invalid active public key: ${public_key}", ("public_key", active_key_str))
+      } EOS_RETHROW_EXCEPTIONS(public_key_type_exception, "Invalid active public key: ${public_key}", ("public_key", active_key_str))
       send_actions({create_newaccount(creator, account_name, owner_key, active_key)});
    });
 
@@ -623,7 +623,7 @@ int main( int argc, char** argv ) {
       public_key_type public_key;
       try {
          public_key = public_key_type(public_key_str);
-      } EOS_CAPTURE_AND_RETHROW(public_key_type_exception, "Invalid public key: ${public_key}", ("public_key", public_key_str))
+      } EOS_RETHROW_EXCEPTIONS(public_key_type_exception, "Invalid public key: ${public_key}", ("public_key", public_key_str))
       auto arg = fc::mutable_variant_object( "public_key", public_key);
       std::cout << fc::json::to_pretty_string(call(get_key_accounts_func, arg)) << std::endl;
    });
@@ -646,7 +646,7 @@ int main( int argc, char** argv ) {
       transaction_id_type transaction_id;
       try {
          transaction_id = transaction_id_type(transaction_id_str);
-      } EOS_CAPTURE_AND_RETHROW(transaction_id_type_exception, "Invalid transaction ID: ${transaction_id}", ("transaction_id", transaction_id_str))
+      } EOS_RETHROW_EXCEPTIONS(transaction_id_type_exception, "Invalid transaction ID: ${transaction_id}", ("transaction_id", transaction_id_str))
       auto arg= fc::mutable_variant_object( "transaction_id", transaction_id);
       std::cout << fc::json::to_pretty_string(call(get_transaction_func, arg)) << std::endl;
    });
@@ -666,14 +666,14 @@ int main( int argc, char** argv ) {
          uint64_t skip_seq;
          try {
             skip_seq = boost::lexical_cast<uint64_t>(skip_seq_str);
-         } EOS_CAPTURE_AND_RETHROW(chain_type_exception, "Invalid Skip Seq: ${skip_seq}", ("skip_seq", skip_seq_str))
+         } EOS_RETHROW_EXCEPTIONS(chain_type_exception, "Invalid Skip Seq: ${skip_seq}", ("skip_seq", skip_seq_str))
          if (num_seq_str.empty()) {
             arg = fc::mutable_variant_object( "account_name", account_name)("skip_seq", skip_seq);
          } else {
             uint64_t num_seq;
             try {
                num_seq = boost::lexical_cast<uint64_t>(num_seq_str);
-            } EOS_CAPTURE_AND_RETHROW(chain_type_exception, "Invalid Num Seq: ${num_seq}", ("num_seq", num_seq_str))
+            } EOS_RETHROW_EXCEPTIONS(chain_type_exception, "Invalid Num Seq: ${num_seq}", ("num_seq", num_seq_str))
             arg = fc::mutable_variant_object( "account_name", account_name)("skip_seq", skip_seq_str)("num_seq", num_seq);
          }
       }
@@ -733,7 +733,7 @@ int main( int argc, char** argv ) {
       if (abi->count()) {
          try {
             actions.emplace_back( create_setabi(account, fc::json::from_file(abiPath).as<contracts::abi_def>()) );
-         } EOS_CAPTURE_AND_RETHROW(abi_type_exception,  "Fail to parse ABI JSON")
+         } EOS_RETHROW_EXCEPTIONS(abi_type_exception,  "Fail to parse ABI JSON")
       }
 
       std::cout << localized("Publishing contract...") << std::endl;
@@ -965,7 +965,7 @@ int main( int argc, char** argv ) {
       fc::variant action_args_var;
       try {
          action_args_var = fc::json::from_string(data);
-      } EOS_CAPTURE_AND_RETHROW(action_type_exception, "Fail to parse action JSON")
+      } EOS_RETHROW_EXCEPTIONS(action_type_exception, "Fail to parse action JSON")
 
       auto arg= fc::mutable_variant_object
                 ("code", contract)
@@ -991,7 +991,7 @@ int main( int argc, char** argv ) {
          } else {
             trx_var = fc::json::from_string(trx_to_push);
          }
-      } EOS_CAPTURE_AND_RETHROW(transaction_type_exception, "Fail to parse transaction JSON")
+      } EOS_RETHROW_EXCEPTIONS(transaction_type_exception, "Fail to parse transaction JSON")
       signed_transaction trx = trx_var.as<signed_transaction>();
       auto trx_result = call(push_txn_func, packed_transaction(trx, packed_transaction::none));
       std::cout << fc::json::to_pretty_string(trx_result) << std::endl;
@@ -1005,7 +1005,7 @@ int main( int argc, char** argv ) {
       fc::variant trx_var;
       try {
          trx_var = fc::json::from_string(trxsJson);
-      } EOS_CAPTURE_AND_RETHROW(transaction_type_exception, "Fail to parse transaction JSON")
+      } EOS_RETHROW_EXCEPTIONS(transaction_type_exception, "Fail to parse transaction JSON")
       auto trxs_result = call(push_txns_func, trx_var);
       std::cout << fc::json::to_pretty_string(trxs_result) << std::endl;
    });

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -991,7 +991,8 @@ int main( int argc, char** argv ) {
          } else {
             trx_var = fc::json::from_string(trx_to_push);
          }
-      } EOS_CAPTURE_AND_RETHROW(transaction_type_exception, "Fail to parse transaction JSON")      signed_transaction trx = trx_var.as<signed_transaction>();
+      } EOS_CAPTURE_AND_RETHROW(transaction_type_exception, "Fail to parse transaction JSON")
+      signed_transaction trx = trx_var.as<signed_transaction>();
       auto trx_result = call(push_txn_func, packed_transaction(trx, packed_transaction::none));
       std::cout << fc::json::to_pretty_string(trx_result) << std::endl;
    });

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -344,7 +344,7 @@ struct set_account_permission_subcommand {
             if (boost::istarts_with(authorityJsonOrFile, "EOS")) {
                try {
                   auth = authority(public_key_type(authorityJsonOrFile));
-               } EOS_CAPTURE_AND_RETHROW(public_key_type_exception, "")
+               } EOS_CAPTURE_AND_RETHROW(public_key_type_exception, "Invalid public key: ${public_key}", ("public_key", authorityJsonOrFile))
             } else {
                fc::variant parsedAuthority;
                try {
@@ -475,8 +475,10 @@ int main( int argc, char** argv ) {
       public_key_type owner_key, active_key;
       try {
          owner_key = public_key_type(owner_key_str);
+      } EOS_CAPTURE_AND_RETHROW(public_key_type_exception, "Invalid owner public key: ${public_key}", ("public_key", owner_key_str))
+      try {
          active_key = public_key_type(active_key_str);
-      } EOS_CAPTURE_AND_RETHROW(public_key_type_exception, "Invalid Public Key")
+      } EOS_CAPTURE_AND_RETHROW(public_key_type_exception, "Invalid active public key: ${public_key}", ("public_key", active_key_str))
       send_actions({create_newaccount(creator, account_name, owner_key, active_key)});
    });
 
@@ -572,6 +574,7 @@ int main( int argc, char** argv ) {
    // get currency balance
    string symbol;
    auto get_currency = get->add_subcommand( "currency", localized("Retrieve information related to standard currencies"), true);
+   get_currency->require_subcommand();
    auto get_balance = get_currency->add_subcommand( "balance", localized("Retrieve the balance of an account for a given currency"), false);
    get_balance->add_option( "contract", code, localized("The contract that operates the currency") )->required();
    get_balance->add_option( "account", accountName, localized("The account to query balances for") )->required();
@@ -613,11 +616,15 @@ int main( int argc, char** argv ) {
    });
 
    // get accounts
-   string publicKey;
+   string public_key_str;
    auto getAccounts = get->add_subcommand("accounts", localized("Retrieve accounts associated with a public key"), false);
-   getAccounts->add_option("public_key", publicKey, localized("The public key to retrieve accounts for"))->required();
+   getAccounts->add_option("public_key", public_key_str, localized("The public key to retrieve accounts for"))->required();
    getAccounts->set_callback([&] {
-      auto arg = fc::mutable_variant_object( "public_key", publicKey);
+      public_key_type public_key;
+      try {
+         public_key = public_key_type(public_key_str);
+      } EOS_CAPTURE_AND_RETHROW(public_key_type_exception, "Invalid public key: ${public_key}", ("public_key", public_key_str))
+      auto arg = fc::mutable_variant_object( "public_key", public_key);
       std::cout << fc::json::to_pretty_string(call(get_key_accounts_func, arg)) << std::endl;
    });
 
@@ -632,27 +639,44 @@ int main( int argc, char** argv ) {
    });
 
    // get transaction
-   string transactionId;
+   string transaction_id_str;
    auto getTransaction = get->add_subcommand("transaction", localized("Retrieve a transaction from the blockchain"), false);
-   getTransaction->add_option("id", transactionId, localized("ID of the transaction to retrieve"))->required();
+   getTransaction->add_option("id", transaction_id_str, localized("ID of the transaction to retrieve"))->required();
    getTransaction->set_callback([&] {
-      auto arg= fc::mutable_variant_object( "transaction_id", transactionId);
+      transaction_id_type transaction_id;
+      try {
+         transaction_id = transaction_id_type(transaction_id_str);
+      } EOS_CAPTURE_AND_RETHROW(transaction_id_type_exception, "Invalid transaction ID: ${transaction_id}", ("transaction_id", transaction_id_str))
+      auto arg= fc::mutable_variant_object( "transaction_id", transaction_id);
       std::cout << fc::json::to_pretty_string(call(get_transaction_func, arg)) << std::endl;
    });
 
    // get transactions
-   string skip_seq;
-   string num_seq;
+   string skip_seq_str;
+   string num_seq_str;
    auto getTransactions = get->add_subcommand("transactions", localized("Retrieve all transactions with specific account name referenced in their scope"), false);
    getTransactions->add_option("account_name", account_name, localized("name of account to query on"))->required();
-   getTransactions->add_option("skip_seq", skip_seq, localized("Number of most recent transactions to skip (0 would start at most recent transaction)"));
-   getTransactions->add_option("num_seq", num_seq, localized("Number of transactions to return"));
+   getTransactions->add_option("skip_seq", skip_seq_str, localized("Number of most recent transactions to skip (0 would start at most recent transaction)"));
+   getTransactions->add_option("num_seq", num_seq_str, localized("Number of transactions to return"));
    getTransactions->set_callback([&] {
-      auto arg = (skip_seq.empty())
-                  ? fc::mutable_variant_object( "account_name", account_name)
-                  : (num_seq.empty())
-                     ? fc::mutable_variant_object( "account_name", account_name)("skip_seq", skip_seq)
-                     : fc::mutable_variant_object( "account_name", account_name)("skip_seq", skip_seq)("num_seq", num_seq);
+      fc::mutable_variant_object arg;
+      if (skip_seq_str.empty()) {
+         arg = fc::mutable_variant_object( "account_name", account_name);
+      } else {
+         uint64_t skip_seq;
+         try {
+            skip_seq = boost::lexical_cast<uint64_t>(skip_seq_str);
+         } EOS_CAPTURE_AND_RETHROW(chain_type_exception, "Invalid Skip Seq: ${skip_seq}", ("skip_seq", skip_seq_str))
+         if (num_seq_str.empty()) {
+            arg = fc::mutable_variant_object( "account_name", account_name)("skip_seq", skip_seq);
+         } else {
+            uint64_t num_seq;
+            try {
+               num_seq = boost::lexical_cast<uint64_t>(num_seq_str);
+            } EOS_CAPTURE_AND_RETHROW(chain_type_exception, "Invalid Num Seq: ${num_seq}", ("num_seq", num_seq_str))
+            arg = fc::mutable_variant_object( "account_name", account_name)("skip_seq", skip_seq_str)("num_seq", num_seq);
+         }
+      }
       auto result = call(get_transactions_func, arg);
       std::cout << fc::json::to_pretty_string(call(get_transactions_func, arg)) << std::endl;
 
@@ -847,13 +871,18 @@ int main( int argc, char** argv ) {
    });
 
    // import keys into wallet
-   string wallet_key;
+   string wallet_key_str;
    auto importWallet = wallet->add_subcommand("import", localized("Import private key into wallet"), false);
    importWallet->add_option("-n,--name", wallet_name, localized("The name of the wallet to import key into"));
-   importWallet->add_option("key", wallet_key, localized("Private key in WIF format to import"))->required();
-   importWallet->set_callback([&wallet_name, &wallet_key] {
-      private_key_type key( wallet_key );
-      public_key_type pubkey = key.get_public_key();
+   importWallet->add_option("key", wallet_key_str, localized("Private key in WIF format to import"))->required();
+   importWallet->set_callback([&wallet_name, &wallet_key_str] {
+      private_key_type wallet_key;
+      try {
+         wallet_key = private_key_type( wallet_key_str );
+      } catch (...) {
+          EOS_THROW(private_key_type_exception, "Invalid private key: ${private_key}", ("private_key", wallet_key_str))
+      }
+      public_key_type pubkey = wallet_key.get_public_key();
 
       fc::variants vs = {fc::variant(wallet_name), fc::variant(wallet_key)};
       const auto& v = call(wallet_host, wallet_port, wallet_import_key, vs);

--- a/tests/api_tests/api_tests.cpp
+++ b/tests/api_tests/api_tests.cpp
@@ -244,8 +244,8 @@ BOOST_FIXTURE_TEST_CASE(action_tests, tester) { try {
 	CALL_TEST_FUNCTION( *this, "test_action", "assert_true", {});
 
    //test assert_false
-   BOOST_CHECK_EXCEPTION(CALL_TEST_FUNCTION( *this, "test_action", "assert_false", {}), fc::assert_exception,
-         [](const fc::assert_exception& e) {
+   BOOST_CHECK_EXCEPTION(CALL_TEST_FUNCTION( *this, "test_action", "assert_false", {}), transaction_exception,
+         [](const fc::exception& e) {
             return expect_assert_message(e, "test_action::assert_false");
          }
       );
@@ -352,8 +352,8 @@ BOOST_FIXTURE_TEST_CASE(action_tests, tester) { try {
 
    // test now
    produce_block();
-   BOOST_CHECK_EXCEPTION(CALL_TEST_FUNCTION( *this, "test_action", "now", fc::raw::pack(now)), fc::assert_exception,
-         [](const fc::assert_exception& e) {
+   BOOST_CHECK_EXCEPTION(CALL_TEST_FUNCTION( *this, "test_action", "now", fc::raw::pack(now)), transaction_exception,
+         [](const fc::exception& e) {
             return expect_assert_message(e, "assertion failed: tmp == now");
          }
       );
@@ -370,8 +370,8 @@ BOOST_FIXTURE_TEST_CASE(action_tests, tester) { try {
    CALL_TEST_FUNCTION( *this, "test_action", "test_publication_time", fc::raw::pack(pub_time) );
 
    // test test_abort
-   BOOST_CHECK_EXCEPTION(CALL_TEST_FUNCTION( *this, "test_action", "test_abort", {} ), fc::assert_exception,
-         [](const fc::assert_exception& e) {
+   BOOST_CHECK_EXCEPTION(CALL_TEST_FUNCTION( *this, "test_action", "test_abort", {} ), transaction_exception,
+         [](const fc::exception& e) {
             return expect_assert_message(e, "abort() called");
          }
       );
@@ -404,7 +404,7 @@ BOOST_FIXTURE_TEST_CASE(cf_action_tests, tester) { try {
       auto sigs = trx.sign(get_private_key(N(testapi), "active"), chain_id_type());
 
       BOOST_CHECK_EXCEPTION(push_transaction(trx), tx_irrelevant_sig,
-                            [](const fc::assert_exception& e) {
+                            [](const fc::exception& e) {
                                edump((e.what()));
                                return expect_assert_message(e, "signatures");
                             }
@@ -434,8 +434,8 @@ BOOST_FIXTURE_TEST_CASE(cf_action_tests, tester) { try {
       set_tapos(trx);
       // run normal passing case
       sigs = trx.sign(get_private_key(N(testapi), "active"), chain_id_type());
-      BOOST_CHECK_EXCEPTION(push_transaction(trx), fc::assert_exception,
-                            [](const fc::assert_exception& e) {
+      BOOST_CHECK_EXCEPTION(push_transaction(trx), transaction_exception,
+                            [](const fc::exception& e) {
                                return expect_assert_message(e, "may only be called from context_free");
                             }
       );
@@ -456,8 +456,8 @@ BOOST_FIXTURE_TEST_CASE(cf_action_tests, tester) { try {
          trx.signatures.clear();
          set_tapos(trx);
          sigs = trx.sign(get_private_key(N(testapi), "active"), chain_id_type());
-         BOOST_CHECK_EXCEPTION(push_transaction(trx), fc::assert_exception,
-              [](const fc::assert_exception& e) {
+         BOOST_CHECK_EXCEPTION(push_transaction(trx), transaction_exception,
+              [](const fc::exception& e) {
                  return expect_assert_message(e, "context_free: only context free api's can be used in this context");
               }
          );
@@ -473,8 +473,8 @@ BOOST_FIXTURE_TEST_CASE(cf_action_tests, tester) { try {
       BOOST_CHECK_EQUAL(ttrace.action_traces[1].act.name == account_name("event1"), true);
       BOOST_CHECK_EQUAL(ttrace.action_traces[1].act.authorization.size(), 0);
 
-      BOOST_CHECK_EXCEPTION(CALL_TEST_FUNCTION( *this, "test_transaction", "send_cf_action_fail", {} ), fc::assert_exception,
-           [](const fc::assert_exception& e) {
+      BOOST_CHECK_EXCEPTION(CALL_TEST_FUNCTION( *this, "test_transaction", "send_cf_action_fail", {} ), transaction_exception,
+           [](const fc::exception& e) {
               return expect_assert_message(e, "context free actions cannot have authorizations");
            }
       );
@@ -547,8 +547,8 @@ BOOST_FIXTURE_TEST_CASE(compiler_builtins_tests, tester) { try {
    CALL_TEST_FUNCTION( *this, "test_compiler_builtins", "test_divti3", {});
 
    // test test_divti3_by_0
-   BOOST_CHECK_EXCEPTION(CALL_TEST_FUNCTION( *this, "test_compiler_builtins", "test_divti3_by_0", {}), fc::assert_exception,
-         [](const fc::assert_exception& e) {
+   BOOST_CHECK_EXCEPTION(CALL_TEST_FUNCTION( *this, "test_compiler_builtins", "test_divti3_by_0", {}), transaction_exception,
+         [](const fc::exception& e) {
             return expect_assert_message(e, "divide by zero");
          }
       );
@@ -557,8 +557,8 @@ BOOST_FIXTURE_TEST_CASE(compiler_builtins_tests, tester) { try {
    CALL_TEST_FUNCTION( *this, "test_compiler_builtins", "test_udivti3", {});
 
    // test test_udivti3_by_0
-   BOOST_CHECK_EXCEPTION(CALL_TEST_FUNCTION( *this, "test_compiler_builtins", "test_udivti3_by_0", {}), fc::assert_exception,
-         [](const fc::assert_exception& e) {
+   BOOST_CHECK_EXCEPTION(CALL_TEST_FUNCTION( *this, "test_compiler_builtins", "test_udivti3_by_0", {}), transaction_exception,
+         [](const fc::exception& e) {
             return expect_assert_message(e, "divide by zero");
          }
       );
@@ -567,8 +567,8 @@ BOOST_FIXTURE_TEST_CASE(compiler_builtins_tests, tester) { try {
    CALL_TEST_FUNCTION( *this, "test_compiler_builtins", "test_modti3", {});
 
    // test test_modti3_by_0
-   BOOST_CHECK_EXCEPTION(CALL_TEST_FUNCTION( *this, "test_compiler_builtins", "test_modti3_by_0", {}), fc::assert_exception,
-         [](const fc::assert_exception& e) {
+   BOOST_CHECK_EXCEPTION(CALL_TEST_FUNCTION( *this, "test_compiler_builtins", "test_modti3_by_0", {}), transaction_exception,
+         [](const fc::exception& e) {
             return expect_assert_message(e, "divide by zero");
          }
       );
@@ -604,15 +604,15 @@ BOOST_FIXTURE_TEST_CASE(transaction_tests, tester) { try {
    CALL_TEST_FUNCTION(*this, "test_transaction", "send_action_empty", {});
 
    // test send_action_large
-   BOOST_CHECK_EXCEPTION(CALL_TEST_FUNCTION(*this, "test_transaction", "send_action_large", {}), fc::assert_exception,
-         [](const fc::assert_exception& e) {
+   BOOST_CHECK_EXCEPTION(CALL_TEST_FUNCTION(*this, "test_transaction", "send_action_large", {}), transaction_exception,
+         [](const fc::exception& e) {
             return expect_assert_message(e, "data_len < config::default_max_inline_action_size: inline action too big");
          }
       );
 
    // test send_action_inline_fail
-   BOOST_CHECK_EXCEPTION(CALL_TEST_FUNCTION(*this, "test_transaction", "send_action_inline_fail", {}), fc::assert_exception,
-         [](const fc::assert_exception& e) {
+   BOOST_CHECK_EXCEPTION(CALL_TEST_FUNCTION(*this, "test_transaction", "send_action_inline_fail", {}), transaction_exception,
+         [](const fc::exception& e) {
             return expect_assert_message(e, "test_action::assert_false");
          }
       );
@@ -623,8 +623,8 @@ BOOST_FIXTURE_TEST_CASE(transaction_tests, tester) { try {
    control->push_deferred_transactions( true );
 
    // test send_transaction_empty
-   BOOST_CHECK_EXCEPTION(CALL_TEST_FUNCTION(*this, "test_transaction", "send_transaction_empty", {}), fc::assert_exception,
-         [](const fc::assert_exception& e) {
+   BOOST_CHECK_EXCEPTION(CALL_TEST_FUNCTION(*this, "test_transaction", "send_transaction_empty", {}), transaction_exception,
+         [](const fc::exception& e) {
             return expect_assert_message(e, "transaction must have at least one action");
          }
       );
@@ -789,33 +789,33 @@ BOOST_FIXTURE_TEST_CASE(multi_index_tests, tester) { try {
    CALL_TEST_FUNCTION( *this, "test_multi_index", "idx256_general", {});
    CALL_TEST_FUNCTION( *this, "test_multi_index", "idx_double_general", {});
    CALL_TEST_FUNCTION_AND_CHECK_EXCEPTION( *this, "test_multi_index", "idx64_pk_iterator_exceed_end", {},
-                                           fc::assert_exception, "cannot increment end iterator");
+                                           transaction_exception, "cannot increment end iterator");
    CALL_TEST_FUNCTION_AND_CHECK_EXCEPTION( *this, "test_multi_index", "idx64_sk_iterator_exceed_end", {},
-                                           fc::assert_exception, "cannot increment end iterator");
+                                           transaction_exception, "cannot increment end iterator");
    CALL_TEST_FUNCTION_AND_CHECK_EXCEPTION( *this, "test_multi_index", "idx64_pk_iterator_exceed_begin", {},
-                                           fc::assert_exception, "cannot decrement iterator at beginning of table");
+                                           transaction_exception, "cannot decrement iterator at beginning of table");
    CALL_TEST_FUNCTION_AND_CHECK_EXCEPTION( *this, "test_multi_index", "idx64_sk_iterator_exceed_begin", {},
-                                           fc::assert_exception, "cannot decrement iterator at beginning of index");
+                                           transaction_exception, "cannot decrement iterator at beginning of index");
    CALL_TEST_FUNCTION_AND_CHECK_EXCEPTION( *this, "test_multi_index", "idx64_pass_pk_ref_to_other_table", {},
-                                           fc::assert_exception, "object passed to iterator_to is not in multi_index");
+                                           transaction_exception, "object passed to iterator_to is not in multi_index");
    CALL_TEST_FUNCTION_AND_CHECK_EXCEPTION( *this, "test_multi_index", "idx64_pass_sk_ref_to_other_table", {},
-                                           fc::assert_exception, "object passed to iterator_to is not in multi_index");
+                                           transaction_exception, "object passed to iterator_to is not in multi_index");
    CALL_TEST_FUNCTION_AND_CHECK_EXCEPTION( *this, "test_multi_index", "idx64_pass_pk_end_itr_to_iterator_to", {},
-                                           fc::assert_exception, "object passed to iterator_to is not in multi_index");
+                                           transaction_exception, "object passed to iterator_to is not in multi_index");
    CALL_TEST_FUNCTION_AND_CHECK_EXCEPTION( *this, "test_multi_index", "idx64_pass_pk_end_itr_to_modify", {},
-                                           fc::assert_exception, "cannot pass end iterator to modify");
+                                           transaction_exception, "cannot pass end iterator to modify");
    CALL_TEST_FUNCTION_AND_CHECK_EXCEPTION( *this, "test_multi_index", "idx64_pass_pk_end_itr_to_erase", {},
-                                           fc::assert_exception, "cannot pass end iterator to erase");
+                                           transaction_exception, "cannot pass end iterator to erase");
    CALL_TEST_FUNCTION_AND_CHECK_EXCEPTION( *this, "test_multi_index", "idx64_pass_sk_end_itr_to_iterator_to", {},
-                                           fc::assert_exception, "object passed to iterator_to is not in multi_index");
+                                           transaction_exception, "object passed to iterator_to is not in multi_index");
    CALL_TEST_FUNCTION_AND_CHECK_EXCEPTION( *this, "test_multi_index", "idx64_pass_sk_end_itr_to_modify", {},
-                                           fc::assert_exception, "cannot pass end iterator to modify");
+                                           transaction_exception, "cannot pass end iterator to modify");
    CALL_TEST_FUNCTION_AND_CHECK_EXCEPTION( *this, "test_multi_index", "idx64_pass_sk_end_itr_to_erase", {},
-                                           fc::assert_exception, "cannot pass end iterator to erase");
+                                           transaction_exception, "cannot pass end iterator to erase");
    CALL_TEST_FUNCTION_AND_CHECK_EXCEPTION( *this, "test_multi_index", "idx64_modify_primary_key", {},
-                                           fc::assert_exception, "updater cannot change primary key when modifying an object");
+                                           transaction_exception, "updater cannot change primary key when modifying an object");
    CALL_TEST_FUNCTION_AND_CHECK_EXCEPTION( *this, "test_multi_index", "idx64_run_out_of_avl_pk", {},
-                                           fc::assert_exception, "next primary key in table is at autoincrement limit");
+                                           transaction_exception, "next primary key in table is at autoincrement limit");
    CALL_TEST_FUNCTION( *this, "test_multi_index", "idx64_sk_cache_pk_lookup", {});
    CALL_TEST_FUNCTION( *this, "test_multi_index", "idx64_pk_cache_sk_lookup", {});
 
@@ -836,8 +836,8 @@ BOOST_FIXTURE_TEST_CASE(fixedpoint_tests, tester) { try {
 	CALL_TEST_FUNCTION( *this, "test_fixedpoint", "test_subtraction", {});
 	CALL_TEST_FUNCTION( *this, "test_fixedpoint", "test_multiplication", {});
 	CALL_TEST_FUNCTION( *this, "test_fixedpoint", "test_division", {});
-	BOOST_CHECK_EXCEPTION(CALL_TEST_FUNCTION( *this, "test_fixedpoint", "test_division_by_0", {}), fc::assert_exception,
-         [](const fc::assert_exception& e) {
+	BOOST_CHECK_EXCEPTION(CALL_TEST_FUNCTION( *this, "test_fixedpoint", "test_division_by_0", {}), transaction_exception,
+         [](const fc::exception& e) {
             return expect_assert_message(e, "divide by zero");
          }
       );
@@ -859,8 +859,8 @@ BOOST_FIXTURE_TEST_CASE(real_tests, tester) { try {
    CALL_TEST_FUNCTION( *this, "test_real", "test_addition", {} );
    CALL_TEST_FUNCTION( *this, "test_real", "test_multiplication", {} );
    CALL_TEST_FUNCTION( *this, "test_real", "test_division", {} );
-	BOOST_CHECK_EXCEPTION(CALL_TEST_FUNCTION( *this, "test_real", "test_division_by_0", {}), fc::assert_exception,
-         [](const fc::assert_exception& e) {
+	BOOST_CHECK_EXCEPTION(CALL_TEST_FUNCTION( *this, "test_real", "test_division_by_0", {}), transaction_exception,
+         [](const fc::exception& e) {
             return expect_assert_message(e, "divide by zero");
          }
       );
@@ -898,8 +898,8 @@ BOOST_FIXTURE_TEST_CASE(crypto_tests, tester) { try {
       CALL_TEST_FUNCTION( *this, "test_crypto", "test_recover_key", payload );
       CALL_TEST_FUNCTION( *this, "test_crypto", "test_recover_key_assert_true", payload );
       payload[payload.size()-1] = 0;
-      BOOST_CHECK_EXCEPTION( CALL_TEST_FUNCTION( *this, "test_crypto", "test_recover_key_assert_false", payload ), fc::assert_exception,
-            [](const fc::assert_exception& e) {
+      BOOST_CHECK_EXCEPTION( CALL_TEST_FUNCTION( *this, "test_crypto", "test_recover_key_assert_false", payload ), transaction_exception,
+            [](const fc::exception& e) {
                return expect_assert_message( e, "check == p: Error expected key different than recovered key" );
             }
          );
@@ -914,40 +914,40 @@ BOOST_FIXTURE_TEST_CASE(crypto_tests, tester) { try {
    CALL_TEST_FUNCTION( *this, "test_crypto", "sha512_no_data", {} );
    CALL_TEST_FUNCTION( *this, "test_crypto", "ripemd160_no_data", {} );
 
-   BOOST_CHECK_EXCEPTION(CALL_TEST_FUNCTION( *this, "test_crypto", "assert_sha256_false", {} ), fc::assert_exception,
-         [](const fc::assert_exception& e) {
+   BOOST_CHECK_EXCEPTION(CALL_TEST_FUNCTION( *this, "test_crypto", "assert_sha256_false", {} ), transaction_exception,
+         [](const fc::exception& e) {
             return expect_assert_message(e, "hash miss match");
          }
       );
 
    CALL_TEST_FUNCTION( *this, "test_crypto", "assert_sha256_true", {} );
 
-   BOOST_CHECK_EXCEPTION(CALL_TEST_FUNCTION( *this, "test_crypto", "assert_sha1_false", {} ), fc::assert_exception,
-         [](const fc::assert_exception& e) {
+   BOOST_CHECK_EXCEPTION(CALL_TEST_FUNCTION( *this, "test_crypto", "assert_sha1_false", {} ), transaction_exception,
+         [](const fc::exception& e) {
             return expect_assert_message(e, "hash miss match");
          }
       );
 
    CALL_TEST_FUNCTION( *this, "test_crypto", "assert_sha1_true", {} );
 
-   BOOST_CHECK_EXCEPTION(CALL_TEST_FUNCTION( *this, "test_crypto", "assert_sha1_false", {} ), fc::assert_exception,
-         [](const fc::assert_exception& e) {
+   BOOST_CHECK_EXCEPTION(CALL_TEST_FUNCTION( *this, "test_crypto", "assert_sha1_false", {} ), transaction_exception,
+         [](const fc::exception& e) {
             return expect_assert_message(e, "hash miss match");
          }
       );
 
    CALL_TEST_FUNCTION( *this, "test_crypto", "assert_sha1_true", {} );
 
-   BOOST_CHECK_EXCEPTION(CALL_TEST_FUNCTION( *this, "test_crypto", "assert_sha512_false", {} ), fc::assert_exception,
-         [](const fc::assert_exception& e) {
+   BOOST_CHECK_EXCEPTION(CALL_TEST_FUNCTION( *this, "test_crypto", "assert_sha512_false", {} ), transaction_exception,
+         [](const fc::exception& e) {
             return expect_assert_message(e, "hash miss match");
          }
       );
 
    CALL_TEST_FUNCTION( *this, "test_crypto", "assert_sha512_true", {} );
 
-   BOOST_CHECK_EXCEPTION(CALL_TEST_FUNCTION( *this, "test_crypto", "assert_ripemd160_false", {} ), fc::assert_exception,
-         [](const fc::assert_exception& e) {
+   BOOST_CHECK_EXCEPTION(CALL_TEST_FUNCTION( *this, "test_crypto", "assert_ripemd160_false", {} ), transaction_exception,
+         [](const fc::exception& e) {
             return expect_assert_message(e, "hash miss match");
          }
       );
@@ -1121,8 +1121,8 @@ BOOST_FIXTURE_TEST_CASE(math_tests, tester) { try {
       CALL_TEST_FUNCTION( *this, "test_math", "test_diveq", fc::raw::pack(act));
    }
    // test diveq for divide by zero
-	BOOST_CHECK_EXCEPTION(CALL_TEST_FUNCTION( *this, "test_math", "test_diveq_by_0", {}), fc::assert_exception,
-          [](const fc::assert_exception& e) {
+	BOOST_CHECK_EXCEPTION(CALL_TEST_FUNCTION( *this, "test_math", "test_diveq_by_0", {}), transaction_exception,
+          [](const fc::exception& e) {
             return expect_assert_message(e, "divide by zero");
          }
       );
@@ -1141,8 +1141,8 @@ BOOST_FIXTURE_TEST_CASE(math_tests, tester) { try {
    std::copy(d_vals.whole, d_vals.whole+sizeof(d_vals), ds.begin());
    CALL_TEST_FUNCTION( *this, "test_math", "test_double_to_i64", ds);
 
-	BOOST_CHECK_EXCEPTION(CALL_TEST_FUNCTION( *this, "test_math", "test_double_api_div_0", {}), fc::assert_exception,
-          [](const fc::assert_exception& e) {
+	BOOST_CHECK_EXCEPTION(CALL_TEST_FUNCTION( *this, "test_math", "test_double_api_div_0", {}), transaction_exception,
+          [](const fc::exception& e) {
             return expect_assert_message(e, "divide by zero");
          }
       );
@@ -1222,8 +1222,8 @@ BOOST_FIXTURE_TEST_CASE(privileged_tests, tester) { try {
 	}
 
    CALL_TEST_FUNCTION( *this, "test_privileged", "test_is_privileged", {} );
-   BOOST_CHECK_EXCEPTION( CALL_TEST_FUNCTION( *this, "test_privileged", "test_is_privileged", {} ), fc::assert_exception,
-         [](const fc::assert_exception& e) {
+   BOOST_CHECK_EXCEPTION( CALL_TEST_FUNCTION( *this, "test_privileged", "test_is_privileged", {} ), transaction_exception,
+         [](const fc::exception& e) {
             return expect_assert_message(e, "context.privileged: testapi does not have permission to call this API");
          }
        );

--- a/tests/wasm_tests/currency_tests.cpp
+++ b/tests/wasm_tests/currency_tests.cpp
@@ -161,7 +161,7 @@ BOOST_FIXTURE_TEST_CASE( test_overspend, currency_tester ) try {
          ("quantity", "101.0000 CUR")
          ("memo", "overspend! Alice");
 
-      BOOST_CHECK_EXCEPTION(push_action(N(alice), N(transfer), data), fc::assert_exception, assert_message_is("overdrawn balance"));
+      BOOST_CHECK_EXCEPTION(push_action(N(alice), N(transfer), data), transaction_exception, assert_message_is("overdrawn balance"));
       produce_block();
 
       BOOST_REQUIRE_EQUAL(get_balance(N(alice)), asset::from_string( "100.0000 CUR" ));

--- a/tests/wasm_tests/wasm_tests.cpp
+++ b/tests/wasm_tests/wasm_tests.cpp
@@ -110,7 +110,7 @@ BOOST_FIXTURE_TEST_CASE( basic_test, tester ) try {
       trx.sign( get_private_key( N(asserter), "active" ), chain_id_type() );
       yes_assert_id = trx.id();
 
-      BOOST_CHECK_THROW(push_transaction( trx ), fc::assert_exception);
+      BOOST_CHECK_THROW(push_transaction( trx ), transaction_exception);
    }
 
    produce_blocks(1);
@@ -820,7 +820,7 @@ BOOST_FIXTURE_TEST_CASE( check_table_maximum, tester ) try {
    trx.sign(get_private_key( N(tbl), "active" ), chain_id_type());
 
    //should fail, a check to make sure assert() in wasm is being evaluated correctly
-   BOOST_CHECK_THROW(push_transaction(trx), fc::assert_exception);
+   BOOST_CHECK_THROW(push_transaction(trx), transaction_exception);
    }
 
    produce_blocks(1);


### PR DESCRIPTION
Fourth PR for DAWN-513

Improve eosioc error message for get, set, net, and wallet subcommand. After this, only push subcommand left.

Update:
As 16 March, this PR is updated to include error message improvement for push subcommand. This should be the last PR for DAWN-513