### PR TITLE
Generate genesis.json in launcher. Fix up script.

### DIFF
--- a/programs/eosio-launcher/main.cpp
+++ b/programs/eosio-launcher/main.cpp
@@ -32,6 +32,7 @@
 #include <sys/types.h>
 #include <netinet/in.h>
 #include <net/if.h>
+#include <eosio/chain/contracts/genesis_state.hpp>
 
 #include "config.hpp"
 
@@ -1053,8 +1054,9 @@ launcher_def::init_genesis () {
   bfs::path genesis_path = bfs::current_path() / "genesis.json";
    bfs::ifstream src(genesis_path);
    if (!src.good()) {
-      cerr << "unable to open " << genesis_path << "\n";
-      exit(9);
+      cout << "generating default genesis file " << genesis_path << endl;
+      eosio::chain::contracts::genesis_state_type default_genesis;
+      fc::json::save_to_file( default_genesis, genesis_path, true );
    }
    string bioskey = string(network.nodes["bios"].keys[0].get_public_key());
    string str;

--- a/scripts/eosio-tn_up.sh
+++ b/scripts/eosio-tn_up.sh
@@ -56,7 +56,7 @@ relaunch() {
 
 if [ -z "$EOSIO_LEVEL" ]; then
     echo starting with no modifiers
-    relaunch $prog $rundir $*
+    relaunch $*
     if [ "$connected" -eq 0 ]; then
         EOSIO_LEVEL=replay
     else
@@ -66,7 +66,7 @@ fi
 
 if [ "$EOSIO_LEVEL" == replay ]; then
     echo starting with replay
-    relaunch $prog $rundir $* --replay
+    relaunch $* --replay
     if [  "$connected" -eq 0 ]; then
         EOSIO_LEVEL=resync
     else


### PR DESCRIPTION
Generates the default genesis.json when one is not passed to the launcher (fixes nodeos_run_test).
Fixes some problems in the up script used by the launcher.