### PR TITLE
Add additional unit tests for checking account creation

### DIFF
--- a/libraries/chain/contracts/eosio_contract.cpp
+++ b/libraries/chain/contracts/eosio_contract.cpp
@@ -49,7 +49,10 @@ void apply_eosio_newaccount(apply_context& context) {
    auto& db = context.mutable_db;
 
    EOS_ASSERT( create.name.to_string().size() <= 12, action_validate_exception, "account names can only be 12 chars long" );
-   if( !context.privileged ) {
+
+   // Check if the creator is privileged
+   const auto &creator = db.get<account_object, by_name>(create.creator);
+   if( !creator.privileged ) {
       EOS_ASSERT( name(create.name).to_string().find( "eosio." ) == std::string::npos, action_validate_exception, "only privileged accounts can have names that contain 'eosio.'" );
    }
 

--- a/tests/chain_tests/auth_tests.cpp
+++ b/tests/chain_tests/auth_tests.cpp
@@ -258,6 +258,22 @@ try {
    BOOST_TEST(string(joe_active_authority.auth.keys[0].key) == string(chain.get_public_key("joe", "active")));
    BOOST_TEST(joe_active_authority.auth.keys[0].weight == 1);
 
+   // Create duplicate name
+   BOOST_CHECK_EXCEPTION(chain.create_account("joe"), action_validate_exception,
+                         assert_message_is("Cannot create account named joe, as that name is already taken"));
+
+   // Creating account with name more than 12 chars
+   BOOST_CHECK_EXCEPTION(chain.create_account("aaaaaaaaaaaaa"), action_validate_exception,
+                         assert_message_is("account names can only be 12 chars long"));
+
+   // Creating account with eosio. prefix with priveleged account
+   chain.create_account("eosio.test1");
+
+   // Creating account with eosio. prefix with non-privileged account, should fail
+   BOOST_CHECK_EXCEPTION(chain.create_account("eosio.test2", "joe"), action_validate_exception,
+                         assert_message_is("only privileged accounts can have names that contain 'eosio.'"));
+
+
 } FC_LOG_AND_RETHROW() }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Also fixes the problem where privileged status is inferred from the action receiver instead of creator when creating an account with "eosio." prefix.

For #1710 