### PR TITLE
Fix Docker builds

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -77,7 +77,7 @@ ENV SOFTFLOAT_ROOT /opt/berkeley-softfloat-3
 # FROM huangminghuang/eos_builder as builder
 
 RUN git clone -b master --depth 1 https://github.com/EOSIO/eos.git --recursive \
-    && cd eos && echo $PWD \
+    && cd eos \
     && cmake -H. -B"/tmp/build" -GNinja -DCMAKE_BUILD_TYPE=Release -DWASM_ROOT=/opt/wasm -DCMAKE_CXX_COMPILER=clang++ \
        -DCMAKE_C_COMPILER=clang -DCMAKE_INSTALL_PREFIX=/tmp/build  -DSecp256k1_ROOT_DIR=/usr/local \
     && cmake --build /tmp/build --target install

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -32,26 +32,26 @@ RUN wget https://dl.bintray.com/boostorg/release/1.64.0/source/boost_1_64_0.tar.
     && echo 'using clang : 4.0 : clang++-4.0 ;' >> project-config.jam \
     && ./b2 -d0 -j$(nproc) --with-thread --with-date_time --with-system --with-filesystem --with-program_options \
        --with-signals --with-serialization --with-chrono --with-test --with-context --with-locale --with-coroutine --with-iostreams toolset=clang link=static install \
-    && cd .. && rm -rf boost_1_64_0
+    && cd - && rm -rf boost_1_64_0
 
 RUN wget https://github.com/mongodb/mongo-c-driver/releases/download/1.9.3/mongo-c-driver-1.9.3.tar.gz -O - | tar -xz \
     && cd mongo-c-driver-1.9.3 \
     && ./configure --disable-automatic-init-and-cleanup --prefix=/usr/local \
     && make -j$(nproc) install \
-    && cd .. && rm -rf mongo-c-driver-1.9.3
+    && cd - && rm -rf mongo-c-driver-1.9.3
 
 RUN git clone --depth 1 --single-branch --branch release_40 https://github.com/llvm-mirror/llvm.git \
     && git clone --depth 1 --single-branch --branch release_40 https://github.com/llvm-mirror/clang.git llvm/tools/clang \
     && cd llvm \
     && cmake -H. -Bbuild -GNinja -DCMAKE_INSTALL_PREFIX=/opt/wasm -DLLVM_TARGETS_TO_BUILD= -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=WebAssembly -DCMAKE_BUILD_TYPE=Release  \
     && cmake --build build --target install \
-    && cd .. && rm -rf llvm
+    && cd - && rm -rf llvm
 
 RUN wget https://github.com/WebAssembly/binaryen/archive/1.37.21.tar.gz -O - | tar -xz \
   && cd binaryen-1.37.21 \
   && cmake -H. -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Release \
   && cmake --build build --target install \
-  && cd .. && rm -rf binaryen-1.37.21
+  && cd - && rm -rf binaryen-1.37.21
 
 
 RUN git clone --depth 1 git://github.com/cryptonomex/secp256k1-zkp \
@@ -59,29 +59,37 @@ RUN git clone --depth 1 git://github.com/cryptonomex/secp256k1-zkp \
     && ./autogen.sh \
     && ./configure --prefix=/usr/local \
     && make -j$(nproc) install \
-    && cd .. && rm -rf secp256k1-zkp
+    && cd - && rm -rf secp256k1-zkp
 
 RUN git clone --depth 1 -b releases/stable git://github.com/mongodb/mongo-cxx-driver \
     && cd mongo-cxx-driver \
     && cmake -H. -Bbuild -G Ninja -DCMAKE_BUILD_TYPE=Release  -DCMAKE_INSTALL_PREFIX=/usr/local\
-    && cmake --build build --target install
+    && cmake --build build --target install && cd - && rm -rf mongo-cxx-driver
+
+RUN git clone --depth 1 --single-branch --branch master https://github.com/ucb-bar/berkeley-softfloat-3.git \
+    && cd berkeley-softfloat-3/build/Linux-x86_64-GCC \
+    && make -j${nproc} SPECIALIZE_TYPE="8086-SSE" SOFTFLOAT_OPS="-DSOFTFLOAT_ROUND_EVEN -DINLINE_LEVEL=5 -DSOFTFLOAT_FAST_DIV32TO16 -DSOFTFLOAT_FAST_DIV64TO32" \
+    && mkdir -p /opt/berkeley-softfloat-3 && cp softfloat.a /opt/berkeley-softfloat-3/libsoftfloat.a \
+    && mv ../../source/include /opt/berkeley-softfloat-3/include && cd - && rm -rf berkeley-softfloat-3
+ENV SOFTFLOAT_ROOT /opt/berkeley-softfloat-3
 
 ### If you don't want to change the depedencies, you can comment out above lines and uncomnent the following line to get faster build time.
 # FROM huangminghuang/eos_builder as builder
 
 RUN git clone -b master --depth 1 https://github.com/EOSIO/eos.git --recursive \
-    && cd eos \
+    && cd eos && echo $PWD \
     && cmake -H. -B"/tmp/build" -GNinja -DCMAKE_BUILD_TYPE=Release -DWASM_ROOT=/opt/wasm -DCMAKE_CXX_COMPILER=clang++ \
-       -DCMAKE_C_COMPILER=clang -DCMAKE_INSTALL_PREFIX=/opt/eos  -DSecp256k1_ROOT_DIR=/usr/local \
+       -DCMAKE_C_COMPILER=clang -DCMAKE_INSTALL_PREFIX=/tmp/build  -DSecp256k1_ROOT_DIR=/usr/local \
     && cmake --build /tmp/build --target install
 
 FROM ubuntu:16.04
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install openssl && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /usr/local/lib/* /usr/local/lib/
-COPY --from=builder /tmp/build/install/bin /opt/eosio/bin
+COPY --from=builder /tmp/build/bin /opt/eosio/bin
 COPY --from=builder /tmp/build/contracts /contracts
 COPY --from=builder /eos/Docker/config.ini /eos/genesis.json /
 COPY start_eosiod.sh /opt/eosio/bin/start_eosiod.sh
+ENV EOSIO_ROOT=/opt/eosio
 RUN chmod +x /opt/eosio/bin/start_eosiod.sh
 ENV LD_LIBRARY_PATH /usr/local/lib
 VOLUME /opt/eosio/bin/data-dir


### PR DESCRIPTION
Docker builds are failing due to the introduction of the softfloat dependency (PR #1570) . Additionally, EOS_ROOT environmental variable has been introduced (PR #1516) and is now implemented in the Dockerfile.