### PR TITLE
Update bios boot script

### DIFF
--- a/testnet.template
+++ b/testnet.template
@@ -65,14 +65,18 @@ ecmd get info
 
 wcmd create -n ignition
 # Manual deployers, add a line below this block that looks like:
-#    wcmd import -n ignition $BIOSKEY
+#    wcmd import -n ignition $PRODKEY[0]
+#    wcmd import -n ignition $PRODKEY[1]
+#    ...
+#    wcmd import -n ignition $PRODKEY[20]
+
 # where $BIOSKEY is replaced by the private key for the bios node
 # ------ DO NOT ALTER THE NEXT LINE -------
-###INSERT bioskey
+###INSERT prodkeys
 
 # Manual deployers, add a series of lines below this block that looks like:
-#    cacmd $PRODNAME[0] $DWNERKEY[0] $ACTIVEKEY[0]
-#    cacmd $PRODNAME[1] $OWNERKEY[1] $ACTOVEKEY[1]
+#    cacmd $PRODNAME[0] $OWNERKEY[0] $ACTIVEKEY[0]
+#    cacmd $PRODNAME[1] $OWNERKEY[1] $ACTiVEKEY[1]
 #    ...
 #    cacmd $PRODNAME[20] $OWNERKEY[20] $ACTIVEKEY[20]
 # where $PRODNAME is the producer account name and $OWNERKEY and $ACTIVEKEY are both the producer's
@@ -81,11 +85,11 @@ wcmd create -n ignition
 ###INSERT cacmd
 
 
-ecmd set contract eosio contracts/test.system/test.system.wast contracts/test.system/test.system.abi
+ecmd set contract eosio contracts/eosio.bios/eosio.bios.wast contracts/eosio.bios/eosio.bios.abi
 
 #the setprods.json argument cannot pass through the function call due to embedded quotes
 echo ===== Start: $step ============ >> $logfile
-echo executing: cleos --wallet-port $wdport -p $biosport -H $bioshost push action eosio setprods "$(cat setprods.json)" -p eosio@active | tee -a $logfile
+echo executing: cleos --wallet-port $wdport -p $biosport -H $bioshost push action eosio setprods \"$(cat setprods.json)\" -p eosio@active | tee -a $logfile
 echo ----------------------- >> $logfile
 programs/cleos/cleos --wallet-port $wdport --wallet-host $wdhost -p $biosport -H $bioshost push action eosio setprods "$(cat setprods.json)" -p eosio@active >> $logfile 2>&1
 echo ==== End: $step ============== >> $logfile


### PR DESCRIPTION
update the generated bios_boot.sh to conform to updated eosio.bios abi. The launcher now uses "block_signing_key" and also imports all producer keys into the local wallet. Codifies my field patch to the bios_boot template. Related to  issue #1768 