### PR TITLE
Restore OOB table unit test

### DIFF
--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -83,8 +83,6 @@ namespace eosio { namespace testing {
          transaction_trace    push_action( const account_name& code, const action_name& acttype, const account_name& actor, const variant_object& data, uint32_t expiration = DEFAULT_EXPIRATION_DELTA, uint32_t delay_sec = 0 );
          transaction_trace    push_action( const account_name& code, const action_name& acttype, const vector<account_name>& actors, const variant_object& data, uint32_t expiration = DEFAULT_EXPIRATION_DELTA, uint32_t delay_sec = 0 );
 
-         void                 set_tapos( signed_transaction& trx, uint32_t expiration = DEFAULT_EXPIRATION_DELTA ) const;
-
          void                 set_transaction_headers(signed_transaction& trx,
                                                       uint32_t expiration = DEFAULT_EXPIRATION_DELTA,
                                                       uint32_t delay_sec = 0)const;

--- a/tests/wasm_tests/wasm_tests.cpp
+++ b/tests/wasm_tests/wasm_tests.cpp
@@ -1039,7 +1039,6 @@ BOOST_FIXTURE_TEST_CASE( check_table_maximum, TESTER ) try {
    }
 
    produce_blocks(1);
-#if 0
    {
    signed_transaction trx;
    action act;
@@ -1047,7 +1046,7 @@ BOOST_FIXTURE_TEST_CASE( check_table_maximum, TESTER ) try {
    act.account = N(tbl);
    act.authorization = vector<permission_level>{{N(tbl),config::active_name}};
    trx.actions.push_back(act);
-   set_tapos(trx);
+   set_transaction_headers(trx);
    trx.sign(get_private_key( N(tbl), "active" ), chain_id_type());
    push_transaction(trx);
    }
@@ -1061,14 +1060,12 @@ BOOST_FIXTURE_TEST_CASE( check_table_maximum, TESTER ) try {
    act.account = N(tbl);
    act.authorization = vector<permission_level>{{N(tbl),config::active_name}};
    trx.actions.push_back(act);
-   set_tapos(trx);
+   set_transaction_headers(trx);
    trx.sign(get_private_key( N(tbl), "active" ), chain_id_type());
 
    //an element that is out of range and has no mmap access permission either (should be a trapped segv)
    BOOST_CHECK_EXCEPTION(push_transaction(trx), eosio::chain::wasm_execution_error, [](const eosio::chain::wasm_execution_error &e) {return true;});
    }
-#endif
-
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( protected_globals, TESTER ) try {


### PR DESCRIPTION
Now that WAVM is properly catching SEGVs, restore this test.

Replaces PR #1849
Issue #1823 