### PR TITLE
Add new WASM constraint on function stack usage

### DIFF
--- a/libraries/chain/include/eosio/chain/wasm_eosio_constraints.hpp
+++ b/libraries/chain/include/eosio/chain/wasm_eosio_constraints.hpp
@@ -12,6 +12,7 @@ namespace eosio { namespace chain { namespace wasm_constraints {
    constexpr unsigned maximum_mutable_globals    = 1024;        //bytes
    constexpr unsigned maximum_table_elements     = 1024;        //elements
    constexpr unsigned maximum_linear_memory_init = 64*1024;     //bytes
+   constexpr unsigned maximum_func_local_bytes   = 8192;        //bytes
 
    static constexpr unsigned wasm_page_size      = 64*1024;
 
@@ -19,6 +20,8 @@ namespace eosio { namespace chain { namespace wasm_constraints {
    static_assert(maximum_mutable_globals%4                 == 0, "maximum_mutable_globals must be mulitple of 4");
    static_assert(maximum_table_elements*8%4096             == 0, "maximum_table_elements*8 must be mulitple of 4096");
    static_assert(maximum_linear_memory_init%wasm_page_size == 0, "maximum_linear_memory_init must be mulitple of wasm page size");
+   static_assert(maximum_func_local_bytes%8                == 0, "maximum_func_local_bytes must be mulitple of 8");
+   static_assert(maximum_func_local_bytes>32                   , "maximum_func_local_bytes must be greater than 32");
 } // namespace  wasm_constraints
 
 }} // namespace eosio, chain

--- a/libraries/chain/include/eosio/chain/wasm_eosio_validation.hpp
+++ b/libraries/chain/include/eosio/chain/wasm_eosio_validation.hpp
@@ -34,6 +34,10 @@ namespace eosio { namespace chain { namespace wasm_validations {
       static void validate( const IR::Module& m );
    };
 
+   struct maximum_function_stack_visitor {
+      static void validate( const IR::Module& m );
+   };
+
    using wasm_validate_func = std::function<void(IR::Module&)>;
 
   
@@ -295,7 +299,8 @@ namespace eosio { namespace chain { namespace wasm_validations {
       using standard_module_constraints_validators = constraints_validators< memories_validation_visitor,
                                                                              data_segments_validation_visitor,
                                                                              tables_validation_visitor,
-                                                                             globals_validation_visitor>;
+                                                                             globals_validation_visitor,
+                                                                             maximum_function_stack_visitor>;
       public:
          wasm_binary_validation( IR::Module& mod ) : _module( &mod ) {
             // initialize validators here

--- a/libraries/chain/wasm_eosio_validation.cpp
+++ b/libraries/chain/wasm_eosio_validation.cpp
@@ -59,4 +59,19 @@ void globals_validation_visitor::validate( const Module& m ) {
             ("k", wasm_constraints::maximum_mutable_globals));
 }
 
+void maximum_function_stack_visitor::validate( const IR::Module& m ) {
+   for(const FunctionDef& func : m.functions.defs) {
+      unsigned function_stack_usage = 0;
+      for(const ValueType& local : func.nonParameterLocalTypes)
+         function_stack_usage += getTypeBitWidth(local)/8;
+      for(const ValueType& params : m.types[func.type.index]->parameters)
+         function_stack_usage += getTypeBitWidth(params)/8;
+
+      if(function_stack_usage > wasm_constraints::maximum_func_local_bytes)
+         FC_THROW_EXCEPTION(wasm_execution_error, "Smart contract function has more than ${k} bytes of stack usage",
+            ("k", wasm_constraints::maximum_func_local_bytes));
+   }
+
+}
+
 }}} // namespace eosio chain validation

--- a/tests/wasm_tests/wasm_tests.cpp
+++ b/tests/wasm_tests/wasm_tests.cpp
@@ -956,4 +956,128 @@ BOOST_FIXTURE_TEST_CASE( protected_globals, tester ) try {
    produce_blocks(1);
 } FC_LOG_AND_RETHROW()
 
+BOOST_FIXTURE_TEST_CASE( lotso_stack, tester ) try {
+   produce_blocks(2);
+
+   create_accounts( {N(stackz)} );
+   produce_block();
+
+   {
+   std::stringstream ss;
+   ss << "(module ";
+   ss << "  (func ";
+   for(unsigned int i = 0; i < wasm_constraints::maximum_func_local_bytes; i+=4)
+      ss << "(local i32)";
+   ss << "  )";
+   ss << ")";
+   set_code(N(stackz), ss.str().c_str());
+   produce_blocks(1);
+   }
+   {
+   std::stringstream ss;
+   ss << "(module ";
+   ss << "  (func ";
+   for(unsigned int i = 0; i < wasm_constraints::maximum_func_local_bytes; i+=8)
+      ss << "(local f64)";
+   ss << "  )";
+   ss << ")";
+   set_code(N(stackz), ss.str().c_str());
+   produce_blocks(1);
+   }
+
+   //try to use contract with this many locals (so that it actually gets compiled). Note that
+   //at this time not having an apply() is an acceptable non-error.
+   {
+   signed_transaction trx;
+   action act;
+   act.account = N(stackz);
+   act.name = N();
+   act.authorization = vector<permission_level>{{N(stackz),config::active_name}};
+   trx.actions.push_back(act);
+
+   set_tapos(trx);
+   trx.sign(get_private_key( N(stackz), "active" ), chain_id_type());
+   push_transaction(trx);
+   }
+
+
+   //too many locals! should fail validation
+   {
+   std::stringstream ss;
+   ss << "(module ";
+   ss << "  (func ";
+   for(unsigned int i = 0; i < wasm_constraints::maximum_func_local_bytes+4; i+=4)
+      ss << "(local i32)";
+   ss << "  )";
+   ss << ")";
+   BOOST_CHECK_THROW(set_code(N(stackz), ss.str().c_str()), fc::exception);
+   produce_blocks(1);
+   }
+
+   //try again but with parameters
+   {
+   std::stringstream ss;
+   ss << "(module ";
+   ss << "  (func ";
+   for(unsigned int i = 0; i < wasm_constraints::maximum_func_local_bytes; i+=4)
+      ss << "(param i32)";
+   ss << "  )";
+   ss << ")";
+   set_code(N(stackz), ss.str().c_str());
+   produce_blocks(1);
+   }
+   //try to use contract with this many params
+   {
+   signed_transaction trx;
+   action act;
+   act.account = N(stackz);
+   act.name = N();
+   act.authorization = vector<permission_level>{{N(stackz),config::active_name}};
+   trx.actions.push_back(act);
+
+   set_tapos(trx);
+   trx.sign(get_private_key( N(stackz), "active" ), chain_id_type());
+   push_transaction(trx);
+   }
+
+   //too many params!
+   {
+   std::stringstream ss;
+   ss << "(module ";
+   ss << "  (func ";
+   for(unsigned int i = 0; i < wasm_constraints::maximum_func_local_bytes+4; i+=4)
+      ss << "(param i32)";
+   ss << "  )";
+   ss << ")";
+   BOOST_CHECK_THROW(set_code(N(stackz), ss.str().c_str()), fc::exception);
+   produce_blocks(1);
+   }
+
+   //let's mix params and locals are make sure it's counted correctly in mixed case
+   {
+   std::stringstream ss;
+   ss << "(module ";
+   ss << "  (func (param i64) (param f32) ";
+   for(unsigned int i = 12; i < wasm_constraints::maximum_func_local_bytes; i+=4)
+      ss << "(local i32)";
+   ss << "  )";
+   ss << ")";
+   set_code(N(stackz), ss.str().c_str());
+   produce_blocks(1);
+   }
+   {
+   std::stringstream ss;
+   ss << "(module ";
+   ss << "  (func (param i64) (param f32) ";
+   for(unsigned int i = 12; i < wasm_constraints::maximum_func_local_bytes+4; i+=4)
+      ss << "(local f32)";
+   ss << "  )";
+   ss << ")";
+   BOOST_CHECK_THROW(set_code(N(stackz), ss.str().c_str()), fc::exception);
+   produce_blocks(1);
+   }
+
+
+} FC_LOG_AND_RETHROW()
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Add a new constraint for each WASM function limiting the amount of stack it can use. This is  intended to bound the stack usage per function in a deterministic manner.

8192 chosen via fair dice roll. Opinions welcome.

To deterministically limit the entire stack size, another change will be required to track call depth.