### PR TITLE
fix prevent datastream decoding pointer types (2069)

### DIFF
--- a/contracts/eosiolib/datastream.hpp
+++ b/contracts/eosiolib/datastream.hpp
@@ -349,6 +349,7 @@ DataStream& operator>>( DataStream& ds, std::tuple<Args...>& t ) {
 
 template<typename DataStream, typename T, std::enable_if_t<std::is_fundamental<T>::value == false, int> = 0>
 DataStream& operator<<( DataStream& ds, const T& v ) {
+   static_assert(!std::is_pointer<T>::value, "Pointers should not be serialized" );
    boost::pfr::for_each_field(v, [&](const auto& field) {
       ds << field;
    });
@@ -356,6 +357,7 @@ DataStream& operator<<( DataStream& ds, const T& v ) {
 }
 template<typename DataStream, typename T, std::enable_if_t<std::is_fundamental<T>::value == false, int> = 0>
 DataStream& operator>>( DataStream& ds, T& v ) {
+   static_assert(!std::is_pointer<T>::value, "Pointers should not be serialized" );
    boost::pfr::for_each_field(v, [&](auto& field) {
       ds >> field;
    });

--- a/contracts/test_api/test_api.cpp
+++ b/contracts/test_api/test_api.cpp
@@ -18,6 +18,7 @@
 #include "test_transaction.cpp"
 #include "test_checktime.cpp"
 #include "test_permission.cpp"
+#include "test_datastream.cpp"
 
 account_name global_receiver;
 
@@ -169,6 +170,9 @@ extern "C" {
       // test checktime
       WASM_TEST_HANDLER(test_checktime, checktime_pass);
       WASM_TEST_HANDLER(test_checktime, checktime_failure);
+
+      // test datastream
+      WASM_TEST_HANDLER(test_datastream, test_basic);
 
       // test permission
       WASM_TEST_HANDLER_EX(test_permission, check_authorization);

--- a/contracts/test_api/test_api.hpp
+++ b/contracts/test_api/test_api.hpp
@@ -250,3 +250,7 @@ struct test_softfloat {
 struct test_permission {
   static void check_authorization(uint64_t receiver, uint64_t code, uint64_t action);
 };
+
+struct test_datastream {
+  static void test_basic();
+};

--- a/contracts/test_api/test_datastream.cpp
+++ b/contracts/test_api/test_datastream.cpp
@@ -1,0 +1,60 @@
+
+#include <eosiolib/eosio.hpp>
+#include <eosiolib/datastream.hpp>
+
+#include "test_api.hpp"
+
+template <typename T>
+struct testtype {
+    static void run(const T &v, const char *errmsg = "") {
+        char buf[128];
+        eosio::datastream<char *> ds(buf, sizeof(buf));
+        ds << v;
+        T v2;
+        ds.seekp(0);
+        ds >> v2;
+        eosio_assert(v == v2, errmsg);            
+    }
+};
+
+void test_datastream::test_basic()
+{
+
+    testtype<bool>::run(true, "bool");
+    testtype<bool>::run(false, "bool");
+    testtype<char>::run(-123, "int8");
+    testtype<unsigned char>::run(127, "uint8");
+    testtype<short>::run(-12345, "int16");
+    testtype<unsigned short>::run(12345, "uint16");
+    testtype<int>::run(-1234567890, "int32");
+    testtype<unsigned int>::run(3234567890u, "uint32");
+    testtype<long long>::run(0x8000000000000000ull, "int64");
+    testtype<unsigned long long>::run(0x7fffffffffffffffull, "uint64");
+    testtype<float>::run(1.234f, "float");
+    testtype<double>::run(0.333333333333333333, "double");
+
+    // this should generate compile error
+    //testtype<char *>::run((char *)0x12345678, "pointer");
+
+    struct Pair {
+        int a;
+        double d;
+        bool operator==(const Pair &p) const { return a == p.a && d == p.d;} 
+    };
+    testtype<Pair>::run({1, 1.23456}, "struct");
+
+    struct StaticArray {
+        int a[2];
+        bool operator==(const StaticArray &o) const { return a[0] == o.a[0] && a[1] == o.a[1]; }
+    };
+    testtype<StaticArray>::run({10,20}, "staticArray");
+
+    testtype<std::string>::run("hello", "string");
+
+    testtype<std::vector<int> >::run({10,20,30}, "vector");
+    testtype<std::vector<int> >::run({}, "empty vector");
+    testtype<std::array<int, 3> >::run({10,20,30}, "std::array<T,N>");
+    testtype<std::map<int, std::string> >::run({{1,"apple"}, {2,"cat"}, {3,"panda"}}, "map");
+    testtype<std::tuple<int, std::string, double> >::run({1, "abc", 3.3333}, "tuple");
+}
+

--- a/tests/api_tests/api_tests.cpp
+++ b/tests/api_tests/api_tests.cpp
@@ -1486,4 +1486,19 @@ BOOST_FIXTURE_TEST_CASE(privileged_tests, tester) { try {
 } FC_LOG_AND_RETHROW() }
 #endif
 
+/*************************************************************************************
+ * real_tests test cases
+ *************************************************************************************/
+BOOST_FIXTURE_TEST_CASE(datastream_tests, TESTER) { try {
+   produce_blocks(1000);
+   create_account(N(testapi) );
+   produce_blocks(1000);
+   set_code(N(testapi), test_api_wast);
+   produce_blocks(1000);
+
+   CALL_TEST_FUNCTION( *this, "test_datastream", "test_basic", {} );
+
+   BOOST_REQUIRE_EQUAL( validate(), true );
+} FC_LOG_AND_RETHROW() }
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
fix #2069, prevent datastream encoding pointer types (try to serialize pointer type will result in compile error), add unitest cases for datastream with different types.