### PR TITLE
Made corrections for the new data and config folders.

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ You can read more on eosio-launcher and its settings [here](https://github.com/E
 <a name="publictestnet"></a>
 ### Running a local node connected to the public testnet
 
-The `master` branch is no longer compatible with the `dawn-2.x` public testnet.  To run on the public testnet, please see [DAWN-2018-02-14/eos/README.md](https://github.com/EOSIO/eos/blob/dawn-2.x/README.md)
+The `master` branch is no longer compatible with the `dawn-2.x` public testnet.  To run on the public testnet, please see [dawn-2.x/eos/README.md](https://github.com/EOSIO/eos/blob/dawn-2.x/README.md)
 
 ## Next Steps
 <a name="nextsteps"></a>

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ EOS.IO currently supports the following operating systems:
    4. [Install the executables](#installexecutables)
 3. [Running a node](#runanode)
    1. [Creating and launching a single-node testnet](#singlenode)
-   2. [Running local testnet](#localtestnet)
+   2. [Running a multi-node local testnet](#localtestnet)
    3. [Running on the public testnet](#publictestnet)
    4. [Next steps](#nextsteps)
 4. [Example Currency Contract Walkthrough](#smartcontracts)
@@ -49,9 +49,9 @@ EOS.IO currently supports the following operating systems:
    4. [Upload sample contract to blockchain](#uploadsmartcontract)
    5. [Pushing a message to a sample contract](#pushamessage)
    6. [Reading Currency Contract Balance](#readingcontract)
-7. [Doxygen documentation](#doxygen)
-8. [Running EOS in Docker](#docker)
-9. [Manual installation of the dependencies](#manualdep)
+5. [Doxygen documentation](#doxygen)
+6. [Running EOS in Docker](#docker)
+7. [Manual installation of the dependencies](#manualdep)
    1. [Clean install Amazon 2017.09 and higher](#manualdepamazon)
    2. [Clean install Centos 7 and higher](#manualdepcentos)
    3. [Clean install Fedora 25 and higher](#manualdepfedora)
@@ -91,7 +91,7 @@ EOS comes with a number of programs:
 * keosd - EOS wallet
 * eosio-launcher - application for nodes network composing and deployment; [more on eosio-launcher](https://github.com/EOSIO/eos/blob/master/testnet.md)
 
-The build places content in the `eos/build` folder.  The executables can be found in the `eos/build/programs` folder.
+The build places content in the `eos/build` folder.  The executables can be found in subfolders within the `eos/build/programs` folder.
 
 <a name="autobuild"></a>
 #### Automated build script
@@ -141,6 +141,7 @@ make test
 For ease of contract development, content can be installed in the `/usr/local` folder using the `make install` target.  This step is run from the `build` folder.  Adequate permission is required to install.
 
 ```bash
+cd build
 sudo make install
 ```
 
@@ -152,10 +153,10 @@ sudo make install
 
 After successfully building the project, the `nodeos` binary should be present in the `build/programs/nodeos` folder.  `nodeos` can be run directly from the `build` folder using `programs/nodeos/nodeos`.
 
-`nodeos` uses a custom configuration folder, the location of this folder is determined by your system.
+`nodeos` uses a custom configuration folder.  The location of this folder is determined by your system.
 
-- Mac OS: `~/Library/Application Support/eosio`
-- Linux: `~/.local/share/eosio`
+- Mac OS: `~/Library/Application Support/eosio/nodeos/config`
+- Linux: `~/.local/share/eosio/nodeos/config`
 
 The build seeds this folder with a default `genesis.json` file.  Alternatively, a configuration folder can be specified using the `--config-dir` command line argument to `nodeos`.  If you use this option, you will need to manually copy a genesis.json file to your config folder.
 
@@ -190,10 +191,15 @@ When running `nodeos` you should get log messages similar to below. It means the
 ...
 ```
 
-By default, `nodeos` uses `var/lib/eosio/node_00` as its data folder (where shared memory and log content are stored).  Alternatively, a data folder can be specified using the `--data-dir` command line argument to `nodeos`.
+`nodeos` stores runtime data (e.g., shared memory and log content) in a custom data folder.  The location of this folder is determined by your system.
+
+- Mac OS: `~/Library/Application Support/eosio/nodeos/data`
+- Linux: `~/.local/share/eosio/nodeos/data`
+
+A data folder can be specified using the `--data-dir` command line argument to `nodeos`.
 
 <a name="localtestnet"></a>
-### Running multi-node local testnet
+### Running a multi-node local testnet
 
 To run a local testnet you can use the `eosio-launcher` application provided in the `~/eos/build/programs/eosio-launcher` folder.
 
@@ -230,7 +236,7 @@ You can read more on eosio-launcher and its settings [here](https://github.com/E
 
 The `master` branch is no longer compatible with the `dawn-2.x` public testnet.  To run on the public testnet, please see [DAWN-2018-02-14/eos/README.md](https://github.com/EOSIO/eos/blob/dawn-2.x/README.md)
 
-### Next Steps
+## Next Steps
 <a name="nextsteps"></a>
 
 Further documentation is available in the [wiki](https://github.com/EOSIO/eos/wiki). Wiki pages include detailed reference documentation for all programs and tools and the database schema and API. The wiki also includes a section describing smart contract development. A simple walkthrough of the "currency" contract follows.

--- a/README.md
+++ b/README.md
@@ -31,15 +31,16 @@ EOS.IO currently supports the following operating systems:
 
 1. [Getting Started](#gettingstarted)
 2. [Setting up a build/development environment](#setup)
-   1. [Automated build script](#autobuild)
-      1. [Clean install Linux (Amazon, Centos, Fedora, Mint, & Ubuntu) for a local testnet](#autoubuntulocal)
-      2. [Clean install Linux (Amazon, Centos, Fedora, Mint, & Ubuntu) for the public testnet](#autoubuntupublic)
-      3. [MacOS for a local testnet](#automaclocal)
-      4. [MacOS for the public testnet](#automacpublic)
-3. [Building EOS and running a node](#runanode)
    1. [Getting the code](#getcode)
-   2. [Building from source code](#build)
-   3. [Creating and launching a single-node testnet](#singlenode)
+   2. [Building the executables](#build)
+      1. [Automated build script](#autobuild)
+      2. [Manual build](#manualbuild)
+   3. [Build validation](#basicvalidation)
+   4. [Install the executables](#installexecutables)
+3. [Running a node](#runanode)
+   1. [Creating and launching a single-node testnet](#singlenode)
+   2. [Running local testnet](#localtestnet)
+   3. [Running on the public testnet](#publictestnet)
    4. [Next steps](#nextsteps)
 4. [Example Currency Contract Walkthrough](#smartcontracts)
    1. [Example Contracts](#smartcontractexample)
@@ -48,8 +49,6 @@ EOS.IO currently supports the following operating systems:
    4. [Upload sample contract to blockchain](#uploadsmartcontract)
    5. [Pushing a message to a sample contract](#pushamessage)
    6. [Reading Currency Contract Balance](#readingcontract)
-5. [Running local testnet](#localtestnet)
-6. [Running a node on the public testnet](#publictestnet)
 7. [Doxygen documentation](#doxygen)
 8. [Running EOS in Docker](#docker)
 9. [Manual installation of the dependencies](#manualdep)
@@ -67,116 +66,10 @@ The following instructions detail the process of getting the software, building 
 <a name="setup"></a>
 ## Setting up a build/development environment
 
-<a name="autobuild"></a>
-### Automated build script
-
-Supported Operating Systems:  
-1. Amazon 2017.09 and higher.  
-2. Centos 7.  
-3. Fedora 25 and higher (Fedora 27 recommended).  
-4. Mint 18.  
-5. Ubuntu 16.04 (Ubuntu 16.10 recommended).  
-6. MacOS Darwin 10.12 and higher (MacOS 10.13.x recommended).  
-
-For Amazon, Centos, Fedora, Mint, Ubuntu, & MacOS there is an automated build script that can install all dependencies and builds EOS.  We are working on supporting other Linux/Unix distributions in future releases.
-
-Choose whether you will be building for a local testnet or for the public testnet and jump to the appropriate section below.  Clone the EOS repository recursively as described and run eosio_build.sh located in the root `eos` folder.
-
-:warning: **As of February 2018, `master` is under heavy development and is not suitable for experimentation.** :warning:
-
-We strongly recommend following the instructions for building the public testnet version for [Linux](#autoubuntupublic) or [Mac OS X](#automacpublic). `master` is in pieces on the garage floor while we rebuild this hotrod. This notice will be removed when `master` is usable again. Your patience is appreciated.
-
-<a name="autoubuntulocal"></a>
-#### Clean install Linux (Amazon, Centos, Fedora, Mint, & Ubuntu) for a local testnet
-
-Clone the `eos` repository and run the build script.
-
-```bash
-git clone https://github.com/eosio/eos --recursive
-cd eos
-./eosio_build.sh
-```
-
-The eosio_build.sh script puts content in the `build` folder.  Key executables (nodeos, cleos, etc.) can be found in the `build/programs` folder.
-
-Optionally, a set of tests can be run against your build to perform some basic validation.
-
-```bash
-cd build
-make test
-```
- 
-For ease of contract development, content can be installed in the `/usr/local` folder using the `make install` target.  This step is run from the `build` folder.
-
-If not already in the `build` folder:
-
-```bash
-cd build
-```
-
-Run `make install`.
-
-```bash
-sudo make install
-```
-
-Now you can proceed to the next step - [Creating and launching a single-node testnet](#singlenode)
-
-<a name="autoubuntupublic"></a>
-#### Clean install Linux (Amazon, Centos, Fedora, Mint, & Ubuntu) for the public testnet
-
-The `master` branch is no longer compatible with the `dawn-2.x` public testnet.  To run on the public testnet, please see [DAWN-2018-02-14/eos/README.md](https://github.com/EOSIO/eos/blob/DAWN-2018-02-14/README.md)
-
-<a name="automaclocal"></a>
-#### MacOS for a local testnet
-
-Before running the script make sure you have installed/updated XCode. Note: The build script will install homebrew if it is not already installed on you system. [Homebrew Website](https://brew.sh)
-
-Clone the `eos` repository and run the build script.
-
-```bash
-git clone https://github.com/eosio/eos --recursive
-cd eos
-./eosio_build.sh
-```
-
-The eosio_build.sh script puts content in the `build` folder.  Key executables (nodeos, cleos, etc.) can be found in the `build/programs` folder.
-
-Optionally, a set of tests can be run against your build to perform some basic validation.
-
-```bash
-cd build
-make test
-```
- 
-For ease of contract development, content can be installed in the `/usr/local` folder using the `make install` target.  This step is run from the `build` folder.
-
-If not already in the `build` folder:
-
-```bash
-cd build
-```
-
-Run `make install`.
-
-```bash
-sudo make install
-```
-
-Now you can proceed to the next step - [Creating and launching a single-node testnet](#singlenode)
-
-<a name="automacpublic"></a>
-#### MacOS for the public testnet
-
-The `master` branch is no longer compatible with the `dawn-2.x` public testnet.  To run on the public testnet, please see [DAWN-2018-02-14/eos/README.md](https://github.com/EOSIO/eos/blob/DAWN-2018-02-14/README.md)
-
-<a name="runanode"></a>
-## Building EOS and running a node
-
 <a name="getcode"></a>
 ### Getting the code
 
-To download all of the code, download EOS source code and a recursion or two of submodules. The easiest way to get all of this is to do a recursive clone:
+To download all of the code, clone the eos repository and its submodules.
 
 ```bash
 git clone https://github.com/eosio/eos --recursive
@@ -189,11 +82,36 @@ git submodule update --init --recursive
 ```
 
 <a name="build"></a>
-### Building from source code
+### Building the executables
+
+EOS comes with a number of programs:
+
+* nodeos - server-side blockchain node component
+* cleos - command line interface to interact with the blockchain
+* keosd - EOS wallet
+* eosio-launcher - application for nodes network composing and deployment; [more on eosio-launcher](https://github.com/EOSIO/eos/blob/master/testnet.md)
+
+The build places content in the `eos/build` folder.  The executables can be found in the `eos/build/programs` folder.
+
+<a name="autobuild"></a>
+#### Automated build script
+
+There is an automated build script that can install all dependencies and build EOS.  We are working on supporting other Linux/Unix distributions in future releases.
+
+Run the build script.
+
+```bash
+cd eos
+./eosio_build.sh
+```
+
+<a name="manualbuild"></a>
+#### Manual build
+
+To manually build, use the following steps to create a `build` folder within your `eos` folder and then perform the build.  The steps below assume the `eos` repository was cloned into your home (i.e., `~`) folder.
 
 ```bash
 cd ~
-git clone https://github.com/eosio/eos --recursive
 mkdir -p ~/eos/build && cd ~/eos/build
 cmake -DBINARYEN_BIN=~/binaryen/bin -DWASM_ROOT=~/wasm-compiler/llvm -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl -DOPENSSL_LIBRARIES=/usr/local/opt/openssl/lib ..
 make -j$( nproc )
@@ -207,18 +125,32 @@ For a debug build, add `-DCMAKE_BUILD_TYPE=Debug`. Other common build types incl
 
 To run the test suite after building, run the `chain_test` executable in the `tests` folder.
 
-EOS comes with a number of programs you can find in `~/eos/build/programs`. They are listed below:
+<a name="basicvalidation"></a>
+### Build validation 
 
-* nodeos - server-side blockchain node component
-* cleos - command line interface to interact with the blockchain
-* keosd - EOS wallet
-* eosio-launcher - application for nodes network composing and deployment; [more on eosio-launcher](https://github.com/EOSIO/eos/blob/master/testnet.md)
+Optionally, a set of tests can be run against your build to perform some basic validation.
+
+```bash
+cd build
+make test
+```
+
+<a name="installexecutables"></a>
+### Install the executables 
+ 
+For ease of contract development, content can be installed in the `/usr/local` folder using the `make install` target.  This step is run from the `build` folder.  Adequate permission is required to install.
+
+```bash
+sudo make install
+```
+
+<a name="runanode"></a>
+## Running a node
 
 <a name="singlenode"></a>
-### Creating and launching a single-node testnet
+### Running a single-node testnet
 
-After successfully building the project, the `nodeos` binary should be present in the `build/programs/nodeos` folder.  `nodeos` can be run directly from the `build` folder using `programs/nodeos/nodeos`. The instructions here assume 
-running from the `build` folder.
+After successfully building the project, the `nodeos` binary should be present in the `build/programs/nodeos` folder.  `nodeos` can be run directly from the `build` folder using `programs/nodeos/nodeos`.
 
 `nodeos` uses a custom configuration folder, the location of this folder is determined by your system.
 
@@ -260,8 +192,46 @@ When running `nodeos` you should get log messages similar to below. It means the
 
 By default, `nodeos` uses `var/lib/eosio/node_00` as its data folder (where shared memory and log content are stored).  Alternatively, a data folder can be specified using the `--data-dir` command line argument to `nodeos`.
 
-<a name="nextsteps"></a>
+<a name="localtestnet"></a>
+### Running multi-node local testnet
+
+To run a local testnet you can use the `eosio-launcher` application provided in the `~/eos/build/programs/eosio-launcher` folder.
+
+For testing purposes you will run two local production nodes talking to each other.
+
+```bash
+cd ~/eos/build
+cp ../genesis.json ./
+./programs/eosio-launcher/eosio-launcher -p2 --skip-signature
+```
+
+This command will generate two data folders for each instance of the node: `tn_data_00` and `tn_data_01`.
+
+You should see the following response:
+
+```bash
+spawning child, programs/nodeos/nodeos --skip-transaction-signatures --data-dir tn_data_0
+spawning child, programs/nodeos/nodeos --skip-transaction-signatures --data-dir tn_data_1
+```
+
+To confirm the nodes are running, run the following `cleos` commands:
+```bash
+~/eos/build/programs/cleos
+./cleos -p 8888 get info
+./cleos -p 8889 get info
+```
+
+For each command, you should get a JSON response with blockchain information.
+
+You can read more on eosio-launcher and its settings [here](https://github.com/EOSIO/eos/blob/master/testnet.md)
+
+<a name="publictestnet"></a>
+### Running a local node connected to the public testnet
+
+The `master` branch is no longer compatible with the `dawn-2.x` public testnet.  To run on the public testnet, please see [DAWN-2018-02-14/eos/README.md](https://github.com/EOSIO/eos/blob/dawn-2.x/README.md)
+
 ### Next Steps
+<a name="nextsteps"></a>
 
 Further documentation is available in the [wiki](https://github.com/EOSIO/eos/wiki). Wiki pages include detailed reference documentation for all programs and tools and the database schema and API. The wiki also includes a section describing smart contract development. A simple walkthrough of the "currency" contract follows.
 
@@ -340,7 +310,8 @@ If all went well, you will receive output similar to the following:
   "staked_balance": "0.0001 EOS",
   "unstaking_balance": "0.0000 EOS",
   "last_unstaking_time": "2035-10-29T06:32:22",
-...
+   ...
+}
 ```
 
 Now import the active private key generated previously in the wallet:
@@ -444,84 +415,6 @@ So now check the state of both of the accounts involved in the previous transact
 ```
 
 As expected, the receiving account **eosio** now has a balance of **20** tokens, and the sending account now has **20** less tokens than its initial supply.
-
-<a name="localtestnet"></a>
-## Running multi-node local testnet
-
-To run a local testnet you can use the `eosio-launcher` application provided in the `~/eos/build/programs/eosio-launcher` folder.
-
-For testing purposes you will run two local production nodes talking to each other.
-
-```bash
-cd ~/eos/build
-cp ../genesis.json ./
-./programs/eosio-launcher/eosio-launcher -p2 --skip-signature
-```
-
-This command will generate two data folders for each instance of the node: `tn_data_00` and `tn_data_01`.
-
-You should see the following response:
-
-```bash
-spawning child, programs/nodeos/nodeos --skip-transaction-signatures --data-dir tn_data_0
-spawning child, programs/nodeos/nodeos --skip-transaction-signatures --data-dir tn_data_1
-```
-
-To confirm the nodes are running, run the following `cleos` commands:
-```bash
-~/eos/build/programs/cleos
-./cleos -p 8888 get info
-./cleos -p 8889 get info
-```
-
-For each command, you should get a JSON response with blockchain information.
-
-You can read more on eosio-launcher and its settings [here](https://github.com/EOSIO/eos/blob/master/testnet.md)
-
-<a name="publictestnet"></a>
-## Running a local node connected to the public testnet
-
-To run a local node connected to the public testnet operated by block.one, a script is provided.
-
-```bash
-cd ~/eos/build/scripts
-./start_npnode.sh
-```
-
-This command will use the data folder provided for the instance called `testnet_np`.
-
-You should see the following response:
-
-```bash
-Launched eosd.
-See testnet_np/stderr.txt for eosd output.
-Synching requires at least 8 minutes, depending on network conditions.
-```
-
-To confirm eosd operation and synchronization:
-
-```bash
-tail -F testnet_np/stderr.txt
-```
-
-To exit tail, use Ctrl-C.  During synchronization, you will see log messages similar to:
-
-```bash
-3439731ms            chain_plugin.cpp:272          accept_block         ] Syncing Blockchain --- Got block: #200000 time: 2017-12-09T07:56:32 producer: initu
-3454532ms            chain_plugin.cpp:272          accept_block         ] Syncing Blockchain --- Got block: #210000 time: 2017-12-09T13:29:52 producer: initc
-```
-
-Synchronization is complete when you see log messages similar to:
-
-```bash
-42467ms            net_plugin.cpp:1245           start_sync           ] Catching up with chain, our last req is 351734, theirs is 351962 peer ip-10-160-11-116:9876
-42792ms            chain_controller.cpp:208      _push_block          ] initt #351947 @2017-12-12T22:59:44  | 0 trx, 0 pending, exectime_ms=0
-42793ms            chain_controller.cpp:208      _push_block          ] inito #351948 @2017-12-12T22:59:46  | 0 trx, 0 pending, exectime_ms=0
-42793ms            chain_controller.cpp:208      _push_block          ] initd #351949 @2017-12-12T22:59:48  | 0 trx, 0 pending, exectime_ms=0
-```
-
-This eosd instance listens on 127.0.0.1:8888 for http requests, on all interfaces at port 9877
-for p2p requests, and includes the wallet plugins.
 
 <a name="doxygen"></a>
 ## Doxygen documentation


### PR DESCRIPTION
Also removed a lot of redundant text.  There were separate sections saying basically the same thing, that are no longer needed because the automated build script handles the differences within it.  There were still some old references to the public testnet that have been pulled out for now with reference to the dawn-2.x readme.  When the new details are ready, that section can be recreated.