### PR TITLE
Wasm Exit - exit contract code immediately without running destructors

### DIFF
--- a/contracts/eosiolib/system.h
+++ b/contracts/eosiolib/system.h
@@ -32,6 +32,12 @@ extern "C" {
    void  eosio_assert( uint32_t test, const char* cstr );
 
    /**
+    * This method will abort execution of wasm without failing the contract. This
+    * is used to bypass all cleanup / destructors that would normally be called.
+    */
+   void  eosio_exit( int32_t code );
+
+   /**
     *  Returns the time in seconds from 1970 of the last accepted block (not the block including this action)
     *  @brief Get time of the last accepted block
     *  @return time in seconds from 1970 of the last accepted block

--- a/contracts/eosiolib/system.h
+++ b/contracts/eosiolib/system.h
@@ -35,7 +35,7 @@ extern "C" {
     * This method will abort execution of wasm without failing the contract. This
     * is used to bypass all cleanup / destructors that would normally be called.
     */
-   void  eosio_exit( int32_t code );
+   [[noreturn]] void  eosio_exit( int32_t code );
 
    /**
     *  Returns the time in seconds from 1970 of the last accepted block (not the block including this action)

--- a/contracts/exchange/exchange.cpp
+++ b/contracts/exchange/exchange.cpp
@@ -236,7 +236,6 @@ namespace eosio {
          default:
             return _excurrencies.apply( contract, act );
       }
-      eosio_exit(0);
    }
 
 } /// namespace eosio
@@ -245,6 +244,8 @@ namespace eosio {
 
 extern "C" {
    void apply( uint64_t code, uint64_t action ) {
-       eosio::exchange( current_receiver() ).apply( code, action );
+      eosio::exchange  ex( current_receiver() );
+      ex.apply( code, action );
+      eosio_exit(0);
    }
 }

--- a/contracts/exchange/exchange.cpp
+++ b/contracts/exchange/exchange.cpp
@@ -236,6 +236,7 @@ namespace eosio {
          default:
             return _excurrencies.apply( contract, act );
       }
+      eosio_exit(0);
    }
 
 } /// namespace eosio

--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -18,15 +18,16 @@ void apply_context::exec_one()
       auto native = mutable_controller.find_apply_handler(receiver, act.account, act.name);
       if (native) {
          (*native)(*this);
-      } else {
-         if (a.code.size() > 0) {
-            // get code from cache
-            auto code = mutable_controller.get_wasm_cache().checkout_scoped(a.code_version, a.code.data(),
-                                                                            a.code.size());
+      } 
+      else if (a.code.size() > 0) {
+         // get code from cache
+         auto code = mutable_controller.get_wasm_cache().checkout_scoped(a.code_version, a.code.data(),
+                                                                         a.code.size());
+         try {
             // get wasm_interface
             auto &wasm = wasm_interface::get();
             wasm.apply(code, *this);
-      }
+         } catch ( const wasm_exit& ){}
       }
    } FC_CAPTURE_AND_RETHROW((_pending_console_output.str()));
 

--- a/libraries/chain/include/eosio/chain/wasm_interface.hpp
+++ b/libraries/chain/include/eosio/chain/wasm_interface.hpp
@@ -10,6 +10,10 @@ namespace eosio { namespace chain {
       class intrinsics_accessor;
    } }
 
+   struct wasm_exit {
+      int32_t code = 0;
+   };
+
    /**
     * @class wasm_cache
     *

--- a/libraries/chain/wasm_interface.cpp
+++ b/libraries/chain/wasm_interface.cpp
@@ -38,9 +38,6 @@ namespace eosio { namespace chain {
    using namespace webassembly;
    using namespace webassembly::common;
 
-   struct wasm_exit {
-      int32_t code = 0;
-   };
 
    /**
     *  Implementation class for the wasm cache

--- a/libraries/chain/wasm_interface.cpp
+++ b/libraries/chain/wasm_interface.cpp
@@ -38,6 +38,10 @@ namespace eosio { namespace chain {
    using namespace webassembly;
    using namespace webassembly::common;
 
+   struct wasm_exit {
+      int32_t code = 0;
+   };
+
    /**
     *  Implementation class for the wasm cache
     *  it is responsible for compiling and storing instances of wasm code for use
@@ -337,27 +341,31 @@ namespace eosio { namespace chain {
    }
 
    void wasm_interface::apply( wasm_cache::entry& code, apply_context& context, vm_type vm ) {
-      auto context_guard = scoped_context(my->current_context, code, context, vm);
-      switch (vm) {
-         case vm_type::wavm:
-            code.wavm.call_apply(context);
-            break;
-         case vm_type::binaryen:
-            code.binaryen.call_apply(context);
-            break;
-      }
+      try {
+         auto context_guard = scoped_context(my->current_context, code, context, vm);
+         switch (vm) {
+            case vm_type::wavm:
+               code.wavm.call_apply(context);
+               break;
+            case vm_type::binaryen:
+               code.binaryen.call_apply(context);
+               break;
+         }
+      } catch ( const wasm_exit& ){}
    }
 
    void wasm_interface::error( wasm_cache::entry& code, apply_context& context, vm_type vm ) {
-      auto context_guard = scoped_context(my->current_context, code, context, vm);
-      switch (vm) {
-         case vm_type::wavm:
-            code.wavm.call_error(context);
-            break;
-         case vm_type::binaryen:
-            code.binaryen.call_error(context);
-            break;
-      }
+      try {
+         auto context_guard = scoped_context(my->current_context, code, context, vm);
+         switch (vm) {
+            case vm_type::wavm:
+               code.wavm.call_error(context);
+               break;
+            case vm_type::binaryen:
+               code.binaryen.call_error(context);
+               break;
+         }
+      } catch ( const wasm_exit& ){}
    }
 
    wasm_context& common::intrinsics_accessor::get_context(wasm_interface &wasm) {
@@ -816,6 +824,10 @@ class system_api : public context_aware_api {
             edump((message));
             FC_ASSERT( condition, "assertion failed: ${s}", ("s",message));
          }
+      }
+
+      void eosio_exit(int32_t code) {
+         throw wasm_exit{code};
       }
 
       fc::time_point_sec now() {
@@ -1763,6 +1775,7 @@ REGISTER_INTRINSICS(string_api,
 REGISTER_INTRINSICS(system_api,
    (abort,        void())
    (eosio_assert, void(int, int))
+   (eosio_exit,   void(int ))
    (now,          int())
 );
 

--- a/libraries/chain/webassembly/wavm.cpp
+++ b/libraries/chain/webassembly/wavm.cpp
@@ -48,6 +48,7 @@ void entry::call(const string &entry_point, const vector <Value> &args, apply_co
 
       runInstanceStartFunc(instance);
       Runtime::invokeFunction(call,args);
+   } catch( const wasm_exit& e ) {
    } catch( const Runtime::Exception& e ) {
       FC_THROW_EXCEPTION(wasm_execution_error,
                          "cause: ${cause}\n${callstack}",


### PR DESCRIPTION
This pull request implements solution for #1611 which allows contracts to bypass unnecessary cleanup code and exit execution. It works by throwing a special exception that is caught and ignored.