### PR TITLE
DAWN-556 p2p_network testing containing reduced throughput, lossy & s…

### DIFF
--- a/tests/impaird_network.py
+++ b/tests/impaird_network.py
@@ -1,0 +1,29 @@
+import testUtils
+import p2p_test_peers
+import random
+
+RemoteCmd = p2p_test_peers.P2PTestPeers
+
+class ImpairedNetwork:
+    prefix="tc qdisc add dev eth0 root tbf rate"
+    cmds=["1mbps","500kbps","100kbps","10kbps","1kbps","1bps"]
+
+    def maxIndex(self):
+        return len(self.cmds)
+
+    def execute(self, cmdInd, node, testerAccount, eosio):
+        print("\n==== impaired network test: set network speed into %s ====" % (self.cmds[cmdInd]))
+        RemoteCmd.exec("ssh", self.prefix + " " + self.cmds[cmdInd])
+        s=""
+        for i in range(12):
+            s=s+random.choice("abcdefghijklmnopqrstuvwxyz12345")
+        testerAccount.name = s
+        transIdlist = []
+        print("==== creating account %s ====" % (s))
+        trans = node.createAccount(testerAccount, eosio, stakedDeposit=0, waitForTransBlock=True)
+        transIdlist.append(node.getTransId(trans))
+        return transIdlist
+    
+    def on_exit(self):
+        RemoteCmd.exec("ssh", self.prefix + " " + self.cmds[0])
+

--- a/tests/impaired_network.py
+++ b/tests/impaired_network.py
@@ -5,15 +5,17 @@ import random
 RemoteCmd = p2p_test_peers.P2PTestPeers
 
 class ImpairedNetwork:
-    prefix="tc qdisc add dev eth0 root tbf rate"
-    cmds=["1mbps","500kbps","100kbps","10kbps","1kbps","1bps"]
+    cmd="tc qdisc add dev {dev} root tbf limit 65536 burst 65536 rate"
+    args=["1mbps","500kbps","100kbps","10kbps","1kbps"] #,"1bps"]
+
+    resetcmd="tc qdisc del dev {dev} root"
 
     def maxIndex(self):
-        return len(self.cmds)
+        return len(self.args)
 
     def execute(self, cmdInd, node, testerAccount, eosio):
-        print("\n==== impaired network test: set network speed into %s ====" % (self.cmds[cmdInd]))
-        RemoteCmd.exec("ssh", self.prefix + " " + self.cmds[cmdInd])
+        print("\n==== impaired network test: set network speed to %s ====" % (self.args[cmdInd]))
+        RemoteCmd.exec(self.cmd + " " + self.args[cmdInd])
         s=""
         for i in range(12):
             s=s+random.choice("abcdefghijklmnopqrstuvwxyz12345")
@@ -22,8 +24,7 @@ class ImpairedNetwork:
         print("==== creating account %s ====" % (s))
         trans = node.createAccount(testerAccount, eosio, stakedDeposit=0, waitForTransBlock=True)
         transIdlist.append(node.getTransId(trans))
-        return transIdlist
+        return (transIdlist, "", 0.0)
     
     def on_exit(self):
-        RemoteCmd.exec("ssh", self.prefix + " " + self.cmds[0])
-
+        RemoteCmd.exec(self.resetcmd)

--- a/tests/impaired_network.py
+++ b/tests/impaired_network.py
@@ -23,8 +23,10 @@ class ImpairedNetwork:
         transIdlist = []
         print("==== creating account %s ====" % (s))
         trans = node.createAccount(testerAccount, eosio, stakedDeposit=0, waitForTransBlock=True)
+        if trans is None:
+            return ([], "", 0.0, "failed to create account")
         transIdlist.append(node.getTransId(trans))
-        return (transIdlist, "", 0.0)
+        return (transIdlist, "", 0.0, "")
     
     def on_exit(self):
         RemoteCmd.exec(self.resetcmd)

--- a/tests/lossy_network.py
+++ b/tests/lossy_network.py
@@ -23,8 +23,10 @@ class LossyNetwork:
         transIdlist = []
         print("==== creating account %s ====" % (s))
         trans = node.createAccount(testerAccount, eosio, stakedDeposit=0, waitForTransBlock=True)
+        if trans is None:
+            return ([], "", 0.0, "failed to create account")
         transIdlist.append(node.getTransId(trans))
-        return (transIdlist, "", 0.0)
+        return (transIdlist, "", 0.0, "")
     
     def on_exit(self):
         RemoteCmd.exec(self.resetcmd)

--- a/tests/lossy_network.py
+++ b/tests/lossy_network.py
@@ -1,0 +1,28 @@
+import testUtils
+import p2p_test_peers
+import random
+
+RemoteCmd = p2p_test_peers.P2PTestPeers
+
+class LossyNetwork:
+    prefix="tc qdisc add dev eth0 root netem loss"
+    cmds=["0%", "1%", "10%", "50%", "90%", "99%"]
+
+    def maxIndex(self):
+        return len(self.cmds)
+
+    def execute(self, cmdInd, node, testerAccount, eosio):
+        print("\n==== lossy network test: set loss ratio into %s ====" % (self.cmds[cmdInd]))
+        RemoteCmd.exec("ssh", self.prefix + " " + self.cmds[cmdInd])
+        s=""
+        for i in range(12):
+            s=s+random.choice("abcdefghijklmnopqrstuvwxyz12345")
+        testerAccount.name = s
+        transIdlist = []
+        print("==== creating account %s ====" % (s))
+        trans = node.createAccount(testerAccount, eosio, stakedDeposit=0, waitForTransBlock=True)
+        transIdlist.append(node.getTransId(trans))
+        return transIdlist
+    
+    def on_exit(self):
+        RemoteCmd.exec("ssh", self.prefix + " " + self.cmds[0])

--- a/tests/lossy_network.py
+++ b/tests/lossy_network.py
@@ -5,15 +5,17 @@ import random
 RemoteCmd = p2p_test_peers.P2PTestPeers
 
 class LossyNetwork:
-    prefix="tc qdisc add dev eth0 root netem loss"
-    cmds=["0%", "1%", "10%", "50%", "90%", "99%"]
+    cmd="tc qdisc add dev {dev} root netem loss"
+    args=["0%", "1%", "10%", "50%", "90%", "99%"]
+
+    resetcmd="tc qdisc del dev {dev} root"
 
     def maxIndex(self):
-        return len(self.cmds)
+        return len(self.args)
 
     def execute(self, cmdInd, node, testerAccount, eosio):
-        print("\n==== lossy network test: set loss ratio into %s ====" % (self.cmds[cmdInd]))
-        RemoteCmd.exec("ssh", self.prefix + " " + self.cmds[cmdInd])
+        print("\n==== lossy network test: set loss ratio to %s ====" % (self.args[cmdInd]))
+        RemoteCmd.exec(self.cmd + " " + self.args[cmdInd])
         s=""
         for i in range(12):
             s=s+random.choice("abcdefghijklmnopqrstuvwxyz12345")
@@ -22,7 +24,7 @@ class LossyNetwork:
         print("==== creating account %s ====" % (s))
         trans = node.createAccount(testerAccount, eosio, stakedDeposit=0, waitForTransBlock=True)
         transIdlist.append(node.getTransId(trans))
-        return transIdlist
+        return (transIdlist, "", 0.0)
     
     def on_exit(self):
-        RemoteCmd.exec("ssh", self.prefix + " " + self.cmds[0])
+        RemoteCmd.exec(self.resetcmd)

--- a/tests/p2p_network_test.py
+++ b/tests/p2p_network_test.py
@@ -165,10 +165,7 @@ if trans is None:
 else:
     Print("transaction id %s" % (node0.getTransId(trans)))
 
-time.sleep(3.0)
-
 try:
-
     maxIndex = module.maxIndex()
     for cmdInd in range(maxIndex):
         (transIdList, checkacct, expBal, errmsg) = module.execute(cmdInd, node0, testeraAccount, eosio)

--- a/tests/p2p_network_test.py
+++ b/tests/p2p_network_test.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+
+import testUtils
+import p2p_test_peers
+import impaird_network
+import lossy_network
+import p2p_stress
+
+import copy
+import decimal
+import argparse
+import random
+import re
+
+Remote = p2p_test_peers.P2PTestPeers
+
+hosts=Remote.hosts
+ports=Remote.ports
+
+TEST_OUTPUT_DEFAULT="p2p_network_test_log.txt"
+DEFAULT_HOST=hosts[0]
+DEFAULT_PORT=ports[0]
+
+parser = argparse.ArgumentParser(add_help=False)
+walletMgr=testUtils.WalletMgr(True)
+Print=testUtils.Utils.Print
+errorExit=testUtils.Utils.errorExit
+
+# Override default help argument so that only --help (and not -h) can call help
+parser.add_argument('-?', action='help', default=argparse.SUPPRESS,
+                    help=argparse._('show this help message and exit'))
+parser.add_argument("-o", "--output", type=str, help="output file", default=TEST_OUTPUT_DEFAULT)
+parser.add_argument("--inita_prvt_key", type=str, help="Inita private key.",
+                    default=testUtils.Cluster.initaAccount.ownerPrivateKey)
+parser.add_argument("--initb_prvt_key", type=str, help="Initb private key.",
+                    default=testUtils.Cluster.initbAccount.ownerPrivateKey)
+parser.add_argument("--impaired_network", help="test impaired network", action='store_true')
+parser.add_argument("--lossy_network", help="test lossy network", action='store_true')
+parser.add_argument("--stress_network", help="test load/stress network", action='store_true')
+
+args = parser.parse_args()
+testOutputFile=args.output
+enableMongo=False
+initaPrvtKey=args.inita_prvt_key
+initbPrvtKey=args.initb_prvt_key
+
+if args.impaired_network is True:
+    module = impaird_network.ImpairedNetwork()
+elif args.lossy_network is True:
+    module = lossy_network.LossyNetwork()
+elif args.stress_network is True:
+    module = p2p_stress.StressNetwork()
+else:
+    errorExit("one of impaird_network & lossy_network must be set. Please also check peer configs in p2p_test_peers.py.")
+
+cluster=testUtils.Cluster(walletd=True, enableMongo=enableMongo, initaPrvtKey=initaPrvtKey, initbPrvtKey=initbPrvtKey)
+
+print("BEGIN")
+print("TEST_OUTPUT: %s" % (testOutputFile))
+
+print("list of hosts:")
+for i in range(len(hosts)):
+    Print("%s:%d" % (hosts[i], ports[i]))
+
+init_str='{"nodes":['
+for i in range(len(hosts)):
+    if i > 0:
+        init_str=init_str+','
+    init_str=init_str+'{"host":"' + hosts[i] + '", "port":'+str(ports[i])+'}'
+init_str=init_str+']}'
+
+Print('init nodes with json str %s',(init_str))
+cluster.initializeNodesFromJson(init_str);
+
+print('killing all wallets')
+walletMgr.killall()
+walletMgr.cleanup()
+
+print('creating account keys')
+accounts=testUtils.Cluster.createAccountKeys(3)
+if accounts is None:
+    errorExit("FAILURE - create keys")
+testeraAccount=accounts[0]
+testeraAccount.name="testera"
+currencyAccount=accounts[1]
+currencyAccount.name="currency"
+exchangeAccount=accounts[2]
+exchangeAccount.name="exchange"
+
+PRV_KEY1=testeraAccount.ownerPrivateKey
+PUB_KEY1=testeraAccount.ownerPublicKey
+PRV_KEY2=currencyAccount.ownerPrivateKey
+PUB_KEY2=currencyAccount.ownerPublicKey
+PRV_KEY3=exchangeAccount.activePrivateKey
+PUB_KEY3=exchangeAccount.activePublicKey
+
+testeraAccount.activePrivateKey=currencyAccount.activePrivateKey=PRV_KEY3
+testeraAccount.activePublicKey=currencyAccount.activePublicKey=PUB_KEY3
+
+exchangeAccount.ownerPrivateKey=PRV_KEY2
+exchangeAccount.ownerPublicKey=PUB_KEY2
+
+print("Stand up walletd")
+if walletMgr.launch() is False:
+    cmdError("%s" % (WalletdName))
+    errorExit("Failed to stand up eos walletd.")
+
+testWalletName="test"
+Print("Creating wallet \"%s\"." % (testWalletName))
+testWallet=walletMgr.create(testWalletName)
+if testWallet is None:
+    cmdError("eos wallet create")
+    errorExit("Failed to create wallet %s." % (testWalletName))
+
+for account in accounts:
+    Print("Importing keys for account %s into wallet %s." % (account.name, testWallet.name))
+    if not walletMgr.importKey(account, testWallet):
+        cmdError("%s wallet import" % (ClientName))
+        errorExit("Failed to import key for account %s" % (account.name))
+
+initaWalletName="inita"
+Print("Creating wallet \"%s\"." % (initaWalletName))
+initaWallet=walletMgr.create(initaWalletName)
+if initaWallet is None:
+    cmdError("eos wallet create")
+    errorExit("Failed to create wallet %s." % (initaWalletName))
+
+initaAccount=testUtils.Cluster.initaAccount
+# initbAccount=testUtils.Cluster.initbAccount
+
+Print("Importing keys for account %s into wallet %s." % (initaAccount.name, initaWallet.name))
+if not walletMgr.importKey(initaAccount, initaWallet):
+     cmdError("%s wallet import" % (ClientName))
+     errorExit("Failed to import key for account %s" % (initaAccount.name))
+
+node0=cluster.getNode(0)
+if node0 is None:
+    errorExit("cluster in bad state, received None node")
+
+# eosio should have the same key as inita
+eosio = copy.copy(initaAccount)
+eosio.name = "eosio"
+
+try:
+    maxIndex = module.maxIndex()
+    for cmdInd in range(maxIndex):
+        transIdList = module.execute(cmdInd, node0, testeraAccount, eosio)
+        if len(transIdList) == 0:
+            errorExit("no transaction returned")
+        Print("got %d transaction(s)" % (len(transIdList)))
+        for i in range(len(hosts)):
+            for j in range(len(transIdList)):
+                trans = cluster.getNode(i).getTransaction(transIdList[j])
+            if trans is None:
+                errorExit("Failed to retrieve transId %s in host %s" % (transIdList[j], hosts[i]))
+        Print("%d transaction(s) verified in %d hosts" % (len(transIdList), len(hosts)))
+finally:
+    Print("\nfinally: restore everything")
+    module.on_exit()
+exit(0)

--- a/tests/p2p_stress.py
+++ b/tests/p2p_stress.py
@@ -1,0 +1,47 @@
+import testUtils
+import p2p_test_peers
+import random
+import time
+
+class StressNetwork:
+    speeds=[1,5,10,30,60,100,500]
+    sec=5
+
+    def maxIndex(self):
+        return len(self.speeds)
+
+    def execute(self, cmdInd, node, ta, eosio):
+        print("\n==== stress network test: %d transaction(s)/s for %d secs ====" % (self.speeds[cmdInd], self.sec))
+        total = self.speeds[cmdInd] * self.sec
+        acclist = []
+        for k in range(total):
+            s=""
+            for i in range(10):
+                s=s+random.choice("abcdefghijklmnopqrstuvwxyz12345")
+            acclist.append(s)
+        ta.name = s
+        transIdlist = []
+        print("==== creating %d account(s) ====" % (total))
+        delay = 1.0 / self.speeds[cmdInd]
+        t00 = time.time()
+        t0 = time.time()
+        trList = []
+        for k in range(total):
+            ta.name = acclist[k]
+            tr = node.createAccount(ta, eosio, stakedDeposit=0, waitForTransBlock=False)
+            trList.append(tr)
+            t1 = time.time()
+            if (t1-t0 < delay):
+                time.sleep(delay - (t1-t0))
+                t0 = time.time()
+            else:
+                t0 = t1
+        t11 = time.time()
+        print("time used = %lf" % (t11 - t00))
+        for k in range(total):
+            transIdlist.append(node.getTransId(trList[k]))
+        return transIdlist
+    
+    def on_exit(self):
+        print("end of stress network tests")
+

--- a/tests/p2p_stress.py
+++ b/tests/p2p_stress.py
@@ -2,46 +2,94 @@ import testUtils
 import p2p_test_peers
 import random
 import time
+import copy
+import threading
 
 class StressNetwork:
     speeds=[1,5,10,30,60,100,500]
-    sec=5
+    sec=10
+    maxthreads=100
+    trList=[]
 
     def maxIndex(self):
         return len(self.speeds)
 
+    def randAcctName(self):
+        s=""
+        for i in range(12):
+            s=s+random.choice("abcdefghijklmnopqrstuvwxyz12345")
+        return s
+    
+    def _transfer(self, node, acc1, acc2, amount, threadId, round):
+        memo="%d %d" % (threadId, round)
+        tr = node.transferFunds(acc1, acc2, amount, memo)
+        self.trList.append(tr)
+
     def execute(self, cmdInd, node, ta, eosio):
-        print("\n==== stress network test: %d transaction(s)/s for %d secs ====" % (self.speeds[cmdInd], self.sec))
+        print("\n==== network stress test: %d transaction(s)/s for %d secs ====" % (self.speeds[cmdInd], self.sec))
         total = self.speeds[cmdInd] * self.sec
-        acclist = []
-        for k in range(total):
-            s=""
-            for i in range(10):
-                s=s+random.choice("abcdefghijklmnopqrstuvwxyz12345")
-            acclist.append(s)
-        ta.name = s
-        transIdlist = []
-        print("==== creating %d account(s) ====" % (total))
-        delay = 1.0 / self.speeds[cmdInd]
+
+        ta.name = self.randAcctName()
+        acc1 = copy.copy(ta)
+        print("creating new account %s" % (ta.name))
+        tr = node.createAccount(ta, eosio, stakedDeposit=0, waitForTransBlock=False)
+        print("transaction id %s" % (node.getTransId(tr)))
+
+        ta.name = self.randAcctName()
+        acc2 = copy.copy(ta)
+        print("creating new account %s" % (ta.name))
+        tr = node.createAccount(ta, eosio, stakedDeposit=0, waitForTransBlock=False)
+        print("transaction id %s" % (node.getTransId(tr)))
+
+        time.sleep(1.0)
+
+        print("issue currency into %s" % (acc1.name))
+        contract="eosio"
+        action="issue"
+        data="{\"to\":\"" + acc1.name + "\",\"quantity\":\"1000000.0000 EOS\"}"
+        opts="--permission eosio@active"
+        tr=node.pushMessage(contract, action, data, opts)
+        print("transaction id %s" % (node.getTransId(tr[1])))
+
+        time.sleep(1.0)
+
+        self.trList = []
+        expBal = 0
+        nthreads=self.maxthreads
+        if nthreads > self.speeds[cmdInd]:
+            nthreads = self.speeds[cmdInd]
+        cycle = int(total / nthreads)
+        total = cycle * nthreads # rounding
+        delay = 1.0 / self.speeds[cmdInd] * nthreads
+
+        print("start currency trasfer from %s to %s for %d times with %d threads" % (acc1.name, acc2.name, total, nthreads))
+
         t00 = time.time()
-        t0 = time.time()
-        trList = []
-        for k in range(total):
-            ta.name = acclist[k]
-            tr = node.createAccount(ta, eosio, stakedDeposit=0, waitForTransBlock=False)
-            trList.append(tr)
+        for k in range(cycle):
+            t0 = time.time()
+            amount = 1
+            threadList = []
+            for m in range(nthreads):
+                th = threading.Thread(target = self._transfer,args = (node, acc1, acc2, amount, m, k))
+                th.start()
+                threadList.append(th)
+            for m in range(len(threadList)):
+                threadList[m].join()
+            expBal = expBal + amount * nthreads
             t1 = time.time()
             if (t1-t0 < delay):
                 time.sleep(delay - (t1-t0))
-                t0 = time.time()
-            else:
-                t0 = t1
         t11 = time.time()
         print("time used = %lf" % (t11 - t00))
-        for k in range(total):
-            transIdlist.append(node.getTransId(trList[k]))
-        return transIdlist
+
+        actBal = node.getAccountBalance(acc2.name)
+        print("account %s: expect Balance:%d, actual Balance %d" % (acc2.name, expBal, actBal))
+
+        transIdlist = []
+        for k in range(len(self.trList)):
+            transIdlist.append(node.getTransId(self.trList[k]))
+        return (transIdlist, acc2.name, expBal)
     
     def on_exit(self):
-        print("end of stress network tests")
+        print("end of network stress tests")
 

--- a/tests/p2p_test_peers.py
+++ b/tests/p2p_test_peers.py
@@ -1,0 +1,16 @@
+import subprocess
+
+class P2PTestPeers:
+    Debug = False
+
+    hosts = ["localhost", "127.0.0.1"]
+    ports = [8888, 8888]
+
+    @staticmethod
+    def exec(prefix, args, toprint=True):
+        for i in range(len(P2PTestPeers.hosts)):
+            cmd = prefix + ' ' + P2PTestPeers.hosts[i] + ' ' + args
+            if toprint is True:
+                print('execute:{0} in host {1}'.format(cmd, P2PTestPeers.hosts[i]))
+            subprocess.call(cmd, shell=True)
+

--- a/tests/p2p_test_peers.py
+++ b/tests/p2p_test_peers.py
@@ -1,16 +1,24 @@
 import subprocess
 
 class P2PTestPeers:
-    Debug = False
 
-    hosts = ["localhost", "127.0.0.1"]
-    ports = [8888, 8888]
+    #for testing with localhost
+    sshname = "testnet" # ssh name for executing remote commands
+    hosts = ["localhost"] # host list
+    ports = [8888] # eosiod listening port of each host
+    devs = ["lo0"] # network device of each host
+
+    #for testing with testnet2
+    #sshname = "testnet" # ssh name for executing remote commands
+    #hosts = ["10.160.11.101", "10.160.12.102", "10.160.13.103", "10.160.11.104", "10.160.12.105", "10.160.13.106", "10.160.11.107", "10.160.12.108", "10.160.13.109", "10.160.11.110", "10.160.12.111", "10.160.13.112", "10.160.11.113", "10.160.12.114", "10.160.13.115", "10.160.11.116", "10.160.12.117", "10.160.13.118", "10.160.11.119", "10.160.12.120", "10.160.13.121", "10.160.11.122"] # host list
+    #ports = [8888, 8888,8888,8888,8888,8888,8888,8888,8888,8888,8888,8888,8888,8888,8888,8888,8888,8888,8888,8888,8888, 8888] # eosiod listening port of each host
+    #devs = ["ens3", "ens3", "ens3", "ens3", "ens3", "ens3", "ens3", "ens3", "ens3", "ens3", "ens3", "ens3", "ens3", "ens3", "ens3", "ens3", "ens3", "ens3", "ens3", "ens3", "ens3", "ens3"] # network device of each host
 
     @staticmethod
-    def exec(prefix, args, toprint=True):
+    def exec(remoteCmd, toprint=True):
         for i in range(len(P2PTestPeers.hosts)):
-            cmd = prefix + ' ' + P2PTestPeers.hosts[i] + ' ' + args
+            remoteCmd2 = remoteCmd.replace("{dev}", P2PTestPeers.devs[i])
+            cmd = "ssh " + P2PTestPeers.sshname + "@" + P2PTestPeers.hosts[i] + ' ' + remoteCmd2
             if toprint is True:
-                print('execute:{0} in host {1}'.format(cmd, P2PTestPeers.hosts[i]))
+                print("execute:" + cmd)
             subprocess.call(cmd, shell=True)
-


### PR DESCRIPTION
This contains the test scripts for the following subtasks:
DAWN-558 Impaired networking
DAWN-560 Lossy network
DAWN-562 Load/stress test

dependency script: testUtils.py

How to run:
1) modify tests/p2p_test_peers.py with the list of remote host names that you want to test
    by default it is pointing localhosts: _hosts = ["localhost", "127.0.0.1"]_
2) ensure eosiod is running on each host and the remote ssh command is working
3) run one or more following tests(order doesn't matter, no need to cleanup database)
  3a) ./tests/p2p_network_test.py --impaired_network
  3b) ./tests/p2p_network_test.py --lossy_network
  3c) ./tests/p2p_network_test.py --stress_network

The script will try to create random accounts and check resulting transactions on each host.
  
 
 
 
 
sample output:

_Fredriks-MacBook-Pro:build jiaendu$ ./tests/p2p_network_test.py --stress_network
BEGIN
TEST_OUTPUT: p2p_network_test_log.txt
list of hosts:
localhost:8888
127.0.0.1:8888
init nodes with json str %s {"nodes":[{"host":"localhost", "port":8888},{"host":"127.0.0.1", "port":8888}]}
killing all wallets
creating account keys
Stand up walletd
 cmd: programs/eosiowd/eosiowd --data-dir test_wallet_0 --config-dir test_wallet_0 --http-server-address=localhost:8899
Creating wallet "test".
Importing keys for account testera into wallet test.
Importing keys for account currency into wallet test.
 WARNING: This key is already imported into the wallet.
Importing keys for account exchange into wallet test.
 WARNING: This key is already imported into the wallet.
 WARNING: This key is already imported into the wallet.
Creating wallet "inita".
Importing keys for account inita into wallet inita.
 WARNING: This key is already imported into the wallet.

==== stress network test: 1 transaction(s)/s for 5 secs ====
==== creating 5 account(s) ====
time used = 5.009646
got 5 transaction(s)
5 transaction(s) verified in 2 hosts

==== stress network test: 5 transaction(s)/s for 5 secs ====
==== creating 25 account(s) ====
time used = 5.066934
got 25 transaction(s)
25 transaction(s) verified in 2 hosts

==== stress network test: 10 transaction(s)/s for 5 secs ====
==== creating 50 account(s) ====
time used = 5.114180
got 50 transaction(s)
50 transaction(s) verified in 2 hosts

==== stress network test: 30 transaction(s)/s for 5 secs ====
==== creating 150 account(s) ====
time used = 5.289232
got 150 transaction(s)
150 transaction(s) verified in 2 hosts

==== stress network test: 60 transaction(s)/s for 5 secs ====
==== creating 300 account(s) ====
time used = 7.621658
got 300 transaction(s)
300 transaction(s) verified in 2 hosts

==== stress network test: 100 transaction(s)/s for 5 secs ====
==== creating 500 account(s) ====
time used = 85.427170
got 500 transaction(s)
500 transaction(s) verified in 2 hosts

==== stress network test: 500 transaction(s)/s for 5 secs ====
==== creating 2500 account(s) ====
time used = 6090.650222
got 2500 transaction(s)
2500 transaction(s) verified in 2 hosts

finally: restore everything
end of stress network tests_