### PR TITLE
fix 2020(softfloat truncation overflow) and adding related unittest c…

### DIFF
--- a/libraries/chain/wasm_interface.cpp
+++ b/libraries/chain/wasm_interface.cpp
@@ -545,7 +545,7 @@ class softfloat_api : public context_aware_api {
       }
       int32_t _eosio_f32_trunc_i32s( float af ) {
          float32_t a = to_softfloat32(af);
-         if (_eosio_f32_ge(af, 2147483648.0f) || _eosio_f32_le(af, -2147483649.0f))
+         if (_eosio_f32_ge(af, 2147483648.0f) || _eosio_f32_lt(af, -2147483648.0f))
             FC_THROW_EXCEPTION( eosio::chain::wasm_execution_error, "Error, f32.convert_s/i32 overflow" );
 
          if (is_nan(a))
@@ -554,7 +554,7 @@ class softfloat_api : public context_aware_api {
       }
       int32_t _eosio_f64_trunc_i32s( double af ) {
          float64_t a = to_softfloat64(af);
-         if (_eosio_f64_ge(af, 2147483648.0) || _eosio_f64_le(af, -2147483649.0))
+         if (_eosio_f64_ge(af, 2147483648.0) || _eosio_f64_lt(af, -2147483648.0))
             FC_THROW_EXCEPTION( eosio::chain::wasm_execution_error, "Error, f64.convert_s/i32 overflow");
          if (is_nan(a))
             FC_THROW_EXCEPTION( eosio::chain::wasm_execution_error, "Error, f64.convert_s/i32 unrepresentable");
@@ -578,7 +578,7 @@ class softfloat_api : public context_aware_api {
       }
       int64_t _eosio_f32_trunc_i64s( float af ) {
          float32_t a = to_softfloat32(af);
-         if (_eosio_f32_ge(af, 9223372036854775808.0f) || _eosio_f32_le(af, -9223372036854775809.0f))
+         if (_eosio_f32_ge(af, 9223372036854775808.0f) || _eosio_f32_lt(af, -9223372036854775808.0f))
             FC_THROW_EXCEPTION( eosio::chain::wasm_execution_error, "Error, f32.convert_s/i64 overflow");
          if (is_nan(a))
             FC_THROW_EXCEPTION( eosio::chain::wasm_execution_error, "Error, f32.convert_s/i64 unrepresentable");
@@ -586,7 +586,7 @@ class softfloat_api : public context_aware_api {
       }
       int64_t _eosio_f64_trunc_i64s( double af ) {
          float64_t a = to_softfloat64(af);
-         if (_eosio_f64_ge(af, 9223372036854775808.0) || _eosio_f64_le(af, -9223372036854775809.0))
+         if (_eosio_f64_ge(af, 9223372036854775808.0) || _eosio_f64_lt(af, -9223372036854775808.0))
             FC_THROW_EXCEPTION( eosio::chain::wasm_execution_error, "Error, f64.convert_s/i64 overflow");
          if (is_nan(a))
             FC_THROW_EXCEPTION( eosio::chain::wasm_execution_error, "Error, f64.convert_s/i64 unrepresentable");

--- a/tests/wasm_tests/test_softfloat_wasts.hpp
+++ b/tests/wasm_tests/test_softfloat_wasts.hpp
@@ -21647,3 +21647,38 @@ static const char f32_f64_conv_wast[] = R"=====(
     (call $assert_returnf64 (call $f64_convert_u_i64 (i64.const 9007199254740995)) (f64.const 9007199254740996) (i32.const 1040))
 ))
 )=====";
+
+
+static const char i32_overflow_wast[] = R"=====(
+(module
+  (import "env" "require_auth" (func $require_auth (param i64)))
+  (import "env" "eosio_assert" (func $eosio_assert (param i32 i32)))
+   (table 0 anyfunc)
+   (memory $0 1)
+   (export "apply" (func $apply))
+   (func $i32_trunc_s_f32 (param $0 f32) (result i32) (i32.trunc_s/f32 (get_local $0)))
+   (func $i32_trunc_u_f32 (param $0 f32) (result i32) (i32.trunc_u/f32 (get_local $0)))
+   (func $i32_trunc_s_f64 (param $0 f64) (result i32) (i32.trunc_s/f64 (get_local $0)))
+   (func $i32_trunc_u_f64 (param $0 f64) (result i32) (i32.trunc_u/f64 (get_local $0)))
+   (func $test (param $0 i32))
+   (func $apply (param $0 i64)(param $1 i64)(param $2 i64)
+    (call $test (call $%s (%s)))
+))
+)=====";
+
+static const char i64_overflow_wast[] = R"=====(
+(module
+  (import "env" "require_auth" (func $require_auth (param i64)))
+  (import "env" "eosio_assert" (func $eosio_assert (param i32 i32)))
+   (table 0 anyfunc)
+   (memory $0 1)
+   (export "apply" (func $apply))
+   (func $i64_trunc_s_f32 (param $0 f32) (result i64) (i64.trunc_s/f32 (get_local $0)))
+   (func $i64_trunc_u_f32 (param $0 f32) (result i64) (i64.trunc_u/f32 (get_local $0)))
+   (func $i64_trunc_s_f64 (param $0 f64) (result i64) (i64.trunc_s/f64 (get_local $0)))
+   (func $i64_trunc_u_f64 (param $0 f64) (result i64) (i64.trunc_u/f64 (get_local $0)))
+   (func $test (param $0 i64))
+   (func $apply (param $0 i64)(param $1 i64)(param $2 i64)
+    (call $test (call $%s (%s)))
+))
+)=====";


### PR DESCRIPTION
fix #2020 truncation overflow checks with the following reason:

-2147483649.0f is not representable in IEEE float32 format(only 24 bit precision in mantissa, see https://en.wikipedia.org/wiki/Single-precision_floating-point_format). Instead, it will be truncated into -2147483648.0f at compile time. Therefore, 

_eosio_f32_le(af, -2147483649.0f)) 

should be changed into 

_eosio_f32_lt(af, -2147483648.0f))

Add unitest cases for softfloat truncation overflow tests.

