### PR TITLE
remove potential dangerous arbitrary precision int_t

### DIFF
--- a/libraries/chain/include/eosio/chain/contracts/types.hpp
+++ b/libraries/chain/include/eosio/chain/contracts/types.hpp
@@ -13,7 +13,7 @@ using namespace boost::multiprecision;
 
 template<size_t Size>
 using uint_t = number<cpp_int_backend<Size, Size, unsigned_magnitude, unchecked, void> >;
-template<size_t Size>
+
 
 using uint8     = uint_t<8>;
 using uint16    = uint_t<16>;

--- a/libraries/chain/include/eosio/chain/contracts/types.hpp
+++ b/libraries/chain/include/eosio/chain/contracts/types.hpp
@@ -14,7 +14,6 @@ using namespace boost::multiprecision;
 template<size_t Size>
 using uint_t = number<cpp_int_backend<Size, Size, unsigned_magnitude, unchecked, void> >;
 
-
 using uint8     = uint_t<8>;
 using uint16    = uint_t<16>;
 using uint32    = uint_t<32>;

--- a/libraries/chain/include/eosio/chain/contracts/types.hpp
+++ b/libraries/chain/include/eosio/chain/contracts/types.hpp
@@ -14,7 +14,6 @@ using namespace boost::multiprecision;
 template<size_t Size>
 using uint_t = number<cpp_int_backend<Size, Size, unsigned_magnitude, unchecked, void> >;
 template<size_t Size>
-using int_t = number<cpp_int_backend<Size, Size, signed_magnitude, unchecked, void> >;
 
 using uint8     = uint_t<8>;
 using uint16    = uint_t<16>;


### PR DESCRIPTION
1.  int_t is not being used by any file in the systems
2. `number<MinBits, MaxBits, SignedType, Checked, Allocator>` struct cpp_int is from multiprecision of Boost, which `number<cpp_int_backend<Size, Size, signed_magnitude, unchecked, void> >` signed_magnitude which indicate allowing arbitrary precision, which may lead to nondeterministic state.
![image](https://user-images.githubusercontent.com/16319106/37754082-fd6c5134-2dda-11e8-834c-42a177a935ae.png)

> **arbitrary/bignum** whose digits of precision are limited only by the available memory of the host system.
> [Boost_multiprecision_cpp_int](http://www.boost.org/doc/libs/1_66_0/libs/multiprecision/doc/html/boost_multiprecision/tut/ints/cpp_int.html)
