### PR TITLE
(unofficial) FreeBSD build support & fixups

### DIFF
--- a/libraries/fc/src/byteswap.hpp
+++ b/libraries/fc/src/byteswap.hpp
@@ -6,6 +6,9 @@
 #elif defined(__APPLE__)
 # include <libkern/OSByteOrder.h>
 # define bswap_64(x) OSSwapInt64(x)
+#elif defined(__FreeBSD__)
+# include <sys/endian.h>
+# define bswap_64(x) bswap64(x)
 #else
 # include <byteswap.h>
 #endif

--- a/libraries/fc/src/crypto/elliptic_common.cpp
+++ b/libraries/fc/src/crypto/elliptic_common.cpp
@@ -7,6 +7,8 @@
 
 #ifdef _WIN32
 # include <malloc.h>
+#elif defined(__FreeBSD__)
+# include <stdlib.h>
 #else
 # include <alloca.h>
 #endif

--- a/libraries/fc/src/crypto/elliptic_secp256k1.cpp
+++ b/libraries/fc/src/crypto/elliptic_secp256k1.cpp
@@ -14,6 +14,8 @@
 
 #if _WIN32
 # include <malloc.h>
+#elif defined(__FreeBSD__)
+# include <stdlib.h>
 #else
 # include <alloca.h>
 #endif

--- a/libraries/wasm-jit/Source/Platform/POSIX.cpp
+++ b/libraries/wasm-jit/Source/Platform/POSIX.cpp
@@ -28,6 +28,12 @@
 	#include <execinfo.h>
 	#include <dlfcn.h>
 #endif
+#ifdef __FreeBSD__
+	#include <execinfo.h>
+	#include <dlfcn.h>
+	#include <pthread_np.h>
+	#include <iostream>
+#endif
 
 namespace Platform
 {
@@ -102,12 +108,16 @@ namespace Platform
 
 	bool describeInstructionPointer(Uptr ip,std::string& outDescription)
 	{
-		#ifdef __linux__
+		#if defined __linux__ || defined __FreeBSD__
 			// Look up static symbol information for the address.
 			Dl_info symbolInfo;
 			if(dladdr((void*)ip,&symbolInfo) && symbolInfo.dli_sname)
 			{
-				outDescription = symbolInfo.dli_sname;
+				#ifdef __linux__
+					outDescription = symbolInfo.dli_sname;
+				#else
+					outDescription.append(symbolInfo.dli_sname);
+				#endif
 				return true;
 			}
 		#endif
@@ -137,11 +147,16 @@ namespace Platform
 			// Get the stack address from pthreads, but use getrlimit to find the maximum size of the stack instead of the current.
 			struct rlimit stackLimit;
 			getrlimit(RLIMIT_STACK,&stackLimit);
-			#ifdef __linux__
+			#if defined __linux__ || defined __FreeBSD__
 				// Linux uses pthread_getattr_np/pthread_attr_getstack, and returns a pointer to the minimum address of the stack.
 				pthread_attr_t threadAttributes;
-				memset(&threadAttributes,0,sizeof(threadAttributes));
-				pthread_getattr_np(pthread_self(),&threadAttributes);
+				#ifdef __linux__
+					memset(&threadAttributes,0,sizeof(threadAttributes));
+					pthread_getattr_np(pthread_self(),&threadAttributes);
+				#else
+					pthread_attr_init(&threadAttributes);
+					pthread_attr_get_np(pthread_self(), &threadAttributes);
+				#endif
 				Uptr stackSize;
 				pthread_attr_getstack(&threadAttributes,(void**)&stackMinAddr,&stackSize);
 				pthread_attr_destroy(&threadAttributes);
@@ -159,7 +174,11 @@ namespace Platform
 		}
 	}
 
-	THREAD_LOCAL jmp_buf signalReturnEnv;
+	#ifdef __FreeBSD__
+		THREAD_LOCAL sigjmp_buf signalReturnEnv;
+	#else
+		THREAD_LOCAL jmp_buf signalReturnEnv;
+	#endif
 	THREAD_LOCAL HardwareTrapType signalType = HardwareTrapType::none;
 	THREAD_LOCAL CallStack* signalCallStack = nullptr;
 	THREAD_LOCAL Uptr* signalOperand = nullptr;
@@ -267,7 +286,7 @@ namespace Platform
 
 	CallStack captureCallStack(Uptr numOmittedFramesFromTop)
 	{
-		#ifdef __linux__
+		#if defined __linux__ || defined __FreeBSD__
 			// Unwind the callstack.
 			enum { maxCallStackSize = signalStackNumBytes / sizeof(void*) / 8 };
 			void* callstackAddresses[maxCallStackSize];

--- a/libraries/wasm-jit/Source/Platform/POSIX.cpp
+++ b/libraries/wasm-jit/Source/Platform/POSIX.cpp
@@ -14,6 +14,7 @@
 #include <sys/resource.h>
 #include <string.h>
 #include <iostream>
+#include <string>
 
 #include <sys/time.h>
 
@@ -113,11 +114,7 @@ namespace Platform
 			Dl_info symbolInfo;
 			if(dladdr((void*)ip,&symbolInfo) && symbolInfo.dli_sname)
 			{
-				#ifdef __linux__
-					outDescription = symbolInfo.dli_sname;
-				#else
-					outDescription.append(symbolInfo.dli_sname);
-				#endif
+				outDescription = symbolInfo.dli_sname;
 				return true;
 			}
 		#endif
@@ -150,11 +147,10 @@ namespace Platform
 			#if defined __linux__ || defined __FreeBSD__
 				// Linux uses pthread_getattr_np/pthread_attr_getstack, and returns a pointer to the minimum address of the stack.
 				pthread_attr_t threadAttributes;
+				pthread_attr_init(&threadAttributes);
 				#ifdef __linux__
-					memset(&threadAttributes,0,sizeof(threadAttributes));
 					pthread_getattr_np(pthread_self(),&threadAttributes);
 				#else
-					pthread_attr_init(&threadAttributes);
 					pthread_attr_get_np(pthread_self(), &threadAttributes);
 				#endif
 				Uptr stackSize;
@@ -174,11 +170,7 @@ namespace Platform
 		}
 	}
 
-	#ifdef __FreeBSD__
-		THREAD_LOCAL sigjmp_buf signalReturnEnv;
-	#else
-		THREAD_LOCAL jmp_buf signalReturnEnv;
-	#endif
+	THREAD_LOCAL sigjmp_buf signalReturnEnv;
 	THREAD_LOCAL HardwareTrapType signalType = HardwareTrapType::none;
 	THREAD_LOCAL CallStack* signalCallStack = nullptr;
 	THREAD_LOCAL Uptr* signalOperand = nullptr;

--- a/plugins/mongo_db_plugin/CMakeLists.txt
+++ b/plugins/mongo_db_plugin/CMakeLists.txt
@@ -21,14 +21,30 @@ if(BUILD_MONGO_DB_PLUGIN)
 
       find_package(libbsoncxx REQUIRED)
       message(STATUS "Found bsoncxx headers: ${LIBBSONCXX_INCLUDE_DIRS}")
-      find_library(EOS_LIBBSONCXX ${LIBBSONCXX_LIBRARIES}
-                   PATHS ${LIBBSONCXX_LIBRARY_DIRS} NO_DEFAULT_PATH)
+
+      # mongo-cxx-driver 3.2 release altered LIBBSONCXX_LIBRARIES semantics. Instead of library names,
+      #  it now hold library paths.
+      if((LIBBSONCXX_VERSION_MAJOR LESS 3) OR ((LIBBSONCXX_VERSION_MAJOR EQUAL 3) AND (LIBBSONCXX_VERSION_MINOR LESS 2)))
+        find_library(EOS_LIBBSONCXX ${LIBBSONCXX_LIBRARIES}
+          PATHS ${LIBBSONCXX_LIBRARY_DIRS} NO_DEFAULT_PATH)
+      else()
+        set(EOS_LIBBSONCXX ${LIBBSONCXX_LIBRARIES})
+      endif()
+
       message(STATUS "Found bsoncxx library: ${EOS_LIBBSONCXX}")
 
       find_package(libmongocxx REQUIRED)
       message(STATUS "Found mongocxx headers: ${LIBMONGOCXX_INCLUDE_DIRS}")
-      find_library(EOS_LIBMONGOCXX ${LIBMONGOCXX_LIBRARIES}
-                   PATHS ${LIBMONGOCXX_LIBRARY_DIRS} NO_DEFAULT_PATH)
+
+      # mongo-cxx-driver 3.2 release altered LIBBSONCXX_LIBRARIES semantics. Instead of library names,
+      #  it now hold library paths.
+      if((LIBMONGOCXX_VERSION_MAJOR LESS 3) OR ((LIBMONGOCXX_VERSION_MAJOR EQUAL 3) AND (LIBMONGOCXX_VERSION_MINOR LESS 2)))
+        find_library(EOS_LIBMONGOCXX ${LIBMONGOCXX_LIBRARIES}
+          PATHS ${LIBMONGOCXX_LIBRARY_DIRS} NO_DEFAULT_PATH)
+      else()
+        set(EOS_LIBMONGOCXX ${LIBMONGOCXX_LIBRARIES})
+      endif()
+
       message(STATUS "Found mongocxx library: ${EOS_LIBMONGOCXX}")
   else()
       message("Could NOT find MongoDB. mongo_db_plugin with MongoDB support will not be included.")


### PR DESCRIPTION
This PR replaces PR #1061. Some of the fixes @zrts identified when getting FreeBSD building apply to Linux/macos (the `pthread_attr_init` and `sigjmp_buf` changes). I have left the new added includes unchanged except for adding an include to string.

FreeBSD builds are still not officially supported -- block.one performs no testing on this platform.

Issue #1060 