### PR TITLE
Quick fixes to multi_index bugs

### DIFF
--- a/contracts/eosiolib/action.h
+++ b/contracts/eosiolib/action.h
@@ -108,7 +108,7 @@ extern "C" {
 
    /**
     *  Send an inline action in the context of this action's parent transaction
-    * @param serialized_action - serialized action 
+    * @param serialized_action - serialized action
     * @param size - size of serialized action in bytes
     */
    void send_inline(char *serialized_action, size_t size);
@@ -147,5 +147,12 @@ extern "C" {
     *  @return the account which specifies the sender of the action
     */
    account_name current_sender();
+
+   /**
+    *  Get the current receiver of the action
+    *  @brief Get the current receiver of the action
+    *  @return the account which specifies the current receiver of the action
+    */
+   account_name current_receiver();
    ///@ } actioncapi
 }

--- a/contracts/eosiolib/multi_index.hpp
+++ b/contracts/eosiolib/multi_index.hpp
@@ -619,6 +619,8 @@ class multi_index
 
       template<typename Lambda>
       const_iterator emplace( uint64_t payer, Lambda&& constructor ) {
+         eosio_assert( _code == current_receiver(), "cannot modify objects in table of another contract" ); // Quick fix for mutating db using multi_index that shouldn't allow mutation. Real fix can come in RC2.
+         
          auto itm = std::make_unique<item>( this, [&]( auto& i ){
             T& obj = static_cast<T&>(i);
             constructor( obj );
@@ -670,6 +672,7 @@ class multi_index
          const auto& objitem = static_cast<const item&>(obj);
          eosio_assert( objitem.__idx == this, "object passed to modify is not in multi_index" );
          auto& mutableitem = const_cast<item&>(objitem);
+         eosio_assert( _code == current_receiver(), "cannot modify objects in table of another contract" ); // Quick fix for mutating db using multi_index that shouldn't allow mutation. Real fix can come in RC2.
 
          auto secondary_keys = boost::hana::transform( _indices, [&]( auto&& idx ) {
             typedef typename decltype(+hana::at_c<0>(idx))::type index_type;
@@ -752,6 +755,7 @@ class multi_index
       void erase( const T& obj ) {
          const auto& objitem = static_cast<const item&>(obj);
          eosio_assert( objitem.__idx == this, "object passed to erase is not in multi_index" );
+         eosio_assert( _code == current_receiver(), "cannot erase objects in table of another contract" ); // Quick fix for mutating db using multi_index that shouldn't allow mutation. Real fix can come in RC2.
 
          auto pk = objitem.primary_key();
          auto itr2 = std::find_if(_items_vector.rbegin(), _items_vector.rend(), [&](const item_ptr& ptr) {

--- a/contracts/eosiolib/multi_index.hpp
+++ b/contracts/eosiolib/multi_index.hpp
@@ -619,8 +619,8 @@ class multi_index
 
       template<typename Lambda>
       const_iterator emplace( uint64_t payer, Lambda&& constructor ) {
-         eosio_assert( _code == current_receiver(), "cannot modify objects in table of another contract" ); // Quick fix for mutating db using multi_index that shouldn't allow mutation. Real fix can come in RC2.
-         
+         eosio_assert( _code == current_receiver(), "cannot create objects in table of another contract" ); // Quick fix for mutating db using multi_index that shouldn't allow mutation. Real fix can come in RC2.
+
          auto itm = std::make_unique<item>( this, [&]( auto& i ){
             T& obj = static_cast<T&>(i);
             constructor( obj );

--- a/contracts/eosiolib/multi_index.hpp
+++ b/contracts/eosiolib/multi_index.hpp
@@ -31,107 +31,106 @@ using boost::multi_index::const_mem_fun;
 namespace hana = boost::hana;
 
 template<typename T>
-struct secondary_iterator;
+struct secondary_index_db_functions;
 
 #define WRAP_SECONDARY_SIMPLE_TYPE(IDX, TYPE)\
 template<>\
-struct secondary_iterator<TYPE> {\
-   static int32_t db_idx_next( int32_t iterator, uint64_t* primary )     { return db_##IDX##_next( iterator, primary ); }\
-   static int32_t db_idx_previous( int32_t iterator, uint64_t* primary ) { return db_##IDX##_previous( iterator, primary ); }\
-   static void    db_idx_remove( int32_t iterator  )                     { db_##IDX##_remove( iterator ); }\
+struct secondary_index_db_functions<TYPE> {\
+   static int32_t db_idx_next( int32_t iterator, uint64_t* primary )          { return db_##IDX##_next( iterator, primary ); }\
+   static int32_t db_idx_previous( int32_t iterator, uint64_t* primary )      { return db_##IDX##_previous( iterator, primary ); }\
+   static void    db_idx_remove( int32_t iterator  )                          { db_##IDX##_remove( iterator ); }\
    static int32_t db_idx_end( uint64_t code, uint64_t scope, uint64_t table ) { return db_##IDX##_end( code, scope, table ); }\
-};\
-int32_t db_idx_store( uint64_t scope, uint64_t table, uint64_t payer, uint64_t id, const TYPE& secondary ) {\
-   return db_##IDX##_store( scope, table, payer, id, &secondary );\
-}\
-void    db_idx_update( int32_t iterator, uint64_t payer, const TYPE& secondary ) {\
-   db_##IDX##_update( iterator, payer, &secondary );\
-}\
-int32_t db_idx_find_primary( uint64_t code, uint64_t scope, uint64_t table, uint64_t primary, TYPE& secondary ) {\
-   return db_##IDX##_find_primary( code, scope, table, &secondary, primary );\
-}\
-int32_t db_idx_find_secondary( uint64_t code, uint64_t scope, uint64_t table, const TYPE& secondary, uint64_t& primary ) {\
-   return db_##IDX##_find_secondary( code, scope, table, &secondary, &primary );\
-}\
-int32_t db_idx_lowerbound( uint64_t code, uint64_t scope, uint64_t table, TYPE& secondary, uint64_t& primary ) {\
-   return db_##IDX##_lowerbound( code, scope, table, &secondary, &primary );\
-}\
-int32_t db_idx_upperbound( uint64_t code, uint64_t scope, uint64_t table, TYPE& secondary, uint64_t& primary ) {\
-   return db_##IDX##_upperbound( code, scope, table, &secondary, &primary );\
-}
+   static int32_t db_idx_store( uint64_t scope, uint64_t table, uint64_t payer, uint64_t id, const TYPE& secondary ) {\
+      return db_##IDX##_store( scope, table, payer, id, &secondary );\
+   }\
+   static void    db_idx_update( int32_t iterator, uint64_t payer, const TYPE& secondary ) {\
+      db_##IDX##_update( iterator, payer, &secondary );\
+   }\
+   static int32_t db_idx_find_primary( uint64_t code, uint64_t scope, uint64_t table, uint64_t primary, TYPE& secondary ) {\
+      return db_##IDX##_find_primary( code, scope, table, &secondary, primary );\
+   }\
+   static int32_t db_idx_find_secondary( uint64_t code, uint64_t scope, uint64_t table, const TYPE& secondary, uint64_t& primary ) {\
+      return db_##IDX##_find_secondary( code, scope, table, &secondary, &primary );\
+   }\
+   static int32_t db_idx_lowerbound( uint64_t code, uint64_t scope, uint64_t table, TYPE& secondary, uint64_t& primary ) {\
+      return db_##IDX##_lowerbound( code, scope, table, &secondary, &primary );\
+   }\
+   static int32_t db_idx_upperbound( uint64_t code, uint64_t scope, uint64_t table, TYPE& secondary, uint64_t& primary ) {\
+      return db_##IDX##_upperbound( code, scope, table, &secondary, &primary );\
+   }\
+};
 
 #define WRAP_SECONDARY_ARRAY_TYPE(IDX, TYPE)\
 template<>\
-struct secondary_iterator<TYPE> {\
-   static int32_t db_idx_next( int32_t iterator, uint64_t* primary )     { return db_##IDX##_next( iterator, primary ); }\
-   static int32_t db_idx_previous( int32_t iterator, uint64_t* primary ) { return db_##IDX##_previous( iterator, primary ); }\
-   static void    db_idx_remove( int32_t iterator )                      { db_##IDX##_remove( iterator ); }\
+struct secondary_index_db_functions<TYPE> {\
+   static int32_t db_idx_next( int32_t iterator, uint64_t* primary )          { return db_##IDX##_next( iterator, primary ); }\
+   static int32_t db_idx_previous( int32_t iterator, uint64_t* primary )      { return db_##IDX##_previous( iterator, primary ); }\
+   static void    db_idx_remove( int32_t iterator )                           { db_##IDX##_remove( iterator ); }\
    static int32_t db_idx_end( uint64_t code, uint64_t scope, uint64_t table ) { return db_##IDX##_end( code, scope, table ); }\
+   static int32_t db_idx_store( uint64_t scope, uint64_t table, uint64_t payer, uint64_t id, const TYPE& secondary ) {\
+      return db_##IDX##_store( scope, table, payer, id, secondary.data(), TYPE::num_words() );\
+   }\
+   static void    db_idx_update( int32_t iterator, uint64_t payer, const TYPE& secondary ) {\
+      db_##IDX##_update( iterator, payer, secondary.data(), TYPE::num_words() );\
+   }\
+   static int32_t db_idx_find_primary( uint64_t code, uint64_t scope, uint64_t table, uint64_t primary, TYPE& secondary ) {\
+      return db_##IDX##_find_primary( code, scope, table, secondary.data(), TYPE::num_words(), primary );\
+   }\
+   static int32_t db_idx_find_secondary( uint64_t code, uint64_t scope, uint64_t table, const TYPE& secondary, uint64_t& primary ) {\
+      return db_##IDX##_find_secondary( code, scope, table, secondary.data(), TYPE::num_words(), &primary );\
+   }\
+   static int32_t db_idx_lowerbound( uint64_t code, uint64_t scope, uint64_t table, TYPE& secondary, uint64_t& primary ) {\
+      return db_##IDX##_lowerbound( code, scope, table, secondary.data(), TYPE::num_words(), &primary );\
+   }\
+   static int32_t db_idx_upperbound( uint64_t code, uint64_t scope, uint64_t table, TYPE& secondary, uint64_t& primary ) {\
+      return db_##IDX##_upperbound( code, scope, table, secondary.data(), TYPE::num_words(), &primary );\
+   }\
 };\
-int32_t db_idx_store( uint64_t scope, uint64_t table, uint64_t payer, uint64_t id, const TYPE& secondary ) {\
-   return db_##IDX##_store( scope, table, payer, id, secondary.data(), TYPE::num_words() );\
-}\
-void    db_idx_update( int32_t iterator, uint64_t payer, const TYPE& secondary ) {\
-   db_##IDX##_update( iterator, payer, secondary.data(), TYPE::num_words() );\
-}\
-int32_t db_idx_find_primary( uint64_t code, uint64_t scope, uint64_t table, uint64_t primary, TYPE& secondary ) {\
-   return db_##IDX##_find_primary( code, scope, table, secondary.data(), TYPE::num_words(), primary );\
-}\
-int32_t db_idx_find_secondary( uint64_t code, uint64_t scope, uint64_t table, const TYPE& secondary, uint64_t& primary ) {\
-   return db_##IDX##_find_secondary( code, scope, table, secondary.data(), TYPE::num_words(), &primary );\
-}\
-int32_t db_idx_lowerbound( uint64_t code, uint64_t scope, uint64_t table, TYPE& secondary, uint64_t& primary ) {\
-   return db_##IDX##_lowerbound( code, scope, table, secondary.data(), TYPE::num_words(), &primary );\
-}\
-int32_t db_idx_upperbound( uint64_t code, uint64_t scope, uint64_t table, TYPE& secondary, uint64_t& primary ) {\
-   return db_##IDX##_upperbound( code, scope, table, secondary.data(), TYPE::num_words(), &primary );\
-}
 
 WRAP_SECONDARY_SIMPLE_TYPE(idx64,  uint64_t)
 WRAP_SECONDARY_SIMPLE_TYPE(idx128, uint128_t)
 WRAP_SECONDARY_ARRAY_TYPE(idx256, key256)
 
 template<>
-struct secondary_iterator<double> {
-   static int32_t db_idx_next( int32_t iterator, uint64_t* primary )     { return db_idx_double_next( iterator, primary ); }
-   static int32_t db_idx_previous( int32_t iterator, uint64_t* primary ) { return db_idx_double_previous( iterator, primary ); }
-   static void db_idx_remove( int32_t iterator  )                        { db_idx_double_remove( iterator ); }
+struct secondary_index_db_functions<double> {
+   static int32_t db_idx_next( int32_t iterator, uint64_t* primary )          { return db_idx_double_next( iterator, primary ); }
+   static int32_t db_idx_previous( int32_t iterator, uint64_t* primary )      { return db_idx_double_previous( iterator, primary ); }
+   static void    db_idx_remove( int32_t iterator  )                          { db_idx_double_remove( iterator ); }
    static int32_t db_idx_end( uint64_t code, uint64_t scope, uint64_t table ) { return db_idx_double_end( code, scope, table ); }
+   static int32_t db_idx_store( uint64_t scope, uint64_t table, uint64_t payer, uint64_t id, double secondary ) {
+      uint64_t val = *(uint64_t*)(&secondary); // Get uint64_t representation of double secondary
+      return db_idx_double_store( scope, table, payer, id, &val );
+   }
+   static void    db_idx_update( int32_t iterator, uint64_t payer, double secondary ) {
+      uint64_t val = *(uint64_t*)(&secondary); // Get uint64_t representation of double secondary
+      db_idx_double_update( iterator, payer, &val );
+   }
+   static int32_t db_idx_find_primary( uint64_t code, uint64_t scope, uint64_t table, uint64_t primary, double& secondary ) {
+      uint64_t val = 0;
+      auto itr = db_idx_double_find_primary( code, scope, table, &val, primary );
+      if( itr >= 0 )
+         secondary = *(double*)(&val); // Store double secondary from uint64_t representation stored in val
+      return itr;
+   }
+   static int32_t db_idx_find_secondary( uint64_t code, uint64_t scope, uint64_t table, double secondary, uint64_t& primary ) {
+      uint64_t val = *(uint64_t*)(&secondary);
+      return db_idx_double_find_secondary( code, scope, table, &val, &primary );
+   }
+   static int32_t db_idx_lowerbound( uint64_t code, uint64_t scope, uint64_t table, double& secondary, uint64_t& primary ) {
+      uint64_t val = *(uint64_t*)(&secondary); // Get uint64_t representation of double secondary
+      auto itr = db_idx_double_lowerbound( code, scope, table, &val, &primary );
+      if( itr >= 0 )
+         secondary = *(double*)(&val); // Store double secondary from uint64_t representation stored in val
+      return itr;
+   }
+   static int32_t db_idx_upperbound( uint64_t code, uint64_t scope, uint64_t table, double& secondary, uint64_t& primary ) {
+      uint64_t val = *(uint64_t*)(&secondary); // Get uint64_t representation of double secondary
+      auto itr = db_idx_double_upperbound( code, scope, table, &val, &primary );
+      if( itr >= 0 )
+         secondary = *(double*)(&val); // Store double secondary from uint64_t representation stored in val
+      return itr;
+   }
 };
-int32_t db_idx_store( uint64_t scope, uint64_t table, uint64_t payer, uint64_t id, double secondary ) {
-   uint64_t val = *(uint64_t*)(&secondary); // Get uint64_t representation of double secondary
-   return db_idx_double_store( scope, table, payer, id, &val );
-}
-void    db_idx_update( int32_t iterator, uint64_t payer, double secondary ) {
-   uint64_t val = *(uint64_t*)(&secondary); // Get uint64_t representation of double secondary
-   db_idx_double_update( iterator, payer, &val );
-}
-int32_t db_idx_find_primary( uint64_t code, uint64_t scope, uint64_t table, uint64_t primary, double& secondary ) {
-   uint64_t val = 0;
-   auto itr = db_idx_double_find_primary( code, scope, table, &val, primary );
-   if( itr >= 0 )
-      secondary = *(double*)(&val); // Store double secondary from uint64_t representation stored in val
-   return itr;
-}
-int32_t db_idx_find_secondary( uint64_t code, uint64_t scope, uint64_t table, double secondary, uint64_t& primary ) {
-   uint64_t val = *(uint64_t*)(&secondary);
-   return db_idx_double_find_secondary( code, scope, table, &val, &primary );
-}
-int32_t db_idx_lowerbound( uint64_t code, uint64_t scope, uint64_t table, double& secondary, uint64_t& primary ) {
-   uint64_t val = *(uint64_t*)(&secondary); // Get uint64_t representation of double secondary
-   auto itr = db_idx_double_lowerbound( code, scope, table, &val, &primary );
-   if( itr >= 0 )
-      secondary = *(double*)(&val); // Store double secondary from uint64_t representation stored in val
-   return itr;
-}
-int32_t db_idx_upperbound( uint64_t code, uint64_t scope, uint64_t table, double& secondary, uint64_t& primary ) {
-   uint64_t val = *(uint64_t*)(&secondary); // Get uint64_t representation of double secondary
-   auto itr = db_idx_double_upperbound( code, scope, table, &val, &primary );
-   if( itr >= 0 )
-      secondary = *(double*)(&val); // Store double secondary from uint64_t representation stored in val
-   return itr;
-}
-
 
 template<uint64_t TableName, typename T, typename... Indices>
 class multi_index;
@@ -240,14 +239,13 @@ class multi_index
 
                      if( _item->__iters[Number] == -1 ) {
                         secondary_key_type temp_secondary_key;
-                        auto idxitr = db_idx_find_primary(_idx->get_code(), _idx->get_scope(), _idx->name(),
-                                                          _item->primary_key(), temp_secondary_key);
+                        auto idxitr = secondary_index_db_functions<secondary_key_type>::db_idx_find_primary(_idx->get_code(), _idx->get_scope(), _idx->name(), _item->primary_key(), temp_secondary_key);
                         auto& mi = const_cast<item&>( *_item );
                         mi.__iters[Number] = idxitr;
                      }
 
                      uint64_t next_pk = 0;
-                     auto next_itr = secondary_iterator<secondary_key_type>::db_idx_next( _item->__iters[Number], &next_pk );
+                     auto next_itr = secondary_index_db_functions<secondary_key_type>::db_idx_next( _item->__iters[Number], &next_pk );
                      if( next_itr < 0 ) {
                         _item = nullptr;
                         return *this;
@@ -266,19 +264,18 @@ class multi_index
                      int32_t  prev_itr = -1;
 
                      if( !_item ) {
-                        auto ei = secondary_iterator<secondary_key_type>::db_idx_end(_idx->get_code(), _idx->get_scope(), _idx->name());
+                        auto ei = secondary_index_db_functions<secondary_key_type>::db_idx_end(_idx->get_code(), _idx->get_scope(), _idx->name());
                         eosio_assert( ei != -1, "cannot decrement end iterator when the index is empty" );
-                        prev_itr = secondary_iterator<secondary_key_type>::db_idx_previous( ei , &prev_pk );
+                        prev_itr = secondary_index_db_functions<secondary_key_type>::db_idx_previous( ei , &prev_pk );
                         eosio_assert( prev_itr >= 0, "cannot decrement end iterator when the index is empty" );
                      } else {
                         if( _item->__iters[Number] == -1 ) {
                            secondary_key_type temp_secondary_key;
-                           auto idxitr = db_idx_find_primary(_idx->get_code(), _idx->get_scope(), _idx->name(),
-                                                             _item->primary_key(), temp_secondary_key);
+                           auto idxitr = secondary_index_db_functions<secondary_key_type>::db_idx_find_primary(_idx->get_code(), _idx->get_scope(), _idx->name(), _item->primary_key(), temp_secondary_key);
                            auto& mi = const_cast<item&>( *_item );
                            mi.__iters[Number] = idxitr;
                         }
-                        prev_itr = secondary_iterator<secondary_key_type>::db_idx_previous( _item->__iters[Number], &prev_pk );
+                        prev_itr = secondary_index_db_functions<secondary_key_type>::db_idx_previous( _item->__iters[Number], &prev_pk );
                         eosio_assert( prev_itr >= 0, "cannot decrement iterator at beginning of index" );
                      }
 
@@ -332,7 +329,7 @@ class multi_index
             const_iterator lower_bound( const secondary_key_type& secondary )const {
                uint64_t primary = 0;
                secondary_key_type secondary_copy(secondary);
-               auto itr = db_idx_lowerbound( get_code(), get_scope(), name(), secondary_copy, primary );
+               auto itr = secondary_index_db_functions<secondary_key_type>::db_idx_lowerbound( get_code(), get_scope(), name(), secondary_copy, primary );
                if( itr < 0 ) return cend();
 
                const T& obj = *_multidx->find( primary );
@@ -348,7 +345,7 @@ class multi_index
             const_iterator upper_bound( const secondary_key_type& secondary )const {
                uint64_t primary = 0;
                secondary_key_type secondary_copy(secondary);
-               auto itr = db_idx_upperbound( get_code(), get_scope(), name(), secondary_copy, primary );
+               auto itr = secondary_index_db_functions<secondary_key_type>::db_idx_upperbound( get_code(), get_scope(), name(), secondary_copy, primary );
                if( itr < 0 ) return cend();
 
                const T& obj = *_multidx->find( primary );
@@ -364,8 +361,7 @@ class multi_index
 
                if( objitem.__iters[Number] == -1 ) {
                   secondary_key_type temp_secondary_key;
-                  auto idxitr = db_idx_find_primary(get_code(), get_scope(), name(),
-                                                    objitem.primary_key(), temp_secondary_key);
+                  auto idxitr = secondary_index_db_functions<secondary_key_type>::db_idx_find_primary(get_code(), get_scope(), name(), objitem.primary_key(), temp_secondary_key);
                   auto& mi = const_cast<item&>( objitem );
                   mi.__iters[Number] = idxitr;
                }
@@ -649,7 +645,7 @@ class multi_index
             boost::hana::for_each( _indices, [&]( auto& idx ) {
                typedef typename decltype(+hana::at_c<0>(idx))::type index_type;
 
-               i.__iters[index_type::number()] = db_idx_store( _scope, index_type::name(), payer, obj.primary_key(), index_type::extract_secondary_key(obj) );
+               i.__iters[index_type::number()] = secondary_index_db_functions<typename index_type::secondary_key_type>::db_idx_store( _scope, index_type::name(), payer, obj.primary_key(), index_type::extract_secondary_key(obj) );
             });
          });
 
@@ -712,10 +708,11 @@ class multi_index
 
                if( indexitr < 0 ) {
                   typename index_type::secondary_key_type temp_secondary_key;
-                  indexitr = mutableitem.__iters[index_type::number()] = db_idx_find_primary( _code, _scope, index_type::name(), pk,  temp_secondary_key );
+                  indexitr = mutableitem.__iters[index_type::number()]
+                           = secondary_index_db_functions<typename index_type::secondary_key_type>::db_idx_find_primary( _code, _scope, index_type::name(), pk,  temp_secondary_key );
                }
 
-               db_idx_update( indexitr, payer, secondary );
+               secondary_index_db_functions<typename index_type::secondary_key_type>::db_idx_update( indexitr, payer, secondary );
             }
          });
       }
@@ -772,10 +769,10 @@ class multi_index
             auto i = objitem.__iters[index_type::number()];
             if( i < 0 ) {
               typename index_type::secondary_key_type secondary;
-              i = db_idx_find_primary( _code, _scope, index_type::name(), objitem.primary_key(),  secondary );
+              i = secondary_index_db_functions<typename index_type::secondary_key_type>::db_idx_find_primary( _code, _scope, index_type::name(), objitem.primary_key(),  secondary );
             }
             if( i >= 0 )
-               secondary_iterator<typename index_type::secondary_key_type>::db_idx_remove( i );
+               secondary_index_db_functions<typename index_type::secondary_key_type>::db_idx_remove( i );
          });
       }
 

--- a/contracts/eosiolib/multi_index.hpp
+++ b/contracts/eosiolib/multi_index.hpp
@@ -668,6 +668,7 @@ class multi_index
       template<typename Lambda>
       void modify( const T& obj, uint64_t payer, Lambda&& updater ) {
          const auto& objitem = static_cast<const item&>(obj);
+         eosio_assert( objitem.__idx == this, "object passed to modify is not in multi_index" );
          auto& mutableitem = const_cast<item&>(objitem);
 
          auto secondary_keys = boost::hana::transform( _indices, [&]( auto&& idx ) {

--- a/libraries/chain/wasm_interface.cpp
+++ b/libraries/chain/wasm_interface.cpp
@@ -835,6 +835,10 @@ class action_api : public context_aware_api {
             return name();
          }
       }
+
+      name current_receiver() {
+         return context.receiver;
+      }
 };
 
 class console_api : public context_aware_api {
@@ -1542,6 +1546,7 @@ REGISTER_INTRINSICS(action_api,
    (action_data_size,       int()          )
    (publication_time,   int32_t()          )
    (current_sender,     int64_t()          )
+   (current_receiver,   int64_t()          )
 );
 
 REGISTER_INTRINSICS(apply_context,


### PR DESCRIPTION
Changes in this PR:
* Put all secondary db functions into template struct to remove some unused symbols in wast.
* Add check to see if object belongs to this `multi_index` in `modify` (similar check already existed in `erase`).
* Add back `current_receiver()` intrinsic and use it to provide a quick fix to `multi_index` bug (until the better solution is implemented for RC2). The `multi_index` bug was that attempts to use `multi_index` to create/modify/erase table rows of accounts other than the current receiver would not fail as it should and would instead likely unintentionally trample over data in the current receiver's tables.