### PR TITLE
Fix for #2105

### DIFF
--- a/libraries/chain/chain_controller.cpp
+++ b/libraries/chain/chain_controller.cpp
@@ -1204,8 +1204,8 @@ static uint32_t calculate_transaction_cpu_usage( const transaction_trace& trace,
 
    // charge a system controlled amount for signature verification/recovery
    uint32_t signature_cpu_usage = 0;
-   if( meta.signing_keys ) {
-      signature_cpu_usage = (uint32_t)meta.signing_keys->size() * chain_configuration.per_signature_cpu_usage;
+   if( meta.signature_count ) {
+      signature_cpu_usage = meta.signature_count * chain_configuration.per_signature_cpu_usage;
    }
 
    uint32_t context_free_cpu_usage = (uint32_t)((uint64_t)context_free_actual_cpu_usage * chain_configuration.context_free_discount_cpu_usage_num / chain_configuration.context_free_discount_cpu_usage_den);

--- a/libraries/chain/include/eosio/chain/transaction_metadata.hpp
+++ b/libraries/chain/include/eosio/chain/transaction_metadata.hpp
@@ -43,6 +43,7 @@ class transaction_metadata {
       uint32_t                              cycle_index           = 0;
       uint32_t                              shard_index           = 0;
       uint32_t                              billable_packed_size  = 0;
+      uint32_t                              signature_count       = 0;
       time_point                            published;
       fc::microseconds                      delay;
 

--- a/libraries/chain/transaction_metadata.cpp
+++ b/libraries/chain/transaction_metadata.cpp
@@ -10,6 +10,7 @@ transaction_metadata::transaction_metadata( const packed_transaction& t, chain_i
    ,context_free_data(t.get_context_free_data())
    ,id(decompressed_trx->id())
    ,billable_packed_size( t.get_billable_size() )
+   ,signature_count(t.signatures.size())
    ,published(published)
    ,raw_data(raw_trx->data())
    ,raw_size(raw_trx->size())


### PR DESCRIPTION
derive signature count from signatures not recovered keys.  Also do it the same whether in push_transaction or apply_block EOSIO/eos#2105

This resolves #2105 