### PR TITLE
Added argument documentation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ git clone https://github.com/eosio/eos --recursive
 cd eos
 git checkout DAWN-2018-02-14
 git submodule update --recursive
-./build.sh
+./build.sh ubuntu
 ```
 
 For ease of contract development, one further step is required:
@@ -162,7 +162,7 @@ git clone https://github.com/eosio/eos --recursive
 cd eos
 git checkout DAWN-2018-02-14
 git submodule update --recursive
-./build.sh
+./build.sh darwin
 ```
 
 For ease of contract development, one further step is required:


### PR DESCRIPTION
The script `build.sh` requires an argument. On linux, the argument is `ubuntu` and on macOS it is `darwin`.