### PR TITLE
Fix docker-compose and documentation

### DIFF
--- a/Docker/README.md
+++ b/Docker/README.md
@@ -46,23 +46,23 @@ curl http://127.0.0.1:8888/v1/chain/get_info
 docker-compose up
 ```
 
-After `docker-compose up`, two services named eosd and walletd will be started. eosd service would expose ports 8888 and 9876 to the host. walletd service does not expose any port to the host, it is only accessible to eosc when runing eosc is running inside the walletd container as described in "Execute eosc commands" section.
+After `docker-compose up`, two services named eosd and eosiowd will be started. eosd service would expose ports 8888 and 9876 to the host. eosiowd service does not expose any port to the host, it is only accessible to eosioc when runing eosc is running inside the walletd container as described in "Execute eosioc commands" section.
 
 
-### Execute eosc commands
+### Execute eosioc commands
 
-You can run the `eosc` commands via a bash alias.
+You can run the `eosioc` commands via a bash alias.
 
 ```bash
-alias eosc='docker-compose exec walletd /opt/eos/bin/eosc -H eosd'
-eosc get info
-eosc get account inita
+alias eosioc='docker-compose exec walletd /opt/eosio/bin/eosioc -H eosd'
+eosioc get info
+eosioc get account inita
 ```
 
 Upload sample exchange contract
 
 ```bash
-eosc set contract exchange contracts/exchange/exchange.wast contracts/exchange/exchange.abi
+eosioc set contract exchange contracts/exchange/exchange.wast contracts/exchange/exchange.abi
 ```
 
 If you don't need walletd afterwards, you can stop the walletd service using

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -5,22 +5,22 @@ services:
     build:
       context: .
     image: eosio/eos
-    command: /opt/eos/bin/start_eosd.sh
+    command: /opt/eosio/bin/start_eosiod.sh
     ports:
       - 8888:8888
       - 9876:9876
     expose:
       - "8888"
     volumes:
-      - eosd-data-volume:/opt/eos/bin/data-dir
+      - eosd-data-volume:/opt/eosio/bin/data-dir
 
   walletd:
     image: eosio/eos
-    command: /opt/eos/bin/eos-walletd
+    command: /opt/eosio/bin/eosiowd
     links:
       - eosd
     volumes:
-      - walletd-data-volume:/opt/eos/bin/data-dir
+      - walletd-data-volume:/opt/eosio/bin/data-dir
 
 volumes:
   eosd-data-volume:


### PR DESCRIPTION
The docker-compose config file was out of date for Dawn-2.0
I updated it, and updated the related documentation. 