### PR TITLE
Schedule deferred transactions

### DIFF
--- a/contracts/eosiolib/transaction.h
+++ b/contracts/eosiolib/transaction.h
@@ -59,9 +59,9 @@ extern "C" {
     * @{
     */
 
-   void send_deferred(uint64_t sender_id, time delay_until, char *serialized_transaction, size_t size);
+   void send_deferred(const uint128_t& sender_id, time delay_until, char *serialized_transaction, size_t size);
 
-   void cancel_deferred(uint64_t sender_id);
+   void cancel_deferred(const uint128_t& sender_id);
 
    /**
     * access a copy of the currently executing transaction

--- a/contracts/eosiolib/transaction.hpp
+++ b/contracts/eosiolib/transaction.hpp
@@ -48,7 +48,7 @@ namespace eosio {
 
    class deferred_transaction : public transaction {
       public:
-         uint64_t     sender_id;
+         uint128_t     sender_id;
          account_name sender;
          time         delay_until;
 

--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -244,7 +244,7 @@ void apply_context::execute_deferred( deferred_transaction&& trx ) {
    } FC_CAPTURE_AND_RETHROW((trx));
 }
 
-void apply_context::cancel_deferred( uint64_t sender_id ) {
+void apply_context::cancel_deferred( uint128_t sender_id ) {
    results.deferred_transaction_requests.push_back(deferred_reference(receiver, sender_id));
 }
 

--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -279,7 +279,7 @@ vector<account_name> apply_context::get_active_producers() const {
 
 void apply_context::checktime(uint32_t instruction_count) const {
    if (trx_meta.processing_deadline && fc::time_point::now() > (*trx_meta.processing_deadline)) {
-      //throw checktime_exceeded();
+      throw checktime_exceeded();
    }
 }
 

--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -279,7 +279,7 @@ vector<account_name> apply_context::get_active_producers() const {
 
 void apply_context::checktime(uint32_t instruction_count) const {
    if (trx_meta.processing_deadline && fc::time_point::now() > (*trx_meta.processing_deadline)) {
-      throw checktime_exceeded();
+      //throw checktime_exceeded();
    }
 }
 

--- a/libraries/chain/chain_controller.cpp
+++ b/libraries/chain/chain_controller.cpp
@@ -735,6 +735,7 @@ void chain_controller::__apply_block(const signed_block& next_block)
                      const auto* gtrx = _db.find<generated_transaction_object,by_trx_id>(receipt.id);
                      if (gtrx != nullptr) {
                         auto trx = fc::raw::unpack<deferred_transaction>(gtrx->packed_trx.data(), gtrx->packed_trx.size());
+                        FC_ASSERT( trx.execute_after <= head_block_time() , "deffered transaction executed prematurely" );
                         _temp.emplace(trx, gtrx->published, trx.sender, trx.sender_id, gtrx->packed_trx.data(), gtrx->packed_trx.size() );
                         return &*_temp;
                      } else {

--- a/libraries/chain/chain_controller.cpp
+++ b/libraries/chain/chain_controller.cpp
@@ -361,12 +361,12 @@ void chain_controller::_start_pending_block()
    _apply_on_block_transaction();
    _finalize_pending_cycle();
 
+   _start_pending_cycle();
    push_deferred_transactions(true); //implicitly starts new cycle if there are deferred transactions ready for execution
    if (_pending_cycle_trace && _pending_cycle_trace->shard_traces.size() > 0) {
       _finalize_pending_cycle();
+      _start_pending_cycle();
    }
-
-   _start_pending_cycle();
 }
 
 transaction chain_controller::_get_on_block_transaction()

--- a/libraries/chain/chain_controller.cpp
+++ b/libraries/chain/chain_controller.cpp
@@ -365,8 +365,8 @@ void chain_controller::_start_pending_block( bool skip_deferred )
    _start_pending_cycle();
 
    if ( !skip_deferred ) {
-      _push_deferred_transactions(true);
-      if (_pending_cycle_trace && _pending_cycle_trace->shard_traces.size() > 0) {
+      _push_deferred_transactions( false );
+      if (_pending_cycle_trace && _pending_cycle_trace->shard_traces.size() > 0 && _pending_cycle_trace->shard_traces.back().transaction_traces.size() > 0) {
          _finalize_pending_cycle();
          _start_pending_cycle();
       }

--- a/libraries/chain/chain_controller.cpp
+++ b/libraries/chain/chain_controller.cpp
@@ -1647,7 +1647,7 @@ vector<transaction_trace> chain_controller::_push_deferred_transactions( bool fl
       candidates.emplace_back(&gtrx);
    }
 
-   auto deferred_transactions_deadline = fc::time_point::now() + fc::microseconds(20*1000);
+   auto deferred_transactions_deadline = fc::time_point::now() + fc::microseconds(config::deffered_transactions_max_time_per_block_us);
    vector<transaction_trace> res;
    for (const auto* trx_p: candidates) {
       if (!is_known_transaction(trx_p->trx_id)) {

--- a/libraries/chain/include/eosio/chain/apply_context.hpp
+++ b/libraries/chain/include/eosio/chain/apply_context.hpp
@@ -464,7 +464,7 @@ class apply_context {
       void execute_inline( action &&a );
       void execute_context_free_inline( action &&a );
       void execute_deferred( deferred_transaction &&trx );
-      void cancel_deferred( uint64_t sender_id );
+      void cancel_deferred( uint128_t sender_id );
 
       /**
        * @brief Require @ref account to have approved of this message

--- a/libraries/chain/include/eosio/chain/chain_controller.hpp
+++ b/libraries/chain/include/eosio/chain/chain_controller.hpp
@@ -87,8 +87,7 @@ namespace eosio { namespace chain {
 
          void push_block( const signed_block& b, uint32_t skip = skip_nothing );
          transaction_trace push_transaction( const packed_transaction& trx, uint32_t skip = skip_nothing );
-         vector<transaction_trace> push_deferred_transactions( bool flush = false );
-
+         vector<transaction_trace> push_deferred_transactions( bool flush = false, uint32_t skip = skip_nothing );
 
 
       /**
@@ -314,6 +313,7 @@ namespace eosio { namespace chain {
          transaction_trace _apply_transaction( transaction_metadata& data );
          transaction_trace __apply_transaction( transaction_metadata& data );
          transaction_trace _apply_error( transaction_metadata& data );
+         vector<transaction_trace> _push_deferred_transactions( bool flush = false );
 
          /// Reset the object graph in-memory
          void _initialize_indexes();
@@ -402,7 +402,7 @@ namespace eosio { namespace chain {
          void _spinup_db();
          void _spinup_fork_db();
 
-         void _start_pending_block();
+         void _start_pending_block( bool skip_deferred = false );
          void _start_pending_cycle();
          void _start_pending_shard();
          void _finalize_pending_cycle();

--- a/libraries/chain/include/eosio/chain/config.hpp
+++ b/libraries/chain/include/eosio/chain/config.hpp
@@ -73,6 +73,11 @@ const static eosio::chain::wasm_interface::vm_type default_wasm_runtime = eosio:
 const static int producer_repetitions = 12;
 
 /**
+ * In block production, at the begining of each block we schedule deferred transactions until reach this time
+ */
+const static uint32_t deffered_transactions_max_time_per_block_us = 20*1000; //20ms
+
+/**
  * The number of blocks produced per round is based upon all producers having a chance
  * to produce all of their consecutive blocks.
  */

--- a/libraries/chain/include/eosio/chain/generated_transaction_object.hpp
+++ b/libraries/chain/include/eosio/chain/generated_transaction_object.hpp
@@ -29,7 +29,7 @@ namespace eosio { namespace chain {
          id_type                       id;
          transaction_id_type           trx_id;
          account_name                  sender;
-         uint64_t                      sender_id = 0; /// ID given this transaction by the sender
+         uint128_t                     sender_id = 0; /// ID given this transaction by the sender
          time_point                    delay_until; /// this generated transaction will not be applied until the specified time
          time_point                    expiration; /// this generated transaction will not be applied after this time
          time_point                    published;
@@ -62,7 +62,7 @@ namespace eosio { namespace chain {
          ordered_unique< tag<by_sender_id>,
             composite_key< generated_transaction_object,
                BOOST_MULTI_INDEX_MEMBER( generated_transaction_object, account_name, sender),
-               BOOST_MULTI_INDEX_MEMBER( generated_transaction_object, uint64_t, sender_id)
+               BOOST_MULTI_INDEX_MEMBER( generated_transaction_object, uint128_t, sender_id)
             >
          >
       >

--- a/libraries/chain/include/eosio/chain/transaction.hpp
+++ b/libraries/chain/include/eosio/chain/transaction.hpp
@@ -213,7 +213,7 @@ namespace eosio { namespace chain {
     */
    struct deferred_transaction : public transaction
    {
-      uint64_t       sender_id; /// ID assigned by sender of generated, accessible via WASM api when executing normal or error
+      uint128_t       sender_id; /// ID assigned by sender of generated, accessible via WASM api when executing normal or error
       account_name   sender; /// receives error handler callback
       time_point_sec execute_after; /// delayed exeuction
    };
@@ -224,7 +224,7 @@ namespace eosio { namespace chain {
       {}
 
       account_name   sender;
-      uint64_t       sender_id;
+      uint128_t       sender_id;
    };
 
    struct data_access_info {

--- a/libraries/chain/include/eosio/chain/transaction.hpp
+++ b/libraries/chain/include/eosio/chain/transaction.hpp
@@ -220,7 +220,7 @@ namespace eosio { namespace chain {
 
       deferred_transaction() = default;
 
-      deferred_transaction(uint32_t sender_id, account_name sender, time_point_sec execute_after, const transaction& txn)
+      deferred_transaction(uint128_t sender_id, account_name sender, time_point_sec execute_after, const transaction& txn)
       : transaction(txn),
         sender_id(sender_id),
         sender(sender),
@@ -229,7 +229,7 @@ namespace eosio { namespace chain {
    };
 
    struct deferred_reference {
-      deferred_reference( const account_name& sender, uint64_t sender_id)
+      deferred_reference( const account_name& sender, uint128_t sender_id)
       :sender(sender),sender_id(sender_id)
       {}
 

--- a/libraries/chain/include/eosio/chain/transaction_metadata.hpp
+++ b/libraries/chain/include/eosio/chain/transaction_metadata.hpp
@@ -47,7 +47,7 @@ class transaction_metadata {
 
       // things for processing deferred transactions
       optional<account_name>                sender;
-      uint32_t                              sender_id = 0;
+      uint128_t                             sender_id = 0;
 
       // packed form to pass to contracts if needed
       const char*                           raw_data = nullptr;

--- a/libraries/chain/include/eosio/chain/transaction_metadata.hpp
+++ b/libraries/chain/include/eosio/chain/transaction_metadata.hpp
@@ -16,6 +16,14 @@ class transaction_metadata {
          ,sender(sender),sender_id(sender_id),raw_data(raw_data),raw_size(raw_size),_trx(&t)
       {}
 
+      transaction_metadata( const transaction& t, const time_point& published, const account_name& sender, uint32_t sender_id, const char* raw_data, size_t raw_size, fc::time_point deadline )
+         :id(t.id())
+         ,published(published)
+         ,sender(sender),sender_id(sender_id),raw_data(raw_data),raw_size(raw_size)
+         ,processing_deadline(deadline)
+         ,_trx(&t)
+      {}
+
       transaction_metadata( const packed_transaction& t, chain_id_type chainid, const time_point& published );
 
       transaction_metadata( transaction_metadata && ) = default;

--- a/libraries/chain/wasm_interface.cpp
+++ b/libraries/chain/wasm_interface.cpp
@@ -1030,23 +1030,24 @@ class transaction_api : public context_aware_api {
          context.execute_context_free_inline(std::move(act));
       }
 
-      void send_deferred( uint64_t sender_id, const fc::time_point_sec& execute_after, array_ptr<char> data, size_t data_len ) {
+      void send_deferred( const unsigned __int128& val, const fc::time_point_sec& execute_after, array_ptr<char> data, size_t data_len ) {
          try {
-            // TODO: use global properties object for dynamic configuration of this default_max_gen_trx_size
+            fc::uint128_t sender_id(val>>64, uint64_t(val) );
             const auto& gpo = context.controller.get_global_properties();
             FC_ASSERT(data_len < gpo.configuration.max_generated_transaction_size, "generated transaction too big");
 
             deferred_transaction dtrx;
             fc::raw::unpack<transaction>(data, data_len, dtrx);
             dtrx.sender = context.receiver;
-            dtrx.sender_id = sender_id;
+            dtrx.sender_id = (unsigned __int128)sender_id;
             dtrx.execute_after = execute_after;
             context.execute_deferred(std::move(dtrx));
          } FC_CAPTURE_AND_RETHROW((fc::to_hex(data, data_len)));
       }
 
-      void cancel_deferred( uint64_t sender_id ) {
-         context.cancel_deferred( sender_id );
+      void cancel_deferred( const unsigned __int128& val ) {
+         fc::uint128_t sender_id(val>>64, uint64_t(val) );
+         context.cancel_deferred( (unsigned __int128)sender_id );
       }
 };
 
@@ -1553,8 +1554,8 @@ REGISTER_INTRINSICS(context_free_transaction_api,
 REGISTER_INTRINSICS(transaction_api,
    (send_inline,               void(int, int)               )
    (send_context_free_inline,  void(int, int)               )
-   (send_deferred,             void(int64_t, int, int, int) )
-   (cancel_deferred,           void(int64_t)                )
+   (send_deferred,             void(int, int, int, int) )
+   (cancel_deferred,           void(int)                )
 );
 
 REGISTER_INTRINSICS(context_free_api,

--- a/libraries/fc/include/fc/static_variant.hpp
+++ b/libraries/fc/include/fc/static_variant.hpp
@@ -195,7 +195,7 @@ class static_variant {
     static_assert(impl::type_info<Types...>::no_reference_types, "Reference types are not permitted in static_variant.");
     static_assert(impl::type_info<Types...>::no_duplicates, "static_variant type arguments contain duplicate types.");
 
-    alignas(__int128) char storage[impl::type_info<Types...>::size];
+    alignas(Types...) char storage[impl::type_info<Types...>::size];
     int _tag;
 
     template<typename X>

--- a/libraries/fc/include/fc/static_variant.hpp
+++ b/libraries/fc/include/fc/static_variant.hpp
@@ -195,8 +195,8 @@ class static_variant {
     static_assert(impl::type_info<Types...>::no_reference_types, "Reference types are not permitted in static_variant.");
     static_assert(impl::type_info<Types...>::no_duplicates, "static_variant type arguments contain duplicate types.");
 
+    alignas(__int128) char storage[impl::type_info<Types...>::size];
     int _tag;
-    char storage[impl::type_info<Types...>::size];
 
     template<typename X>
     void init(const X& x) {

--- a/libraries/fc/src/uint128.cpp
+++ b/libraries/fc/src/uint128.cpp
@@ -376,8 +376,12 @@ namespace fc
 
    void to_variant( const uint128& var,  variant& vo )  { vo = std::string(var);         }
    void from_variant( const variant& var,  uint128& vo ){ vo = uint128(var.as_string()); }
-   void to_variant( const unsigned __int128& var,  variant& vo ) { to_variant( *((uint128*)var), vo); }
-   void from_variant( const variant& var,  unsigned __int128& vo ) { from_variant( var, *((uint128*)&vo)); }
+   void to_variant( const unsigned __int128& var,  variant& vo ) { to_variant( uint128(var), vo); }
+   void from_variant( const variant& var,  unsigned __int128& vo ) {
+      uint128 tmp;
+      from_variant( var, tmp );
+      vo = (unsigned __int128)tmp;
+   }
 
 } // namespace fc
 

--- a/tests/api_tests/api_tests.cpp
+++ b/tests/api_tests/api_tests.cpp
@@ -363,7 +363,7 @@ BOOST_FIXTURE_TEST_CASE(action_tests, tester) { try {
 
    // test send_action_sender
    CALL_TEST_FUNCTION( *this, "test_transaction", "send_action_sender", fc::raw::pack(N(testapi)));
-   control->push_deferred_transactions( true );
+   produce_block();
 
    // test_publication_time
    uint32_t pub_time = control->head_block_time().sec_since_epoch();
@@ -658,11 +658,11 @@ BOOST_FIXTURE_TEST_CASE(deferred_transaction_tests, tester) { try {
    produce_blocks(1);
 
    //schedule
-   CALL_TEST_FUNCTION(*this, "test_transaction", "send_deferred_transaction", fc::raw::pack(uint64_t(1)) );
+   CALL_TEST_FUNCTION(*this, "test_transaction", "send_deferred_transaction", {} );
    //check that it doesn't get executed immediately
    auto traces = control->push_deferred_transactions( true );
    BOOST_CHECK_EQUAL( 0, traces.size() );
-   produce_blocks(24);
+   produce_block( fc::seconds(2) );
    //check that it gets executed afterwards
    traces = control->push_deferred_transactions( true );
    BOOST_CHECK_EQUAL( 1, traces.size() );
@@ -670,7 +670,7 @@ BOOST_FIXTURE_TEST_CASE(deferred_transaction_tests, tester) { try {
    //schedule twice (second deferred transaction should replace first one)
    CALL_TEST_FUNCTION(*this, "test_transaction", "send_deferred_transaction", {});
    CALL_TEST_FUNCTION(*this, "test_transaction", "send_deferred_transaction", {});
-   produce_blocks( 24 );
+   produce_block( fc::seconds(2) );
    //check that only one deferred transaction executed
    traces = control->push_deferred_transactions( true );
    BOOST_CHECK_EQUAL( 1, traces.size() );
@@ -678,14 +678,14 @@ BOOST_FIXTURE_TEST_CASE(deferred_transaction_tests, tester) { try {
    //schedule and cancel
    CALL_TEST_FUNCTION(*this, "test_transaction", "send_deferred_transaction", {});
    CALL_TEST_FUNCTION(*this, "test_transaction", "cancel_deferred_transaction", {});
-   produce_blocks( 24 );
+   produce_block( fc::seconds(2) );
    traces = control->push_deferred_transactions( true );
    BOOST_CHECK_EQUAL( 0, traces.size() );
 
    //cancel_deferred() before scheduling transaction should not prevent the transaction from being scheduled (check that previous bug is fixed)
    CALL_TEST_FUNCTION(*this, "test_transaction", "cancel_deferred_transaction", {});
    CALL_TEST_FUNCTION(*this, "test_transaction", "send_deferred_transaction", {});
-   produce_blocks( 24 );
+   produce_block( fc::seconds(2) );
    traces = control->push_deferred_transactions( true );
    BOOST_CHECK_EQUAL( 1, traces.size() );
 } FC_LOG_AND_RETHROW() }

--- a/tests/chain_tests/delay_tests.cpp
+++ b/tests/chain_tests/delay_tests.cpp
@@ -128,16 +128,12 @@ BOOST_AUTO_TEST_CASE( link_delay_direct_test ) { try {
    liquid_balance = get_currency_balance(chain, N(tester2));
    BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
 
-   chain.control->push_deferred_transactions(true);
-
    chain.produce_blocks();
 
    liquid_balance = get_currency_balance(chain, N(tester));
    BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
    liquid_balance = get_currency_balance(chain, N(tester2));
    BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
-
-   chain.control->push_deferred_transactions(true);
 
    chain.produce_blocks(18);
 
@@ -146,16 +142,12 @@ BOOST_AUTO_TEST_CASE( link_delay_direct_test ) { try {
    liquid_balance = get_currency_balance(chain, N(tester2));
    BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
 
-   chain.control->push_deferred_transactions(true);
-
    chain.produce_blocks();
 
    liquid_balance = get_currency_balance(chain, N(tester));
    BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
    liquid_balance = get_currency_balance(chain, N(tester2));
    BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
-
-   chain.control->push_deferred_transactions(true);
 
    chain.produce_blocks();
 
@@ -276,16 +268,12 @@ BOOST_AUTO_TEST_CASE( link_delay_direct_parent_permission_test ) { try {
    liquid_balance = get_currency_balance(chain, N(tester2));
    BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
 
-   chain.control->push_deferred_transactions(true);
-
    chain.produce_blocks();
 
    liquid_balance = get_currency_balance(chain, N(tester));
    BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
    liquid_balance = get_currency_balance(chain, N(tester2));
    BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
-
-   chain.control->push_deferred_transactions(true);
 
    chain.produce_blocks(28);
 
@@ -294,16 +282,12 @@ BOOST_AUTO_TEST_CASE( link_delay_direct_parent_permission_test ) { try {
    liquid_balance = get_currency_balance(chain, N(tester2));
    BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
 
-   chain.control->push_deferred_transactions(true);
-
    chain.produce_blocks();
 
    liquid_balance = get_currency_balance(chain, N(tester));
    BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
    liquid_balance = get_currency_balance(chain, N(tester2));
    BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
-
-   chain.control->push_deferred_transactions(true);
 
    chain.produce_blocks();
 
@@ -430,16 +414,12 @@ BOOST_AUTO_TEST_CASE( link_delay_direct_walk_parent_permissions_test ) { try {
    liquid_balance = get_currency_balance(chain, N(tester2));
    BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
 
-   chain.control->push_deferred_transactions(true);
-
    chain.produce_blocks();
 
    liquid_balance = get_currency_balance(chain, N(tester));
    BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
    liquid_balance = get_currency_balance(chain, N(tester2));
    BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
-
-   chain.control->push_deferred_transactions(true);
 
    chain.produce_blocks(38);
 
@@ -448,16 +428,12 @@ BOOST_AUTO_TEST_CASE( link_delay_direct_walk_parent_permissions_test ) { try {
    liquid_balance = get_currency_balance(chain, N(tester2));
    BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
 
-   chain.control->push_deferred_transactions(true);
-
    chain.produce_blocks();
 
    liquid_balance = get_currency_balance(chain, N(tester));
    BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
    liquid_balance = get_currency_balance(chain, N(tester2));
    BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
-
-   chain.control->push_deferred_transactions(true);
 
    chain.produce_blocks();
 
@@ -573,8 +549,6 @@ BOOST_AUTO_TEST_CASE( link_delay_permission_change_test ) { try {
    liquid_balance = get_currency_balance(chain, N(tester2));
    BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
 
-   chain.control->push_deferred_transactions(true);
-
    chain.produce_blocks(16);
 
    liquid_balance = get_currency_balance(chain, N(tester));
@@ -601,8 +575,6 @@ BOOST_AUTO_TEST_CASE( link_delay_permission_change_test ) { try {
    liquid_balance = get_currency_balance(chain, N(tester2));
    BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
 
-   chain.control->push_deferred_transactions(true);
-
    chain.produce_blocks();
 
    liquid_balance = get_currency_balance(chain, N(tester));
@@ -611,8 +583,6 @@ BOOST_AUTO_TEST_CASE( link_delay_permission_change_test ) { try {
    BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
 
    // first transfer will finally be performed
-   chain.control->push_deferred_transactions(true);
-
    chain.produce_blocks();
 
    liquid_balance = get_currency_balance(chain, N(tester));
@@ -630,8 +600,6 @@ BOOST_AUTO_TEST_CASE( link_delay_permission_change_test ) { try {
    BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace.status);
    BOOST_REQUIRE_EQUAL(0, trace.deferred_transaction_requests.size());
 
-   chain.control->push_deferred_transactions(true);
-
    chain.produce_blocks();
 
    liquid_balance = get_currency_balance(chain, N(tester));
@@ -639,16 +607,12 @@ BOOST_AUTO_TEST_CASE( link_delay_permission_change_test ) { try {
    liquid_balance = get_currency_balance(chain, N(tester2));
    BOOST_REQUIRE_EQUAL(asset::from_string("11.0000 CUR"), liquid_balance);
 
-   chain.control->push_deferred_transactions(true);
-
    chain.produce_blocks(15);
 
    liquid_balance = get_currency_balance(chain, N(tester));
    BOOST_REQUIRE_EQUAL(asset::from_string("89.0000 CUR"), liquid_balance);
    liquid_balance = get_currency_balance(chain, N(tester2));
    BOOST_REQUIRE_EQUAL(asset::from_string("11.0000 CUR"), liquid_balance);
-
-   chain.control->push_deferred_transactions(true);
 
    chain.produce_blocks();
 
@@ -658,8 +622,6 @@ BOOST_AUTO_TEST_CASE( link_delay_permission_change_test ) { try {
    BOOST_REQUIRE_EQUAL(asset::from_string("11.0000 CUR"), liquid_balance);
 
    // second transfer finally is performed
-   chain.control->push_deferred_transactions(true);
-
    chain.produce_blocks();
 
    liquid_balance = get_currency_balance(chain, N(tester));
@@ -780,8 +742,6 @@ BOOST_AUTO_TEST_CASE( link_delay_permission_change_with_delay_heirarchy_test ) {
    liquid_balance = get_currency_balance(chain, N(tester2));
    BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
 
-   chain.control->push_deferred_transactions(true);
-
    chain.produce_blocks(16);
 
    liquid_balance = get_currency_balance(chain, N(tester));
@@ -808,8 +768,6 @@ BOOST_AUTO_TEST_CASE( link_delay_permission_change_with_delay_heirarchy_test ) {
    liquid_balance = get_currency_balance(chain, N(tester2));
    BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
 
-   chain.control->push_deferred_transactions(true);
-
    chain.produce_blocks();
 
    liquid_balance = get_currency_balance(chain, N(tester));
@@ -818,8 +776,6 @@ BOOST_AUTO_TEST_CASE( link_delay_permission_change_with_delay_heirarchy_test ) {
    BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
 
    // first transfer will finally be performed
-   chain.control->push_deferred_transactions(true);
-
    chain.produce_blocks();
 
    liquid_balance = get_currency_balance(chain, N(tester));
@@ -837,8 +793,6 @@ BOOST_AUTO_TEST_CASE( link_delay_permission_change_with_delay_heirarchy_test ) {
    BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace.status);
    BOOST_REQUIRE_EQUAL(0, trace.deferred_transaction_requests.size());
 
-   chain.control->push_deferred_transactions(true);
-
    chain.produce_blocks();
 
    liquid_balance = get_currency_balance(chain, N(tester));
@@ -846,16 +800,12 @@ BOOST_AUTO_TEST_CASE( link_delay_permission_change_with_delay_heirarchy_test ) {
    liquid_balance = get_currency_balance(chain, N(tester2));
    BOOST_REQUIRE_EQUAL(asset::from_string("11.0000 CUR"), liquid_balance);
 
-   chain.control->push_deferred_transactions(true);
-
    chain.produce_blocks(15);
 
    liquid_balance = get_currency_balance(chain, N(tester));
    BOOST_REQUIRE_EQUAL(asset::from_string("89.0000 CUR"), liquid_balance);
    liquid_balance = get_currency_balance(chain, N(tester2));
    BOOST_REQUIRE_EQUAL(asset::from_string("11.0000 CUR"), liquid_balance);
-
-   chain.control->push_deferred_transactions(true);
 
    chain.produce_blocks();
 
@@ -865,8 +815,6 @@ BOOST_AUTO_TEST_CASE( link_delay_permission_change_with_delay_heirarchy_test ) {
    BOOST_REQUIRE_EQUAL(asset::from_string("11.0000 CUR"), liquid_balance);
 
    // second transfer finally is performed
-   chain.control->push_deferred_transactions(true);
-
    chain.produce_blocks();
 
    liquid_balance = get_currency_balance(chain, N(tester));
@@ -986,8 +934,6 @@ BOOST_AUTO_TEST_CASE( link_delay_link_change_test ) { try {
    liquid_balance = get_currency_balance(chain, N(tester2));
    BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
 
-   chain.control->push_deferred_transactions(true);
-
    chain.produce_blocks(16);
 
    liquid_balance = get_currency_balance(chain, N(tester));
@@ -1014,8 +960,6 @@ BOOST_AUTO_TEST_CASE( link_delay_link_change_test ) { try {
    liquid_balance = get_currency_balance(chain, N(tester2));
    BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
 
-   chain.control->push_deferred_transactions(true);
-
    chain.produce_blocks();
 
    liquid_balance = get_currency_balance(chain, N(tester));
@@ -1024,8 +968,6 @@ BOOST_AUTO_TEST_CASE( link_delay_link_change_test ) { try {
    BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
 
    // first transfer will finally be performed
-   chain.control->push_deferred_transactions(true);
-
    chain.produce_blocks();
 
    liquid_balance = get_currency_balance(chain, N(tester));
@@ -1043,8 +985,6 @@ BOOST_AUTO_TEST_CASE( link_delay_link_change_test ) { try {
    BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace.status);
    BOOST_REQUIRE_EQUAL(0, trace.deferred_transaction_requests.size());
 
-   chain.control->push_deferred_transactions(true);
-
    chain.produce_blocks();
 
    liquid_balance = get_currency_balance(chain, N(tester));
@@ -1052,16 +992,12 @@ BOOST_AUTO_TEST_CASE( link_delay_link_change_test ) { try {
    liquid_balance = get_currency_balance(chain, N(tester2));
    BOOST_REQUIRE_EQUAL(asset::from_string("11.0000 CUR"), liquid_balance);
 
-   chain.control->push_deferred_transactions(true);
-
    chain.produce_blocks(15);
 
    liquid_balance = get_currency_balance(chain, N(tester));
    BOOST_REQUIRE_EQUAL(asset::from_string("89.0000 CUR"), liquid_balance);
    liquid_balance = get_currency_balance(chain, N(tester2));
    BOOST_REQUIRE_EQUAL(asset::from_string("11.0000 CUR"), liquid_balance);
-
-   chain.control->push_deferred_transactions(true);
 
    chain.produce_blocks();
 
@@ -1071,8 +1007,6 @@ BOOST_AUTO_TEST_CASE( link_delay_link_change_test ) { try {
    BOOST_REQUIRE_EQUAL(asset::from_string("11.0000 CUR"), liquid_balance);
 
    // second transfer finally is performed
-   chain.control->push_deferred_transactions(true);
-
    chain.produce_blocks();
 
    liquid_balance = get_currency_balance(chain, N(tester));
@@ -1198,8 +1132,6 @@ BOOST_AUTO_TEST_CASE( link_delay_link_change_heirarchy_test ) { try {
    liquid_balance = get_currency_balance(chain, N(tester2));
    BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
 
-   chain.control->push_deferred_transactions(true);
-
    chain.produce_blocks(16);
 
    liquid_balance = get_currency_balance(chain, N(tester));
@@ -1226,8 +1158,6 @@ BOOST_AUTO_TEST_CASE( link_delay_link_change_heirarchy_test ) { try {
    liquid_balance = get_currency_balance(chain, N(tester2));
    BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
 
-   chain.control->push_deferred_transactions(true);
-
    chain.produce_blocks();
 
    liquid_balance = get_currency_balance(chain, N(tester));
@@ -1236,8 +1166,6 @@ BOOST_AUTO_TEST_CASE( link_delay_link_change_heirarchy_test ) { try {
    BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
 
    // first transfer will finally be performed
-   chain.control->push_deferred_transactions(true);
-
    chain.produce_blocks();
 
    liquid_balance = get_currency_balance(chain, N(tester));
@@ -1255,8 +1183,6 @@ BOOST_AUTO_TEST_CASE( link_delay_link_change_heirarchy_test ) { try {
    BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace.status);
    BOOST_REQUIRE_EQUAL(0, trace.deferred_transaction_requests.size());
 
-   chain.control->push_deferred_transactions(true);
-
    chain.produce_blocks();
 
    liquid_balance = get_currency_balance(chain, N(tester));
@@ -1264,16 +1190,12 @@ BOOST_AUTO_TEST_CASE( link_delay_link_change_heirarchy_test ) { try {
    liquid_balance = get_currency_balance(chain, N(tester2));
    BOOST_REQUIRE_EQUAL(asset::from_string("11.0000 CUR"), liquid_balance);
 
-   chain.control->push_deferred_transactions(true);
-
    chain.produce_blocks(15);
 
    liquid_balance = get_currency_balance(chain, N(tester));
    BOOST_REQUIRE_EQUAL(asset::from_string("89.0000 CUR"), liquid_balance);
    liquid_balance = get_currency_balance(chain, N(tester2));
    BOOST_REQUIRE_EQUAL(asset::from_string("11.0000 CUR"), liquid_balance);
-
-   chain.control->push_deferred_transactions(true);
 
    chain.produce_blocks();
 
@@ -1283,8 +1205,6 @@ BOOST_AUTO_TEST_CASE( link_delay_link_change_heirarchy_test ) { try {
    BOOST_REQUIRE_EQUAL(asset::from_string("11.0000 CUR"), liquid_balance);
 
    // second transfer finally is performed
-   chain.control->push_deferred_transactions(true);
-
    chain.produce_blocks();
 
    liquid_balance = get_currency_balance(chain, N(tester));
@@ -1400,16 +1320,12 @@ BOOST_AUTO_TEST_CASE( mindelay_test ) { try {
    liquid_balance = get_currency_balance(chain, N(tester2));
    BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
 
-   chain.control->push_deferred_transactions(true);
-
    chain.produce_blocks();
 
    liquid_balance = get_currency_balance(chain, N(tester));
    BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
    liquid_balance = get_currency_balance(chain, N(tester2));
    BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
-
-   chain.control->push_deferred_transactions(true);
 
    chain.produce_blocks(18);
 
@@ -1418,16 +1334,12 @@ BOOST_AUTO_TEST_CASE( mindelay_test ) { try {
    liquid_balance = get_currency_balance(chain, N(tester2));
    BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
 
-   chain.control->push_deferred_transactions(true);
-
    chain.produce_blocks();
 
    liquid_balance = get_currency_balance(chain, N(tester));
    BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
    liquid_balance = get_currency_balance(chain, N(tester2));
    BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
-
-   chain.control->push_deferred_transactions(true);
 
    chain.produce_blocks();
 
@@ -1543,8 +1455,6 @@ BOOST_AUTO_TEST_CASE( canceldelay_test ) { try {
    liquid_balance = get_currency_balance(chain, N(tester2));
    BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
 
-   chain.control->push_deferred_transactions(true);
-
    chain.produce_blocks(16);
 
    liquid_balance = get_currency_balance(chain, N(tester));
@@ -1582,9 +1492,7 @@ BOOST_AUTO_TEST_CASE( canceldelay_test ) { try {
    BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace.status);
    BOOST_REQUIRE_EQUAL(1, trace.deferred_transaction_requests.size());
    const auto sender_id_canceled = trace.deferred_transaction_requests[0].get<deferred_reference>().sender_id;
-   BOOST_REQUIRE_EQUAL(sender_id_to_cancel, sender_id_canceled);
-
-   chain.control->push_deferred_transactions(true);
+   BOOST_REQUIRE_EQUAL(std::string(uint128(sender_id_to_cancel)), std::string(uint128(sender_id_canceled)));
 
    chain.produce_blocks();
 
@@ -1594,8 +1502,6 @@ BOOST_AUTO_TEST_CASE( canceldelay_test ) { try {
    BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
 
    // first transfer will finally be performed
-   chain.control->push_deferred_transactions(true);
-
    chain.produce_blocks();
 
    liquid_balance = get_currency_balance(chain, N(tester));
@@ -1613,8 +1519,6 @@ BOOST_AUTO_TEST_CASE( canceldelay_test ) { try {
    BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace.status);
    BOOST_REQUIRE_EQUAL(0, trace.deferred_transaction_requests.size());
 
-   chain.control->push_deferred_transactions(true);
-
    chain.produce_blocks();
 
    liquid_balance = get_currency_balance(chain, N(tester));
@@ -1622,16 +1526,12 @@ BOOST_AUTO_TEST_CASE( canceldelay_test ) { try {
    liquid_balance = get_currency_balance(chain, N(tester2));
    BOOST_REQUIRE_EQUAL(asset::from_string("10.0000 CUR"), liquid_balance);
 
-   chain.control->push_deferred_transactions(true);
-
    chain.produce_blocks(15);
 
    liquid_balance = get_currency_balance(chain, N(tester));
    BOOST_REQUIRE_EQUAL(asset::from_string("90.0000 CUR"), liquid_balance);
    liquid_balance = get_currency_balance(chain, N(tester2));
    BOOST_REQUIRE_EQUAL(asset::from_string("10.0000 CUR"), liquid_balance);
-
-   chain.control->push_deferred_transactions(true);
 
    chain.produce_blocks();
 
@@ -1641,8 +1541,6 @@ BOOST_AUTO_TEST_CASE( canceldelay_test ) { try {
    BOOST_REQUIRE_EQUAL(asset::from_string("10.0000 CUR"), liquid_balance);
 
    // second transfer finally is performed
-   chain.control->push_deferred_transactions(true);
-
    chain.produce_blocks();
 
    liquid_balance = get_currency_balance(chain, N(tester));

--- a/tests/wasm_tests/currency_tests.cpp
+++ b/tests/wasm_tests/currency_tests.cpp
@@ -324,13 +324,12 @@ BOOST_FIXTURE_TEST_CASE( test_proxy, currency_tester ) try {
    }
 
    while(control->head_block_time() < expected_delivery) {
-      control->push_deferred_transactions(true);
       produce_block();
       BOOST_REQUIRE_EQUAL(get_balance( N(proxy)), asset::from_string("5.0000 CUR"));
       BOOST_REQUIRE_EQUAL(get_balance( N(alice)),   asset::from_string("0.0000 CUR"));
    }
 
-   control->push_deferred_transactions(true);
+   produce_block();
    BOOST_REQUIRE_EQUAL(get_balance( N(proxy)), asset::from_string("0.0000 CUR"));
    BOOST_REQUIRE_EQUAL(get_balance( N(alice)),   asset::from_string("5.0000 CUR"));
 
@@ -381,7 +380,6 @@ BOOST_FIXTURE_TEST_CASE( test_deferred_failure, currency_tester ) try {
    auto deferred_id = trace.deferred_transaction_requests.back().get<deferred_transaction>().id();
 
    while(control->head_block_time() < expected_delivery) {
-      control->push_deferred_transactions(true);
       produce_block();
       BOOST_REQUIRE_EQUAL(get_balance( N(proxy)), asset::from_string("5.0000 CUR"));
       BOOST_REQUIRE_EQUAL(get_balance( N(bob)),   asset::from_string("0.0000 CUR"));
@@ -390,7 +388,6 @@ BOOST_FIXTURE_TEST_CASE( test_deferred_failure, currency_tester ) try {
    }
 
    fc::time_point expected_redelivery(fc::seconds(control->head_block_time().sec_since_epoch()) + fc::seconds(10));
-   control->push_deferred_transactions(true);
    produce_block();
    BOOST_REQUIRE_EQUAL(chain_has_transaction(deferred_id), true);
    BOOST_REQUIRE_EQUAL(get_transaction_receipt(deferred_id).status, transaction_receipt::soft_fail);
@@ -416,19 +413,18 @@ BOOST_FIXTURE_TEST_CASE( test_deferred_failure, currency_tester ) try {
    }
 
    while(control->head_block_time() < expected_redelivery) {
-      control->push_deferred_transactions(true);
       produce_block();
       BOOST_REQUIRE_EQUAL(get_balance( N(proxy)), asset::from_string("5.0000 CUR"));
       BOOST_REQUIRE_EQUAL(get_balance( N(bob)),   asset::from_string("0.0000 CUR"));
       BOOST_REQUIRE_EQUAL(get_balance( N(bob)),   asset::from_string("0.0000 CUR"));
    }
 
-   control->push_deferred_transactions(true);
+   produce_block();
    BOOST_REQUIRE_EQUAL(get_balance( N(proxy)), asset::from_string("0.0000 CUR"));
    BOOST_REQUIRE_EQUAL(get_balance( N(alice)), asset::from_string("0.0000 CUR"));
    BOOST_REQUIRE_EQUAL(get_balance( N(bob)),   asset::from_string("5.0000 CUR"));
 
-   control->push_deferred_transactions(true);
+   produce_block();
 
    BOOST_REQUIRE_EQUAL(get_balance( N(proxy)), asset::from_string("0.0000 CUR"));
    BOOST_REQUIRE_EQUAL(get_balance( N(alice)), asset::from_string("5.0000 CUR"));

--- a/tests/wasm_tests/eosio.system_tests.cpp
+++ b/tests/wasm_tests/eosio.system_tests.cpp
@@ -207,17 +207,16 @@ BOOST_FIXTURE_TEST_CASE( stake_unstake, eosio_system_tester ) try {
    BOOST_REQUIRE_EQUAL( asset::from_string("0.0000 EOS").amount, total["storage_stake"].as_uint64());
    BOOST_REQUIRE_EQUAL( 0, total["storage_bytes"].as_uint64());
    REQUIRE_MATCHING_OBJECT( voter( "alice", "0.00 EOS" ), get_voter_info( "alice" ) );
-   control->push_deferred_transactions(true);
+   produce_blocks(1);
    BOOST_REQUIRE_EQUAL( asset::from_string("200.0000 EOS"), get_balance( "alice" ) );
 
    //after 2 days balance should not be available yet
    produce_block( fc::hours(3*24-1) );
-   control->push_deferred_transactions(true);
+   produce_blocks(1);
    BOOST_REQUIRE_EQUAL( asset::from_string("200.0000 EOS"), get_balance( "alice" ) );
-
    //after 3 days funds should be released
    produce_block( fc::hours(1) );
-   control->push_deferred_transactions(true);
+   produce_blocks(1);
    BOOST_REQUIRE_EQUAL( asset::from_string("1000.0000 EOS"), get_balance( "alice" ) );
 
 } FC_LOG_AND_RETHROW()
@@ -502,10 +501,10 @@ BOOST_FIXTURE_TEST_CASE( adding_stake_partial_unstake, eosio_system_tester ) try
 
    //combined amount should be available only in 3 days
    produce_block( fc::days(2) );
-   control->push_deferred_transactions(true);
+   produce_blocks(1);
    BOOST_REQUIRE_EQUAL( asset::from_string("430.0000 EOS"), get_balance( "alice" ) );
    produce_block( fc::days(1) );
-   control->push_deferred_transactions(true);
+   produce_blocks(1);
    BOOST_REQUIRE_EQUAL( asset::from_string("790.0000 EOS"), get_balance( "alice" ) );
 
 } FC_LOG_AND_RETHROW()
@@ -661,7 +660,7 @@ BOOST_FIXTURE_TEST_CASE( vote_for_producer, eosio_system_tester ) try {
    BOOST_REQUIRE_EQUAL( string(key.begin(), key.end()), to_string(prod["packed_key"]) );
    //carol should receive funds in 3 days
    produce_block( fc::days(3) );
-   control->push_deferred_transactions(true);
+   produce_block();
    BOOST_REQUIRE_EQUAL( asset::from_string("3000.0000 EOS"), get_balance( "carol" ) );
 
 } FC_LOG_AND_RETHROW()


### PR DESCRIPTION
1. producer execute deferred transactions during first 20ms of each block
2. sender_id changed from uint64 to uint128
3. in __apply_block check that deferred transactions were executed after "execute_after"