### PR TITLE
Delayed Transactions

### DIFF
--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -355,6 +355,17 @@ int apply_context::get_context_free_data( uint32_t index, char* buffer, size_t b
    return s;
 }
 
+uint32_t apply_context::get_next_sender_id() {
+   require_write_lock( config::eosio_auth_scope );
+   const auto& t_id = find_or_create_table(config::system_account_name, config::eosio_auth_scope, N(deferred.seq));
+   uint64_t key = N(config::eosio_auth_scope);
+   uint32_t next_serial = 0;
+   front_record<contracts::key_value_index, contracts::by_scope_primary>(t_id, &key, (char *)&next_serial, sizeof(uint32_t));
+
+   uint32_t result = next_serial++;
+   store_record<key_value_object>(t_id, config::system_account_name, &key, (char *)&next_serial, sizeof(uint32_t));
+   return result;
+}
 
 int apply_context::db_store_i64( uint64_t scope, uint64_t table, const account_name& payer, uint64_t id, const char* buffer, size_t buffer_size ) {
    require_write_lock( scope );

--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -363,14 +363,20 @@ int apply_context::get_context_free_data( uint32_t index, char* buffer, size_t b
 }
 
 uint32_t apply_context::get_next_sender_id() {
-   require_write_lock( config::eosio_auth_scope );
-   const auto& t_id = find_or_create_table(config::system_account_name, config::eosio_auth_scope, N(deferred.seq));
-   uint64_t key = N(config::eosio_auth_scope);
-   uint32_t next_serial = 0;
-   front_record<contracts::key_value_index, contracts::by_scope_primary>(t_id, &key, (char *)&next_serial, sizeof(uint32_t));
+   const uint64_t id = N(config::eosio_auth_scope);
+   const auto table = N(deferred.seq);
+   const auto payer = config::system_account_name;
+   const auto iter = db_find_i64(config::system_account_name, config::eosio_auth_scope, table, id);
+   if (iter == -1) {
+      const uint32_t next_serial = 1;
+      db_store_i64(config::system_account_name, config::eosio_auth_scope, table, payer, id, (const char*)&next_serial, sizeof(next_serial));
+      return 0;
+   }
 
-   uint32_t result = next_serial++;
-   store_record<key_value_object>(t_id, config::system_account_name, &key, (char *)&next_serial, sizeof(uint32_t));
+   uint32_t next_serial = 0;
+   db_get_i64(iter, (char*)&next_serial, sizeof(next_serial));
+   const auto result = next_serial++;
+   db_update_i64(iter, payer, (const char*)&next_serial, sizeof(next_serial));
    return result;
 }
 

--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -381,8 +381,12 @@ uint32_t apply_context::get_next_sender_id() {
 }
 
 int apply_context::db_store_i64( uint64_t scope, uint64_t table, const account_name& payer, uint64_t id, const char* buffer, size_t buffer_size ) {
+   return db_store_i64( receiver, scope, table, payer, id, buffer, buffer_size);
+}
+
+int apply_context::db_store_i64( uint64_t code, uint64_t scope, uint64_t table, const account_name& payer, uint64_t id, const char* buffer, size_t buffer_size ) {
    require_write_lock( scope );
-   const auto& tab = find_or_create_table( receiver, scope, table );
+   const auto& tab = find_or_create_table( code, scope, table );
    auto tableid = tab.id;
 
    FC_ASSERT( payer != account_name(), "must specify a valid account to pay for new record" );

--- a/libraries/chain/chain_controller.cpp
+++ b/libraries/chain/chain_controller.cpp
@@ -1614,7 +1614,7 @@ vector<transaction_trace> chain_controller::push_deferred_transactions( bool flu
    auto& generated_index = generated_transaction_idx.indices().get<by_delay>();
    vector<const generated_transaction_object*> candidates;
 
-   for( auto itr = generated_index.rbegin(); itr != generated_index.rend() && (head_block_time() >= itr->delay_until); ++itr) {
+   for( auto itr = generated_index.begin(); itr != generated_index.end() && (head_block_time() >= itr->delay_until); ++itr) {
       const auto &gtrx = *itr;
       candidates.emplace_back(&gtrx);
    }

--- a/libraries/chain/chain_controller.cpp
+++ b/libraries/chain/chain_controller.cpp
@@ -298,14 +298,13 @@ transaction_trace chain_controller::_push_transaction(const packed_transaction& 
       deferred_transaction dtrx(context.get_next_sender_id(), config::system_account_name, execute_after, trx);
       FC_ASSERT( dtrx.execute_after < dtrx.expiration, "transaction expires before it can execute" );
 
-      result.deferred_transactions.push_back(std::move(dtrx));
+      result.deferred_transaction_requests.push_back(std::move(dtrx));
 
       // notify anyone listening to pending transactions
       on_pending_transaction(std::move(mtrx), packed_trx);
 
-      store_deferred_transaction(result.deferred_transactions[0]);
+      store_deferred_transaction(result.deferred_transaction_requests[0].get<deferred_transaction>());
    }
-
    return result;
 
 } FC_CAPTURE_AND_RETHROW() }

--- a/libraries/chain/contracts/chain_initializer.cpp
+++ b/libraries/chain/contracts/chain_initializer.cpp
@@ -46,6 +46,8 @@ void chain_initializer::register_types(chain_controller& chain, chainbase::datab
    SET_APP_HANDLER( eosio, eosio, postrecovery, eosio );
    SET_APP_HANDLER( eosio, eosio, passrecovery, eosio );
    SET_APP_HANDLER( eosio, eosio, vetorecovery, eosio );
+   SET_APP_HANDLER( eosio, eosio, canceldelay, eosio );
+   SET_APP_HANDLER( eosio, eosio, mindelay, eosio );
 }
 
 
@@ -73,6 +75,8 @@ abi_def chain_initializer::eos_contract_abi(const abi_def& eosio_system_abi)
    eos_abi.actions.push_back( action_def{name("vetorecovery"), "vetorecovery"} );
    eos_abi.actions.push_back( action_def{name("onerror"), "onerror"} );
    eos_abi.actions.push_back( action_def{name("onblock"), "onblock"} );
+   eos_abi.actions.push_back( action_def{name("canceldelay"), "canceldelay"} );
+   eos_abi.actions.push_back( action_def{name("mindelay"), "mindelay"} );
 
    // ACTION PAYLOADS
 
@@ -99,6 +103,7 @@ abi_def chain_initializer::eos_contract_abi(const abi_def& eosio_system_abi)
          {"permission", "permission_name"},
          {"parent", "permission_name"},
          {"data", "authority"},
+         {"delay", "uint32"}
       }
    });
 
@@ -153,6 +158,18 @@ abi_def chain_initializer::eos_contract_abi(const abi_def& eosio_system_abi)
    eos_abi.structs.emplace_back( struct_def {
       "vetorecovery", "", {
          {"account", "account_name"},
+      }
+   });
+
+   eos_abi.structs.emplace_back( struct_def {
+      "canceldelay", "", {
+         {"sender_id", "uint32"},
+      }
+   });
+
+   eos_abi.structs.emplace_back( struct_def {
+      "mindelay", "", {
+         {"delay", "uint32"},
       }
    });
 

--- a/libraries/chain/contracts/eosio_contract.cpp
+++ b/libraries/chain/contracts/eosio_contract.cpp
@@ -200,6 +200,7 @@ void apply_eosio_updateauth(apply_context& context) {
          po.auth = update.data;
          po.parent = parent_id;
          po.last_updated = context.controller.head_block_time();
+         po.delay = time_point_sec(update.delay.convert_to<uint64_t>());
       });
    }  else {
       // TODO/QUESTION: If we are creating a new permission, should we check if the message declared
@@ -210,6 +211,7 @@ void apply_eosio_updateauth(apply_context& context) {
          po.auth = update.data;
          po.parent = parent_id;
          po.last_updated = context.controller.head_block_time();
+         po.delay = time_point_sec(update.delay.convert_to<uint64_t>());
       });
    }
 }

--- a/libraries/chain/include/eosio/chain/apply_context.hpp
+++ b/libraries/chain/include/eosio/chain/apply_context.hpp
@@ -504,6 +504,8 @@ class apply_context {
 
       const bytes&         get_packed_transaction();
 
+      uint32_t get_next_sender_id();
+
       const chain_controller&       controller;
       const chainbase::database&    db;  ///< database where state is stored
       const action&                 act; ///< message being applied

--- a/libraries/chain/include/eosio/chain/apply_context.hpp
+++ b/libraries/chain/include/eosio/chain/apply_context.hpp
@@ -587,6 +587,8 @@ class apply_context {
       const table_id_object* find_table( name code, name scope, name table );
       const table_id_object& find_or_create_table( name code, name scope, name table );
 
+      int  db_store_i64( uint64_t code, uint64_t scope, uint64_t table, const account_name& payer, uint64_t id, const char* buffer, size_t buffer_size );
+
       vector<account_name>                _notified; ///< keeps track of new accounts to be notifed of current message
       vector<action>                      _inline_actions; ///< queued inline messages
       vector<action>                      _cfa_inline_actions; ///< queued inline messages

--- a/libraries/chain/include/eosio/chain/chain_controller.hpp
+++ b/libraries/chain/include/eosio/chain/chain_controller.hpp
@@ -284,13 +284,13 @@ namespace eosio { namespace chain {
           * @param allow_unused_signatures - true if method should not assert on unused signatures
           * @param provided_accounts - the set of accounts which have authorized the transaction (presumed to be owner)
           *
-          * @return true if the provided keys and accounts are sufficient to authorize actions of the transaction
+          * @return time_point set to the max delay that this authorization requires to complete
           */
-         void check_authorization( const vector<action>& actions,
-                                   const flat_set<public_key_type>& provided_keys,
-                                   bool                             allow_unused_signatures = false,
-                                   flat_set<account_name>           provided_accounts = flat_set<account_name>()
-                                   )const;
+         time_point check_authorization( const vector<action>& actions,
+                                         const flat_set<public_key_type>& provided_keys,
+                                         bool                             allow_unused_signatures = false,
+                                         flat_set<account_name>           provided_accounts = flat_set<account_name>()
+                                         )const;
 
 
       private:
@@ -337,10 +337,10 @@ namespace eosio { namespace chain {
             return f();
          }
 
-         void check_transaction_authorization(const transaction& trx,
-                                              const vector<signature_type>& signatures,
-                                              const vector<bytes>&  cfd = vector<bytes>(),
-                                              bool allow_unused_signatures = false)const;
+         time_point check_transaction_authorization(const transaction& trx,
+                                                    const vector<signature_type>& signatures,
+                                                    const vector<bytes>&  cfd = vector<bytes>(),
+                                                    bool allow_unused_signatures = false)const;
 
 
          void require_scope(const scope_name& name) const;
@@ -381,6 +381,17 @@ namespace eosio { namespace chain {
                                                              scope_name code_account,
                                                              action_name type) const;
 
+         /**
+          * @brief Find the linked permission for the passed in parameters
+          * @param authorizer_account The account authorizing the message
+          * @param code_account The account which publishes the contract that handles the message
+          * @param type The type of message
+          * @return an optional<permission_name> for the linked permission if one exists; otherwise an invalid
+          * optional<permission_name>
+          */
+         optional<permission_name> lookup_linked_permission( account_name authorizer_account,
+                                                             scope_name code_account,
+                                                             action_name type) const;
 
          bool should_check_for_duplicate_transactions()const { return !(_skip_flags&skip_transaction_dupe_check); }
          bool should_check_tapos()const                      { return !(_skip_flags&skip_tapos_check);            }

--- a/libraries/chain/include/eosio/chain/chain_controller.hpp
+++ b/libraries/chain/include/eosio/chain/chain_controller.hpp
@@ -413,6 +413,7 @@ namespace eosio { namespace chain {
          transaction _get_on_block_transaction();
          void _apply_on_block_transaction();
 
+         void store_deferred_transaction(const deferred_transaction& dtrx);
 
       //        producer_schedule_type calculate_next_round( const signed_block& next_block );
 

--- a/libraries/chain/include/eosio/chain/contracts/eos_contract.hpp
+++ b/libraries/chain/include/eosio/chain/contracts/eos_contract.hpp
@@ -29,6 +29,9 @@ namespace eosio { namespace chain { namespace contracts {
    void apply_eosio_setabi(apply_context&);
 
    void apply_eosio_onerror(apply_context&);
+
+   void apply_eosio_canceldelay(apply_context&);
+   void apply_eosio_mindelay(apply_context&);
    ///@}  end action handlers
 
 } } } /// namespace eosio::contracts

--- a/libraries/chain/include/eosio/chain/contracts/types.hpp
+++ b/libraries/chain/include/eosio/chain/contracts/types.hpp
@@ -150,6 +150,7 @@ struct updateauth {
    permission_name                   permission;
    permission_name                   parent;
    authority                         data;
+   uint32                            delay;
 
    static account_name get_account() {
       return config::system_account_name;
@@ -304,7 +305,7 @@ FC_REFLECT( eosio::chain::contracts::abi_def                          , (types)(
 FC_REFLECT( eosio::chain::contracts::newaccount                       , (creator)(name)(owner)(active)(recovery) )
 FC_REFLECT( eosio::chain::contracts::setcode                          , (account)(vmtype)(vmversion)(code) ) //abi
 FC_REFLECT( eosio::chain::contracts::setabi                           , (account)(abi) )
-FC_REFLECT( eosio::chain::contracts::updateauth                       , (account)(permission)(parent)(data) )
+FC_REFLECT( eosio::chain::contracts::updateauth                       , (account)(permission)(parent)(data)(delay) )
 FC_REFLECT( eosio::chain::contracts::deleteauth                       , (account)(permission) )
 FC_REFLECT( eosio::chain::contracts::linkauth                         , (account)(code)(type)(requirement) )
 FC_REFLECT( eosio::chain::contracts::unlinkauth                       , (account)(code)(type) )

--- a/libraries/chain/include/eosio/chain/contracts/types.hpp
+++ b/libraries/chain/include/eosio/chain/contracts/types.hpp
@@ -268,6 +268,29 @@ struct vetorecovery {
    }
 };
 
+struct canceldelay {
+   uint32   sender_id;
+
+   static account_name get_account() {
+      return config::system_account_name;
+   }
+
+   static action_name get_name() {
+      return N(canceldelay);
+   }
+};
+
+struct mindelay {
+   uint32   delay;
+
+   static account_name get_account() {
+      return config::system_account_name;
+   }
+
+   static action_name get_name() {
+      return N(mindelay);
+   }
+};
 
 } } } /// namespace eosio::chain::contracts
 
@@ -288,3 +311,5 @@ FC_REFLECT( eosio::chain::contracts::unlinkauth                       , (account
 FC_REFLECT( eosio::chain::contracts::postrecovery                     , (account)(data)(memo) )
 FC_REFLECT( eosio::chain::contracts::passrecovery                     , (account) )
 FC_REFLECT( eosio::chain::contracts::vetorecovery                     , (account) )
+FC_REFLECT( eosio::chain::contracts::canceldelay                      , (sender_id) )
+FC_REFLECT( eosio::chain::contracts::mindelay                         , (delay) )

--- a/libraries/chain/include/eosio/chain/permission_object.hpp
+++ b/libraries/chain/include/eosio/chain/permission_object.hpp
@@ -17,6 +17,7 @@ namespace eosio { namespace chain {
       permission_name   name; ///< human-readable name for the permission
       shared_authority  auth; ///< authority required to execute this permission
       time_point        last_updated; ///< the last time this authority was updated
+      time_point        delay; ///< delay associated with this permission
 
       /**
        * @brief Checks if this permission is equivalent or greater than other
@@ -108,7 +109,7 @@ CHAINBASE_SET_INDEX_TYPE(eosio::chain::permission_object, eosio::chain::permissi
 CHAINBASE_SET_INDEX_TYPE(eosio::chain::permission_usage_object, eosio::chain::permission_usage_index)
 
 FC_REFLECT(chainbase::oid<eosio::chain::permission_object>, (_id))
-FC_REFLECT(eosio::chain::permission_object, (id)(owner)(parent)(name)(auth))
+FC_REFLECT(eosio::chain::permission_object, (id)(owner)(parent)(name)(auth)(last_updated)(delay))
 
 FC_REFLECT(chainbase::oid<eosio::chain::permission_usage_object>, (_id))
 FC_REFLECT(eosio::chain::permission_usage_object, (id)(account)(permission)(last_used))

--- a/libraries/chain/include/eosio/chain/transaction.hpp
+++ b/libraries/chain/include/eosio/chain/transaction.hpp
@@ -82,7 +82,8 @@ namespace eosio { namespace chain {
       enum status_enum {
          executed  = 0, ///< succeed, no error handler executed
          soft_fail = 1, ///< objectively failed (not executed), error handler executed
-         hard_fail = 2  ///< objectively failed and error handler objectively failed thus no state change
+         hard_fail = 2, ///< objectively failed and error handler objectively failed thus no state change
+         delayed   = 3  ///< transaction delayed
       };
 
       transaction_receipt() : status(hard_fail) {}
@@ -216,6 +217,15 @@ namespace eosio { namespace chain {
       uint64_t       sender_id; /// ID assigned by sender of generated, accessible via WASM api when executing normal or error
       account_name   sender; /// receives error handler callback
       time_point_sec execute_after; /// delayed exeuction
+
+      deferred_transaction() = default;
+
+      deferred_transaction(uint32_t sender_id, account_name sender, time_point_sec execute_after, const transaction& txn)
+      : transaction(txn),
+        sender_id(sender_id),
+        sender(sender),
+        execute_after(execute_after)
+      {}
    };
 
    struct deferred_reference {
@@ -270,7 +280,7 @@ FC_REFLECT_ENUM( eosio::chain::data_access_info::access_type, (read)(write))
 FC_REFLECT( eosio::chain::data_access_info, (type)(code)(scope)(sequence))
 FC_REFLECT( eosio::chain::action_trace, (receiver)(act)(console)(region_id)(cycle_index)(data_access) )
 FC_REFLECT( eosio::chain::transaction_receipt, (status)(id))
-FC_REFLECT_ENUM( eosio::chain::transaction_receipt::status_enum, (executed)(soft_fail)(hard_fail))
+FC_REFLECT_ENUM( eosio::chain::transaction_receipt::status_enum, (executed)(soft_fail)(hard_fail)(delayed) )
 FC_REFLECT_DERIVED( eosio::chain::transaction_trace, (eosio::chain::transaction_receipt), (action_traces)(deferred_transaction_requests) )
 
 

--- a/libraries/fc/include/fc/time.hpp
+++ b/libraries/fc/include/fc/time.hpp
@@ -62,6 +62,7 @@ namespace fc {
         time_point&  operator += ( const microseconds& m)                           { elapsed+=m; return *this;                 }
         time_point&  operator -= ( const microseconds& m)                           { elapsed-=m; return *this;                 }
         time_point   operator + (const microseconds& m) const { return time_point(elapsed+m); }
+        time_point   operator + (const time_point& m) const { return time_point(elapsed+m.elapsed); }
         time_point   operator - (const microseconds& m) const { return time_point(elapsed-m); }
         microseconds operator - (const time_point& m) const { return microseconds(elapsed.count() - m.elapsed.count()); }
     private:
@@ -102,8 +103,10 @@ namespace fc {
         friend bool      operator != ( const time_point_sec& a, const time_point_sec& b ) { return a.utc_seconds != b.utc_seconds; }
         time_point_sec&  operator += ( uint32_t m ) { utc_seconds+=m; return *this; }
         time_point_sec&  operator += ( microseconds m ) { utc_seconds+=m.to_seconds(); return *this; }
+        time_point_sec&  operator += ( time_point_sec m ) { utc_seconds+=m.utc_seconds; return *this; }
         time_point_sec&  operator -= ( uint32_t m ) { utc_seconds-=m; return *this; }
         time_point_sec&  operator -= ( microseconds m ) { utc_seconds-=m.to_seconds(); return *this; }
+        time_point_sec&  operator -= ( time_point_sec m ) { utc_seconds-=m.utc_seconds; return *this; }
         time_point_sec   operator +( uint32_t offset )const { return time_point_sec(utc_seconds + offset); }
         time_point_sec   operator -( uint32_t offset )const { return time_point_sec(utc_seconds - offset); }
 

--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -78,7 +78,7 @@ namespace eosio { namespace testing {
          transaction_trace push_transaction( signed_transaction& trx, uint32_t skip_flag = skip_nothing  );
          action_result     push_action(action&& cert_act, uint64_t authorizer);
 
-         transaction_trace push_action( const account_name& code, const action_name& act, const account_name& signer, const variant_object &data );
+         transaction_trace push_action( const account_name& code, const action_name& act, const account_name& signer, const variant_object &data, int32_t expiration = -1 );
 
 
          void              set_tapos( signed_transaction& trx ) const;
@@ -96,7 +96,7 @@ namespace eosio { namespace testing {
          void delete_authority( account_name account, permission_name perm,  const vector<permission_level>& auths, const vector<private_key_type>& keys );
          void delete_authority( account_name account, permission_name perm );
 
-         void              create_account( account_name name, account_name creator = config::system_account_name, bool multisig = false );
+         void create_account( account_name name, account_name creator = config::system_account_name, bool multisig = false );
 
          transaction_trace push_reqauth( account_name from, const vector<permission_level>& auths, const vector<private_key_type>& keys );
          transaction_trace push_reqauth(account_name from, string role, bool multi_sig = false);

--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -64,6 +64,8 @@ namespace eosio { namespace testing {
       public:
          typedef string action_result;
 
+         static const uint32_t DEFAULT_EXPIRATION_DELTA = 6;
+
          base_tester(chain_controller::runtime_limits limits = chain_controller::runtime_limits());
          explicit base_tester(chain_controller::controller_config config);
 
@@ -78,10 +80,10 @@ namespace eosio { namespace testing {
          transaction_trace push_transaction( signed_transaction& trx, uint32_t skip_flag = skip_nothing  );
          action_result     push_action(action&& cert_act, uint64_t authorizer);
 
-         transaction_trace push_action( const account_name& code, const action_name& act, const account_name& signer, const variant_object &data, int32_t expiration = -1 );
+         transaction_trace push_action( const account_name& code, const action_name& acttype, const account_name& actor, const variant_object& data, uint32_t expiration = DEFAULT_EXPIRATION_DELTA );
+         transaction_trace push_action( const account_name& code, const action_name& acttype, const vector<account_name>& actors, const variant_object& data, uint32_t expiration = DEFAULT_EXPIRATION_DELTA );
 
-
-         void              set_tapos( signed_transaction& trx ) const;
+         void              set_tapos( signed_transaction& trx, uint32_t expiration = DEFAULT_EXPIRATION_DELTA ) const;
 
          void              create_accounts( vector<account_name> names, bool multisig = false ) {
             for( auto n : names ) create_account(n, config::system_account_name, multisig );

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -169,7 +169,8 @@ namespace eosio { namespace testing {
    transaction_trace base_tester::push_action( const account_name& code,
                              const action_name& acttype,
                              const account_name& actor,
-                             const variant_object& data )
+                             const variant_object& data,
+                             int32_t expiration)
 
    { try {
       const auto& acnt = control->get_database().get<account_object,by_name>(code);
@@ -188,6 +189,8 @@ namespace eosio { namespace testing {
       act.data = abis.variant_to_binary(action_type_name, data);
 
       signed_transaction trx;
+      if (expiration > -1)
+         trx.expiration = time_point_sec(control->head_block_time()) + expiration;
       trx.actions.emplace_back(std::move(act));
       set_tapos(trx);
       trx.sign(get_private_key(actor, "active"), chain_id_type());

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2253,7 +2253,11 @@ namespace eosio {
                         }
                      }
                      break;
-                  }}
+                  }
+                  case transaction_receipt::delayed:
+#warning TODO: Not sure what should happen here
+                     break;
+                  }
                }
             }
          }

--- a/tests/chain_tests/block_tests.cpp
+++ b/tests/chain_tests/block_tests.cpp
@@ -225,12 +225,14 @@ BOOST_AUTO_TEST_CASE(order_dependent_transactions)
               ("account", "tester")
               ("permission", "first")
               ("parent", "active")
-              ("data",  authority(chain.get_public_key(name("tester"), "first"))));
+              ("data",  authority(chain.get_public_key(name("tester"), "first")))
+              ("delay", 0));
       chain.push_action(name("eosio"), name("updateauth"), name("tester"), fc::mutable_variant_object()
               ("account", "tester")
               ("permission", "second")
               ("parent", "first")
-              ("data",  authority(chain.get_public_key(name("tester"), "second"))));
+              ("data",  authority(chain.get_public_key(name("tester"), "second")))
+              ("delay", 0));
 
       // Ensure the related auths are created
       const auto* first_auth = chain.find<permission_object, by_owner>(boost::make_tuple(name("tester"), name("first")));

--- a/tests/chain_tests/delay_tests.cpp
+++ b/tests/chain_tests/delay_tests.cpp
@@ -73,7 +73,7 @@ BOOST_AUTO_TEST_CASE( link_delay_direct_test ) { try {
        ("memo", "hi" )
    );
    BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace.status);
-   BOOST_REQUIRE_EQUAL(0, trace.deferred_transactions.size());
+   BOOST_REQUIRE_EQUAL(0, trace.deferred_transaction_requests.size());
 
    chain.produce_blocks();
 
@@ -90,7 +90,7 @@ BOOST_AUTO_TEST_CASE( link_delay_direct_test ) { try {
    );
 
    BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace.status);
-   BOOST_REQUIRE_EQUAL(0, trace.deferred_transactions.size());
+   BOOST_REQUIRE_EQUAL(0, trace.deferred_transaction_requests.size());
 
    chain.produce_blocks();
 
@@ -108,7 +108,7 @@ BOOST_AUTO_TEST_CASE( link_delay_direct_test ) { try {
            ("data",  authority(chain.get_public_key(tester_account, "first")))
            ("delay", 10));
    BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace.status);
-   BOOST_REQUIRE_EQUAL(0, trace.deferred_transactions.size());
+   BOOST_REQUIRE_EQUAL(0, trace.deferred_transaction_requests.size());
 
    chain.produce_blocks();
 
@@ -120,9 +120,8 @@ BOOST_AUTO_TEST_CASE( link_delay_direct_test ) { try {
        20
    );
    BOOST_REQUIRE_EQUAL(transaction_receipt::delayed, trace.status);
-   BOOST_REQUIRE_EQUAL(1, trace.deferred_transactions.size());
+   BOOST_REQUIRE_EQUAL(1, trace.deferred_transaction_requests.size());
    BOOST_REQUIRE_EQUAL(0, trace.action_traces.size());
-   BOOST_REQUIRE_EQUAL(0, trace.canceled_deferred.size());
 
    liquid_balance = get_currency_balance(chain, N(tester));
    BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
@@ -222,7 +221,7 @@ BOOST_AUTO_TEST_CASE( link_delay_direct_parent_permission_test ) { try {
        ("memo", "hi" )
    );
    BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace.status);
-   BOOST_REQUIRE_EQUAL(0, trace.deferred_transactions.size());
+   BOOST_REQUIRE_EQUAL(0, trace.deferred_transaction_requests.size());
 
    chain.produce_blocks();
 
@@ -239,7 +238,7 @@ BOOST_AUTO_TEST_CASE( link_delay_direct_parent_permission_test ) { try {
    );
 
    BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace.status);
-   BOOST_REQUIRE_EQUAL(0, trace.deferred_transactions.size());
+   BOOST_REQUIRE_EQUAL(0, trace.deferred_transaction_requests.size());
 
    chain.produce_blocks();
 
@@ -257,7 +256,7 @@ BOOST_AUTO_TEST_CASE( link_delay_direct_parent_permission_test ) { try {
            ("data",  authority(chain.get_public_key(tester_account, "active")))
            ("delay", 15));
    BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace.status);
-   BOOST_REQUIRE_EQUAL(0, trace.deferred_transactions.size());
+   BOOST_REQUIRE_EQUAL(0, trace.deferred_transaction_requests.size());
 
    chain.produce_blocks();
 
@@ -269,9 +268,8 @@ BOOST_AUTO_TEST_CASE( link_delay_direct_parent_permission_test ) { try {
        20
    );
    BOOST_REQUIRE_EQUAL(transaction_receipt::delayed, trace.status);
-   BOOST_REQUIRE_EQUAL(1, trace.deferred_transactions.size());
+   BOOST_REQUIRE_EQUAL(1, trace.deferred_transaction_requests.size());
    BOOST_REQUIRE_EQUAL(0, trace.action_traces.size());
-   BOOST_REQUIRE_EQUAL(0, trace.canceled_deferred.size());
 
    liquid_balance = get_currency_balance(chain, N(tester));
    BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
@@ -377,7 +375,7 @@ BOOST_AUTO_TEST_CASE( link_delay_direct_walk_parent_permissions_test ) { try {
        ("memo", "hi" )
    );
    BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace.status);
-   BOOST_REQUIRE_EQUAL(0, trace.deferred_transactions.size());
+   BOOST_REQUIRE_EQUAL(0, trace.deferred_transaction_requests.size());
 
    chain.produce_blocks();
 
@@ -394,7 +392,7 @@ BOOST_AUTO_TEST_CASE( link_delay_direct_walk_parent_permissions_test ) { try {
    );
 
    BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace.status);
-   BOOST_REQUIRE_EQUAL(0, trace.deferred_transactions.size());
+   BOOST_REQUIRE_EQUAL(0, trace.deferred_transaction_requests.size());
 
    chain.produce_blocks();
 
@@ -412,7 +410,7 @@ BOOST_AUTO_TEST_CASE( link_delay_direct_walk_parent_permissions_test ) { try {
            ("data",  authority(chain.get_public_key(tester_account, "first")))
            ("delay", 20));
    BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace.status);
-   BOOST_REQUIRE_EQUAL(0, trace.deferred_transactions.size());
+   BOOST_REQUIRE_EQUAL(0, trace.deferred_transaction_requests.size());
 
    chain.produce_blocks();
 
@@ -424,9 +422,8 @@ BOOST_AUTO_TEST_CASE( link_delay_direct_walk_parent_permissions_test ) { try {
        30
    );
    BOOST_REQUIRE_EQUAL(transaction_receipt::delayed, trace.status);
-   BOOST_REQUIRE_EQUAL(1, trace.deferred_transactions.size());
+   BOOST_REQUIRE_EQUAL(1, trace.deferred_transaction_requests.size());
    BOOST_REQUIRE_EQUAL(0, trace.action_traces.size());
-   BOOST_REQUIRE_EQUAL(0, trace.canceled_deferred.size());
 
    liquid_balance = get_currency_balance(chain, N(tester));
    BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
@@ -526,7 +523,7 @@ BOOST_AUTO_TEST_CASE( link_delay_permission_change_test ) { try {
        ("memo", "hi" )
    );
    BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace.status);
-   BOOST_REQUIRE_EQUAL(0, trace.deferred_transactions.size());
+   BOOST_REQUIRE_EQUAL(0, trace.deferred_transaction_requests.size());
 
    chain.produce_blocks();
 
@@ -545,9 +542,8 @@ BOOST_AUTO_TEST_CASE( link_delay_permission_change_test ) { try {
    );
 
    BOOST_REQUIRE_EQUAL(transaction_receipt::delayed, trace.status);
-   BOOST_REQUIRE_EQUAL(1, trace.deferred_transactions.size());
+   BOOST_REQUIRE_EQUAL(1, trace.deferred_transaction_requests.size());
    BOOST_REQUIRE_EQUAL(0, trace.action_traces.size());
-   BOOST_REQUIRE_EQUAL(0, trace.canceled_deferred.size());
 
    chain.produce_blocks();
 
@@ -567,9 +563,8 @@ BOOST_AUTO_TEST_CASE( link_delay_permission_change_test ) { try {
            ("delay", 0),
            30);
    BOOST_REQUIRE_EQUAL(transaction_receipt::delayed, trace.status);
-   BOOST_REQUIRE_EQUAL(1, trace.deferred_transactions.size());
+   BOOST_REQUIRE_EQUAL(1, trace.deferred_transaction_requests.size());
    BOOST_REQUIRE_EQUAL(0, trace.action_traces.size());
-   BOOST_REQUIRE_EQUAL(0, trace.canceled_deferred.size());
 
    chain.produce_blocks();
 
@@ -596,9 +591,8 @@ BOOST_AUTO_TEST_CASE( link_delay_permission_change_test ) { try {
        30
    );
    BOOST_REQUIRE_EQUAL(transaction_receipt::delayed, trace.status);
-   BOOST_REQUIRE_EQUAL(1, trace.deferred_transactions.size());
+   BOOST_REQUIRE_EQUAL(1, trace.deferred_transaction_requests.size());
    BOOST_REQUIRE_EQUAL(0, trace.action_traces.size());
-   BOOST_REQUIRE_EQUAL(0, trace.canceled_deferred.size());
 
    chain.produce_blocks();
 
@@ -634,7 +628,7 @@ BOOST_AUTO_TEST_CASE( link_delay_permission_change_test ) { try {
        ("memo", "hi" )
    );
    BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace.status);
-   BOOST_REQUIRE_EQUAL(0, trace.deferred_transactions.size());
+   BOOST_REQUIRE_EQUAL(0, trace.deferred_transaction_requests.size());
 
    chain.control->push_deferred_transactions(true);
 

--- a/tests/chain_tests/delay_tests.cpp
+++ b/tests/chain_tests/delay_tests.cpp
@@ -1,0 +1,678 @@
+#include <boost/test/unit_test.hpp>
+#include <eosio/testing/tester_network.hpp>
+#include <eosio/chain/producer_object.hpp>
+#include <eosio.system/eosio.system.wast.hpp>
+#include <eosio.system/eosio.system.abi.hpp>
+#include <currency/currency.wast.hpp>
+#include <currency/currency.abi.hpp>
+
+using namespace eosio;
+using namespace eosio::chain;
+using namespace eosio::chain::contracts;
+using namespace eosio::testing;
+
+
+BOOST_AUTO_TEST_SUITE(delay_tests)
+
+asset get_currency_balance(const tester& chain, account_name account) {
+   return chain.get_currency_balance(N(currency), symbol(SY(4,CUR)), account);
+}
+
+// test link to permission with delay directly on it
+BOOST_AUTO_TEST_CASE( link_delay_direct_test ) { try {
+   tester chain;
+
+   const auto& tester_account = N(tester);
+
+   chain.set_code(config::system_account_name, eosio_system_wast);
+   chain.set_abi(config::system_account_name, eosio_system_abi);
+
+   chain.produce_blocks();
+   chain.create_account(N(currency));
+   chain.produce_blocks(10);
+
+   chain.set_code(N(currency), currency_wast);
+   chain.set_abi(N(currency), currency_abi);
+
+   chain.produce_blocks();
+   chain.create_account(N(tester));
+   chain.create_account(N(tester2));
+   chain.produce_blocks(10);
+
+   chain.push_action(config::system_account_name, contracts::updateauth::get_name(), tester_account, fc::mutable_variant_object()
+           ("account", "tester")
+           ("permission", "first")
+           ("parent", "active")
+           ("data",  authority(chain.get_public_key(tester_account, "first")))
+           ("delay", 0));
+   chain.push_action(config::system_account_name, contracts::linkauth::get_name(), tester_account, fc::mutable_variant_object()
+           ("account", "tester")
+           ("code", "currency")
+           ("type", "transfer")
+           ("requirement", "first"));
+
+   chain.produce_blocks();
+   chain.push_action(N(currency), N(create), N(currency), mutable_variant_object()
+           ("issuer", "currency" )
+           ("maximum_supply", "9000000.0000 CUR" )
+           ("can_freeze", 0)
+           ("can_recall", 0)
+           ("can_whitelist", 0)
+   );
+
+   chain.push_action(N(currency), name("issue"), N(currency), fc::mutable_variant_object()
+           ("to",       "currency")
+           ("quantity", "1000000.0000 CUR")
+           ("memo", "for stuff")
+   );
+
+   auto trace = chain.push_action(N(currency), name("transfer"), N(currency), fc::mutable_variant_object()
+       ("from", "currency")
+       ("to", "tester")
+       ("quantity", "100.0000 CUR")
+       ("memo", "hi" )
+   );
+   BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace.status);
+   BOOST_REQUIRE_EQUAL(0, trace.deferred_transactions.size());
+
+   chain.produce_blocks();
+
+   auto liquid_balance = get_currency_balance(chain, N(currency));
+   BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
+
+   trace = chain.push_action(N(currency), name("transfer"), N(tester), fc::mutable_variant_object()
+       ("from", "tester")
+       ("to", "tester2")
+       ("quantity", "1.0000 CUR")
+       ("memo", "hi" )
+   );
+
+   BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace.status);
+   BOOST_REQUIRE_EQUAL(0, trace.deferred_transactions.size());
+
+   chain.produce_blocks();
+
+   liquid_balance = get_currency_balance(chain, N(currency));
+   BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
+
+   trace = chain.push_action(config::system_account_name, contracts::updateauth::get_name(), tester_account, fc::mutable_variant_object()
+           ("account", "tester")
+           ("permission", "first")
+           ("parent", "active")
+           ("data",  authority(chain.get_public_key(tester_account, "first")))
+           ("delay", 10));
+   BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace.status);
+   BOOST_REQUIRE_EQUAL(0, trace.deferred_transactions.size());
+
+   chain.produce_blocks();
+
+   trace = chain.push_action(N(currency), name("transfer"), N(tester), fc::mutable_variant_object()
+       ("from", "tester")
+       ("to", "tester2")
+       ("quantity", "3.0000 CUR")
+       ("memo", "hi" ),
+       20
+   );
+   BOOST_REQUIRE_EQUAL(transaction_receipt::delayed, trace.status);
+   BOOST_REQUIRE_EQUAL(1, trace.deferred_transactions.size());
+   BOOST_REQUIRE_EQUAL(0, trace.action_traces.size());
+   BOOST_REQUIRE_EQUAL(0, trace.canceled_deferred.size());
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
+
+   chain.control->push_deferred_transactions(true);
+
+   chain.produce_blocks();
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
+
+   chain.control->push_deferred_transactions(true);
+
+   chain.produce_blocks(18);
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
+
+   chain.control->push_deferred_transactions(true);
+
+   chain.produce_blocks();
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
+
+   chain.control->push_deferred_transactions(true);
+
+   chain.produce_blocks();
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("96.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("4.0000 CUR"), liquid_balance);
+
+} FC_LOG_AND_RETHROW() }/// schedule_test
+
+// test link to permission with delay on permission which is parent of min permission (special logic in permission_object::satisfies)
+BOOST_AUTO_TEST_CASE( link_delay_direct_parent_permission_test ) { try {
+   tester chain;
+
+   const auto& tester_account = N(tester);
+
+   chain.set_code(config::system_account_name, eosio_system_wast);
+   chain.set_abi(config::system_account_name, eosio_system_abi);
+
+   chain.produce_blocks();
+   chain.create_account(N(currency));
+   chain.produce_blocks(10);
+
+   chain.set_code(N(currency), currency_wast);
+   chain.set_abi(N(currency), currency_abi);
+
+   chain.produce_blocks();
+   chain.create_account(N(tester));
+   chain.create_account(N(tester2));
+   chain.produce_blocks(10);
+
+   chain.push_action(config::system_account_name, contracts::updateauth::get_name(), tester_account, fc::mutable_variant_object()
+           ("account", "tester")
+           ("permission", "first")
+           ("parent", "active")
+           ("data",  authority(chain.get_public_key(tester_account, "first")))
+           ("delay", 0));
+   chain.push_action(config::system_account_name, contracts::linkauth::get_name(), tester_account, fc::mutable_variant_object()
+           ("account", "tester")
+           ("code", "currency")
+           ("type", "transfer")
+           ("requirement", "first"));
+
+   chain.produce_blocks();
+   chain.push_action(N(currency), N(create), N(currency), mutable_variant_object()
+           ("issuer", "currency" )
+           ("maximum_supply", "9000000.0000 CUR" )
+           ("can_freeze", 0)
+           ("can_recall", 0)
+           ("can_whitelist", 0)
+   );
+
+   chain.push_action(N(currency), name("issue"), N(currency), fc::mutable_variant_object()
+           ("to",       "currency")
+           ("quantity", "1000000.0000 CUR")
+           ("memo", "for stuff")
+   );
+
+   auto trace = chain.push_action(N(currency), name("transfer"), N(currency), fc::mutable_variant_object()
+       ("from", "currency")
+       ("to", "tester")
+       ("quantity", "100.0000 CUR")
+       ("memo", "hi" )
+   );
+   BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace.status);
+   BOOST_REQUIRE_EQUAL(0, trace.deferred_transactions.size());
+
+   chain.produce_blocks();
+
+   auto liquid_balance = get_currency_balance(chain, N(currency));
+   BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
+
+   trace = chain.push_action(N(currency), name("transfer"), N(tester), fc::mutable_variant_object()
+       ("from", "tester")
+       ("to", "tester2")
+       ("quantity", "1.0000 CUR")
+       ("memo", "hi" )
+   );
+
+   BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace.status);
+   BOOST_REQUIRE_EQUAL(0, trace.deferred_transactions.size());
+
+   chain.produce_blocks();
+
+   liquid_balance = get_currency_balance(chain, N(currency));
+   BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
+
+   trace = chain.push_action(config::system_account_name, contracts::updateauth::get_name(), tester_account, fc::mutable_variant_object()
+           ("account", "tester")
+           ("permission", "active")
+           ("parent", "owner")
+           ("data",  authority(chain.get_public_key(tester_account, "active")))
+           ("delay", 15));
+   BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace.status);
+   BOOST_REQUIRE_EQUAL(0, trace.deferred_transactions.size());
+
+   chain.produce_blocks();
+
+   trace = chain.push_action(N(currency), name("transfer"), N(tester), fc::mutable_variant_object()
+       ("from", "tester")
+       ("to", "tester2")
+       ("quantity", "3.0000 CUR")
+       ("memo", "hi" ),
+       20
+   );
+   BOOST_REQUIRE_EQUAL(transaction_receipt::delayed, trace.status);
+   BOOST_REQUIRE_EQUAL(1, trace.deferred_transactions.size());
+   BOOST_REQUIRE_EQUAL(0, trace.action_traces.size());
+   BOOST_REQUIRE_EQUAL(0, trace.canceled_deferred.size());
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
+
+   chain.control->push_deferred_transactions(true);
+
+   chain.produce_blocks();
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
+
+   chain.control->push_deferred_transactions(true);
+
+   chain.produce_blocks(28);
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
+
+   chain.control->push_deferred_transactions(true);
+
+   chain.produce_blocks();
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
+
+   chain.control->push_deferred_transactions(true);
+
+   chain.produce_blocks();
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("96.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("4.0000 CUR"), liquid_balance);
+
+} FC_LOG_AND_RETHROW() }/// schedule_test
+
+// test link to permission with delay on permission between min permission and authorizing permission it
+BOOST_AUTO_TEST_CASE( link_delay_direct_walk_parent_permissions_test ) { try {
+   tester chain;
+
+   const auto& tester_account = N(tester);
+
+   chain.set_code(config::system_account_name, eosio_system_wast);
+   chain.set_abi(config::system_account_name, eosio_system_abi);
+
+   chain.produce_blocks();
+   chain.create_account(N(currency));
+   chain.produce_blocks(10);
+
+   chain.set_code(N(currency), currency_wast);
+   chain.set_abi(N(currency), currency_abi);
+
+   chain.produce_blocks();
+   chain.create_account(N(tester));
+   chain.create_account(N(tester2));
+   chain.produce_blocks(10);
+
+   chain.push_action(config::system_account_name, contracts::updateauth::get_name(), tester_account, fc::mutable_variant_object()
+           ("account", "tester")
+           ("permission", "first")
+           ("parent", "active")
+           ("data",  authority(chain.get_public_key(tester_account, "first")))
+           ("delay", 0));
+   chain.push_action(config::system_account_name, contracts::updateauth::get_name(), tester_account, fc::mutable_variant_object()
+           ("account", "tester")
+           ("permission", "second")
+           ("parent", "first")
+           ("data",  authority(chain.get_public_key(tester_account, "second")))
+           ("delay", 0));
+   chain.push_action(config::system_account_name, contracts::linkauth::get_name(), tester_account, fc::mutable_variant_object()
+           ("account", "tester")
+           ("code", "currency")
+           ("type", "transfer")
+           ("requirement", "second"));
+
+   chain.produce_blocks();
+   chain.push_action(N(currency), N(create), N(currency), mutable_variant_object()
+           ("issuer", "currency" )
+           ("maximum_supply", "9000000.0000 CUR" )
+           ("can_freeze", 0)
+           ("can_recall", 0)
+           ("can_whitelist", 0)
+   );
+
+   chain.push_action(N(currency), name("issue"), N(currency), fc::mutable_variant_object()
+           ("to",       "currency")
+           ("quantity", "1000000.0000 CUR")
+           ("memo", "for stuff")
+   );
+
+   auto trace = chain.push_action(N(currency), name("transfer"), N(currency), fc::mutable_variant_object()
+       ("from", "currency")
+       ("to", "tester")
+       ("quantity", "100.0000 CUR")
+       ("memo", "hi" )
+   );
+   BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace.status);
+   BOOST_REQUIRE_EQUAL(0, trace.deferred_transactions.size());
+
+   chain.produce_blocks();
+
+   auto liquid_balance = get_currency_balance(chain, N(currency));
+   BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
+
+   trace = chain.push_action(N(currency), name("transfer"), N(tester), fc::mutable_variant_object()
+       ("from", "tester")
+       ("to", "tester2")
+       ("quantity", "1.0000 CUR")
+       ("memo", "hi" )
+   );
+
+   BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace.status);
+   BOOST_REQUIRE_EQUAL(0, trace.deferred_transactions.size());
+
+   chain.produce_blocks();
+
+   liquid_balance = get_currency_balance(chain, N(currency));
+   BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
+
+   trace = chain.push_action(config::system_account_name, contracts::updateauth::get_name(), tester_account, fc::mutable_variant_object()
+           ("account", "tester")
+           ("permission", "first")
+           ("parent", "active")
+           ("data",  authority(chain.get_public_key(tester_account, "first")))
+           ("delay", 20));
+   BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace.status);
+   BOOST_REQUIRE_EQUAL(0, trace.deferred_transactions.size());
+
+   chain.produce_blocks();
+
+   trace = chain.push_action(N(currency), name("transfer"), N(tester), fc::mutable_variant_object()
+       ("from", "tester")
+       ("to", "tester2")
+       ("quantity", "3.0000 CUR")
+       ("memo", "hi" ),
+       30
+   );
+   BOOST_REQUIRE_EQUAL(transaction_receipt::delayed, trace.status);
+   BOOST_REQUIRE_EQUAL(1, trace.deferred_transactions.size());
+   BOOST_REQUIRE_EQUAL(0, trace.action_traces.size());
+   BOOST_REQUIRE_EQUAL(0, trace.canceled_deferred.size());
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
+
+   chain.control->push_deferred_transactions(true);
+
+   chain.produce_blocks();
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
+
+   chain.control->push_deferred_transactions(true);
+
+   chain.produce_blocks(38);
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
+
+   chain.control->push_deferred_transactions(true);
+
+   chain.produce_blocks();
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
+
+   chain.control->push_deferred_transactions(true);
+
+   chain.produce_blocks();
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("96.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("4.0000 CUR"), liquid_balance);
+
+} FC_LOG_AND_RETHROW() }/// schedule_test
+
+// test removing delay on permission
+BOOST_AUTO_TEST_CASE( link_delay_permission_change_test ) { try {
+   tester chain;
+
+   const auto& tester_account = N(tester);
+
+   chain.set_code(config::system_account_name, eosio_system_wast);
+   chain.set_abi(config::system_account_name, eosio_system_abi);
+
+   chain.produce_blocks();
+   chain.create_account(N(currency));
+   chain.produce_blocks(10);
+
+   chain.set_code(N(currency), currency_wast);
+   chain.set_abi(N(currency), currency_abi);
+
+   chain.produce_blocks();
+   chain.create_account(N(tester));
+   chain.create_account(N(tester2));
+   chain.produce_blocks(10);
+
+   chain.push_action(config::system_account_name, contracts::updateauth::get_name(), tester_account, fc::mutable_variant_object()
+           ("account", "tester")
+           ("permission", "first")
+           ("parent", "active")
+           ("data",  authority(chain.get_public_key(tester_account, "first")))
+           ("delay", 10));
+   chain.push_action(config::system_account_name, contracts::linkauth::get_name(), tester_account, fc::mutable_variant_object()
+           ("account", "tester")
+           ("code", "currency")
+           ("type", "transfer")
+           ("requirement", "first"));
+
+   chain.produce_blocks();
+   chain.push_action(N(currency), N(create), N(currency), mutable_variant_object()
+           ("issuer", "currency" )
+           ("maximum_supply", "9000000.0000 CUR" )
+           ("can_freeze", 0)
+           ("can_recall", 0)
+           ("can_whitelist", 0)
+   );
+
+   chain.push_action(N(currency), name("issue"), N(currency), fc::mutable_variant_object()
+           ("to",       "currency")
+           ("quantity", "1000000.0000 CUR")
+           ("memo", "for stuff")
+   );
+
+   auto trace = chain.push_action(N(currency), name("transfer"), N(currency), fc::mutable_variant_object()
+       ("from", "currency")
+       ("to", "tester")
+       ("quantity", "100.0000 CUR")
+       ("memo", "hi" )
+   );
+   BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace.status);
+   BOOST_REQUIRE_EQUAL(0, trace.deferred_transactions.size());
+
+   chain.produce_blocks();
+
+   auto liquid_balance = get_currency_balance(chain, N(currency));
+   BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
+
+   // this transaction will be delayed 20 sec
+   trace = chain.push_action(N(currency), name("transfer"), N(tester), fc::mutable_variant_object()
+       ("from", "tester")
+       ("to", "tester2")
+       ("quantity", "1.0000 CUR")
+       ("memo", "hi" ),
+       30
+   );
+
+   BOOST_REQUIRE_EQUAL(transaction_receipt::delayed, trace.status);
+   BOOST_REQUIRE_EQUAL(1, trace.deferred_transactions.size());
+   BOOST_REQUIRE_EQUAL(0, trace.action_traces.size());
+   BOOST_REQUIRE_EQUAL(0, trace.canceled_deferred.size());
+
+   chain.produce_blocks();
+
+   liquid_balance = get_currency_balance(chain, N(currency));
+   BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
+
+   // this transaction will be delayed 20 sec
+   trace = chain.push_action(config::system_account_name, contracts::updateauth::get_name(), tester_account, fc::mutable_variant_object()
+           ("account", "tester")
+           ("permission", "first")
+           ("parent", "active")
+           ("data",  authority(chain.get_public_key(tester_account, "first")))
+           ("delay", 0),
+           30);
+   BOOST_REQUIRE_EQUAL(transaction_receipt::delayed, trace.status);
+   BOOST_REQUIRE_EQUAL(1, trace.deferred_transactions.size());
+   BOOST_REQUIRE_EQUAL(0, trace.action_traces.size());
+   BOOST_REQUIRE_EQUAL(0, trace.canceled_deferred.size());
+
+   chain.produce_blocks();
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
+
+   chain.control->push_deferred_transactions(true);
+
+   chain.produce_blocks(16);
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
+
+   // this transaction will be delayed 20 sec
+   trace = chain.push_action(N(currency), name("transfer"), N(tester), fc::mutable_variant_object()
+       ("from", "tester")
+       ("to", "tester2")
+       ("quantity", "5.0000 CUR")
+       ("memo", "hi" ),
+       30
+   );
+   BOOST_REQUIRE_EQUAL(transaction_receipt::delayed, trace.status);
+   BOOST_REQUIRE_EQUAL(1, trace.deferred_transactions.size());
+   BOOST_REQUIRE_EQUAL(0, trace.action_traces.size());
+   BOOST_REQUIRE_EQUAL(0, trace.canceled_deferred.size());
+
+   chain.produce_blocks();
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
+
+   chain.control->push_deferred_transactions(true);
+
+   chain.produce_blocks();
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
+
+   // first transfer will finally performed
+   chain.control->push_deferred_transactions(true);
+
+   chain.produce_blocks();
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
+
+   // this transfer is performed right away since delay is removed
+   trace = chain.push_action(N(currency), name("transfer"), N(tester), fc::mutable_variant_object()
+       ("from", "tester")
+       ("to", "tester2")
+       ("quantity", "10.0000 CUR")
+       ("memo", "hi" )
+   );
+   BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace.status);
+   BOOST_REQUIRE_EQUAL(0, trace.deferred_transactions.size());
+
+   chain.control->push_deferred_transactions(true);
+
+   chain.produce_blocks();
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("89.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("11.0000 CUR"), liquid_balance);
+
+   chain.control->push_deferred_transactions(true);
+
+   chain.produce_blocks(15);
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("89.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("11.0000 CUR"), liquid_balance);
+
+   chain.control->push_deferred_transactions(true);
+
+   chain.produce_blocks();
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("89.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("11.0000 CUR"), liquid_balance);
+
+   // second transfer finally is performed
+   chain.control->push_deferred_transactions(true);
+
+   chain.produce_blocks();
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("84.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("16.0000 CUR"), liquid_balance);
+
+} FC_LOG_AND_RETHROW() }/// schedule_test
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/tests/abi_tests.cpp
+++ b/tests/tests/abi_tests.cpp
@@ -1937,7 +1937,8 @@ BOOST_AUTO_TEST_CASE(updateauth)
                    {"key" : "EOS5eVr9TVnqwnUBNwf9kwMTbrHvX5aPyyEG97dz2b2TNeqWRzbJf", "weight" : 57605} ],
         "accounts" : [ {"permission" : {"actor" : "prm.acct1", "permission" : "prm.prm1"}, "weight" : 53005 },
                        {"permission" : {"actor" : "prm.acct2", "permission" : "prm.prm2"}, "weight" : 53405 }]
-     }
+     },
+     "delay" : 0
    }
    )=====";
 


### PR DESCRIPTION
DAWN-398
#1022 
Added processing to box and delay transactions with actions that are either:
Linked to permissions with a non-zero delay
updateauth for a permission that has a delay
linkauth or unlinkauth to a previous permission that has a delay

Also added processing for canceldelay and mindelay actions.