### PR TITLE
DAWN-691 - Add additional multi index tests

### DIFF
--- a/contracts/test_api/test_api.hpp
+++ b/contracts/test_api/test_api.hpp
@@ -172,6 +172,22 @@ struct test_multi_index {
    static void idx128_autoincrement_test_part2();
    static void idx256_general();
    static void idx_double_general();
+   static void idx64_pk_iterator_exceed_end();
+   static void idx64_sk_iterator_exceed_end();
+   static void idx64_pk_iterator_exceed_begin();
+   static void idx64_sk_iterator_exceed_begin();
+   static void idx64_pass_pk_ref_to_other_table();
+   static void idx64_pass_sk_ref_to_other_table();
+   static void idx64_pass_pk_end_itr_to_iterator_to();
+   static void idx64_pass_pk_end_itr_to_modify();
+   static void idx64_pass_pk_end_itr_to_erase();
+   static void idx64_pass_sk_end_itr_to_iterator_to();
+   static void idx64_pass_sk_end_itr_to_modify();
+   static void idx64_pass_sk_end_itr_to_erase();
+   static void idx64_modify_primary_key();
+   static void idx64_run_out_of_avl_pk();
+   static void idx64_sk_cache_pk_lookup();
+   static void idx64_pk_cache_sk_lookup();
 };
 
 struct test_crypto {

--- a/contracts/test_api_multi_index/test_api_multi_index.cpp
+++ b/contracts/test_api_multi_index/test_api_multi_index.cpp
@@ -26,6 +26,22 @@ extern "C" {
       WASM_TEST_HANDLER(test_multi_index, idx128_autoincrement_test_part2);
       WASM_TEST_HANDLER(test_multi_index, idx256_general);
       WASM_TEST_HANDLER(test_multi_index, idx_double_general);
+      WASM_TEST_HANDLER(test_multi_index, idx64_pk_iterator_exceed_end);
+      WASM_TEST_HANDLER(test_multi_index, idx64_sk_iterator_exceed_end);
+      WASM_TEST_HANDLER(test_multi_index, idx64_pk_iterator_exceed_begin);
+      WASM_TEST_HANDLER(test_multi_index, idx64_sk_iterator_exceed_begin);
+      WASM_TEST_HANDLER(test_multi_index, idx64_pass_pk_ref_to_other_table);
+      WASM_TEST_HANDLER(test_multi_index, idx64_pass_sk_ref_to_other_table);
+      WASM_TEST_HANDLER(test_multi_index, idx64_pass_pk_end_itr_to_iterator_to);
+      WASM_TEST_HANDLER(test_multi_index, idx64_pass_pk_end_itr_to_modify);
+      WASM_TEST_HANDLER(test_multi_index, idx64_pass_pk_end_itr_to_erase);
+      WASM_TEST_HANDLER(test_multi_index, idx64_pass_sk_end_itr_to_iterator_to);
+      WASM_TEST_HANDLER(test_multi_index, idx64_pass_sk_end_itr_to_modify);
+      WASM_TEST_HANDLER(test_multi_index, idx64_pass_sk_end_itr_to_erase);
+      WASM_TEST_HANDLER(test_multi_index, idx64_modify_primary_key);
+      WASM_TEST_HANDLER(test_multi_index, idx64_run_out_of_avl_pk);
+      WASM_TEST_HANDLER(test_multi_index, idx64_sk_cache_pk_lookup);
+      WASM_TEST_HANDLER(test_multi_index, idx64_pk_cache_sk_lookup);
 
       //unhandled test call
       eosio_assert(false, "Unknown Test");

--- a/tests/api_tests/api_tests.cpp
+++ b/tests/api_tests/api_tests.cpp
@@ -166,6 +166,14 @@ void CallFunction(tester& test, T ac, const vector<char>& data, const vector<acc
 #define CALL_TEST_FUNCTION(TESTER, CLS, MTH, DATA) CallFunction(TESTER, test_api_action<TEST_METHOD(CLS, MTH)>{}, DATA)
 #define CALL_TEST_FUNCTION_SYSTEM(TESTER, CLS, MTH, DATA) CallFunction(TESTER, test_chain_action<TEST_METHOD(CLS, MTH)>{}, DATA, {N(eosio)} )
 #define CALL_TEST_FUNCTION_SCOPE(TESTER, CLS, MTH, DATA, ACCOUNT) CallFunction(TESTER, test_api_action<TEST_METHOD(CLS, MTH)>{}, DATA, ACCOUNT)
+#define CALL_TEST_FUNCTION_AND_CHECK_EXCEPTION(TESTER, CLS, MTH, DATA, EXC, EXC_MESSAGE) \
+BOOST_CHECK_EXCEPTION( \
+   CALL_TEST_FUNCTION( TESTER, CLS, MTH, DATA), \
+                       EXC, \
+                       [](const EXC& e) { \
+                          return expect_assert_message(e, EXC_MESSAGE); \
+                     } \
+);
 
 bool is_access_violation(fc::unhandled_exception const & e) {
    try {
@@ -792,6 +800,37 @@ BOOST_FIXTURE_TEST_CASE(multi_index_tests, tester) { try {
    CALL_TEST_FUNCTION( *this, "test_multi_index", "idx128_autoincrement_test_part2", {});
    CALL_TEST_FUNCTION( *this, "test_multi_index", "idx256_general", {});
    CALL_TEST_FUNCTION( *this, "test_multi_index", "idx_double_general", {});
+   CALL_TEST_FUNCTION_AND_CHECK_EXCEPTION( *this, "test_multi_index", "idx64_pk_iterator_exceed_end", {},
+                                           fc::assert_exception, "cannot increment end iterator");
+   CALL_TEST_FUNCTION_AND_CHECK_EXCEPTION( *this, "test_multi_index", "idx64_sk_iterator_exceed_end", {},
+                                           fc::assert_exception, "cannot increment end iterator");
+   CALL_TEST_FUNCTION_AND_CHECK_EXCEPTION( *this, "test_multi_index", "idx64_pk_iterator_exceed_begin", {},
+                                           fc::assert_exception, "cannot decrement iterator at beginning of table");
+   CALL_TEST_FUNCTION_AND_CHECK_EXCEPTION( *this, "test_multi_index", "idx64_sk_iterator_exceed_begin", {},
+                                           fc::assert_exception, "cannot decrement iterator at beginning of index");
+   CALL_TEST_FUNCTION_AND_CHECK_EXCEPTION( *this, "test_multi_index", "idx64_pass_pk_ref_to_other_table", {},
+                                           fc::assert_exception, "object passed to iterator_to is not in multi_index");
+   CALL_TEST_FUNCTION_AND_CHECK_EXCEPTION( *this, "test_multi_index", "idx64_pass_sk_ref_to_other_table", {},
+                                           fc::assert_exception, "object passed to iterator_to is not in multi_index");
+   CALL_TEST_FUNCTION_AND_CHECK_EXCEPTION( *this, "test_multi_index", "idx64_pass_pk_end_itr_to_iterator_to", {},
+                                           fc::assert_exception, "object passed to iterator_to is not in multi_index");
+   CALL_TEST_FUNCTION_AND_CHECK_EXCEPTION( *this, "test_multi_index", "idx64_pass_pk_end_itr_to_modify", {},
+                                           fc::assert_exception, "cannot pass end iterator to modify");
+   CALL_TEST_FUNCTION_AND_CHECK_EXCEPTION( *this, "test_multi_index", "idx64_pass_pk_end_itr_to_erase", {},
+                                           fc::assert_exception, "cannot pass end iterator to erase");
+   CALL_TEST_FUNCTION_AND_CHECK_EXCEPTION( *this, "test_multi_index", "idx64_pass_sk_end_itr_to_iterator_to", {},
+                                           fc::assert_exception, "object passed to iterator_to is not in multi_index");
+   CALL_TEST_FUNCTION_AND_CHECK_EXCEPTION( *this, "test_multi_index", "idx64_pass_sk_end_itr_to_modify", {},
+                                           fc::assert_exception, "cannot pass end iterator to modify");
+   CALL_TEST_FUNCTION_AND_CHECK_EXCEPTION( *this, "test_multi_index", "idx64_pass_sk_end_itr_to_erase", {},
+                                           fc::assert_exception, "cannot pass end iterator to erase");
+   CALL_TEST_FUNCTION_AND_CHECK_EXCEPTION( *this, "test_multi_index", "idx64_modify_primary_key", {},
+                                           fc::assert_exception, "updater cannot change primary key when modifying an object");
+   CALL_TEST_FUNCTION_AND_CHECK_EXCEPTION( *this, "test_multi_index", "idx64_run_out_of_avl_pk", {},
+                                           fc::assert_exception, "next primary key in table is at autoincrement limit");
+   CALL_TEST_FUNCTION( *this, "test_multi_index", "idx64_sk_cache_pk_lookup", {});
+   CALL_TEST_FUNCTION( *this, "test_multi_index", "idx64_pk_cache_sk_lookup", {});
+
 } FC_LOG_AND_RETHROW() }
 
 /*************************************************************************************


### PR DESCRIPTION
This PR adds additional unit tests for multi-index as described in DAWN-691.

Any additional idea for testing cache inconsistency will be added later on and made as another PR.