### PR TITLE
multi_index refactor and additions to make interface more consistent with Boost MultiIndex

### DIFF
--- a/contracts/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/eosio.system.hpp
@@ -184,7 +184,7 @@ namespace eosiosystem {
                });
             }
             else {
-               del_index.update( itr, del.from, [&]( auto& dbo ){
+               del_index.modify( itr, del.from, [&]( auto& dbo ){
                   dbo.net_weight = del.stake_net_quantity;
                   dbo.cpu_weight = del.stake_cpu_quantity;
                });
@@ -198,7 +198,7 @@ namespace eosiosystem {
                   tot.total_cpu_weight += del.stake_cpu_quantity;
                });
             } else {
-               total_index.update( tot_itr, 0, [&]( auto& tot ) {
+               total_index.modify( tot_itr, 0, [&]( auto& tot ) {
                   tot.total_net_weight += del.stake_net_quantity;
                   tot.total_cpu_weight += del.stake_cpu_quantity;
                });
@@ -229,14 +229,14 @@ namespace eosiosystem {
             eosio_assert( dbw.net_weight >= del.unstake_net_quantity, "insufficient staked net bandwidth" );
             eosio_assert( dbw.cpu_weight >= del.unstake_cpu_quantity, "insufficient staked cpu bandwidth" );
 
-            del_index.update( del_index.iterator_to(dbw), del.from, [&]( auto& dbo ){
+            del_index.modify( dbw, del.from, [&]( auto& dbo ){
                dbo.net_weight -= del.unstake_net_quantity;
                dbo.cpu_weight -= del.unstake_cpu_quantity;
 
             });
 
             const auto& totals = total_index.get( del.receiver );
-            total_index.update( total_index.iterator_to(totals), 0, [&]( auto& tot ) {
+            total_index.modify( totals, 0, [&]( auto& tot ) {
                tot.total_net_weight -= del.unstake_net_quantity;
                tot.total_cpu_weight -= del.unstake_cpu_quantity;
             });
@@ -308,13 +308,13 @@ namespace eosiosystem {
             producer_votes_index_type votes( SystemAccount, SystemAccount );
 
             for( auto p : acv->producers ) {
-               votes.update( votes.find( p ), 0, [&]( auto& v ) {
+               votes.modify( votes.get( p ), 0, [&]( auto& v ) {
                   v.total_votes -= old_weight;
                   v.total_votes += new_weight;
                });
             }
 
-            avotes.update( acv, 0, [&]( auto av ) {
+            avotes.modify( acv, 0, [&]( auto av ) {
                av.last_update = now();
                av.staked += sv.amount;
             });
@@ -361,14 +361,14 @@ namespace eosiosystem {
             for( const auto& delta : producer_vote_changes ) {
                if( delta.second.first != delta.second.second ) {
                   const auto& provote = votes.get( delta.first );
-                  votes.update( votes.iterator_to(provote), 0, [&]( auto& pv ){
+                  votes.modify( provote, 0, [&]( auto& pv ){
                      pv.total_votes -= delta.second.first;
                      pv.total_votes += delta.second.second;
                   });
                }
             }
 
-            avotes.update( avotes.iterator_to(existing), 0, [&]( auto& av ) {
+            avotes.modify( existing, 0, [&]( auto& av ) {
               av.proxy = vp.proxy;
               av.last_update = now();
               av.producers = vp.producers;

--- a/contracts/eosiolib/generic_currency.hpp
+++ b/contracts/eosiolib/generic_currency.hpp
@@ -96,7 +96,7 @@ namespace eosio {
              };
              auto itr = t.find( symbol );
              if( itr != t.end() ) {
-                t.update( itr, update_bill_to, f);
+                t.modify( itr, update_bill_to, f);
              } else {
                 t.emplace( create_bill_to, f);
              }
@@ -108,7 +108,7 @@ namespace eosio {
              stats t( code, code );
              auto itr = t.find( symbol );
              if( itr != t.end() ) {
-                t.update(itr, 0, [&](currency_stats& s) { s.supply += act.quantity; });
+                t.modify(itr, 0, [&](currency_stats& s) { s.supply += act.quantity; });
              } else {
                 t.emplace(code, [&](currency_stats& s) { s.supply = act.quantity; });
              }

--- a/contracts/eosiolib/generic_currency.hpp
+++ b/contracts/eosiolib/generic_currency.hpp
@@ -96,7 +96,7 @@ namespace eosio {
              };
              auto itr = t.find( symbol );
              if( itr != t.end() ) {
-                t.update( *itr, update_bill_to, f);
+                t.update( itr, update_bill_to, f);
              } else {
                 t.emplace( create_bill_to, f);
              }
@@ -108,7 +108,7 @@ namespace eosio {
              stats t( code, code );
              auto itr = t.find( symbol );
              if( itr != t.end() ) {
-                t.update(*itr, 0, [&](currency_stats& s) { s.supply += act.quantity; });
+                t.update(itr, 0, [&](currency_stats& s) { s.supply += act.quantity; });
              } else {
                 t.emplace(code, [&](currency_stats& s) { s.supply = act.quantity; });
              }

--- a/contracts/eosiolib/generic_currency.hpp
+++ b/contracts/eosiolib/generic_currency.hpp
@@ -84,8 +84,8 @@ namespace eosio {
 
           static token_type get_balance( account_name owner ) {
              accounts t( code, owner );
-             auto ptr = t.find( symbol );
-             return ptr ? ptr->balance : token_type( asset(0, symbol) );
+             auto itr = t.find( symbol );
+             return itr != t.end() ? itr->balance : token_type( asset(0, symbol) );
           }
 
          static void set_balance( account_name owner, token_type balance, account_name create_bill_to, account_name update_bill_to ) {
@@ -94,9 +94,9 @@ namespace eosio {
                 acc.symbol = symbol;
                 acc.balance = balance;
              };
-             auto ptr = t.find( symbol );
-             if (ptr) {
-                t.update( *ptr, update_bill_to, f);
+             auto itr = t.find( symbol );
+             if( itr != t.end() ) {
+                t.update( *itr, update_bill_to, f);
              } else {
                 t.emplace( create_bill_to, f);
              }
@@ -106,9 +106,9 @@ namespace eosio {
              require_auth( code );
 
              stats t( code, code );
-             auto ptr = t.find( symbol );
-             if (ptr) {
-                t.update(*ptr, 0, [&](currency_stats& s) { s.supply += act.quantity; });
+             auto itr = t.find( symbol );
+             if( itr != t.end() ) {
+                t.update(*itr, 0, [&](currency_stats& s) { s.supply += act.quantity; });
              } else {
                 t.emplace(code, [&](currency_stats& s) { s.supply = act.quantity; });
              }

--- a/contracts/eosiolib/multi_index.hpp
+++ b/contracts/eosiolib/multi_index.hpp
@@ -556,7 +556,7 @@ class multi_index
         return typename decltype(+res.value())::type(*this);
       }
 
-      const_iterator iterator_to( const T& obj ) {
+      const_iterator iterator_to( const T& obj )const {
          const auto& objitem = static_cast<const item&>(obj);
          eosio_assert( &objitem.__idx == this, "object passed to iterator_to is not in multi_index" );
          return {*this, &objitem};
@@ -634,20 +634,20 @@ class multi_index
 
       const T& get( uint64_t primary )const {
          auto result = find( primary );
-         eosio_assert( result != nullptr, "unable to find key" );
+         eosio_assert( result != end(), "unable to find key" );
          return *result;
       }
 
-      const T* find( uint64_t primary )const {
+      const_iterator find( uint64_t primary )const {
          auto cacheitr = _items_index.find(primary);
          if( cacheitr != _items_index.end() )
-            return &*cacheitr;
+            return iterator_to(*cacheitr);
 
          int itr = db_find_i64( _code, _scope, TableName, primary );
-         if( itr < 0 ) return nullptr;
+         if( itr < 0 ) return end();
 
          const item& i = load_object_by_primary_iterator( itr );
-         return &static_cast<const T&>(i);
+         return iterator_to(static_cast<const T&>(i));
       }
 
       void remove( const T& obj ) {

--- a/contracts/eosiolib/multi_index.hpp
+++ b/contracts/eosiolib/multi_index.hpp
@@ -1,4 +1,9 @@
+/**
+ *  @file
+ *  @copyright defined in eos/LICENSE.txt
+ */
 #pragma once
+
 #include <tuple>
 #include <boost/hana.hpp>
 #include <functional>
@@ -22,6 +27,8 @@ namespace eosio {
 
 namespace bmi = boost::multi_index;
 using boost::multi_index::const_mem_fun;
+
+namespace hana = boost::hana;
 
 template<typename T>
 struct secondary_iterator;
@@ -84,75 +91,11 @@ WRAP_SECONDARY_SIMPLE_TYPE(idx64,  uint64_t)
 WRAP_SECONDARY_SIMPLE_TYPE(idx128, uint128_t)
 WRAP_SECONDARY_ARRAY_TYPE(idx256, key256)
 
-
-template<uint64_t TableName, typename T, typename... Indices>
-class multi_index;
-
 template<uint64_t IndexName, typename Extractor>
 struct indexed_by {
    enum constants { index_name   = IndexName };
-   typedef  Extractor                        secondary_extractor_type;
-   typedef  decltype( Extractor()(nullptr) ) secondary_type;
+   typedef Extractor secondary_extractor_type;
 };
-
-
-template<uint64_t TableName, uint64_t IndexName, typename T, typename Extractor, int N = 0>
-struct index_by {
-   typedef  Extractor  secondary_extractor_type;
-   typedef  typename std::decay<decltype( Extractor()(nullptr) )>::type secondary_type;
-
-   index_by(){}
-
-   enum constants {
-      table_name   = TableName,
-      index_name   = IndexName,
-      index_number = N,
-      index_table_name = (TableName & 0xFFFFFFFFFFFFFFF0ULL) | (N & 0x000000000000000FULL) // Assuming no more than 16 secondary indices are allowed
-   };
-
-   constexpr static int number()    { return N; }
-   constexpr static uint64_t name() {
-      // return IndexName;
-      return index_table_name;
-   }
-
-   private:
-      template<uint64_t, typename, typename... >
-      friend class multi_index;
-
-      static auto extract_secondary_key(const T& obj) { return secondary_extractor_type()(obj); }
-
-      static int store( uint64_t scope, uint64_t payer, const T& obj ) {
-         return db_idx_store( scope, name(), payer, obj.primary_key(), extract_secondary_key(obj) );
-      }
-
-      static void update( int iterator, uint64_t payer, const secondary_type& secondary ) {
-         db_idx_update( iterator, payer, secondary );
-      }
-
-      static int find_primary( uint64_t code, uint64_t scope, uint64_t primary, secondary_type& secondary ) {
-         return db_idx_find_primary( code, scope, name(), primary,  secondary );
-      }
-
-      static void remove( int itr ) {
-         secondary_iterator<secondary_type>::db_idx_remove( itr );
-      }
-
-      static int find_secondary( uint64_t code, uint64_t scope, secondary_type& secondary, uint64_t& primary ) {
-         return db_idx_find_secondary( code, scope, name(), secondary, primary );
-      }
-
-      static int lower_bound( uint64_t code, uint64_t scope, secondary_type& secondary, uint64_t& primary ) {
-         return db_idx_lowerbound( code, scope, name(), secondary, primary );
-      }
-
-      static int upper_bound( uint64_t code, uint64_t scope, secondary_type& secondary, uint64_t& primary ) {
-         return db_idx_upperbound( code, scope, name(), secondary, primary );
-      }
-};
-
-
-namespace hana = boost::hana;
 
 template<uint64_t TableName, typename T, typename... Indices>
 class multi_index
@@ -161,7 +104,7 @@ class multi_index
 
       static_assert( sizeof...(Indices) <= 16, "multi_index only supports a maximum of 16 secondary indices" );
 
-      constexpr static bool validate_table_name(uint64_t n) {
+      constexpr static bool validate_table_name( uint64_t n ) {
          // Limit table names to 12 characters so that the last character (4 bits) can be used to distinguish between the secondary indices.
          return (n & 0x000000000000000FULL) == 0;
       }
@@ -191,6 +134,232 @@ class multi_index
          unset_next_primary_key = static_cast<uint64_t>(-1)
       };
 
+      template<uint64_t IndexName, typename Extractor, uint64_t Number>
+      struct index {
+         public:
+            typedef Extractor  secondary_extractor_type;
+            typedef typename std::decay<decltype( Extractor()(nullptr) )>::type secondary_key_type;
+
+            constexpr static bool validate_index_name( uint64_t n ) {
+               return n != 0 && n != N(primary); // Primary is a reserve index name.
+            }
+
+            static_assert( validate_index_name(IndexName), "invalid index name used in multi_index" );
+
+            enum constants {
+               table_name   = TableName,
+               index_name   = IndexName,
+               index_number = Number,
+               index_table_name = (TableName & 0xFFFFFFFFFFFFFFF0ULL) | (Number & 0x000000000000000FULL) // Assuming no more than 16 secondary indices are allowed
+            };
+
+            constexpr static uint64_t name()   { return index_table_name; }
+            constexpr static uint64_t number() { return Number; }
+
+            struct const_iterator : public std::iterator<std::bidirectional_iterator_tag, const T> {
+               public:
+                  friend bool operator == ( const const_iterator& a, const const_iterator& b ) {
+                     return a._item == b._item;
+                  }
+                  friend bool operator != ( const const_iterator& a, const const_iterator& b ) {
+                     return a._item != b._item;
+                  }
+
+                  const T& operator*()const { return *static_cast<const T*>(_item); }
+                  const T* operator->()const { return static_cast<const T*>(_item); }
+
+                  const_iterator operator++(int)const {
+                     return ++(const_iterator(*this));
+                  }
+
+                  const_iterator operator--(int)const {
+                     return --(const_iterator(*this));
+                  }
+
+                  const_iterator& operator++() {
+                     eosio_assert( _item != nullptr, "cannot increment end iterator" );
+                     const auto& idx = _idx.get();
+
+                     if( _item->__iters[Number] == -1 ) {
+                        secondary_key_type temp_secondary_key;
+                        auto idxitr = db_idx_find_primary(idx.get_code(),
+                                                          idx.get_scope(),
+                                                          idx.name(),
+                                                          _item->primary_key(), temp_secondary_key);
+                        auto& mi = const_cast<item&>( *_item );
+                        mi.__iters[Number] = idxitr;
+                     }
+
+                     uint64_t next_pk = 0;
+                     auto next_itr = secondary_iterator<secondary_key_type>::db_idx_next( _item->__iters[Number], &next_pk );
+                     if( next_itr < 0 ) {
+                        _item = nullptr;
+                        return *this;
+                     }
+
+                     const T& obj = *idx._multidx.find( next_pk );
+                     auto& mi = const_cast<item&>( static_cast<const item&>(obj) );
+                     mi.__iters[Number] = next_itr;
+                     _item = &mi;
+
+                     return *this;
+                  }
+
+                  const_iterator& operator--() {
+                     uint64_t prev_pk = 0;
+                     int prev_itr = -1;
+                     const auto& idx = _idx.get();
+
+                     if( !_item ) {
+                        auto ei = secondary_iterator<secondary_key_type>::db_idx_end(idx.get_code(), idx.get_scope(), idx.name());
+                        eosio_assert( ei != -1, "cannot decrement end iterator when the index is empty" );
+                        prev_itr = secondary_iterator<secondary_key_type>::db_idx_previous( ei , &prev_pk );
+                        eosio_assert( prev_itr >= 0, "cannot decrement end iterator when the index is empty" );
+                     } else {
+                        if( _item->__iters[Number] == -1 ) {
+                           secondary_key_type temp_secondary_key;
+                           auto idxitr = db_idx_find_primary(idx.get_code(),
+                                                             idx.get_scope(),
+                                                             idx.name(),
+                                                             _item->primary_key(), temp_secondary_key);
+                           auto& mi = const_cast<item&>( *_item );
+                           mi.__iters[Number] = idxitr;
+                        }
+                        prev_itr = secondary_iterator<secondary_key_type>::db_idx_previous( _item->__iters[Number], &prev_pk );
+                        eosio_assert( prev_itr >= 0, "cannot decrement iterator at beginning of index" );
+                     }
+
+                     const T& obj = *idx._multidx.find( prev_pk );
+                     auto& mi = const_cast<item&>( static_cast<const item&>(obj) );
+                     mi.__iters[Number] = prev_itr;
+                     _item = &mi;
+
+                     return *this;
+                  }
+
+               private:
+                  friend struct index;
+                  const_iterator( const index& idx, const item* i = nullptr )
+                  :_idx(std::cref(idx)), _item(i){}
+
+                  std::reference_wrapper<const index> _idx;
+                  const item* _item;
+            }; /// struct multi_index::index::const_iterator
+
+            typedef std::reverse_iterator<const_iterator> const_reverse_iterator;
+
+            const_iterator cbegin()const {
+               return lower_bound(std::numeric_limits<secondary_key_type>::lowest());
+            }
+            const_iterator begin()const  { return cbegin(); }
+
+            const_iterator cend()const   { return const_iterator( *this ); }
+            const_iterator end()const    { return cend(); }
+
+            const_reverse_iterator crbegin()const { return std::make_reverse_iterator(cend()); }
+            const_reverse_iterator rbegin()const  { return crbegin(); }
+
+            const_reverse_iterator crend()const   { return std::make_reverse_iterator(cbegin()); }
+            const_reverse_iterator rend()const    { return crend(); }
+
+            const_iterator find( secondary_key_type&& secondary )const {
+               auto lb = lower_bound( secondary );
+               auto e = end();
+               if( lb == e ) return e;
+
+               if( secondary != secondary_extractor_type()(*lb) )
+                  return e;
+               return lb;
+            }
+
+            const_iterator lower_bound( secondary_key_type&& secondary )const {
+               return lower_bound( secondary );
+            }
+            const_iterator lower_bound( const secondary_key_type& secondary )const {
+               uint64_t primary = 0;
+               secondary_key_type secondary_copy(secondary);
+               auto itr = lower_bound( get_code(), get_scope(), secondary_copy, primary );
+               if( itr < 0 ) return end();
+
+               const T& obj = *_multidx.find( primary );
+               auto& mi = const_cast<item&>( static_cast<const item&>(obj) );
+               mi.__iters[Number] = itr;
+
+               return {*this, &mi};
+            }
+            const_iterator upper_bound( secondary_key_type&& secondary )const {
+               return upper_bound( secondary );
+            }
+            const_iterator upper_bound( const secondary_key_type& secondary )const {
+               uint64_t primary = 0;
+               secondary_key_type secondary_copy(secondary);
+               auto itr = upper_bound( get_code(), get_scope(), secondary_copy, primary );
+               if( itr < 0 ) return end();
+
+               const T& obj = *_multidx.find( primary );
+               auto& mi = const_cast<item&>( static_cast<const item&>(obj) );
+               mi.__iters[Number] = itr;
+
+               return {*this, &mi};
+            }
+
+            const_iterator iterator_to( const T& obj ) {
+               const auto& objitem = static_cast<const item&>(obj);
+               eosio_assert( &objitem.__idx == &_multidx, "object passed to iterator_to is not in multi_index" );
+
+               if( objitem.__iters[Number] == -1 ) {
+                  secondary_key_type temp_secondary_key;
+                  auto idxitr = db_idx_find_primary(get_code(),
+                                                    get_scope(),
+                                                    name(),
+                                                    objitem.primary_key(), temp_secondary_key);
+                  auto& mi = const_cast<item&>( objitem );
+                  mi.__iters[Number] = idxitr;
+               }
+
+               return {*this, &objitem};
+            }
+
+            uint64_t get_code()const  { return _multidx.get_code(); }
+            uint64_t get_scope()const { return _multidx.get_scope(); }
+
+            static auto extract_secondary_key(const T& obj) { return secondary_extractor_type()(obj); }
+
+            static int store( uint64_t scope, uint64_t payer, const T& obj ) {
+               return db_idx_store( scope, name(), payer, obj.primary_key(), extract_secondary_key(obj) );
+            }
+
+            static void update( int iterator, uint64_t payer, const secondary_key_type& secondary ) {
+               db_idx_update( iterator, payer, secondary );
+            }
+
+            static int find_primary( uint64_t code, uint64_t scope, uint64_t primary, secondary_key_type& secondary ) {
+               return db_idx_find_primary( code, scope, name(), primary,  secondary );
+            }
+
+            static void remove( int itr ) {
+               secondary_iterator<secondary_key_type>::db_idx_remove( itr );
+            }
+
+            static int find_secondary( uint64_t code, uint64_t scope, secondary_key_type& secondary, uint64_t& primary ) {
+               return db_idx_find_secondary( code, scope, name(), secondary, primary );
+            }
+
+            static int lower_bound( uint64_t code, uint64_t scope, secondary_key_type& secondary, uint64_t& primary ) {
+               return db_idx_lowerbound( code, scope, name(), secondary, primary );
+            }
+
+            static int upper_bound( uint64_t code, uint64_t scope, secondary_key_type& secondary, uint64_t& primary ) {
+               return db_idx_upperbound( code, scope, name(), secondary, primary );
+            }
+
+         private:
+            friend class multi_index;
+            index( const multi_index& midx ):_multidx(midx){}
+
+            const multi_index& _multidx;
+      }; /// struct multi_index::index
+
       template<uint64_t I>
       struct intc { enum e{ value = I }; operator uint64_t()const{ return I; }  };
 
@@ -204,11 +373,9 @@ class multi_index
          return hana::transform( indices_input_type(), [&]( auto&& idx ){
              typedef typename std::decay<decltype(hana::at_c<0>(idx))>::type num_type;
              typedef typename std::decay<decltype(hana::at_c<1>(idx))>::type idx_type;
-             return index_by<TableName,
-                             idx_type::index_name,
-                             T,
-                             typename idx_type::secondary_extractor_type,
-                             num_type::e::value>();
+             return hana::type_c<index<idx_type::index_name,
+                          typename idx_type::secondary_extractor_type,
+                          num_type::e::value> >;
 
          });
       }
@@ -246,16 +413,16 @@ class multi_index
 
             i.__primary_itr = itr;
             boost::hana::for_each( _indices, [&]( auto& idx ) {
-               i.__iters[ idx.number() ] = -1;
+               typedef typename decltype(+idx)::type index_type;
+
+               i.__iters[ index_type::number() ] = -1;
             });
          });
 
          // eosio_assert( result.second, "failed to insert object, likely a uniqueness constraint was violated" );
 
          return *result.first;
-      } /// load_object_by_iterator
-
-      friend struct const_iterator;
+      } /// load_object_by_primary_iterator
 
    public:
 
@@ -266,175 +433,7 @@ class multi_index
       uint64_t get_code()const { return _code; }
       uint64_t get_scope()const { return _scope; }
 
-      template<typename MultiIndexType, typename IndexType, uint64_t Number>
-      struct index {
-         private:
-            typedef typename MultiIndexType::item item_type;
-            typedef typename IndexType::secondary_type secondary_key_type;
-
-         public:
-            typedef typename IndexType::secondary_extractor_type  secondary_extractor_type;
-            static constexpr uint64_t name() { return IndexType::name(); }
-
-            struct const_iterator : std::iterator<std::bidirectional_iterator_tag, const T> {
-               public:
-                  friend bool operator == ( const const_iterator& a, const const_iterator& b ) {
-                     return a._item == b._item;
-                  }
-                  friend bool operator != ( const const_iterator& a, const const_iterator& b ) {
-                     return a._item != b._item;
-                  }
-
-                  const_iterator operator++(int)const {
-                     return ++(const_iterator(*this));
-                  }
-
-                  const_iterator operator--(int)const {
-                     return --(const_iterator(*this));
-                  }
-
-                  const_iterator& operator++() {
-                     eosio_assert( _item != nullptr, "cannot increment end iterator" );
-                     const auto& idx = _idx.get();
-
-                     if( _item->__iters[Number] == -1 ) {
-                        secondary_key_type temp_secondary_key;
-                        auto idxitr = db_idx_find_primary(idx.get_code(),
-                                                          idx.get_scope(),
-                                                          idx.name(),
-                                                          _item->primary_key(), temp_secondary_key);
-                        auto& mi = const_cast<item_type&>( *_item );
-                        mi.__iters[Number] = idxitr;
-                     }
-
-                     uint64_t next_pk = 0;
-                     auto next_itr = secondary_iterator<secondary_key_type>::db_idx_next( _item->__iters[Number], &next_pk );
-                     if( next_itr < 0 ) {
-                        _item = nullptr;
-                        return *this;
-                     }
-
-                     const T& obj = *idx._multidx.find( next_pk );
-                     auto& mi = const_cast<item_type&>( static_cast<const item_type&>(obj) );
-                     mi.__iters[Number] = next_itr;
-                     _item = &mi;
-
-                     return *this;
-                  }
-
-                  const_iterator& operator--() {
-                     uint64_t prev_pk = 0;
-                     int prev_itr = -1;
-                     const auto& idx = _idx.get();
-
-                     if( !_item ) {
-                        auto ei = secondary_iterator<secondary_key_type>::db_idx_end(idx.get_code(), idx.get_scope(), idx.name());
-                        eosio_assert( ei != -1, "cannot decrement end iterator when the index is empty" );
-                        prev_itr = secondary_iterator<secondary_key_type>::db_idx_previous( ei , &prev_pk );
-                        eosio_assert( prev_itr >= 0, "cannot decrement end iterator when the index is empty" );
-                     } else {
-                        if( _item->__iters[Number] == -1 ) {
-                           secondary_key_type temp_secondary_key;
-                           auto idxitr = db_idx_find_primary(idx.get_code(),
-                                                             idx.get_scope(),
-                                                             idx.name(),
-                                                             _item->primary_key(), temp_secondary_key);
-                           auto& mi = const_cast<item_type&>( *_item );
-                           mi.__iters[Number] = idxitr;
-                        }
-                        prev_itr = secondary_iterator<secondary_key_type>::db_idx_previous( _item->__iters[Number], &prev_pk );
-                        eosio_assert( prev_itr >= 0, "cannot decrement iterator at beginning of index" );
-                     }
-
-                     const T& obj = *idx._multidx.find( prev_pk );
-                     auto& mi = const_cast<item_type&>( static_cast<const item_type&>(obj) );
-                     mi.__iters[Number] = prev_itr;
-                     _item = &mi;
-
-                     return *this;
-                  }
-
-                  const T& operator*()const { return *static_cast<const T*>(_item); }
-                  const T* operator->()const { return static_cast<const T*>(_item); }
-
-               private:
-                  friend struct index;
-                  const_iterator( const index& idx, const typename MultiIndexType::item* i = nullptr )
-                  :_idx(std::cref(idx)), _item(i){}
-
-                  std::reference_wrapper<const index> _idx;
-                  const typename MultiIndexType::item* _item;
-            };
-
-            typedef std::reverse_iterator<const_iterator> const_reverse_iterator;
-
-            const_iterator cbegin()const {
-               return lower_bound(std::numeric_limits<typename IndexType::secondary_type>::lowest());
-            }
-            const_iterator begin()const  { return cbegin(); }
-
-            const_iterator cend()const   { return const_iterator( *this ); }
-            const_iterator end()const    { return cend(); }
-
-            const_reverse_iterator crbegin()const { return std::make_reverse_iterator(cend()); }
-            const_reverse_iterator rbegin()const  { return crbegin(); }
-
-            const_reverse_iterator crend()const   { return std::make_reverse_iterator(cbegin()); }
-            const_reverse_iterator rend()const    { return crend(); }
-
-            const_iterator find( typename IndexType::secondary_type&& secondary )const {
-               auto lb = lower_bound( secondary );
-               auto e = end();
-               if( lb == e ) return e;
-
-               if( secondary != typename IndexType::secondary_extractor_type()(*lb) )
-                  return e;
-               return lb;
-            }
-
-            const_iterator lower_bound( typename IndexType::secondary_type&& secondary )const {
-               return lower_bound( secondary );
-            }
-            const_iterator lower_bound( const typename IndexType::secondary_type& secondary )const {
-               uint64_t primary = 0;
-               typename IndexType::secondary_type secondary_copy(secondary);
-               auto itr = IndexType::lower_bound( get_code(), get_scope(), secondary_copy, primary );
-               if( itr < 0 ) return end();
-
-               const T& obj = *_multidx.find( primary );
-               auto& mi = const_cast<item_type&>( static_cast<const item_type&>(obj) );
-               mi.__iters[Number] = itr;
-
-               return const_iterator( *this, &mi );
-            }
-            const_iterator upper_bound( typename IndexType::secondary_type&& secondary )const {
-               return upper_bound( secondary );
-            }
-            const_iterator upper_bound( const typename IndexType::secondary_type& secondary )const {
-               uint64_t primary = 0;
-               typename IndexType::secondary_type secondary_copy(secondary);
-               auto itr = IndexType::upper_bound( get_code(), get_scope(), secondary_copy, primary );
-               if( itr < 0 ) return end();
-
-               const T& obj = *_multidx.find( primary );
-               auto& mi = const_cast<item_type&>( static_cast<const item_type&>(obj) );
-               mi.__iters[Number] = itr;
-
-               return const_iterator( *this, &mi );
-            }
-
-            uint64_t get_code()const  { return _multidx.get_code(); }
-            uint64_t get_scope()const { return _multidx.get_scope(); }
-
-         private:
-            friend class multi_index;
-            index( const MultiIndexType& midx ) //, const IndexType& idx )
-            :_multidx(midx){}
-
-            const MultiIndexType& _multidx;
-      };
-
-      struct const_iterator : std::iterator<std::bidirectional_iterator_tag, const T> {
+      struct const_iterator : public std::iterator<std::bidirectional_iterator_tag, const T> {
          friend bool operator == ( const const_iterator& a, const const_iterator& b ) {
             return a._item == b._item;
          }
@@ -490,7 +489,7 @@ class multi_index
             std::reference_wrapper<const multi_index> _multidx;
             const item*  _item;
             friend class multi_index;
-      };
+      }; /// struct multi_index::const_iterator
 
       typedef std::reverse_iterator<const_iterator> const_reverse_iterator;
 
@@ -512,14 +511,14 @@ class multi_index
          auto itr = db_lowerbound_i64( _code, _scope, TableName, primary );
          if( itr < 0 ) return end();
          auto& obj = load_object_by_primary_iterator( itr );
-         return const_iterator( *this, &obj );
+         return {*this, &obj};
       }
 
       const_iterator upper_bound( uint64_t primary )const {
          auto itr = db_upperbound_i64( _code, _scope, TableName, primary );
          if( itr < 0 ) return end();
          auto& obj = load_object_by_primary_iterator( itr );
-         return const_iterator( *this, &obj );
+         return {*this, &obj};
       }
 
       /** Ideally this method would only be used to determine the appropriate primary key to use within new objects added to a
@@ -548,11 +547,19 @@ class multi_index
 
       template<uint64_t IndexName>
       auto get_index()const  {
-        auto idx = boost::hana::find_if( _indices, []( auto&& in ) {
-            return std::integral_constant<bool, std::decay<decltype(in)>::type::index_name == IndexName>();
-        }).value();
+        auto res = boost::hana::find_if( _indices, []( auto&& in ) {
+            return std::integral_constant<bool, std::decay<typename decltype(+in)::type>::type::index_name == IndexName>();
+        });
 
-        return index<multi_index, decltype(idx), idx.number()>( *this );
+        static_assert( res != hana::nothing, "name provided is not the name of any secondary index within multi_index" );
+
+        return typename decltype(+res.value())::type(*this);
+      }
+
+      const_iterator iterator_to( const T& obj ) {
+         const auto& objitem = static_cast<const item&>(obj);
+         eosio_assert( &objitem.__idx == this, "object passed to iterator_to is not in multi_index" );
+         return {*this, &objitem};
       }
 
       template<typename Lambda>
@@ -573,7 +580,9 @@ class multi_index
                _next_primary_key = (pk >= no_available_primary_key) ? no_available_primary_key : (pk + 1);
 
             boost::hana::for_each( _indices, [&]( auto& idx ) {
-               i.__iters[idx.number()] = idx.store( _scope, payer, obj );
+               typedef typename decltype(+idx)::type index_type;
+
+               i.__iters[index_type::number()] = index_type::store( _scope, payer, obj );
             });
          });
 
@@ -589,7 +598,9 @@ class multi_index
          // eosio_assert( &objitem.__idx == this, "invalid object" );
 
          auto secondary_keys = boost::hana::transform( _indices, [&]( auto&& idx ) {
-             return idx.extract_secondary_key( obj );
+            typedef typename decltype(+idx)::type index_type;
+
+            return index_type::extract_secondary_key( obj );
          });
 
          auto& mutableobj = const_cast<T&>(obj); // Do not forget the auto& otherwise it would make a copy and thus not update at all.
@@ -607,16 +618,16 @@ class multi_index
             _next_primary_key = (pk >= no_available_primary_key) ? no_available_primary_key : (pk + 1);
 
          boost::hana::for_each( _indices, [&]( auto& idx ) {
-            typedef typename std::decay<decltype(idx)>::type index_type;
+            typedef typename decltype(+idx)::type index_type;
 
-            auto secondary = idx.extract_secondary_key( obj );
+            auto secondary = index_type::extract_secondary_key( obj );
             if( hana::at_c<index_type::index_number>(secondary_keys) != secondary ) {
-               auto indexitr = mutableitem.__iters[idx.number()];
+               auto indexitr = mutableitem.__iters[index_type::number()];
 
                if( indexitr < 0 )
-                  indexitr = mutableitem.__iters[idx.number()] = idx.find_primary( _code, _scope, pk, secondary );
+                  indexitr = mutableitem.__iters[index_type::number()] = index_type::find_primary( _code, _scope, pk, secondary );
 
-               idx.update( indexitr, payer, secondary );
+               index_type::update( indexitr, payer, secondary );
             }
          });
       }
@@ -647,13 +658,15 @@ class multi_index
          db_remove_i64( objitem.__primary_itr );
 
          boost::hana::for_each( _indices, [&]( auto& idx ) {
-            auto i = objitem.__iters[idx.number()];
+            typedef typename decltype(+idx)::type index_type;
+
+            auto i = objitem.__iters[index_type::number()];
             if( i < 0 ) {
-              typename std::decay<decltype(idx)>::type::secondary_type second;
-              i = idx.find_primary( _code, _scope, objitem.primary_key(), second );
+              typename index_type::secondary_key_type second;
+              i = index_type::find_primary( _code, _scope, objitem.primary_key(), second );
             }
             if( i >= 0 )
-              idx.remove( i );
+              index_type::remove( i );
          });
 
          auto cacheitr = _items_index.find(obj.primary_key());

--- a/contracts/eosiolib/singleton.hpp
+++ b/contracts/eosiolib/singleton.hpp
@@ -35,29 +35,29 @@ namespace  eosio {
 
          static T get( scope_name scope = Code ) {
             table t( Code, scope );
-            auto ptr = t.find( pk_value );
-            eosio_assert( bool(ptr), "singleton does not exist" );
-            return ptr->value;
+            auto itr = t.find( pk_value );
+            eosio_assert( itr != t.end(), "singleton does not exist" );
+            return itr->value;
          }
 
          static T get_or_default( scope_name scope = Code, const T& def = T() ) {
             table t( Code, scope );
-            auto ptr = t.find( pk_value );
-            return ptr ? ptr->value : def;
+            auto itr = t.find( pk_value );
+            return itr != t.end() ? itr->value : def;
          }
 
          static T get_or_create( scope_name scope = Code, const T& def = T() ) {
             table t( Code, scope );
-            auto ptr = t.find( pk_value );
-            return ptr ? ptr->value
+            auto itr = t.find( pk_value );
+            return itr != t.end() ? itr->value
                : t.emplace(BillToAccount, [&](row& r) { r.value = def; });
          }
 
          static void set( const T& value = T(), scope_name scope = Code, account_name b = BillToAccount ) {
             table t( Code, scope );
-            auto ptr = t.find( pk_value );
-            if (ptr) {
-               t.update(*ptr, b, [&](row& r) { r.value = value; });
+            auto itr = t.find( pk_value );
+            if( itr != t.end() ) {
+               t.update(*itr, b, [&](row& r) { r.value = value; });
             } else {
                t.emplace(b, [&](row& r) { r.value = value; });
             }
@@ -65,9 +65,9 @@ namespace  eosio {
 
          static void remove( scope_name scope = Code ) {
             table t( Code, scope );
-            auto ptr = t.find( pk_value );
-            if (ptr) {
-               t.remove(*ptr);
+            auto itr = t.find( pk_value );
+            if( itr != t.end() ) {
+               t.remove(*itr);
             }
          }
    };

--- a/contracts/eosiolib/singleton.hpp
+++ b/contracts/eosiolib/singleton.hpp
@@ -57,7 +57,7 @@ namespace  eosio {
             table t( Code, scope );
             auto itr = t.find( pk_value );
             if( itr != t.end() ) {
-               t.update(*itr, b, [&](row& r) { r.value = value; });
+               t.update(itr, b, [&](row& r) { r.value = value; });
             } else {
                t.emplace(b, [&](row& r) { r.value = value; });
             }
@@ -67,7 +67,7 @@ namespace  eosio {
             table t( Code, scope );
             auto itr = t.find( pk_value );
             if( itr != t.end() ) {
-               t.remove(*itr);
+               t.remove(itr);
             }
          }
    };

--- a/contracts/eosiolib/singleton.hpp
+++ b/contracts/eosiolib/singleton.hpp
@@ -57,7 +57,7 @@ namespace  eosio {
             table t( Code, scope );
             auto itr = t.find( pk_value );
             if( itr != t.end() ) {
-               t.update(itr, b, [&](row& r) { r.value = value; });
+               t.modify(itr, b, [&](row& r) { r.value = value; });
             } else {
                t.emplace(b, [&](row& r) { r.value = value; });
             }
@@ -67,7 +67,7 @@ namespace  eosio {
             table t( Code, scope );
             auto itr = t.find( pk_value );
             if( itr != t.end() ) {
-               t.remove(itr);
+               t.erase(itr);
             }
          }
    };

--- a/contracts/exchange/exchange.hpp
+++ b/contracts/exchange/exchange.hpp
@@ -109,13 +109,13 @@ class exchange {
          switch( d.amount.symbol ) {
             case base_token_type::symbol:
                BaseCurrency::inline_transfer( d.from, ExchangeAccount, base_token_type(d.amount.amount) );
-               _accounts.update( owner, 0, [&]( auto& a ) {
+               _accounts.modify( owner, 0, [&]( auto& a ) {
                   a.base_balance += base_token_type(d.amount);
                });
                break;
             case quote_token_type::symbol:
                QuoteCurrency::inline_transfer( d.from, ExchangeAccount, quote_token_type(d.amount.amount) );
-               _accounts.update( owner, 0, [&]( auto& a ) {
+               _accounts.modify( owner, 0, [&]( auto& a ) {
                   a.quote_balance += quote_token_type(d.amount);
                });
                break;
@@ -141,7 +141,7 @@ class exchange {
             case base_token_type::symbol:
                eosio_assert( owner->base_balance >= base_token_type(w.amount), "insufficient balance" );
 
-               _accounts.update( owner, 0, [&]( auto& a ) {
+               _accounts.modify( owner, 0, [&]( auto& a ) {
                   a.base_balance -= base_token_type(w.amount);
                });
 
@@ -150,7 +150,7 @@ class exchange {
             case quote_token_type::symbol:
                eosio_assert( owner->quote_balance >= quote_token_type(w.amount), "insufficient balance" );
 
-               _accounts.update( owner, 0, [&]( auto& a ) {
+               _accounts.modify( owner, 0, [&]( auto& a ) {
                   a.quote_balance -= quote_token_type(w.amount);
                });
 
@@ -210,7 +210,7 @@ class exchange {
          auto idx = _base_quote_orders.template get_index<N(ownerid)>();
          auto itr = idx.find( limit_base_quote::get_owner_id( order.owner, order.id ) );
          if( itr != idx.end() ) {
-            idx.remove(itr);
+            idx.erase(itr);
          }
       }
 

--- a/contracts/exchange/exchange.hpp
+++ b/contracts/exchange/exchange.hpp
@@ -101,21 +101,21 @@ class exchange {
 
          auto owner = _accounts.find( d.from );
          if( owner == _accounts.end() ) {
-            owner = _accounts.iterator_to(_accounts.emplace( d.from, [&]( auto& a ) {
+            owner = _accounts.emplace( d.from, [&]( auto& a ) {
               a.owner = d.from;
-            }));
+            });
          }
 
          switch( d.amount.symbol ) {
             case base_token_type::symbol:
                BaseCurrency::inline_transfer( d.from, ExchangeAccount, base_token_type(d.amount.amount) );
-               _accounts.update( *owner, 0, [&]( auto& a ) {
+               _accounts.update( owner, 0, [&]( auto& a ) {
                   a.base_balance += base_token_type(d.amount);
                });
                break;
             case quote_token_type::symbol:
                QuoteCurrency::inline_transfer( d.from, ExchangeAccount, quote_token_type(d.amount.amount) );
-               _accounts.update( *owner, 0, [&]( auto& a ) {
+               _accounts.update( owner, 0, [&]( auto& a ) {
                   a.quote_balance += quote_token_type(d.amount);
                });
                break;
@@ -141,7 +141,7 @@ class exchange {
             case base_token_type::symbol:
                eosio_assert( owner->base_balance >= base_token_type(w.amount), "insufficient balance" );
 
-               _accounts.update( *owner, 0, [&]( auto& a ) {
+               _accounts.update( owner, 0, [&]( auto& a ) {
                   a.base_balance -= base_token_type(w.amount);
                });
 
@@ -150,7 +150,7 @@ class exchange {
             case quote_token_type::symbol:
                eosio_assert( owner->quote_balance >= quote_token_type(w.amount), "insufficient balance" );
 
-               _accounts.update( *owner, 0, [&]( auto& a ) {
+               _accounts.update( owner, 0, [&]( auto& a ) {
                   a.quote_balance -= quote_token_type(w.amount);
                });
 
@@ -210,7 +210,7 @@ class exchange {
          auto idx = _base_quote_orders.template get_index<N(ownerid)>();
          auto itr = idx.find( limit_base_quote::get_owner_id( order.owner, order.id ) );
          if( itr != idx.end() ) {
-            _base_quote_orders.remove(*itr);
+            idx.remove(itr);
          }
       }
 

--- a/contracts/identity/identity.hpp
+++ b/contracts/identity/identity.hpp
@@ -191,7 +191,7 @@ namespace identity {
                         }
                      } else if (DeployToAccount == current_receiver()){
                         //the certifier is no longer trusted, need to unset the flag
-                        idx.update(itr, 0, [&](certrow& r) {
+                        idx.modify(itr, 0, [&](certrow& r) {
                               r.trusted = 0;
                            });
                      } else {
@@ -216,7 +216,7 @@ namespace identity {
                   if (ident == get_claimed_identity(account) && is_trusted(itr->certifier)) {
                      if (DeployToAccount == current_receiver()) {
                         // the certifier became trusted and we have permissions to update the flag
-                        idx.update(itr, 0, [&](certrow& r) {
+                        idx.modify(itr, 0, [&](certrow& r) {
                               r.trusted = 1;
                            });
                      }
@@ -272,7 +272,7 @@ namespace identity {
                      row.account = t.trusting;
                   });
             } else if( itr != table.end() && t.trust == 0 ) {
-               table.remove(itr);
+               table.erase(itr);
             }
          }
 
@@ -307,7 +307,7 @@ namespace identity {
                   auto itr = idx.lower_bound( certrow::key(value.property, trusted, cert.certifier) );
 
                   if (itr != idx.end() && itr->property == value.property && itr->trusted == trusted && itr->certifier == cert.certifier) {
-                     idx.update(itr, 0, [&](certrow& row) {
+                     idx.modify(itr, 0, [&](certrow& row) {
                            row.confidence = value.confidence;
                            row.type       = value.type;
                            row.data       = value.data;
@@ -327,7 +327,7 @@ namespace identity {
 
                   auto itr_old = idx.lower_bound( certrow::key(value.property, !trusted, cert.certifier) );
                   if (itr_old != idx.end() && itr_old->property == value.property && itr_old->trusted == !trusted && itr_old->certifier == cert.certifier) {
-                     idx.remove(itr_old);
+                     idx.erase(itr_old);
                   }
 
                   //special handling for owner
@@ -342,13 +342,13 @@ namespace identity {
                   bool removed = false;
                   auto itr = idx.lower_bound( certrow::key(value.property, trusted, cert.certifier) );
                   if (itr != idx.end() && itr->property == value.property && itr->trusted == trusted && itr->certifier == cert.certifier) {
-                     idx.remove(itr);
+                     idx.erase(itr);
                   } else {
                      removed = true;
                   }
                   itr = idx.lower_bound( certrow::key(value.property, !trusted, cert.certifier) );
                   if (itr != idx.end() && itr->property == value.property && itr->trusted == !trusted && itr->certifier == cert.certifier) {
-                     idx.remove(itr);
+                     idx.erase(itr);
                   } else {
                      removed = true;
                   }

--- a/contracts/identity/identity.hpp
+++ b/contracts/identity/identity.hpp
@@ -191,7 +191,7 @@ namespace identity {
                         }
                      } else if (DeployToAccount == current_receiver()){
                         //the certifier is no longer trusted, need to unset the flag
-                        certs.update(*itr, 0, [&](certrow& r) {
+                        idx.update(itr, 0, [&](certrow& r) {
                               r.trusted = 0;
                            });
                      } else {
@@ -216,7 +216,7 @@ namespace identity {
                   if (ident == get_claimed_identity(account) && is_trusted(itr->certifier)) {
                      if (DeployToAccount == current_receiver()) {
                         // the certifier became trusted and we have permissions to update the flag
-                        certs.update(*itr, 0, [&](certrow& r) {
+                        idx.update(itr, 0, [&](certrow& r) {
                               r.trusted = 1;
                            });
                      }
@@ -272,7 +272,7 @@ namespace identity {
                      row.account = t.trusting;
                   });
             } else if( itr != table.end() && t.trust == 0 ) {
-               table.remove(*itr);
+               table.remove(itr);
             }
          }
 
@@ -307,7 +307,7 @@ namespace identity {
                   auto itr = idx.lower_bound( certrow::key(value.property, trusted, cert.certifier) );
 
                   if (itr != idx.end() && itr->property == value.property && itr->trusted == trusted && itr->certifier == cert.certifier) {
-                     certs.update(*itr, 0, [&](certrow& row) {
+                     idx.update(itr, 0, [&](certrow& row) {
                            row.confidence = value.confidence;
                            row.type       = value.type;
                            row.data       = value.data;
@@ -327,7 +327,7 @@ namespace identity {
 
                   auto itr_old = idx.lower_bound( certrow::key(value.property, !trusted, cert.certifier) );
                   if (itr_old != idx.end() && itr_old->property == value.property && itr_old->trusted == !trusted && itr_old->certifier == cert.certifier) {
-                     certs.remove(*itr_old);
+                     idx.remove(itr_old);
                   }
 
                   //special handling for owner
@@ -342,13 +342,13 @@ namespace identity {
                   bool removed = false;
                   auto itr = idx.lower_bound( certrow::key(value.property, trusted, cert.certifier) );
                   if (itr != idx.end() && itr->property == value.property && itr->trusted == trusted && itr->certifier == cert.certifier) {
-                     certs.remove(*itr);
+                     idx.remove(itr);
                   } else {
                      removed = true;
                   }
                   itr = idx.lower_bound( certrow::key(value.property, !trusted, cert.certifier) );
                   if (itr != idx.end() && itr->property == value.property && itr->trusted == !trusted && itr->certifier == cert.certifier) {
-                     certs.remove(*itr);
+                     idx.remove(itr);
                   } else {
                      removed = true;
                   }

--- a/contracts/identity/identity.hpp
+++ b/contracts/identity/identity.hpp
@@ -244,7 +244,7 @@ namespace identity {
 
          static bool is_trusted_by( account_name trusted, account_name by ) {
             trust_table t( code, by );
-            return t.find( trusted );
+            return t.find( trusted ) != t.end();
          }
 
          static bool is_trusted( account_name acnt ) {
@@ -266,21 +266,21 @@ namespace identity {
             require_recipient( t.trusting );
 
             trust_table table( code, t.trustor );
-            auto ptr = table.find(t.trusting);
-            if (!ptr && t.trust > 0) {
+            auto itr = table.find(t.trusting);
+            if( itr == table.end() && t.trust > 0 ) {
                table.emplace( t.trustor, [&](trustrow& row) {
                      row.account = t.trusting;
                   });
-            } else if (ptr && t.trust == 0) {
-               table.remove(*ptr);
+            } else if( itr != table.end() && t.trust == 0 ) {
+               table.remove(*itr);
             }
          }
 
          static void on( const create& c ) {
             require_auth( c.creator );
             idents_table t( code, code);
-            auto ptr = t.find( c.identity );
-            eosio_assert( !ptr, "identity already exists" );
+            auto itr = t.find( c.identity );
+            eosio_assert( itr == t.end(), "identity already exists" );
             eosio_assert( c.identity != 0, "identity=0 is not allowed" );
             t.emplace(c.creator, [&](identrow& i) {
                   i.identity = c.identity;
@@ -294,8 +294,7 @@ namespace identity {
                require_auth( cert.bill_storage_to );
 
             idents_table t( code, code );
-            auto ptr = t.find( cert.identity );
-            eosio_assert( ptr != nullptr, "identity does not exist" );
+            eosio_assert( t.find( cert.identity ) != t.end(), "identity does not exist" );
 
             /// the table exists in the scope of the identity
             certs_table certs( code, cert.identity );

--- a/contracts/multi_index_test/multi_index_test.cpp
+++ b/contracts/multi_index_test/multi_index_test.cpp
@@ -80,8 +80,8 @@ struct limit_order {
                      print(" ID=", item.id, ", expiration=", item.expiration, ", owner=", name(item.owner), "\n");
                   }
 
-                  print("Updating expiration of order with ID=2 to 400.\n");
-                  orders.update( order2, payer, [&]( auto& o ) {
+                  print("Modifying expiration of order with ID=2 to 400.\n");
+                  orders.modify( order2, payer, [&]( auto& o ) {
                      o.expiration = 400;
                   });
 
@@ -148,7 +148,7 @@ struct limit_order {
                   print("First entry with a val greater than 42 has ID=", upper->id, ".\n");
 
                   print("Removed entry with ID=", lower1->id, ".\n");
-                  validx.remove( lower1 );
+                  validx.erase( lower1 );
 
                   print("Items sorted by primary key:\n");
                   for( const auto& item : testtable ) {

--- a/contracts/multi_index_test/multi_index_test.cpp
+++ b/contracts/multi_index_test/multi_index_test.cpp
@@ -118,7 +118,7 @@ struct limit_order {
                      o.val = key256::make_from_word_sequence<uint64_t>(0ULL, 0ULL, 0ULL, 42ULL);
                   });
 
-                  const auto* e = testtable.find( 2 );
+                  auto itr = testtable.find( 2 );
 
                   print("Items sorted by primary key:\n");
                   for( const auto& item : testtable ) {
@@ -133,7 +133,7 @@ struct limit_order {
                   auto lower2 = validx.lower_bound(key256::make_from_word_sequence<uint64_t>(0ULL, 0ULL, 0ULL, 50ULL));
                   print("First entry with a val of at least 50 has ID=", lower2->id, ".\n");
 
-                  if( &*lower2 == e ) {
+                  if( testtable.iterator_to(*lower2) == itr ) {
                      print("Previously found entry is the same as the one found earlier with a primary key value of 2.\n");
                   }
 

--- a/contracts/multi_index_test/multi_index_test.cpp
+++ b/contracts/multi_index_test/multi_index_test.cpp
@@ -56,13 +56,13 @@ struct limit_order {
                      indexed_by< N(byprice), const_mem_fun<limit_order, uint128_t, &limit_order::get_price> >
                      > orders( N(multitest), N(multitest) );
 
-                  const auto& order1 = orders.emplace( payer, [&]( auto& o ) {
+                  orders.emplace( payer, [&]( auto& o ) {
                     o.id = 1;
                     o.expiration = 300;
                     o.owner = N(dan);
                   });
 
-                  const auto& order2 = orders.emplace( payer, [&]( auto& o ) {
+                  auto order2 = orders.emplace( payer, [&]( auto& o ) {
                      o.id = 2;
                      o.expiration = 200;
                      o.owner = N(alice);
@@ -103,17 +103,17 @@ struct limit_order {
                      indexed_by< N(byval), const_mem_fun<test_k256, key256, &test_k256::get_val> >
                   > testtable( N(multitest), N(exchange) ); // Code must be same as the receiver? Scope doesn't have to be.
 
-                  const auto& entry1 = testtable.emplace( payer, [&]( auto& o ) {
+                  testtable.emplace( payer, [&]( auto& o ) {
                      o.id = 1;
                      o.val = key256::make_from_word_sequence<uint64_t>(0ULL, 0ULL, 0ULL, 42ULL);
                   });
 
-                  const auto& entry2 = testtable.emplace( payer, [&]( auto& o ) {
+                  testtable.emplace( payer, [&]( auto& o ) {
                      o.id = 2;
                      o.val = key256::make_from_word_sequence<uint64_t>(1ULL, 2ULL, 3ULL, 4ULL);
                   });
 
-                  const auto& entry3 = testtable.emplace( payer, [&]( auto& o ) {
+                  testtable.emplace( payer, [&]( auto& o ) {
                      o.id = 3;
                      o.val = key256::make_from_word_sequence<uint64_t>(0ULL, 0ULL, 0ULL, 42ULL);
                   });
@@ -148,7 +148,7 @@ struct limit_order {
                   print("First entry with a val greater than 42 has ID=", upper->id, ".\n");
 
                   print("Removed entry with ID=", lower1->id, ".\n");
-                  testtable.remove( *lower1 );
+                  validx.remove( lower1 );
 
                   print("Items sorted by primary key:\n");
                   for( const auto& item : testtable ) {

--- a/contracts/test_api_multi_index/test_multi_index.cpp
+++ b/contracts/test_api_multi_index/test_multi_index.cpp
@@ -144,7 +144,7 @@ namespace _test_multi_index {
          }
       }
 
-      // update and remove
+      // modify and erase
       {
          const uint64_t ssn = 421;
          const auto& new_person = table.emplace( payer, [&]( auto& r ) {
@@ -152,16 +152,16 @@ namespace _test_multi_index {
             r.sec = N(bob);
          });
 
-         table.update(new_person, payer, [&]( auto& r ) {
+         table.modify(new_person, payer, [&]( auto& r ) {
             r.sec = N(billy);
          });
 
          auto itr1 = table.find(ssn);
-         eosio_assert(itr1 != table.end() && itr1->sec == N(billy), "idx64_general - table.update()");
+         eosio_assert(itr1 != table.end() && itr1->sec == N(billy), "idx64_general - table.modify()");
 
-         table.remove(itr1);
+         table.erase(itr1);
          auto itr2 = table.find(ssn);
-         eosio_assert( itr2 == table.end(), "idx64_general - table.remove()");
+         eosio_assert( itr2 == table.end(), "idx64_general - table.erase()");
       }
    }
 
@@ -214,11 +214,11 @@ void test_multi_index::idx128_autoincrement_test()
    auto itr = table.find(3);
    eosio_assert( itr != table.end(), "idx128_autoincrement_test - could not find object with primary key of 3" );
 
-   table.update(itr, payer, [&]( auto& r ) {
+   table.modify(itr, payer, [&]( auto& r ) {
       r.id = 100;
    });
 
-   eosio_assert( table.available_primary_key() == 101, "idx128_autoincrement_test - next_primary_key was not correct after record update" );
+   eosio_assert( table.available_primary_key() == 101, "idx128_autoincrement_test - next_primary_key was not correct after record modify" );
 }
 
 void test_multi_index::idx128_autoincrement_test_part1()
@@ -242,7 +242,7 @@ void test_multi_index::idx128_autoincrement_test_part1()
       });
    }
 
-   table.remove(table.find(0));
+   table.erase(table.get(0));
 
    uint64_t expected_key = 2;
    for( const auto& r : table.get_index<N(bysecondary)>() )
@@ -300,7 +300,7 @@ void test_multi_index::idx128_autoincrement_test_part2()
    auto itr = table.find(3);
    eosio_assert( itr != table.end(), "idx128_autoincrement_test_part2 - could not find object with primary key of 3" );
 
-   table.update(itr, payer, [&]( auto& r ) {
+   table.modify(itr, payer, [&]( auto& r ) {
       r.id = 100;
    });
 
@@ -396,7 +396,7 @@ void test_multi_index::idx256_general()
    eosio_assert( upper->id == 2, "idx256_general - upper_bound" );
 
    print("Removed entry with ID=", lower1->id, ".\n");
-   secidx.remove( lower1 );
+   secidx.erase( lower1 );
 
    print("Items reverse sorted by primary key:\n");
    for( const auto& item : boost::make_iterator_range(table.rbegin(), table.rend()) ) {

--- a/contracts/test_api_multi_index/test_multi_index.cpp
+++ b/contracts/test_api_multi_index/test_multi_index.cpp
@@ -159,7 +159,7 @@ namespace _test_multi_index {
          auto itr1 = table.find(ssn);
          eosio_assert(itr1 != table.end() && itr1->sec == N(billy), "idx64_general - table.update()");
 
-         table.remove(*itr1);
+         table.remove(itr1);
          auto itr2 = table.find(ssn);
          eosio_assert( itr2 == table.end(), "idx64_general - table.remove()");
       }
@@ -214,7 +214,7 @@ void test_multi_index::idx128_autoincrement_test()
    auto itr = table.find(3);
    eosio_assert( itr != table.end(), "idx128_autoincrement_test - could not find object with primary key of 3" );
 
-   table.update(*itr, payer, [&]( auto& r ) {
+   table.update(itr, payer, [&]( auto& r ) {
       r.id = 100;
    });
 
@@ -242,7 +242,7 @@ void test_multi_index::idx128_autoincrement_test_part1()
       });
    }
 
-   table.remove(table.get(0));
+   table.remove(table.find(0));
 
    uint64_t expected_key = 2;
    for( const auto& r : table.get_index<N(bysecondary)>() )
@@ -300,7 +300,7 @@ void test_multi_index::idx128_autoincrement_test_part2()
    auto itr = table.find(3);
    eosio_assert( itr != table.end(), "idx128_autoincrement_test_part2 - could not find object with primary key of 3" );
 
-   table.update(*itr, payer, [&]( auto& r ) {
+   table.update(itr, payer, [&]( auto& r ) {
       r.id = 100;
    });
 
@@ -326,17 +326,17 @@ void test_multi_index::idx256_general()
    //auto onetwothreefour = key256::make_from_word_sequence<uint64_t>(1ULL, 2ULL, 3ULL, 4ULL);
    auto onetwothreefour = key256{std::array<uint32_t, 8>{{0,1, 0,2, 0,3, 0,4}}};
 
-   const auto& entry1 = table.emplace( payer, [&]( auto& o ) {
+   table.emplace( payer, [&]( auto& o ) {
       o.id = 1;
       o.sec = fourtytwo;
    });
 
-   const auto& entry2 = table.emplace( payer, [&]( auto& o ) {
+   table.emplace( payer, [&]( auto& o ) {
       o.id = 2;
       o.sec = onetwothreefour;
    });
 
-   const auto& entry3 = table.emplace( payer, [&]( auto& o ) {
+   table.emplace( payer, [&]( auto& o ) {
       o.id = 3;
       o.sec = fourtytwo;
    });
@@ -396,7 +396,7 @@ void test_multi_index::idx256_general()
    eosio_assert( upper->id == 2, "idx256_general - upper_bound" );
 
    print("Removed entry with ID=", lower1->id, ".\n");
-   table.remove( *lower1 );
+   secidx.remove( lower1 );
 
    print("Items reverse sorted by primary key:\n");
    for( const auto& item : boost::make_iterator_range(table.rbegin(), table.rend()) ) {


### PR DESCRIPTION
`multi_index` has been refactored to simplify the number of structs involved.

`iterator_to` has been added to `multi_index` so that the contract developer can use an object reference to get a primary table iterator to that object in constant time. `iterator_to` has also been added into each of the indices of `multi_index` which allows the contract developer to use an object reference to get a secondary index iterator to that object (this will be in constant time if the appropriate secondary index iterator is already loaded into the `item` within the `multi_index` cache, otherwise it will automatically call `db_idx_find_primary` to get and cache the appropriate secondary index iterator).

The interface for `find`, `emplace`, `update`, and `remove` have been modified to be a little more consistent with Boost MultiIndex. In particular, `update` and `remove` methods have been renamed to `modify` and `erase` respectively, and overloads of those methods are also provided that take an iterator to the object (to modify or erase) rather than an object reference. Also, `find` and `emplace` now return an iterator to the object rather than a reference to the object. Furthermore, the `erase` method that takes an iterator also returns an iterator to the object that comes directly after (within the primary table) the object that is to be erased.   Finally,  `modify` and `erase` have also been added to each of the indices of `multi_index` again to be more consistent with Boost MultiIndex and so that the contract developer can more conveniently modify and erase an object using a secondary index iterator directly. (Note: when using the `erase` method in a secondary index, it returns a secondary index iterator to the object that comes after the object to be erased within that secondary index.)

