### PR TITLE
added check to prevent sigabort in net_plugin #2324

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -1055,7 +1055,7 @@ namespace eosio {
 
    void connection::fetch_timeout( boost::system::error_code ec ) {
       if( !ec ) {
-         if( !( pending_fetch->req_trx.empty( ) || pending_fetch->req_blocks.empty( ) ) ) {
+         if( pending_fetch.valid() && !( pending_fetch->req_trx.empty( ) || pending_fetch->req_blocks.empty( ) ) ) {
             my_impl->big_msg_master->retry_fetch (shared_from_this() );
          }
       }


### PR DESCRIPTION
nodeos reproducibly crashes with SIGABRT
this is the fix for that. it fixes the code that calls empty function