### PR TITLE
Change how the macro "N" is undef'ed wrt clang 6 fix

### DIFF
--- a/libraries/abi_generator/include/eosio/abi_generator/abi_generator.hpp
+++ b/libraries/abi_generator/include/eosio/abi_generator/abi_generator.hpp
@@ -9,7 +9,8 @@
 #include <eosio/chain/contracts/types.hpp>
 #include <fc/io/json.hpp>
 
-//clashes with something deep in the AST includes
+//clashes with something deep in the AST includes in clang 6 and possibly other versions of clang
+#pragma push_macro("N")
 #undef N
 
 #include "clang/Driver/Options.h"
@@ -228,3 +229,5 @@ namespace eosio {
    };
 
 } //ns eosio
+
+#pragma pop_macro("N")


### PR DESCRIPTION
This ensures N is left untouched after abi_generator.hpp is included

Hopefully cleaner fix vs PR #1665