### PR TITLE
docker-compose fix

### DIFF
--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: .
     image: eosio/eos
-    command: /opt/eosio/bin/nodeosd.sh
+    command: /opt/eosio/bin/start_nodeos.sh
     ports:
       - 8888:8888
       - 9876:9876


### PR DESCRIPTION
fixes bad reference to the startup command to the `nodeos` section