### PR TITLE
Issue 2096 - Removed directives from CMakeLists.txt that install bad files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,10 +193,7 @@ add_subdirectory( debian )
 install(FILES genesis.json DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/genesis.json ${CMAKE_CURRENT_BINARY_DIR}/genesis.json COPYONLY)
 
-install(FILES genesis.json DESTINATION ${CMAKE_INSTALL_FULL_SYSCONFDIR}/eosio/node_00)
 install_directory_permissions(DIRECTORY ${CMAKE_INSTALL_FULL_SYSCONFDIR}/eosio)
-install_directory_permissions(DIRECTORY ${CMAKE_INSTALL_FULL_SYSCONFDIR}/eosio/node_00)
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/genesis.json ${CMAKE_CURRENT_BINARY_DIR}/etc/eosio/node_00/genesis.json COPYONLY)
 
 install(FILES testnet.template DESTINATION ${CMAKE_INSTALL_FULL_SYSCONFDIR}/eosio/launcher)
 install_directory_permissions(DIRECTORY ${CMAKE_INSTALL_FULL_SYSCONFDIR}/eosio)


### PR DESCRIPTION
The make install target was installing unnecessary files in the build/etc/eosio/node_00 folder.  Because the install must be done using sudo, the permissions on the files were being set to root.  The make test target had some tests that tried to cleanup that folder and failed because the files couldn't be removed.  This change removes the unneeded install directives from CMakeLists so that the files are not even installed.   Issue 1886 has addressed the tests unnecessarily cleaning up the node_00 folder.