### PR TITLE
Canceling a delayed transaction with transaction id

### DIFF
--- a/contracts/eosio.system/native.hpp
+++ b/contracts/eosio.system/native.hpp
@@ -190,9 +190,9 @@ namespace eosiosystem {
          }
          
          ACTION( SystemAccount, canceldelay ) {
-            uint32_t   sender_id;
+            checksum256   trx_id;
             
-            EOSLIB_SERIALIZE( canceldelay, (sender_id) )
+            EOSLIB_SERIALIZE( canceldelay, (trx_id) )
          };
          
          static void on( const canceldelay& ) {

--- a/libraries/chain/contracts/chain_initializer.cpp
+++ b/libraries/chain/contracts/chain_initializer.cpp
@@ -163,7 +163,7 @@ abi_def chain_initializer::eos_contract_abi(const abi_def& eosio_system_abi)
 
    eos_abi.structs.emplace_back( struct_def {
       "canceldelay", "", {
-         {"sender_id", "uint32"},
+         {"trx_id", "checksum256"},
       }
    });
 

--- a/libraries/chain/contracts/eosio_contract.cpp
+++ b/libraries/chain/contracts/eosio_contract.cpp
@@ -554,6 +554,7 @@ void apply_eosio_canceldelay(apply_context& context) {
    auto cancel = context.act.data_as<canceldelay>();
    //const auto sender_id = cancel.sender_id.convert_to<uint32_t>();
    const auto& trx_id = cancel.trx_id;
+
    const auto& generated_transaction_idx = context.controller.get_database().get_index<generated_transaction_multi_index>();
    const auto& generated_index = generated_transaction_idx.indices().get<by_trx_id>();
    const auto& itr = generated_index.lower_bound(trx_id);
@@ -578,7 +579,8 @@ void apply_eosio_canceldelay(apply_context& context) {
 
    FC_ASSERT (found, "canceldelay action must be signed with the \"active\" permission for one of the actors"
                      " provided in the authorizations on the original transaction");
-   context.cancel_deferred(itr->sender_id);
+
+   context.cancel_deferred(trx_id);
 }
 
 void apply_eosio_mindelay(apply_context& context) {

--- a/libraries/chain/include/eosio/chain/apply_context.hpp
+++ b/libraries/chain/include/eosio/chain/apply_context.hpp
@@ -466,7 +466,8 @@ class apply_context {
       void execute_inline( action &&a );
       void execute_context_free_inline( action &&a );
       void execute_deferred( deferred_transaction &&trx );
-      void cancel_deferred( uint128_t sender_id );
+      void cancel_deferred( const uint128_t& sender_id );
+      void cancel_deferred( const transaction_id_type& trx_id );
 
       /**
        * @brief Require @ref account to have approved of this message

--- a/libraries/chain/include/eosio/chain/contracts/types.hpp
+++ b/libraries/chain/include/eosio/chain/contracts/types.hpp
@@ -270,7 +270,7 @@ struct vetorecovery {
 };
 
 struct canceldelay {
-   uint32   sender_id;
+   transaction_id_type   trx_id;
 
    static account_name get_account() {
       return config::system_account_name;
@@ -312,5 +312,5 @@ FC_REFLECT( eosio::chain::contracts::unlinkauth                       , (account
 FC_REFLECT( eosio::chain::contracts::postrecovery                     , (account)(data)(memo) )
 FC_REFLECT( eosio::chain::contracts::passrecovery                     , (account) )
 FC_REFLECT( eosio::chain::contracts::vetorecovery                     , (account) )
-FC_REFLECT( eosio::chain::contracts::canceldelay                      , (sender_id) )
+FC_REFLECT( eosio::chain::contracts::canceldelay                      , (trx_id) )
 FC_REFLECT( eosio::chain::contracts::mindelay                         , (delay) )

--- a/libraries/chain/include/eosio/chain/transaction.hpp
+++ b/libraries/chain/include/eosio/chain/transaction.hpp
@@ -4,7 +4,7 @@
  */
 #pragma once
 #include <eosio/chain/types.hpp>
-
+#include <eosio/chain/config.hpp>
 #include <numeric>
 
 namespace eosio { namespace chain {
@@ -233,11 +233,18 @@ namespace eosio { namespace chain {
 
    struct deferred_reference {
       deferred_reference(){}
-      deferred_reference( const account_name& sender, uint128_t sender_id)
+      deferred_reference( const account_name& sender, const uint128_t& sender_id)
       :sender(sender),sender_id(sender_id)
       {}
-      account_name  sender;
-      uint128_t     sender_id;
+      deferred_reference( const account_name& sender, const uint128_t& sender_id, const transaction_id_type& trx_id)
+      :sender(sender),sender_id(sender_id),trx_id(trx_id)
+      {
+         FC_ASSERT( sender == config::system_account_name, "deferred reference from transaction id can only come from system account" );
+      }
+
+      account_name                      sender;
+      uint128_t                         sender_id;
+      fc::optional<transaction_id_type> trx_id;
    };
 } } // eosio::chain
 
@@ -251,7 +258,7 @@ FC_REFLECT_DERIVED( eosio::chain::signed_transaction, (eosio::chain::transaction
 FC_REFLECT_ENUM( eosio::chain::packed_transaction::compression_type, (none)(zlib))
 FC_REFLECT( eosio::chain::packed_transaction, (signatures)(context_free_data)(compression)(data) )
 FC_REFLECT_DERIVED( eosio::chain::deferred_transaction, (eosio::chain::transaction), (sender_id)(sender)(payer)(execute_after) )
-FC_REFLECT( eosio::chain::deferred_reference, (sender_id)(sender) )
+FC_REFLECT( eosio::chain::deferred_reference, (sender)(sender_id)(trx_id) )
 
 
 

--- a/libraries/chain/include/eosio/chain/transaction.hpp
+++ b/libraries/chain/include/eosio/chain/transaction.hpp
@@ -218,7 +218,7 @@ namespace eosio { namespace chain {
       uint128_t      sender_id; /// ID assigned by sender of generated, accessible via WASM api when executing normal or error
       account_name   sender; /// receives error handler callback
       account_name   payer;
-      time_point_sec execute_after; /// delayed exeuction
+      time_point_sec execute_after; /// delayed execution
 
       deferred_transaction() = default;
 
@@ -236,9 +236,8 @@ namespace eosio { namespace chain {
       deferred_reference( const account_name& sender, uint128_t sender_id)
       :sender(sender),sender_id(sender_id)
       {}
-
-      account_name   sender;
-      uint128_t       sender_id;
+      account_name  sender;
+      uint128_t     sender_id;
    };
 } } // eosio::chain
 

--- a/tests/chain_tests/delay_tests.cpp
+++ b/tests/chain_tests/delay_tests.cpp
@@ -1425,7 +1425,7 @@ BOOST_AUTO_TEST_CASE( canceldelay_test ) { try {
    BOOST_REQUIRE_EQUAL(transaction_receipt::delayed, trace.status);
    BOOST_REQUIRE_EQUAL(1, trace.deferred_transaction_requests.size());
    BOOST_REQUIRE_EQUAL(0, trace.action_traces.size());
-   const auto sender_id_to_cancel = trace.deferred_transaction_requests[0].get<deferred_transaction>().sender_id;
+   const auto sender_id_to_cancel = trace.deferred_transaction_requests[0].get<deferred_transaction>().id();
 
    chain.produce_blocks();
 
@@ -1489,11 +1489,14 @@ BOOST_AUTO_TEST_CASE( canceldelay_test ) { try {
    chain.set_transaction_headers(trx);
    trx.sign(chain.get_private_key(N(tester), "active"), chain_id_type());
    trace = chain.push_transaction(trx);
+   //const auto sender_id_canceled = trace.deferred_transaction_requests[0].get<deferred_reference>().trx_id;
+   const auto sender_id_canceled = trace.deferred_transaction_requests[0].get<deferred_transaction>().id();
+   BOOST_TEST_MESSAGE( "SENDER "+std::string(uint128(sender_id_canceled)));
    BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace.status);
    BOOST_REQUIRE_EQUAL(1, trace.deferred_transaction_requests.size());
-   const auto sender_id_canceled = trace.deferred_transaction_requests[0].get<deferred_reference>().sender_id;
-   BOOST_REQUIRE_EQUAL(std::string(uint128(sender_id_to_cancel)), std::string(uint128(sender_id_canceled)));
+   //BOOST_REQUIRE_EQUAL(std::string(uint128(sender_id_to_cancel)), std::string(uint128(sender_id_canceled)));
 
+#if 0
    chain.produce_blocks();
 
    liquid_balance = get_currency_balance(chain, N(tester));
@@ -1547,7 +1550,7 @@ BOOST_AUTO_TEST_CASE( canceldelay_test ) { try {
    BOOST_REQUIRE_EQUAL(asset::from_string("85.0000 CUR"), liquid_balance);
    liquid_balance = get_currency_balance(chain, N(tester2));
    BOOST_REQUIRE_EQUAL(asset::from_string("15.0000 CUR"), liquid_balance);
-
+#endif
 } FC_LOG_AND_RETHROW() }/// schedule_test
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/chain_tests/delay_tests.cpp
+++ b/tests/chain_tests/delay_tests.cpp
@@ -1355,7 +1355,7 @@ BOOST_AUTO_TEST_CASE( canceldelay_test ) { try {
    tester chain;
 
    const auto& tester_account = N(tester);
-
+   std::vector<transaction_id_type> ids;
    chain.set_code(config::system_account_name, eosio_system_wast);
    chain.set_abi(config::system_account_name, eosio_system_abi);
 
@@ -1422,10 +1422,11 @@ BOOST_AUTO_TEST_CASE( canceldelay_test ) { try {
        ("memo", "hi" ),
        30
    );
+   ids.push_back(trace.id);
    BOOST_REQUIRE_EQUAL(transaction_receipt::delayed, trace.status);
    BOOST_REQUIRE_EQUAL(1, trace.deferred_transaction_requests.size());
    BOOST_REQUIRE_EQUAL(0, trace.action_traces.size());
-   const auto sender_id_to_cancel = trace.deferred_transaction_requests[0].get<deferred_transaction>().id();
+   const auto sender_id_to_cancel = trace.deferred_transaction_requests[0].get<deferred_transaction>().sender_id;
 
    chain.produce_blocks();
 
@@ -1444,6 +1445,7 @@ BOOST_AUTO_TEST_CASE( canceldelay_test ) { try {
            ("data",  authority(chain.get_public_key(tester_account, "first")))
            ("delay", 0),
            30);
+   ids.push_back(trace.id);
    BOOST_REQUIRE_EQUAL(transaction_receipt::delayed, trace.status);
    BOOST_REQUIRE_EQUAL(1, trace.deferred_transaction_requests.size());
    BOOST_REQUIRE_EQUAL(0, trace.action_traces.size());
@@ -1470,6 +1472,7 @@ BOOST_AUTO_TEST_CASE( canceldelay_test ) { try {
        ("memo", "hi" ),
        30
    );
+   ids.push_back(trace.id);
    BOOST_REQUIRE_EQUAL(transaction_receipt::delayed, trace.status);
    BOOST_REQUIRE_EQUAL(1, trace.deferred_transaction_requests.size());
    BOOST_REQUIRE_EQUAL(0, trace.action_traces.size());
@@ -1484,19 +1487,17 @@ BOOST_AUTO_TEST_CASE( canceldelay_test ) { try {
    // send canceldelay for first delayed transaction
    signed_transaction trx;
    trx.actions.emplace_back(vector<permission_level>{{N(tester), config::active_name}},
-                            chain::contracts::canceldelay{sender_id_to_cancel});
+                            chain::contracts::canceldelay{ids[0]});
 
    chain.set_transaction_headers(trx);
    trx.sign(chain.get_private_key(N(tester), "active"), chain_id_type());
    trace = chain.push_transaction(trx);
-   //const auto sender_id_canceled = trace.deferred_transaction_requests[0].get<deferred_reference>().trx_id;
-   const auto sender_id_canceled = trace.deferred_transaction_requests[0].get<deferred_transaction>().id();
-   BOOST_TEST_MESSAGE( "SENDER "+std::string(uint128(sender_id_canceled)));
+
+   const auto sender_id_canceled = trace.deferred_transaction_requests[0].get<deferred_reference>().sender_id;
    BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace.status);
    BOOST_REQUIRE_EQUAL(1, trace.deferred_transaction_requests.size());
-   //BOOST_REQUIRE_EQUAL(std::string(uint128(sender_id_to_cancel)), std::string(uint128(sender_id_canceled)));
+   BOOST_REQUIRE_EQUAL(std::string(uint128(sender_id_to_cancel)), std::string(uint128(sender_id_canceled)));
 
-#if 0
    chain.produce_blocks();
 
    liquid_balance = get_currency_balance(chain, N(tester));
@@ -1550,7 +1551,6 @@ BOOST_AUTO_TEST_CASE( canceldelay_test ) { try {
    BOOST_REQUIRE_EQUAL(asset::from_string("85.0000 CUR"), liquid_balance);
    liquid_balance = get_currency_balance(chain, N(tester2));
    BOOST_REQUIRE_EQUAL(asset::from_string("15.0000 CUR"), liquid_balance);
-#endif
 } FC_LOG_AND_RETHROW() }/// schedule_test
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Modified canceldelay to now take a transaction id instead of a sender id.  This allows the user to cancel a delayed transaction with the transaction id from the transaction they pushed and not the auto generated sender id. 