### PR TITLE
Added mongo drivers to Darwin build.

### DIFF
--- a/scripts/eosio_build_darwin.sh
+++ b/scripts/eosio_build_darwin.sh
@@ -86,7 +86,6 @@
 		fi
 
 		printf "\tHome Brew installation found.\n\n"
-	# 	DEPS="git automake libtool openssl cmake wget boost llvm@4 gmp gettext"
 		DCOUNT=0
 		COUNT=1
 		PERMISSION_GETTEXT=0
@@ -110,6 +109,10 @@
 			else 
 				let DCOUNT++
 				
+				if [ $pkg = "mongod" ]; then
+					pkg="mongodb"
+				fi
+
 				if [ $pkg = "LLVM" ]; then
 					pkg="llvm@4"
 				fi
@@ -159,6 +162,74 @@
 	}
 
 	process_dep
+
+	printf "\n\tChecking for MongoDB C++ driver\n"
+    # install libmongocxx.dylib
+    if [ ! -e /usr/local/lib/libmongocxx.dylib ]; then
+		cd ${TEMP_DIR}
+		brew install --force pkgconfig
+		brew unlink pkgconfig && brew link --force pkgconfig
+		curl -LO https://github.com/mongodb/mongo-c-driver/releases/download/1.9.3/mongo-c-driver-1.9.3.tar.gz
+		if [ $? -ne 0 ]; then
+			rm -f ${TEMP_DIR}/mongo-c-driver-1.9.3.tar.gz
+			printf "\tUnable to download MondgDB C driver at this time.\n"
+			printf "\tExiting now.\n\n"
+			exit;
+		fi
+		tar xf mongo-c-driver-1.9.3.tar.gz
+		rm -f ${TEMP_DIR}/mongo-c-driver-1.9.3.tar.gz
+		cd mongo-c-driver-1.9.3
+		./configure --enable-ssl=darwin --disable-automatic-init-and-cleanup --prefix=/usr/local
+		if [ $? -ne 0 ]; then
+			printf "\tConfiguring MondgDB C driver has encountered the errors above.\n"
+			printf "\tExiting now.\n\n"
+			exit;
+		fi
+		make -j${CPU_CORE}
+		if [ $? -ne 0 ]; then
+			printf "\tError compiling MondgDB C driver.\n"
+			printf "\tExiting now.\n\n"
+			exit;
+		fi
+		sudo make install
+		if [ $? -ne 0 ]; then
+			printf "\tError installing MondgDB C driver.\nMake sure you have sudo privileges.\n"
+			printf "\tExiting now.\n\n"
+			exit;
+		fi
+		cd ..
+		rm -rf ${TEMP_DIR}/mongo-c-driver-1.9.3
+		cd ${TEMP_DIR}
+		git clone https://github.com/mongodb/mongo-cxx-driver.git --branch releases/stable --depth 1
+		if [ $? -ne 0 ]; then
+			printf "\tUnable to clone MondgDB C++ driver at this time.\n"
+			printf "\tExiting now.\n\n"
+			exit;
+		fi
+		cd mongo-cxx-driver/build
+		cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local ..
+		if [ $? -ne 0 ]; then
+			printf "\tCmake has encountered the above errors building the MongoDB C++ driver.\n"
+			printf "\tExiting now.\n\n"
+			exit;
+		fi
+		make -j${CPU_CORE}
+		if [ $? -ne 0 ]; then
+			printf "\tError compiling MondgDB C++ driver.\n"
+			printf "\tExiting now.\n\n"
+			exit;
+		fi
+		sudo make install
+		if [ $? -ne 0 ]; then
+			printf "\tError installing MondgDB C++ driver.\nMake sure you have sudo privileges.\n"
+			printf "\tExiting now.\n\n"
+			exit;
+		fi
+		cd ..
+		rm -rf ${TEMP_DIR}/mongo-cxx-driver
+	else
+		printf "\tMongo C++ driver found at /usr/local/lib/libmongocxx.dylib.\n"
+	fi
 
 	printf "\n\tChecking for secp256k1-zkp\n"
     # install secp256k1-zkp (Cryptonomex branch)

--- a/scripts/eosio_build_dep
+++ b/scripts/eosio_build_dep
@@ -7,3 +7,4 @@ cmake,https://cmake.org/files/v3.10/cmake-3.10.1-Darwin-x86_64.tar.gz
 boost,https://dl.bintray.com/boostorg/release/1.66.0/source/boost_1_66_0.tar.gz
 gmp,https://ftp.gnu.org/gnu/gmp/gmp-6.1.2.tar.bz2
 gettext,https://ftp.gnu.org/pub/gnu/gettext/gettext-latest.tar.gz
+mongod,https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-3.6.3.tgz


### PR DESCRIPTION
Added support for installing MongoDB via homebrew and compiling mong-c-driver-1.9.3 && mongo-cxx-driver to darwin OS.
Files changed:
scripts/eosio_build_darwin.sh