### PR TITLE
Build Ubuntu/Mint with MongoDB server and MongoDB C & C++ Drivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The public testnet described in the [wiki](https://github.com/EOSIO/eos/wiki/Tes
 EOS.IO currently supports the following operating systems:  
 1. Amazon 2017.09 and higher.  
 2. Fedora 25 and higher (Fedora 27 recommended).  
-3. Ubuntu 16.04 and higher (Ubuntu 16.10 recommended).  
+3. Ubuntu 16.04 (Ubuntu 16.10 recommended).  
 4. MacOS Darwin 10.12 and higher (MacOS 10.13.x recommended).  
 
 # Resources
@@ -34,8 +34,8 @@ EOS.IO currently supports the following operating systems:
 1. [Getting Started](#gettingstarted)
 2. [Setting up a build/development environment](#setup)
 	1. [Automated build script](#autobuild)
-      1. [Clean install Linux (Amazon, Centos, Fedora, & Ubuntu/Mint) for a local testnet](#autoubuntulocal)
-      2. [Clean install Linux (Amazon, Centos, Fedora, & Ubuntu/Mint) for the public testnet](#autoubuntupublic)
+      1. [Clean install Linux (Amazon, Centos, Fedora, Mint, & Ubuntu) for a local testnet](#autoubuntulocal)
+      2. [Clean install Linux (Amazon, Centos, Fedora, Mint, & Ubuntu) for the public testnet](#autoubuntupublic)
       3. [MacOS for a local testnet](#automaclocal)
       4. [MacOS for the public testnet](#automacpublic)
 3. [Building EOS and running a node](#runanode)
@@ -58,8 +58,8 @@ EOS.IO currently supports the following operating systems:
    1. [Clean install Amazon 2017.09 and higher](#manualdepamazon)
    2. [Clean install Centos 7 and higher](#manualdepcentos)
    3. [Clean install Fedora 25 and higher](#manualdepfedora)
-   4. [Clean install Mint 18 and higher](#manualdepubuntu)
-   4. [Clean install Ubuntu 16.04 and higher](#manualdepubuntu)
+   4. [Clean install Mint 18](#manualdepubuntu)
+   4. [Clean install Ubuntu 16](#manualdepubuntu)
    5. [Clean install MacOS Sierra 10.12 and higher](#manualdepmacos)
 
 <a name="gettingstarted"></a>
@@ -76,8 +76,8 @@ Supported Operating Systems:
 1. Amazon 2017.09 and higher.  
 2. Centos 7 and higher.  
 3. Fedora 25 and higher (Fedora 27 recommended).  
-4. Mint 18 and higher.  
-5. Ubuntu 16.04 and higher (Ubuntu 16.10 recommended), Mint 18 and higher.  
+4. Mint 18.  
+5. Ubuntu 16.04 (Ubuntu 16.10 recommended), Mint 18.  
 6. MacOS Darwin 10.12 and higher (MacOS 10.13.x recommended).  
 
 For Amazon, Centos, Fedora, Mint, Ubuntu, & MacOS there is an automated build script that can install all dependencies and builds EOS.
@@ -767,7 +767,7 @@ make -j$( nproc ) install
 Your environment is set up. Now you can <a href="#runanode">build EOS and run a node</a>.
 
 <a name="manualdepubuntu"></a>
-### Clean install Ubuntu 16.04 & higher or Linux Mint 18 & higher
+### Clean install Ubuntu 16.04 & Linux Mint 18
 
 Install the development toolkit:
 

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ EOS.IO currently supports the following operating systems:
 1. [Getting Started](#gettingstarted)
 2. [Setting up a build/development environment](#setup)
 	1. [Automated build script](#autobuild)
-      1. [Clean install Linux (Amazon, Centos, Fedora, & Ubuntu) for a local testnet](#autoubuntulocal)
-      2. [Clean install Linux (Amazon, Centos, Fedora, & Ubuntu) for the public testnet](#autoubuntupublic)
+      1. [Clean install Linux (Amazon, Centos, Fedora, & Ubuntu/Mint) for a local testnet](#autoubuntulocal)
+      2. [Clean install Linux (Amazon, Centos, Fedora, & Ubuntu/Mint) for the public testnet](#autoubuntupublic)
       3. [MacOS for a local testnet](#automaclocal)
       4. [MacOS for the public testnet](#automacpublic)
 3. [Building EOS and running a node](#runanode)
@@ -58,6 +58,7 @@ EOS.IO currently supports the following operating systems:
    1. [Clean install Amazon 2017.09 and higher](#manualdepamazon)
    2. [Clean install Centos 7 and higher](#manualdepcentos)
    3. [Clean install Fedora 25 and higher](#manualdepfedora)
+   4. [Clean install Mint 18 and higher](#manualdepubuntu)
    4. [Clean install Ubuntu 16.04 and higher](#manualdepubuntu)
    5. [Clean install MacOS Sierra 10.12 and higher](#manualdepmacos)
 
@@ -75,10 +76,11 @@ Supported Operating Systems:
 1. Amazon 2017.09 and higher.  
 2. Centos 7 and higher.  
 3. Fedora 25 and higher (Fedora 27 recommended).  
-4. Ubuntu 16.04 and higher (Ubuntu 16.10 recommended).  
-5. MacOS Darwin 10.12 and higher (MacOS 10.13.x recommended).  
+4. Mint 18 and higher.  
+5. Ubuntu 16.04 and higher (Ubuntu 16.10 recommended), Mint 18 and higher.  
+6. MacOS Darwin 10.12 and higher (MacOS 10.13.x recommended).  
 
-For Amazon, Centos, Fedora, Ubuntu & MacOS there is an automated build script that can install all dependencies and builds EOS.
+For Amazon, Centos, Fedora, Mint, Ubuntu, & MacOS there is an automated build script that can install all dependencies and builds EOS.
 We are working on supporting other Linux/Unix distributions in future releases.
 
 Choose whether you will be building for a local testnet or for the public testnet and jump to the appropriate section below.  Clone the EOS repository recursively as described and run eosio_build.sh located in the root `eos` folder.
@@ -88,7 +90,7 @@ Choose whether you will be building for a local testnet or for the public testne
 We strongly recommend following the instructions for building the public testnet version for [Ubuntu](#autoubuntupublic) or [Mac OS X](#automacpublic). `master` is in pieces on the garage floor while we rebuild this hotrod. This notice will be removed when `master` is usable again. Your patience is appreciated.
 
 <a name="autoubuntulocal"></a>
-#### :no_entry: Clean install Linux (Amazon, Centos, Fedora & Ubuntu) for a local testnet :no_entry:
+#### :no_entry: Clean install Linux (Amazon, Centos, Fedora, Mint, & Ubuntu) for a local testnet :no_entry:
 
 ```bash
 git clone https://github.com/eosio/eos --recursive
@@ -106,7 +108,7 @@ sudo make install
 Now you can proceed to the next step - [Creating and launching a single-node testnet](#singlenode)
 
 <a name="autoubuntupublic"></a>
-#### Clean install Linux (Amazon, Centos, Fedora & Ubuntu) for the public testnet
+#### Clean install Linux (Amazon, Centos, Fedora, Mint, & Ubuntu) for the public testnet
 
 ```bash
 git clone https://github.com/eosio/eos --recursive
@@ -765,7 +767,7 @@ make -j$( nproc ) install
 Your environment is set up. Now you can <a href="#runanode">build EOS and run a node</a>.
 
 <a name="manualdepubuntu"></a>
-### Clean install Ubuntu 16.04 & Higher
+### Clean install Ubuntu 16.04 & higher or Linux Mint 18 & higher
 
 Install the development toolkit:
 
@@ -776,7 +778,7 @@ sudo apt-get install clang-4.0 lldb-4.0 libclang-4.0-dev cmake make \
                      libbz2-dev libssl-dev libgmp3-dev \
                      autotools-dev build-essential \
                      libbz2-dev libicu-dev python-dev \
-                     autoconf libtool git
+                     autoconf libtool git mongodb
 ```
 
 Install Boost 1.66:
@@ -791,6 +793,22 @@ source ~/.bash_profile
 ./bootstrap.sh "--prefix=$BOOST_ROOT"
 ./b2 install
 source ~/.bash_profile
+```
+
+Install MongoDB C++ driver:
+
+```bash
+cd ~
+curl -LO https://github.com/mongodb/mongo-c-driver/releases/download/1.9.3/mongo-c-driver-1.9.3.tar.gz
+tar xf mongo-c-driver-1.9.3.tar.gz
+cd mongo-c-driver-1.9.3
+./configure --enable-ssl=openssl --disable-automatic-init-and-cleanup --prefix=/usr/local
+make -j$( nproc )
+sudo make install
+git clone https://github.com/mongodb/mongo-cxx-driver.git --branch releases/stable --depth 1
+cd mongo-cxx-driver/build
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local ..
+sudo make -j$( nproc )
 ```
 
 Install [secp256k1-zkp (Cryptonomex branch)](https://github.com/cryptonomex/secp256k1-zkp.git):

--- a/eosio_build.sh
+++ b/eosio_build.sh
@@ -67,11 +67,13 @@
 				CXX_COMPILER=g++
 				C_COMPILER=gcc
 				export LLVM_DIR=${HOME}/opt/wasm/lib/cmake/llvm
+				BUILD_MONGODB=false
 			;;
 			"Linux Mint")
 				FILE=${WORK_DIR}/scripts/eosio_build_ubuntu.sh
 				CXX_COMPILER=clang++-4.0
 				C_COMPILER=clang-4.0
+				BUILD_MONGODB=true
 			;;
 			"CentOS Linux")
 				FILE=${WORK_DIR}/scripts/eosio_build_centos.sh
@@ -79,17 +81,20 @@
 				CXX_COMPILER=g++
 				C_COMPILER=gcc
 				export LLVM_DIR=${HOME}/opt/wasm/lib/cmake/llvm
+				BUILD_MONGODB=false
 			;;
 			"Fedora")
 				FILE=${WORK_DIR}/scripts/eosio_build_fedora.sh
 				CXX_COMPILER=g++
 				C_COMPILER=gcc
 				export LLVM_DIR=${HOME}/opt/wasm/lib/cmake/llvm
+				BUILD_MONGODB=false
 			;;
 			"Ubuntu")
 				FILE=${WORK_DIR}/scripts/eosio_build_ubuntu.sh
 				CXX_COMPILER=clang++-4.0
 				C_COMPILER=clang-4.0
+				BUILD_MONGODB=true
 			;;
 			*)
 				printf "\n\tUnsupported Linux Distribution. Exiting now.\n\n"
@@ -100,7 +105,7 @@
 		export OPENSSL_ROOT_DIR=/usr/include/openssl
 		export OPENSSL_LIBRARIES=/usr/include/openssl
 		export WASM_ROOT=${HOME}/opt/wasm
-      export SOFTFLOAT_ROOT=${HOME}/opt/berkeley-softfloat-3
+		export SOFTFLOAT_ROOT=${HOME}/opt/berkeley-softfloat-3
 	
 	 . $FILE
 	
@@ -110,7 +115,7 @@
 		OPENSSL_ROOT_DIR=/usr/local/opt/openssl
 		OPENSSL_LIBRARIES=/usr/local/opt/openssl/lib
 		export WASM_ROOT=/usr/local/wasm
-      export SOFTFLOAT_ROOT=/usr/local/berkeley-softfloat-3
+		export SOFTFLOAT_ROOT=/usr/local/berkeley-softfloat-3
 		CXX_COMPILER=clang++
 		C_COMPILER=clang
 
@@ -133,7 +138,7 @@
 	
 	$CMAKE -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DCMAKE_CXX_COMPILER=${CXX_COMPILER} \
 	-DCMAKE_C_COMPILER=${C_COMPILER} -DWASM_ROOT=${WASM_ROOT} -DSOFTFLOAT_ROOT=${SOFTFLOAT_ROOT} \
-	-DOPENSSL_ROOT_DIR=${OPENSSL_ROOT_DIR} \
+	-DOPENSSL_ROOT_DIR=${OPENSSL_ROOT_DIR} -DBUILD_MONGO_DB_PLUGIN=${BUILD_MONGODB} \
 	-DOPENSSL_LIBRARIES=${OPENSSL_LIBRARIES} ..
 	
 	if [ $? -ne 0 ]; then

--- a/eosio_build.sh
+++ b/eosio_build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 ##########################################################################
-# This is EOS automated install script for Linux and OS X.
+# This is the EOSIO automated install script for Linux and Mac OS.
 # This file was downloaded from https://github.com/EOSIO/eos
 #
 # Copyright (c) 2017, Respective Authors all rights reserved.
@@ -49,12 +49,14 @@
 	if [ $ARCH == "Linux" ]; then
 		
 		if [ ! -e /etc/os-release ]; then
-			printf "EOSIO currently supports Amazon, Centos, Fedora & Ubuntu Linux only.\n"
-			printf "Please install on the latest version of one of these Linux distributions.\n"
-			printf "https://aws.amazon.com/amazon-linux-ami/\n"
-			printf "https://start.fedoraproject.org/en/\n"
-			printf "https://www.ubuntu.com/\n"
-			printf "Exiting now.\n"
+			printf "\n\tEOSIO currently supports Amazon, Centos, Fedora, Mint & Ubuntu Linux only.\n"
+			printf "\tPlease install on the latest version of one of these Linux distributions.\n"
+			printf "\thttps://aws.amazon.com/amazon-linux-ami/\n"
+			printf "\thttps://www.centos.org/\n"
+			printf "\thttps://start.fedoraproject.org/\n"
+			printf "\thttps://linuxmint.com/\n"
+			printf "\thttps://www.ubuntu.com/\n"
+			printf "\tExiting now.\n"
 			exit 1
 		fi
 	
@@ -67,13 +69,7 @@
 				CXX_COMPILER=g++
 				C_COMPILER=gcc
 				export LLVM_DIR=${HOME}/opt/wasm/lib/cmake/llvm
-				BUILD_MONGODB=false
-			;;
-			"Linux Mint")
-				FILE=${WORK_DIR}/scripts/eosio_build_ubuntu.sh
-				CXX_COMPILER=clang++-4.0
-				C_COMPILER=clang-4.0
-				BUILD_MONGODB=true
+				BUILD_MONGO_DB_PLUGIN=false
 			;;
 			"CentOS Linux")
 				FILE=${WORK_DIR}/scripts/eosio_build_centos.sh
@@ -81,20 +77,26 @@
 				CXX_COMPILER=g++
 				C_COMPILER=gcc
 				export LLVM_DIR=${HOME}/opt/wasm/lib/cmake/llvm
-				BUILD_MONGODB=false
+				BUILD_MONGO_DB_PLUGIN=false
 			;;
 			"Fedora")
 				FILE=${WORK_DIR}/scripts/eosio_build_fedora.sh
 				CXX_COMPILER=g++
 				C_COMPILER=gcc
 				export LLVM_DIR=${HOME}/opt/wasm/lib/cmake/llvm
-				BUILD_MONGODB=false
+				BUILD_MONGO_DB_PLUGIN=false
+			;;
+			"Linux Mint")
+				FILE=${WORK_DIR}/scripts/eosio_build_ubuntu.sh
+				CXX_COMPILER=clang++-4.0
+				C_COMPILER=clang-4.0
+				BUILD_MONGO_DB_PLUGIN=true
 			;;
 			"Ubuntu")
 				FILE=${WORK_DIR}/scripts/eosio_build_ubuntu.sh
 				CXX_COMPILER=clang++-4.0
 				C_COMPILER=clang-4.0
-				BUILD_MONGODB=true
+				BUILD_MONGO_DB_PLUGIN=true
 			;;
 			*)
 				printf "\n\tUnsupported Linux Distribution. Exiting now.\n\n"
@@ -118,7 +120,7 @@
 		export SOFTFLOAT_ROOT=/usr/local/berkeley-softfloat-3
 		CXX_COMPILER=clang++
 		C_COMPILER=clang
-		BUILD_MONGODB=false
+		BUILD_MONGO_DB_PLUGIN=false
 
 	  . scripts/eosio_build_darwin.sh
 	fi
@@ -139,7 +141,7 @@
 	
 	$CMAKE -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DCMAKE_CXX_COMPILER=${CXX_COMPILER} \
 	-DCMAKE_C_COMPILER=${C_COMPILER} -DWASM_ROOT=${WASM_ROOT} -DSOFTFLOAT_ROOT=${SOFTFLOAT_ROOT} \
-	-DOPENSSL_ROOT_DIR=${OPENSSL_ROOT_DIR} -DBUILD_MONGO_DB_PLUGIN=${BUILD_MONGODB} \
+	-DOPENSSL_ROOT_DIR=${OPENSSL_ROOT_DIR} -DBUILD_MONGO_DB_PLUGIN=${BUILD_MONGO_DB_PLUGIN} \
 	-DOPENSSL_LIBRARIES=${OPENSSL_LIBRARIES} ..
 	
 	if [ $? -ne 0 ]; then

--- a/eosio_build.sh
+++ b/eosio_build.sh
@@ -120,7 +120,7 @@
 		export SOFTFLOAT_ROOT=/usr/local/berkeley-softfloat-3
 		CXX_COMPILER=clang++
 		C_COMPILER=clang
-		BUILD_MONGO_DB_PLUGIN=false
+		BUILD_MONGO_DB_PLUGIN=true
 
 	  . scripts/eosio_build_darwin.sh
 	fi

--- a/eosio_build.sh
+++ b/eosio_build.sh
@@ -120,7 +120,7 @@
 		export SOFTFLOAT_ROOT=/usr/local/berkeley-softfloat-3
 		CXX_COMPILER=clang++
 		C_COMPILER=clang
-		BUILD_MONGO_DB_PLUGIN=true
+		BUILD_MONGO_DB_PLUGIN=false
 
 	  . scripts/eosio_build_darwin.sh
 	fi

--- a/eosio_build.sh
+++ b/eosio_build.sh
@@ -118,6 +118,7 @@
 		export SOFTFLOAT_ROOT=/usr/local/berkeley-softfloat-3
 		CXX_COMPILER=clang++
 		C_COMPILER=clang
+		BUILD_MONGODB=true
 
 	  . scripts/eosio_build_darwin.sh
 	fi

--- a/eosio_build.sh
+++ b/eosio_build.sh
@@ -118,7 +118,7 @@
 		export SOFTFLOAT_ROOT=/usr/local/berkeley-softfloat-3
 		CXX_COMPILER=clang++
 		C_COMPILER=clang
-		BUILD_MONGODB=true
+		BUILD_MONGODB=false
 
 	  . scripts/eosio_build_darwin.sh
 	fi

--- a/scripts/eosio_build_ubuntu.sh
+++ b/scripts/eosio_build_ubuntu.sh
@@ -47,7 +47,7 @@
 		exit 1
 	fi
 
-	DEP_ARRAY=(clang-4.0 lldb-4.0 libclang-4.0-dev cmake make libbz2-dev libssl-dev libgmp3-dev autotools-dev build-essential libbz2-dev libicu-dev python-dev autoconf libtool curl)
+	DEP_ARRAY=(clang-4.0 lldb-4.0 libclang-4.0-dev cmake make libbz2-dev libssl-dev libgmp3-dev autotools-dev build-essential libbz2-dev libicu-dev python-dev autoconf libtool curl mongodb)
 	DCOUNT=0
 	COUNT=1
 	DISPLAY=""
@@ -110,6 +110,73 @@
 		rm -f  ${TEMP_DIR}/boost_1.66.0.tar.bz2
 	else
 		printf "\tBoost 1.66 found at ${HOME}/opt/boost_1_66_0\n"
+	fi
+
+	printf "\n\tChecking for MongoDB C++ driver.\n"
+    # install libmongocxx.dylib
+    if [ ! -e /usr/local/lib/libmongocxx.so ]; then
+		printf "\n\tInstalling MongoDB C & C++ drivers.\n"
+		cd ${TEMP_DIR}
+		curl -LO https://github.com/mongodb/mongo-c-driver/releases/download/1.9.3/mongo-c-driver-1.9.3.tar.gz
+		if [ $? -ne 0 ]; then
+			rm -f ${TEMP_DIR}/mongo-c-driver-1.9.3.tar.gz
+			printf "\tUnable to download MondgDB C driver at this time.\n"
+			printf "\tExiting now.\n\n"
+			exit;
+		fi
+		tar xf mongo-c-driver-1.9.3.tar.gz
+		rm -f ${TEMP_DIR}/mongo-c-driver-1.9.3.tar.gz
+		cd mongo-c-driver-1.9.3
+		./configure --enable-ssl=openssl --disable-automatic-init-and-cleanup --prefix=/usr/local
+		if [ $? -ne 0 ]; then
+			printf "\tConfiguring MondgDB C driver has encountered the errors above.\n"
+			printf "\tExiting now.\n\n"
+			exit;
+		fi
+		make -j${CPU_CORE}
+		if [ $? -ne 0 ]; then
+			printf "\tError compiling MondgDB C driver.\n"
+			printf "\tExiting now.\n\n"
+			exit;
+		fi
+		sudo make install
+		if [ $? -ne 0 ]; then
+			printf "\tError installing MondgDB C driver.\nMake sure you have sudo privileges.\n"
+			printf "\tExiting now.\n\n"
+			exit;
+		fi
+		cd ..
+		rm -rf ${TEMP_DIR}/mongo-c-driver-1.9.3
+		cd ${TEMP_DIR}
+		git clone https://github.com/mongodb/mongo-cxx-driver.git --branch releases/stable --depth 1
+		if [ $? -ne 0 ]; then
+			printf "\tUnable to clone MondgDB C++ driver at this time.\n"
+			printf "\tExiting now.\n\n"
+			exit;
+		fi
+		cd mongo-cxx-driver/build
+		cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local ..
+		if [ $? -ne 0 ]; then
+			printf "\tCmake has encountered the above errors building the MongoDB C++ driver.\n"
+			printf "\tExiting now.\n\n"
+			exit;
+		fi
+		sudo make -j${CPU_CORE}
+		if [ $? -ne 0 ]; then
+			printf "\tError compiling MondgDB C++ driver.\n"
+			printf "\tExiting now.\n\n"
+			exit;
+		fi
+		sudo make install
+		if [ $? -ne 0 ]; then
+			printf "\tError installing MondgDB C++ driver.\nMake sure you have sudo privileges.\n"
+			printf "\tExiting now.\n\n"
+			exit;
+		fi
+		cd ..
+		sudo rm -rf ${TEMP_DIR}/mongo-cxx-driver
+	else
+		printf "\tMongo C++ driver found at /usr/local/lib/libmongocxx.so.\n"
 	fi
 
 	printf "\n\tChecking for secp256k1-zkp\n"

--- a/scripts/eosio_build_ubuntu.sh
+++ b/scripts/eosio_build_ubuntu.sh
@@ -119,7 +119,7 @@
 		cd ${TEMP_DIR}
 		curl -LO https://github.com/mongodb/mongo-c-driver/releases/download/1.9.3/mongo-c-driver-1.9.3.tar.gz
 		if [ $? -ne 0 ]; then
-			rm -f ${TEMP_DIR}/mongo-c-driver-1.9.3.tar.gz
+			rm -f ${TEMP_DIR}/mongo-c-driver-1.9.3.tar.gz 2>/dev/null
 			printf "\tUnable to download MondgDB C driver at this time.\n"
 			printf "\tExiting now.\n\n"
 			exit;


### PR DESCRIPTION
For Ubuntu/Mint Linux:
Added installing MongoDB from dpkg.
Added compiling MongoDB C driver version 1.9.3.
Added compiling MongoDB C++ driver from git --branch releases/stable.
Added dynamic cmake option to compile EOSIO with/without MongoDB plug in.
Added Linux Mint documentation to supported Operating Systems in README.md
Added manual install documentation for MongoDB C & C++ drivers in Ubuntu/Mint manual dependency section of README.md.

Files Changed:
eosio_build.sh
README.md
scripts/eosio_build_ubuntu.sh

