### PR TITLE
Add support for Linux Mint (as an ubuntu variant) to the build scripts

### DIFF
--- a/eosio_build.sh
+++ b/eosio_build.sh
@@ -60,6 +60,11 @@
 		OS_NAME=$( cat /etc/os-release | grep ^NAME | cut -d'=' -f2 | sed 's/\"//gI' )
 	
 		case $OS_NAME in
+			"Linux Mint")
+				FILE=${WORK_DIR}/scripts/eosio_build_ubuntu.sh
+				CXX_COMPILER=clang++-4.0
+				C_COMPILER=clang-4.0
+			;;
 			"Ubuntu")
 				FILE=${WORK_DIR}/scripts/eosio_build_ubuntu.sh
 				CXX_COMPILER=clang++-4.0

--- a/scripts/eosio_build_ubuntu.sh
+++ b/scripts/eosio_build_ubuntu.sh
@@ -24,11 +24,22 @@
 		exit 1
 	fi
 
-	if [ $OS_MIN -lt 4 ]; then
-		printf "\tYou must be running Ubuntu 16.04.x or higher to install EOSIO.\n"
-		printf "\tExiting now.\n"
-		exit 1
-	fi
+        case $OS_NAME in
+                "Linux Mint")
+                       if [ $OS_MAJ -lt 18 ]; then
+                               printf "\tYou must be running Linux Mint 18.x or higher to install EOSIO.\n"
+                               printf "\tExiting now.\n"
+                               exit 1
+                       fi
+                ;;
+                "Ubuntu")
+                        if [ $OS_MIN -lt 4 ]; then
+                                printf "\tYou must be running Ubuntu 16.04.x or higher to install EOSIO.\n"
+                                printf "\tExiting now.\n"
+                                exit 1
+                        fi
+                ;;
+        esac
 
 	if [ $DISK_AVAIL -lt $DISK_MIN ]; then
 		printf "\tYou must have at least 100GB of available storage to install EOSIO.\n"


### PR DESCRIPTION
All that was needed was to accept Linux Mint as an allowed OS and verify a version number corresponding to the allowed ubuntu version.