### PR TITLE
Fix problems with large json strings in cleos commands

### DIFF
--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -71,6 +71,7 @@ Options:
 */
 #include <string>
 #include <vector>
+#include <regex>
 #include <boost/asio.hpp>
 #include <boost/format.hpp>
 #include <iostream>
@@ -398,7 +399,8 @@ chain::action create_unlinkauth(const name& account, const name& code, const nam
 
 fc::variant json_from_file_or_string(const string& file_or_str, fc::json::parse_type ptype = fc::json::legacy_parser)
 {
-   if ( !boost::istarts_with(file_or_str, "{") && is_regular_file(file_or_str) ) {
+   regex r("^[ \t]*[\{\[]");
+   if ( !regex_search(file_or_str, r) && is_regular_file(file_or_str) ) {
       return fc::json::from_file(file_or_str, ptype);
    } else {
       return fc::json::from_string(file_or_str, ptype);

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -398,7 +398,7 @@ chain::action create_unlinkauth(const name& account, const name& code, const nam
 
 fc::variant json_from_file_or_string(const string& file_or_str, fc::json::parse_type ptype = fc::json::legacy_parser)
 {
-   if ( is_regular_file(file_or_str) ) {
+   if ( !boost::istarts_with(file_or_str, "{") && is_regular_file(file_or_str) ) {
       return fc::json::from_file(file_or_str, ptype);
    } else {
       return fc::json::from_string(file_or_str, ptype);


### PR DESCRIPTION
The PR for Issue 2077 does not work for large json strings (fails with a boost error).

This change looks for a '{' character before checking if the string is a file.

ATC:

Call a cleos command with a large (> 2000 chars) json string.
