### PR TITLE
Unit tests to ensure WASM validation on global idx enforced

### DIFF
--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -77,6 +77,7 @@ namespace eosio { namespace testing {
          private_key_type  get_private_key( name keyname, string role = "owner" ) const;
 
          void              set_code( account_name name, const char* wast );
+         void              set_code( account_name name, const vector<uint8_t> wasm );
          void              set_abi( account_name name, const char* abi_json );
 
 

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -348,8 +348,10 @@ namespace eosio { namespace testing {
    }
 
    void base_tester::set_code( account_name account, const char* wast ) try {
-      auto wasm = wast_to_wasm(wast);
+      set_code(account, wast_to_wasm(wast));
+   } FC_CAPTURE_AND_RETHROW( (account)(wast) )
 
+   void base_tester::set_code( account_name account, const vector<uint8_t> wasm ) try {
       signed_transaction trx;
       trx.actions.emplace_back( vector<permission_level>{{account,config::active_name}},
                                 contracts::setcode{
@@ -362,7 +364,7 @@ namespace eosio { namespace testing {
       set_tapos( trx );
       trx.sign( get_private_key( account, "active" ), chain_id_type()  );
       push_transaction( trx );
-   } FC_CAPTURE_AND_RETHROW( (account)(wast) )
+   } FC_CAPTURE_AND_RETHROW( (account) )
 
    void base_tester::set_abi( account_name account, const char* abi_json) {
       auto abi = fc::json::from_string(abi_json).template as<contracts::abi_def>();

--- a/tests/wasm_tests/test_wasts.hpp
+++ b/tests/wasm_tests/test_wasts.hpp
@@ -292,3 +292,117 @@ static const char table_checker_small_wast[] = R"=====(
  (elem (i32.const 0) $apple)
 )
 )=====";
+
+static const char global_protection_none_get_wast[] = R"=====(
+(module
+ (export "apply" (func $apply))
+ (func $apply (param $0 i64) (param $1 i64)
+   (drop (get_global 0))
+ )
+)
+)=====";
+
+static const char global_protection_some_get_wast[] = R"=====(
+(module
+ (global i32 (i32.const -11))
+ (global i32 (i32.const 56))
+ (export "apply" (func $apply))
+ (func $apply (param $0 i64) (param $1 i64)
+   (drop (get_global 1))
+   (drop (get_global 2))
+ )
+)
+)=====";
+
+static const char global_protection_none_set_wast[] = R"=====(
+(module
+ (export "apply" (func $apply))
+ (func $apply (param $0 i64) (param $1 i64)
+   (set_global 0 (get_local 0))
+ )
+)
+)=====";
+
+static const char global_protection_some_set_wast[] = R"=====(
+(module
+ (global i64 (i64.const -11))
+ (global i64 (i64.const 56))
+ (export "apply" (func $apply))
+ (func $apply (param $0 i64) (param $1 i64)
+   (set_global 2 (get_local 0))
+ )
+)
+)=====";
+
+static const std::vector<uint8_t> global_protection_okay_get_wasm{
+   0x00, 'a', 's', 'm', 0x01, 0x00, 0x00, 0x00,
+   0x01, 0x06, 0x01, 0x60, 0x02, 0x7e, 0x7e, 0x00,                  //type section containing a function as void(i64,i64)
+   0x03, 0x02, 0x01, 0x00,                                          //a function
+
+   0x06, 0x06, 0x01, 0x7f, 0x00, 0x41, 0x75, 0x0b,                  //global
+
+   0x07, 0x09, 0x01, 0x05, 'a', 'p', 'p', 'l', 'y', 0x00, 0x00,     //export function 0 as "apply"
+   0x0a, 0x07, 0x01,                                                //code section
+   0x05, 0x00,                                                      //function body start with length 5; no locals
+   0x23, 0x00,                                                      //get global 0
+   0x1a,                                                            //drop
+   0x0b                                                             //end
+};
+
+static const std::vector<uint8_t> global_protection_none_get_wasm{
+   0x00, 'a', 's', 'm', 0x01, 0x00, 0x00, 0x00,
+   0x01, 0x06, 0x01, 0x60, 0x02, 0x7e, 0x7e, 0x00,                  //type section containing a function as void(i64,i64)
+   0x03, 0x02, 0x01, 0x00,                                          //a function
+
+   0x07, 0x09, 0x01, 0x05, 'a', 'p', 'p', 'l', 'y', 0x00, 0x00,     //export function 0 as "apply"
+   0x0a, 0x07, 0x01,                                                //code section
+   0x05, 0x00,                                                      //function body start with length 5; no locals
+   0x23, 0x00,                                                      //get global 0
+   0x1a,                                                            //drop
+   0x0b                                                             //end
+};
+
+static const std::vector<uint8_t> global_protection_some_get_wasm{
+   0x00, 'a', 's', 'm', 0x01, 0x00, 0x00, 0x00,
+   0x01, 0x06, 0x01, 0x60, 0x02, 0x7e, 0x7e, 0x00,                  //type section containing a function as void(i64,i64)
+   0x03, 0x02, 0x01, 0x00,                                          //a function
+
+   0x06, 0x06, 0x01, 0x7f, 0x00, 0x41, 0x75, 0x0b,                  //global
+
+   0x07, 0x09, 0x01, 0x05, 'a', 'p', 'p', 'l', 'y', 0x00, 0x00,     //export function 0 as "apply"
+   0x0a, 0x07, 0x01,                                                //code section
+   0x05, 0x00,                                                      //function body start with length 5; no locals
+   0x23, 0x01,                                                      //get global 1
+   0x1a,                                                            //drop
+   0x0b                                                             //end
+};
+
+static const std::vector<uint8_t> global_protection_okay_set_wasm{
+   0x00, 'a', 's', 'm', 0x01, 0x00, 0x00, 0x00,
+   0x01, 0x06, 0x01, 0x60, 0x02, 0x7e, 0x7e, 0x00,                  //type section containing a function as void(i64,i64)
+   0x03, 0x02, 0x01, 0x00,                                          //a function
+
+   0x06, 0x06, 0x01, 0x7e, 0x01, 0x42, 0x75, 0x0b,                  //global.. this time with i64 & global mutablity
+
+   0x07, 0x09, 0x01, 0x05, 'a', 'p', 'p', 'l', 'y', 0x00, 0x00,     //export function 0 as "apply"
+   0x0a, 0x08, 0x01,                                                //code section
+   0x06, 0x00,                                                      //function body start with length 6; no locals
+   0x20, 0x00,                                                      //get local 0
+   0x24, 0x00,                                                      //set global 0
+   0x0b                                                             //end
+};
+
+static const std::vector<uint8_t> global_protection_some_set_wasm{
+   0x00, 'a', 's', 'm', 0x01, 0x00, 0x00, 0x00,
+   0x01, 0x06, 0x01, 0x60, 0x02, 0x7e, 0x7e, 0x00,                  //type section containing a function as void(i64,i64)
+   0x03, 0x02, 0x01, 0x00,                                          //a function
+
+   0x06, 0x06, 0x01, 0x7e, 0x01, 0x42, 0x75, 0x0b,                  //global.. this time with i64 & global mutablity
+
+   0x07, 0x09, 0x01, 0x05, 'a', 'p', 'p', 'l', 'y', 0x00, 0x00,     //export function 0 as "apply"
+   0x0a, 0x08, 0x01,                                                //code section
+   0x06, 0x00,                                                      //function body start with length 6; no locals
+   0x20, 0x00,                                                      //get local 0
+   0x24, 0x01,                                                      //set global 1
+   0x0b                                                             //end
+};

--- a/tests/wasm_tests/wasm_tests.cpp
+++ b/tests/wasm_tests/wasm_tests.cpp
@@ -772,4 +772,39 @@ BOOST_FIXTURE_TEST_CASE( check_table_maximum, tester ) try {
 } FC_LOG_AND_RETHROW()
 #endif
 
+BOOST_FIXTURE_TEST_CASE( protected_globals, tester ) try {
+   produce_blocks(2);
+
+   create_accounts( {N(gob)} );
+   produce_block();
+
+   BOOST_CHECK_THROW(set_code(N(gob), global_protection_none_get_wast), fc::exception);
+   produce_blocks(1);
+
+   BOOST_CHECK_THROW(set_code(N(gob), global_protection_some_get_wast), fc::exception);
+   produce_blocks(1);
+
+   BOOST_CHECK_THROW(set_code(N(gob), global_protection_none_set_wast), fc::exception);
+   produce_blocks(1);
+
+   BOOST_CHECK_THROW(set_code(N(gob), global_protection_some_set_wast), fc::exception);
+   produce_blocks(1);
+
+   //sanity to make sure I got general binary construction okay
+   set_code(N(gob), global_protection_okay_get_wasm);
+   produce_blocks(1);
+
+   BOOST_CHECK_THROW(set_code(N(gob), global_protection_none_get_wasm), fc::exception);
+   produce_blocks(1);
+
+   BOOST_CHECK_THROW(set_code(N(gob), global_protection_some_get_wasm), fc::exception);
+   produce_blocks(1);
+
+   set_code(N(gob), global_protection_okay_set_wasm);
+   produce_blocks(1);
+
+   BOOST_CHECK_THROW(set_code(N(gob), global_protection_some_set_wasm), fc::exception);
+   produce_blocks(1);
+} FC_LOG_AND_RETHROW()
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Add some unit tests to make super duper ultra sure that global index validation is being applied to WASMs. Since globals are accessed by index and are not aliasable, this means injected globals will be completely hidden from validated WASM. Using injected globals to count instructions, etc, will be much higher performance than constantly thunking out to native code since globals can very easily be promoted to registers.