### PR TITLE
Fix for stale _head in fork_database 

### DIFF
--- a/libraries/chain/chain_controller.cpp
+++ b/libraries/chain/chain_controller.cpp
@@ -252,6 +252,7 @@ bool chain_controller::_push_block(const signed_block& new_block)
       session.push();
    } catch ( const fc::exception& e ) {
       elog("Failed to push new block:\n${e}", ("e", e.to_detail_string()));
+      _fork_db.pop_block();
       _fork_db.remove(new_block.id());
       throw;
    }

--- a/libraries/chain/fork_database.cpp
+++ b/libraries/chain/fork_database.cpp
@@ -20,8 +20,7 @@ void fork_database::pop_block()
 {
    FC_ASSERT( _head, "no blocks to pop" );
    auto prev = _head->prev.lock();
-   FC_ASSERT( prev, "poping block would leave head block null" );
-    _head = prev;
+   _head = prev;
 }
 
 void     fork_database::start_block(signed_block b)


### PR DESCRIPTION
# Description

Now, this is a story all about how
My log got flipped-turned upside down
And I'd like to take a minute
Just sit right there
I'll tell you how I got to writing out a bum block in there...

# Recipe for Disaster

Given 2 producers (A and B) and the current net code,

At some point in time, A produces Block(N) which is the last of their 12 block series.  The chain has been well behaved up to then, so B had produced Block(N - 12).  Since both producers have approved Block(N-12) that is the Last Irreversible Block at this point.

Producer B receives Block-Summary(N) and attempts to reconstruct Block(N) but is not sure if it is successful due to the current ambiguity between input transactions, deferred transactions and implicit transactions (aka on-block) in the summary.  For the sake of explanation lets say this is actually the nefarious incomplete Block(N)*

Producer B attempts to push Block(N)* locally, which pushes the block into the fork_database here:

https://github.com/EOSIO/eos/blob/cc3f7a3611b1f1d554bf9bd1e4bf1fe7e5cf1cf6/libraries/chain/chain_controller.cpp#L186

throws an exception here:

https://github.com/EOSIO/eos/blob/cc3f7a3611b1f1d554bf9bd1e4bf1fe7e5cf1cf6/libraries/chain/chain_controller.cpp#L251

and removes Block(N)* from the fork_database here:

https://github.com/EOSIO/eos/blob/cc3f7a3611b1f1d554bf9bd1e4bf1fe7e5cf1cf6/libraries/chain/chain_controller.cpp#L255

All side effects of the chain are rolled back correctly and from the point of view of chain_controller Block(N-1) is the head block

HOWEVER, inside fork_database `_head` still points to Block(N)* .

Now, Producer B retries its assembly of Block(N) and successfully generates it and pushes it to chain controller.  This will call `fork_database::push_block` here:

https://github.com/EOSIO/eos/blob/cc3f7a3611b1f1d554bf9bd1e4bf1fe7e5cf1cf6/libraries/chain/chain_controller.cpp#L186

which will *only* overwrite `_head` IF the new block is a *higher* number than the old:

https://github.com/EOSIO/eos/blob/cc3f7a3611b1f1d554bf9bd1e4bf1fe7e5cf1cf6/libraries/chain/fork_database.cpp#L74-L79

Since `_head` is Block(N)* and N == N, `_head` is left pointing to the nefarious incomplete block.

Otherwise, this block completes normally and we are in a state where:
  - chain controller correctly has Block(N) as the head block
  - fork database is correctly only storing Block(N) in its database
  - fork databases internal `_head` is pointing to Block(N)*

At this point several things could happen which would correct our little gaff and *one* thing (at least) can happen that will ruin our block log.... <drumroll>

We can produce Block(N + 1) on producer B and in a 2 producer environment this will be enough confirmations of Block(N) to advance irreversibility to N.  When we generate the block, we call `update_last_irreversible_block` with the fork_database in a different state than when we push a block.  In particular, the block we are processing is added to fork_database _after_ this call when we are generating a block.  Which means, fork database is still in its corrupt state when we trigger the processing of, the now irreversible, Block(N) by the block log here:

https://github.com/EOSIO/eos/blob/cc3f7a3611b1f1d554bf9bd1e4bf1fe7e5cf1cf6/libraries/chain/chain_controller.cpp#L1848-L1857

You may be wondering what `fetch_block_by_number` does... and you would be right to be suspicious because that will start at `_head` in the fork_database and go backwards until it finds the right number.  

And if you are paying attention, `_head` has bad data in it right now but IS the right height so, off to the disk it goes. 

Goodnight sweet block log... you are now useless.   All because we didn't clean up `_head` on an exception and exercised this one weird trick with two producers.

`</snark>`

