### PR TITLE
Update permission without waiting on apply block check.

### DIFF
--- a/libraries/chain/contracts/eosio_contract.cpp
+++ b/libraries/chain/contracts/eosio_contract.cpp
@@ -259,8 +259,7 @@ void apply_eosio_deleteauth(apply_context& context) {
                  "Cannot delete a linked authority. Unlink the authority first");
    }
 
-   if (context.controller.is_applying_block())
-      db.remove(permission);
+   db.remove(permission);
 }
 
 void apply_eosio_linkauth(apply_context& context) {
@@ -280,11 +279,10 @@ void apply_eosio_linkauth(apply_context& context) {
    if (link) {
       EOS_ASSERT(link->required_permission != requirement.requirement, action_validate_exception,
                  "Attempting to update required authority, but new requirement is same as old");
-      if (context.controller.is_applying_block())
-         db.modify(*link, [requirement = requirement.requirement](permission_link_object& link) {
-            link.required_permission = requirement;
-         });
-   } else if (context.controller.is_applying_block()) {
+      db.modify(*link, [requirement = requirement.requirement](permission_link_object& link) {
+          link.required_permission = requirement;
+      });
+   } else {
       db.create<permission_link_object>([&requirement](permission_link_object& link) {
          link.account = requirement.account;
          link.code = requirement.code;
@@ -303,8 +301,7 @@ void apply_eosio_unlinkauth(apply_context& context) {
    auto link_key = boost::make_tuple(unlink.account, unlink.code, unlink.type);
    auto link = db.find<permission_link_object, by_action_name>(link_key);
    EOS_ASSERT(link != nullptr, action_validate_exception, "Attempting to unlink authority, but no link found");
-   if (context.controller.is_applying_block())
-      db.remove(*link);
+   db.remove(*link);
 }
 
 

--- a/libraries/chain/include/eosio/chain/chain_controller.hpp
+++ b/libraries/chain/include/eosio/chain/chain_controller.hpp
@@ -116,19 +116,6 @@ namespace eosio { namespace chain {
 
 
 
-
-
-
-
-
-
-
-
-         /**
-          * @brief Check whether the controller is currently applying a block or not
-          * @return True if the controller is now applying a block; false otherwise
-          */
-         bool is_applying_block()const { return _currently_applying_block; }
          bool is_start_of_round( block_num_type n )const;
          uint32_t blocks_per_round()const;
 

--- a/tests/eosiod_run_test.py
+++ b/tests/eosiod_run_test.py
@@ -537,14 +537,12 @@ try:
         cmdError("%s set action permission set" % (ClientName))
         errorExit("Failed to set permission")
 
-# TODO remove failed on eos-noon
-    if not amINoon:
-        Print("remove permission")
-        requirement="null"
-        trans=node.setPermission(testeraAccount.name, code, pType, requirement, waitForTransBlock=True)
-        if trans is None:
-            cmdError("%s set action permission set" % (ClientName))
-            errorExit("Failed to remove permission")
+    Print("remove permission")
+    requirement="null"
+    trans=node.setPermission(testeraAccount.name, code, pType, requirement, waitForTransBlock=True)
+    if trans is None:
+        cmdError("%s set action permission set" % (ClientName))
+        errorExit("Failed to remove permission")
                   
     Print("Locking all wallets.")
     if not walletMgr.lockAllWallets():


### PR DESCRIPTION
Remove apply block check for applying permissions. This should keep the database state consistent across all nodes instead of only applying permissions on nodes doing apply_block.