### PR TITLE
Resurrect wasm unit test with new “OOB” wasm unit tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -44,8 +44,8 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/consensus-validation-malicious-produc
 
 #Manually run chain_test for all supported runtimes
 #To run chain_test with all log from blockchain displayed, put --verbose after --, i.e. chain_test -- --verbose
-add_test(NAME chain_test_binaryen COMMAND chain_test --report_level=detailed --color_output -- --binaryen)
-add_test(NAME chain_test_wavm COMMAND chain_test --report_level=detailed --color_output -- --wavm)
+add_test(NAME chain_test_binaryen COMMAND chain_test -t +oob_wasm_tests --report_level=detailed --color_output -- --binaryen)
+add_test(NAME chain_test_wavm COMMAND chain_test -t +oob_wasm_tests --catch_system_errors=no --report_level=detailed --color_output -- --wavm)
 #add_test(NAME nodeos_run_test COMMAND tests/nodeos_run_test.py -v --dump-error-detail WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 # add_test(NAME nodeos_run_remote_test COMMAND tests/nodeos_run_remote_test.py --dump-error-detail WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 add_test(NAME p2p_dawn515_test COMMAND tests/p2p_tests/dawn_515/test.sh WORKING_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/tests/wasm_tests/oob_test_wasts.hpp
+++ b/tests/wasm_tests/oob_test_wasts.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+// These are handcrafted or otherwise tricky to generate with our tool chain
+
+static const char table_oob_wast[] = R"=====(
+(module
+ (import "env" "eosio_assert" (func $assert (param i32 i32)))
+ (import "env" "printi" (func $printi (param i64)))
+ (type $SIG$vj (func (param i64)))
+ (table 128 anyfunc)
+ (memory $0 1)
+ (export "apply" (func $apply))
+ (func $apply (param $0 i64) (param $1 i64)
+   (call_indirect (type $SIG$vj)
+     (i64.shr_u
+       (get_local $1)
+       (i64.const 32)
+     )
+     (i32.wrap/i64
+       (get_local $1)
+     )
+   )
+ )
+ (func $apple (type $SIG$vj) (param $0 i64)
+   (call $assert
+     (i64.eq
+       (get_local $0)
+       (i64.const 555)
+     )
+     (i32.const 0)
+   )
+ )
+ (elem (i32.const 0) $apple)
+)
+)=====";

--- a/tests/wasm_tests/oob_wasm_tests.cpp
+++ b/tests/wasm_tests/oob_wasm_tests.cpp
@@ -1,0 +1,44 @@
+#include <boost/test/unit_test.hpp>
+#include <eosio/testing/tester.hpp>
+#include <eosio/chain/wasm_eosio_constraints.hpp>
+#include <eosio/chain/chain_controller.hpp>
+#include <eosio/chain/exceptions.hpp>
+
+#include "oob_test_wasts.hpp"
+
+#include <array>
+#include <utility>
+
+using namespace eosio;
+using namespace eosio::chain;
+using namespace eosio::chain::contracts;
+using namespace eosio::testing;
+
+
+BOOST_AUTO_TEST_SUITE(oob_wasm_tests, *boost::unit_test::disabled())
+
+BOOST_FIXTURE_TEST_CASE( oob_table_access, tester ) try {
+   produce_blocks(2);
+
+   create_accounts( {N(tbl)} );
+   produce_block();
+
+   set_code(N(tbl), table_oob_wast);
+   produce_blocks(1);
+
+   {
+   signed_transaction trx;
+   action act;
+   act.name = 888ULL;
+   act.account = N(tbl);
+   act.authorization = vector<permission_level>{{N(tbl),config::active_name}};
+   trx.actions.push_back(act);
+   set_tapos(trx);
+   trx.sign(get_private_key( N(tbl), "active" ), chain_id_type());
+
+   //an element that is out of range, but within element maximum, and has no mmap access permission either (should be a trapped segv)
+   BOOST_CHECK_EXCEPTION(push_transaction(trx), eosio::chain::wasm_execution_error, [](const eosio::chain::wasm_execution_error &e) {return true;});
+   }
+} FC_LOG_AND_RETHROW()
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/wasm_tests/wasm_tests.cpp
+++ b/tests/wasm_tests/wasm_tests.cpp
@@ -873,7 +873,7 @@ BOOST_FIXTURE_TEST_CASE( check_table_maximum, tester ) try {
    }
 
    produce_blocks(1);
-#if 0
+
    {
    signed_transaction trx;
    action act;
@@ -885,24 +885,6 @@ BOOST_FIXTURE_TEST_CASE( check_table_maximum, tester ) try {
    trx.sign(get_private_key( N(tbl), "active" ), chain_id_type());
    push_transaction(trx);
    }
-   set_code(N(tbl), table_checker_small_wast);
-   produce_blocks(1);
-
-   {
-   signed_transaction trx;
-   action act;
-   act.name = 888ULL;
-   act.account = N(tbl);
-   act.authorization = vector<permission_level>{{N(tbl),config::active_name}};
-   trx.actions.push_back(act);
-   set_tapos(trx);
-   trx.sign(get_private_key( N(tbl), "active" ), chain_id_type());
-
-   //an element that is out of range and has no mmap access permission either (should be a trapped segv)
-   BOOST_CHECK_EXCEPTION(push_transaction(trx), eosio::chain::wasm_execution_error, [](const eosio::chain::wasm_execution_error &e) {return true;});
-   }
-#endif
-
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( protected_globals, tester ) try {


### PR DESCRIPTION
We have a unit test that is #if 0ed (and some additional unit tests incoming) that attempt to access out of bounds memory. WAVM handles this cleanly by trapping the SEGV and then we retire the transaction as a failure.

However in chain_test the Boost Test framework by default tries to grab SEGV for itself. So depending on the tests that execute WAVM will be unable to trap the SEGV and instead it will be bubbled up to Boost Test as a test failure.

I tried a few approaches to resolve this cleanly but long story short nothing great came about. I need to set --catch_system_errors=no for operation in WAVM but I could not figure out an appropriate way of easily doing this at runtime via code. So.. adding it to ctest command.

But, I can’t have those troublesome tests run when someone just simply runs ‘chain_test’. Originally I tried to dynamically add/remove the oob tests based on if --catch_system_errors=no was set and/or we were running WAVM or not. But unfortunately disabled _at runtime_ tests are considered “skipped” by Boost Test which actually results in a failure return code.

So instead require these OOB tests to be opted in to manually… Added in the ctest file.

Fixes #1823