### PR TITLE
Make get_table_rows via chain_plugin (and thus cleos) easier to use

### DIFF
--- a/contracts/currency/currency.abi
+++ b/contracts/currency/currency.abi
@@ -35,15 +35,15 @@
       "name": "account",
       "base": "",
       "fields": [
-        {"name":"currency", "type":"uint64"},
-        {"name":"balance", "type":"uint64"}
+        {"name":"currency", "type":"symbol"},
+        {"name":"balance", "type":"int64"}
       ]
     },{
       "name": "currency_stats",
       "base": "",
       "fields": [
-        {"name":"currency", "type":"uint64"},
-        {"name":"supply", "type":"uint64"}
+        {"name":"currency", "type":"symbol_name"},
+        {"name":"supply", "type":"int64"}
       ]
     }
   ],
@@ -60,7 +60,7 @@
 
   ],
   "tables": [{
-      "name": "account",
+      "name": "accounts",
       "type": "account",
       "index_type": "i64",
       "key_names" : ["currency"],

--- a/contracts/currency/currency.abi
+++ b/contracts/currency/currency.abi
@@ -42,7 +42,7 @@
       "name": "currency_stats",
       "base": "",
       "fields": [
-        {"name":"currency", "type":"symbol_name"},
+        {"name":"currency", "type":"symbol_code"},
         {"name":"supply", "type":"int64"}
       ]
     }

--- a/contracts/currency/currency.abi
+++ b/contracts/currency/currency.abi
@@ -35,15 +35,22 @@
       "name": "account",
       "base": "",
       "fields": [
-        {"name":"currency", "type":"symbol"},
-        {"name":"balance", "type":"int64"}
+         {"name":"balance",   "type":"asset"},
+         {"name":"frozen",    "type":"uint8"},
+         {"name":"whitelist", "type":"uint8"}
       ]
     },{
       "name": "currency_stats",
       "base": "",
       "fields": [
-        {"name":"currency", "type":"symbol_code"},
-        {"name":"supply", "type":"int64"}
+         {"name":"supply",            "type":"asset"},
+         {"name":"max_supply",        "type":"asset"},
+         {"name":"issuer",            "type":"account_name"},
+         {"name":"can_freeze",        "type":"uint8"},
+         {"name":"can_recall",        "type":"uint8"},
+         {"name":"can_whitelist",     "type":"uint8"},
+         {"name":"is_frozen",         "type":"uint8"},
+         {"name":"enforce_whitelist", "type":"uint8"}
       ]
     }
   ],

--- a/libraries/chain/contracts/abi_serializer.cpp
+++ b/libraries/chain/contracts/abi_serializer.cpp
@@ -59,7 +59,7 @@ namespace eosio { namespace chain { namespace contracts {
 
       //symbol.hpp
       built_in_types.emplace("symbol",                    pack_unpack<symbol>());
-      built_in_types.emplace("symbol_name",               pack_unpack<symbol_name>());
+      built_in_types.emplace("symbol_code",               pack_unpack<symbol_code>());
 
       //asset.hpp
       built_in_types.emplace("asset",                     pack_unpack<asset>());

--- a/libraries/chain/contracts/abi_serializer.cpp
+++ b/libraries/chain/contracts/abi_serializer.cpp
@@ -48,10 +48,6 @@ namespace eosio { namespace chain { namespace contracts {
       );
    }
 
-   struct symbol_name {
-      uint64_t value;
-   };
-
    abi_serializer::abi_serializer( const abi_def& abi ) {
       configure_built_in_types();
       set_abi(abi);
@@ -328,14 +324,3 @@ namespace eosio { namespace chain { namespace contracts {
    }
 
 } } }
-
-namespace fc {
-   inline void to_variant(const eosio::chain::contracts::symbol_name& var, fc::variant& vo) {
-      vo = eosio::chain::symbol(var.value << 8).name();
-   }
-   inline void from_variant(const fc::variant& var, eosio::chain::contracts::symbol_name& vo) {
-      vo.value = (eosio::chain::symbol(0, var.get_string().c_str()).value() >> 8);
-   }
-}
-
-FC_REFLECT(eosio::chain::contracts::symbol_name, (value))

--- a/libraries/chain/contracts/abi_serializer.cpp
+++ b/libraries/chain/contracts/abi_serializer.cpp
@@ -48,6 +48,10 @@ namespace eosio { namespace chain { namespace contracts {
       );
    }
 
+   struct symbol_name {
+      uint64_t value;
+   };
+
    abi_serializer::abi_serializer( const abi_def& abi ) {
       configure_built_in_types();
       set_abi(abi);
@@ -59,6 +63,7 @@ namespace eosio { namespace chain { namespace contracts {
 
       //symbol.hpp
       built_in_types.emplace("symbol",                    pack_unpack<symbol>());
+      built_in_types.emplace("symbol_name",               pack_unpack<symbol_name>());
 
       //asset.hpp
       built_in_types.emplace("asset",                     pack_unpack<asset>());
@@ -102,7 +107,7 @@ namespace eosio { namespace chain { namespace contracts {
 
       for( const auto& st : abi.structs )
          structs[st.name] = st;
-      
+
       for( const auto& td : abi.types ) {
          FC_ASSERT(is_type(td.type), "invalid type", ("type",td.type));
          typedefs[td.new_type_name] = td.type;
@@ -140,9 +145,9 @@ namespace eosio { namespace chain { namespace contracts {
          return boost::lexical_cast<int>(stype.substr(4));
       } else {
          return boost::lexical_cast<int>(stype.substr(3));
-      }      
+      }
    }
-   
+
    bool abi_serializer::is_struct(const type_name& type)const {
       return structs.find(resolve_type(type)) != structs.end();
    }
@@ -256,7 +261,7 @@ namespace eosio { namespace chain { namespace contracts {
         fc::raw::unpack(stream, flag);
         return flag ? binary_to_variant(ftype, stream) : fc::variant();
       }
-      
+
       fc::mutable_variant_object mvo;
       binary_to_variant(rtype, stream, mvo);
       return fc::variant( std::move(mvo) );
@@ -322,4 +327,15 @@ namespace eosio { namespace chain { namespace contracts {
       return type_name();
    }
 
-} } } 
+} } }
+
+namespace fc {
+   inline void to_variant(const eosio::chain::contracts::symbol_name& var, fc::variant& vo) {
+      vo = eosio::chain::symbol(var.value << 8).name();
+   }
+   inline void from_variant(const fc::variant& var, eosio::chain::contracts::symbol_name& vo) {
+      vo.value = (eosio::chain::symbol(0, var.get_string().c_str()).value() >> 8);
+   }
+}
+
+FC_REFLECT(eosio::chain::contracts::symbol_name, (value))

--- a/libraries/chain/include/eosio/chain/symbol.hpp
+++ b/libraries/chain/include/eosio/chain/symbol.hpp
@@ -51,7 +51,7 @@ namespace eosio {
          } FC_CAPTURE_LOG_AND_RETHROW((str))
       }
 
-      struct symbol_name {
+      struct symbol_code {
          uint64_t value;
       };
 
@@ -110,7 +110,7 @@ namespace eosio {
                return result;
             }
 
-            symbol_name to_symbol_name()const { return {m_value >> 8}; }
+            symbol_code to_symbol_code()const { return {m_value >> 8}; }
 
             explicit operator string() const
             {
@@ -167,14 +167,14 @@ namespace fc {
 }
 
 namespace fc {
-   inline void to_variant(const eosio::chain::symbol_name& var, fc::variant& vo) {
+   inline void to_variant(const eosio::chain::symbol_code& var, fc::variant& vo) {
       vo = eosio::chain::symbol(var.value << 8).name();
    }
-   inline void from_variant(const fc::variant& var, eosio::chain::symbol_name& vo) {
-      vo = eosio::chain::symbol(0, var.get_string().c_str()).to_symbol_name();
+   inline void from_variant(const fc::variant& var, eosio::chain::symbol_code& vo) {
+      vo = eosio::chain::symbol(0, var.get_string().c_str()).to_symbol_code();
    }
 }
 
-FC_REFLECT(eosio::chain::symbol_name, (value))
+FC_REFLECT(eosio::chain::symbol_code, (value))
 FC_REFLECT(eosio::chain::symbol, (m_value))
 FC_REFLECT(eosio::chain::extended_symbol, (sym)(contract))

--- a/libraries/chain/include/eosio/chain/symbol.hpp
+++ b/libraries/chain/include/eosio/chain/symbol.hpp
@@ -19,11 +19,11 @@ namespace eosio {
          from_string constructs a symbol from an input a string of the form "4,EOS"
          where the integer represents number of decimals. Number of decimals must be larger than zero.
        */
-      
+
       static constexpr uint64_t string_to_symbol_c(uint8_t precision, const char* str) {
          uint32_t len = 0;
          while (str[len]) ++len;
-         
+
          uint64_t result = 0;
          // No validation is done at compile time
          for (uint32_t i = 0; i < len; ++i) {
@@ -33,7 +33,7 @@ namespace eosio {
          result |= uint64_t(precision);
          return result;
       }
-      
+
 #define SY(P,X) ::eosio::chain::string_to_symbol_c(P,#X)
 
       static uint64_t string_to_symbol(uint8_t precision, const char* str) {
@@ -50,6 +50,10 @@ namespace eosio {
             return result;
          } FC_CAPTURE_LOG_AND_RETHROW((str))
       }
+
+      struct symbol_name {
+         uint64_t value;
+      };
 
       class symbol {
          public:
@@ -105,7 +109,9 @@ namespace eosio {
                }
                return result;
             }
-            
+
+            symbol_name to_symbol_name()const { return {m_value >> 8}; }
+
             explicit operator string() const
             {
                uint64_t v = m_value;
@@ -122,7 +128,7 @@ namespace eosio {
             {
                return ds << s.to_string();
             }
-            
+
          private:
             uint64_t m_value;
             friend struct fc::reflector<symbol>;
@@ -150,7 +156,7 @@ namespace eosio {
          return lhs.value() > rhs.value();
       }
 
-   } // namespace chain   
+   } // namespace chain
 } // namespace eosio
 
 namespace fc {
@@ -160,5 +166,15 @@ namespace fc {
    }
 }
 
+namespace fc {
+   inline void to_variant(const eosio::chain::symbol_name& var, fc::variant& vo) {
+      vo = eosio::chain::symbol(var.value << 8).name();
+   }
+   inline void from_variant(const fc::variant& var, eosio::chain::symbol_name& vo) {
+      vo = eosio::chain::symbol(0, var.get_string().c_str()).to_symbol_name();
+   }
+}
+
+FC_REFLECT(eosio::chain::symbol_name, (value))
 FC_REFLECT(eosio::chain::symbol, (m_value))
 FC_REFLECT(eosio::chain::extended_symbol, (sym)(contract))

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -182,12 +182,6 @@ public:
 
    fc::variant get_currency_stats( const get_currency_stats_params& params )const;
 
-   static void copy_row(const chain::contracts::key_value_object& obj, vector<char>& data) {
-      data.resize( sizeof(uint64_t) + obj.value.size() );
-      memcpy( data.data(), &obj.primary_key, sizeof(uint64_t) );
-      memcpy( data.data()+sizeof(uint64_t), obj.value.data(), obj.value.size() );
-   }
-
    static void copy_inline_row(const chain::contracts::key_value_object& obj, vector<char>& data) {
       data.resize( obj.value.size() );
       memcpy( data.data(), obj.value.data(), obj.value.size() );
@@ -265,7 +259,7 @@ public:
          unsigned int count = 0;
          auto itr = lower;
          for (itr = lower; itr != upper; ++itr) {
-            copy_row(*itr, data);
+            copy_inline_row(*itr, data);
 
             if (p.json) {
                result.rows.emplace_back(abis.binary_to_variant(abis.get_table_type(p.table), data));

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -14,6 +14,8 @@
 #include <eosio/chain/contracts/abi_serializer.hpp>
 
 #include <boost/container/flat_set.hpp>
+#include <boost/algorithm/string.hpp>
+#include <boost/lexical_cast.hpp>
 
 namespace fc { class variant; }
 
@@ -145,7 +147,7 @@ public:
    struct get_table_rows_params {
       bool        json = false;
       name        code;
-      name        scope;
+      string      scope;
       name        table;
 //      string      table_type;
       string      table_key;
@@ -215,9 +217,32 @@ public:
       read_only::get_table_rows_result result;
       const auto& d = db.get_database();
 
+      uint64_t scope = 0;
+      try {
+         name s(p.scope);
+         scope = s.value;
+      } catch( ... ) {
+         try {
+            auto trimmed_scope_str = p.scope;
+            boost::trim(trimmed_scope_str);
+            scope = boost::lexical_cast<uint64_t>(trimmed_scope_str.c_str(), trimmed_scope_str.size());
+         } catch( ... ) {
+            try {
+               auto symb = eosio::chain::symbol::from_string(p.scope);
+               scope = symb.value();
+            } catch( ... ) {
+               try {
+                  scope = ( eosio::chain::string_to_symbol( 0, p.scope.c_str() ) >> 8 );
+               } catch( ... ) {
+                  FC_ASSERT( false, "could not convert scope string to any of the following: uint64_t, valid name, or valid symbol (with or without the precision)" );
+               }
+            }
+         }
+      }
+
       abi_serializer abis;
       abis.set_abi(abi);
-      const auto* t_id = d.find<chain::contracts::table_id_object, chain::contracts::by_code_scope_table>(boost::make_tuple(p.code, p.scope, p.table));
+      const auto* t_id = d.find<chain::contracts::table_id_object, chain::contracts::by_code_scope_table>(boost::make_tuple(p.code, scope, p.table));
       if (t_id != nullptr) {
          const auto &idx = d.get_index<IndexType, Scope>();
          decltype(t_id->id) next_tid(t_id->id._id + 1);

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -141,7 +141,7 @@ void add_standard_transaction_options(CLI::App* cmd, string default_permission =
       if (res.size() == 0 || !CLI::detail::lexical_cast(res[0], value_s)) {
          return false;
       }
-      
+
       tx_expiration = fc::seconds(static_cast<uint64_t>(value_s));
       return true;
    };
@@ -245,9 +245,9 @@ chain::action create_newaccount(const name& creator, const name& newaccount, pub
    return action {
       tx_permission.empty() ? vector<chain::permission_level>{{creator,config::active_name}} : get_account_permissions(tx_permission),
       contracts::newaccount{
-         .creator      = creator, 
-         .name         = newaccount, 
-         .owner        = eosio::chain::authority{1, {{owner, 1}}, {}}, 
+         .creator      = creator,
+         .name         = newaccount,
+         .owner        = eosio::chain::authority{1, {{owner, 1}}, {}},
          .active       = eosio::chain::authority{1, {{active, 1}}, {}},
          .recovery     = eosio::chain::authority{1, {}, {{{creator, config::active_name}, 1}}}
       }
@@ -261,7 +261,7 @@ chain::action create_transfer(const name& sender, const name& recipient, uint64_
       ("to", recipient)
       ("quantity", asset(amount))
       ("memo", memo);
-   
+
    auto args = fc::mutable_variant_object
       ("code", name(config::system_account_name))
       ("action", "transfer")
@@ -276,7 +276,7 @@ chain::action create_transfer(const name& sender, const name& recipient, uint64_
 }
 
 chain::action create_setabi(const name& account, const contracts::abi_def& abi) {
-   return action { 
+   return action {
       tx_permission.empty() ? vector<chain::permission_level>{{account,config::active_name}} : get_account_permissions(tx_permission),
       contracts::setabi{
          .account   = account,
@@ -286,13 +286,13 @@ chain::action create_setabi(const name& account, const contracts::abi_def& abi) 
 }
 
 chain::action create_setcode(const name& account, const bytes& code) {
-   return action { 
+   return action {
       tx_permission.empty() ? vector<chain::permission_level>{{account,config::active_name}} : get_account_permissions(tx_permission),
       contracts::setcode{
          .account   = account,
          .vmtype    = 0,
          .vmversion = 0,
-         .code      = code 
+         .code      = code
       }
    };
 }
@@ -336,7 +336,7 @@ struct set_account_permission_subcommand {
          name account = name(accountStr);
          name permission = name(permissionStr);
          bool is_delete = boost::iequals(authorityJsonOrFile, "null");
-         
+
          if (is_delete) {
             send_actions({create_deleteauth(account, permission)});
          } else {
@@ -355,7 +355,7 @@ struct set_account_permission_subcommand {
                   }
                   auth = parsedAuthority.as<authority>();
                } EOS_CAPTURE_AND_RETHROW(authority_type_exception, "Fail to parse Authority JSON")
-                 
+
             }
 
             name parent;
@@ -363,10 +363,10 @@ struct set_account_permission_subcommand {
                // see if we can auto-determine the proper parent
                const auto account_result = call(get_account_func, fc::mutable_variant_object("account_name", accountStr));
                const auto& existing_permissions = account_result.get_object()["permissions"].get_array();
-               auto permissionPredicate = [this](const auto& perm) { 
-                  return perm.is_object() && 
+               auto permissionPredicate = [this](const auto& perm) {
+                  return perm.is_object() &&
                         perm.get_object().contains("permission") &&
-                        boost::equals(perm.get_object()["permission"].get_string(), permissionStr); 
+                        boost::equals(perm.get_object()["permission"].get_string(), permissionStr);
                };
 
                auto itr = boost::find_if(existing_permissions, permissionPredicate);
@@ -382,10 +382,10 @@ struct set_account_permission_subcommand {
             }
 
             send_actions({create_updateauth(account, permission, parent, auth)});
-         }      
+         }
       });
    }
-   
+
 };
 
 struct set_action_permission_subcommand {
@@ -408,13 +408,13 @@ struct set_action_permission_subcommand {
          name code = name(codeStr);
          name type = name(typeStr);
          bool is_delete = boost::iequals(requirementStr, "null");
-         
+
          if (is_delete) {
             send_actions({create_unlinkauth(account, code, type)});
          } else {
             name requirement = name(requirementStr);
             send_actions({create_linkauth(account, code, type, requirement)});
-         }      
+         }
       });
    }
 };
@@ -422,7 +422,7 @@ struct set_action_permission_subcommand {
 int main( int argc, char** argv ) {
    fc::path binPath = argv[0];
    if (binPath.is_relative()) {
-      binPath = relative(binPath, current_path()); 
+      binPath = relative(binPath, current_path());
    }
 
    setlocale(LC_ALL, "");
@@ -534,7 +534,7 @@ int main( int argc, char** argv ) {
       }
    });
 
-   // get table 
+   // get table
    string scope;
    string code;
    string table;
@@ -544,8 +544,8 @@ int main( int argc, char** argv ) {
    bool binary = false;
    uint32_t limit = 10;
    auto getTable = get->add_subcommand( "table", localized("Retrieve the contents of a database table"), false);
-   getTable->add_option( "scope", scope, localized("The account scope where the table is found") )->required();
-   getTable->add_option( "contract", code, localized("The contract within scope who owns the table") )->required();
+   getTable->add_option( "contract", code, localized("The contract who owns the table") )->required();
+   getTable->add_option( "scope", scope, localized("The scope within the contract in which the table is found") )->required();
    getTable->add_option( "table", table, localized("The name of the table as specified by the contract abi") )->required();
    getTable->add_option( "-b,--binary", binary, localized("Return the value as BINARY rather than using abi to interpret as JSON") );
    getTable->add_option( "-l,--limit", limit, localized("The maximum number of rows to return") );
@@ -555,8 +555,8 @@ int main( int argc, char** argv ) {
 
    getTable->set_callback([&] {
       auto result = call(get_table_func, fc::mutable_variant_object("json", !binary)
-                         ("scope",scope)
                          ("code",code)
+                         ("scope",scope)
                          ("table",table)
                          ("table_key",table_key)
                          ("lower_bound",lower)
@@ -685,7 +685,7 @@ int main( int argc, char** argv ) {
          ->check(CLI::ExistingFile);
    auto abi = contractSubcommand->add_option("abi-file,-a,--abi", abiPath, localized("The ABI for the contract"))
               ->check(CLI::ExistingFile);
-   
+
    add_standard_transaction_options(contractSubcommand, "account@active");
    contractSubcommand->set_callback([&] {
       std::string wast;
@@ -724,7 +724,7 @@ int main( int argc, char** argv ) {
 
    // set action
    auto setAction = setSubcommand->add_subcommand("action", localized("set or update blockchain action state"))->require_subcommand();
-   
+
    // set action permission
    auto setActionPermission = set_action_permission_subcommand(setAction);
 
@@ -747,11 +747,11 @@ int main( int argc, char** argv ) {
          memo = generate_nonce_value();
          tx_force_unique = false;
       }
-      
+
       send_actions({create_transfer(sender, recipient, amount, memo)});
    });
 
-   // Net subcommand 
+   // Net subcommand
    string new_host;
    auto net = app.add_subcommand( "net", localized("Interact with local p2p network connections"), false );
    net->require_subcommand();

--- a/tests/api_tests/api_tests.cpp
+++ b/tests/api_tests/api_tests.cpp
@@ -477,7 +477,11 @@ BOOST_FIXTURE_TEST_CASE(checktime_pass_tests, tester) { try {
 } FC_LOG_AND_RETHROW() }
 
 BOOST_AUTO_TEST_CASE(checktime_fail_tests) { try {
-   tester t( {fc::milliseconds(100), fc::milliseconds(100)} );
+	// TODO: This is an extremely fragile test. It needs improvements:
+	//       1) compilation of the smart contract should probably not count towards the CPU time of a transaction that first uses it;
+	//       2) checktime should eventually switch to a deterministic metric which should hopefully fix the inconsistencies
+	//          of this test succeeding/failing on different machines (for example, succeeding on our local dev machines but failing on Jenkins).
+   tester t( {fc::milliseconds(5000), fc::milliseconds(5000)} );
    t.produce_blocks(2);
 
    t.create_account( N(testapi) );


### PR DESCRIPTION
Added `symbol_name` built_in_type to abi_serializer, which is like `symbol` except it does not include the leading precision in the displayed string.

Now treating scope string as (in order of attempts): `name`, `uint64_t`, `symbol`, or `symbol_name`. Only throw error if the string cannot be interpreted as any of those four types. Ambiguity between a name consisting of only the digits 1 through 5 and an actual `uint64_t` number can be resolved by adding whitespace to the beginning or end of the string representation of the `uint64_t` number passed into cleos.

Switched order of scope and code arguments in cleos to better reflect the table structure.

Updated currency.abi to use the more descriptive types (such as `symbol` and `symbol_name`) and also to use the correct table name ("accounts") for the accounts tables.

This PR should fix issue #1742, #1827 and maybe #1832.