### PR TITLE
Fix indeterministic static initializer in wasm validator/injector

### DIFF
--- a/libraries/chain/include/eosio/chain/wasm_eosio_binary_ops.hpp
+++ b/libraries/chain/include/eosio/chain/wasm_eosio_binary_ops.hpp
@@ -654,7 +654,10 @@ template <class Op_Types>
 struct EOSIO_OperatorDecoderStream
 {
    EOSIO_OperatorDecoderStream(const std::vector<U8>& codeBytes)
-   : start(codeBytes.data()), nextByte(codeBytes.data()), end(codeBytes.data()+codeBytes.size()) {}
+   : start(codeBytes.data()), nextByte(codeBytes.data()), end(codeBytes.data()+codeBytes.size()) {
+     if(!_cached_ops)
+        _cached_ops = cached_ops<Op_Types>::get_cached_ops();
+   }
 
    operator bool() const { return nextByte < end; }
 
@@ -697,7 +700,7 @@ private:
 };
 
 template <class Op_Types>
-const std::vector<instr*>* EOSIO_OperatorDecoderStream<Op_Types>::_cached_ops = cached_ops<Op_Types>::get_cached_ops();
+const std::vector<instr*>* EOSIO_OperatorDecoderStream<Op_Types>::_cached_ops;
 
 }}} // namespace eosio, chain, wasm_ops
 


### PR DESCRIPTION
gcc 6.4.1 (Fedora 25) appears to be getting burned by ordering of static initializers in the new wasm validation & injecting code. Fix it.