### PR TITLE
Bounty Tokens reserve connector function

### DIFF
--- a/contracts/exchange/exchange.abi
+++ b/contracts/exchange/exchange.abi
@@ -105,7 +105,7 @@
      "base": "",
      "fields": [
         {"name":"issuer", "type":"account_name"},
-        {"name":"maximum_supply", "type":"asset"},
+        {"name":"maximum_supply", "type":"extended_asset"},
         {"name":"can_freeze", "type":"uint8"},
         {"name":"can_recall", "type":"uint8"},
         {"name":"can_whitelist", "type":"uint8"}
@@ -115,7 +115,7 @@
      "base": "",
      "fields": [
         {"name":"to", "type":"account_name"},
-        {"name":"quantity", "type":"asset"},
+        {"name":"quantity", "type":"extended_asset"},
         {"name":"memo", "type":"string"}
      ]
   },{


### PR DESCRIPTION
For `create/issue` struct, the initial_supply could change to `extended_asset` which contains yet-to-be-activated connector regardless empty connector balance