### PR TITLE
Add delay_sec to transaction header + declare cpu usage for full transaction

### DIFF
--- a/contracts/eosiolib/transaction.hpp
+++ b/contracts/eosiolib/transaction.hpp
@@ -38,12 +38,13 @@ namespace eosio {
       uint16_t        ref_block_num;
       uint32_t        ref_block_prefix;
       unsigned_int    net_usage_words = 0UL; /// number of 8 byte words this transaction can serialize into after compressions
-      unsigned_int    context_free_kilo_cpu_usage = 0UL; /// number of CPU usage units to bill transaction for
+      unsigned_int    kcpu_usage = 0UL; /// number of CPU usage units to bill transaction for
+      unsigned_int    delay_sec = 0UL; /// number of CPU usage units to bill transaction for
 
       vector<action>  context_free_actions;
       vector<action>  actions;
 
-      EOSLIB_SERIALIZE( transaction, (expiration)(region)(ref_block_num)(ref_block_prefix)(net_usage_words)(context_free_kilo_cpu_usage)(context_free_actions)(actions) )
+      EOSLIB_SERIALIZE( transaction, (expiration)(region)(ref_block_num)(ref_block_prefix)(net_usage_words)(kcpu_usage)(delay_sec)(context_free_actions)(actions) )
    };
 
    class deferred_transaction : public transaction {

--- a/contracts/test_api/test_transaction.cpp
+++ b/contracts/test_api/test_transaction.cpp
@@ -157,6 +157,7 @@ void test_transaction::test_transaction_size() {
    using namespace eosio;
    uint32_t trans_size = 0;
    read_action_data( (char*)&trans_size, sizeof(uint32_t) );
+   print( "size: ", transaction_size() );
    eosio_assert( trans_size == transaction_size(), "transaction size does not match" );
 }
 

--- a/libraries/chain/contracts/chain_initializer.cpp
+++ b/libraries/chain/contracts/chain_initializer.cpp
@@ -240,7 +240,8 @@ abi_def chain_initializer::eos_contract_abi(const abi_def& eosio_system_abi)
          {"ref_block_num", "uint16"},
          {"ref_block_prefix", "uint16"},
          {"net_usage_words", "varuint32"},
-         {"context_free_kilo_cpu_usage", "varuint32"}
+         {"kcpu_usage", "varuint32"},
+         {"delay_sec", "varuint32"}
       }
    });
 

--- a/libraries/chain/contracts/eosio_contract.cpp
+++ b/libraries/chain/contracts/eosio_contract.cpp
@@ -121,6 +121,8 @@ void apply_eosio_setcode(apply_context& context) {
    int64_t old_size = (int64_t)account.code.size() * config::setcode_ram_bytes_multiplier;
    int64_t new_size = code_size * config::setcode_ram_bytes_multiplier;
 
+
+   FC_ASSERT( account.code_version != code_id, "contract is already running this version of code" );
 //   wlog( "set code: ${size}", ("size",act.code.size()));
    db.modify( account, [&]( auto& a ) {
       /** TODO: consider whether a microsecond level local timestamp is sufficient to detect code version changes*/

--- a/libraries/chain/include/eosio/chain/transaction.hpp
+++ b/libraries/chain/include/eosio/chain/transaction.hpp
@@ -113,11 +113,12 @@ namespace eosio { namespace chain {
     */
    struct transaction_header {
       time_point_sec         expiration;   ///< the time at which a transaction expires
-      uint16_t               region        = 0U; ///< the computational memory region this transaction applies to.
-      uint16_t               ref_block_num = 0U; ///< specifies a block num in the last 2^16 blocks.
+      uint16_t               region           = 0U; ///< the computational memory region this transaction applies to.
+      uint16_t               ref_block_num    = 0U; ///< specifies a block num in the last 2^16 blocks.
       uint32_t               ref_block_prefix = 0UL; ///< specifies the lower 32 bits of the blockid at get_ref_blocknum
-      fc::unsigned_int       net_usage_words = 0UL; /// number of 8 byte words this transaction serialize too taking any compression into account
-      fc::unsigned_int       context_free_kilo_cpu_usage = 0UL; /// number of kilo CPU usage units to bill transaction for to process context free actions
+      fc::unsigned_int       net_usage_words  = 0UL; /// number of 8 byte words this transaction serialize too taking any compression into account
+      fc::unsigned_int       kcpu_usage       = 0UL; /// number of kilo CPU usage units to bill transaction for to process all free actions
+      fc::unsigned_int       delay_sec        = 0UL; /// number of seconds to delay this transaction for during which it may be canceled.
 
       /**
        * @return the absolute block number given the relative ref_block_num
@@ -150,7 +151,7 @@ namespace eosio { namespace chain {
 //      signed_transaction( const signed_transaction& ) = default;
 //      signed_transaction( signed_transaction&& ) = default;
       signed_transaction( transaction&& trx, const vector<signature_type>& signatures, const vector<bytes>& context_free_data)
-      : transaction(std::forward<transaction>(trx))
+      : transaction(std::move(trx))
       , signatures(signatures)
       , context_free_data(context_free_data)
       {
@@ -243,7 +244,8 @@ namespace eosio { namespace chain {
 FC_REFLECT( eosio::chain::permission_level, (actor)(permission) )
 FC_REFLECT( eosio::chain::action, (account)(name)(authorization)(data) )
 FC_REFLECT( eosio::chain::transaction_receipt, (status)(id))
-FC_REFLECT( eosio::chain::transaction_header, (expiration)(region)(ref_block_num)(ref_block_prefix)(net_usage_words)(context_free_kilo_cpu_usage) )
+FC_REFLECT( eosio::chain::transaction_header, (expiration)(region)(ref_block_num)(ref_block_prefix)
+                                              (net_usage_words)(kcpu_usage)(delay_sec) )
 FC_REFLECT_DERIVED( eosio::chain::transaction, (eosio::chain::transaction_header), (context_free_actions)(actions) )
 FC_REFLECT_DERIVED( eosio::chain::signed_transaction, (eosio::chain::transaction), (signatures)(context_free_data) )
 FC_REFLECT_ENUM( eosio::chain::packed_transaction::compression_type, (none)(zlib))

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -118,7 +118,7 @@ namespace eosio { namespace testing {
      trx.net_usage_words = estimated_size / 8;
 
      // estimate the usage of the context free actions
-     trx.context_free_kilo_cpu_usage = extra_cf_cpu_usage + (trx.context_free_actions.size() * config::default_base_per_action_cpu_usage * 10);
+     trx.kcpu_usage = 30000 + extra_cf_cpu_usage + (trx.context_free_actions.size() * config::default_base_per_action_cpu_usage * 10);
   }
 
    void base_tester::create_account( account_name a, account_name creator, bool multisig ) {
@@ -147,14 +147,14 @@ namespace eosio { namespace testing {
       push_transaction( trx );
    }
 
-   transaction_trace base_tester::push_transaction( packed_transaction& trx, uint32_t skip_flag ) {
+   transaction_trace base_tester::push_transaction( packed_transaction& trx, uint32_t skip_flag ) { try {
       return control->push_transaction( trx, skip_flag );
-   }
+   } FC_CAPTURE_AND_RETHROW( (transaction_header(trx.get_transaction())) ) }
 
-   transaction_trace base_tester::push_transaction( signed_transaction& trx, uint32_t skip_flag ) {
+   transaction_trace base_tester::push_transaction( signed_transaction& trx, uint32_t skip_flag ) { try {
       auto ptrx = packed_transaction(trx);
       return push_transaction( ptrx, skip_flag );
-   }
+   } FC_CAPTURE_AND_RETHROW( (transaction_header(trx)) ) }
 
    base_tester::action_result base_tester::push_action(action&& act, uint64_t authorizer) {
       signed_transaction trx;
@@ -236,6 +236,7 @@ namespace eosio { namespace testing {
       signed_transaction trx;
       contracts::abi_serializer::from_variant(pretty_trx, trx, get_resolver());
       set_transaction_headers(trx);
+      wdump((trx));
       for(auto iter = keys.begin(); iter != keys.end(); iter++)
          trx.sign( *iter, chain_id_type() );
       return push_transaction( trx );

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -177,9 +177,11 @@ void chain_plugin::plugin_initialize(const variables_map& options) {
 
 void chain_plugin::plugin_startup()
 { try {
-   FC_ASSERT( fc::exists( my->genesis_file ),
-              "unable to find genesis file '${f}', check --genesis-json argument",
-              ("f",my->genesis_file.generic_string()) );
+   if( !fc::exists( my->genesis_file ) ) {
+      wlog( "\n generating default genesis file ${f}", ("f", my->genesis_file.generic_string() ) );
+      contracts::genesis_state_type default_genesis;
+      fc::json::save_to_file( default_genesis, my->genesis_file, true );
+   }
    my->chain_config->block_log_dir = my->block_log_dir;
    my->chain_config->shared_memory_dir = app().data_dir() / default_shared_memory_dir;
    my->chain_config->read_only = my->readonly;
@@ -211,7 +213,7 @@ void chain_plugin::plugin_startup()
 
    my->chain_config.reset();
 
-   } FC_CAPTURE_AND_RETHROW( (my->genesis_file.generic_string()) ) }
+} FC_CAPTURE_LOG_AND_RETHROW( (my->genesis_file.generic_string()) ) }
 
 void chain_plugin::plugin_shutdown() {
    my->chain.reset();

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -263,7 +263,7 @@ fc::variant push_transaction( signed_transaction& trx, packed_transaction::compr
    auto required_keys = determine_required_keys(trx);
    size_t num_keys = required_keys.is_array() ? required_keys.get_array().size() : 1;
 
-   trx.context_free_kilo_cpu_usage = estimate_transaction_context_free_kilo_cpu_usage(trx);
+   trx.kcpu_usage = estimate_transaction_context_free_kilo_cpu_usage(trx);
    trx.net_usage_words = estimate_transaction_net_usage_words(trx, compression, num_keys);
 
    if (!tx_skip_sign) {

--- a/tests/api_tests/api_tests.cpp
+++ b/tests/api_tests/api_tests.cpp
@@ -651,13 +651,13 @@ BOOST_FIXTURE_TEST_CASE(transaction_tests, tester) { try {
    control->push_deferred_transactions( true );
 
    // test test_transaction_size
-   CALL_TEST_FUNCTION(*this, "test_transaction", "test_transaction_size", fc::raw::pack(54) );
+   CALL_TEST_FUNCTION(*this, "test_transaction", "test_transaction_size", fc::raw::pack(57) );
    control->push_deferred_transactions( true );
 
    // test test_read_transaction
    // this is a bit rough, but I couldn't figure out a better way to compare the hashes
    auto tx_trace = CALL_TEST_FUNCTION( *this, "test_transaction", "test_read_transaction", {} );
-   string sha_expect = "96f7634b737511212dedb9c3eb42672882b066c7af3601a4b50beda56deb977e";
+   string sha_expect = "274e873c8b2e4de20de06e53c99fe703b5099ce4faaf5d78195a4a2538caba15";
    BOOST_CHECK_EQUAL(tx_trace.action_traces.front().console == sha_expect, true);
    // test test_tapos_block_num
    CALL_TEST_FUNCTION(*this, "test_transaction", "test_tapos_block_num", fc::raw::pack(control->head_block_num()) );

--- a/tests/tests/abi_tests.cpp
+++ b/tests/tests/abi_tests.cpp
@@ -1696,7 +1696,8 @@ BOOST_AUTO_TEST_CASE(general)
         "context_free_actions":[{"account":"contextfree1", "name":"cfactionname1", "authorization":[{"actor":"cfacc1","permission":"cfpermname1"}], "data":"778899"}],
         "actions":[{"account":"accountname1", "name":"actionname1", "authorization":[{"actor":"acc1","permission":"permname1"}], "data":"445566"}],
         "net_usage_words":15,
-        "context_free_kilo_cpu_usage":43
+        "kcpu_usage":43,
+        "delay_sec":0
       },
       "transaction_arr": [{
         "ref_block_num":"1",
@@ -1706,7 +1707,8 @@ BOOST_AUTO_TEST_CASE(general)
         "context_free_actions":[{"account":"contextfree1", "name":"cfactionname1", "authorization":[{"actor":"cfacc1","permission":"cfpermname1"}], "data":"778899"}],
         "actions":[{"account":"acc1", "name":"actionname1", "authorization":[{"actor":"acc1","permission":"permname1"}], "data":"445566"}],
         "net_usage_words":15,
-        "context_free_kilo_cpu_usage":43
+        "kcpu_usage":43,
+        "delay_sec":0
       },{
         "ref_block_num":"2",
         "ref_block_prefix":"3",
@@ -1715,7 +1717,8 @@ BOOST_AUTO_TEST_CASE(general)
         "context_free_actions":[{"account":"contextfree1", "name":"cfactionname1", "authorization":[{"actor":"cfacc1","permission":"cfpermname1"}], "data":"778899"}],
         "actions":[{"account":"acc2", "name":"actionname2", "authorization":[{"actor":"acc2","permission":"permname2"}], "data":""}],
         "net_usage_words":21,
-        "context_free_kilo_cpu_usage":87
+        "kcpu_usage":87,
+        "delay_sec":0
       }],
       "strx": {
         "ref_block_num":"1",
@@ -1727,7 +1730,8 @@ BOOST_AUTO_TEST_CASE(general)
         "context_free_actions":[{"account":"contextfree1", "name":"cfactionname1", "authorization":[{"actor":"cfacc1","permission":"cfpermname1"}], "data":"778899"}],
         "actions":[{"account":"accountname1", "name":"actionname1", "authorization":[{"actor":"acc1","permission":"permname1"}], "data":"445566"}],
         "net_usage_words":15,
-        "context_free_kilo_cpu_usage":43
+        "kcpu_usage":43,
+        "delay_sec":0
       },
       "strx_arr": [{
         "ref_block_num":"1",
@@ -1739,7 +1743,8 @@ BOOST_AUTO_TEST_CASE(general)
         "context_free_actions":[{"account":"contextfree1", "name":"cfactionname1", "authorization":[{"actor":"cfacc1","permission":"cfpermname1"}], "data":"778899"}],
         "actions":[{"account":"acc1", "name":"actionname1", "authorization":[{"actor":"acc1","permission":"permname1"}], "data":"445566"}],
         "net_usage_words":15,
-        "context_free_kilo_cpu_usage":43
+        "kcpu_usage":43,
+        "delay_sec":0
       },{
         "ref_block_num":"2",
         "ref_block_prefix":"3",
@@ -1750,7 +1755,8 @@ BOOST_AUTO_TEST_CASE(general)
         "context_free_actions":[{"account":"contextfree2", "name":"cfactionname2", "authorization":[{"actor":"cfacc2","permission":"cfpermname2"}], "data":"667788"}],
         "actions":[{"account":"acc2", "name":"actionname2", "authorization":[{"actor":"acc2","permission":"permname2"}], "data":""}],
         "net_usage_words":15,
-        "context_free_kilo_cpu_usage":43
+        "kcpu_usage":43,
+        "delay_sec":0
       }],
       "keyweight": {"key":"EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV", "weight":"100"},
       "keyweight_arr": [{"key":"EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV", "weight":"100"},{"key":"EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV", "weight":"200"}],
@@ -2561,7 +2567,7 @@ BOOST_AUTO_TEST_CASE(packed_transaction)
          vector<permission_level>{{N(testapi4), config::active_name}},
          action2{ 61, 23, (uint8_t)2});
    txn.net_usage_words = 15;
-   txn.context_free_kilo_cpu_usage = 43;
+   txn.kcpu_usage = 43;
 
    // pack the transaction to verify that the var unpacking logic is correct
    auto packed_txn = chain::packed_transaction(txn);
@@ -2642,7 +2648,7 @@ BOOST_AUTO_TEST_CASE(packed_transaction)
    for (unsigned int i = 0; i < txn.actions.size(); ++i)
       verify_action_equal<action2>(txn.actions[i], txn2.actions[i]);
    BOOST_REQUIRE_EQUAL(txn.net_usage_words.value, txn2.net_usage_words.value);
-   BOOST_REQUIRE_EQUAL(txn.context_free_kilo_cpu_usage.value, txn2.context_free_kilo_cpu_usage.value);
+   BOOST_REQUIRE_EQUAL(txn.kcpu_usage.value, txn2.kcpu_usage.value);
 } FC_LOG_AND_RETHROW() }
 
 BOOST_AUTO_TEST_CASE(abi_type_repeat)


### PR DESCRIPTION
This request is the first part of a refactor designed to declare resource usage in headers so things can be pruned / skipped during replay.

It has a fallback option that allows you to set 0 declared usage in which case you should be billed actual usage. 