### PR TITLE
Fix README.md build command for DAWN-2018-02-14 branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ git clone https://github.com/eosio/eos --recursive
 cd eos
 
 git checkout DAWN-2018-02-14 --recurse-submodules
-./eosio_build.sh
+./build.sh
 ```
 
 For ease of contract development, one further step is required:


### PR DESCRIPTION
The build command in README.md is "./eosio_build.sh", which should be "./build.sh" when checkout DAWN-2018-02-14 branch.

https://github.com/EOSIO/eos#autoubuntupublic

Signed-off-by: Joel <joeloneplusone@gmail.com>