### PR TITLE
Add support for Linux Mint (as an ubuntu variant) to the build scripts

### DIFF
--- a/eosio_build.sh
+++ b/eosio_build.sh
@@ -68,6 +68,11 @@
 				C_COMPILER=gcc
 				export LLVM_DIR=${HOME}/opt/wasm/lib/cmake/llvm
 			;;
+			"Linux Mint")
+				FILE=${WORK_DIR}/scripts/eosio_build_ubuntu.sh
+				CXX_COMPILER=clang++-4.0
+				C_COMPILER=clang-4.0
+			;;
 			"CentOS Linux")
 				FILE=${WORK_DIR}/scripts/eosio_build_centos.sh
 				export CMAKE=${HOME}/opt/cmake/bin/cmake

--- a/scripts/eosio_build_ubuntu.sh
+++ b/scripts/eosio_build_ubuntu.sh
@@ -24,11 +24,22 @@
 		exit 1
 	fi
 
-	if [ $OS_MIN -lt 4 ]; then
-		printf "\tYou must be running Ubuntu 16.04.x or higher to install EOSIO.\n"
-		printf "\tExiting now.\n"
-		exit 1
-	fi
+        case $OS_NAME in
+                "Linux Mint")
+                       if [ $OS_MAJ -lt 18 ]; then
+                               printf "\tYou must be running Linux Mint 18.x or higher to install EOSIO.\n"
+                               printf "\tExiting now.\n"
+                               exit 1
+                       fi
+                ;;
+                "Ubuntu")
+                        if [ $OS_MIN -lt 4 ]; then
+                                printf "\tYou must be running Ubuntu 16.04.x or higher to install EOSIO.\n"
+                                printf "\tExiting now.\n"
+                                exit 1
+                        fi
+                ;;
+        esac
 
 	if [ $DISK_AVAIL -lt $DISK_MIN ]; then
 		printf "\tYou must have at least ${DISK_MIN}GB of available storage to install EOSIO.\n"


### PR DESCRIPTION
Linux Mint is allowed as a OS distribution and the version number is checked (that corresponding to ubuntu 1604).