### PR TITLE
Make per-txn console print a debug-log-level print

### DIFF
--- a/libraries/chain/chain_controller.cpp
+++ b/libraries/chain/chain_controller.cpp
@@ -572,17 +572,19 @@ void chain_controller::_apply_cycle_trace( const cycle_trace& res )
             }
          }
          ///TODO: hook this up as a signal handler in a de-coupled "logger" that may just silently drop them
-         for (const auto &ar : tr.action_traces) {
-            if (!ar.console.empty()) {
-               auto prefix = fc::format_string(
-                  "\n[(${a},${n})->${r}]",
-                  fc::mutable_variant_object()
-                     ("a", ar.act.account)
-                     ("n", ar.act.name)
-                     ("r", ar.receiver));
-               ilog(prefix + ": CONSOLE OUTPUT BEGIN =====================\n"
-                    + ar.console
-                    + prefix + ": CONSOLE OUTPUT END   =====================" );
+         if(fc::logger::get(DEFAULT_LOGGER).is_enabled(fc::log_level::debug)) {
+            for (const auto &ar : tr.action_traces) {
+               if (!ar.console.empty()) {
+                  auto prefix = fc::format_string(
+                     "\n[(${a},${n})->${r}]",
+                     fc::mutable_variant_object()
+                        ("a", ar.act.account)
+                        ("n", ar.act.name)
+                        ("r", ar.receiver));
+                  dlog(prefix + ": CONSOLE OUTPUT BEGIN =====================\n"
+                       + ar.console
+                       + prefix + ": CONSOLE OUTPUT END   =====================" );
+               }
             }
          }
       }


### PR DESCRIPTION
The per-txn console print is just way... too... much.. spam. Move this print to be at debug log level (hidden by default). cleos prints the console output for a transaction so most use cases where someone would be interested in this output are handled there.

Issue #2201