### PR TITLE
Add rend support in C DB API and reverse iteration in multi_index

### DIFF
--- a/contracts/eosiolib/db.h
+++ b/contracts/eosiolib/db.h
@@ -1035,6 +1035,7 @@ int32_t db_find_i64(account_name code, account_name scope, table_name table, uin
 int32_t db_lowerbound_i64(account_name code, account_name scope, table_name table, uint64_t id);
 int32_t db_upperbound_i64(account_name code, account_name scope, table_name table, uint64_t id);
 int32_t db_end_i64(account_name code, account_name scope, table_name table);
+int32_t db_rend_i64(account_name code, account_name scope, table_name table);
 
 int32_t db_idx64_store(account_name scope, table_name table, account_name payer, uint64_t id, const uint64_t* secondary);
 void db_idx64_update(int32_t iterator, account_name payer, const uint64_t* secondary);
@@ -1046,6 +1047,7 @@ int32_t db_idx64_find_secondary(account_name code, account_name scope, table_nam
 int32_t db_idx64_lowerbound(account_name code, account_name scope, table_name table, uint64_t* secondary, uint64_t* primary);
 int32_t db_idx64_upperbound(account_name code, account_name scope, table_name table, uint64_t* secondary, uint64_t* primary);
 int32_t db_idx64_end(account_name code, account_name scope, table_name table);
+int32_t db_idx64_rend(account_name code, account_name scope, table_name table);
 
 int32_t db_idx128_store(account_name scope, table_name table, account_name payer, uint64_t id, const uint128_t* secondary);
 void db_idx128_update(int32_t iterator, account_name payer, const uint128_t* secondary);
@@ -1057,6 +1059,7 @@ int32_t db_idx128_find_secondary(account_name code, account_name scope, table_na
 int32_t db_idx128_lowerbound(account_name code, account_name scope, table_name table, uint128_t* secondary, uint64_t* primary);
 int32_t db_idx128_upperbound(account_name code, account_name scope, table_name table, uint128_t* secondary, uint64_t* primary);
 int32_t db_idx128_end(account_name code, account_name scope, table_name table);
+int32_t db_idx128_rend(account_name code, account_name scope, table_name table);
 
 int32_t db_idx256_store(account_name scope, table_name table, account_name payer, uint64_t id, const void* data, uint32_t data_len );
 void db_idx256_update(int32_t iterator, account_name payer, const void* data, uint32_t data_len);
@@ -1068,5 +1071,6 @@ int32_t db_idx256_find_secondary(account_name code, account_name scope, table_na
 int32_t db_idx256_lowerbound(account_name code, account_name scope, table_name table, void* data, uint32_t data_len, uint64_t* primary);
 int32_t db_idx256_upperbound(account_name code, account_name scope, table_name table, void* data, uint32_t data_len, uint64_t* primary);
 int32_t db_idx256_end(account_name code, account_name scope, table_name table);
+int32_t db_idx256_rend(account_name code, account_name scope, table_name table);
 
 }

--- a/contracts/test_api_multi_index/test_multi_index.cpp
+++ b/contracts/test_api_multi_index/test_multi_index.cpp
@@ -141,7 +141,7 @@ namespace _test_multi_index {
 
          auto pk_itr = pks.begin();
 
-         auto itr = static_cast<typename decltype(secondary_index)::const_reverse_iterator>(secondary_index.find(N(emily)));
+         auto itr = --std::make_reverse_iterator( secondary_index.find( N(emily) ) );
          for( ; itr != secondary_index.rend(); ++itr ) {
             eosio_assert(pk_itr != pks.end(), "idx64_general - unexpected continuation of secondary index in reverse iteration");
             eosio_assert(*pk_itr == itr->id, "idx64_general - primary key mismatch in reverse iteration");

--- a/contracts/test_api_multi_index/test_multi_index.cpp
+++ b/contracts/test_api_multi_index/test_multi_index.cpp
@@ -1,6 +1,7 @@
 #include <eosiolib/multi_index.hpp>
 #include "../test_api/test_api.hpp"
 #include <eosiolib/print.hpp>
+#include <boost/range/iterator_range.hpp>
 
 namespace _test_multi_index {
 
@@ -115,7 +116,7 @@ namespace _test_multi_index {
          eosio_assert(itr == secondary_index.end(), "idx64_general - increment secondary iterator to end");
       }
 
-      // iterate backward staring with second bob
+      // iterate backward starting with second bob
       {
          auto ptr = table.find(781);
          eosio_assert(ptr != nullptr && ptr->sec == N(bob), "idx64_general - table.find() of existing primary key");
@@ -132,6 +133,20 @@ namespace _test_multi_index {
 
          --itr;
          eosio_assert(itr == secondary_index.begin() && itr->id == 265 && itr->sec == N(alice), "idx64_general - decrement secondary iterator to beginning");
+      }
+
+      // iterate backward starting with emily using const_reverse_iterator
+      {
+         std::array<uint64_t, 6> pks{{976, 234, 781, 540, 650, 265}};
+
+         auto pk_itr = pks.begin();
+
+         auto itr = static_cast<typename decltype(secondary_index)::const_reverse_iterator>(secondary_index.find(N(emily)));
+         for( ; itr != secondary_index.rend(); ++itr ) {
+            eosio_assert(pk_itr != pks.end(), "idx64_general - unexpected continuation of secondary index in reverse iteration");
+            eosio_assert(*pk_itr == itr->id, "idx64_general - primary key mismatch in reverse iteration");
+            ++pk_itr;
+         }
       }
 
       // update and remove
@@ -274,7 +289,6 @@ void test_multi_index::idx128_autoincrement_test_part2()
    for( int i = 3; i < 5; ++i ) {
       table.emplace( payer, [&]( auto& r ) {
          auto itr = table.available_primary_key();
-         print(itr, "\n");
          r.id = itr;
          r.sec = 1000 - static_cast<uint128_t>(r.id);
       });
@@ -387,17 +401,17 @@ void test_multi_index::idx256_general()
    print("Removed entry with ID=", lower1->id, ".\n");
    table.remove( *lower1 );
 
-   print("Items sorted by primary key:\n");
-   for( const auto& item : table ) {
+   print("Items reverse sorted by primary key:\n");
+   for( const auto& item : boost::make_iterator_range(table.rbegin(), table.rend()) ) {
       print(" ID=", item.primary_key(), ", secondary=", item.sec, "\n");
    }
 
    {
-      auto itr = table.begin();
-      eosio_assert( itr->primary_key() == 2 && itr->get_secondary() == onetwothreefour, "idx256_general - primary key sort after remove" );
-      ++itr;
+      auto itr = table.rbegin();
       eosio_assert( itr->primary_key() == 3 && itr->get_secondary() == fourtytwo, "idx256_general - primary key sort after remove" );
       ++itr;
-      eosio_assert( itr == table.end(), "idx256_general - primary key sort after remove" );
+      eosio_assert( itr->primary_key() == 2 && itr->get_secondary() == onetwothreefour, "idx256_general - primary key sort after remove" );
+      ++itr;
+      eosio_assert( itr == table.rend(), "idx256_general - primary key sort after remove" );
    }
 }

--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -415,47 +415,66 @@ int apply_context::db_get_i64( int iterator, char* buffer, size_t buffer_size ) 
 }
 
 int apply_context::db_next_i64( int iterator, uint64_t& primary ) {
-   if( iterator < -1 ) return -1; // cannot increment past end iterator of table
+   if( keyval_cache.is_end_iterator(iterator) ) return -1; // cannot increment past end iterator of table
+
+   const auto& idx = db.get_index<contracts::key_value_index, contracts::by_scope_primary>();
+
+   if( keyval_cache.is_rend_iterator(iterator) ) {
+      auto tab = keyval_cache.find_table_by_rend_iterator(iterator);
+      FC_ASSERT( tab, "not a valid rend iterator" );
+
+      auto itr = idx.lower_bound(tab->id);
+      if( itr == idx.end() || itr->t_id != tab->id ) // Empty table
+         return keyval_cache.get_end_iterator_by_table_id(tab->id);
+
+      primary = itr->primary_key;
+      return keyval_cache.add(*itr);
+   }
 
    const auto& obj = keyval_cache.get( iterator ); // Check for iterator != -1 happens in this call
-   const auto& idx = db.get_index<contracts::key_value_index, contracts::by_scope_primary>();
 
    auto itr = idx.iterator_to( obj );
    ++itr;
 
-   if( itr == idx.end() || itr->t_id != obj.t_id ) return keyval_cache.get_end_iterator_by_table_id(obj.t_id);
+   if( itr == idx.end() || itr->t_id != obj.t_id )
+      return keyval_cache.get_end_iterator_by_table_id(obj.t_id);
 
    primary = itr->primary_key;
    return keyval_cache.add( *itr );
 }
 
 int apply_context::db_previous_i64( int iterator, uint64_t& primary ) {
+   if( keyval_cache.is_rend_iterator(iterator) ) return -1; // cannot decrement past rend iterator of table
+
    const auto& idx = db.get_index<contracts::key_value_index, contracts::by_scope_primary>();
 
-   if( iterator < -1 ) // is end iterator
-   {
+   if( keyval_cache.is_end_iterator(iterator) ) {
       auto tab = keyval_cache.find_table_by_end_iterator(iterator);
       FC_ASSERT( tab, "not a valid end iterator" );
 
       auto itr = idx.upper_bound(tab->id);
-      if( itr == idx.begin() ) return -1; // Empty table
+      if( idx.begin() == idx.end() || itr == idx.begin() ) // Empty table
+         return keyval_cache.get_rend_iterator_by_table_id(tab->id);
 
       --itr;
 
-      if( itr->t_id != tab->id ) return -1; // Empty table
+      if( itr->t_id != tab->id ) // Empty table
+         return keyval_cache.get_rend_iterator_by_table_id(tab->id);
 
       primary = itr->primary_key;
       return keyval_cache.add(*itr);
    }
 
-   const auto& obj = keyval_cache.get(iterator);
+   const auto& obj = keyval_cache.get(iterator); // Check for iterator != -1 happens in this call
 
    auto itr = idx.iterator_to(obj);
-   if( itr == idx.begin() ) return -1; // cannot decrement past beginning iterator of table
+   if( itr == idx.begin() )
+      return keyval_cache.get_rend_iterator_by_table_id(obj.t_id);
 
    --itr;
 
-   if( itr->t_id != obj.t_id ) return -1; // cannot decrement past beginning iterator of table
+   if( itr->t_id != obj.t_id )
+      return keyval_cache.get_rend_iterator_by_table_id(obj.t_id);
 
    primary = itr->primary_key;
    return keyval_cache.add(*itr);
@@ -468,7 +487,7 @@ int apply_context::db_find_i64( uint64_t code, uint64_t scope, uint64_t table, u
    if( !tab ) return -1;
    validate_table_key(*tab, contracts::table_key_type::type_i64);
 
-   auto table_end_itr = keyval_cache.cache_table( *tab );
+   auto table_end_itr = keyval_cache.index_to_end_iterator( keyval_cache.cache_table( *tab ) );
 
    const key_value_object* obj = db.find<key_value_object, contracts::by_scope_primary>( boost::make_tuple( tab->id, id ) );
    if( !obj ) return table_end_itr;
@@ -483,7 +502,7 @@ int apply_context::db_lowerbound_i64( uint64_t code, uint64_t scope, uint64_t ta
    if( !tab ) return -1;
    validate_table_key(*tab, contracts::table_key_type::type_i64);
 
-   auto table_end_itr = keyval_cache.cache_table( *tab );
+   auto table_end_itr = keyval_cache.index_to_end_iterator( keyval_cache.cache_table( *tab ) );
 
    const auto& idx = db.get_index<contracts::key_value_index, contracts::by_scope_primary>();
    auto itr = idx.lower_bound( boost::make_tuple( tab->id, id ) );
@@ -500,7 +519,7 @@ int apply_context::db_upperbound_i64( uint64_t code, uint64_t scope, uint64_t ta
    if( !tab ) return -1;
    validate_table_key(*tab, contracts::table_key_type::type_i64);
 
-   auto table_end_itr = keyval_cache.cache_table( *tab );
+   auto table_end_itr = keyval_cache.index_to_end_iterator( keyval_cache.cache_table( *tab ) );
 
    const auto& idx = db.get_index<contracts::key_value_index, contracts::by_scope_primary>();
    auto itr = idx.upper_bound( boost::make_tuple( tab->id, id ) );
@@ -517,7 +536,17 @@ int apply_context::db_end_i64( uint64_t code, uint64_t scope, uint64_t table ) {
    if( !tab ) return -1;
    validate_table_key(*tab, contracts::table_key_type::type_i64);
 
-   return keyval_cache.cache_table( *tab );
+   return keyval_cache.index_to_end_iterator( keyval_cache.cache_table( *tab ) );
+}
+
+int apply_context::db_rend_i64( uint64_t code, uint64_t scope, uint64_t table ) {
+   require_read_lock( code, scope ); // redundant?
+
+   const auto* tab = find_table( code, scope, table );
+   if( !tab ) return -1;
+   validate_table_key(*tab, contracts::table_key_type::type_i64);
+
+   return keyval_cache.index_to_rend_iterator( keyval_cache.cache_table( *tab ) );
 }
 
 template<>

--- a/libraries/chain/wasm_interface.cpp
+++ b/libraries/chain/wasm_interface.cpp
@@ -688,6 +688,9 @@ class console_api : public context_aware_api {
       int db_##IDX##_end( uint64_t code, uint64_t scope, uint64_t table ) {\
          return context.IDX.end_secondary(code, scope, table);\
       }\
+      int db_##IDX##_rend( uint64_t code, uint64_t scope, uint64_t table ) {\
+         return context.IDX.rend_secondary(code, scope, table);\
+      }\
       int db_##IDX##_next( int iterator, uint64_t& primary  ) {\
          return context.IDX.next_secondary(iterator, primary);\
       }\
@@ -738,6 +741,9 @@ class console_api : public context_aware_api {
       int db_##IDX##_end( uint64_t code, uint64_t scope, uint64_t table ) {\
          return context.IDX.end_secondary(code, scope, table);\
       }\
+      int db_##IDX##_rend( uint64_t code, uint64_t scope, uint64_t table ) {\
+         return context.IDX.rend_secondary(code, scope, table);\
+      }\
       int db_##IDX##_next( int iterator, uint64_t& primary  ) {\
          return context.IDX.next_secondary(iterator, primary);\
       }\
@@ -779,6 +785,9 @@ class database_api : public context_aware_api {
       }
       int db_end_i64( uint64_t code, uint64_t scope, uint64_t table ) {
          return context.db_end_i64( code, scope, table );
+      }
+      int db_rend_i64( uint64_t code, uint64_t scope, uint64_t table ) {
+         return context.db_rend_i64( code, scope, table );
       }
 
       DB_API_METHOD_WRAPPERS_SIMPLE_SECONDARY(idx64,  uint64_t)
@@ -1336,6 +1345,7 @@ REGISTER_INTRINSICS(producer_api,
    (db_##IDX##_lowerbound,     int(int64_t,int64_t,int64_t,int,int))\
    (db_##IDX##_upperbound,     int(int64_t,int64_t,int64_t,int,int))\
    (db_##IDX##_end,            int(int64_t,int64_t,int64_t))\
+   (db_##IDX##_rend,           int(int64_t,int64_t,int64_t))\
    (db_##IDX##_next,           int(int, int))\
    (db_##IDX##_previous,       int(int, int))
 
@@ -1348,6 +1358,7 @@ REGISTER_INTRINSICS(producer_api,
       (db_##IDX##_lowerbound,     int(int64_t,int64_t,int64_t,int,int,int))\
       (db_##IDX##_upperbound,     int(int64_t,int64_t,int64_t,int,int,int))\
       (db_##IDX##_end,            int(int64_t,int64_t,int64_t))\
+      (db_##IDX##_rend,           int(int64_t,int64_t,int64_t))\
       (db_##IDX##_next,           int(int, int))\
       (db_##IDX##_previous,       int(int, int))
 
@@ -1362,6 +1373,7 @@ REGISTER_INTRINSICS( database_api,
    (db_lowerbound_i64,   int(int64_t,int64_t,int64_t,int64_t))
    (db_upperbound_i64,   int(int64_t,int64_t,int64_t,int64_t))
    (db_end_i64,          int(int64_t,int64_t,int64_t))
+   (db_rend_i64,         int(int64_t,int64_t,int64_t))
 
    DB_SECONDARY_INDEX_METHODS_SIMPLE(idx64)
    DB_SECONDARY_INDEX_METHODS_SIMPLE(idx128)


### PR DESCRIPTION
`multi_index` now makes it possible for contract developers to easily iterate through the objects in a table in reverse order of primary key or any of the secondary keys (using the `rbegin()` and `rend()` methods familiar from the C++ standard library containers).