### PR TITLE
Fix boost file name

### DIFF
--- a/scripts/eosio_build_ubuntu.sh
+++ b/scripts/eosio_build_ubuntu.sh
@@ -110,12 +110,12 @@
 			printf "\tExiting now.\n\n"
 			exit;
 		fi
-		tar xf boost_1.66.0.tar.bz2
+		tar xf boost_1_66_0.tar.bz2
 		cd boost_1_66_0/
 		./bootstrap.sh "--prefix=$BOOST_ROOT"
 		./b2 -j${CPU_CORE} install
 		rm -rf ${TEMP_DIR}/boost_1_66_0/
-		rm -f  ${TEMP_DIR}/boost_1.66.0.tar.bz2
+		rm -f  ${TEMP_DIR}/boost_1_66_0.tar.bz2
 	else
 		printf "\tBoost 1.66 found at ${HOME}/opt/boost_1_66_0\n"
 	fi


### PR DESCRIPTION
Resolves #2175 

ATC:
Perform fresh install on ubuntu, verify builds.