### PR TITLE
Build the mongo c++ support libraries for static linkage

### DIFF
--- a/README.md
+++ b/README.md
@@ -622,12 +622,12 @@ cd ~
 curl -LO https://github.com/mongodb/mongo-c-driver/releases/download/1.9.3/mongo-c-driver-1.9.3.tar.gz
 tar xf mongo-c-driver-1.9.3.tar.gz
 cd mongo-c-driver-1.9.3
-./configure --enable-ssl=openssl --disable-automatic-init-and-cleanup --prefix=/usr/local
+./configure --enable-static --enable-ssl=openssl --disable-automatic-init-and-cleanup --prefix=/usr/local
 make -j$( nproc )
 sudo make install
 git clone https://github.com/mongodb/mongo-cxx-driver.git --branch releases/stable --depth 1
 cd mongo-cxx-driver/build
-cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local ..
+cmake -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local ..
 sudo make -j$( nproc )
 ```
 
@@ -745,12 +745,12 @@ cd ~
 curl -LO https://github.com/mongodb/mongo-c-driver/releases/download/1.9.3/mongo-c-driver-1.9.3.tar.gz
 tar xf mongo-c-driver-1.9.3.tar.gz
 cd mongo-c-driver-1.9.3
-./configure --enable-ssl=openssl --disable-automatic-init-and-cleanup --prefix=/usr/local
+./configure --enable-static --enable-ssl=openssl --disable-automatic-init-and-cleanup --prefix=/usr/local
 make -j$( nproc )
 sudo make install
 git clone https://github.com/mongodb/mongo-cxx-driver.git --branch releases/stable --depth 1
 cd mongo-cxx-driver/build
-cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local ..
+cmake -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local ..
 sudo make -j$( nproc )
 ```
 
@@ -819,12 +819,12 @@ cd ~
 curl -LO https://github.com/mongodb/mongo-c-driver/releases/download/1.9.3/mongo-c-driver-1.9.3.tar.gz
 tar xf mongo-c-driver-1.9.3.tar.gz
 cd mongo-c-driver-1.9.3
-./configure --enable-ssl=openssl --disable-automatic-init-and-cleanup --prefix=/usr/local
+./configure --enable-static --enable-ssl=openssl --disable-automatic-init-and-cleanup --prefix=/usr/local
 make -j$( nproc )
 sudo make install
 git clone https://github.com/mongodb/mongo-cxx-driver.git --branch releases/stable --depth 1
 cd mongo-cxx-driver/build
-cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local ..
+cmake -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local ..
 sudo make -j$( nproc )
 ```
 
@@ -893,12 +893,12 @@ cd ~
 curl -LO https://github.com/mongodb/mongo-c-driver/releases/download/1.9.3/mongo-c-driver-1.9.3.tar.gz
 tar xf mongo-c-driver-1.9.3.tar.gz
 cd mongo-c-driver-1.9.3
-./configure --enable-ssl=openssl --disable-automatic-init-and-cleanup --prefix=/usr/local
+./configure --enable-static --enable-ssl=openssl --disable-automatic-init-and-cleanup --prefix=/usr/local
 make -j$( nproc )
 sudo make install
 git clone https://github.com/mongodb/mongo-cxx-driver.git --branch releases/stable --depth 1
 cd mongo-cxx-driver/build
-cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local ..
+cmake -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local ..
 sudo make -j$( nproc )
 ```
 
@@ -969,7 +969,7 @@ curl -LO https://github.com/mongodb/mongo-c-driver/releases/download/1.9.3/mongo
 tar xf mongo-c-driver-1.9.3.tar.gz
 rm -f mongo-c-driver-1.9.3.tar.gz
 cd mongo-c-driver-1.9.3
-./configure --enable-ssl=darwin --disable-automatic-init-and-cleanup --prefix=/usr/local
+./configure --enable-static --enable-ssl=darwin --disable-automatic-init-and-cleanup --prefix=/usr/local
 make -j$( sysctl -in machdep.cpu.core_count )
 sudo make install
 cd ..
@@ -977,7 +977,7 @@ rm -rf mongo-c-driver-1.9.3
 
 git clone https://github.com/mongodb/mongo-cxx-driver.git --branch releases/stable --depth 1
 cd mongo-cxx-driver/build
-cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local ..
+cmake -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local ..
 make -j$( sysctl -in machdep.cpu.core_count )
 sudo make install
 cd ..

--- a/plugins/mongo_db_plugin/CMakeLists.txt
+++ b/plugins/mongo_db_plugin/CMakeLists.txt
@@ -19,30 +19,30 @@ if(BUILD_MONGO_DB_PLUGIN)
       # link step for all executables using this archive must include the
       # mongo-cxx-driver libraries libmongocxx and libbsoncxx.
 
-      find_package(libbsoncxx REQUIRED)
-      message(STATUS "Found bsoncxx headers: ${LIBBSONCXX_INCLUDE_DIRS}")
+      find_package(libbsoncxx-static REQUIRED)
+      message(STATUS "Found bsoncxx headers: ${LIBBSONCXX_STATIC_INCLUDE_DIRS}")
 
       # mongo-cxx-driver 3.2 release altered LIBBSONCXX_LIBRARIES semantics. Instead of library names,
       #  it now hold library paths.
-      if((LIBBSONCXX_VERSION_MAJOR LESS 3) OR ((LIBBSONCXX_VERSION_MAJOR EQUAL 3) AND (LIBBSONCXX_VERSION_MINOR LESS 2)))
-        find_library(EOS_LIBBSONCXX ${LIBBSONCXX_LIBRARIES}
-          PATHS ${LIBBSONCXX_LIBRARY_DIRS} NO_DEFAULT_PATH)
+      if((LIBBSONCXX_STATIC_VERSION_MAJOR LESS 3) OR ((LIBBSONCXX_STATIC_VERSION_MAJOR EQUAL 3) AND (LIBBSONCXX_STATIC_VERSION_MINOR LESS 2)))
+        find_library(EOS_LIBBSONCXX ${LIBBSONCXX_STATIC_LIBRARIES}
+          PATHS ${LIBBSONCXX_STATIC_LIBRARY_DIRS} NO_DEFAULT_PATH)
       else()
-        set(EOS_LIBBSONCXX ${LIBBSONCXX_LIBRARIES})
+        set(EOS_LIBBSONCXX ${LIBBSONCXX_STATIC_LIBRARIES})
       endif()
 
       message(STATUS "Found bsoncxx library: ${EOS_LIBBSONCXX}")
 
-      find_package(libmongocxx REQUIRED)
-      message(STATUS "Found mongocxx headers: ${LIBMONGOCXX_INCLUDE_DIRS}")
+      find_package(libmongocxx-static REQUIRED)
+      message(STATUS "Found mongocxx headers: ${LIBMONGOCXX_STATIC_INCLUDE_DIRS}")
 
       # mongo-cxx-driver 3.2 release altered LIBBSONCXX_LIBRARIES semantics. Instead of library names,
       #  it now hold library paths.
-      if((LIBMONGOCXX_VERSION_MAJOR LESS 3) OR ((LIBMONGOCXX_VERSION_MAJOR EQUAL 3) AND (LIBMONGOCXX_VERSION_MINOR LESS 2)))
-        find_library(EOS_LIBMONGOCXX ${LIBMONGOCXX_LIBRARIES}
-          PATHS ${LIBMONGOCXX_LIBRARY_DIRS} NO_DEFAULT_PATH)
+      if((LIBMONGOCXX_STATIC_VERSION_MAJOR LESS 3) OR ((LIBMONGOCXX_STATIC_VERSION_MAJOR EQUAL 3) AND (LIBMONGOCXX_STATIC_VERSION_MINOR LESS 2)))
+        find_library(EOS_LIBMONGOCXX ${LIBMONGOCXX_STATIC_LIBRARIES}
+          PATHS ${LIBMONGOCXX_STATIC_LIBRARY_DIRS} NO_DEFAULT_PATH)
       else()
-        set(EOS_LIBMONGOCXX ${LIBMONGOCXX_LIBRARIES})
+        set(EOS_LIBMONGOCXX ${LIBMONGOCXX_STATIC_LIBRARIES})
       endif()
 
       message(STATUS "Found mongocxx library: ${EOS_LIBMONGOCXX}")
@@ -58,7 +58,7 @@ if(BUILD_MONGO_DB_PLUGIN)
       #
       # git clone https://github.com/mongodb/mongo-cxx-driver.git --branch releases/stable --depth 1
       # cd mongo-cxx-driver/build
-      # cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local ..
+      # cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local -DBUILD_SHARED_LIBS=OFF ..
       # sudo make EP_mnmlstc_core
       # make
       # sudo make install
@@ -67,20 +67,18 @@ if(BUILD_MONGO_DB_PLUGIN)
   endif()
 
   target_include_directories(mongo_db_plugin
-          PRIVATE ${LIBMONGOCXX_INCLUDE_DIRS} ${LIBBSONCXX_INCLUDE_DIRS}
+          PRIVATE ${LIBMONGOCXX_STATIC_INCLUDE_DIRS} ${LIBBSONCXX_STATIC_INCLUDE_DIRS}
           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include"
           )
 
   target_compile_definitions(mongo_db_plugin
-    PRIVATE ${LIBMONGOCXX_DEFINITIONS} ${LIBBSONCXX_DEFINITIONS}
+    PRIVATE ${LIBMONGOCXX_STATIC_DEFINITIONS} ${LIBBSONCXX_STATIC_DEFINITIONS}
     )
 
   target_link_libraries(mongo_db_plugin
           PUBLIC chain_plugin eosio_chain appbase
           ${EOS_LIBMONGOCXX} ${EOS_LIBBSONCXX}
           )
-
-  set(CPACK_DEBIAN_PACKAGE_DEPENDS "libmongoc-1.0-0 (>= 1.3)" PARENT_SCOPE)
 else()
   message("mongo_db_plugin not selected and will be omitted.")
 endif()

--- a/scripts/eosio_build_amazon.sh
+++ b/scripts/eosio_build_amazon.sh
@@ -176,7 +176,7 @@ mongodconf
 	fi
 	
 	printf "\n\tChecking MongoDB C++ driver installation.\n"
-    if [ ! -e /usr/local/lib/libmongocxx.so ]; then
+    if [ ! -e /usr/local/lib/libmongocxx-static.a ]; then
 		cd ${TEMP_DIR}
 		curl -LO https://github.com/mongodb/mongo-c-driver/releases/download/1.9.3/mongo-c-driver-1.9.3.tar.gz
 		if [ $? -ne 0 ]; then
@@ -188,7 +188,7 @@ mongodconf
 		tar xf mongo-c-driver-1.9.3.tar.gz
 		rm -f ${TEMP_DIR}/mongo-c-driver-1.9.3.tar.gz
 		cd mongo-c-driver-1.9.3
-		./configure --enable-ssl=openssl --disable-automatic-init-and-cleanup --prefix=/usr/local
+		./configure --enable-static --enable-ssl=openssl --disable-automatic-init-and-cleanup --prefix=/usr/local
 		if [ $? -ne 0 ]; then
 			printf "\tConfiguring MondgDB C driver has encountered the errors above.\n"
 			printf "\tExiting now.\n\n"
@@ -216,7 +216,7 @@ mongodconf
 			exit;
 		fi
 		cd mongo-cxx-driver/build
-		${CMAKE} -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local ..
+		${CMAKE} -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local ..
 		if [ $? -ne 0 ]; then
 			printf "\tCmake has encountered the above errors building the MongoDB C++ driver.\n"
 			printf "\tExiting now.\n\n"
@@ -237,7 +237,7 @@ mongodconf
 		cd ..
 		sudo rm -rf ${TEMP_DIR}/mongo-cxx-driver
 	else
-		printf "\tMongo C++ driver found at /usr/local/lib/libmongocxx.so.\n"
+		printf "\tMongo C++ driver found at /usr/local/lib/libmongocxx-static.a.\n"
 	fi
 
 	printf "\n\tChecking secp256k1-zkp installation.\n"

--- a/scripts/eosio_build_amazon.sh
+++ b/scripts/eosio_build_amazon.sh
@@ -209,6 +209,7 @@ mongodconf
 		cd ..
 		rm -rf ${TEMP_DIR}/mongo-c-driver-1.9.3
 		cd ${TEMP_DIR}
+		sudo rm -rf ${TEMP_DIR}/mongo-cxx-driver
 		git clone https://github.com/mongodb/mongo-cxx-driver.git --branch releases/stable --depth 1
 		if [ $? -ne 0 ]; then
 			printf "\tUnable to clone MondgDB C++ driver at this time.\n"

--- a/scripts/eosio_build_amazon.sh
+++ b/scripts/eosio_build_amazon.sh
@@ -188,7 +188,7 @@ mongodconf
 		tar xf mongo-c-driver-1.9.3.tar.gz
 		rm -f ${TEMP_DIR}/mongo-c-driver-1.9.3.tar.gz
 		cd mongo-c-driver-1.9.3
-		./configure --enable-static --enable-ssl=openssl --disable-automatic-init-and-cleanup --prefix=/usr/local
+		./configure --enable-static --with-libbson=bundled --enable-ssl=openssl --disable-automatic-init-and-cleanup --prefix=/usr/local
 		if [ $? -ne 0 ]; then
 			printf "\tConfiguring MondgDB C driver has encountered the errors above.\n"
 			printf "\tExiting now.\n\n"

--- a/scripts/eosio_build_centos.sh
+++ b/scripts/eosio_build_centos.sh
@@ -283,6 +283,7 @@ mongodconf
 		cd ..
 		rm -rf ${TEMP_DIR}/mongo-c-driver-1.9.3
 		cd ${TEMP_DIR}
+		sudo rm -rf ${TEMP_DIR}/mongo-cxx-driver
 		git clone https://github.com/mongodb/mongo-cxx-driver.git --branch releases/stable --depth 1
 		if [ $? -ne 0 ]; then
 			printf "\tUnable to clone MondgDB C++ driver at this time.\n"

--- a/scripts/eosio_build_centos.sh
+++ b/scripts/eosio_build_centos.sh
@@ -249,7 +249,7 @@ mongodconf
 	fi
 
 	printf "\n\tChecking for MongoDB C++ driver.\n"
-    if [ ! -e /usr/local/lib/libmongocxx.so ]; then
+    if [ ! -e /usr/local/lib/libmongocxx-static.a ]; then
 		printf "\n\tInstalling MongoDB C & C++ drivers.\n"
 		cd ${TEMP_DIR}
 		curl -LO https://github.com/mongodb/mongo-c-driver/releases/download/1.9.3/mongo-c-driver-1.9.3.tar.gz
@@ -262,7 +262,7 @@ mongodconf
 		tar xf mongo-c-driver-1.9.3.tar.gz
 		rm -f ${TEMP_DIR}/mongo-c-driver-1.9.3.tar.gz
 		cd mongo-c-driver-1.9.3
-		./configure --enable-ssl=openssl --disable-automatic-init-and-cleanup --prefix=/usr/local
+		./configure --enable-static --enable-ssl=openssl --disable-automatic-init-and-cleanup --prefix=/usr/local
 		if [ $? -ne 0 ]; then
 			printf "\tConfiguring MondgDB C driver has encountered the errors above.\n"
 			printf "\tExiting now.\n\n"
@@ -290,7 +290,7 @@ mongodconf
 			exit;
 		fi
 		cd mongo-cxx-driver/build
-		${CMAKE} -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local ..
+		${CMAKE} -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local ..
 		if [ $? -ne 0 ]; then
 			printf "\tCmake has encountered the above errors building the MongoDB C++ driver.\n"
 			printf "\tExiting now.\n\n"
@@ -311,7 +311,7 @@ mongodconf
 		cd
 		sudo rm -rf ${TEMP_DIR}/mongo-cxx-driver
 	else
-		printf "\tMongo C++ driver found at /usr/local/lib/libmongocxx.so.\n"
+		printf "\tMongo C++ driver found at /usr/local/lib/libmongocxx-static.a.\n"
 	fi	
 	printf "\n\tChecking for secp256k1-zkp\n"
     if [ ! -e /usr/local/lib/libsecp256k1.a ]; then

--- a/scripts/eosio_build_centos.sh
+++ b/scripts/eosio_build_centos.sh
@@ -262,7 +262,7 @@ mongodconf
 		tar xf mongo-c-driver-1.9.3.tar.gz
 		rm -f ${TEMP_DIR}/mongo-c-driver-1.9.3.tar.gz
 		cd mongo-c-driver-1.9.3
-		./configure --enable-static --enable-ssl=openssl --disable-automatic-init-and-cleanup --prefix=/usr/local
+		./configure --enable-static --with-libbson=bundled --enable-ssl=openssl --disable-automatic-init-and-cleanup --prefix=/usr/local
 		if [ $? -ne 0 ]; then
 			printf "\tConfiguring MondgDB C driver has encountered the errors above.\n"
 			printf "\tExiting now.\n\n"

--- a/scripts/eosio_build_darwin.sh
+++ b/scripts/eosio_build_darwin.sh
@@ -190,6 +190,7 @@
 		cd ..
 		rm -rf ${TEMP_DIR}/mongo-c-driver-1.9.3
 		cd ${TEMP_DIR}
+		rm -rf ${TEMP_DIR}/mongo-cxx-driver
 		git clone https://github.com/mongodb/mongo-cxx-driver.git --branch releases/stable --depth 1
 		if [ $? -ne 0 ]; then
 			printf "\tUnable to clone MondgDB C++ driver at this time.\n"

--- a/scripts/eosio_build_darwin.sh
+++ b/scripts/eosio_build_darwin.sh
@@ -169,7 +169,7 @@
 		tar xf mongo-c-driver-1.9.3.tar.gz
 		rm -f ${TEMP_DIR}/mongo-c-driver-1.9.3.tar.gz
 		cd mongo-c-driver-1.9.3
-		./configure --enable-static --enable-ssl=darwin --disable-automatic-init-and-cleanup --prefix=/usr/local
+		./configure --enable-static --with-libbson=bundled --enable-ssl=darwin --disable-automatic-init-and-cleanup --prefix=/usr/local
 		if [ $? -ne 0 ]; then
 			printf "\tConfiguring MondgDB C driver has encountered the errors above.\n"
 			printf "\tExiting now.\n\n"

--- a/scripts/eosio_build_darwin.sh
+++ b/scripts/eosio_build_darwin.sh
@@ -155,7 +155,7 @@
 		
 	printf "\n\tChecking for MongoDB C++ driver\n"
     # install libmongocxx.dylib
-    if [ ! -e /usr/local/lib/libmongocxx.dylib ]; then
+    if [ ! -e /usr/local/lib/libmongocxx-static.a ]; then
 		cd ${TEMP_DIR}
 		brew install --force pkgconfig
 		brew unlink pkgconfig && brew link --force pkgconfig
@@ -169,7 +169,7 @@
 		tar xf mongo-c-driver-1.9.3.tar.gz
 		rm -f ${TEMP_DIR}/mongo-c-driver-1.9.3.tar.gz
 		cd mongo-c-driver-1.9.3
-		./configure --enable-ssl=darwin --disable-automatic-init-and-cleanup --prefix=/usr/local
+		./configure --enable-static --enable-ssl=darwin --disable-automatic-init-and-cleanup --prefix=/usr/local
 		if [ $? -ne 0 ]; then
 			printf "\tConfiguring MondgDB C driver has encountered the errors above.\n"
 			printf "\tExiting now.\n\n"
@@ -197,7 +197,7 @@
 			exit;
 		fi
 		cd mongo-cxx-driver/build
-		cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local ..
+		cmake -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local ..
 		if [ $? -ne 0 ]; then
 			printf "\tCmake has encountered the above errors building the MongoDB C++ driver.\n"
 			printf "\tExiting now.\n\n"
@@ -218,7 +218,7 @@
 		cd
 		rm -rf ${TEMP_DIR}/mongo-cxx-driver
 	else
-		printf "\tMongo C++ driver found at /usr/local/lib/libmongocxx.dylib.\n"
+		printf "\tMongo C++ driver found at /usr/local/lib/libmongocxx-static.a.\n"
 	fi
 
 	printf "\n\tChecking for secp256k1-zkp\n"

--- a/scripts/eosio_build_fedora.sh
+++ b/scripts/eosio_build_fedora.sh
@@ -137,7 +137,7 @@
 		tar xf mongo-c-driver-1.9.3.tar.gz
 		rm -f ${TEMP_DIR}/mongo-c-driver-1.9.3.tar.gz
 		cd mongo-c-driver-1.9.3
-		./configure --enable-static --enable-ssl=openssl --disable-automatic-init-and-cleanup --prefix=/usr/local
+		./configure --enable-static --with-libbson=bundled --enable-ssl=openssl --disable-automatic-init-and-cleanup --prefix=/usr/local
 		if [ $? -ne 0 ]; then
 			printf "\tConfiguring MondgDB C driver has encountered the errors above.\n"
 			printf "\tExiting now.\n\n"

--- a/scripts/eosio_build_fedora.sh
+++ b/scripts/eosio_build_fedora.sh
@@ -158,6 +158,7 @@
 		cd ..
 		rm -rf ${TEMP_DIR}/mongo-c-driver-1.9.3
 		cd ${TEMP_DIR}
+		sudo rm -rf ${TEMP_DIR}/mongo-cxx-driver
 		git clone https://github.com/mongodb/mongo-cxx-driver.git --branch releases/stable --depth 1
 		if [ $? -ne 0 ]; then
 			printf "\tUnable to clone MondgDB C++ driver at this time.\n"

--- a/scripts/eosio_build_fedora.sh
+++ b/scripts/eosio_build_fedora.sh
@@ -124,8 +124,7 @@
 	fi
 
 	printf "\n\tChecking for MongoDB C++ driver.\n"
-    # install libmongocxx.dylib
-    if [ ! -e /usr/local/lib/libmongocxx.so ]; then
+    if [ ! -e /usr/local/lib/libmongocxx-static.a ]; then
 		printf "\n\tInstalling MongoDB C & C++ drivers.\n"
 		cd ${TEMP_DIR}
 		curl -LO https://github.com/mongodb/mongo-c-driver/releases/download/1.9.3/mongo-c-driver-1.9.3.tar.gz
@@ -138,7 +137,7 @@
 		tar xf mongo-c-driver-1.9.3.tar.gz
 		rm -f ${TEMP_DIR}/mongo-c-driver-1.9.3.tar.gz
 		cd mongo-c-driver-1.9.3
-		./configure --enable-ssl=openssl --disable-automatic-init-and-cleanup --prefix=/usr/local
+		./configure --enable-static --enable-ssl=openssl --disable-automatic-init-and-cleanup --prefix=/usr/local
 		if [ $? -ne 0 ]; then
 			printf "\tConfiguring MondgDB C driver has encountered the errors above.\n"
 			printf "\tExiting now.\n\n"
@@ -166,7 +165,7 @@
 			exit;
 		fi
 		cd mongo-cxx-driver/build
-		cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local ..
+		cmake -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local ..
 		if [ $? -ne 0 ]; then
 			printf "\tCmake has encountered the above errors building the MongoDB C++ driver.\n"
 			printf "\tExiting now.\n\n"
@@ -187,7 +186,7 @@
 		cd
 		sudo rm -rf ${TEMP_DIR}/mongo-cxx-driver
 	else
-		printf "\tMongo C++ driver found at /usr/local/lib/libmongocxx.so.\n"
+		printf "\tMongo C++ driver found at /usr/local/lib/libmongocxx-static.a.\n"
 	fi
 
 	printf "\n\tChecking for secp256k1-zkp\n"

--- a/scripts/eosio_build_ubuntu.sh
+++ b/scripts/eosio_build_ubuntu.sh
@@ -130,7 +130,7 @@
 		tar xf mongo-c-driver-1.9.3.tar.gz
 		rm -f ${TEMP_DIR}/mongo-c-driver-1.9.3.tar.gz
 		cd mongo-c-driver-1.9.3
-		./configure --enable-static --enable-ssl=openssl --disable-automatic-init-and-cleanup --prefix=/usr/local
+		./configure --enable-static --with-libbson=bundled --enable-ssl=openssl --disable-automatic-init-and-cleanup --prefix=/usr/local
 		if [ $? -ne 0 ]; then
 			printf "\tConfiguring MondgDB C driver has encountered the errors above.\n"
 			printf "\tExiting now.\n\n"

--- a/scripts/eosio_build_ubuntu.sh
+++ b/scripts/eosio_build_ubuntu.sh
@@ -151,6 +151,7 @@
 		cd ..
 		rm -rf ${TEMP_DIR}/mongo-c-driver-1.9.3
 		cd ${TEMP_DIR}
+		sudo rm -rf ${TEMP_DIR}/mongo-cxx-driver
 		git clone https://github.com/mongodb/mongo-cxx-driver.git --branch releases/stable --depth 1
 		if [ $? -ne 0 ]; then
 			printf "\tUnable to clone MondgDB C++ driver at this time.\n"

--- a/scripts/eosio_build_ubuntu.sh
+++ b/scripts/eosio_build_ubuntu.sh
@@ -117,8 +117,7 @@
 	fi
 
 	printf "\n\tChecking for MongoDB C++ driver.\n"
-    # install libmongocxx.dylib
-    if [ ! -e /usr/local/lib/libmongocxx.so ]; then
+    if [ ! -e /usr/local/lib/libmongocxx-static.a ]; then
 		printf "\n\tInstalling MongoDB C & C++ drivers.\n"
 		cd ${TEMP_DIR}
 		curl -LO https://github.com/mongodb/mongo-c-driver/releases/download/1.9.3/mongo-c-driver-1.9.3.tar.gz
@@ -131,7 +130,7 @@
 		tar xf mongo-c-driver-1.9.3.tar.gz
 		rm -f ${TEMP_DIR}/mongo-c-driver-1.9.3.tar.gz
 		cd mongo-c-driver-1.9.3
-		./configure --enable-ssl=openssl --disable-automatic-init-and-cleanup --prefix=/usr/local
+		./configure --enable-static --enable-ssl=openssl --disable-automatic-init-and-cleanup --prefix=/usr/local
 		if [ $? -ne 0 ]; then
 			printf "\tConfiguring MondgDB C driver has encountered the errors above.\n"
 			printf "\tExiting now.\n\n"
@@ -159,7 +158,7 @@
 			exit;
 		fi
 		cd mongo-cxx-driver/build
-		cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local ..
+		cmake -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local ..
 		if [ $? -ne 0 ]; then
 			printf "\tCmake has encountered the above errors building the MongoDB C++ driver.\n"
 			printf "\tExiting now.\n\n"
@@ -180,7 +179,7 @@
 		cd
 		sudo rm -rf ${TEMP_DIR}/mongo-cxx-driver
 	else
-		printf "\tMongo C++ driver found at /usr/local/lib/libmongocxx.so.\n"
+		printf "\tMongo C++ driver found at /usr/local/lib/libmongocxx-static.a.\n"
 	fi
 
 	printf "\n\tChecking for secp256k1-zkp\n"


### PR DESCRIPTION
Nearly all other libraries we link to is via static linkage (boost, k1 lib, llvm/clang, etc) so this one should follow suit. Otherwise users would still need to install it when using a binary package. Plus with at least a stock F27 it didn't "just work" after a make install for me.