### PR TITLE
Txn test dependencies fix

### DIFF
--- a/libraries/chain/chain_controller.cpp
+++ b/libraries/chain/chain_controller.cpp
@@ -43,7 +43,7 @@ bool chain_controller::is_start_of_round( block_num_type block_num )const  {
 }
 
 uint32_t chain_controller::blocks_per_round()const {
-  return get_global_properties().active_producers.producers.size()*config::producer_repititions;
+  return get_global_properties().active_producers.producers.size()*config::producer_repetitions;
 }
 
 chain_controller::chain_controller( const chain_controller::controller_config& cfg )
@@ -1365,8 +1365,8 @@ account_name chain_controller::get_scheduled_producer(uint32_t slot_num)const
    uint64_t current_aslot = dpo.current_absolute_slot + slot_num;
    const auto& gpo = _db.get<global_property_object>();
    auto number_of_active_producers = gpo.active_producers.producers.size();
-   auto index = current_aslot % (number_of_active_producers * config::producer_repititions);
-   index /= config::producer_repititions;
+   auto index = current_aslot % (number_of_active_producers * config::producer_repetitions);
+   index /= config::producer_repetitions;
    FC_ASSERT( gpo.active_producers.producers.size() > 0, "no producers defined" );
 
    return gpo.active_producers.producers[index].producer_name;

--- a/libraries/chain/include/eosio/chain/config.hpp
+++ b/libraries/chain/include/eosio/chain/config.hpp
@@ -67,13 +67,13 @@ const static uint16_t   max_recursion_depth = 6;
 /**
  *  The number of sequential blocks produced by a single producer
  */
-const static int producer_repititions = 12;
+const static int producer_repetitions = 12;
 
 /**
  * The number of blocks produced per round is based upon all producers having a chance
  * to produce all of their consecutive blocks.
  */
-//const static int blocks_per_round = producer_count * producer_repititions;
+//const static int blocks_per_round = producer_count * producer_repetitions;
 
 const static int irreversible_threshold_percent= 70 * percent_1;
 

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -379,7 +379,7 @@ namespace eosio {
       time_point   start_time; ///< time request made or received
    };
 
-      struct handshake_initializer {
+   struct handshake_initializer {
       static void populate(handshake_message &hello);
    };
 

--- a/plugins/txn_test_gen_plugin/CMakeLists.txt
+++ b/plugins/txn_test_gen_plugin/CMakeLists.txt
@@ -6,3 +6,5 @@ add_library( txn_test_gen_plugin
 target_link_libraries( txn_test_gen_plugin appbase fc http_plugin chain_plugin )
 target_include_directories( txn_test_gen_plugin PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" )
 target_include_directories( txn_test_gen_plugin PUBLIC ${CMAKE_BINARY_DIR}/contracts )
+
+add_dependencies( txn_test_gen_plugin currency )

--- a/tests/tests/database_tests.cpp
+++ b/tests/tests/database_tests.cpp
@@ -65,9 +65,9 @@ BOOST_AUTO_TEST_SUITE(database_tests)
             if( max_reversible_rounds == 0) {
                return head_block_num - 1;
             } else {
-               const auto current_round = head_block_num / config::producer_repititions;
+               const auto current_round = head_block_num / config::producer_repetitions;
                const auto irreversible_round = current_round - max_reversible_rounds;
-               return (irreversible_round + 1) * config::producer_repititions - 1;
+               return (irreversible_round + 1) * config::producer_repetitions - 1;
             }
          };
 


### PR DESCRIPTION
This fixes a dependency issue when building with high parallelism (w/ 32 cores).

This includes some typos fixups.. I can extract it if necessary. (builds on https://github.com/EOSIO/eos/pull/1606 )