### PR TITLE
Cleanup unneeded local WAVM modifications; add upstream idx validator

### DIFF
--- a/libraries/wasm-jit/Include/IR/Operators.h
+++ b/libraries/wasm-jit/Include/IR/Operators.h
@@ -24,19 +24,17 @@ namespace IR
 
 	struct BranchTableImm
 	{
-      static_assert(sizeof(Uptr) == 8, "SIZEE");
 		Uptr defaultTargetDepth;
 		Uptr branchTableIndex; // An index into the FunctionDef's branchTables array.
 	};
 
-  
 	template<typename Value>
 	struct LiteralImm
 	{
 		Value value;
 	};
 
- 	template<bool isGlobal>
+	template<bool isGlobal>
 	struct GetOrSetVariableImm
 	{
 		U32 variableIndex;
@@ -46,7 +44,6 @@ namespace IR
 	{
 		U32 functionIndex;
 	};
-
 
 	struct CallIndirectImm
 	{
@@ -59,7 +56,6 @@ namespace IR
 		U8 alignmentLog2;
 		U32 offset;
 	};
-
 
 	#if ENABLE_SIMD_PROTOTYPE
 	template<Uptr numLanes>
@@ -127,21 +123,16 @@ namespace IR
 		ATOMICRMW : (i32,T) -> T
 	*/
 
-   #define ENUM_MEMORY_OPERATORS(visitOp) \
-		visitOp(0x3f,current_memory,"current_memory",MemoryImm,NULLARY(i32)) \
-		visitOp(0x40,grow_memory,"grow_memory",MemoryImm,UNARY(i32,i32))
-
-   #define ENUM_NONCONTROL_NONPARAMETRIC_OPERATORS(visitOp) \
-      ENUM_NONFLOAT_NONCONTROL_NONPARAMETRIC_OPERATORS(visitOp) \
-      ENUM_FLOAT_NONCONTROL_NONPARAMETRIC_OPERATORS(visitOp)
-
-	#define ENUM_NONFLOAT_NONCONTROL_NONPARAMETRIC_OPERATORS(visitOp) \
+	#define ENUM_NONCONTROL_NONPARAMETRIC_OPERATORS(visitOp) \
 		visitOp(0x01,nop,"nop",NoImm,NULLARY(none)) \
 		\
-		ENUM_MEMORY_OPERATORS(visitOp) \
+		visitOp(0x3f,current_memory,"current_memory",MemoryImm,NULLARY(i32)) \
+		visitOp(0x40,grow_memory,"grow_memory",MemoryImm,UNARY(i32,i32)) \
 		\
 		visitOp(0x28,i32_load,"i32.load",LoadOrStoreImm<2>,LOAD(i32)) \
 		visitOp(0x29,i64_load,"i64.load",LoadOrStoreImm<3>,LOAD(i64)) \
+		visitOp(0x2a,f32_load,"f32.load",LoadOrStoreImm<2>,LOAD(f32)) \
+		visitOp(0x2b,f64_load,"f64.load",LoadOrStoreImm<3>,LOAD(f64)) \
 		visitOp(0x2c,i32_load8_s,"i32.load8_s",LoadOrStoreImm<0>,LOAD(i32)) \
 		visitOp(0x2d,i32_load8_u,"i32.load8_u",LoadOrStoreImm<0>,LOAD(i32)) \
 		visitOp(0x2e,i32_load16_s,"i32.load16_s",LoadOrStoreImm<1>,LOAD(i32)) \
@@ -155,6 +146,8 @@ namespace IR
 		\
 		visitOp(0x36,i32_store,"i32.store",LoadOrStoreImm<2>,STORE(i32)) \
 		visitOp(0x37,i64_store,"i64.store",LoadOrStoreImm<3>,STORE(i64)) \
+		visitOp(0x38,f32_store,"f32.store",LoadOrStoreImm<2>,STORE(f32)) \
+		visitOp(0x39,f64_store,"f64.store",LoadOrStoreImm<3>,STORE(f64)) \
 		visitOp(0x3a,i32_store8,"i32.store8",LoadOrStoreImm<0>,STORE(i32)) \
 		visitOp(0x3b,i32_store16,"i32.store16",LoadOrStoreImm<1>,STORE(i32)) \
 		visitOp(0x3c,i64_store8,"i64.store8",LoadOrStoreImm<0>,STORE(i64)) \
@@ -163,6 +156,8 @@ namespace IR
 		\
 		visitOp(0x41,i32_const,"i32.const",LiteralImm<I32>,NULLARY(i32)) \
 		visitOp(0x42,i64_const,"i64.const",LiteralImm<I64>,NULLARY(i64)) \
+		visitOp(0x43,f32_const,"f32.const",LiteralImm<F32>,NULLARY(f32)) \
+		visitOp(0x44,f64_const,"f64.const",LiteralImm<F64>,NULLARY(f64)) \
 		\
 		visitOp(0x45,i32_eqz,"i32.eqz",NoImm,UNARY(i32,i32)) \
 		visitOp(0x46,i32_eq,"i32.eq",NoImm,BINARY(i32,i32)) \
@@ -187,6 +182,20 @@ namespace IR
 		visitOp(0x58,i64_le_u,"i64.le_u",NoImm,BINARY(i64,i32)) \
 		visitOp(0x59,i64_ge_s,"i64.ge_s",NoImm,BINARY(i64,i32)) \
 		visitOp(0x5a,i64_ge_u,"i64.ge_u",NoImm,BINARY(i64,i32)) \
+		\
+		visitOp(0x5b,f32_eq,"f32.eq",NoImm,BINARY(f32,i32)) \
+		visitOp(0x5c,f32_ne,"f32.ne",NoImm,BINARY(f32,i32)) \
+		visitOp(0x5d,f32_lt,"f32.lt",NoImm,BINARY(f32,i32)) \
+		visitOp(0x5e,f32_gt,"f32.gt",NoImm,BINARY(f32,i32)) \
+		visitOp(0x5f,f32_le,"f32.le",NoImm,BINARY(f32,i32)) \
+		visitOp(0x60,f32_ge,"f32.ge",NoImm,BINARY(f32,i32)) \
+		\
+		visitOp(0x61,f64_eq,"f64.eq",NoImm,BINARY(f64,i32)) \
+		visitOp(0x62,f64_ne,"f64.ne",NoImm,BINARY(f64,i32)) \
+		visitOp(0x63,f64_lt,"f64.lt",NoImm,BINARY(f64,i32)) \
+		visitOp(0x64,f64_gt,"f64.gt",NoImm,BINARY(f64,i32)) \
+		visitOp(0x65,f64_le,"f64.le",NoImm,BINARY(f64,i32)) \
+		visitOp(0x66,f64_ge,"f64.ge",NoImm,BINARY(f64,i32)) \
 		\
 		visitOp(0x67,i32_clz,"i32.clz",NoImm,UNARY(i32,i32)) \
 		visitOp(0x68,i32_ctz,"i32.ctz",NoImm,UNARY(i32,i32)) \
@@ -228,99 +237,71 @@ namespace IR
 		visitOp(0x89,i64_rotl,"i64.rotl",NoImm,BINARY(i64,i64)) \
 		visitOp(0x8a,i64_rotr,"i64.rotr",NoImm,BINARY(i64,i64)) \
 		\
+		visitOp(0x8b,f32_abs,"f32.abs",NoImm,UNARY(f32,f32)) \
+		visitOp(0x8c,f32_neg,"f32.neg",NoImm,UNARY(f32,f32)) \
+		visitOp(0x8d,f32_ceil,"f32.ceil",NoImm,UNARY(f32,f32)) \
+		visitOp(0x8e,f32_floor,"f32.floor",NoImm,UNARY(f32,f32)) \
+		visitOp(0x8f,f32_trunc,"f32.trunc",NoImm,UNARY(f32,f32)) \
+		visitOp(0x90,f32_nearest,"f32.nearest",NoImm,UNARY(f32,f32)) \
+		visitOp(0x91,f32_sqrt,"f32.sqrt",NoImm,UNARY(f32,f32)) \
+		\
+		visitOp(0x92,f32_add,"f32.add",NoImm,BINARY(f32,f32)) \
+		visitOp(0x93,f32_sub,"f32.sub",NoImm,BINARY(f32,f32)) \
+		visitOp(0x94,f32_mul,"f32.mul",NoImm,BINARY(f32,f32)) \
+		visitOp(0x95,f32_div,"f32.div",NoImm,BINARY(f32,f32)) \
+		visitOp(0x96,f32_min,"f32.min",NoImm,BINARY(f32,f32)) \
+		visitOp(0x97,f32_max,"f32.max",NoImm,BINARY(f32,f32)) \
+		visitOp(0x98,f32_copysign,"f32.copysign",NoImm,BINARY(f32,f32)) \
+		\
+		visitOp(0x99,f64_abs,"f64.abs",NoImm,UNARY(f64,f64)) \
+		visitOp(0x9a,f64_neg,"f64.neg",NoImm,UNARY(f64,f64)) \
+		visitOp(0x9b,f64_ceil,"f64.ceil",NoImm,UNARY(f64,f64)) \
+		visitOp(0x9c,f64_floor,"f64.floor",NoImm,UNARY(f64,f64)) \
+		visitOp(0x9d,f64_trunc,"f64.trunc",NoImm,UNARY(f64,f64)) \
+		visitOp(0x9e,f64_nearest,"f64.nearest",NoImm,UNARY(f64,f64)) \
+		visitOp(0x9f,f64_sqrt,"f64.sqrt",NoImm,UNARY(f64,f64)) \
+		\
+		visitOp(0xa0,f64_add,"f64.add",NoImm,BINARY(f64,f64)) \
+		visitOp(0xa1,f64_sub,"f64.sub",NoImm,BINARY(f64,f64)) \
+		visitOp(0xa2,f64_mul,"f64.mul",NoImm,BINARY(f64,f64)) \
+		visitOp(0xa3,f64_div,"f64.div",NoImm,BINARY(f64,f64)) \
+		visitOp(0xa4,f64_min,"f64.min",NoImm,BINARY(f64,f64)) \
+		visitOp(0xa5,f64_max,"f64.max",NoImm,BINARY(f64,f64)) \
+		visitOp(0xa6,f64_copysign,"f64.copysign",NoImm,BINARY(f64,f64)) \
+		\
 		visitOp(0xa7,i32_wrap_i64,"i32.wrap/i64",NoImm,UNARY(i64,i32)) \
+		visitOp(0xa8,i32_trunc_s_f32,"i32.trunc_s/f32",NoImm,UNARY(f32,i32)) \
+		visitOp(0xa9,i32_trunc_u_f32,"i32.trunc_u/f32",NoImm,UNARY(f32,i32)) \
+		visitOp(0xaa,i32_trunc_s_f64,"i32.trunc_s/f64",NoImm,UNARY(f64,i32)) \
+		visitOp(0xab,i32_trunc_u_f64,"i32.trunc_u/f64",NoImm,UNARY(f64,i32)) \
 		visitOp(0xac,i64_extend_s_i32,"i64.extend_s/i32",NoImm,UNARY(i32,i64)) \
 		visitOp(0xad,i64_extend_u_i32,"i64.extend_u/i32",NoImm,UNARY(i32,i64)) \
-		ENUM_NONFLOAT_SIMD_OPERATORS(visitOp) \
-		ENUM_NONFLOAT_THREADING_OPERATORS(visitOp)
-
-   #define ENUM_FLOAT_NONCONTROL_NONPARAMETRIC_OPERATORS(visitOp) \
-      visitOp(0x2a,f32_load,"f32.load",LoadOrStoreImm<2>,LOAD(f32)) \
-      visitOp(0x2b,f64_load,"f64.load",LoadOrStoreImm<3>,LOAD(f64)) \
-      \
-      visitOp(0x38,f32_store,"f32.store",LoadOrStoreImm<2>,STORE(f32)) \
-      visitOp(0x39,f64_store,"f64.store",LoadOrStoreImm<3>,STORE(f64)) \
-      \
-      visitOp(0x43,f32_const,"f32.const",LiteralImm<F32>,NULLARY(f32)) \
-      visitOp(0x44,f64_const,"f64.const",LiteralImm<F64>,NULLARY(f64)) \
-      \
-      visitOp(0x5b,f32_eq,"f32.eq",NoImm,BINARY(f32,i32)) \
-      visitOp(0x5c,f32_ne,"f32.ne",NoImm,BINARY(f32,i32)) \
-      visitOp(0x5d,f32_lt,"f32.lt",NoImm,BINARY(f32,i32)) \
-      visitOp(0x5e,f32_gt,"f32.gt",NoImm,BINARY(f32,i32)) \
-      visitOp(0x5f,f32_le,"f32.le",NoImm,BINARY(f32,i32)) \
-      visitOp(0x60,f32_ge,"f32.ge",NoImm,BINARY(f32,i32)) \
-      \
-      visitOp(0x61,f64_eq,"f64.eq",NoImm,BINARY(f64,i32)) \
-      visitOp(0x62,f64_ne,"f64.ne",NoImm,BINARY(f64,i32)) \
-      visitOp(0x63,f64_lt,"f64.lt",NoImm,BINARY(f64,i32)) \
-      visitOp(0x64,f64_gt,"f64.gt",NoImm,BINARY(f64,i32)) \
-      visitOp(0x65,f64_le,"f64.le",NoImm,BINARY(f64,i32)) \
-      visitOp(0x66,f64_ge,"f64.ge",NoImm,BINARY(f64,i32)) \
-      \
-      visitOp(0x8b,f32_abs,"f32.abs",NoImm,UNARY(f32,f32)) \
-      visitOp(0x8c,f32_neg,"f32.neg",NoImm,UNARY(f32,f32)) \
-      visitOp(0x8d,f32_ceil,"f32.ceil",NoImm,UNARY(f32,f32)) \
-      visitOp(0x8e,f32_floor,"f32.floor",NoImm,UNARY(f32,f32)) \
-      visitOp(0x8f,f32_trunc,"f32.trunc",NoImm,UNARY(f32,f32)) \
-      visitOp(0x90,f32_nearest,"f32.nearest",NoImm,UNARY(f32,f32)) \
-      visitOp(0x91,f32_sqrt,"f32.sqrt",NoImm,UNARY(f32,f32)) \
-      \
-      visitOp(0x92,f32_add,"f32.add",NoImm,BINARY(f32,f32)) \
-      visitOp(0x93,f32_sub,"f32.sub",NoImm,BINARY(f32,f32)) \
-      visitOp(0x94,f32_mul,"f32.mul",NoImm,BINARY(f32,f32)) \
-      visitOp(0x95,f32_div,"f32.div",NoImm,BINARY(f32,f32)) \
-      visitOp(0x96,f32_min,"f32.min",NoImm,BINARY(f32,f32)) \
-      visitOp(0x97,f32_max,"f32.max",NoImm,BINARY(f32,f32)) \
-      visitOp(0x98,f32_copysign,"f32.copysign",NoImm,BINARY(f32,f32)) \
-      \
-      visitOp(0x99,f64_abs,"f64.abs",NoImm,UNARY(f64,f64)) \
-      visitOp(0x9a,f64_neg,"f64.neg",NoImm,UNARY(f64,f64)) \
-      visitOp(0x9b,f64_ceil,"f64.ceil",NoImm,UNARY(f64,f64)) \
-      visitOp(0x9c,f64_floor,"f64.floor",NoImm,UNARY(f64,f64)) \
-      visitOp(0x9d,f64_trunc,"f64.trunc",NoImm,UNARY(f64,f64)) \
-      visitOp(0x9e,f64_nearest,"f64.nearest",NoImm,UNARY(f64,f64)) \
-      visitOp(0x9f,f64_sqrt,"f64.sqrt",NoImm,UNARY(f64,f64)) \
-      \
-      visitOp(0xa0,f64_add,"f64.add",NoImm,BINARY(f64,f64)) \
-      visitOp(0xa1,f64_sub,"f64.sub",NoImm,BINARY(f64,f64)) \
-      visitOp(0xa2,f64_mul,"f64.mul",NoImm,BINARY(f64,f64)) \
-      visitOp(0xa3,f64_div,"f64.div",NoImm,BINARY(f64,f64)) \
-      visitOp(0xa4,f64_min,"f64.min",NoImm,BINARY(f64,f64)) \
-      visitOp(0xa5,f64_max,"f64.max",NoImm,BINARY(f64,f64)) \
-      visitOp(0xa6,f64_copysign,"f64.copysign",NoImm,BINARY(f64,f64)) \
-      \
-      visitOp(0xa8,i32_trunc_s_f32,"i32.trunc_s/f32",NoImm,UNARY(f32,i32)) \
-      visitOp(0xa9,i32_trunc_u_f32,"i32.trunc_u/f32",NoImm,UNARY(f32,i32)) \
-      visitOp(0xaa,i32_trunc_s_f64,"i32.trunc_s/f64",NoImm,UNARY(f64,i32)) \
-      visitOp(0xab,i32_trunc_u_f64,"i32.trunc_u/f64",NoImm,UNARY(f64,i32)) \
-      visitOp(0xae,i64_trunc_s_f32,"i64.trunc_s/f32",NoImm,UNARY(f32,i64)) \
-      visitOp(0xaf,i64_trunc_u_f32,"i64.trunc_u/f32",NoImm,UNARY(f32,i64)) \
-      visitOp(0xb0,i64_trunc_s_f64,"i64.trunc_s/f64",NoImm,UNARY(f64,i64)) \
-      visitOp(0xb1,i64_trunc_u_f64,"i64.trunc_u/f64",NoImm,UNARY(f64,i64)) \
-      visitOp(0xb2,f32_convert_s_i32,"f32.convert_s/i32",NoImm,UNARY(i32,f32)) \
-      visitOp(0xb3,f32_convert_u_i32,"f32.convert_u/i32",NoImm,UNARY(i32,f32)) \
-      visitOp(0xb4,f32_convert_s_i64,"f32.convert_s/i64",NoImm,UNARY(i64,f32)) \
-      visitOp(0xb5,f32_convert_u_i64,"f32.convert_u/i64",NoImm,UNARY(i64,f32)) \
-      visitOp(0xb6,f32_demote_f64,"f32.demote/f64",NoImm,UNARY(f64,f32)) \
-      visitOp(0xb7,f64_convert_s_i32,"f64.convert_s/i32",NoImm,UNARY(i32,f64)) \
-      visitOp(0xb8,f64_convert_u_i32,"f64.convert_u/i32",NoImm,UNARY(i32,f64)) \
-      visitOp(0xb9,f64_convert_s_i64,"f64.convert_s/i64",NoImm,UNARY(i64,f64)) \
-      visitOp(0xba,f64_convert_u_i64,"f64.convert_u/i64",NoImm,UNARY(i64,f64)) \
-      visitOp(0xbb,f64_promote_f32,"f64.promote/f32",NoImm,UNARY(f32,f64)) \
-      visitOp(0xbc,i32_reinterpret_f32,"i32.reinterpret/f32",NoImm,UNARY(f32,i32)) \
-      visitOp(0xbd,i64_reinterpret_f64,"i64.reinterpret/f64",NoImm,UNARY(f64,i64)) \
-      visitOp(0xbe,f32_reinterpret_i32,"f32.reinterpret/i32",NoImm,UNARY(i32,f32)) \
-      visitOp(0xbf,f64_reinterpret_i64,"f64.reinterpret/i64",NoImm,UNARY(i64,f64)) \
-      ENUM_FLOAT_SIMD_OPERATORS(visitOp) \
-      ENUM_FLOAT_THREADING_OPERATORS(visitOp)
+		visitOp(0xae,i64_trunc_s_f32,"i64.trunc_s/f32",NoImm,UNARY(f32,i64)) \
+		visitOp(0xaf,i64_trunc_u_f32,"i64.trunc_u/f32",NoImm,UNARY(f32,i64)) \
+		visitOp(0xb0,i64_trunc_s_f64,"i64.trunc_s/f64",NoImm,UNARY(f64,i64)) \
+		visitOp(0xb1,i64_trunc_u_f64,"i64.trunc_u/f64",NoImm,UNARY(f64,i64)) \
+		visitOp(0xb2,f32_convert_s_i32,"f32.convert_s/i32",NoImm,UNARY(i32,f32)) \
+		visitOp(0xb3,f32_convert_u_i32,"f32.convert_u/i32",NoImm,UNARY(i32,f32)) \
+		visitOp(0xb4,f32_convert_s_i64,"f32.convert_s/i64",NoImm,UNARY(i64,f32)) \
+		visitOp(0xb5,f32_convert_u_i64,"f32.convert_u/i64",NoImm,UNARY(i64,f32)) \
+		visitOp(0xb6,f32_demote_f64,"f32.demote/f64",NoImm,UNARY(f64,f32)) \
+		visitOp(0xb7,f64_convert_s_i32,"f64.convert_s/i32",NoImm,UNARY(i32,f64)) \
+		visitOp(0xb8,f64_convert_u_i32,"f64.convert_u/i32",NoImm,UNARY(i32,f64)) \
+		visitOp(0xb9,f64_convert_s_i64,"f64.convert_s/i64",NoImm,UNARY(i64,f64)) \
+		visitOp(0xba,f64_convert_u_i64,"f64.convert_u/i64",NoImm,UNARY(i64,f64)) \
+		visitOp(0xbb,f64_promote_f32,"f64.promote/f32",NoImm,UNARY(f32,f64)) \
+		visitOp(0xbc,i32_reinterpret_f32,"i32.reinterpret/f32",NoImm,UNARY(f32,i32)) \
+		visitOp(0xbd,i64_reinterpret_f64,"i64.reinterpret/f64",NoImm,UNARY(f64,i64)) \
+		visitOp(0xbe,f32_reinterpret_i32,"f32.reinterpret/i32",NoImm,UNARY(i32,f32)) \
+		visitOp(0xbf,f64_reinterpret_i64,"f64.reinterpret/i64",NoImm,UNARY(i64,f64)) \
+		ENUM_SIMD_OPERATORS(visitOp) \
+		ENUM_THREADING_OPERATORS(visitOp)
 
 	#if !ENABLE_SIMD_PROTOTYPE
-	#define ENUM_NONFLOAT_SIMD_OPERATORS(visitOp)
-   #define ENUM_FLOAT_SIMD_OPERATORS(visitOp)
+	#define ENUM_SIMD_OPERATORS(visitOp)
 	#else
 	#define SIMDOP(simdOpIndex) (0xfd00|simdOpIndex)
-	#define ENUM_NONFLOAT_SIMD_OPERATORS(visitOp) \
+	#define ENUM_SIMD_OPERATORS(visitOp) \
 		visitOp(SIMDOP(0),v128_const,"v128.const",LiteralImm<V128>,NULLARY(v128)) \
 		visitOp(SIMDOP(1),v128_load,"v128.load",LoadOrStoreImm<4>,LOAD(v128)) \
 		visitOp(SIMDOP(2),v128_store,"v128.store",LoadOrStoreImm<4>,STORE(v128)) \
@@ -329,6 +310,8 @@ namespace IR
 		visitOp(SIMDOP(4),i16x8_splat,"i16x8.splat",NoImm,UNARY(i32,v128)) \
 		visitOp(SIMDOP(5),i32x4_splat,"i32x4.splat",NoImm,UNARY(i32,v128)) \
 		visitOp(SIMDOP(6),i64x2_splat,"i64x2.splat",NoImm,UNARY(i64,v128)) \
+		visitOp(SIMDOP(7),f32x4_splat,"f32x4.splat",NoImm,UNARY(f32,v128)) \
+		visitOp(SIMDOP(8),f64x2_splat,"f64x2.splat",NoImm,UNARY(f64,v128)) \
 		\
 		visitOp(SIMDOP(9),i8x16_extract_lane_s,"i8x16.extract_lane_s",LaneIndexImm<16>,UNARY(v128,i32)) \
 		visitOp(SIMDOP(10),i8x16_extract_lane_u,"i8x16.extract_lane_u",LaneIndexImm<16>,UNARY(v128,i32)) \
@@ -336,11 +319,15 @@ namespace IR
 		visitOp(SIMDOP(12),i16x8_extract_lane_u,"i16x8.extract_lane_u",LaneIndexImm<8>,UNARY(v128,i32)) \
 		visitOp(SIMDOP(13),i32x4_extract_lane,"i32x4.extract_lane",LaneIndexImm<4>,UNARY(v128,i32)) \
 		visitOp(SIMDOP(14),i64x2_extract_lane,"i64x2.extract_lane",LaneIndexImm<2>,UNARY(v128,i64)) \
+		visitOp(SIMDOP(15),f32x4_extract_lane,"f32x4.extract_lane",LaneIndexImm<4>,UNARY(v128,f32)) \
+		visitOp(SIMDOP(16),f64x2_extract_lane,"f64x2.extract_lane",LaneIndexImm<2>,UNARY(v128,f64)) \
 		\
 		visitOp(SIMDOP(17),i8x16_replace_lane,"i8x16.replace_lane",LaneIndexImm<16>,REPLACELANE(i32,v128)) \
 		visitOp(SIMDOP(18),i16x8_replace_lane,"i16x8.replace_lane",LaneIndexImm<8>,REPLACELANE(i32,v128)) \
 		visitOp(SIMDOP(19),i32x4_replace_lane,"i32x4.replace_lane",LaneIndexImm<4>,REPLACELANE(i32,v128)) \
 		visitOp(SIMDOP(20),i64x2_replace_lane,"i64x2.replace_lane",LaneIndexImm<2>,REPLACELANE(i64,v128)) \
+		visitOp(SIMDOP(21),f32x4_replace_lane,"f32x4.replace_lane",LaneIndexImm<4>,REPLACELANE(f32,v128)) \
+		visitOp(SIMDOP(22),f64x2_replace_lane,"f64x2.replace_lane",LaneIndexImm<2>,REPLACELANE(f64,v128)) \
 		\
 		visitOp(SIMDOP(23),v8x16_shuffle,"v8x16.shuffle",ShuffleImm<16>,BINARY(v128,v128)) \
 		\
@@ -406,10 +393,14 @@ namespace IR
 		visitOp(SIMDOP(72),i8x16_eq,"i8x16.eq",NoImm,BINARY(v128,v128)) \
 		visitOp(SIMDOP(73),i16x8_eq,"i16x8.eq",NoImm,BINARY(v128,v128)) \
 		visitOp(SIMDOP(74),i32x4_eq,"i32x4.eq",NoImm,BINARY(v128,v128)) \
+		visitOp(SIMDOP(75),f32x4_eq,"f32x4.eq",NoImm,BINARY(v128,v128)) \
+		visitOp(SIMDOP(76),f64x2_eq,"f64x2.eq",NoImm,BINARY(v128,v128)) \
 		\
 		visitOp(SIMDOP(77),i8x16_ne,"i8x16.ne",NoImm,BINARY(v128,v128)) \
 		visitOp(SIMDOP(78),i16x8_ne,"i16x8.ne",NoImm,BINARY(v128,v128)) \
 		visitOp(SIMDOP(79),i32x4_ne,"i32x4.ne",NoImm,BINARY(v128,v128)) \
+		visitOp(SIMDOP(80),f32x4_ne,"f32x4.ne",NoImm,BINARY(v128,v128)) \
+		visitOp(SIMDOP(81),f64x2_ne,"f64x2.ne",NoImm,BINARY(v128,v128)) \
 		\
 		visitOp(SIMDOP(82),i8x16_lt_s,"i8x16.lt_s",NoImm,BINARY(v128,v128)) \
 		visitOp(SIMDOP(83),i8x16_lt_u,"i8x16.lt_u",NoImm,BINARY(v128,v128)) \
@@ -417,6 +408,8 @@ namespace IR
 		visitOp(SIMDOP(85),i16x8_lt_u,"i16x8.lt_u",NoImm,BINARY(v128,v128)) \
 		visitOp(SIMDOP(86),i32x4_lt_s,"i32x4.lt_s",NoImm,BINARY(v128,v128)) \
 		visitOp(SIMDOP(87),i32x4_lt_u,"i32x4.lt_u",NoImm,BINARY(v128,v128)) \
+		visitOp(SIMDOP(88),f32x4_lt,"f32x4.lt",NoImm,BINARY(v128,v128)) \
+		visitOp(SIMDOP(89),f64x2_lt,"f64x2.lt",NoImm,BINARY(v128,v128)) \
 		\
 		visitOp(SIMDOP(90),i8x16_le_s,"i8x16.le_s",NoImm,BINARY(v128,v128)) \
 		visitOp(SIMDOP(91),i8x16_le_u,"i8x16.le_u",NoImm,BINARY(v128,v128)) \
@@ -424,6 +417,8 @@ namespace IR
 		visitOp(SIMDOP(93),i16x8_le_u,"i16x8.le_u",NoImm,BINARY(v128,v128)) \
 		visitOp(SIMDOP(94),i32x4_le_s,"i32x4.le_s",NoImm,BINARY(v128,v128)) \
 		visitOp(SIMDOP(95),i32x4_le_u,"i32x4.le_u",NoImm,BINARY(v128,v128)) \
+		visitOp(SIMDOP(96),f32x4_le,"f32x4.le",NoImm,BINARY(v128,v128)) \
+		visitOp(SIMDOP(97),f64x2_le,"f64x2.le",NoImm,BINARY(v128,v128)) \
 		\
 		visitOp(SIMDOP(98),i8x16_gt_s,"i8x16.gt_s",NoImm,BINARY(v128,v128)) \
 		visitOp(SIMDOP(99),i8x16_gt_u,"i8x16.gt_u",NoImm,BINARY(v128,v128)) \
@@ -431,84 +426,60 @@ namespace IR
 		visitOp(SIMDOP(101),i16x8_gt_u,"i16x8.gt_u",NoImm,BINARY(v128,v128)) \
 		visitOp(SIMDOP(102),i32x4_gt_s,"i32x4.gt_s",NoImm,BINARY(v128,v128)) \
 		visitOp(SIMDOP(103),i32x4_gt_u,"i32x4.gt_u",NoImm,BINARY(v128,v128)) \
+		visitOp(SIMDOP(104),f32x4_gt,"f32x4.gt",NoImm,BINARY(v128,v128)) \
+		visitOp(SIMDOP(105),f64x2_gt,"f64x2.gt",NoImm,BINARY(v128,v128)) \
 		\
 		visitOp(SIMDOP(106),i8x16_ge_s,"i8x16.ge_s",NoImm,BINARY(v128,v128)) \
 		visitOp(SIMDOP(107),i8x16_ge_u,"i8x16.ge_u",NoImm,BINARY(v128,v128)) \
 		visitOp(SIMDOP(108),i16x8_ge_s,"i16x8.ge_s",NoImm,BINARY(v128,v128)) \
 		visitOp(SIMDOP(109),i16x8_ge_u,"i16x8.ge_u",NoImm,BINARY(v128,v128)) \
 		visitOp(SIMDOP(110),i32x4_ge_s,"i32x4.ge_s",NoImm,BINARY(v128,v128)) \
-		visitOp(SIMDOP(111),i32x4_ge_u,"i32x4.ge_u",NoImm,BINARY(v128,v128))
-   #define ENUM_FLOAT_SIMD_OPERATORS(visitOp) \
-      visitOp(SIMDOP(7),f32x4_splat,"f32x4.splat",NoImm,UNARY(f32,v128)) \
-      visitOp(SIMDOP(8),f64x2_splat,"f64x2.splat",NoImm,UNARY(f64,v128)) \
-      \
-      visitOp(SIMDOP(15),f32x4_extract_lane,"f32x4.extract_lane",LaneIndexImm<4>,UNARY(v128,f32)) \
-      visitOp(SIMDOP(16),f64x2_extract_lane,"f64x2.extract_lane",LaneIndexImm<2>,UNARY(v128,f64)) \
-      \
-      visitOp(SIMDOP(21),f32x4_replace_lane,"f32x4.replace_lane",LaneIndexImm<4>,REPLACELANE(f32,v128)) \
-      visitOp(SIMDOP(22),f64x2_replace_lane,"f64x2.replace_lane",LaneIndexImm<2>,REPLACELANE(f64,v128)) \
-      \
-      visitOp(SIMDOP(75),f32x4_eq,"f32x4.eq",NoImm,BINARY(v128,v128)) \
-      visitOp(SIMDOP(76),f64x2_eq,"f64x2.eq",NoImm,BINARY(v128,v128)) \
-      \
-      visitOp(SIMDOP(80),f32x4_ne,"f32x4.ne",NoImm,BINARY(v128,v128)) \
-      visitOp(SIMDOP(81),f64x2_ne,"f64x2.ne",NoImm,BINARY(v128,v128)) \
-      \
-      visitOp(SIMDOP(88),f32x4_lt,"f32x4.lt",NoImm,BINARY(v128,v128)) \
-      visitOp(SIMDOP(89),f64x2_lt,"f64x2.lt",NoImm,BINARY(v128,v128)) \
-      \
-      visitOp(SIMDOP(96),f32x4_le,"f32x4.le",NoImm,BINARY(v128,v128)) \
-      visitOp(SIMDOP(97),f64x2_le,"f64x2.le",NoImm,BINARY(v128,v128)) \
-      \
-      visitOp(SIMDOP(104),f32x4_gt,"f32x4.gt",NoImm,BINARY(v128,v128)) \
-      visitOp(SIMDOP(105),f64x2_gt,"f64x2.gt",NoImm,BINARY(v128,v128)) \
-      \
-      visitOp(SIMDOP(112),f32x4_ge,"f32x4.ge",NoImm,BINARY(v128,v128)) \
-      visitOp(SIMDOP(113),f64x2_ge,"f64x2.ge",NoImm,BINARY(v128,v128)) \
-      \
-      visitOp(SIMDOP(114),f32x4_neg,"f32x4.neg",NoImm,UNARY(v128,v128)) \
-      visitOp(SIMDOP(115),f64x2_neg,"f64x2.neg",NoImm,UNARY(v128,v128)) \
-      \
-      visitOp(SIMDOP(116),f32x4_abs,"f32x4.abs",NoImm,UNARY(v128,v128)) \
-      visitOp(SIMDOP(117),f64x2_abs,"f64x2.abs",NoImm,UNARY(v128,v128)) \
-      \
-      visitOp(SIMDOP(118),f32x4_min,"f32x4.min",NoImm,BINARY(v128,v128)) \
-      visitOp(SIMDOP(119),f64x2_min,"f64x2.min",NoImm,BINARY(v128,v128)) \
-      \
-      visitOp(SIMDOP(120),f32x4_max,"f32x4.max",NoImm,BINARY(v128,v128)) \
-      visitOp(SIMDOP(121),f64x2_max,"f64x2.max",NoImm,BINARY(v128,v128)) \
-      \
-      visitOp(SIMDOP(122),f32x4_add,"f32x4.add",NoImm,BINARY(v128,v128)) \
-      visitOp(SIMDOP(123),f64x2_add,"f64x2.add",NoImm,BINARY(v128,v128)) \
-      \
-      visitOp(SIMDOP(124),f32x4_sub,"f32x4.sub",NoImm,BINARY(v128,v128)) \
-      visitOp(SIMDOP(125),f64x2_sub,"f64x2.sub",NoImm,BINARY(v128,v128)) \
-      \
-      visitOp(SIMDOP(126),f32x4_div,"f32x4.div",NoImm,BINARY(v128,v128)) \
-      visitOp(SIMDOP(127),f64x2_div,"f64x2.div",NoImm,BINARY(v128,v128)) \
-      \
-      visitOp(SIMDOP(128),f32x4_mul,"f32x4.mul",NoImm,BINARY(v128,v128)) \
-      visitOp(SIMDOP(129),f64x2_mul,"f64x2.mul",NoImm,BINARY(v128,v128)) \
-      \
-      visitOp(SIMDOP(130),f32x4_sqrt,"f32x4.sqrt",NoImm,UNARY(v128,v128)) \
-      visitOp(SIMDOP(131),f64x2_sqrt,"f64x2.sqrt",NoImm,UNARY(v128,v128)) \
-      \
-      visitOp(SIMDOP(132),f32x4_convert_s_i32x4,"f32x4.convert_s/i32x4",NoImm,UNARY(v128,v128)) \
-      visitOp(SIMDOP(133),f32x4_convert_u_i32x4,"f32x4.convert_u/i32x4",NoImm,UNARY(v128,v128)) \
-      visitOp(SIMDOP(134),f64x2_convert_s_i64x2,"f64x2.convert_s/i64x2",NoImm,UNARY(v128,v128)) \
-      visitOp(SIMDOP(135),f64x2_convert_u_i64x2,"f64x2.convert_u/i64x2",NoImm,UNARY(v128,v128)) \
-      \
-      visitOp(SIMDOP(136),i32x4_trunc_s_f32x4_sat,"i32x4.trunc_s/f32x4:sat",NoImm,UNARY(v128,v128)) \
-      visitOp(SIMDOP(137),i32x4_trunc_u_f32x4_sat,"i32x4.trunc_u/f32x4:sat",NoImm,UNARY(v128,v128)) \
-      visitOp(SIMDOP(138),i64x2_trunc_s_f64x2_sat,"i64x2.trunc_s/f64x2:sat",NoImm,UNARY(v128,v128)) \
-      visitOp(SIMDOP(139),i64x2_trunc_u_f64x2_sat,"i64x2.trunc_u/f64x2:sat",NoImm,UNARY(v128,v128))
+		visitOp(SIMDOP(111),i32x4_ge_u,"i32x4.ge_u",NoImm,BINARY(v128,v128)) \
+		visitOp(SIMDOP(112),f32x4_ge,"f32x4.ge",NoImm,BINARY(v128,v128)) \
+		visitOp(SIMDOP(113),f64x2_ge,"f64x2.ge",NoImm,BINARY(v128,v128)) \
+		\
+		visitOp(SIMDOP(114),f32x4_neg,"f32x4.neg",NoImm,UNARY(v128,v128)) \
+		visitOp(SIMDOP(115),f64x2_neg,"f64x2.neg",NoImm,UNARY(v128,v128)) \
+		\
+		visitOp(SIMDOP(116),f32x4_abs,"f32x4.abs",NoImm,UNARY(v128,v128)) \
+		visitOp(SIMDOP(117),f64x2_abs,"f64x2.abs",NoImm,UNARY(v128,v128)) \
+		\
+		visitOp(SIMDOP(118),f32x4_min,"f32x4.min",NoImm,BINARY(v128,v128)) \
+		visitOp(SIMDOP(119),f64x2_min,"f64x2.min",NoImm,BINARY(v128,v128)) \
+		\
+		visitOp(SIMDOP(120),f32x4_max,"f32x4.max",NoImm,BINARY(v128,v128)) \
+		visitOp(SIMDOP(121),f64x2_max,"f64x2.max",NoImm,BINARY(v128,v128)) \
+		\
+		visitOp(SIMDOP(122),f32x4_add,"f32x4.add",NoImm,BINARY(v128,v128)) \
+		visitOp(SIMDOP(123),f64x2_add,"f64x2.add",NoImm,BINARY(v128,v128)) \
+		\
+		visitOp(SIMDOP(124),f32x4_sub,"f32x4.sub",NoImm,BINARY(v128,v128)) \
+		visitOp(SIMDOP(125),f64x2_sub,"f64x2.sub",NoImm,BINARY(v128,v128)) \
+		\
+		visitOp(SIMDOP(126),f32x4_div,"f32x4.div",NoImm,BINARY(v128,v128)) \
+		visitOp(SIMDOP(127),f64x2_div,"f64x2.div",NoImm,BINARY(v128,v128)) \
+		\
+		visitOp(SIMDOP(128),f32x4_mul,"f32x4.mul",NoImm,BINARY(v128,v128)) \
+		visitOp(SIMDOP(129),f64x2_mul,"f64x2.mul",NoImm,BINARY(v128,v128)) \
+		\
+		visitOp(SIMDOP(130),f32x4_sqrt,"f32x4.sqrt",NoImm,UNARY(v128,v128)) \
+		visitOp(SIMDOP(131),f64x2_sqrt,"f64x2.sqrt",NoImm,UNARY(v128,v128)) \
+		\
+		visitOp(SIMDOP(132),f32x4_convert_s_i32x4,"f32x4.convert_s/i32x4",NoImm,UNARY(v128,v128)) \
+		visitOp(SIMDOP(133),f32x4_convert_u_i32x4,"f32x4.convert_u/i32x4",NoImm,UNARY(v128,v128)) \
+		visitOp(SIMDOP(134),f64x2_convert_s_i64x2,"f64x2.convert_s/i64x2",NoImm,UNARY(v128,v128)) \
+		visitOp(SIMDOP(135),f64x2_convert_u_i64x2,"f64x2.convert_u/i64x2",NoImm,UNARY(v128,v128)) \
+		\
+		visitOp(SIMDOP(136),i32x4_trunc_s_f32x4_sat,"i32x4.trunc_s/f32x4:sat",NoImm,UNARY(v128,v128)) \
+		visitOp(SIMDOP(137),i32x4_trunc_u_f32x4_sat,"i32x4.trunc_u/f32x4:sat",NoImm,UNARY(v128,v128)) \
+		visitOp(SIMDOP(138),i64x2_trunc_s_f64x2_sat,"i64x2.trunc_s/f64x2:sat",NoImm,UNARY(v128,v128)) \
+		visitOp(SIMDOP(139),i64x2_trunc_u_f64x2_sat,"i64x2.trunc_u/f64x2:sat",NoImm,UNARY(v128,v128))
 	#endif
 
 	#if !ENABLE_THREADING_PROTOTYPE
-	#define ENUM_NONFLOAT_THREADING_OPERATORS(visitOp)
-   #define ENUM_FLOAT_THREADING_OPERATORS(visitOp)
+	#define ENUM_THREADING_OPERATORS(visitOp)
 	#else
-	#define ENUM_NONFLOAT_THREADING_OPERATORS(visitOp) \
+	#define ENUM_THREADING_OPERATORS(visitOp) \
 		visitOp(0xc0,i32_extend_s_i8,"i32.extend_s/i8",NoImm,UNARY(i32,i32)) \
 		visitOp(0xc1,i32_extend_s_i16,"i32.extend_s/i16",NoImm,UNARY(i32,i32)) \
 		visitOp(0xc2,i64_extend_s_i8,"i64.extend_s/i8",NoImm,UNARY(i64,i64)) \
@@ -544,6 +515,8 @@ namespace IR
 		visitOp(0xfe27,i64_atomic_load32_u,"i64.atomic.load32_u",AtomicLoadOrStoreImm<2>,LOAD(i64)) \
 		visitOp(0xfe28,i32_atomic_store,"i32.atomic.store",AtomicLoadOrStoreImm<2>,STORE(i32)) \
 		visitOp(0xfe29,i64_atomic_store,"i64.atomic.store",AtomicLoadOrStoreImm<3>,STORE(i64)) \
+		visitOp(0xfe2a,f32_atomic_store,"f32.atomic.store",AtomicLoadOrStoreImm<2>,STORE(f32)) \
+		visitOp(0xfe2b,f64_atomic_store,"f64.atomic.store",AtomicLoadOrStoreImm<3>,STORE(f64)) \
 		visitOp(0xfe2c,i32_atomic_store8,"i32.atomic.store8",AtomicLoadOrStoreImm<0>,STORE(i32)) \
 		visitOp(0xfe2d,i32_atomic_store16,"i32.atomic.store16",AtomicLoadOrStoreImm<1>,STORE(i32)) \
 		visitOp(0xfe2e,i64_atomic_store8,"i64.atomic.store8",AtomicLoadOrStoreImm<0>,STORE(i64)) \
@@ -589,26 +562,15 @@ namespace IR
 		visitOp(0xfe76,i64_atomic_rmw8_u_xor,"i64.atomic.rmw8_u.xor",AtomicLoadOrStoreImm<0>,ATOMICRMW(i64)) \
 		visitOp(0xfe78,i64_atomic_rmw16_u_xor,"i64.atomic.rmw16_u.xor",AtomicLoadOrStoreImm<1>,ATOMICRMW(i64)) \
 		visitOp(0xfe7a,i64_atomic_rmw32_u_xor,"i64.atomic.rmw32_u.xor",AtomicLoadOrStoreImm<2>,ATOMICRMW(i64))
-   #define ENUM_FLOAT_THREADING_OPERATORS(visitOp) \
-      visitOp(0xfe2a,f32_atomic_store,"f32.atomic.store",AtomicLoadOrStoreImm<2>,STORE(f32)) \
-      visitOp(0xfe2b,f64_atomic_store,"f64.atomic.store",AtomicLoadOrStoreImm<3>,STORE(f64))
 	#endif
 
 	#define ENUM_NONCONTROL_OPERATORS(visitOp) \
 		ENUM_PARAMETRIC_OPERATORS(visitOp) \
 		ENUM_NONCONTROL_NONPARAMETRIC_OPERATORS(visitOp)
 
-  #define ENUM_NONFLOAT_NONCONTROL_OPERATORS(visitOp) \
-      ENUM_PARAMETRIC_OPERATORS(visitOp) \
-      ENUM_NONFLOAT_NONCONTROL_NONPARAMETRIC_OPERATORS(visitOp)
-
 	#define ENUM_OPERATORS(visitOp) \
 		ENUM_NONCONTROL_OPERATORS(visitOp) \
 		ENUM_CONTROL_OPERATORS(visitOp)
-
-   #define ENUM_NONFLOAT_OPERATORS(visitOp) \
-      ENUM_NONFLOAT_NONCONTROL_OPERATORS(visitOp) \
-      ENUM_CONTROL_OPERATORS(visitOp)
 
 	enum class Opcode : U16
 	{
@@ -686,7 +648,7 @@ namespace IR
 			nextByte = savedNextByte;
 			return result;
 		}
-  
+
 	private:
 
 		const U8* nextByte;

--- a/libraries/wasm-jit/Include/Runtime/Runtime.h
+++ b/libraries/wasm-jit/Include/Runtime/Runtime.h
@@ -122,12 +122,7 @@ namespace Runtime
 
 	// Invokes a FunctionInstance with the given parameters, and returns the result.
 	// Throws a Runtime::Exception if a trap occurs.
-	Result invokeFunction(FunctionInstance* function,const std::vector<Value>& parameters);
-
-	void invokeFunction2(FunctionInstance* function,const std::vector<Value>& parameters);
-
-  void test( int a );
-	Result testPointerPass(int64_t function, int64_t test2);
+	RUNTIME_API Result invokeFunction(FunctionInstance* function,const std::vector<Value>& parameters);
 
 	// Returns the type of a FunctionInstance.
 	RUNTIME_API const IR::FunctionType* getFunctionType(FunctionInstance* function);

--- a/libraries/wasm-jit/Include/WASM/WASM.h
+++ b/libraries/wasm-jit/Include/WASM/WASM.h
@@ -11,7 +11,6 @@ namespace Serialization { struct InputStream; struct OutputStream; }
 
 namespace WASM
 {
-   WEBASSEMBLY_API void serialize(Serialization::InputStream& stream,IR::Module& module);
-   WEBASSEMBLY_API void serializeWithInjection(Serialization::InputStream& stream,IR::Module& module);
-   WEBASSEMBLY_API void serialize(Serialization::OutputStream& stream,const IR::Module& module);
+	WEBASSEMBLY_API void serialize(Serialization::InputStream& stream,IR::Module& module);
+	WEBASSEMBLY_API void serialize(Serialization::OutputStream& stream,const IR::Module& module);
 }

--- a/libraries/wasm-jit/Source/Runtime/LLVMEmitIR.cpp
+++ b/libraries/wasm-jit/Source/Runtime/LLVMEmitIR.cpp
@@ -43,12 +43,8 @@ namespace LLVMJIT
 		, llvmModule(new llvm::Module("",context))
 		, diBuilder(*llvmModule)
 		{
-			diModuleScope = diBuilder.createFile("debug.info",".");
-#ifdef _DEBUG
-			diCompileUnit = diBuilder.createCompileUnit(llvm::dwarf::DW_LANG_C, diModuleScope,"WAVM",0,"",0);
-#else
+			diModuleScope = diBuilder.createFile("unknown","unknown");
 			diCompileUnit = diBuilder.createCompileUnit(0xffff,diModuleScope,"WAVM",true,"",0);
-#endif
 
 			diValueTypes[(Uptr)ValueType::any] = nullptr;
 			diValueTypes[(Uptr)ValueType::i32] = diBuilder.createBasicType("i32",32,llvm::dwarf::DW_ATE_signed);

--- a/libraries/wasm-jit/Source/Runtime/LLVMJIT.cpp
+++ b/libraries/wasm-jit/Source/Runtime/LLVMJIT.cpp
@@ -5,15 +5,6 @@
 #include "RuntimePrivate.h"
 
 #ifdef _DEBUG
-#include <cctype>
-#include <cstdio>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
-#include <unistd.h>
-#endif
-
-#ifdef _DEBUG
 	// This needs to be 1 to allow debuggers such as Visual Studio to place breakpoints and step through the JITed code.
 	#define USE_WRITEABLE_JIT_CODE_PAGES 1
 
@@ -748,31 +739,6 @@ namespace LLVMJIT
 
 		return reinterpret_cast<InvokeFunctionPointer>(jitUnit->symbol->baseAddress);
 	}
-
-#ifdef _DEBUG
-   int isDebuggerPresent()
-   {
-      char buff[1024];
-      int debuggerPresent = 0;
-      int status_fd = open("/proc/self/status", O_RDONLY);
-      if (status_fd == -1)
-         return 0;
-
-      ssize_t num_read = read(status_fd, buff, sizeof(buff));
-
-      if (num_read > 0) {
-         static const char tracerPID[] = "TracerPID:";
-         char *tracer_pid;
-         buff[num_read] = 0;
-         tracer_pid = strstr(buff, tracerPID);
-
-         if (tracer_pid)
-            debuggerPresent = !!atoi(tracer_pid + sizeof(tracerPID) -1 );
-      }
-
-      return debuggerPresent;
-   }   
-#endif
 
 	void init()
 	{

--- a/libraries/wasm-jit/Source/WASM/WASMSerialization.cpp
+++ b/libraries/wasm-jit/Source/WASM/WASMSerialization.cpp
@@ -277,9 +277,7 @@ namespace WASM
 	void serialize(Stream& stream,CallIndirectImm& imm,const FunctionDef&)
 	{
 		serializeVarUInt32(stream,imm.type.index);
-
-		U8 reserved = 0;
-		serializeVarUInt1(stream,reserved);
+		serializeConstant(stream,"call_indirect immediate reserved field must be 0",0);
 	}
 
 	template<typename Stream,Uptr naturalAlignmentLog2>
@@ -291,8 +289,7 @@ namespace WASM
 	template<typename Stream>
 	void serialize(Stream& stream,MemoryImm& imm,const FunctionDef&)
 	{
-		U8 reserved = 0;
-		serializeVarUInt1(stream,reserved);
+		serializeConstant(stream,"grow_memory/current_memory immediate reserved field must be 0",0);
 	}
 
 	#if ENABLE_SIMD_PROTOTYPE

--- a/libraries/wasm-jit/Source/WASM/WASMSerialization.cpp
+++ b/libraries/wasm-jit/Source/WASM/WASMSerialization.cpp
@@ -277,7 +277,7 @@ namespace WASM
 	void serialize(Stream& stream,CallIndirectImm& imm,const FunctionDef&)
 	{
 		serializeVarUInt32(stream,imm.type.index);
-		serializeConstant(stream,"call_indirect immediate reserved field must be 0",0);
+		serializeConstant(stream,"call_indirect immediate reserved field must be 0",U8(0));
 	}
 
 	template<typename Stream,Uptr naturalAlignmentLog2>
@@ -289,7 +289,7 @@ namespace WASM
 	template<typename Stream>
 	void serialize(Stream& stream,MemoryImm& imm,const FunctionDef&)
 	{
-		serializeConstant(stream,"grow_memory/current_memory immediate reserved field must be 0",0);
+		serializeConstant(stream,"grow_memory/current_memory immediate reserved field must be 0",U8(0));
 	}
 
 	#if ENABLE_SIMD_PROTOTYPE

--- a/libraries/wasm-jit/Source/WASM/WASMSerialization.cpp
+++ b/libraries/wasm-jit/Source/WASM/WASMSerialization.cpp
@@ -7,8 +7,6 @@
 #include "IR/Types.h"
 #include "IR/Validate.h"
 
-#include <iostream>
-
 using namespace Serialization;
 
 static void throwIfNotValidUTF8(const std::string& string)
@@ -19,7 +17,7 @@ static void throwIfNotValidUTF8(const std::string& string)
 		throw FatalSerializationException("invalid UTF-8 encoding");
 	}
 }
-
+	
 // These serialization functions need to be declared in the IR namespace for the array serializer in the Serialization namespace to find them.
 namespace IR
 {
@@ -176,128 +174,12 @@ namespace IR
 	}
 }
 
-using namespace IR;
-
-class ChecktimeInjection
-{
-public:
-   ChecktimeInjection()
-   : typeSlot(-1)
-   {}
-
-
-   void addCall(Module& module, OperatorEncoderStream& operatorEncoderStream, CodeValidationStream& codeValidationStream)
-   {
-      // make sure the import is added
-      addImport(module);
-      LiteralImm<I32> param_imm { 11 };
-      codeValidationStream.i32_const(param_imm);
-      operatorEncoderStream.i32_const(param_imm);
-      CallImm checktime_imm { checktimeIndex(module) };
-      codeValidationStream.call(checktime_imm);
-      operatorEncoderStream.call(checktime_imm);
-   }
-
-   static U32 checktimeIndex(const Module& module)
-   {
-      return module.functions.imports.size() - 1;
-   }
-
-   void setTypeSlot(const Module& module, ResultType returnType, const std::vector<ValueType>& parameterTypes)
-   {
-      if (returnType == ResultType::none && parameterTypes.size() == 1 && parameterTypes[0] == ValueType::i32 )
-        typeSlot = module.types.size() - 1;
-   }
-
-   void addTypeSlot(Module& module)
-   {
-      if (typeSlot < 0)
-      {
-         // add a type for void func(void)
-         typeSlot = module.types.size();
-         module.types.push_back(FunctionType::get(ResultType::none, std::vector<ValueType>(1, ValueType::i32)));
-      }
-   }
-
-   void addImport(Module& module)
-   {
-      if (module.functions.imports.size() == 0 || module.functions.imports.back().exportName.compare(u8"checktime") != 0) {
-         if (typeSlot < 0) {
-            addTypeSlot(module);
-         }
-
-         const U32 functionTypeIndex = typeSlot;
-         module.functions.imports.push_back({{functionTypeIndex}, std::move(u8"env"), std::move(u8"checktime")});
-      }
-   }
-
-   void conditionallyAddCall(Opcode opcode, const ControlStructureImm& imm, Module& module, OperatorEncoderStream& operatorEncoderStream, CodeValidationStream& codeValidationStream)
-   {
-      switch(opcode)
-      {
-      case Opcode::loop:
-      case Opcode::block:
-         addCall(module, operatorEncoderStream, codeValidationStream);
-      default:
-         break;
-      };
-   }
-
-   template<typename Imm>
-   void conditionallyAddCall(Opcode , const Imm& , Module& , OperatorEncoderStream& , CodeValidationStream& )
-   {
-   }
-
-   void adjustIfFunctionIndex(Uptr& index, ObjectKind kind)
-   {
-      if (kind == ObjectKind::function)
-         ++index;
-   }
-
-   void adjustExportIndex(Module& module)
-   {
-      // all function exports need to have their index increased to account for inserted definition
-      for (auto& exportDef : module.exports)
-      {
-         adjustIfFunctionIndex(exportDef.index, exportDef.kind);
-      }
-   }
-
-   void adjustCallIndex(const Module& module, CallImm& imm)
-   {
-      if (imm.functionIndex >= checktimeIndex(module))
-         ++imm.functionIndex;
-   }
-
-   template<typename Imm>
-   void adjustCallIndex(const Module& , Imm& )
-   {
-   }
-
-private:
-   int typeSlot;
-};
-
-struct NoOpInjection
-{
-   void addCall(Module& , OperatorEncoderStream& , CodeValidationStream& ) {}
-   void setTypeSlot(const Module& , ResultType , const std::vector<ValueType>& ) {}
-   void addTypeSlot(Module& ) {}
-   void addImport(Module& ) {}
-   template<typename Imm>
-   void conditionallyAddCall(Opcode , const Imm& , Module& , OperatorEncoderStream& , CodeValidationStream& ) {}
-   void adjustIfFunctionIndex(Uptr& , ObjectKind ) {}
-   void adjustExportIndex(Module& ) {}
-   template<typename Imm>
-   void adjustCallIndex(const Module& , Imm& ) {}
-};
-
 namespace WASM
 {
-   using namespace IR;
-   using namespace Serialization;
-
-   enum
+	using namespace IR;
+	using namespace Serialization;
+	
+	enum
 	{
 		magicNumber=0x6d736100, // "\0asm"
 		currentVersion=1
@@ -500,10 +382,10 @@ namespace WASM
 	{
 		serializeConstant(stream,"expected user section (section ID 0)",(U8)SectionType::user);
 		ArrayOutputStream sectionStream;
-		Serialization::serialize(sectionStream,userSection.name);
+		serialize(sectionStream,userSection.name);
 		serializeBytes(sectionStream,userSection.data.data(),userSection.data.size());
 		std::vector<U8> sectionBytes = sectionStream.getBytes();
-		Serialization::serialize(stream,sectionBytes);
+		serialize(stream,sectionBytes);
 	}
 	
 	void serialize(InputStream& stream,UserSection& userSection)
@@ -513,10 +395,10 @@ namespace WASM
 		serializeVarUInt32(stream,numSectionBytes);
 		
 		MemoryInputStream sectionStream(stream.advance(numSectionBytes),numSectionBytes);
-		Serialization::serialize(sectionStream,userSection.name);
+		serialize(sectionStream,userSection.name);
 		throwIfNotValidUTF8(userSection.name);
 		userSection.data.resize(sectionStream.capacity());
-		Serialization::serializeBytes(sectionStream,userSection.data.data(),userSection.data.size());
+		serializeBytes(sectionStream,userSection.data.data(),userSection.data.size());
 		assert(!sectionStream.capacity());
 	}
 
@@ -558,417 +440,386 @@ namespace WASM
 		Serialization::OutputStream& byteStream;
 		FunctionDef& functionDef;
 	};
-   
-	template<typename Injection>
-   struct WasmSerializationImpl
-   {
-      Injection injection;
 
-      void serializeFunctionBody(OutputStream& sectionStream,Module& module,FunctionDef& functionDef)
-      {
-         ArrayOutputStream bodyStream;
+	void serializeFunctionBody(OutputStream& sectionStream,Module& module,FunctionDef& functionDef)
+	{
+		ArrayOutputStream bodyStream;
 
-         // Convert the function's local types into LocalSets: runs of locals of the same type.
-         LocalSet* localSets = (LocalSet*)alloca(sizeof(LocalSet)*functionDef.nonParameterLocalTypes.size());
-         Uptr numLocalSets = 0;
-         if(functionDef.nonParameterLocalTypes.size())
-         {
-            localSets[0].type = ValueType::any;
-            localSets[0].num = 0;
-            for(auto localType : functionDef.nonParameterLocalTypes)
-            {
-               if(localSets[numLocalSets].type != localType)
-               {
-                  if(localSets[numLocalSets].type != ValueType::any) { ++numLocalSets; }
-                  localSets[numLocalSets].type = localType;
-                  localSets[numLocalSets].num = 0;
-               }
-               ++localSets[numLocalSets].num;
-            }
-            if(localSets[numLocalSets].type != ValueType::any) { ++numLocalSets; }
-         }
+		// Convert the function's local types into LocalSets: runs of locals of the same type.
+		LocalSet* localSets = (LocalSet*)alloca(sizeof(LocalSet)*functionDef.nonParameterLocalTypes.size());
+		Uptr numLocalSets = 0;
+		if(functionDef.nonParameterLocalTypes.size())
+		{
+			localSets[0].type = ValueType::any;
+			localSets[0].num = 0;
+			for(auto localType : functionDef.nonParameterLocalTypes)
+			{
+				if(localSets[numLocalSets].type != localType)
+				{
+					if(localSets[numLocalSets].type != ValueType::any) { ++numLocalSets; }
+					localSets[numLocalSets].type = localType;
+					localSets[numLocalSets].num = 0;
+				}
+				++localSets[numLocalSets].num;
+			}
+			if(localSets[numLocalSets].type != ValueType::any) { ++numLocalSets; }
+		}
 
-         // Serialize the local sets.
-         serializeVarUInt32(bodyStream,numLocalSets);
-         for(Uptr setIndex = 0;setIndex < numLocalSets;++setIndex) { serialize(bodyStream,localSets[setIndex]); }
+		// Serialize the local sets.
+		serializeVarUInt32(bodyStream,numLocalSets);
+		for(Uptr setIndex = 0;setIndex < numLocalSets;++setIndex) { serialize(bodyStream,localSets[setIndex]); }
 
-         // Serialize the function code.
-         OperatorDecoderStream irDecoderStream(functionDef.code);
-         OperatorSerializerStream wasmOpEncoderStream(bodyStream,functionDef);
-         while(irDecoderStream) { irDecoderStream.decodeOp(wasmOpEncoderStream); };
+		// Serialize the function code.
+		OperatorDecoderStream irDecoderStream(functionDef.code);
+		OperatorSerializerStream wasmOpEncoderStream(bodyStream,functionDef);
+		while(irDecoderStream) { irDecoderStream.decodeOp(wasmOpEncoderStream); };
 
-         std::vector<U8> bodyBytes = bodyStream.getBytes();
-         serialize(sectionStream,bodyBytes);
-      }
+		std::vector<U8> bodyBytes = bodyStream.getBytes();
+		serialize(sectionStream,bodyBytes);
+	}
+	
+	void serializeFunctionBody(InputStream& sectionStream,Module& module,FunctionDef& functionDef)
+	{
+		Uptr numBodyBytes = 0;
+		serializeVarUInt32(sectionStream,numBodyBytes);
 
-      void serializeFunctionBody(InputStream& sectionStream,Module& module,FunctionDef& functionDef)
-      {
-         Uptr numBodyBytes = 0;
-         serializeVarUInt32(sectionStream,numBodyBytes);
+		MemoryInputStream bodyStream(sectionStream.advance(numBodyBytes),numBodyBytes);
+		
+		// Deserialize local sets and unpack them into a linear array of local types.
+		Uptr numLocalSets = 0;
+		serializeVarUInt32(bodyStream,numLocalSets);
+		for(Uptr setIndex = 0;setIndex < numLocalSets;++setIndex)
+		{
+			LocalSet localSet;
+			serialize(bodyStream,localSet);
+			for(Uptr index = 0;index < localSet.num;++index) { functionDef.nonParameterLocalTypes.push_back(localSet.type); }
+		}
 
-         MemoryInputStream bodyStream(sectionStream.advance(numBodyBytes),numBodyBytes);
+		// Deserialize the function code, validate it, and re-encode it in the IR format.
+		ArrayOutputStream irCodeByteStream;
+		OperatorEncoderStream irEncoderStream(irCodeByteStream);
+		CodeValidationStream codeValidationStream(module,functionDef);
+		while(bodyStream.capacity())
+		{
+			Opcode opcode;
+			serialize(bodyStream,opcode);
+			switch(opcode)
+			{
+			#define VISIT_OPCODE(_,name,nameString,Imm,...) \
+				case Opcode::name: \
+				{ \
+					Imm imm; \
+					serialize(bodyStream,imm,functionDef); \
+					codeValidationStream.name(imm); \
+					irEncoderStream.name(imm); \
+					break; \
+				}
+			ENUM_OPERATORS(VISIT_OPCODE)
+			#undef VISIT_OPCODE
+			default: throw FatalSerializationException("unknown opcode");
+			};
+		};
+		codeValidationStream.finish();
 
-         // Deserialize local sets and unpack them into a linear array of local types.
-         Uptr numLocalSets = 0;
-         serializeVarUInt32(bodyStream,numLocalSets);
-         for(Uptr setIndex = 0;setIndex < numLocalSets;++setIndex)
-         {
-            LocalSet localSet;
-            serialize(bodyStream,localSet);
-            for(Uptr index = 0;index < localSet.num;++index) { functionDef.nonParameterLocalTypes.push_back(localSet.type); }
-         }
+		functionDef.code = std::move(irCodeByteStream.getBytes());
+	}
+	
+	template<typename Stream>
+	void serializeTypeSection(Stream& moduleStream,Module& module)
+	{
+		serializeSection(moduleStream,SectionType::type,[&module](Stream& sectionStream)
+		{
+			serializeArray(sectionStream,module.types,[](Stream& stream,const FunctionType*& functionType)
+			{
+				serializeConstant(stream,"function type tag",U8(0x60));
+				if(Stream::isInput)
+				{
+					std::vector<ValueType> parameterTypes;
+					ResultType returnType;
+					serialize(stream,parameterTypes);
+					serialize(stream,returnType);
+					functionType = FunctionType::get(returnType,parameterTypes);
+				}
+				else
+				{
+					serialize(stream,const_cast<std::vector<ValueType>&>(functionType->parameters));
+					serialize(stream,const_cast<ResultType&>(functionType->ret));
+				}
+			});
+		});
+	}
+	template<typename Stream>
+	void serializeImportSection(Stream& moduleStream,Module& module)
+	{
+		serializeSection(moduleStream,SectionType::import,[&module](Stream& sectionStream)
+		{
+			Uptr size = module.functions.imports.size()
+				+ module.tables.imports.size()
+				+ module.memories.imports.size()
+				+ module.globals.imports.size();
+			serializeVarUInt32(sectionStream,size);
+			if(Stream::isInput)
+			{
+				for(Uptr index = 0;index < size;++index)
+				{
+					std::string moduleName;
+					std::string exportName;
+					ObjectKind kind = ObjectKind::invalid;
+					serialize(sectionStream,moduleName);
+					serialize(sectionStream,exportName);
+					throwIfNotValidUTF8(moduleName);
+					throwIfNotValidUTF8(exportName);
+					serialize(sectionStream,kind);
+					switch(kind)
+					{
+					case ObjectKind::function:
+					{
+						U32 functionTypeIndex = 0;
+						serializeVarUInt32(sectionStream,functionTypeIndex);
+						if(functionTypeIndex >= module.types.size())
+						{
+							throw FatalSerializationException("invalid import function type index");
+						}
+						module.functions.imports.push_back({{functionTypeIndex},std::move(moduleName),std::move(exportName)});
+						break;
+					}
+					case ObjectKind::table:
+					{
+						TableType tableType;
+						serialize(sectionStream,tableType);
+						module.tables.imports.push_back({tableType,std::move(moduleName),std::move(exportName)});
+						break;
+					}
+					case ObjectKind::memory:
+					{
+						MemoryType memoryType;
+						serialize(sectionStream,memoryType);
+						module.memories.imports.push_back({memoryType,std::move(moduleName),std::move(exportName)});
+						break;
+					}
+					case ObjectKind::global:
+					{
+						GlobalType globalType;
+						serialize(sectionStream,globalType);
+						module.globals.imports.push_back({globalType,std::move(moduleName),std::move(exportName)});
+						break;
+					}
+					default: throw FatalSerializationException("invalid ObjectKind");
+					}
+				}
+			}
+			else
+			{
+				for(auto& functionImport : module.functions.imports)
+				{
+					serialize(sectionStream,functionImport.moduleName);
+					serialize(sectionStream,functionImport.exportName);
+					ObjectKind kind = ObjectKind::function;
+					serialize(sectionStream,kind);
+					serializeVarUInt32(sectionStream,functionImport.type.index);
+				}
+				for(auto& tableImport : module.tables.imports)
+				{
+					serialize(sectionStream,tableImport.moduleName);
+					serialize(sectionStream,tableImport.exportName);
+					ObjectKind kind = ObjectKind::table;
+					serialize(sectionStream,kind);
+					serialize(sectionStream,tableImport.type);
+				}
+				for(auto& memoryImport : module.memories.imports)
+				{
+					serialize(sectionStream,memoryImport.moduleName);
+					serialize(sectionStream,memoryImport.exportName);
+					ObjectKind kind = ObjectKind::memory;
+					serialize(sectionStream,kind);
+					serialize(sectionStream,memoryImport.type);
+				}
+				for(auto& globalImport : module.globals.imports)
+				{
+					serialize(sectionStream,globalImport.moduleName);
+					serialize(sectionStream,globalImport.exportName);
+					ObjectKind kind = ObjectKind::global;
+					serialize(sectionStream,kind);
+					serialize(sectionStream,globalImport.type);
+				}
+			}
+		});
+	}
 
-         // Deserialize the function code, validate it, and re-encode it in the IR format.
-         ArrayOutputStream irCodeByteStream;
+	template<typename Stream>
+	void serializeFunctionSection(Stream& moduleStream,Module& module)
+	{
+		serializeSection(moduleStream,SectionType::functionDeclarations,[&module](Stream& sectionStream)
+		{
+			Uptr numFunctions = module.functions.defs.size();
+			serializeVarUInt32(sectionStream,numFunctions);
+			if(Stream::isInput)
+			{
+				// Grow the vector one element at a time:
+				// try to get a serialization exception before making a huge allocation for malformed input.
+				module.functions.defs.clear();
+				for(Uptr functionIndex = 0;functionIndex < numFunctions;++functionIndex)
+				{
+					U32 functionTypeIndex = 0;
+					serializeVarUInt32(sectionStream,functionTypeIndex);
+					if(functionTypeIndex >= module.types.size()) { throw FatalSerializationException("invalid function type index"); }
+					module.functions.defs.push_back({{functionTypeIndex},{},{}});
+				}
+				module.functions.defs.shrink_to_fit();
+			}
+			else
+			{
+				for(FunctionDef& function : module.functions.defs)
+				{
+					serializeVarUInt32(sectionStream,function.type.index);
+				}
+			}
+		});
+	}
 
-         CodeValidationStream codeValidationStream(module,functionDef);
+	template<typename Stream>
+	void serializeTableSection(Stream& moduleStream,Module& module)
+	{
+		serializeSection(moduleStream,SectionType::table,[&module](Stream& sectionStream)
+		{
+			serialize(sectionStream,module.tables.defs);
+		});
+	}
 
-         OperatorEncoderStream irEncoderStream(irCodeByteStream);
-         injection.addCall(module, irEncoderStream, codeValidationStream);
-         while(bodyStream.capacity())
-         {
-            Opcode opcode;
-            serialize(bodyStream,opcode);
-            switch(opcode)
-            {
-            #define VISIT_OPCODE(_,name,nameString,Imm,...) \
-               case Opcode::name: \
-               { \
-                  Imm imm; \
-                  serialize(bodyStream,imm,functionDef); \
-                  injection.adjustCallIndex(module, imm); \
-                  codeValidationStream.name(imm); \
-                  irEncoderStream.name(imm); \
-                  injection.conditionallyAddCall(opcode, imm, module, irEncoderStream, codeValidationStream); \
-                  break; \
-               }
-            ENUM_OPERATORS(VISIT_OPCODE)
-            #undef VISIT_OPCODE
-            default: throw FatalSerializationException("unknown opcode");
-            };
-         };
-         codeValidationStream.finish();
+	template<typename Stream>
+	void serializeMemorySection(Stream& moduleStream,Module& module)
+	{
+		serializeSection(moduleStream,SectionType::memory,[&module](Stream& sectionStream)
+		{
+			serialize(sectionStream,module.memories.defs);
+		});
+	}
 
-         functionDef.code = std::move(irCodeByteStream.getBytes());
-      }
+	template<typename Stream>
+	void serializeGlobalSection(Stream& moduleStream,Module& module)
+	{
+		serializeSection(moduleStream,SectionType::global,[&module](Stream& sectionStream)
+		{
+			serialize(sectionStream,module.globals.defs);
+		});
+	}
 
-      template<typename Stream>
-      void serializeTypeSection(Stream& moduleStream,Module& module)
-      {
-         Injection& localInjection = injection;
-         serializeSection(moduleStream,SectionType::type,[&module,&localInjection](Stream& sectionStream)
-         {
-            serializeArray(sectionStream,module.types,[&module,&localInjection](Stream& stream,const FunctionType*& functionType)
-            {
-               serializeConstant(stream,"function type tag",U8(0x60));
-               if(Stream::isInput)
-               {
-                  std::vector<ValueType> parameterTypes;
-                  ResultType returnType;
-                  serialize(stream,parameterTypes);
-                  serialize(stream,returnType);
-                  functionType = FunctionType::get(returnType,parameterTypes);
-                  localInjection.setTypeSlot(module, returnType, parameterTypes);
-               }
-               else
-               {
-                  serialize(stream,const_cast<std::vector<ValueType>&>(functionType->parameters));
-                  serialize(stream,const_cast<ResultType&>(functionType->ret));
-               }
-            });
-         });
+	template<typename Stream>
+	void serializeExportSection(Stream& moduleStream,Module& module)
+	{
+		serializeSection(moduleStream,SectionType::export_,[&module](Stream& sectionStream)
+		{
+			serialize(sectionStream,module.exports);
+		});
+	}
 
-         if(Stream::isInput)
-         {
-            injection.addTypeSlot(module);
-         }
-      }
-      template<typename Stream>
-      void serializeImportSection(Stream& moduleStream,Module& module)
-      {
-         Injection& localInjection = injection;
-         serializeSection(moduleStream,SectionType::import,[&module,&localInjection](Stream& sectionStream)
-         {
-            Uptr size = module.functions.imports.size()
-               + module.tables.imports.size()
-               + module.memories.imports.size()
-               + module.globals.imports.size();
-            serializeVarUInt32(sectionStream,size);
-            if(Stream::isInput)
-            {
-               for(Uptr index = 0;index < size;++index)
-               {
-                  std::string moduleName;
-                  std::string exportName;
-                  ObjectKind kind = ObjectKind::invalid;
-                  serialize(sectionStream,moduleName);
-                  serialize(sectionStream,exportName);
-                  throwIfNotValidUTF8(moduleName);
-                  throwIfNotValidUTF8(exportName);
-                  serialize(sectionStream,kind);
-                  switch(kind)
-                  {
-                  case ObjectKind::function:
-                  {
-                     U32 functionTypeIndex = 0;
-                     serializeVarUInt32(sectionStream,functionTypeIndex);
-                     if(functionTypeIndex >= module.types.size())
-                     {
-                        throw FatalSerializationException("invalid import function type index");
-                     }
-                     module.functions.imports.push_back({{functionTypeIndex},std::move(moduleName),std::move(exportName)});
-                     break;
-                  }
-                  case ObjectKind::table:
-                  {
-                     TableType tableType;
-                     serialize(sectionStream,tableType);
-                     module.tables.imports.push_back({tableType,std::move(moduleName),std::move(exportName)});
-                     break;
-                  }
-                  case ObjectKind::memory:
-                  {
-                     MemoryType memoryType;
-                     serialize(sectionStream,memoryType);
-                     module.memories.imports.push_back({memoryType,std::move(moduleName),std::move(exportName)});
-                     break;
-                  }
-                  case ObjectKind::global:
-                  {
-                     GlobalType globalType;
-                     serialize(sectionStream,globalType);
-                     module.globals.imports.push_back({globalType,std::move(moduleName),std::move(exportName)});
-                     break;
-                  }
-                  default: throw FatalSerializationException("invalid ObjectKind");
-                  }
-               }
-               localInjection.addImport(module);
-            }
-            else
-            {
-               for(auto& functionImport : module.functions.imports)
-               {
-                  serialize(sectionStream,functionImport.moduleName);
-                  serialize(sectionStream,functionImport.exportName);
-                  ObjectKind kind = ObjectKind::function;
-                  serialize(sectionStream,kind);
-                  serializeVarUInt32(sectionStream,functionImport.type.index);
-               }
-               for(auto& tableImport : module.tables.imports)
-               {
-                  serialize(sectionStream,tableImport.moduleName);
-                  serialize(sectionStream,tableImport.exportName);
-                  ObjectKind kind = ObjectKind::table;
-                  serialize(sectionStream,kind);
-                  serialize(sectionStream,tableImport.type);
-               }
-               for(auto& memoryImport : module.memories.imports)
-               {
-                  serialize(sectionStream,memoryImport.moduleName);
-                  serialize(sectionStream,memoryImport.exportName);
-                  ObjectKind kind = ObjectKind::memory;
-                  serialize(sectionStream,kind);
-                  serialize(sectionStream,memoryImport.type);
-               }
-               for(auto& globalImport : module.globals.imports)
-               {
-                  serialize(sectionStream,globalImport.moduleName);
-                  serialize(sectionStream,globalImport.exportName);
-                  ObjectKind kind = ObjectKind::global;
-                  serialize(sectionStream,kind);
-                  serialize(sectionStream,globalImport.type);
-               }
-            }
-         });
-      }
+	template<typename Stream>
+	void serializeStartSection(Stream& moduleStream,Module& module)
+	{
+		serializeSection(moduleStream,SectionType::start,[&module](Stream& sectionStream)
+		{
+			serializeVarUInt32(sectionStream,module.startFunctionIndex);
+		});
+	}
 
-      template<typename Stream>
-      void serializeFunctionSection(Stream& moduleStream,Module& module)
-      {
-         serializeSection(moduleStream,SectionType::functionDeclarations,[&module](Stream& sectionStream)
-         {
-            Uptr numFunctions = module.functions.defs.size();
-            serializeVarUInt32(sectionStream,numFunctions);
-            if(Stream::isInput)
-            {
-               // Grow the vector one element at a time:
-               // try to get a serialization exception before making a huge allocation for malformed input.
-               module.functions.defs.clear();
-               for(Uptr functionIndex = 0;functionIndex < numFunctions;++functionIndex)
-               {
-                  U32 functionTypeIndex = 0;
-                  serializeVarUInt32(sectionStream,functionTypeIndex);
-                  if(functionTypeIndex >= module.types.size()) { throw FatalSerializationException("invalid function type index"); }
-                  module.functions.defs.push_back({{functionTypeIndex},{},{}});
-               }
-               module.functions.defs.shrink_to_fit();
-            }
-            else
-            {
-               for(FunctionDef& function : module.functions.defs)
-               {
-                  serializeVarUInt32(sectionStream,function.type.index);
-               }
-            }
-         });
-      }
+	template<typename Stream>
+	void serializeElementSection(Stream& moduleStream,Module& module)
+	{
+		serializeSection(moduleStream,SectionType::elem,[&module](Stream& sectionStream)
+		{
+			serialize(sectionStream,module.tableSegments);
+		});
+	}
 
-      template<typename Stream>
-      void serializeTableSection(Stream& moduleStream,Module& module)
-      {
-         serializeSection(moduleStream,SectionType::table,[&module](Stream& sectionStream)
-         {
-            serialize(sectionStream,module.tables.defs);
-         });
-      }
+	template<typename Stream>
+	void serializeCodeSection(Stream& moduleStream,Module& module)
+	{
+		serializeSection(moduleStream,SectionType::functionDefinitions,[&module](Stream& sectionStream)
+		{
+			Uptr numFunctionBodies = module.functions.defs.size();
+			serializeVarUInt32(sectionStream,numFunctionBodies);
+			if(Stream::isInput && numFunctionBodies != module.functions.defs.size())
+				{ throw FatalSerializationException("function and code sections have mismatched function counts"); }
+			for(FunctionDef& functionDef : module.functions.defs) { serializeFunctionBody(sectionStream,module,functionDef); }
+		});
+	}
 
-      template<typename Stream>
-      void serializeMemorySection(Stream& moduleStream,Module& module)
-      {
-         serializeSection(moduleStream,SectionType::memory,[&module](Stream& sectionStream)
-         {
-            serialize(sectionStream,module.memories.defs);
-         });
-      }
+	template<typename Stream>
+	void serializeDataSection(Stream& moduleStream,Module& module)
+	{
+		serializeSection(moduleStream,SectionType::data,[&module](Stream& sectionStream)
+		{
+			serialize(sectionStream,module.dataSegments);
+		});
+	}
 
-      template<typename Stream>
-      void serializeGlobalSection(Stream& moduleStream,Module& module)
-      {
-         serializeSection(moduleStream,SectionType::global,[&module](Stream& sectionStream)
-         {
-            serialize(sectionStream,module.globals.defs);
-         });
-      }
+	void serializeModule(OutputStream& moduleStream,Module& module)
+	{
+		serializeConstant(moduleStream,"magic number",U32(magicNumber));
+		serializeConstant(moduleStream,"version",U32(currentVersion));
 
-      template<typename Stream>
-      void serializeExportSection(Stream& moduleStream,Module& module)
-      {
-         serializeSection(moduleStream,SectionType::export_,[&module](Stream& sectionStream)
-         {
-            serialize(sectionStream,module.exports);
-         });
+		if(module.types.size() > 0) { serializeTypeSection(moduleStream,module); }
+		if(module.functions.imports.size() > 0
+		|| module.tables.imports.size() > 0
+		|| module.memories.imports.size() > 0
+		|| module.globals.imports.size() > 0) { serializeImportSection(moduleStream,module); }
+		if(module.functions.defs.size() > 0) { serializeFunctionSection(moduleStream,module); }
+		if(module.tables.defs.size() > 0) { serializeTableSection(moduleStream,module); }
+		if(module.memories.defs.size() > 0) { serializeMemorySection(moduleStream,module); }
+		if(module.globals.defs.size() > 0) { serializeGlobalSection(moduleStream,module); }
+		if(module.exports.size() > 0) { serializeExportSection(moduleStream,module); }
+		if(module.startFunctionIndex != UINTPTR_MAX) { serializeStartSection(moduleStream,module); }
+		if(module.tableSegments.size() > 0) { serializeElementSection(moduleStream,module); }
+		if(module.functions.defs.size() > 0) { serializeCodeSection(moduleStream,module); }
+		if(module.dataSegments.size() > 0) { serializeDataSection(moduleStream,module); }
 
-         injection.adjustExportIndex(module);
-      }
+		for(auto& userSection : module.userSections) { serialize(moduleStream,userSection); }
+	}
+	void serializeModule(InputStream& moduleStream,Module& module)
+	{
+		serializeConstant(moduleStream,"magic number",U32(magicNumber));
+		serializeConstant(moduleStream,"version",U32(currentVersion));
 
-      template<typename Stream>
-      void serializeStartSection(Stream& moduleStream,Module& module)
-      {
-         serializeSection(moduleStream,SectionType::start,[&module](Stream& sectionStream)
-         {
-            serializeVarUInt32(sectionStream,module.startFunctionIndex);
-         });
-         injection.adjustIfFunctionIndex(module.startFunctionIndex, ObjectKind::function);
-      }
+		SectionType lastKnownSectionType = SectionType::unknown;
+		while(moduleStream.capacity())
+		{
+			const SectionType sectionType = *(SectionType*)moduleStream.peek(sizeof(SectionType));
+			if(sectionType != SectionType::user)
+			{
+				if(sectionType > lastKnownSectionType) { lastKnownSectionType = sectionType; }
+				else { throw FatalSerializationException("incorrect order for known section"); }
+			}
+			switch(sectionType)
+			{
+			case SectionType::type: serializeTypeSection(moduleStream,module); break;
+			case SectionType::import: serializeImportSection(moduleStream,module); break;
+			case SectionType::functionDeclarations: serializeFunctionSection(moduleStream,module); break;
+			case SectionType::table: serializeTableSection(moduleStream,module); break;
+			case SectionType::memory: serializeMemorySection(moduleStream,module); break;
+			case SectionType::global: serializeGlobalSection(moduleStream,module); break;
+			case SectionType::export_: serializeExportSection(moduleStream,module); break;
+			case SectionType::start: serializeStartSection(moduleStream,module); break;
+			case SectionType::elem: serializeElementSection(moduleStream,module); break;
+			case SectionType::functionDefinitions: serializeCodeSection(moduleStream,module); break;
+			case SectionType::data: serializeDataSection(moduleStream,module); break;
+			case SectionType::user:
+			{
+				UserSection& userSection = *module.userSections.insert(module.userSections.end(),UserSection());
+				serialize(moduleStream,userSection);
+				break;
+			}
+			default: throw FatalSerializationException("unknown section ID");
+			};
+		};
+	}
 
-      template<typename Stream>
-      void serializeElementSection(Stream& moduleStream,Module& module)
-      {
-         serializeSection(moduleStream,SectionType::elem,[&module](Stream& sectionStream)
-         {
-            serialize(sectionStream,module.tableSegments);
-         });
-      }
-
-      template<typename Stream>
-      void serializeCodeSection(Stream& moduleStream,Module& module)
-      {
-         serializeSection(moduleStream,SectionType::functionDefinitions,[&module,this](Stream& sectionStream)
-         {
-            Uptr numFunctionBodies = module.functions.defs.size();
-            serializeVarUInt32(sectionStream,numFunctionBodies);
-            if(Stream::isInput && numFunctionBodies != module.functions.defs.size())
-               { throw FatalSerializationException("function and code sections have mismatched function counts"); }
-            for(FunctionDef& functionDef : module.functions.defs) { serializeFunctionBody(sectionStream,module,functionDef); }
-         });
-      }
-
-      template<typename Stream>
-      void serializeDataSection(Stream& moduleStream,Module& module)
-      {
-         serializeSection(moduleStream,SectionType::data,[&module](Stream& sectionStream)
-         {
-            serialize(sectionStream,module.dataSegments);
-         });
-      }
-
-      void serializeModule(OutputStream& moduleStream,Module& module)
-      {
-         serializeConstant(moduleStream,"magic number",U32(magicNumber));
-         serializeConstant(moduleStream,"version",U32(currentVersion));
-
-         if(module.types.size() > 0) { serializeTypeSection(moduleStream,module); }
-         if(module.functions.imports.size() > 0
-         || module.tables.imports.size() > 0
-         || module.memories.imports.size() > 0
-         || module.globals.imports.size() > 0) { serializeImportSection(moduleStream,module); }
-         if(module.functions.defs.size() > 0) { serializeFunctionSection(moduleStream,module); }
-         if(module.tables.defs.size() > 0) { serializeTableSection(moduleStream,module); }
-         if(module.memories.defs.size() > 0) { serializeMemorySection(moduleStream,module); }
-         if(module.globals.defs.size() > 0) { serializeGlobalSection(moduleStream,module); }
-         if(module.exports.size() > 0) { serializeExportSection(moduleStream,module); }
-         if(module.startFunctionIndex != UINTPTR_MAX) { serializeStartSection(moduleStream,module); }
-         if(module.tableSegments.size() > 0) { serializeElementSection(moduleStream,module); }
-         if(module.functions.defs.size() > 0) { serializeCodeSection(moduleStream,module); }
-         if(module.dataSegments.size() > 0) { serializeDataSection(moduleStream,module); }
-
-         for(auto& userSection : module.userSections) { serialize(moduleStream,userSection); }
-      }
-      void serializeModule(InputStream& moduleStream,Module& module)
-      {
-         serializeConstant(moduleStream,"magic number",U32(magicNumber));
-         serializeConstant(moduleStream,"version",U32(currentVersion));
-
-         SectionType lastKnownSectionType = SectionType::unknown;
-         while(moduleStream.capacity())
-         {
-            const SectionType sectionType = *(SectionType*)moduleStream.peek(sizeof(SectionType));
-            if(sectionType != SectionType::user)
-            {
-               if(sectionType > lastKnownSectionType) { lastKnownSectionType = sectionType; }
-               else { throw FatalSerializationException("incorrect order for known section"); }
-            }
-            switch(sectionType)
-            {
-            case SectionType::type: serializeTypeSection(moduleStream,module); break;
-            case SectionType::import: serializeImportSection(moduleStream,module); break;
-            case SectionType::functionDeclarations: serializeFunctionSection(moduleStream,module); break;
-            case SectionType::table: serializeTableSection(moduleStream,module); break;
-            case SectionType::memory: serializeMemorySection(moduleStream,module); break;
-            case SectionType::global: serializeGlobalSection(moduleStream,module); break;
-            case SectionType::export_: serializeExportSection(moduleStream,module); break;
-            case SectionType::start: serializeStartSection(moduleStream,module); break;
-            case SectionType::elem: serializeElementSection(moduleStream,module); break;
-            case SectionType::functionDefinitions: serializeCodeSection(moduleStream,module); break;
-            case SectionType::data: serializeDataSection(moduleStream,module); break;
-            case SectionType::user:
-            {
-               UserSection& userSection = *module.userSections.insert(module.userSections.end(),UserSection());
-               serialize(moduleStream,userSection);
-               break;
-            }
-            default: throw FatalSerializationException("unknown section ID");
-            };
-         };
-      }
-   };
-
-   void serialize(Serialization::InputStream& stream,Module& module)
-   {
-      WasmSerializationImpl<NoOpInjection> impl;
-      impl.serializeModule(stream,module);
-      IR::validateDefinitions(module);
-   }
-   void serializeWithInjection(Serialization::InputStream& stream,Module& module)
-   {
-      WasmSerializationImpl<ChecktimeInjection> impl;
-      impl.serializeModule(stream,module);
-      IR::validateDefinitions(module);
-   }
-   void serialize(Serialization::OutputStream& stream,const Module& module)
-   {
-      WasmSerializationImpl<NoOpInjection> impl;
-      impl.serializeModule(stream,const_cast<Module&>(module));
-   }
+	void serialize(Serialization::InputStream& stream,Module& module)
+	{
+		serializeModule(stream,module);
+		IR::validateDefinitions(module);
+	}
+	void serialize(Serialization::OutputStream& stream,const Module& module)
+	{
+		serializeModule(stream,const_cast<Module&>(module));
+	}
 }

--- a/libraries/wasm-jit/Test/spec/binary.wast
+++ b/libraries/wasm-jit/Test/spec/binary.wast
@@ -42,3 +42,61 @@
 (assert_malformed (module binary "\00asm\00\01\00\00") "unknown binary version")
 (assert_malformed (module binary "\00asm\00\00\01\00") "unknown binary version")
 (assert_malformed (module binary "\00asm\00\00\00\01") "unknown binary version")
+
+;; call_indirect reserved byte equal to zero.
+(assert_malformed
+  (module binary
+    "\00asm" "\01\00\00\00"
+    "\01\04\01\60\00\00"      ;; Type section
+    "\03\02\01\00"            ;; Function section
+    "\04\04\01\70\00\00"      ;; Table section
+    "\0a\09\01"               ;; Code section
+
+    ;; function 0
+    "\07\00"
+    "\41\00"                   ;; i32.const 0
+    "\11\00"                   ;; call_indirect (type 0)
+    "\01"                      ;; call_indirect reserved byte is not equal to zero!
+    "\0b"                      ;; end
+  )
+  "zero flag expected"
+)
+
+;; grow_memory reserved byte equal to zero.
+(assert_malformed
+  (module binary
+    "\00asm" "\01\00\00\00"
+    "\01\04\01\60\00\00"       ;; Type section
+    "\03\02\01\00"             ;; Function section
+    "\05\03\01\00\00"          ;; Memory section
+    "\0a\09\01"                ;; Code section
+
+    ;; function 0
+    "\07\00"
+    "\41\00"                   ;; i32.const 0
+    "\40"                      ;; grow_memory
+    "\01"                      ;; grow_memory reserved byte is not equal to zero!
+    "\1a"                      ;; drop
+    "\0b"                      ;; end
+  )
+  "zero flag expected"
+)
+
+;; current_memory reserved byte equal to zero.
+(assert_malformed
+  (module binary
+    "\00asm" "\01\00\00\00"
+    "\01\04\01\60\00\00"       ;; Type section
+    "\03\02\01\00"             ;; Function section
+    "\05\03\01\00\00"          ;; Memory section
+    "\0a\07\01"                ;; Code section
+
+    ;; function 0
+    "\05\00"
+    "\3f"                      ;; current_memory
+    "\01"                      ;; current_memory reserved byte is not equal to zero!
+    "\1a"                      ;; drop
+    "\0b"                      ;; end
+  )
+  "zero flag expected"
+)


### PR DESCRIPTION
* Remove old WASM injection code; this is done in a common manner elsewhere in our system now
* Remove some vestigial debugging support we attempted to add that apparently didn't work
* Cherry pick from upstream validation enforcement of the reserved byte being 0 in call_indirect/grow_memory/current_memory