### PR TITLE
#1616 - Asset symbol without .

### DIFF
--- a/libraries/chain/asset.cpp
+++ b/libraries/chain/asset.cpp
@@ -6,6 +6,7 @@
 #include <boost/rational.hpp>
 #include <boost/multiprecision/cpp_int.hpp>
 #include <fc/reflect/variant.hpp>
+#include <eosio/chain/exceptions.hpp>
 
 namespace eosio { namespace chain {
 typedef boost::multiprecision::int128_t  int128_t;
@@ -34,37 +35,46 @@ string asset::to_string()const {
 
 asset asset::from_string(const string& from)
 {
-   try { 
-      string s = fc::trim(from);
-      auto dot_pos = s.find(".");
-      FC_ASSERT(dot_pos != string::npos, "dot missing in asset from string");
-      auto space_pos = s.find(" ", dot_pos);
-      FC_ASSERT(space_pos != string::npos, "space missing in asset from string");
-
+   try {
       asset result;
-      
-      auto intpart = s.substr(0, dot_pos);
-      result.amount = fc::to_int64(intpart);
-      string symbol_part;
-      if (dot_pos != string::npos && space_pos != string::npos) {
-         symbol_part = eosio::chain::to_string(space_pos - dot_pos - 1);
-         symbol_part += ',';
-         symbol_part += s.substr(space_pos + 1);
-      }
-      result.sym = symbol::from_string(symbol_part);
+
+      string s = fc::trim(from);
+
+      // Find space in order to split amount and symbol
+      auto space_pos = s.find(' ');
+      EOS_ASSERT((space_pos != string::npos), asset_type_exception, "Asset's amount and symbol should be separated with space");
+      auto symbol_str = fc::trim(s.substr(space_pos + 1));
+      auto amount_str = s.substr(0, space_pos);
+
+      // Ensure that if decimal point is used (.), decimal fraction is specified
+      auto dot_pos = amount_str.find('.');
       if (dot_pos != string::npos) {
-         auto fractpart = "1" + s.substr(dot_pos + 1, space_pos - dot_pos - 1);
-         
-         result.amount *= int64_t(result.precision());
-         if ( intpart[0] == '-' ) {
-            result.amount -= int64_t(fc::to_int64(fractpart));
-            result.amount += int64_t(result.precision());
-         } else {
-            result.amount += int64_t(fc::to_int64(fractpart));
-            result.amount -= int64_t(result.precision());
-         }
-         
+         EOS_ASSERT((dot_pos != amount_str.size() - 1), asset_type_exception, "Missing decimal fraction after decimal point");
       }
+
+      // Parse symbol
+      string precision_digit_str;
+      if (dot_pos != string::npos) {
+         precision_digit_str = eosio::chain::to_string(amount_str.size() - dot_pos - 1);
+      } else {
+         precision_digit_str = "0";
+      }
+      string symbol_part = precision_digit_str + ',' + symbol_str;
+      result.sym = symbol::from_string(symbol_part);
+
+      // Parse amount
+      int64_t int_part, fract_part = 0;
+      if (dot_pos != string::npos) {
+         int_part = fc::to_int64(amount_str.substr(0, dot_pos));
+         fract_part = fc::to_int64(amount_str.substr(dot_pos + 1));
+         if (amount_str[0] == '-') fract_part *= -1;
+      } else {
+         int_part = fc::to_int64(amount_str);
+      }
+      result.amount = int_part;
+      result.amount *= int64_t(result.precision());
+      result.amount += fract_part;
+
       return result;
    }
    FC_CAPTURE_LOG_AND_RETHROW( (from) )

--- a/libraries/chain/include/eosio/chain/exceptions.hpp
+++ b/libraries/chain/include/eosio/chain/exceptions.hpp
@@ -62,6 +62,7 @@ namespace eosio { namespace chain {
    FC_DECLARE_DERIVED_EXCEPTION( action_type_exception,             eosio::chain::chain_type_exception, 3120004, "Invalid action" )
    FC_DECLARE_DERIVED_EXCEPTION( transaction_type_exception,        eosio::chain::chain_type_exception, 3120005, "Invalid transaction" )
    FC_DECLARE_DERIVED_EXCEPTION( abi_type_exception,                eosio::chain::chain_type_exception, 3120006, "Invalid ABI" )
+   FC_DECLARE_DERIVED_EXCEPTION( asset_type_exception,              eosio::chain::chain_type_exception, 3120007, "Invalid asset" )
 
    FC_DECLARE_DERIVED_EXCEPTION( missing_chain_api_plugin_exception,                 eosio::chain::missing_plugin_exception, 3130001, "Missing Chain API Plugin" )
    FC_DECLARE_DERIVED_EXCEPTION( missing_wallet_api_plugin_exception,                eosio::chain::missing_plugin_exception, 3130002, "Missing Wallet API Plugin" )

--- a/libraries/chain/include/eosio/chain/symbol.hpp
+++ b/libraries/chain/include/eosio/chain/symbol.hpp
@@ -42,7 +42,7 @@ namespace eosio {
             while(str[len]) ++len;
             uint64_t result = 0;
             for (uint32_t i = 0; i < len; ++i) {
-               // All characters must be upper case alaphabets
+               // All characters must be upper case alphabets
                FC_ASSERT (str[i] >= 'A' && str[i] <= 'Z', "invalid character in symbol name");
                result |= (uint64_t(str[i]) << (8*(i+1)));
             }
@@ -64,7 +64,6 @@ namespace eosio {
                   FC_ASSERT(comma_pos != string::npos, "missing comma in symbol");
                   auto prec_part = s.substr(0, comma_pos);
                   uint8_t p = fc::to_int64(prec_part);
-                  FC_ASSERT(p > 0, "zero decimals in symbol");
                   string name_part = s.substr(comma_pos + 1);
                   return symbol(string_to_symbol(p, name_part.c_str()));
                } FC_CAPTURE_LOG_AND_RETHROW((from))
@@ -72,7 +71,6 @@ namespace eosio {
             uint64_t value() const { return m_value; }
             bool valid() const
             {
-               if (decimals() == 0) return false;
                const auto& s = name();
                return valid_name(s);
             }

--- a/tests/wasm_tests/currency_tests.cpp
+++ b/tests/wasm_tests/currency_tests.cpp
@@ -315,6 +315,22 @@ BOOST_FIXTURE_TEST_CASE(test_symbol, tester) try {
       BOOST_REQUIRE_EQUAL(a.symbol_name(), "CUR");
    }
 
+   // Negative asset
+   {
+      asset a = asset::from_string("-001000000.00010 CUR");
+      BOOST_REQUIRE_EQUAL(a.amount, -100000000010);
+      BOOST_REQUIRE_EQUAL(a.decimals(), 5);
+      BOOST_REQUIRE_EQUAL(a.symbol_name(), "CUR");
+   }
+
+   // Negative asset below 1
+   {
+      asset a = asset::from_string("-000000000.00100 CUR");
+      BOOST_REQUIRE_EQUAL(a.amount, -100);
+      BOOST_REQUIRE_EQUAL(a.decimals(), 5);
+      BOOST_REQUIRE_EQUAL(a.symbol_name(), "CUR");
+   }
+
 } FC_LOG_AND_RETHROW() /// test_symbol
 
 BOOST_FIXTURE_TEST_CASE( test_proxy, currency_tester ) try {


### PR DESCRIPTION
Allow asset symbol without '.', this will default to an asset with 0 decimal values.
This PR also modify previous unit tests where it rejects asset without '.', and add some additional unit test cases related to asset and symbol parsing.

#1616 