### PR TITLE
Construct an endpoint with a non-zero backlog length for listen(). GH #2016

### DIFF
--- a/libraries/fc/vendor/websocketpp/websocketpp/transport/asio/endpoint.hpp
+++ b/libraries/fc/vendor/websocketpp/websocketpp/transport/asio/endpoint.hpp
@@ -91,7 +91,7 @@ public:
     explicit endpoint()
       : m_io_service(NULL)
       , m_external_io_service(false)
-      , m_listen_backlog(0)
+      , m_listen_backlog(lib::asio::socket_base::max_connections)
       , m_reuse_addr(false)
       , m_state(UNINITIALIZED)
     {


### PR DESCRIPTION
Matches a change in the dev branch of websocketpp.