### PR TITLE
Standardize shortcut of boost::filesystem to bfs

### DIFF
--- a/contracts/exchange/exchange.abi
+++ b/contracts/exchange/exchange.abi
@@ -76,7 +76,7 @@
       "base": "",
       "fields": [
         {"name":"creator", "type":"account_name"},
-        {"name":"initial_supply", "type":"extended_asset"},
+        {"name":"initial_supply", "type":"asset"},
         {"name":"fee", "type":"uint32"},
         {"name":"base_deposit", "type":"extended_asset"},
         {"name":"quote_deposit", "type":"extended_asset"}
@@ -105,7 +105,7 @@
      "base": "",
      "fields": [
         {"name":"issuer", "type":"account_name"},
-        {"name":"maximum_supply", "type":"extended_asset"},
+        {"name":"maximum_supply", "type":"asset"},
         {"name":"can_freeze", "type":"uint8"},
         {"name":"can_recall", "type":"uint8"},
         {"name":"can_whitelist", "type":"uint8"}

--- a/contracts/exchange/exchange.abi
+++ b/contracts/exchange/exchange.abi
@@ -76,7 +76,7 @@
       "base": "",
       "fields": [
         {"name":"creator", "type":"account_name"},
-        {"name":"initial_supply", "type":"asset"},
+        {"name":"initial_supply", "type":"extended_asset"},
         {"name":"fee", "type":"uint32"},
         {"name":"base_deposit", "type":"extended_asset"},
         {"name":"quote_deposit", "type":"extended_asset"}
@@ -105,7 +105,7 @@
      "base": "",
      "fields": [
         {"name":"issuer", "type":"account_name"},
-        {"name":"maximum_supply", "type":"asset"},
+        {"name":"maximum_supply", "type":"extended_asset"},
         {"name":"can_freeze", "type":"uint8"},
         {"name":"can_recall", "type":"uint8"},
         {"name":"can_whitelist", "type":"uint8"}


### PR DESCRIPTION
In [chainbase.hpp](https://github.com/EOSIO/chainbase/blob/master/include/chainbase/chainbase.hpp), [application.hpp](https://github.com/EOSIO/appbase/blob/master/include/appbase/application.hpp), [database_tests.cpp](https://github.com/EOSIO/eos/blob/master/tests/tests/database_tests.cpp), all the shortcut of `boost:filesystem` is `bfs`, this Pull Request is to standardize the shortcut usage for boost:filesystem from `bf` to `bfs`

![image](https://user-images.githubusercontent.com/16319106/37671361-8627211a-2ca6-11e8-9277-ed86aea6744f.png)
![image](https://user-images.githubusercontent.com/16319106/37671373-8b1d7d04-2ca6-11e8-9bd8-61cb907a7874.png)
