### PR TITLE
Fix GitHub issue #1591 and add test case related to the bug

### DIFF
--- a/contracts/eosiolib/generic_currency.hpp
+++ b/contracts/eosiolib/generic_currency.hpp
@@ -67,12 +67,12 @@ namespace eosio {
           };
 
           struct currency_stats {
-             uint64_t   symbol = token_type::symbol;
              token_type supply;
+             uint64_t   symbol = token_type::symbol;
 
              auto primary_key() const { return symbol; }
 
-             EOSLIB_SERIALIZE( currency_stats, (symbol)(supply) )
+             EOSLIB_SERIALIZE( currency_stats, (supply)(symbol) )
           };
 
           /**

--- a/tests/testUtils.py
+++ b/tests/testUtils.py
@@ -33,7 +33,7 @@ class Utils:
 
     EosLauncherPath="programs/eosio-launcher/eosio-launcher"
     MongoPath="mongo"
-    
+
     @staticmethod
     def Print(*args, **kwargs):
         stackDepth=len(inspect.stack())-2
@@ -81,7 +81,7 @@ class Utils:
     @staticmethod
     def getChainStrategies():
         chainSyncStrategies={}
-    
+
         chainSyncStrategy=Utils.SyncStrategy(Utils.SyncNoneTag, 0, "")
         chainSyncStrategies[chainSyncStrategy.name]=chainSyncStrategy
 
@@ -110,20 +110,20 @@ class Table(object):
         self.name=name
         self.keys=[]
         self.data=[]
-        
+
 ###########################################################################################
 class Transaction(object):
     def __init__(self, transId):
         self.transId=transId
         self.tType=None
         self.amount=0
-        
+
 ###########################################################################################
 class Account(object):
     def __init__(self, name):
         self.name=name
         self.balance=0
-        
+
         self.ownerPrivateKey=None
         self.ownerPublicKey=None
         self.activePrivateKey=None
@@ -207,7 +207,7 @@ class Node(object):
         except subprocess.CalledProcessError as ex:
             msg=ex.output
             return (ex.returncode, msg, None)
-        
+
         return (0, outs, errs)
 
     @staticmethod
@@ -216,7 +216,7 @@ class Node(object):
         tmpStr=re.sub(r'ObjectId\("(\w+)"\)', r'"ObjectId-\1"', tmpStr)
         tmpStr=re.sub(r'ISODate\("([\w|\-|\:|\.]+)"\)', r'"ISODate-\1"', tmpStr)
         return tmpStr
-        
+
     @staticmethod
     def runMongoCmdReturnJson(cmdArr, subcommand, trace=False):
         retId,outs,errs=Node.stdinAndCheckOutput(cmdArr, subcommand)
@@ -304,8 +304,8 @@ class Node(object):
                 time.sleep(self.mongoSyncTime)
 
         return None
-    
- 
+
+
     def doesNodeHaveBlockNum(self, blockNum):
         assert isinstance(blockNum, int)
 
@@ -346,7 +346,7 @@ class Node(object):
                 if self.mongoSyncTime is not None:
                     Utils.Debug and Utils.Print("cmd: sleep %d seconds" % (self.mongoSyncTime))
                     time.sleep(self.mongoSyncTime)
-                
+
         return None
 
     def getTransByBlockId(self, blockId, retry=True, silentErrors=False):
@@ -368,11 +368,11 @@ class Node(object):
             if self.mongoSyncTime is not None:
                 Utils.Debug and Utils.Print("cmd: sleep %d seconds" % (self.mongoSyncTime))
                 time.sleep(self.mongoSyncTime)
-                
+
         return None
 
-    
-    
+
+
     def getActionFromDb(self, transId, retry=True, silentErrors=False):
         for i in range(2):
             cmd="%s %s" % (Utils.MongoPath, self.mongoEndpointArgs)
@@ -392,9 +392,9 @@ class Node(object):
             if self.mongoSyncTime is not None:
                 Utils.Debug and Utils.Print("cmd: sleep %d seconds" % (self.mongoSyncTime))
                 time.sleep(self.mongoSyncTime)
-                
+
         return None
-    
+
     def getMessageFromDb(self, transId, retry=True, silentErrors=False):
         for i in range(2):
             cmd="%s %s" % (Utils.MongoPath, self.mongoEndpointArgs)
@@ -414,7 +414,7 @@ class Node(object):
             if self.mongoSyncTime is not None:
                 Utils.Debug and Utils.Print("cmd: sleep %d seconds" % (self.mongoSyncTime))
                 time.sleep(self.mongoSyncTime)
-                
+
         return None
 
     def doesNodeHaveTransId(self, transId):
@@ -536,7 +536,29 @@ class Node(object):
             return trans
         except subprocess.CalledProcessError as ex:
             msg=ex.output.decode("utf-8")
+            Utils.Print("ERROR: Exception during get EOS balance. %s" % (msg))
+            return None
+
+    def getCurrencyBalance(self, contract, account, symbol):
+        cmd="%s %s get currency balance %s %s %s" % (Utils.EosClientPath, self.endpointArgs, contract, account, symbol)
+        Utils.Debug and Utils.Print("cmd: %s" % (cmd))
+        try:
+            trans=Node.runCmdReturnStr(cmd)
+            return trans
+        except subprocess.CalledProcessError as ex:
+            msg=ex.output.decode("utf-8")
             Utils.Print("ERROR: Exception during get currency balance. %s" % (msg))
+            return None
+
+    def getCurrencyStats(self, contract, symbol=""):
+        cmd="%s %s get currency stats %s %s" % (Utils.EosClientPath, self.endpointArgs, contract, symbol)
+        Utils.Debug and Utils.Print("cmd: %s" % (cmd))
+        try:
+            trans=Node.runCmdReturnJson(cmd)
+            return trans
+        except subprocess.CalledProcessError as ex:
+            msg=ex.output.decode("utf-8")
+            Utils.Print("ERROR: Exception during get currency stats. %s" % (msg))
             return None
 
     # Verifies account. Returns "get account" json return object
@@ -563,7 +585,7 @@ class Node(object):
                     time.sleep(self.mongoSyncTime)
 
         return None
-    
+
     def waitForBlockNumOnNode(self, blockNum, timeout=None):
         if timeout is None:
             timeout=Utils.systemWaitTimeout
@@ -604,7 +626,7 @@ class Node(object):
         Utils.Debug and Utils.Print("cmd: remaining time %d seconds" % (remainingTime))
         num=self.getIrreversibleBlockNum()
         Utils.Debug and Utils.Print("Current block number: %s" % (num))
-        
+
         while time.time()-startTime < timeout:
             nextNum=self.getIrreversibleBlockNum()
             if nextNum > num:
@@ -650,7 +672,7 @@ class Node(object):
             Utils.Print("ERROR: validateSpreadFunds> Expected total: %d , actual: %d" % (
                 expectedTotal, actualTotal))
             return False
-    
+
         return True
 
     def getSystemBalance(self, adminAccount, accounts):
@@ -658,7 +680,7 @@ class Node(object):
         for account in accounts:
             balance += self.getAccountBalance(account.name)
         return balance
-    
+
     # Gets accounts mapped to key. Returns json object
     def getAccountsByKey(self, key):
         cmd="%s %s get accounts %s" % (Utils.EosClientPath, self.endpointArgs, key)
@@ -804,7 +826,7 @@ class Node(object):
         if waitForTransBlock and not self.waitForTransIdOnNode(transId):
             return None
         return trans
-    
+
     def getTable(self, account, contract, table):
         cmd="%s %s get table %s %s %s" % (Utils.EosClientPath, self.endpointArgs, account, contract, table)
         Utils.Debug and Utils.Print("cmd: %s" % (cmd))
@@ -839,7 +861,7 @@ class Node(object):
         keys=list(row.keys())
         return keys
 
-    # returns tuple with transaction and 
+    # returns tuple with transaction and
     def pushMessage(self, contract, action, data, opts, silentErrors=False):
         cmd=None
         if Utils.amINoon:
@@ -910,7 +932,7 @@ class Node(object):
         else:
             self.alive=False
             return False
-            
+
     def getHeadBlockNum(self):
         if not self.enableMongo:
             info=self.getInfo()
@@ -960,7 +982,7 @@ class WalletMgr(object):
         if not self.walletd:
             Utils.Print("ERROR: Wallet Manager wasn't configured to launch walletd")
             return False
-            
+
         cmd="%s --data-dir %s --config-dir %s --http-server-address=%s:%d" % (
             Utils.EosWalletPath, WalletMgr.__walletDataDir, WalletMgr.__walletDataDir, self.host, self.port)
         Utils.Print("cmd: %s" % (cmd))
@@ -989,7 +1011,7 @@ class WalletMgr(object):
         p=m.group(1)
         wallet=Wallet(name, p, self.host, self.port)
         self.wallets[name] = wallet
-    
+
         return wallet
 
     def importKey(self, account, wallet):
@@ -1087,7 +1109,7 @@ class WalletMgr(object):
 
         return keys
 
-    
+
     def dumpErrorDetails(self):
         Utils.Print("=================================================================")
         if self.__walletPid is not None:
@@ -1095,12 +1117,12 @@ class WalletMgr(object):
             Utils.Print("=================================================================")
             with open(WalletMgr.__walletLogFile, "r") as f:
                 shutil.copyfileobj(f, sys.stdout)
-    
+
     def killall(self):
         cmd="pkill %s" % (Utils.EosWalletName)
         Utils.Debug and Utils.Print("cmd: %s" % (cmd))
         subprocess.call(cmd.split())
-            
+
     def cleanup(self):
         dataDir=WalletMgr.__walletDataDir
         if os.path.isdir(dataDir) and os.path.exists(dataDir):
@@ -1168,7 +1190,7 @@ class Cluster(object):
         if not self.localCluster:
             Utils.Print("WARNING: Cluster not local, not launching %s." % (Utils.EosServerName))
             return True
-        
+
         if len(self.nodes) > 0:
             raise RuntimeError("Cluster already running.")
 
@@ -1247,7 +1269,7 @@ class Cluster(object):
 
         self.nodes=nodes
         return True
-    
+
     # manually set nodes, alternative to explicit launch
     def setNodes(self, nodes):
         self.nodes=nodes
@@ -1314,7 +1336,7 @@ class Cluster(object):
                 if m is None:
                     Utils.Print("ERROR: Owner key creation regex mismatch")
                     break
-            
+
                 ownerPrivate=m.group(1)
                 ownerPublic=m.group(2)
 
@@ -1325,7 +1347,7 @@ class Cluster(object):
                 if m is None:
                     Utils.Print("ERROR: Owner key creation regex mismatch")
                     break
-            
+
                 activePrivate=m.group(1)
                 activePublic=m.group(2)
 
@@ -1386,7 +1408,7 @@ class Cluster(object):
 
     def getNodes(self):
         return self.nodes
-    
+
     # Spread funds across accounts with transactions spread through cluster nodes.
     #  Validate transactions are synchronized on root node
     def spreadFunds(self, amount=1):
@@ -1424,14 +1446,14 @@ class Cluster(object):
             if nextInstanceFound is False:
                 Utils.Print("ERROR: No active nodes found.")
                 return False
-            
+
             #Utils.Print("nextEosIdx: %d, count: %d" % (nextEosIdx, count))
             node=self.nodes[nextEosIdx]
             Utils.Debug and Utils.Print("Wait for trasaction id %s on node port %d" % (transId, node.port))
             if node.waitForTransIdOnNode(transId) is False:
                 Utils.Print("ERROR: Selected node never received transaction id %s" % (transId))
                 return False
-        
+
             transferAmount -= amount
             fromm=account
             to=self.accounts[i+1] if i < (count-1) else Cluster.initaAccount
@@ -1455,7 +1477,7 @@ class Cluster(object):
         if node.waitForTransIdOnNode(transId) is False:
             Utils.Print("ERROR: Selected node never received transaction id %s" % (transId))
             return False
-    
+
         return True
 
     def validateSpreadFunds(self, expectedTotal):
@@ -1527,7 +1549,7 @@ class Cluster(object):
         except subprocess.CalledProcessError as ex:
             Utils.Print("ERROR: Exception during Nodes creation:", ex)
             raise
-        
+
         return nodes
 
     # Check state of running eosiod process and update EosInstanceInfos
@@ -1592,7 +1614,7 @@ class Cluster(object):
                 Utils.Print("Contents of %s:" % (fileName))
                 with open(fileName, "r") as f:
                     shutil.copyfileobj(f, sys.stdout)
-    
+
     def killall(self):
         cmd="%s -k 15" % (Utils.EosLauncherPath)
         Utils.Debug and Utils.Print("cmd: %s" % (cmd))
@@ -1604,13 +1626,13 @@ class Cluster(object):
                 os.kill(node.pid, signal.SIGKILL)
             except:
                 pass
-            
+
     def waitForNextBlock(self, timeout=None):
         if timeout is None:
             timeout=Utils.systemWaitTimeout
         node=self.nodes[0]
         return node.waitForNextBlock(timeout)
-    
+
     def cleanup(self):
         for f in glob.glob("tn_data_*"):
             shutil.rmtree(f)
@@ -1623,7 +1645,7 @@ class Cluster(object):
             if ret is not 0:
                 Utils.Print("ERROR: Failed to drop database: %s" % (Node.byteArrToStr(errs)) )
 
-            
+
     # Create accounts and validates that the last transaction is received on root node
     def createAccounts(self, creator, waitForTransBlock=True, stakedDeposit=1000):
         if self.accounts is None:


### PR DESCRIPTION
This pull request which fixes issue #1591 has a very similar fix to the one in pull request #1526. In that pull request I had simply forgotten to also swap the `balance` and `symbol` fields in the `currency_stats` struct (of the `generic_currency` contract code) so that it would be compatible with the assumptions made in the `get_currency_stats` method in the chain_plugin. 

None of the tests triggered that particular bug because they did not use `eosioc get currency stats ...`. This pull request also modifies eosiod_run_test to include a couple extra test cases. The first uses `eosioc get currency balance ...` to verify the CUR balance (from the currency contract) of the currency account which had `100000.0000 CUR` issued to it.  The second verifies  that the total supply of CUR tokens is `100000.0000 CUR` using `eosioc get currency stats ...`.