### PR TITLE
Implement name limit of 12 characters #1710

### DIFF
--- a/libraries/chain/contracts/eosio_contract.cpp
+++ b/libraries/chain/contracts/eosio_contract.cpp
@@ -47,6 +47,11 @@ void apply_eosio_newaccount(apply_context& context) {
 
    auto& db = context.mutable_db;
 
+   EOS_ASSERT( create.name.to_string().size() <= 12, action_validate_exception, "account names can only be 12 chars long" );
+   if( !context.privileged ) {
+      EOS_ASSERT( name(create.name).to_string().find( "eosio." ) == std::string::npos, action_validate_exception, "only privileged accounts can have names that contain 'eosio.'" );
+   }
+
    auto existing_account = db.find<account_object, by_name>(create.name);
    EOS_ASSERT(existing_account == nullptr, action_validate_exception,
               "Cannot create account named ${name}, as that name is already taken",

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,7 +21,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/tests/config.hpp.in ${CMAKE_CURRENT_S
 file(GLOB UNIT_TESTS "chain_tests/*.cpp" "api_tests/*.cpp" "tests/abi_tests.cpp" "tests/database_tests.cpp" "tests/misc_tests.cpp" "wasm_tests/*.cpp" "tests/message_buffer_tests.cpp")
 
 add_executable( chain_test ${UNIT_TESTS} ${WASM_UNIT_TESTS} common/main.cpp )
-target_link_libraries( chain_test eosio_testing eosio_chain chainbase eos_utilities eos_egenesis_none chain_plugin abi_generator fc ${PLATFORM_SPECIFIC_LIBS} )
+target_link_libraries( chain_test eosio_testing eosio_chain chainbase eos_utilities chain_plugin abi_generator fc ${PLATFORM_SPECIFIC_LIBS} )
 
 target_include_directories( chain_test PUBLIC ${CMAKE_BINARY_DIR}/contracts ${CMAKE_CURRENT_BINARY_DIR}/tests/contracts )
 target_include_directories( chain_test PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/wasm_tests )

--- a/tests/wasm_tests/wasm_tests.cpp
+++ b/tests/wasm_tests/wasm_tests.cpp
@@ -484,13 +484,13 @@ BOOST_FIXTURE_TEST_CASE( stl_test, tester ) try {
 BOOST_FIXTURE_TEST_CASE( memory_operators, tester ) try {
    produce_blocks(2);
 
-   create_accounts( {N(current_memory)} );
+   create_accounts( {N(curmen)} );
    produce_block();
 
-   BOOST_CHECK_THROW(set_code(N(current_memory), current_memory_wast), eosio::chain::wasm_execution_error);
+   BOOST_CHECK_THROW(set_code(N(curmen), current_memory_wast), eosio::chain::wasm_execution_error);
    produce_blocks(1);
 
-   BOOST_CHECK_THROW(set_code(N(current_memory), grow_memory_wast), eosio::chain::wasm_execution_error);
+   BOOST_CHECK_THROW(set_code(N(curmen), grow_memory_wast), eosio::chain::wasm_execution_error);
    produce_blocks(1);
 
 } FC_LOG_AND_RETHROW()


### PR DESCRIPTION
- enforce that only priv accounts can contain "eosio."
- fix test that had name longer than 12 chars