### PR TITLE
Re-enable mongo test and fix intermittent timing issues

### DIFF
--- a/programs/eosio-launcher/main.cpp
+++ b/programs/eosio-launcher/main.cpp
@@ -7,6 +7,7 @@
 #include <vector>
 #include <math.h>
 #include <sstream>
+#include <regex>
 
 #include <boost/algorithm/string.hpp>
 #include <boost/asio/ip/tcp.hpp>
@@ -1397,7 +1398,18 @@ launcher_def::launch (eosd_def &instance, string &gts) {
     eosdcmd += "--skip-transaction-signatures ";
   }
   if (!eosd_extra_args.empty()) {
-    eosdcmd += eosd_extra_args + " ";
+    if (instance.name == "bios") {
+       // Strip the mongo-related options out of the bios node so
+       // the plugins don't conflict between 00 and bios.
+       regex r("--plugin +eosio::mongo_db_plugin");
+       string args = std::regex_replace (eosd_extra_args,r,"");
+       regex r2("--mongodb-uri +[^ ]+");
+       args = std::regex_replace (args,r2,"");
+       eosdcmd += args + " ";
+    }
+    else {
+       eosdcmd += eosd_extra_args + " ";
+    }
   }
 
   if( add_enable_stale_production ) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -50,7 +50,7 @@ add_test(NAME nodeos_run_test COMMAND tests/nodeos_run_test.py -v --dump-error-d
 # add_test(NAME nodeos_run_remote_test COMMAND tests/nodeos_run_remote_test.py --dump-error-detail WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 add_test(NAME p2p_dawn515_test COMMAND tests/p2p_tests/dawn_515/test.sh WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 if(BUILD_MONGO_DB_PLUGIN)
-#   add_test(NAME nodeos_run_test-mongodb COMMAND tests/nodeos_run_test.py --mongodb --dump-error-detail WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+   add_test(NAME nodeos_run_test-mongodb COMMAND tests/nodeos_run_test.py --mongodb --dump-error-detail WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 endif()
 
 # TODO: Tests removed until working again on master.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -50,7 +50,7 @@ add_test(NAME nodeos_run_test COMMAND tests/nodeos_run_test.py -v --dump-error-d
 # add_test(NAME nodeos_run_remote_test COMMAND tests/nodeos_run_remote_test.py --dump-error-detail WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 add_test(NAME p2p_dawn515_test COMMAND tests/p2p_tests/dawn_515/test.sh WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 if(BUILD_MONGO_DB_PLUGIN)
-   add_test(NAME nodeos_run_test-mongodb COMMAND tests/nodeos_run_test.py --mongodb --dump-error-detail WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+   add_test(NAME nodeos_run_test-mongodb COMMAND tests/nodeos_run_test.py --mongodb -v --dump-error-detail WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 endif()
 
 # TODO: Tests removed until working again on master.

--- a/tests/nodeos_run_test.py
+++ b/tests/nodeos_run_test.py
@@ -81,7 +81,7 @@ if amINoon:
     WalletdName="keosd"
     ClientName="cleos"
     # noon branch requires longer mongo sync time.
-    testUtils.Utils.setMongoSyncTime(50)
+    # testUtils.Utils.setMongoSyncTime(50)
 else:
     testUtils.Utils.iAmNotNoon()
 


### PR DESCRIPTION
The mongo test was failing because of conflicting mongodb plugins in node_00 and node_bios. As a quick fix, I changed the launcher code to not pass mongo-related options through to the bios node. I also removed some extra sleep time from the mongo test as I don't think it is needed any more.