### PR TITLE
Check git submodule status before building

### DIFF
--- a/eosio_build.sh
+++ b/eosio_build.sh
@@ -50,6 +50,13 @@
 	printf "\tCurrent branch: $( git branch | grep \* )\n"
 	printf "\n\tARCHITECTURE: ${ARCH}\n"
 
+	STALE_SUBMODS=$(( `git submodule status | grep -c "^[+\-]"` ))
+	if [ $STALE_SUBMODS -gt 0 ]; then
+		printf "\ngit submodules are not up to date\n"
+		printf "\tPlease run the command 'git submodule update --init --recursive'\n"
+		exit 1
+	fi
+
 	if [ $ARCH == "Linux" ]; then
 		
 		if [ ! -e /etc/os-release ]; then


### PR DESCRIPTION
I added code to eosio_build.sh to check the git submodule status before trying to build. If any submodules are missing or out of date, it will request that the user do a "git submodule update --init --recursive" and exit the build script.