### PR TITLE
fix bug in multi_index::modify and add related test case

### DIFF
--- a/contracts/eosiolib/multi_index.hpp
+++ b/contracts/eosiolib/multi_index.hpp
@@ -689,8 +689,10 @@ class multi_index
             if( hana::at_c<index_type::index_number>(secondary_keys) != secondary ) {
                auto indexitr = mutableitem.__iters[index_type::number()];
 
-               if( indexitr < 0 )
-                  indexitr = mutableitem.__iters[index_type::number()] = db_idx_find_primary( _code, _scope, index_type::name(), pk,  secondary );
+               if( indexitr < 0 ) {
+                  typename index_type::secondary_key_type temp_secondary_key;
+                  indexitr = mutableitem.__iters[index_type::number()] = db_idx_find_primary( _code, _scope, index_type::name(), pk,  temp_secondary_key );
+               }
 
                db_idx_update( indexitr, payer, secondary );
             }

--- a/contracts/test_api/test_api.hpp
+++ b/contracts/test_api/test_api.hpp
@@ -138,6 +138,9 @@ struct test_multi_index {
    static void idx64_general();
    static void idx64_store_only();
    static void idx64_check_without_storing();
+   static void idx128_general();
+   static void idx128_store_only();
+   static void idx128_check_without_storing();
    static void idx128_autoincrement_test();
    static void idx128_autoincrement_test_part1();
    static void idx128_autoincrement_test_part2();

--- a/contracts/test_api_multi_index/test_api_multi_index.cpp
+++ b/contracts/test_api_multi_index/test_api_multi_index.cpp
@@ -18,6 +18,9 @@ extern "C" {
       WASM_TEST_HANDLER(test_multi_index, idx64_general);
       WASM_TEST_HANDLER(test_multi_index, idx64_store_only);
       WASM_TEST_HANDLER(test_multi_index, idx64_check_without_storing);
+      WASM_TEST_HANDLER(test_multi_index, idx128_general);
+      WASM_TEST_HANDLER(test_multi_index, idx128_store_only);
+      WASM_TEST_HANDLER(test_multi_index, idx128_check_without_storing);
       WASM_TEST_HANDLER(test_multi_index, idx128_autoincrement_test);
       WASM_TEST_HANDLER(test_multi_index, idx128_autoincrement_test_part1);
       WASM_TEST_HANDLER(test_multi_index, idx128_autoincrement_test_part2);

--- a/contracts/test_api_multi_index/test_multi_index.cpp
+++ b/contracts/test_api_multi_index/test_multi_index.cpp
@@ -235,7 +235,7 @@ namespace _test_multi_index {
          ++itr;
          eosio_assert( itr->primary_key() == 3 && itr->get_secondary() == multiplier*6, "idx128_general - secondary key sort" );
          ++itr;
-         eosio_assert( itr == secondary_index.end(), "idx256_general - secondary key sort" );
+         eosio_assert( itr == secondary_index.end(), "idx128_general - secondary key sort" );
       }
 
    }

--- a/tests/api_tests/api_tests.cpp
+++ b/tests/api_tests/api_tests.cpp
@@ -674,19 +674,22 @@ BOOST_FIXTURE_TEST_CASE(db_tests, tester) { try {
  * multi_index_tests test case
  *************************************************************************************/
 BOOST_FIXTURE_TEST_CASE(multi_index_tests, tester) { try {
-	produce_blocks(1);
-	create_account( N(testapi) );
-	produce_blocks(1);
-	set_code( N(testapi), test_api_multi_index_wast );
-	produce_blocks(1);
+   produce_blocks(1);
+   create_account( N(testapi) );
+   produce_blocks(1);
+   set_code( N(testapi), test_api_multi_index_wast );
+   produce_blocks(1);
 
-	CALL_TEST_FUNCTION( *this, "test_multi_index", "idx64_general", {});
-	CALL_TEST_FUNCTION( *this, "test_multi_index", "idx64_store_only", {});
-	CALL_TEST_FUNCTION( *this, "test_multi_index", "idx64_check_without_storing", {});
-	CALL_TEST_FUNCTION( *this, "test_multi_index", "idx128_autoincrement_test", {});
-	CALL_TEST_FUNCTION( *this, "test_multi_index", "idx128_autoincrement_test_part1", {});
-	CALL_TEST_FUNCTION( *this, "test_multi_index", "idx128_autoincrement_test_part2", {});
-	CALL_TEST_FUNCTION( *this, "test_multi_index", "idx256_general", {});
+   CALL_TEST_FUNCTION( *this, "test_multi_index", "idx64_general", {});
+   CALL_TEST_FUNCTION( *this, "test_multi_index", "idx64_store_only", {});
+   CALL_TEST_FUNCTION( *this, "test_multi_index", "idx64_check_without_storing", {});
+   CALL_TEST_FUNCTION( *this, "test_multi_index", "idx128_general", {});
+   CALL_TEST_FUNCTION( *this, "test_multi_index", "idx128_store_only", {});
+   CALL_TEST_FUNCTION( *this, "test_multi_index", "idx128_check_without_storing", {});
+   CALL_TEST_FUNCTION( *this, "test_multi_index", "idx128_autoincrement_test", {});
+   CALL_TEST_FUNCTION( *this, "test_multi_index", "idx128_autoincrement_test_part1", {});
+   CALL_TEST_FUNCTION( *this, "test_multi_index", "idx128_autoincrement_test_part2", {});
+   CALL_TEST_FUNCTION( *this, "test_multi_index", "idx256_general", {});
    CALL_TEST_FUNCTION( *this, "test_multi_index", "idx_double_general", {});
 } FC_LOG_AND_RETHROW() }
 


### PR DESCRIPTION
The bug caused secondary keys to not be updated in the DB by `modify()` when the associated secondary index table row iterator was not already in the cache because `db_idx_find_primary` overwrote the to-be-updated value with the old value from the DB.