### PR TITLE
Fix DB memory leak in transaction containers

### DIFF
--- a/libraries/chain/chain_controller.cpp
+++ b/libraries/chain/chain_controller.cpp
@@ -1885,15 +1885,16 @@ void chain_controller::clear_expired_transactions()
    //transactions must have expired by at least two forking windows in order to be removed.
    auto& transaction_idx = _db.get_mutable_index<transaction_multi_index>();
    const auto& dedupe_index = transaction_idx.indices().get<by_expiration>();
-   while( (!dedupe_index.empty()) && (head_block_time() > fc::time_point(dedupe_index.rbegin()->expiration) ) )
-      transaction_idx.remove(*dedupe_index.rbegin());
+   while( (!dedupe_index.empty()) && (head_block_time() > fc::time_point(dedupe_index.begin()->expiration) ) ) {
+      transaction_idx.remove(*dedupe_index.begin());
+   }
 
    //Look for expired transactions in the pending generated list, and remove them.
    //transactions must have expired by at least two forking windows in order to be removed.
    auto& generated_transaction_idx = _db.get_mutable_index<generated_transaction_multi_index>();
    const auto& generated_index = generated_transaction_idx.indices().get<by_expiration>();
-   while( (!generated_index.empty()) && (head_block_time() > generated_index.rbegin()->expiration) ) {
-      _destroy_generated_transaction(*generated_index.rbegin());
+   while( (!generated_index.empty()) && (head_block_time() > generated_index.begin()->expiration) ) {
+      _destroy_generated_transaction(*generated_index.begin());
    }
 
 } FC_CAPTURE_AND_RETHROW() }


### PR DESCRIPTION
Transactions are stored in the DB via a multi-index container for purposes of deduplication checks. The index based on expiry is ordered_unique which means items will be sorted ascending for that index. So when pruning old transactions from this container we need to be removing from the start of the index as that's where the oldest transactions will be.

Issue #2153