### PR TITLE
DAWN 672/ GitHub#1767 - Succinct error reports from ctest/jenkins

### DIFF
--- a/libraries/chain/chain_controller.cpp
+++ b/libraries/chain/chain_controller.cpp
@@ -415,9 +415,9 @@ void chain_controller::_apply_cycle_trace( const cycle_trace& res )
                      ("a", ar.act.account)
                      ("n", ar.act.name)
                      ("r", ar.receiver));
-               std::cerr << prefix << ": CONSOLE OUTPUT BEGIN =====================" << std::endl;
-               std::cerr << ar.console;
-               std::cerr << prefix << ": CONSOLE OUTPUT END   =====================" << std::endl;
+               ilog(prefix + ": CONSOLE OUTPUT BEGIN =====================");
+               ilog(ar.console);
+               ilog(prefix + ": CONSOLE OUTPUT END   =====================");
             }
          }
       }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,8 +43,9 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/nodeos_run_remote_test.py ${CMAKE_CUR
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/consensus-validation-malicious-producers.py ${CMAKE_CURRENT_BINARY_DIR}/consensus-validation-malicious-producers.py COPYONLY)
 
 #Manually run chain_test for all supported runtimes
-add_test(NAME chain_test_binaryen COMMAND chain_test --report_level=detailed -- --binaryen)
-add_test(NAME chain_test_wavm COMMAND chain_test --report_level=detailed -- --wavm)
+#To run chain_test with all log from blockchain displayed, put --verbose after --, i.e. chain_test -- --verbose
+add_test(NAME chain_test_binaryen COMMAND chain_test --report_level=detailed --color_output -- --binaryen)
+add_test(NAME chain_test_wavm COMMAND chain_test --report_level=detailed --color_output -- --wavm)
 add_test(NAME nodeos_run_test COMMAND tests/nodeos_run_test.py -v --dump-error-detail WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 add_test(NAME nodeos_run_remote_test COMMAND tests/nodeos_run_remote_test.py --dump-error-detail WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 add_test(NAME p2p_dawn515_test COMMAND tests/p2p_tests/dawn_515/test.sh WORKING_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/tests/api_tests/api_tests.cpp
+++ b/tests/api_tests/api_tests.cpp
@@ -121,7 +121,7 @@ string U128Str(unsigned __int128 i)
 }
 
 template <typename T>
-void CallAction(tester& test, T ac, const vector<account_name>& scope = {N(testapi)}) {
+transaction_trace CallAction(tester& test, T ac, const vector<account_name>& scope = {N(testapi)}) {
    signed_transaction trx;
 
    auto pl = vector<permission_level>{{scope[0], config::active_name}};
@@ -138,10 +138,11 @@ void CallAction(tester& test, T ac, const vector<account_name>& scope = {N(testa
    auto res = test.push_transaction(trx);
    BOOST_CHECK_EQUAL(res.status, transaction_receipt::executed);
    test.produce_block();
+   return res;
 }
 
 template <typename T>
-void CallFunction(tester& test, T ac, const vector<char>& data, const vector<account_name>& scope = {N(testapi)}) {
+transaction_trace CallFunction(tester& test, T ac, const vector<char>& data, const vector<account_name>& scope = {N(testapi)}) {
 	{
 		signed_transaction trx;
 
@@ -160,6 +161,7 @@ void CallFunction(tester& test, T ac, const vector<char>& data, const vector<acc
 		auto res = test.push_transaction(trx);
 		BOOST_CHECK_EQUAL(res.status, transaction_receipt::executed);
 		test.produce_block();
+      return res;
 	}
 }
 
@@ -222,23 +224,6 @@ struct MySink : public bio::sink
    }
 };
 uint32_t last_fnc_err = 0;
-
-#define CAPTURE(STREAM, EXEC) \
-   {\
-      capture.clear(); \
-      bio::stream_buffer<MySink> sb; sb.open(MySink()); \
-      std::streambuf *oldbuf = std::STREAM.rdbuf(&sb); \
-      EXEC; \
-      std::STREAM.rdbuf(oldbuf); \
-   }
-
-#define CAPTURE_AND_PRE_TEST_PRINT(METHOD) \
-	{ \
-		BOOST_TEST_MESSAGE( "Running test_print::" << METHOD ); \
-		CAPTURE( cerr, CALL_TEST_FUNCTION( *this, "test_print", METHOD, {} ) ); \
-		BOOST_CHECK_EQUAL( capture.size(), 7 ); \
-		captured = capture[3]; \
-	}
 
 /*************************************************************************************
  * action_tests test case
@@ -625,10 +610,9 @@ BOOST_FIXTURE_TEST_CASE(transaction_tests, tester) { try {
 
    // test test_read_transaction
    // this is a bit rough, but I couldn't figure out a better way to compare the hashes
-   CAPTURE( cerr, CALL_TEST_FUNCTION( *this, "test_transaction", "test_read_transaction", {} ) );
-   BOOST_CHECK_EQUAL( capture.size(), 7 );
+   auto tx_trace = CALL_TEST_FUNCTION( *this, "test_transaction", "test_read_transaction", {} );
    string sha_expect = "bdeb5b58dda272e4b23ee7d2a5f0ff034820c156364893b758892e06fa39e7fe";
-   BOOST_CHECK_EQUAL(capture[3] == sha_expect, true);
+   BOOST_CHECK_EQUAL(tx_trace.action_traces.front().console == sha_expect, true);
    // test test_tapos_block_num
    CALL_TEST_FUNCTION(*this, "test_transaction", "test_tapos_block_num", fc::raw::pack(control->head_block_num()) );
 
@@ -755,7 +739,7 @@ BOOST_FIXTURE_TEST_CASE(db_tests, tester) { try {
 	CALL_TEST_FUNCTION( *this, "test_db", "idx64_general", {});
 	CALL_TEST_FUNCTION( *this, "test_db", "idx64_lowerbound", {});
 	CALL_TEST_FUNCTION( *this, "test_db", "idx64_upperbound", {});
-   
+
 } FC_LOG_AND_RETHROW() }
 /*************************************************************************************
  * multi_index_tests test case
@@ -1032,41 +1016,48 @@ BOOST_FIXTURE_TEST_CASE(print_tests, tester) { try {
 	string captured = "";
 
 	// test prints
-	CAPTURE_AND_PRE_TEST_PRINT("test_prints");
-	BOOST_CHECK_EQUAL(captured == "abcefg", true);
+   auto tx1_trace = CALL_TEST_FUNCTION( *this, "test_print", "test_prints", {} );
+   auto tx1_act_cnsl = tx1_trace.action_traces.front().console;
+   BOOST_CHECK_EQUAL(tx1_act_cnsl == "abcefg", true);
 
-	// test prints_l
-	CAPTURE_AND_PRE_TEST_PRINT("test_prints_l");
-	BOOST_CHECK_EQUAL(captured == "abatest", true);
+   // test prints_l
+   auto tx2_trace = CALL_TEST_FUNCTION( *this, "test_print", "test_prints_l", {} );
+   auto tx2_act_cnsl = tx2_trace.action_traces.front().console;
+   BOOST_CHECK_EQUAL(tx2_act_cnsl == "abatest", true);
 
-	// test printi
-	CAPTURE_AND_PRE_TEST_PRINT("test_printi");
-	BOOST_CHECK_EQUAL( captured.substr(0,1), I64Str(0) );
-	BOOST_CHECK_EQUAL( captured.substr(1,6), I64Str(556644) );
-	BOOST_CHECK_EQUAL( captured.substr(7, capture[3].size()), I64Str(-1) );
 
-	// test printui
-	CAPTURE_AND_PRE_TEST_PRINT("test_printui");
-	BOOST_CHECK_EQUAL( captured.substr(0,1), U64Str(0) );
-	BOOST_CHECK_EQUAL( captured.substr(1,6), U64Str(556644) );
-	BOOST_CHECK_EQUAL( captured.substr(7, capture[3].size()), U64Str(-1) ); // "18446744073709551615"
+   // test printi
+   auto tx3_trace = CALL_TEST_FUNCTION( *this, "test_print", "test_printi", {} );
+   auto tx3_act_cnsl = tx3_trace.action_traces.front().console;
+   BOOST_CHECK_EQUAL( tx3_act_cnsl.substr(0,1), I64Str(0) );
+   BOOST_CHECK_EQUAL( tx3_act_cnsl.substr(1,6), I64Str(556644) );
+   BOOST_CHECK_EQUAL( tx3_act_cnsl.substr(7, std::string::npos), I64Str(-1) );
 
-	// test printn
-	CAPTURE_AND_PRE_TEST_PRINT("test_printn");
-	BOOST_CHECK_EQUAL( captured.substr(0,5), "abcde" );
-	BOOST_CHECK_EQUAL( captured.substr(5, 5), "ab.de" );
-	BOOST_CHECK_EQUAL( captured.substr(10, 6), "1q1q1q");
-	BOOST_CHECK_EQUAL( captured.substr(16, 11), "abcdefghijk");
-	BOOST_CHECK_EQUAL( captured.substr(27, 12), "abcdefghijkl");
-	BOOST_CHECK_EQUAL( captured.substr(39, 13), "abcdefghijkl1");
-	BOOST_CHECK_EQUAL( captured.substr(52, 13), "abcdefghijkl1");
-	BOOST_CHECK_EQUAL( captured.substr(65, 13), "abcdefghijkl1");
+   // test printui
+   auto tx4_trace = CALL_TEST_FUNCTION( *this, "test_print", "test_printui", {} );
+   auto tx4_act_cnsl = tx4_trace.action_traces.front().console;
+   BOOST_CHECK_EQUAL( tx4_act_cnsl.substr(0,1), U64Str(0) );
+   BOOST_CHECK_EQUAL( tx4_act_cnsl.substr(1,6), U64Str(556644) );
+   BOOST_CHECK_EQUAL( tx4_act_cnsl.substr(7, std::string::npos), U64Str(-1) ); // "18446744073709551615"
 
-	// test printi128
-	CAPTURE_AND_PRE_TEST_PRINT("test_printi128");
-	BOOST_CHECK_EQUAL( captured.substr(0, 39), U128Str(-1) );
-	BOOST_CHECK_EQUAL( captured.substr(39, 1), U128Str(0) );
-	BOOST_CHECK_EQUAL( captured.substr(40, 11), U128Str(87654323456) );
+   // test printn
+   auto tx5_trace = CALL_TEST_FUNCTION( *this, "test_print", "test_printn", {} );
+   auto tx5_act_cnsl = tx5_trace.action_traces.front().console;
+   BOOST_CHECK_EQUAL( tx5_act_cnsl.substr(0,5), "abcde" );
+   BOOST_CHECK_EQUAL( tx5_act_cnsl.substr(5, 5), "ab.de" );
+   BOOST_CHECK_EQUAL( tx5_act_cnsl.substr(10, 6), "1q1q1q");
+   BOOST_CHECK_EQUAL( tx5_act_cnsl.substr(16, 11), "abcdefghijk");
+   BOOST_CHECK_EQUAL( tx5_act_cnsl.substr(27, 12), "abcdefghijkl");
+   BOOST_CHECK_EQUAL( tx5_act_cnsl.substr(39, 13), "abcdefghijkl1");
+   BOOST_CHECK_EQUAL( tx5_act_cnsl.substr(52, 13), "abcdefghijkl1");
+   BOOST_CHECK_EQUAL( tx5_act_cnsl.substr(65, 13), "abcdefghijkl1");
+
+   // test printi128
+   auto tx6_trace = CALL_TEST_FUNCTION( *this, "test_print", "test_printi128", {} );
+   auto tx6_act_cnsl = tx6_trace.action_traces.front().console;
+   BOOST_CHECK_EQUAL( tx6_act_cnsl.substr(0, 39), U128Str(-1) );
+   BOOST_CHECK_EQUAL( tx6_act_cnsl.substr(39, 1), U128Str(0) );
+   BOOST_CHECK_EQUAL( tx6_act_cnsl.substr(40, 11), U128Str(87654323456) );
 
 } FC_LOG_AND_RETHROW() }
 

--- a/tests/common/main.cpp
+++ b/tests/common/main.cpp
@@ -5,10 +5,24 @@
 #include <cstdlib>
 #include <iostream>
 #include <boost/test/included/unit_test.hpp>
-
+#include <fc/log/logger.hpp>
 //extern uint32_t EOS_TESTING_GENESIS_TIMESTAMP;
 
+
+
 boost::unit_test::test_suite* init_unit_test_suite(int argc, char* argv[]) {
+   // Turn off blockchain logging if no --verbose parameter is not added
+   // To have verbose enabled, call "tests/chain_test --report_level=detailed -- --verbose"
+   bool is_verbose = false;
+   std::string verbose_arg = "--verbose";
+   for (int i = 0; i < argc; i++) {
+      if (verbose_arg == argv[i]) {
+         is_verbose = true;
+         break;
+      }
+   }
+   if(!is_verbose) fc::logger::get(DEFAULT_LOGGER).set_log_level(fc::log_level::off);
+
    std::srand(time(NULL));
    std::cout << "Random number generator seeded to " << time(NULL) << std::endl;
    /*

--- a/tests/tests/abi_tests.cpp
+++ b/tests/tests/abi_tests.cpp
@@ -12,13 +12,14 @@
 #include <fc/variant.hpp>
 #include <fc/io/json.hpp>
 #include <fc/exception/exception.hpp>
+#include <fc/log/logger.hpp>
 
 #include <eosio/chain/contracts/chain_initializer.hpp>
 #include <eosio/chain/contracts/abi_serializer.hpp>
 #include <eosio/abi_generator/abi_generator.hpp>
 
 #include "config.hpp"
-
+#include <boost/test/framework.hpp>
 using namespace eosio;
 using namespace chain;
 using namespace chain::contracts;
@@ -33,8 +34,6 @@ fc::variant verify_byte_round_trip_conversion( const abi_serializer& abis, const
    auto var2 = abis.binary_to_variant(type, bytes);
 
    std::string r = fc::json::to_string(var2);
-
-   std::cout << r << std::endl;
 
    auto bytes2 = abis.variant_to_binary(type, var2);
 
@@ -64,7 +63,6 @@ fc::variant verify_type_round_trip_conversion( const abi_serializer& abis, const
 
    std::string r = fc::json::to_string(var2);
 
-   std::cout << r << std::endl;
 
    auto bytes2 = abis.variant_to_binary(type, var2);
 
@@ -414,8 +412,9 @@ struct abi_gen_helper {
     auto e = fc::to_hex(fc::raw::pack(abi1)) == fc::to_hex(fc::raw::pack(output));
 
     if(!e) {
-      std::cout << "expected: " <<  std::endl << fc::json::to_pretty_string(abi1) << std::endl << std::endl;
-      std::cout << "generated: " <<  std::endl << fc::json::to_pretty_string(output) << std::endl << std::endl;
+      BOOST_TEST_MESSAGE("Generate ABI:\n" <<
+                        "expected: \n" << fc::json::to_pretty_string(abi1) << "\n" <<
+                        "generated: \n" << fc::json::to_pretty_string(output));
     }
 
     return e;
@@ -1898,7 +1897,9 @@ BOOST_AUTO_TEST_CASE(abi_cycle)
    auto abi = chain_initializer::eos_contract_abi(fc::json::from_string(typedef_cycle_abi).as<abi_def>());
    abi_serializer abis(abi);
 
-   auto is_assert_exception = [](fc::assert_exception const & e) -> bool { std::cout << e.to_string() << std::endl; return true; };
+   auto is_assert_exception = [](fc::assert_exception const & e) -> bool {
+      wlog(e.to_string()); return true;
+   };
    BOOST_CHECK_EXCEPTION( abis.validate(), fc::assert_exception, is_assert_exception );
 
    abi = fc::json::from_string(struct_cycle_abi).as<abi_def>();


### PR DESCRIPTION
Suppress the log from blockchain by redirecting all of the output to `fc_log` and set the `log_level` to `off` for chain_test. Also enable color_output, so the error message is easier to read.
Now it looks like the following:
<img width="912" alt="screen shot 2018-03-23 at 3 46 45 pm" src="https://user-images.githubusercontent.com/6541441/37850545-e9be7fe0-2eb1-11e8-8842-d4a38e677f0f.png">

DAWN 672/ GitHub#1767