### PR TITLE
Mongo tests jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,11 +60,6 @@ pipeline {
                             archiveArtifacts 'build/tn_data_00/stderr.txt'
                             archiveArtifacts 'build/test_walletd_output.log'
                         }
-                        always {
-                            sh '''
-                                /usr/bin/mongod --shutdown
-                            '''
-                        }
                     }
                 }
                 stage('MacOS') {
@@ -86,11 +81,6 @@ pipeline {
                             archiveArtifacts 'build/tn_data_00/config.ini'
                             archiveArtifacts 'build/tn_data_00/stderr.txt'
                             archiveArtifacts 'build/test_walletd_output.log'
-                        }
-                        always {
-                            sh '''
-                                /usr/local/bin/mongod --shutdown
-                            '''
                         }
                     }
                 }
@@ -116,11 +106,6 @@ pipeline {
                             archiveArtifacts 'build/tn_data_00/config.ini'
                             archiveArtifacts 'build/tn_data_00/stderr.txt'
                             archiveArtifacts 'build/test_walletd_output.log'
-                        }
-                        always {
-                            sh '''
-                                /usr/bin/mongod --shutdown
-                            '''
                         }
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,7 +43,9 @@ pipeline {
                         unstash 'buildUbuntu'
                         sh '''
                             . $HOME/.bash_profile
-                            mongod -f /etc/mongod.conf > /dev/null 2>&1 &
+                            if ! pgrep mongod &>/dev/null;
+                                mongod -f /etc/mongod.conf > /dev/null 2>&1 &
+                            fi
                             cd build
                             printf "Waiting for testing to be available..."
                             while /usr/bin/pgrep -x ctest > /dev/null; do sleep 1; done
@@ -71,7 +73,9 @@ pipeline {
                         unstash 'buildMacOS'
                         sh '''
                             . $HOME/.bash_profile
-                            mongod -f /usr/local/etc/mongod.conf > /dev/null 2>&1 &
+                            if ! pgrep mongod &>/dev/null;
+                                mongod -f /etc/mongod.conf > /dev/null 2>&1 &
+                            fi
                             cd build
                             ctest --output-on-failure
                         '''
@@ -96,7 +100,9 @@ pipeline {
                         unstash 'buildFedora'
                         sh '''
                             . $HOME/.bash_profile
-                            mongod -f /etc/mongod.conf > /dev/null 2>&1 &
+                            if ! pgrep mongod &>/dev/null;
+                                mongod -f /etc/mongod.conf > /dev/null 2>&1 &
+                            fi
                             cd build
                             printf "Waiting for testing to be available..."
                             while /usr/bin/pgrep -x ctest > /dev/null; do sleep 1; done

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,8 +43,8 @@ pipeline {
                         unstash 'buildUbuntu'
                         sh '''
                             . $HOME/.bash_profile
-                            if ! pgrep mongod &>/dev/null;
-                                mongod -f /etc/mongod.conf > /dev/null 2>&1 &
+                            if ! /usr/bin/pgrep mongod &>/dev/null;
+                                /usr/bin/mongod -f /etc/mongod.conf > /dev/null 2>&1 &
                             fi
                             cd build
                             printf "Waiting for testing to be available..."
@@ -62,7 +62,7 @@ pipeline {
                         }
                         always {
                             sh '''
-                                mongod --shutdown
+                                /usr/bin/mongod --shutdown
                             '''
                         }
                     }
@@ -73,8 +73,8 @@ pipeline {
                         unstash 'buildMacOS'
                         sh '''
                             . $HOME/.bash_profile
-                            if ! pgrep mongod &>/dev/null;
-                                mongod -f /etc/mongod.conf > /dev/null 2>&1 &
+                            if ! /usr/bin/pgrep mongod &>/dev/null;
+                                /usr/bin/mongod -f /etc/mongod.conf > /dev/null 2>&1 &
                             fi
                             cd build
                             ctest --output-on-failure
@@ -89,7 +89,7 @@ pipeline {
                         }
                         always {
                             sh '''
-                                mongod --shutdown
+                                /usr/bin/mongod --shutdown
                             '''
                         }
                     }
@@ -100,8 +100,8 @@ pipeline {
                         unstash 'buildFedora'
                         sh '''
                             . $HOME/.bash_profile
-                            if ! pgrep mongod &>/dev/null;
-                                mongod -f /etc/mongod.conf > /dev/null 2>&1 &
+                            if ! /usr/bin/pgrep mongod &>/dev/null;
+                                /usr/bin/mongod -f /etc/mongod.conf > /dev/null 2>&1 &
                             fi
                             cd build
                             printf "Waiting for testing to be available..."
@@ -119,7 +119,7 @@ pipeline {
                         }
                         always {
                             sh '''
-                                mongod --shutdown
+                                /usr/bin/mongod --shutdown
                             '''
                         }
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,7 +43,7 @@ pipeline {
                         unstash 'buildUbuntu'
                         sh '''
                             . $HOME/.bash_profile
-                            if ! /usr/bin/pgrep mongod &>/dev/null;
+                            if ! /usr/bin/pgrep mongod &>/dev/null; then
                                 /usr/bin/mongod -f /etc/mongod.conf > /dev/null 2>&1 &
                             fi
                             cd build
@@ -73,8 +73,8 @@ pipeline {
                         unstash 'buildMacOS'
                         sh '''
                             . $HOME/.bash_profile
-                            if ! /usr/bin/pgrep mongod &>/dev/null;
-                                /usr/bin/mongod -f /etc/mongod.conf > /dev/null 2>&1 &
+                            if ! /usr/bin/pgrep mongod &>/dev/null; then
+                                /usr/local/bin/mongod -f /usr/local/etc/mongod.conf > /dev/null 2>&1 &
                             fi
                             cd build
                             ctest --output-on-failure
@@ -89,7 +89,7 @@ pipeline {
                         }
                         always {
                             sh '''
-                                /usr/bin/mongod --shutdown
+                                /usr/local/bin/mongod --shutdown
                             '''
                         }
                     }
@@ -100,7 +100,7 @@ pipeline {
                         unstash 'buildFedora'
                         sh '''
                             . $HOME/.bash_profile
-                            if ! /usr/bin/pgrep mongod &>/dev/null;
+                            if ! /usr/bin/pgrep mongod &>/dev/null; then
                                 /usr/bin/mongod -f /etc/mongod.conf > /dev/null 2>&1 &
                             fi
                             cd build


### PR DESCRIPTION
Currently, mongod is starting in eosio_build.sh. With Jenkins, the builds and tests are not always performed on the same machines. As such, tests are failing due to the absence of a running mongod.

To correct this, mongod is started at the beginning of the test stage in Jenkins, and terminated upon completion.