### PR TITLE
Fix disk space detecting issues if showing with TB instead of GB.

### DIFF
--- a/scripts/eosio_build_centos.sh
+++ b/scripts/eosio_build_centos.sh
@@ -7,8 +7,10 @@
 	CPU_CORE=$( lscpu | grep "^CPU(s)" | tr -s ' ' | cut -d\  -f2 )
 
 	DISK_INSTALL=`df -h . | tail -1 | tr -s ' ' | cut -d\  -f1`
-	DISK_TOTAL=`df -h . | tail -1 | tr -s ' ' | cut -d\  -f2 | sed 's/[^0-9\.]//g'`
-	DISK_AVAIL=`df -h . | tail -1 | tr -s ' ' | cut -d\  -f4 | sed 's/[^0-9\.]//g'`
+	DISK_TOTAL_KB=`df . | tail -1 | awk '{print $2}'`
+	DISK_AVAIL_KB=`df . | tail -1 | awk '{print $4}'`
+	DISK_TOTAL=$(( $DISK_TOTAL_KB / 1048576 ))
+	DISK_AVAIL=$(( $DISK_AVAIL_KB / 1048576 ))
 
 	printf "\n\tOS name: $OS_NAME\n"
 	printf "\tOS Version: ${OS_VER}\n"

--- a/scripts/eosio_build_fedora.sh
+++ b/scripts/eosio_build_fedora.sh
@@ -6,8 +6,10 @@
 	CPU_CORE=$( lscpu | grep "^CPU(s)" | tr -s ' ' | cut -d\  -f2 )
 
 	DISK_INSTALL=`df -h . | tail -1 | tr -s ' ' | cut -d\  -f1`
-	DISK_TOTAL=`df -h . | tail -1 | tr -s ' ' | cut -d\  -f2 | sed 's/[^0-9\.]//g'`
-	DISK_AVAIL=`df -h . | tail -1 | tr -s ' ' | cut -d\  -f4 | sed 's/[^0-9\.]//g'`
+	DISK_TOTAL_KB=`df . | tail -1 | awk '{print $2}'`
+	DISK_AVAIL_KB=`df . | tail -1 | awk '{print $4}'`
+	DISK_TOTAL=$(( $DISK_TOTAL_KB / 1048576 ))
+	DISK_AVAIL=$(( $DISK_AVAIL_KB / 1048576 ))
 
 	printf "\n\tOS name: $OS_NAME\n"
 	printf "\tOS Version: ${OS_VER}\n"

--- a/scripts/eosio_build_ubuntu.sh
+++ b/scripts/eosio_build_ubuntu.sh
@@ -8,8 +8,10 @@
 	CPU_CORE=$( lscpu | grep "^CPU(s)" | tr -s ' ' | cut -d\  -f2 )
 
 	DISK_INSTALL=`df -h . | tail -1 | tr -s ' ' | cut -d\  -f1`
-	DISK_TOTAL=`df -h . | tail -1 | tr -s ' ' | cut -d\  -f2 | sed 's/[^0-9\.]//g'`
-	DISK_AVAIL=`df -h . | tail -1 | tr -s ' ' | cut -d\  -f4 | sed 's/[^0-9\.]//g'`
+	DISK_TOTAL_KB=`df . | tail -1 | awk '{print $2}'`
+	DISK_AVAIL_KB=`df . | tail -1 | awk '{print $4}'`
+	DISK_TOTAL=$(( $DISK_TOTAL_KB / 1048576 ))
+	DISK_AVAIL=$(( $DISK_AVAIL_KB / 1048576 ))
 
 	printf "\n\tOS name: $OS_NAME\n"
 	printf "\tOS Version: ${OS_VER}\n"


### PR DESCRIPTION
Similar to pull request #1496 .  
Detects & computes disk space with KB, then transforms to GB.
Fix on Ubuntu, CentOS and Federa.