### PR TITLE
quad precision floating point builtins added

### DIFF
--- a/contracts/eosiolib/compiler_builtins.h
+++ b/contracts/eosiolib/compiler_builtins.h
@@ -46,6 +46,27 @@ extern "C" {
   void __ashlti3(__int128& res, uint64_t lo, uint64_t hi, uint32_t shift);
   void __ashrti3(__int128& res, uint64_t lo, uint64_t hi, uint32_t shift);
 
+  void __addtf3( long double& ret, uint64_t la, uint64_t ha, uint64_t lb, uint64_t hb );
+  void __subtf3( long double& ret, uint64_t la, uint64_t ha, uint64_t lb, uint64_t hb ); 
+  void __multf3( long double& ret, uint64_t la, uint64_t ha, uint64_t lb, uint64_t hb ); 
+  void __divtf3( long double& ret, uint64_t la, uint64_t ha, uint64_t lb, uint64_t hb ); 
+  int __eqtf2( uint64_t la, uint64_t ha, uint64_t lb, uint64_t hb ); 
+  int __netf2( uint64_t la, uint64_t ha, uint64_t lb, uint64_t hb ); 
+  int __getf2( uint64_t la, uint64_t ha, uint64_t lb, uint64_t hb ); 
+  int __gttf2( uint64_t la, uint64_t ha, uint64_t lb, uint64_t hb ); 
+  int __letf2( uint64_t la, uint64_t ha, uint64_t lb, uint64_t hb ); 
+  int __lttf2( uint64_t la, uint64_t ha, uint64_t lb, uint64_t hb ); 
+  int __cmptf2( uint64_t la, uint64_t ha, uint64_t lb, uint64_t hb ); 
+  int __unordtf2( uint64_t la, uint64_t ha, uint64_t lb, uint64_t hb ); 
+  void __extendsftf2( long double& ret, float f ); 
+  void __extenddftf2( long double& ret, double f ); 
+  int64_t __fixtfdi( uint64_t l, uint64_t h ); 
+  int32_t __fixtfsi( uint64_t l, uint64_t h ); 
+  uint64_t __fixunstfdi( uint64_t l, uint64_t h ); 
+  uint32_t __fixunstfsi( uint64_t l, uint64_t h ); 
+  double __trunctfdf2( uint64_t l, uint64_t h ); 
+  float __trunctfsf2( uint64_t l, uint64_t h ); 
+
   void __break_point();
 
 } // extern "C"

--- a/libraries/chain/include/eosio/chain/softfloat.hpp
+++ b/libraries/chain/include/eosio/chain/softfloat.hpp
@@ -11,38 +11,22 @@ extern "C" {
 float16_t ui32_to_f16( uint32_t );
 float32_t ui32_to_f32( uint32_t );
 float64_t ui32_to_f64( uint32_t );
-#ifdef SOFTFLOAT_FAST_INT64
-extFloat80_t ui32_to_extF80( uint32_t );
 float128_t ui32_to_f128( uint32_t );
-#endif
-void ui32_to_extF80M( uint32_t, extFloat80_t * );
 void ui32_to_f128M( uint32_t, float128_t * );
 float16_t ui64_to_f16( uint64_t );
 float32_t ui64_to_f32( uint64_t );
 float64_t ui64_to_f64( uint64_t );
-#ifdef SOFTFLOAT_FAST_INT64
-extFloat80_t ui64_to_extF80( uint64_t );
 float128_t ui64_to_f128( uint64_t );
-#endif
-void ui64_to_extF80M( uint64_t, extFloat80_t * );
 void ui64_to_f128M( uint64_t, float128_t * );
 float16_t i32_to_f16( int32_t );
 float32_t i32_to_f32( int32_t );
 float64_t i32_to_f64( int32_t );
-#ifdef SOFTFLOAT_FAST_INT64
-extFloat80_t i32_to_extF80( int32_t );
 float128_t i32_to_f128( int32_t );
-#endif
-void i32_to_extF80M( int32_t, extFloat80_t * );
 void i32_to_f128M( int32_t, float128_t * );
 float16_t i64_to_f16( int64_t );
 float32_t i64_to_f32( int64_t );
 float64_t i64_to_f64( int64_t );
-#ifdef SOFTFLOAT_FAST_INT64
-extFloat80_t i64_to_extF80( int64_t );
 float128_t i64_to_f128( int64_t );
-#endif
-void i64_to_extF80M( int64_t, extFloat80_t * );
 void i64_to_f128M( int64_t, float128_t * );
 
 /*----------------------------------------------------------------------------
@@ -58,11 +42,7 @@ int_fast32_t f16_to_i32_r_minMag( float16_t, bool );
 int_fast64_t f16_to_i64_r_minMag( float16_t, bool );
 float32_t f16_to_f32( float16_t );
 float64_t f16_to_f64( float16_t );
-#ifdef SOFTFLOAT_FAST_INT64
-extFloat80_t f16_to_extF80( float16_t );
 float128_t f16_to_f128( float16_t );
-#endif
-void f16_to_extF80M( float16_t, extFloat80_t * );
 void f16_to_f128M( float16_t, float128_t * );
 float16_t f16_roundToInt( float16_t, uint_fast8_t, bool );
 float16_t f16_add( float16_t, float16_t );
@@ -93,11 +73,8 @@ int_fast32_t f32_to_i32_r_minMag( float32_t, bool );
 int_fast64_t f32_to_i64_r_minMag( float32_t, bool );
 float16_t f32_to_f16( float32_t );
 float64_t f32_to_f64( float32_t );
-#ifdef SOFTFLOAT_FAST_INT64
-extFloat80_t f32_to_extF80( float32_t );
 float128_t f32_to_f128( float32_t );
-#endif
-void f32_to_extF80M( float32_t, extFloat80_t * );
+
 void f32_to_f128M( float32_t, float128_t * );
 float32_t f32_roundToInt( float32_t, uint_fast8_t, bool );
 float32_t f32_add( float32_t, float32_t );
@@ -128,11 +105,7 @@ int_fast32_t f64_to_i32_r_minMag( float64_t, bool );
 int_fast64_t f64_to_i64_r_minMag( float64_t, bool );
 float16_t f64_to_f16( float64_t );
 float32_t f64_to_f32( float64_t );
-#ifdef SOFTFLOAT_FAST_INT64
-extFloat80_t f64_to_extF80( float64_t );
 float128_t f64_to_f128( float64_t );
-#endif
-void f64_to_extF80M( float64_t, extFloat80_t * );
 void f64_to_f128M( float64_t, float128_t * );
 float64_t f64_roundToInt( float64_t, uint_fast8_t, bool );
 float64_t f64_add( float64_t, float64_t );
@@ -151,75 +124,8 @@ bool f64_lt_quiet( float64_t, float64_t );
 bool f64_isSignalingNaN( float64_t );
 
 /*----------------------------------------------------------------------------
-| Rounding precision for 80-bit extended double-precision floating-point.
-| Valid values are 32, 64, and 80.
-*----------------------------------------------------------------------------*/
-extern THREAD_LOCAL uint_fast8_t extF80_roundingPrecision;
-
-/*----------------------------------------------------------------------------
-| 80-bit extended double-precision floating-point operations.
-*----------------------------------------------------------------------------*/
-#ifdef SOFTFLOAT_FAST_INT64
-uint_fast32_t extF80_to_ui32( extFloat80_t, uint_fast8_t, bool );
-uint_fast64_t extF80_to_ui64( extFloat80_t, uint_fast8_t, bool );
-int_fast32_t extF80_to_i32( extFloat80_t, uint_fast8_t, bool );
-int_fast64_t extF80_to_i64( extFloat80_t, uint_fast8_t, bool );
-uint_fast32_t extF80_to_ui32_r_minMag( extFloat80_t, bool );
-uint_fast64_t extF80_to_ui64_r_minMag( extFloat80_t, bool );
-int_fast32_t extF80_to_i32_r_minMag( extFloat80_t, bool );
-int_fast64_t extF80_to_i64_r_minMag( extFloat80_t, bool );
-float16_t extF80_to_f16( extFloat80_t );
-float32_t extF80_to_f32( extFloat80_t );
-float64_t extF80_to_f64( extFloat80_t );
-float128_t extF80_to_f128( extFloat80_t );
-extFloat80_t extF80_roundToInt( extFloat80_t, uint_fast8_t, bool );
-extFloat80_t extF80_add( extFloat80_t, extFloat80_t );
-extFloat80_t extF80_sub( extFloat80_t, extFloat80_t );
-extFloat80_t extF80_mul( extFloat80_t, extFloat80_t );
-extFloat80_t extF80_div( extFloat80_t, extFloat80_t );
-extFloat80_t extF80_rem( extFloat80_t, extFloat80_t );
-extFloat80_t extF80_sqrt( extFloat80_t );
-bool extF80_eq( extFloat80_t, extFloat80_t );
-bool extF80_le( extFloat80_t, extFloat80_t );
-bool extF80_lt( extFloat80_t, extFloat80_t );
-bool extF80_eq_signaling( extFloat80_t, extFloat80_t );
-bool extF80_le_quiet( extFloat80_t, extFloat80_t );
-bool extF80_lt_quiet( extFloat80_t, extFloat80_t );
-bool extF80_isSignalingNaN( extFloat80_t );
-#endif
-uint_fast32_t extF80M_to_ui32( const extFloat80_t *, uint_fast8_t, bool );
-uint_fast64_t extF80M_to_ui64( const extFloat80_t *, uint_fast8_t, bool );
-int_fast32_t extF80M_to_i32( const extFloat80_t *, uint_fast8_t, bool );
-int_fast64_t extF80M_to_i64( const extFloat80_t *, uint_fast8_t, bool );
-uint_fast32_t extF80M_to_ui32_r_minMag( const extFloat80_t *, bool );
-uint_fast64_t extF80M_to_ui64_r_minMag( const extFloat80_t *, bool );
-int_fast32_t extF80M_to_i32_r_minMag( const extFloat80_t *, bool );
-int_fast64_t extF80M_to_i64_r_minMag( const extFloat80_t *, bool );
-float16_t extF80M_to_f16( const extFloat80_t * );
-float32_t extF80M_to_f32( const extFloat80_t * );
-float64_t extF80M_to_f64( const extFloat80_t * );
-void extF80M_to_f128M( const extFloat80_t *, float128_t * );
-void
- extF80M_roundToInt(
-     const extFloat80_t *, uint_fast8_t, bool, extFloat80_t * );
-void extF80M_add( const extFloat80_t *, const extFloat80_t *, extFloat80_t * );
-void extF80M_sub( const extFloat80_t *, const extFloat80_t *, extFloat80_t * );
-void extF80M_mul( const extFloat80_t *, const extFloat80_t *, extFloat80_t * );
-void extF80M_div( const extFloat80_t *, const extFloat80_t *, extFloat80_t * );
-void extF80M_rem( const extFloat80_t *, const extFloat80_t *, extFloat80_t * );
-void extF80M_sqrt( const extFloat80_t *, extFloat80_t * );
-bool extF80M_eq( const extFloat80_t *, const extFloat80_t * );
-bool extF80M_le( const extFloat80_t *, const extFloat80_t * );
-bool extF80M_lt( const extFloat80_t *, const extFloat80_t * );
-bool extF80M_eq_signaling( const extFloat80_t *, const extFloat80_t * );
-bool extF80M_le_quiet( const extFloat80_t *, const extFloat80_t * );
-bool extF80M_lt_quiet( const extFloat80_t *, const extFloat80_t * );
-bool extF80M_isSignalingNaN( const extFloat80_t * );
-
-/*----------------------------------------------------------------------------
 | 128-bit (quadruple-precision) floating-point operations.
 *----------------------------------------------------------------------------*/
-#ifdef SOFTFLOAT_FAST_INT64
 uint_fast32_t f128_to_ui32( float128_t, uint_fast8_t, bool );
 uint_fast64_t f128_to_ui64( float128_t, uint_fast8_t, bool );
 int_fast32_t f128_to_i32( float128_t, uint_fast8_t, bool );
@@ -231,7 +137,6 @@ int_fast64_t f128_to_i64_r_minMag( float128_t, bool );
 float16_t f128_to_f16( float128_t );
 float32_t f128_to_f32( float128_t );
 float64_t f128_to_f64( float128_t );
-extFloat80_t f128_to_extF80( float128_t );
 float128_t f128_roundToInt( float128_t, uint_fast8_t, bool );
 float128_t f128_add( float128_t, float128_t );
 float128_t f128_sub( float128_t, float128_t );
@@ -247,7 +152,7 @@ bool f128_eq_signaling( float128_t, float128_t );
 bool f128_le_quiet( float128_t, float128_t );
 bool f128_lt_quiet( float128_t, float128_t );
 bool f128_isSignalingNaN( float128_t );
-#endif
+
 uint_fast32_t f128M_to_ui32( const float128_t *, uint_fast8_t, bool );
 uint_fast64_t f128M_to_ui64( const float128_t *, uint_fast8_t, bool );
 int_fast32_t f128M_to_i32( const float128_t *, uint_fast8_t, bool );
@@ -259,7 +164,6 @@ int_fast64_t f128M_to_i64_r_minMag( const float128_t *, bool );
 float16_t f128M_to_f16( const float128_t * );
 float32_t f128M_to_f32( const float128_t * );
 float64_t f128M_to_f64( const float128_t * );
-void f128M_to_extF80M( const float128_t *, extFloat80_t * );
 void f128M_roundToInt( const float128_t *, uint_fast8_t, bool, float128_t * );
 void f128M_add( const float128_t *, const float128_t *, float128_t * );
 void f128M_sub( const float128_t *, const float128_t *, float128_t * );

--- a/libraries/chain/wasm_interface.cpp
+++ b/libraries/chain/wasm_interface.cpp
@@ -360,8 +360,8 @@ class context_aware_api {
       }
 
    protected:
-      apply_context&             context;
       wasm_cache::entry&         code;
+      apply_context&             context;
       wasm_interface::vm_type    vm;
 
 };
@@ -1273,11 +1273,11 @@ class compiler_builtins : public context_aware_api {
          return 0;
       }
       void __extendsftf2( float128_t& ret, uint32_t f ) { 
-         float32_t in = {{ f }};
+         float32_t in = { f };
          ret = f32_to_f128( in ); 
       }
       void __extenddftf2( float128_t& ret, uint64_t f ) { 
-         float64_t in = {{ f }};
+         float64_t in = { f };
          ret = f64_to_f128( in ); 
       }
       int64_t __fixtfdi( uint64_t l, uint64_t h ) { 

--- a/libraries/chain/wasm_interface.cpp
+++ b/libraries/chain/wasm_interface.cpp
@@ -1273,10 +1273,12 @@ class compiler_builtins : public context_aware_api {
          return 0;
       }
       void __extendsftf2( float128_t& ret, uint32_t f ) { 
-         ret = f32_to_f128( {{f}} ); 
+         float32_t in = {{ f }};
+         ret = f32_to_f128( in ); 
       }
       void __extenddftf2( float128_t& ret, uint64_t f ) { 
-         ret = f64_to_f128( {{f}} ); 
+         float64_t in = {{ f }};
+         ret = f64_to_f128( in ); 
       }
       int64_t __fixtfdi( uint64_t l, uint64_t h ) { 
          float128_t f = {{ l, h }};

--- a/libraries/chain/wasm_interface.cpp
+++ b/libraries/chain/wasm_interface.cpp
@@ -1205,6 +1205,103 @@ class compiler_builtins : public context_aware_api {
          lhs %= rhs;
          ret = lhs;
       }
+      
+      void __addtf3( float128_t& ret, uint64_t la, uint64_t ha, uint64_t lb, uint64_t hb ) { 
+         float128_t a = {{ la, ha }};
+         float128_t b = {{ lb, hb }};
+         ret = f128_add( a, b ); 
+      }
+      void __subtf3( float128_t& ret, uint64_t la, uint64_t ha, uint64_t lb, uint64_t hb ) { 
+         float128_t a = {{ la, ha }};
+         float128_t b = {{ lb, hb }};
+         ret = f128_sub( a, b ); 
+      }
+      void __multf3( float128_t& ret, uint64_t la, uint64_t ha, uint64_t lb, uint64_t hb ) { 
+         float128_t a = {{ la, ha }};
+         float128_t b = {{ lb, hb }};
+         ret = f128_mul( a, b ); 
+      }
+      void __divtf3( float128_t& ret, uint64_t la, uint64_t ha, uint64_t lb, uint64_t hb ) { 
+         float128_t a = {{ la, ha }};
+         float128_t b = {{ lb, hb }};
+         ret = f128_div( a, b ); 
+      }
+      int __eqtf2( uint64_t la, uint64_t ha, uint64_t lb, uint64_t hb ) { 
+         float128_t a = {{ la, ha }};
+         float128_t b = {{ la, ha }};
+         return f128_eq( a, b ); 
+      }
+      int __netf2( uint64_t la, uint64_t ha, uint64_t lb, uint64_t hb ) { 
+         float128_t a = {{ la, ha }};
+         float128_t b = {{ la, ha }};
+         return !f128_eq( a, b ); 
+      }
+      int __getf2( uint64_t la, uint64_t ha, uint64_t lb, uint64_t hb ) { 
+         float128_t a = {{ la, ha }};
+         float128_t b = {{ la, ha }};
+         return !f128_lt( a, b ); 
+      }
+      int __gttf2( uint64_t la, uint64_t ha, uint64_t lb, uint64_t hb ) { 
+         float128_t a = {{ la, ha }};
+         float128_t b = {{ la, ha }};
+         return !f128_lt( a, b ) && !f128_eq( a, b ); 
+      }
+      int __letf2( uint64_t la, uint64_t ha, uint64_t lb, uint64_t hb ) { 
+         float128_t a = {{ la, ha }};
+         float128_t b = {{ la, ha }};
+         return f128_le( a, b ); 
+      }
+      int __lttf2( uint64_t la, uint64_t ha, uint64_t lb, uint64_t hb ) { 
+         float128_t a = {{ la, ha }};
+         float128_t b = {{ la, ha }};
+         return f128_lt( a, b ); 
+      }
+      int __cmptf2( uint64_t la, uint64_t ha, uint64_t lb, uint64_t hb ) { 
+         float128_t a = {{ la, ha }};
+         float128_t b = {{ la, ha }};
+         if ( f128_lt( a, b ) )
+            return -1;
+         if ( f128_eq( a, b ) )
+            return 0;
+         return 1;
+      }
+      int __unordtf2( uint64_t la, uint64_t ha, uint64_t lb, uint64_t hb ) { 
+         float128_t a = {{ la, ha }};
+         float128_t b = {{ la, ha }};
+         if ( f128_isSignalingNaN( a ) || f128_isSignalingNaN( b ) )
+            return 1;
+         return 0;
+      }
+      void __extendsftf2( float128_t& ret, uint32_t f ) { 
+         ret = f32_to_f128( {{f}} ); 
+      }
+      void __extenddftf2( float128_t& ret, uint64_t f ) { 
+         ret = f64_to_f128( {{f}} ); 
+      }
+      int64_t __fixtfdi( uint64_t l, uint64_t h ) { 
+         float128_t f = {{ l, h }};
+         return f128_to_i64( f, 0, false ); 
+      } 
+      int32_t __fixtfsi( uint64_t l, uint64_t h ) { 
+         float128_t f = {{ l, h }};
+         return f128_to_i32( f, 0, false ); 
+      } 
+      uint64_t __fixunstfdi( uint64_t l, uint64_t h ) { 
+         float128_t f = {{ l, h }};
+         return f128_to_ui64( f, 0, false ); 
+      } 
+      uint32_t __fixunstfsi( uint64_t l, uint64_t h ) { 
+         float128_t f = {{ l, h }};
+         return f128_to_ui32( f, 0, false ); 
+      } 
+      uint64_t __trunctfdf2( uint64_t l, uint64_t h ) { 
+         float128_t f = {{ l, h }};
+         return f128_to_f64( f ).v; 
+      } 
+      uint32_t __trunctfsf2( uint64_t l, uint64_t h ) { 
+         float128_t f = {{ l, h }};
+         return f128_to_f32( f ).v; 
+      } 
 
       static constexpr uint32_t SHIFT_WIDTH = (sizeof(uint64_t)*8)-1;
 };
@@ -1305,6 +1402,25 @@ REGISTER_INTRINSICS(compiler_builtins,
    (__modti3,      void(int, int64_t, int64_t, int64_t, int64_t)  )
    (__umodti3,     void(int, int64_t, int64_t, int64_t, int64_t)  )
    (__multi3,      void(int, int64_t, int64_t, int64_t, int64_t)  )
+   (__addtf3,      void(int, int64_t, int64_t, int64_t, int64_t)  )
+   (__subtf3,      void(int, int64_t, int64_t, int64_t, int64_t)  )
+   (__multf3,      void(int, int64_t, int64_t, int64_t, int64_t)  )
+   (__divtf3,      void(int, int64_t, int64_t, int64_t, int64_t)  )
+   (__eqtf2,       int(int64_t, int64_t, int64_t, int64_t)        )
+   (__netf2,       int(int64_t, int64_t, int64_t, int64_t)        )
+   (__getf2,       int(int64_t, int64_t, int64_t, int64_t)        )
+   (__gttf2,       int(int64_t, int64_t, int64_t, int64_t)        )
+   (__lttf2,       int(int64_t, int64_t, int64_t, int64_t)        )
+   (__cmptf2,      int(int64_t, int64_t, int64_t, int64_t)        )
+   (__unordtf2,    int(int64_t, int64_t, int64_t, int64_t)        )
+   (__extendsftf2, void(int, int)                                 )      
+   (__extenddftf2, void(int, int64_t)                             )      
+   (__fixtfdi,     int64_t(int64_t, int64_t)                      )
+   (__fixtfsi,     int(int64_t, int64_t)                          )
+   (__fixunstfdi,  int64_t(int64_t, int64_t)                      )
+   (__fixunstfsi,  int(int64_t, int64_t)                          )
+   (__trunctfdf2,  int64_t(int64_t, int64_t)                      )
+   (__trunctfsf2,  int(int64_t, int64_t)                          )
 );
 
 REGISTER_INTRINSICS(privileged_api,


### PR DESCRIPTION
Added compiler builtins for long double (128) and edited softfloat.hpp to no longer allow 80 bit long double functions.