### PR TITLE
mindelay and canceldelay tests for permission delay

### DIFF
--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -198,7 +198,7 @@ void apply_context::require_recipient( account_name code ) {
 void apply_context::execute_inline( action&& a ) {
    if ( !privileged ) {
       if( a.account != receiver ) {
-         const auto delay = controller.check_authorization({a}, flat_set<public_key_type>(), false, {receiver});
+         const auto delay = controller.check_authorization({a}, vector<action>(), flat_set<public_key_type>(), false, {receiver});
          FC_ASSERT( trx_meta.published + delay <= controller.head_block_time(),
                     "inline action uses a permission that imposes a delay that is not met, add an action of mindelay with delay of atleast ${delay}",
                     ("delay", delay.sec_since_epoch()) );
@@ -236,7 +236,7 @@ void apply_context::execute_deferred( deferred_transaction&& trx ) {
             }
          }
          if( check_auth ) {
-            const auto delay = controller.check_authorization(trx.actions, flat_set<public_key_type>(), false, {receiver});
+            const auto delay = controller.check_authorization(trx.actions, vector<action>(), flat_set<public_key_type>(), false, {receiver});
             FC_ASSERT( trx_meta.published + delay <= controller.head_block_time(),
                        "deferred transaction uses a permission that imposes a delay that is not met, add an action of mindelay with delay of atleast ${delay}",
                        ("delay", delay.sec_since_epoch()) );

--- a/libraries/chain/chain_controller.cpp
+++ b/libraries/chain/chain_controller.cpp
@@ -858,6 +858,7 @@ private:
 };
 
 time_point chain_controller::check_authorization( const vector<action>& actions,
+                                                  const vector<action>& context_free_actions,
                                                   const flat_set<public_key_type>& provided_keys,
                                                   bool allow_unused_signatures,
                                                   flat_set<account_name> provided_accounts )const
@@ -938,7 +939,9 @@ time_point chain_controller::check_authorization( const vector<action>& actions,
                        ("auth", declared_auth));
          }
       }
+   }
 
+   for( const auto& act : context_free_actions ) {
       if (act.account == config::system_account_name && act.name == contracts::mindelay::get_name()) {
          const auto mindelay = act.data_as<contracts::mindelay>();
          const time_point delay = time_point_sec{mindelay.delay.convert_to<uint32_t>()};
@@ -964,7 +967,7 @@ time_point chain_controller::check_transaction_authorization(const transaction& 
                                                              const vector<bytes>& cfd,
                                                              bool allow_unused_signatures)const
 {
-   return check_authorization( trx.actions, trx.get_signature_keys( signatures, chain_id_type{}, cfd ), allow_unused_signatures );
+   return check_authorization( trx.actions, trx.context_free_actions, trx.get_signature_keys( signatures, chain_id_type{}, cfd ), allow_unused_signatures );
 }
 
 optional<permission_name> chain_controller::lookup_minimum_permission(account_name authorizer_account,

--- a/libraries/chain/contracts/eosio_contract.cpp
+++ b/libraries/chain/contracts/eosio_contract.cpp
@@ -464,7 +464,7 @@ void apply_eosio_canceldelay(apply_context& context) {
    const auto& generated_transaction_idx = context.controller.get_database().get_index<generated_transaction_multi_index>();
    const auto& generated_index = generated_transaction_idx.indices().get<by_sender_id>();
    const auto& itr = generated_index.lower_bound(boost::make_tuple(config::system_account_name, sender_id));
-   FC_ASSERT (itr == generated_index.end() || itr->sender != config::system_account_name || itr->sender_id != sender_id,
+   FC_ASSERT (itr != generated_index.end() && itr->sender == config::system_account_name && itr->sender_id == sender_id,
               "cannot cancel sender_id=${sid}, there is no deferred transaction with that sender_id",("sid",sender_id));
 
    auto dtrx = fc::raw::unpack<deferred_transaction>(itr->packed_trx.data(), itr->packed_trx.size());

--- a/libraries/chain/include/eosio/chain/chain_controller.hpp
+++ b/libraries/chain/include/eosio/chain/chain_controller.hpp
@@ -280,6 +280,7 @@ namespace eosio { namespace chain {
 
          /**
           * @param actions - the actions to check authorization across
+          * @param context_free_actions - the context free actions to check for mindelays across
           * @param provided_keys - the set of public keys which have authorized the transaction
           * @param allow_unused_signatures - true if method should not assert on unused signatures
           * @param provided_accounts - the set of accounts which have authorized the transaction (presumed to be owner)
@@ -287,6 +288,7 @@ namespace eosio { namespace chain {
           * @return time_point set to the max delay that this authorization requires to complete
           */
          time_point check_authorization( const vector<action>& actions,
+                                         const vector<action>& context_free_actions,
                                          const flat_set<public_key_type>& provided_keys,
                                          bool                             allow_unused_signatures = false,
                                          flat_set<account_name>           provided_accounts = flat_set<account_name>()

--- a/tests/chain_tests/delay_tests.cpp
+++ b/tests/chain_tests/delay_tests.cpp
@@ -610,7 +610,216 @@ BOOST_AUTO_TEST_CASE( link_delay_permission_change_test ) { try {
    liquid_balance = get_currency_balance(chain, N(tester2));
    BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
 
-   // first transfer will finally performed
+   // first transfer will finally be performed
+   chain.control->push_deferred_transactions(true);
+
+   chain.produce_blocks();
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
+
+   // this transfer is performed right away since delay is removed
+   trace = chain.push_action(N(currency), name("transfer"), N(tester), fc::mutable_variant_object()
+       ("from", "tester")
+       ("to", "tester2")
+       ("quantity", "10.0000 CUR")
+       ("memo", "hi" )
+   );
+   BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace.status);
+   BOOST_REQUIRE_EQUAL(0, trace.deferred_transactions.size());
+
+   chain.control->push_deferred_transactions(true);
+
+   chain.produce_blocks();
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("89.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("11.0000 CUR"), liquid_balance);
+
+   chain.control->push_deferred_transactions(true);
+
+   chain.produce_blocks(15);
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("89.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("11.0000 CUR"), liquid_balance);
+
+   chain.control->push_deferred_transactions(true);
+
+   chain.produce_blocks();
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("89.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("11.0000 CUR"), liquid_balance);
+
+   // second transfer finally is performed
+   chain.control->push_deferred_transactions(true);
+
+   chain.produce_blocks();
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("84.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("16.0000 CUR"), liquid_balance);
+
+} FC_LOG_AND_RETHROW() }/// schedule_test
+
+// test moving link with delay on permission
+BOOST_AUTO_TEST_CASE( link_delay_link_change_test ) { try {
+   tester chain;
+
+   const auto& tester_account = N(tester);
+
+   chain.set_code(config::system_account_name, eosio_system_wast);
+   chain.set_abi(config::system_account_name, eosio_system_abi);
+
+   chain.produce_blocks();
+   chain.create_account(N(currency));
+   chain.produce_blocks(10);
+
+   chain.set_code(N(currency), currency_wast);
+   chain.set_abi(N(currency), currency_abi);
+
+   chain.produce_blocks();
+   chain.create_account(N(tester));
+   chain.create_account(N(tester2));
+   chain.produce_blocks(10);
+
+   chain.push_action(config::system_account_name, contracts::updateauth::get_name(), tester_account, fc::mutable_variant_object()
+           ("account", "tester")
+           ("permission", "first")
+           ("parent", "active")
+           ("data",  authority(chain.get_public_key(tester_account, "first")))
+           ("delay", 10));
+   chain.push_action(config::system_account_name, contracts::linkauth::get_name(), tester_account, fc::mutable_variant_object()
+           ("account", "tester")
+           ("code", "currency")
+           ("type", "transfer")
+           ("requirement", "first"));
+   chain.push_action(config::system_account_name, contracts::updateauth::get_name(), tester_account, fc::mutable_variant_object()
+           ("account", "tester")
+           ("permission", "second")
+           ("parent", "active")
+           ("data",  authority(chain.get_public_key(tester_account, "second")))
+           ("delay", 0));
+
+   chain.produce_blocks();
+   chain.push_action(N(currency), N(create), N(currency), mutable_variant_object()
+           ("issuer", "currency" )
+           ("maximum_supply", "9000000.0000 CUR" )
+           ("can_freeze", 0)
+           ("can_recall", 0)
+           ("can_whitelist", 0)
+   );
+
+   chain.push_action(N(currency), name("issue"), N(currency), fc::mutable_variant_object()
+           ("to",       "currency")
+           ("quantity", "1000000.0000 CUR")
+           ("memo", "for stuff")
+   );
+
+   auto trace = chain.push_action(N(currency), name("transfer"), N(currency), fc::mutable_variant_object()
+       ("from", "currency")
+       ("to", "tester")
+       ("quantity", "100.0000 CUR")
+       ("memo", "hi" )
+   );
+   BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace.status);
+   BOOST_REQUIRE_EQUAL(0, trace.deferred_transactions.size());
+
+   chain.produce_blocks();
+
+   auto liquid_balance = get_currency_balance(chain, N(currency));
+   BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
+
+   // this transaction will be delayed 20 sec
+   trace = chain.push_action(N(currency), name("transfer"), N(tester), fc::mutable_variant_object()
+       ("from", "tester")
+       ("to", "tester2")
+       ("quantity", "1.0000 CUR")
+       ("memo", "hi" ),
+       30
+   );
+
+   BOOST_REQUIRE_EQUAL(transaction_receipt::delayed, trace.status);
+   BOOST_REQUIRE_EQUAL(1, trace.deferred_transactions.size());
+   BOOST_REQUIRE_EQUAL(0, trace.action_traces.size());
+   BOOST_REQUIRE_EQUAL(0, trace.canceled_deferred.size());
+
+   chain.produce_blocks();
+
+   liquid_balance = get_currency_balance(chain, N(currency));
+   BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
+
+   // this transaction will be delayed 20 sec
+   chain.push_action(config::system_account_name, contracts::linkauth::get_name(), tester_account, fc::mutable_variant_object()
+           ("account", "tester")
+           ("code", "currency")
+           ("type", "transfer")
+           ("requirement", "second"),
+           30);
+   BOOST_REQUIRE_EQUAL(transaction_receipt::delayed, trace.status);
+   BOOST_REQUIRE_EQUAL(1, trace.deferred_transactions.size());
+   BOOST_REQUIRE_EQUAL(0, trace.action_traces.size());
+   BOOST_REQUIRE_EQUAL(0, trace.canceled_deferred.size());
+
+   chain.produce_blocks();
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
+
+   chain.control->push_deferred_transactions(true);
+
+   chain.produce_blocks(16);
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
+
+   // this transaction will be delayed 20 sec
+   trace = chain.push_action(N(currency), name("transfer"), N(tester), fc::mutable_variant_object()
+       ("from", "tester")
+       ("to", "tester2")
+       ("quantity", "5.0000 CUR")
+       ("memo", "hi" ),
+       30
+   );
+   BOOST_REQUIRE_EQUAL(transaction_receipt::delayed, trace.status);
+   BOOST_REQUIRE_EQUAL(1, trace.deferred_transactions.size());
+   BOOST_REQUIRE_EQUAL(0, trace.action_traces.size());
+   BOOST_REQUIRE_EQUAL(0, trace.canceled_deferred.size());
+
+   chain.produce_blocks();
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
+
+   chain.control->push_deferred_transactions(true);
+
+   chain.produce_blocks();
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
+
+   // first transfer will finally be performed
    chain.control->push_deferred_transactions(true);
 
    chain.produce_blocks();

--- a/tests/chain_tests/delay_tests.cpp
+++ b/tests/chain_tests/delay_tests.cpp
@@ -628,7 +628,7 @@ BOOST_AUTO_TEST_CASE( link_delay_permission_change_test ) { try {
        ("memo", "hi" )
    );
    BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace.status);
-   BOOST_REQUIRE_EQUAL(0, trace.deferred_transactions.size());
+   BOOST_REQUIRE_EQUAL(0, trace.deferred_transaction_requests.size());
 
    chain.control->push_deferred_transactions(true);
 
@@ -730,7 +730,7 @@ BOOST_AUTO_TEST_CASE( link_delay_link_change_test ) { try {
        ("memo", "hi" )
    );
    BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace.status);
-   BOOST_REQUIRE_EQUAL(0, trace.deferred_transactions.size());
+   BOOST_REQUIRE_EQUAL(0, trace.deferred_transaction_requests.size());
 
    chain.produce_blocks();
 
@@ -749,9 +749,8 @@ BOOST_AUTO_TEST_CASE( link_delay_link_change_test ) { try {
    );
 
    BOOST_REQUIRE_EQUAL(transaction_receipt::delayed, trace.status);
-   BOOST_REQUIRE_EQUAL(1, trace.deferred_transactions.size());
+   BOOST_REQUIRE_EQUAL(1, trace.deferred_transaction_requests.size());
    BOOST_REQUIRE_EQUAL(0, trace.action_traces.size());
-   BOOST_REQUIRE_EQUAL(0, trace.canceled_deferred.size());
 
    chain.produce_blocks();
 
@@ -770,9 +769,8 @@ BOOST_AUTO_TEST_CASE( link_delay_link_change_test ) { try {
            ("requirement", "second"),
            30);
    BOOST_REQUIRE_EQUAL(transaction_receipt::delayed, trace.status);
-   BOOST_REQUIRE_EQUAL(1, trace.deferred_transactions.size());
+   BOOST_REQUIRE_EQUAL(1, trace.deferred_transaction_requests.size());
    BOOST_REQUIRE_EQUAL(0, trace.action_traces.size());
-   BOOST_REQUIRE_EQUAL(0, trace.canceled_deferred.size());
 
    chain.produce_blocks();
 
@@ -799,9 +797,8 @@ BOOST_AUTO_TEST_CASE( link_delay_link_change_test ) { try {
        30
    );
    BOOST_REQUIRE_EQUAL(transaction_receipt::delayed, trace.status);
-   BOOST_REQUIRE_EQUAL(1, trace.deferred_transactions.size());
+   BOOST_REQUIRE_EQUAL(1, trace.deferred_transaction_requests.size());
    BOOST_REQUIRE_EQUAL(0, trace.action_traces.size());
-   BOOST_REQUIRE_EQUAL(0, trace.canceled_deferred.size());
 
    chain.produce_blocks();
 

--- a/tests/chain_tests/delay_tests.cpp
+++ b/tests/chain_tests/delay_tests.cpp
@@ -532,7 +532,7 @@ BOOST_AUTO_TEST_CASE( link_delay_permission_change_test ) { try {
    liquid_balance = get_currency_balance(chain, N(tester));
    BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
 
-   // this transaction will be delayed 20 sec
+   // this transaction will be delayed 20 blocks
    trace = chain.push_action(N(currency), name("transfer"), N(tester), fc::mutable_variant_object()
        ("from", "tester")
        ("to", "tester2")
@@ -554,7 +554,7 @@ BOOST_AUTO_TEST_CASE( link_delay_permission_change_test ) { try {
    liquid_balance = get_currency_balance(chain, N(tester2));
    BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
 
-   // this transaction will be delayed 20 sec
+   // this transaction will be delayed 20 blocks
    trace = chain.push_action(config::system_account_name, contracts::updateauth::get_name(), tester_account, fc::mutable_variant_object()
            ("account", "tester")
            ("permission", "first")
@@ -582,7 +582,214 @@ BOOST_AUTO_TEST_CASE( link_delay_permission_change_test ) { try {
    liquid_balance = get_currency_balance(chain, N(tester2));
    BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
 
-   // this transaction will be delayed 20 sec
+   // this transaction will be delayed 20 blocks
+   trace = chain.push_action(N(currency), name("transfer"), N(tester), fc::mutable_variant_object()
+       ("from", "tester")
+       ("to", "tester2")
+       ("quantity", "5.0000 CUR")
+       ("memo", "hi" ),
+       30
+   );
+   BOOST_REQUIRE_EQUAL(transaction_receipt::delayed, trace.status);
+   BOOST_REQUIRE_EQUAL(1, trace.deferred_transaction_requests.size());
+   BOOST_REQUIRE_EQUAL(0, trace.action_traces.size());
+
+   chain.produce_blocks();
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
+
+   chain.control->push_deferred_transactions(true);
+
+   chain.produce_blocks();
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
+
+   // first transfer will finally be performed
+   chain.control->push_deferred_transactions(true);
+
+   chain.produce_blocks();
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
+
+   // this transfer is performed right away since delay is removed
+   trace = chain.push_action(N(currency), name("transfer"), N(tester), fc::mutable_variant_object()
+       ("from", "tester")
+       ("to", "tester2")
+       ("quantity", "10.0000 CUR")
+       ("memo", "hi" )
+   );
+   BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace.status);
+   BOOST_REQUIRE_EQUAL(0, trace.deferred_transaction_requests.size());
+
+   chain.control->push_deferred_transactions(true);
+
+   chain.produce_blocks();
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("89.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("11.0000 CUR"), liquid_balance);
+
+   chain.control->push_deferred_transactions(true);
+
+   chain.produce_blocks(15);
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("89.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("11.0000 CUR"), liquid_balance);
+
+   chain.control->push_deferred_transactions(true);
+
+   chain.produce_blocks();
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("89.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("11.0000 CUR"), liquid_balance);
+
+   // second transfer finally is performed
+   chain.control->push_deferred_transactions(true);
+
+   chain.produce_blocks();
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("84.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("16.0000 CUR"), liquid_balance);
+
+} FC_LOG_AND_RETHROW() }/// schedule_test
+
+// test removing delay on permission based on heirarchy delay
+BOOST_AUTO_TEST_CASE( link_delay_permission_change_with_delay_heirarchy_test ) { try {
+   tester chain;
+
+   const auto& tester_account = N(tester);
+
+   chain.set_code(config::system_account_name, eosio_system_wast);
+   chain.set_abi(config::system_account_name, eosio_system_abi);
+
+   chain.produce_blocks();
+   chain.create_account(N(currency));
+   chain.produce_blocks(10);
+
+   chain.set_code(N(currency), currency_wast);
+   chain.set_abi(N(currency), currency_abi);
+
+   chain.produce_blocks();
+   chain.create_account(N(tester));
+   chain.create_account(N(tester2));
+   chain.produce_blocks(10);
+
+   chain.push_action(config::system_account_name, contracts::updateauth::get_name(), tester_account, fc::mutable_variant_object()
+           ("account", "tester")
+           ("permission", "first")
+           ("parent", "active")
+           ("data",  authority(chain.get_public_key(tester_account, "first")))
+           ("delay", 10));
+   chain.push_action(config::system_account_name, contracts::updateauth::get_name(), tester_account, fc::mutable_variant_object()
+           ("account", "tester")
+           ("permission", "second")
+           ("parent", "first")
+           ("data",  authority(chain.get_public_key(tester_account, "second")))
+           ("delay", 0));
+   chain.push_action(config::system_account_name, contracts::linkauth::get_name(), tester_account, fc::mutable_variant_object()
+           ("account", "tester")
+           ("code", "currency")
+           ("type", "transfer")
+           ("requirement", "second"));
+
+   chain.produce_blocks();
+   chain.push_action(N(currency), N(create), N(currency), mutable_variant_object()
+           ("issuer", "currency" )
+           ("maximum_supply", "9000000.0000 CUR" )
+           ("can_freeze", 0)
+           ("can_recall", 0)
+           ("can_whitelist", 0)
+   );
+
+   chain.push_action(N(currency), name("issue"), N(currency), fc::mutable_variant_object()
+           ("to",       "currency")
+           ("quantity", "1000000.0000 CUR")
+           ("memo", "for stuff")
+   );
+
+   auto trace = chain.push_action(N(currency), name("transfer"), N(currency), fc::mutable_variant_object()
+       ("from", "currency")
+       ("to", "tester")
+       ("quantity", "100.0000 CUR")
+       ("memo", "hi" )
+   );
+   BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace.status);
+   BOOST_REQUIRE_EQUAL(0, trace.deferred_transaction_requests.size());
+
+   chain.produce_blocks();
+
+   auto liquid_balance = get_currency_balance(chain, N(currency));
+   BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
+
+   // this transaction will be delayed 20 blocks
+   trace = chain.push_action(N(currency), name("transfer"), N(tester), fc::mutable_variant_object()
+       ("from", "tester")
+       ("to", "tester2")
+       ("quantity", "1.0000 CUR")
+       ("memo", "hi" ),
+       30
+   );
+
+   BOOST_REQUIRE_EQUAL(transaction_receipt::delayed, trace.status);
+   BOOST_REQUIRE_EQUAL(1, trace.deferred_transaction_requests.size());
+   BOOST_REQUIRE_EQUAL(0, trace.action_traces.size());
+
+   chain.produce_blocks();
+
+   liquid_balance = get_currency_balance(chain, N(currency));
+   BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
+
+   // this transaction will be delayed 20 blocks
+   chain.push_action(config::system_account_name, contracts::updateauth::get_name(), tester_account, fc::mutable_variant_object()
+           ("account", "tester")
+           ("permission", "first")
+           ("parent", "active")
+           ("data",  authority(chain.get_public_key(tester_account, "first")))
+           ("delay", 0),
+           30);
+   BOOST_REQUIRE_EQUAL(transaction_receipt::delayed, trace.status);
+   BOOST_REQUIRE_EQUAL(1, trace.deferred_transaction_requests.size());
+   BOOST_REQUIRE_EQUAL(0, trace.action_traces.size());
+
+   chain.produce_blocks();
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
+
+   chain.control->push_deferred_transactions(true);
+
+   chain.produce_blocks(16);
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
+
+   // this transaction will be delayed 20 blocks
    trace = chain.push_action(N(currency), name("transfer"), N(tester), fc::mutable_variant_object()
        ("from", "tester")
        ("to", "tester2")
@@ -739,7 +946,7 @@ BOOST_AUTO_TEST_CASE( link_delay_link_change_test ) { try {
    liquid_balance = get_currency_balance(chain, N(tester));
    BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
 
-   // this transaction will be delayed 20 sec
+   // this transaction will be delayed 20 blocks
    trace = chain.push_action(N(currency), name("transfer"), N(tester), fc::mutable_variant_object()
        ("from", "tester")
        ("to", "tester2")
@@ -761,7 +968,7 @@ BOOST_AUTO_TEST_CASE( link_delay_link_change_test ) { try {
    liquid_balance = get_currency_balance(chain, N(tester2));
    BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
 
-   // this transaction will be delayed 20 sec
+   // this transaction will be delayed 20 blocks
    chain.push_action(config::system_account_name, contracts::linkauth::get_name(), tester_account, fc::mutable_variant_object()
            ("account", "tester")
            ("code", "currency")
@@ -788,7 +995,7 @@ BOOST_AUTO_TEST_CASE( link_delay_link_change_test ) { try {
    liquid_balance = get_currency_balance(chain, N(tester2));
    BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
 
-   // this transaction will be delayed 20 sec
+   // this transaction will be delayed 20 blocks
    trace = chain.push_action(N(currency), name("transfer"), N(tester), fc::mutable_variant_object()
        ("from", "tester")
        ("to", "tester2")
@@ -872,6 +1079,576 @@ BOOST_AUTO_TEST_CASE( link_delay_link_change_test ) { try {
    BOOST_REQUIRE_EQUAL(asset::from_string("84.0000 CUR"), liquid_balance);
    liquid_balance = get_currency_balance(chain, N(tester2));
    BOOST_REQUIRE_EQUAL(asset::from_string("16.0000 CUR"), liquid_balance);
+
+} FC_LOG_AND_RETHROW() }/// schedule_test
+
+// test moving link with delay on permission's parent
+BOOST_AUTO_TEST_CASE( link_delay_link_change_heirarchy_test ) { try {
+   tester chain;
+
+   const auto& tester_account = N(tester);
+
+   chain.set_code(config::system_account_name, eosio_system_wast);
+   chain.set_abi(config::system_account_name, eosio_system_abi);
+
+   chain.produce_blocks();
+   chain.create_account(N(currency));
+   chain.produce_blocks(10);
+
+   chain.set_code(N(currency), currency_wast);
+   chain.set_abi(N(currency), currency_abi);
+
+   chain.produce_blocks();
+   chain.create_account(N(tester));
+   chain.create_account(N(tester2));
+   chain.produce_blocks(10);
+
+   chain.push_action(config::system_account_name, contracts::updateauth::get_name(), tester_account, fc::mutable_variant_object()
+           ("account", "tester")
+           ("permission", "first")
+           ("parent", "active")
+           ("data",  authority(chain.get_public_key(tester_account, "first")))
+           ("delay", 10));
+   chain.push_action(config::system_account_name, contracts::updateauth::get_name(), tester_account, fc::mutable_variant_object()
+           ("account", "tester")
+           ("permission", "second")
+           ("parent", "first")
+           ("data",  authority(chain.get_public_key(tester_account, "first")))
+           ("delay", 0));
+   chain.push_action(config::system_account_name, contracts::linkauth::get_name(), tester_account, fc::mutable_variant_object()
+           ("account", "tester")
+           ("code", "currency")
+           ("type", "transfer")
+           ("requirement", "second"));
+   chain.push_action(config::system_account_name, contracts::updateauth::get_name(), tester_account, fc::mutable_variant_object()
+           ("account", "tester")
+           ("permission", "third")
+           ("parent", "active")
+           ("data",  authority(chain.get_public_key(tester_account, "third")))
+           ("delay", 0));
+
+   chain.produce_blocks();
+   chain.push_action(N(currency), N(create), N(currency), mutable_variant_object()
+           ("issuer", "currency" )
+           ("maximum_supply", "9000000.0000 CUR" )
+           ("can_freeze", 0)
+           ("can_recall", 0)
+           ("can_whitelist", 0)
+   );
+
+   chain.push_action(N(currency), name("issue"), N(currency), fc::mutable_variant_object()
+           ("to",       "currency")
+           ("quantity", "1000000.0000 CUR")
+           ("memo", "for stuff")
+   );
+
+   auto trace = chain.push_action(N(currency), name("transfer"), N(currency), fc::mutable_variant_object()
+       ("from", "currency")
+       ("to", "tester")
+       ("quantity", "100.0000 CUR")
+       ("memo", "hi" )
+   );
+   BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace.status);
+   BOOST_REQUIRE_EQUAL(0, trace.deferred_transaction_requests.size());
+
+   chain.produce_blocks();
+
+   auto liquid_balance = get_currency_balance(chain, N(currency));
+   BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
+
+   // this transaction will be delayed 20 blocks
+   trace = chain.push_action(N(currency), name("transfer"), N(tester), fc::mutable_variant_object()
+       ("from", "tester")
+       ("to", "tester2")
+       ("quantity", "1.0000 CUR")
+       ("memo", "hi" ),
+       30
+   );
+
+   BOOST_REQUIRE_EQUAL(transaction_receipt::delayed, trace.status);
+   BOOST_REQUIRE_EQUAL(1, trace.deferred_transaction_requests.size());
+   BOOST_REQUIRE_EQUAL(0, trace.action_traces.size());
+
+   chain.produce_blocks();
+
+   liquid_balance = get_currency_balance(chain, N(currency));
+   BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
+
+   // this transaction will be delayed 20 blocks
+   chain.push_action(config::system_account_name, contracts::linkauth::get_name(), tester_account, fc::mutable_variant_object()
+           ("account", "tester")
+           ("code", "currency")
+           ("type", "transfer")
+           ("requirement", "third"),
+           30);
+   BOOST_REQUIRE_EQUAL(transaction_receipt::delayed, trace.status);
+   BOOST_REQUIRE_EQUAL(1, trace.deferred_transaction_requests.size());
+   BOOST_REQUIRE_EQUAL(0, trace.action_traces.size());
+
+   chain.produce_blocks();
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
+
+   chain.control->push_deferred_transactions(true);
+
+   chain.produce_blocks(16);
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
+
+   // this transaction will be delayed 20 blocks
+   trace = chain.push_action(N(currency), name("transfer"), N(tester), fc::mutable_variant_object()
+       ("from", "tester")
+       ("to", "tester2")
+       ("quantity", "5.0000 CUR")
+       ("memo", "hi" ),
+       30
+   );
+   BOOST_REQUIRE_EQUAL(transaction_receipt::delayed, trace.status);
+   BOOST_REQUIRE_EQUAL(1, trace.deferred_transaction_requests.size());
+   BOOST_REQUIRE_EQUAL(0, trace.action_traces.size());
+
+   chain.produce_blocks();
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
+
+   chain.control->push_deferred_transactions(true);
+
+   chain.produce_blocks();
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
+
+   // first transfer will finally be performed
+   chain.control->push_deferred_transactions(true);
+
+   chain.produce_blocks();
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
+
+   // this transfer is performed right away since delay is removed
+   trace = chain.push_action(N(currency), name("transfer"), N(tester), fc::mutable_variant_object()
+       ("from", "tester")
+       ("to", "tester2")
+       ("quantity", "10.0000 CUR")
+       ("memo", "hi" )
+   );
+   BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace.status);
+   BOOST_REQUIRE_EQUAL(0, trace.deferred_transaction_requests.size());
+
+   chain.control->push_deferred_transactions(true);
+
+   chain.produce_blocks();
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("89.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("11.0000 CUR"), liquid_balance);
+
+   chain.control->push_deferred_transactions(true);
+
+   chain.produce_blocks(15);
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("89.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("11.0000 CUR"), liquid_balance);
+
+   chain.control->push_deferred_transactions(true);
+
+   chain.produce_blocks();
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("89.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("11.0000 CUR"), liquid_balance);
+
+   // second transfer finally is performed
+   chain.control->push_deferred_transactions(true);
+
+   chain.produce_blocks();
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("84.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("16.0000 CUR"), liquid_balance);
+
+} FC_LOG_AND_RETHROW() }/// schedule_test
+
+// test mindelay action imposing delay
+BOOST_AUTO_TEST_CASE( mindelay_test ) { try {
+   tester chain;
+
+   const auto& tester_account = N(tester);
+
+   chain.set_code(config::system_account_name, eosio_system_wast);
+   chain.set_abi(config::system_account_name, eosio_system_abi);
+
+   chain.produce_blocks();
+   chain.create_account(N(currency));
+   chain.produce_blocks(10);
+
+   chain.set_code(N(currency), currency_wast);
+   chain.set_abi(N(currency), currency_abi);
+
+   chain.produce_blocks();
+   chain.create_account(N(tester));
+   chain.create_account(N(tester2));
+   chain.produce_blocks(10);
+
+   chain.push_action(N(currency), N(create), N(currency), mutable_variant_object()
+           ("issuer", "currency" )
+           ("maximum_supply", "9000000.0000 CUR" )
+           ("can_freeze", 0)
+           ("can_recall", 0)
+           ("can_whitelist", 0)
+   );
+
+   chain.push_action(N(currency), name("issue"), N(currency), fc::mutable_variant_object()
+           ("to",       "currency")
+           ("quantity", "1000000.0000 CUR")
+           ("memo", "for stuff")
+   );
+
+   auto trace = chain.push_action(N(currency), name("transfer"), N(currency), fc::mutable_variant_object()
+       ("from", "currency")
+       ("to", "tester")
+       ("quantity", "100.0000 CUR")
+       ("memo", "hi" )
+   );
+   BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace.status);
+   BOOST_REQUIRE_EQUAL(0, trace.deferred_transaction_requests.size());
+
+   chain.produce_blocks();
+
+   auto liquid_balance = get_currency_balance(chain, N(currency));
+   BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
+
+   trace = chain.push_action(N(currency), name("transfer"), N(tester), fc::mutable_variant_object()
+       ("from", "tester")
+       ("to", "tester2")
+       ("quantity", "1.0000 CUR")
+       ("memo", "hi" )
+   );
+
+   BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace.status);
+   BOOST_REQUIRE_EQUAL(0, trace.deferred_transaction_requests.size());
+
+   chain.produce_blocks();
+
+   liquid_balance = get_currency_balance(chain, N(currency));
+   BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
+
+   // send transfer and mindelay
+   const auto& acnt = chain.control->get_database().get<account_object,by_name>(N(currency));
+   const auto abi = acnt.get_abi();
+   chain::contracts::abi_serializer abis(abi);
+   const auto a = chain.control->get_database().get<account_object,by_name>(N(currency)).get_abi();
+
+   string action_type_name = abis.get_action_type(name("transfer"));
+
+   action act;
+   act.account = N(currency);
+   act.name = name("transfer");
+   act.authorization.push_back(permission_level{N(tester), config::active_name});
+   act.data = abis.variant_to_binary(action_type_name, fc::mutable_variant_object()
+      ("from", "tester")
+      ("to", "tester2")
+      ("quantity", "3.0000 CUR")
+      ("memo", "hi" )
+   );
+
+   signed_transaction trx;
+   trx.actions.push_back(act);
+
+   trx.context_free_actions.emplace_back(vector<permission_level>(), chain::contracts::mindelay { .delay = 10 });
+
+   chain.set_tapos(trx, 30);
+   trx.sign(chain.get_private_key(N(tester), "active"), chain_id_type());
+   trace = chain.push_transaction(trx);
+   BOOST_REQUIRE_EQUAL(transaction_receipt::delayed, trace.status);
+   BOOST_REQUIRE_EQUAL(1, trace.deferred_transaction_requests.size());
+   BOOST_REQUIRE_EQUAL(0, trace.action_traces.size());
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
+
+   chain.control->push_deferred_transactions(true);
+
+   chain.produce_blocks();
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
+
+   chain.control->push_deferred_transactions(true);
+
+   chain.produce_blocks(18);
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
+
+   chain.control->push_deferred_transactions(true);
+
+   chain.produce_blocks();
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
+
+   chain.control->push_deferred_transactions(true);
+
+   chain.produce_blocks();
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("96.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("4.0000 CUR"), liquid_balance);
+
+} FC_LOG_AND_RETHROW() }/// schedule_test
+
+// test canceldelay action cancelling a delayed transaction
+BOOST_AUTO_TEST_CASE( canceldelay_test ) { try {
+   tester chain;
+
+   const auto& tester_account = N(tester);
+
+   chain.set_code(config::system_account_name, eosio_system_wast);
+   chain.set_abi(config::system_account_name, eosio_system_abi);
+
+   chain.produce_blocks();
+   chain.create_account(N(currency));
+   chain.produce_blocks(10);
+
+   chain.set_code(N(currency), currency_wast);
+   chain.set_abi(N(currency), currency_abi);
+
+   chain.produce_blocks();
+   chain.create_account(N(tester));
+   chain.create_account(N(tester2));
+   chain.produce_blocks(10);
+
+   chain.push_action(config::system_account_name, contracts::updateauth::get_name(), tester_account, fc::mutable_variant_object()
+           ("account", "tester")
+           ("permission", "first")
+           ("parent", "active")
+           ("data",  authority(chain.get_public_key(tester_account, "first")))
+           ("delay", 10));
+   chain.push_action(config::system_account_name, contracts::linkauth::get_name(), tester_account, fc::mutable_variant_object()
+           ("account", "tester")
+           ("code", "currency")
+           ("type", "transfer")
+           ("requirement", "first"));
+
+   chain.produce_blocks();
+   chain.push_action(N(currency), N(create), N(currency), mutable_variant_object()
+           ("issuer", "currency" )
+           ("maximum_supply", "9000000.0000 CUR" )
+           ("can_freeze", 0)
+           ("can_recall", 0)
+           ("can_whitelist", 0)
+   );
+
+   chain.push_action(N(currency), name("issue"), N(currency), fc::mutable_variant_object()
+           ("to",       "currency")
+           ("quantity", "1000000.0000 CUR")
+           ("memo", "for stuff")
+   );
+
+   auto trace = chain.push_action(N(currency), name("transfer"), N(currency), fc::mutable_variant_object()
+       ("from", "currency")
+       ("to", "tester")
+       ("quantity", "100.0000 CUR")
+       ("memo", "hi" )
+   );
+   BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace.status);
+   BOOST_REQUIRE_EQUAL(0, trace.deferred_transaction_requests.size());
+
+   chain.produce_blocks();
+
+   auto liquid_balance = get_currency_balance(chain, N(currency));
+   BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
+
+   // this transaction will be delayed 20 blocks
+   trace = chain.push_action(N(currency), name("transfer"), N(tester), fc::mutable_variant_object()
+       ("from", "tester")
+       ("to", "tester2")
+       ("quantity", "1.0000 CUR")
+       ("memo", "hi" ),
+       30
+   );
+   BOOST_REQUIRE_EQUAL(transaction_receipt::delayed, trace.status);
+   BOOST_REQUIRE_EQUAL(1, trace.deferred_transaction_requests.size());
+   BOOST_REQUIRE_EQUAL(0, trace.action_traces.size());
+   const auto sender_id_to_cancel = trace.deferred_transaction_requests[0].get<deferred_transaction>().sender_id;
+
+   chain.produce_blocks();
+
+   liquid_balance = get_currency_balance(chain, N(currency));
+   BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
+
+   // this transaction will be delayed 20 blocks
+   trace = chain.push_action(config::system_account_name, contracts::updateauth::get_name(), tester_account, fc::mutable_variant_object()
+           ("account", "tester")
+           ("permission", "first")
+           ("parent", "active")
+           ("data",  authority(chain.get_public_key(tester_account, "first")))
+           ("delay", 0),
+           30);
+   BOOST_REQUIRE_EQUAL(transaction_receipt::delayed, trace.status);
+   BOOST_REQUIRE_EQUAL(1, trace.deferred_transaction_requests.size());
+   BOOST_REQUIRE_EQUAL(0, trace.action_traces.size());
+
+   chain.produce_blocks();
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
+
+   chain.control->push_deferred_transactions(true);
+
+   chain.produce_blocks(16);
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
+
+   // this transaction will be delayed 20 blocks
+   trace = chain.push_action(N(currency), name("transfer"), N(tester), fc::mutable_variant_object()
+       ("from", "tester")
+       ("to", "tester2")
+       ("quantity", "5.0000 CUR")
+       ("memo", "hi" ),
+       30
+   );
+   BOOST_REQUIRE_EQUAL(transaction_receipt::delayed, trace.status);
+   BOOST_REQUIRE_EQUAL(1, trace.deferred_transaction_requests.size());
+   BOOST_REQUIRE_EQUAL(0, trace.action_traces.size());
+
+   chain.produce_blocks();
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
+
+   // send canceldelay for first delayed transaction
+   signed_transaction trx;
+   trx.actions.emplace_back(vector<permission_level>{{N(tester), config::active_name}},
+                            chain::contracts::canceldelay{sender_id_to_cancel});
+
+   chain.set_tapos(trx);
+   trx.sign(chain.get_private_key(N(tester), "active"), chain_id_type());
+   trace = chain.push_transaction(trx);
+   BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace.status);
+   BOOST_REQUIRE_EQUAL(1, trace.deferred_transaction_requests.size());
+   const auto sender_id_canceled = trace.deferred_transaction_requests[0].get<deferred_reference>().sender_id;
+   BOOST_REQUIRE_EQUAL(sender_id_to_cancel, sender_id_canceled);
+
+   chain.control->push_deferred_transactions(true);
+
+   chain.produce_blocks();
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
+
+   // first transfer will finally be performed
+   chain.control->push_deferred_transactions(true);
+
+   chain.produce_blocks();
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
+
+   // this transfer is performed right away since delay is removed
+   trace = chain.push_action(N(currency), name("transfer"), N(tester), fc::mutable_variant_object()
+       ("from", "tester")
+       ("to", "tester2")
+       ("quantity", "10.0000 CUR")
+       ("memo", "hi" )
+   );
+   BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace.status);
+   BOOST_REQUIRE_EQUAL(0, trace.deferred_transaction_requests.size());
+
+   chain.control->push_deferred_transactions(true);
+
+   chain.produce_blocks();
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("90.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("10.0000 CUR"), liquid_balance);
+
+   chain.control->push_deferred_transactions(true);
+
+   chain.produce_blocks(15);
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("90.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("10.0000 CUR"), liquid_balance);
+
+   chain.control->push_deferred_transactions(true);
+
+   chain.produce_blocks();
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("90.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("10.0000 CUR"), liquid_balance);
+
+   // second transfer finally is performed
+   chain.control->push_deferred_transactions(true);
+
+   chain.produce_blocks();
+
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("85.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester2));
+   BOOST_REQUIRE_EQUAL(asset::from_string("15.0000 CUR"), liquid_balance);
 
 } FC_LOG_AND_RETHROW() }/// schedule_test
 


### PR DESCRIPTION
DAWN-398
#1022

Added tests for mindelay and canceldelay
Moved mindelay to be a context free action since it has no effect on the context.
Other minor cleanups.