### PR TITLE
Error out when no .git directory exists

### DIFF
--- a/eosio_build.sh
+++ b/eosio_build.sh
@@ -44,6 +44,12 @@
 	bldred=${txtbld}$(tput setaf 1)
 	txtrst=$(tput sgr0)
 
+	if [ ! -d .git ]; then
+		printf "\nThis build script only works with sources cloned from git\n"
+		printf "\tPlease clone a new eos directory with 'git clone https://github.com/EOSIO/eos --recursive'\n"
+		printf "\tSee the wiki for instructions: https://github.com/EOSIO/eos/wiki\n"
+		exit 1
+	fi
 
 	printf "\n\tBeginning build version: ${VERSION}\n"
 	printf "\t$( date -u )\n"


### PR DESCRIPTION
When building in a directory without a .git directory, this change will error out of the script, tell the user to check out using git clone, and point them at the wiki instructions. The goal here is to give clear instructions when someone tries to build using the tar or zip files that github lets them download (which does not include submodules).
