### PR TITLE
Configurable limit on deferred transaction production time

### DIFF
--- a/libraries/chain/include/eosio/chain/chain_controller.hpp
+++ b/libraries/chain/include/eosio/chain/chain_controller.hpp
@@ -69,6 +69,7 @@ namespace eosio { namespace chain {
          struct runtime_limits {
             fc::microseconds               max_push_block_us = fc::microseconds(-1);
             fc::microseconds               max_push_transaction_us = fc::microseconds(-1);
+            fc::microseconds               max_deferred_transactions_us = fc::microseconds(-1);
          };
 
          struct controller_config {

--- a/libraries/chain/include/eosio/chain/config.hpp
+++ b/libraries/chain/include/eosio/chain/config.hpp
@@ -86,11 +86,6 @@ const static eosio::chain::wasm_interface::vm_type default_wasm_runtime = eosio:
 const static int producer_repetitions = 12;
 
 /**
- * In block production, at the begining of each block we schedule deferred transactions until reach this time
- */
-const static uint32_t deferred_transactions_max_time_per_block_us = 20*1000; //20ms
-
-/**
  * The number of blocks produced per round is based upon all producers having a chance
  * to produce all of their consecutive blocks.
  */

--- a/libraries/chain/include/eosio/chain/transaction_metadata.hpp
+++ b/libraries/chain/include/eosio/chain/transaction_metadata.hpp
@@ -10,21 +10,15 @@ namespace eosio { namespace chain {
 
 class transaction_metadata {
    public:
-      transaction_metadata( const transaction& t, const time_point& published, const account_name& sender, uint128_t sender_id, const char* raw_data, size_t raw_size )
-         :id(t.id())
-         ,published(published)
-         ,sender(sender),sender_id(sender_id),raw_data(raw_data),raw_size(raw_size),_trx(&t)
-      {}
-
-      transaction_metadata( const transaction& t, const time_point& published, const account_name& sender, uint128_t sender_id, const char* raw_data, size_t raw_size, fc::time_point deadline )
+      transaction_metadata( const transaction& t, const time_point& published, const account_name& sender, uint128_t sender_id, const char* raw_data, size_t raw_size, const optional<time_point>& processing_deadline )
          :id(t.id())
          ,published(published)
          ,sender(sender),sender_id(sender_id),raw_data(raw_data),raw_size(raw_size)
-         ,processing_deadline(deadline)
+         ,processing_deadline(processing_deadline)
          ,_trx(&t)
       {}
 
-      transaction_metadata( const packed_transaction& t, chain_id_type chainid, const time_point& published, bool implicit=false );
+      transaction_metadata( const packed_transaction& t, chain_id_type chainid, const time_point& published, const optional<time_point>& processing_deadline = optional<time_point>(), bool implicit=false );
 
       transaction_metadata( transaction_metadata && ) = default;
       transaction_metadata& operator= (transaction_metadata &&) = default;

--- a/libraries/chain/transaction_metadata.cpp
+++ b/libraries/chain/transaction_metadata.cpp
@@ -4,7 +4,7 @@
 
 namespace eosio { namespace chain {
 
-transaction_metadata::transaction_metadata( const packed_transaction& t, chain_id_type chainid, const time_point& published, bool implicit )
+transaction_metadata::transaction_metadata( const packed_transaction& t, chain_id_type chainid, const time_point& published, const optional<time_point>& processing_deadline, bool implicit )
    :raw_trx(t.get_raw_transaction())
    ,decompressed_trx(fc::raw::unpack<transaction>(*raw_trx))
    ,context_free_data(t.get_context_free_data())
@@ -15,6 +15,7 @@ transaction_metadata::transaction_metadata( const packed_transaction& t, chain_i
    ,raw_data(raw_trx->data())
    ,raw_size(raw_trx->size())
    ,is_implicit(implicit)
+   ,processing_deadline(processing_deadline)
 { }
 
 digest_type transaction_metadata::calculate_transaction_merkle_root( const vector<transaction_metadata>& metas ) {

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -72,7 +72,7 @@ void chain_plugin::set_program_options(options_description& cli, options_descrip
           "Limits the maximum time (in milliseconds) that a reversible block is allowed to run before being considered invalid")
          ("max-pending-transaction-time", bpo::value<int32_t>()->default_value(-1),
           "Limits the maximum time (in milliseconds) that is allowed a pushed transaction's code to execute before being considered invalid")
-         ("max-deferred-transaction-time", bpo::value<int32_t>()->default_value(-1),
+         ("max-deferred-transaction-time", bpo::value<int32_t>()->default_value(20),
           "Limits the maximum time (in milliseconds) that is allowed a to push deferred transactions at the start of a block")
          ("wasm-runtime", bpo::value<eosio::chain::wasm_interface::vm_type>()->value_name("wavm/binaryen"), "Override default WASM runtime")
 #warning TODO: rate limiting

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -47,8 +47,9 @@ public:
    fc::optional<chain_controller::controller_config> chain_config = chain_controller::controller_config();
    fc::optional<chain_controller>   chain;
    chain_id_type                    chain_id;
-   uint32_t                         max_reversible_block_time_ms;
-   uint32_t                         max_pending_transaction_time_ms;
+   int32_t                          max_reversible_block_time_ms;
+   int32_t                          max_pending_transaction_time_ms;
+   int32_t                          max_deferred_transaction_time_ms;
    //txn_msg_rate_limits              rate_limits;
    fc::optional<vm_type>            wasm_runtime;
 };
@@ -71,6 +72,8 @@ void chain_plugin::set_program_options(options_description& cli, options_descrip
           "Limits the maximum time (in milliseconds) that a reversible block is allowed to run before being considered invalid")
          ("max-pending-transaction-time", bpo::value<int32_t>()->default_value(-1),
           "Limits the maximum time (in milliseconds) that is allowed a pushed transaction's code to execute before being considered invalid")
+         ("max-deferred-transaction-time", bpo::value<int32_t>()->default_value(-1),
+          "Limits the maximum time (in milliseconds) that is allowed a to push deferred transactions at the start of a block")
          ("wasm-runtime", bpo::value<eosio::chain::wasm_interface::vm_type>()->value_name("wavm/binaryen"), "Override default WASM runtime")
 #warning TODO: rate limiting
          /*("per-authorized-account-transaction-msg-rate-limit-time-frame-sec", bpo::value<uint32_t>()->default_value(default_per_auth_account_time_frame_seconds),
@@ -163,6 +166,7 @@ void chain_plugin::plugin_initialize(const variables_map& options) {
 
    my->max_reversible_block_time_ms = options.at("max-reversible-block-time").as<int32_t>();
    my->max_pending_transaction_time_ms = options.at("max-pending-transaction-time").as<int32_t>();
+   my->max_deferred_transaction_time_ms = options.at("max-deferred-transaction-time").as<int32_t>();
 
    if(options.count("wasm-runtime"))
       my->wasm_runtime = options.at("wasm-runtime").as<vm_type>();
@@ -189,6 +193,10 @@ void chain_plugin::plugin_startup()
 
    if (my->max_pending_transaction_time_ms > 0) {
       my->chain_config->limits.max_push_transaction_us = fc::milliseconds(my->max_pending_transaction_time_ms);
+   }
+
+   if (my->max_deferred_transaction_time_ms > 0 ) {
+      my->chain_config->limits.max_deferred_transactions_us = fc::milliseconds(my->max_deferred_transaction_time_ms);
    }
 
    if(my->wasm_runtime)

--- a/tests/api_tests/api_tests.cpp
+++ b/tests/api_tests/api_tests.cpp
@@ -553,7 +553,7 @@ BOOST_AUTO_TEST_CASE(checktime_fail_tests) { try {
 	//       1) compilation of the smart contract should probably not count towards the CPU time of a transaction that first uses it;
 	//       2) checktime should eventually switch to a deterministic metric which should hopefully fix the inconsistencies
 	//          of this test succeeding/failing on different machines (for example, succeeding on our local dev machines but failing on Jenkins).
-   TESTER t( {fc::milliseconds(5000), fc::milliseconds(5000)} );
+   TESTER t( {fc::milliseconds(5000), fc::milliseconds(5000), fc::milliseconds(-1)} );
    t.produce_blocks(2);
 
    t.create_account( N(testapi) );

--- a/tests/chain_tests/block_tests.cpp
+++ b/tests/chain_tests/block_tests.cpp
@@ -85,7 +85,7 @@ BOOST_AUTO_TEST_CASE( push_invalid_block ) { try {
    new_block.producer = sch_pro;
    new_block.block_mroot = chain.control->get_dynamic_global_properties().block_merkle_root.get_root();
    vector<transaction_metadata> input_metas;
-   input_metas.emplace_back(packed_transaction(trx), chain.control->get_chain_id(), chain.control->head_block_time(), true);
+   input_metas.emplace_back(packed_transaction(trx), chain.control->get_chain_id(), chain.control->head_block_time(), optional<time_point>(), true);
    new_block.transaction_mroot = transaction_metadata::calculate_transaction_merkle_root(input_metas);
    new_block.sign(priv_key);
 
@@ -902,7 +902,7 @@ BOOST_AUTO_TEST_CASE(block_id_sig_independent)
       new_block.producer = sch_pro;
       new_block.block_mroot = chain.control->get_dynamic_global_properties().block_merkle_root.get_root();
       vector<transaction_metadata> input_metas;
-      input_metas.emplace_back(packed_transaction(trx), chain.control->get_chain_id(), chain.control->head_block_time(), true);
+      input_metas.emplace_back(packed_transaction(trx), chain.control->get_chain_id(), chain.control->head_block_time(), optional<time_point>(), true);
       new_block.transaction_mroot = transaction_metadata::calculate_transaction_merkle_root(input_metas);
 
       // Sign the block with active signature


### PR DESCRIPTION
Move limit on time spent playing deferred transactions to a chain_controller limit fed by chain_plugin like our other deadlines