### PR TITLE
Fixes and cleanup of check_authorization for updateauth, deleteauth, linkauth, unlinkauth, canceldelay native actions

### DIFF
--- a/contracts/eosio.system/native.hpp
+++ b/contracts/eosio.system/native.hpp
@@ -132,9 +132,10 @@ namespace eosiosystem {
          }
 
          ACTION( SystemAccount, canceldelay ) {
+            permission_level      canceling_auth;
             transaction_id_type   trx_id;
 
-            EOSLIB_SERIALIZE( canceldelay, (trx_id) )
+            EOSLIB_SERIALIZE( canceldelay, (canceling_auth)(trx_id) )
          };
 
          static void on( const canceldelay& ) {

--- a/libraries/chain/contracts/abi_serializer.cpp
+++ b/libraries/chain/contracts/abi_serializer.cpp
@@ -96,6 +96,7 @@ namespace eosio { namespace chain { namespace contracts {
       built_in_types.emplace("permission_name",           pack_unpack<permission_name>());
       built_in_types.emplace("action_name",               pack_unpack<action_name>());
       built_in_types.emplace("scope_name",                pack_unpack<scope_name>());
+      built_in_types.emplace("permission_level",          pack_unpack<permission_level>());
       built_in_types.emplace("producer_schedule",         pack_unpack<producer_schedule_type>());
       built_in_types.emplace("newaccount",                pack_unpack<newaccount>());
    }

--- a/libraries/chain/contracts/chain_initializer.cpp
+++ b/libraries/chain/contracts/chain_initializer.cpp
@@ -75,8 +75,8 @@ abi_def chain_initializer::eos_contract_abi(const abi_def& eosio_system_abi)
    eos_abi.actions.push_back( action_def{name("onerror"), "onerror",""} );
    eos_abi.actions.push_back( action_def{name("onblock"), "onblock",""} );
    eos_abi.actions.push_back( action_def{name("canceldelay"), "canceldelay",""} );
-   
-   // TODO add any clauses 
+
+   // TODO add any clauses
    //
    // ACTION PAYLOADS
 
@@ -163,6 +163,7 @@ abi_def chain_initializer::eos_contract_abi(const abi_def& eosio_system_abi)
 
    eos_abi.structs.emplace_back( struct_def {
       "canceldelay", "", {
+         {"canceling_auth", "permission_level"},
          {"trx_id", "transaction_id_type"},
       }
    });
@@ -270,7 +271,7 @@ abi_def chain_initializer::eos_contract_abi(const abi_def& eosio_system_abi)
    eos_abi.structs.emplace_back( struct_def {
          "clause_pair", "", {
             {"id", "string"},
-            {"body", "string"} 
+            {"body", "string"}
          }
    });
    eos_abi.structs.emplace_back( struct_def {

--- a/libraries/chain/include/eosio/chain/authority_checker.hpp
+++ b/libraries/chain/include/eosio/chain/authority_checker.hpp
@@ -170,7 +170,7 @@ namespace detail {
             return {range.begin(), range.end()};
          }
 
-         const PermissionVisitorFunc& get_permission_visitor() {
+         PermissionVisitorFunc& get_permission_visitor() {
             return permission_visitor;
          }
 

--- a/libraries/chain/include/eosio/chain/chain_controller.hpp
+++ b/libraries/chain/include/eosio/chain/chain_controller.hpp
@@ -92,7 +92,7 @@ namespace eosio { namespace chain {
          void push_block( const signed_block& b, uint32_t skip = skip_nothing );
          transaction_trace push_transaction( const packed_transaction& trx, uint32_t skip = skip_nothing );
          vector<transaction_trace> push_deferred_transactions( bool flush = false, uint32_t skip = skip_nothing );
-         
+
          uint128_t transaction_id_to_sender_id( const transaction_id_type& tid )const;
 
       /**
@@ -265,6 +265,7 @@ namespace eosio { namespace chain {
          const global_property_object&          get_global_properties()const;
          const dynamic_global_property_object&  get_dynamic_global_properties()const;
          const producer_object&                 get_producer(const account_name& ownername)const;
+         const permission_object*               find_permission( const permission_level& level )const;
          const permission_object&               get_permission( const permission_level& level )const;
 
          time_point           head_block_time()const;

--- a/libraries/chain/include/eosio/chain/chain_controller.hpp
+++ b/libraries/chain/include/eosio/chain/chain_controller.hpp
@@ -301,6 +301,12 @@ namespace eosio { namespace chain {
                                                flat_set<permission_level>       provided_levels = flat_set<permission_level>()
                                              )const;
 
+         optional<fc::microseconds> check_updateauth_authorization( const contracts::updateauth& update, const vector<permission_level>& auths )const;
+         fc::microseconds check_deleteauth_authorization( const contracts::deleteauth& del, const vector<permission_level>& auths )const;
+         fc::microseconds check_linkauth_authorization( const contracts::linkauth& link, const vector<permission_level>& auths )const;
+         fc::microseconds check_unlinkauth_authorization( const contracts::unlinkauth& unlink, const vector<permission_level>& auths )const;
+         void             check_canceldelay_authorization( const contracts::canceldelay& cancel, const vector<permission_level>& auths )const;
+
          /**
           * @param account - the account owner of the permission
           * @param permission - the permission name to check for authorization

--- a/libraries/chain/include/eosio/chain/contracts/types.hpp
+++ b/libraries/chain/include/eosio/chain/contracts/types.hpp
@@ -73,7 +73,7 @@ struct action_def {
 
    action_name name;
    type_name   type;
-   string      ricardian_contract; 
+   string      ricardian_contract;
 };
 
 struct table_def {
@@ -92,7 +92,7 @@ struct table_def {
 struct clause_pair {
    clause_pair() = default;
    clause_pair( const string& id, const string& body )
-   : id(id), body(body) 
+   : id(id), body(body)
    {}
 
    string id;
@@ -282,6 +282,7 @@ struct vetorecovery {
 };
 
 struct canceldelay {
+   permission_level      canceling_auth;
    transaction_id_type   trx_id;
 
    static account_name get_account() {
@@ -313,4 +314,4 @@ FC_REFLECT( eosio::chain::contracts::unlinkauth                       , (account
 FC_REFLECT( eosio::chain::contracts::postrecovery                     , (account)(data)(memo) )
 FC_REFLECT( eosio::chain::contracts::passrecovery                     , (account) )
 FC_REFLECT( eosio::chain::contracts::vetorecovery                     , (account) )
-FC_REFLECT( eosio::chain::contracts::canceldelay                      , (trx_id) )
+FC_REFLECT( eosio::chain::contracts::canceldelay                      , (canceling_auth)(trx_id) )

--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -82,6 +82,7 @@ namespace eosio { namespace testing {
 
          transaction_trace    push_action( const account_name& code, const action_name& acttype, const account_name& actor, const variant_object& data, uint32_t expiration = DEFAULT_EXPIRATION_DELTA, uint32_t delay_sec = 0 );
          transaction_trace    push_action( const account_name& code, const action_name& acttype, const vector<account_name>& actors, const variant_object& data, uint32_t expiration = DEFAULT_EXPIRATION_DELTA, uint32_t delay_sec = 0 );
+         transaction_trace    push_action( const account_name& code, const action_name& acttype, const vector<permission_level>& auths, const variant_object& data, uint32_t expiration = DEFAULT_EXPIRATION_DELTA, uint32_t delay_sec = 0 );
 
          void                 set_tapos( signed_transaction& trx, uint32_t expiration = DEFAULT_EXPIRATION_DELTA ) const;
 

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -198,13 +198,30 @@ namespace eosio { namespace testing {
                              uint32_t delay_sec)
 
    { try {
-      return push_action(code, acttype, vector<account_name>{ actor }, data, expiration, delay_sec);
+      vector<permission_level> auths;
+      auths.push_back(permission_level{actor, config::active_name});
+      return push_action(code, acttype, auths, data, expiration, delay_sec);
    } FC_CAPTURE_AND_RETHROW( (code)(acttype)(actor)(data)(expiration) ) }
 
 
    transaction_trace base_tester::push_action( const account_name& code,
                              const action_name& acttype,
                              const vector<account_name>& actors,
+                             const variant_object& data,
+                             uint32_t expiration,
+                             uint32_t delay_sec)
+
+   { try {
+      vector<permission_level> auths;
+      for (const auto& actor : actors) {
+         auths.push_back(permission_level{actor, config::active_name});
+      }
+      return push_action(code, acttype, auths, data, expiration, delay_sec);
+   } FC_CAPTURE_AND_RETHROW( (code)(acttype)(actors)(data)(expiration) ) }
+
+   transaction_trace base_tester::push_action( const account_name& code,
+                             const action_name& acttype,
+                             const vector<permission_level>& auths,
                              const variant_object& data,
                              uint32_t expiration,
                              uint32_t delay_sec)
@@ -222,21 +239,18 @@ namespace eosio { namespace testing {
       action act;
       act.account = code;
       act.name = acttype;
-      for (const auto& actor : actors) {
-         act.authorization.push_back(permission_level{actor, config::active_name});
-      }
+      act.authorization = auths;
       act.data = abis.variant_to_binary(action_type_name, data);
 
       signed_transaction trx;
       trx.actions.emplace_back(std::move(act));
       set_transaction_headers(trx, expiration, delay_sec);
-      for (const auto& actor : actors) {
-         trx.sign(get_private_key(actor, "active"), chain_id_type());
+      for (const auto& auth : auths) {
+         trx.sign(get_private_key(auth.actor, auth.permission.to_string()), chain_id_type());
       }
 
       return push_transaction(trx);
-   } FC_CAPTURE_AND_RETHROW( (code)(acttype)(actors)(data)(expiration) ) }
-
+   } FC_CAPTURE_AND_RETHROW( (code)(acttype)(auths)(data)(expiration) ) }
 
    transaction_trace base_tester::push_reqauth( account_name from, const vector<permission_level>& auths, const vector<private_key_type>& keys ) {
       variant pretty_trx = fc::mutable_variant_object()

--- a/tests/chain_tests/auth_tests.cpp
+++ b/tests/chain_tests/auth_tests.cpp
@@ -79,6 +79,7 @@ BOOST_AUTO_TEST_CASE(update_auths) {
 try {
    TESTER chain;
    chain.create_account("alice");
+   chain.create_account("bob");
 
    // Deleting active or owner should fail
    BOOST_CHECK_THROW(chain.delete_authority("alice", "active"), action_validate_exception);
@@ -132,6 +133,11 @@ try {
    auto spending_pub_key = spending_priv_key.get_public_key();
    auto trading_priv_key = chain.get_private_key("alice", "trading");
    auto trading_pub_key = trading_priv_key.get_public_key();
+
+   // Bob attempts to create new spending auth for Alice
+   BOOST_CHECK_THROW( chain.set_authority( "alice", "spending", authority(spending_pub_key), "active",
+                                           { permission_level{"bob", "active"} }, { chain.get_private_key("bob", "active") } ),
+                      transaction_exception );
 
    // Create new spending auth
    chain.set_authority("alice", "spending", authority(spending_pub_key), "active",

--- a/tests/chain_tests/delay_tests.cpp
+++ b/tests/chain_tests/delay_tests.cpp
@@ -1495,8 +1495,7 @@ BOOST_AUTO_TEST_CASE( canceldelay_test ) { try {
    // send canceldelay for first delayed transaction
    signed_transaction trx;
    trx.actions.emplace_back(vector<permission_level>{{N(tester), config::active_name}},
-                            chain::contracts::canceldelay{ids[0]});
-   trx.actions.back().authorization.push_back({N(tester), config::active_name});
+                            chain::contracts::canceldelay{{N(tester), config::active_name}, ids[0]});
 
    chain.set_transaction_headers(trx);
    trx.sign(chain.get_private_key(N(tester), "active"), chain_id_type());
@@ -1515,7 +1514,7 @@ BOOST_AUTO_TEST_CASE( canceldelay_test ) { try {
    liquid_balance = get_currency_balance(chain, N(tester2));
    BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
 
-   // first transfer will finally be performed
+   // update auth will finally be performed
    chain.produce_blocks();
 
    liquid_balance = get_currency_balance(chain, N(tester));
@@ -1561,6 +1560,259 @@ BOOST_AUTO_TEST_CASE( canceldelay_test ) { try {
    BOOST_REQUIRE_EQUAL(asset::from_string("85.0000 CUR"), liquid_balance);
    liquid_balance = get_currency_balance(chain, N(tester2));
    BOOST_REQUIRE_EQUAL(asset::from_string("15.0000 CUR"), liquid_balance);
-} FC_LOG_AND_RETHROW() }/// schedule_test
+} FC_LOG_AND_RETHROW() }
+
+// test canceldelay action under different permission levels
+BOOST_AUTO_TEST_CASE( canceldelay_test2 ) { try {
+   TESTER chain;
+
+   const auto& tester_account = N(tester);
+   std::vector<transaction_id_type> ids;
+   chain.set_code(config::system_account_name, eosio_system_wast);
+   chain.set_abi(config::system_account_name, eosio_system_abi);
+
+   chain.produce_blocks();
+   chain.create_account(N(currency));
+   chain.produce_blocks();
+
+   chain.set_code(N(currency), currency_wast);
+   chain.set_abi(N(currency), currency_abi);
+
+   chain.produce_blocks();
+   chain.create_account(N(tester));
+   chain.create_account(N(tester2));
+   chain.produce_blocks();
+
+   chain.push_action(config::system_account_name, contracts::updateauth::get_name(), tester_account, fc::mutable_variant_object()
+           ("account", "tester")
+           ("permission", "first")
+           ("parent", "active")
+           ("data",  authority(chain.get_public_key(tester_account, "first")))
+           ("delay", 5));
+   chain.push_action(config::system_account_name, contracts::updateauth::get_name(), tester_account, fc::mutable_variant_object()
+          ("account", "tester")
+          ("permission", "second")
+          ("parent", "first")
+          ("data",  authority(chain.get_public_key(tester_account, "second")))
+          ("delay", 0));
+   chain.push_action(config::system_account_name, contracts::linkauth::get_name(), tester_account, fc::mutable_variant_object()
+           ("account", "tester")
+           ("code", "currency")
+           ("type", "transfer")
+           ("requirement", "first"));
+
+   chain.produce_blocks();
+   chain.push_action(N(currency), N(create), N(currency), mutable_variant_object()
+           ("issuer", "currency" )
+           ("maximum_supply", "9000000.0000 CUR" )
+           ("can_freeze", 0)
+           ("can_recall", 0)
+           ("can_whitelist", 0)
+   );
+
+   chain.push_action(N(currency), name("issue"), N(currency), fc::mutable_variant_object()
+           ("to",       "currency")
+           ("quantity", "1000000.0000 CUR")
+           ("memo", "for stuff")
+   );
+
+   auto trace = chain.push_action(N(currency), name("transfer"), N(currency), fc::mutable_variant_object()
+       ("from", "currency")
+       ("to", "tester")
+       ("quantity", "100.0000 CUR")
+       ("memo", "hi" )
+   );
+   BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace.status);
+   BOOST_REQUIRE_EQUAL(0, trace.deferred_transaction_requests.size());
+
+   chain.produce_blocks();
+   auto liquid_balance = get_currency_balance(chain, N(currency));
+   BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, N(tester));
+   BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
+
+   ilog("attempting first delayed transfer");
+
+   {
+      // this transaction will be delayed 10 blocks
+      trace = chain.push_action(N(currency), name("transfer"), vector<permission_level>{{N(tester), N(first)}}, fc::mutable_variant_object()
+          ("from", "tester")
+          ("to", "tester2")
+          ("quantity", "1.0000 CUR")
+          ("memo", "hi" ),
+          30, 5
+      );
+      auto trx_id = trace.id;
+      BOOST_REQUIRE_EQUAL(transaction_receipt::delayed, trace.status);
+      BOOST_REQUIRE_EQUAL(1, trace.deferred_transaction_requests.size());
+      BOOST_REQUIRE_EQUAL(0, trace.action_traces.size());
+
+      const auto sender_id_to_cancel = trace.deferred_transaction_requests[0].get<deferred_transaction>().sender_id;
+
+      chain.produce_blocks();
+
+      liquid_balance = get_currency_balance(chain, N(tester));
+      BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
+      liquid_balance = get_currency_balance(chain, N(tester2));
+      BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
+
+      // attempt canceldelay with wrong canceling_auth for delayed transfer of 1.0000 CUR
+      {
+         signed_transaction trx;
+         trx.actions.emplace_back(vector<permission_level>{{N(tester), config::active_name}},
+                                  chain::contracts::canceldelay{{N(tester), config::active_name}, trx_id});
+         chain.set_transaction_headers(trx);
+         trx.sign(chain.get_private_key(N(tester), "active"), chain_id_type());
+         BOOST_REQUIRE_THROW( chain.push_transaction(trx), transaction_exception );
+      }
+
+      // attempt canceldelay with "second" permission for delayed transfer of 1.0000 CUR
+      {
+         signed_transaction trx;
+         trx.actions.emplace_back(vector<permission_level>{{N(tester), N(second)}},
+                                  chain::contracts::canceldelay{{N(tester), N(first)}, trx_id});
+         chain.set_transaction_headers(trx);
+         trx.sign(chain.get_private_key(N(tester), "second"), chain_id_type());
+         BOOST_REQUIRE_THROW( chain.push_transaction(trx), tx_irrelevant_auth );
+      }
+
+      // canceldelay with "active" permission for delayed transfer of 1.0000 CUR
+      signed_transaction trx;
+      trx.actions.emplace_back(vector<permission_level>{{N(tester), config::active_name}},
+                               chain::contracts::canceldelay{{N(tester), N(first)}, trx_id});
+      chain.set_transaction_headers(trx);
+      trx.sign(chain.get_private_key(N(tester), "active"), chain_id_type());
+      trace = chain.push_transaction(trx);
+
+      BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace.status);
+      BOOST_REQUIRE_EQUAL(1, trace.deferred_transaction_requests.size());
+
+      const auto sender_id_canceled = trace.deferred_transaction_requests[0].get<deferred_reference>().sender_id;
+      BOOST_REQUIRE_EQUAL(std::string(uint128(sender_id_to_cancel)), std::string(uint128(sender_id_canceled)));
+
+      chain.produce_blocks(10);
+
+      liquid_balance = get_currency_balance(chain, N(tester));
+      BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
+      liquid_balance = get_currency_balance(chain, N(tester2));
+      BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
+   }
+
+   ilog("reset minimum permission of transfer to second permission");
+
+   chain.push_action(config::system_account_name, contracts::linkauth::get_name(), tester_account, fc::mutable_variant_object()
+           ("account", "tester")
+           ("code", "currency")
+           ("type", "transfer")
+           ("requirement", "second"),
+           30, 5
+   );
+
+   chain.produce_blocks(10);
+
+
+   ilog("attempting second delayed transfer");
+   {
+      // this transaction will be delayed 10 blocks
+      trace = chain.push_action(N(currency), name("transfer"), vector<permission_level>{{N(tester), N(second)}}, fc::mutable_variant_object()
+          ("from", "tester")
+          ("to", "tester2")
+          ("quantity", "5.0000 CUR")
+          ("memo", "hi" ),
+          30, 5
+      );
+      auto trx_id = trace.id;
+      BOOST_REQUIRE_EQUAL(transaction_receipt::delayed, trace.status);
+      BOOST_REQUIRE_EQUAL(1, trace.deferred_transaction_requests.size());
+      BOOST_REQUIRE_EQUAL(0, trace.action_traces.size());
+
+      const auto sender_id_to_cancel = trace.deferred_transaction_requests[0].get<deferred_transaction>().sender_id;
+
+      chain.produce_blocks();
+
+      liquid_balance = get_currency_balance(chain, N(tester));
+      BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
+      liquid_balance = get_currency_balance(chain, N(tester2));
+      BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
+
+      // canceldelay with "first" permission for delayed transfer of 5.0000 CUR
+      signed_transaction trx;
+      trx.actions.emplace_back(vector<permission_level>{{N(tester), N(first)}},
+                               chain::contracts::canceldelay{{N(tester), N(second)}, trx_id});
+      chain.set_transaction_headers(trx);
+      trx.sign(chain.get_private_key(N(tester), "first"), chain_id_type());
+      trace = chain.push_transaction(trx);
+
+      BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace.status);
+      BOOST_REQUIRE_EQUAL(1, trace.deferred_transaction_requests.size());
+
+      const auto sender_id_canceled = trace.deferred_transaction_requests[0].get<deferred_reference>().sender_id;
+      BOOST_REQUIRE_EQUAL(std::string(uint128(sender_id_to_cancel)), std::string(uint128(sender_id_canceled)));
+
+      chain.produce_blocks(10);
+
+      liquid_balance = get_currency_balance(chain, N(tester));
+      BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
+      liquid_balance = get_currency_balance(chain, N(tester2));
+      BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
+   }
+
+   ilog("attempting third delayed transfer");
+
+   {
+      // this transaction will be delayed 10 blocks
+      trace = chain.push_action(N(currency), name("transfer"), vector<permission_level>{{N(tester), config::owner_name}}, fc::mutable_variant_object()
+          ("from", "tester")
+          ("to", "tester2")
+          ("quantity", "10.0000 CUR")
+          ("memo", "hi" ),
+          30, 5
+      );
+      auto trx_id = trace.id;
+      BOOST_REQUIRE_EQUAL(transaction_receipt::delayed, trace.status);
+      BOOST_REQUIRE_EQUAL(1, trace.deferred_transaction_requests.size());
+      BOOST_REQUIRE_EQUAL(0, trace.action_traces.size());
+
+      const auto sender_id_to_cancel = trace.deferred_transaction_requests[0].get<deferred_transaction>().sender_id;
+
+      chain.produce_blocks();
+
+      liquid_balance = get_currency_balance(chain, N(tester));
+      BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
+      liquid_balance = get_currency_balance(chain, N(tester2));
+      BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
+
+      // attempt canceldelay with "active" permission for delayed transfer of 10.0000 CUR
+      {
+         signed_transaction trx;
+         trx.actions.emplace_back(vector<permission_level>{{N(tester), N(active)}},
+                                  chain::contracts::canceldelay{{N(tester), config::owner_name}, trx_id});
+         chain.set_transaction_headers(trx);
+         trx.sign(chain.get_private_key(N(tester), "active"), chain_id_type());
+         BOOST_REQUIRE_THROW( chain.push_transaction(trx), tx_irrelevant_auth );
+      }
+
+      // canceldelay with "owner" permission for delayed transfer of 10.0000 CUR
+      signed_transaction trx;
+      trx.actions.emplace_back(vector<permission_level>{{N(tester), config::owner_name}},
+                               chain::contracts::canceldelay{{N(tester), config::owner_name}, trx_id});
+      chain.set_transaction_headers(trx);
+      trx.sign(chain.get_private_key(N(tester), "owner"), chain_id_type());
+      trace = chain.push_transaction(trx);
+
+      BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace.status);
+      BOOST_REQUIRE_EQUAL(1, trace.deferred_transaction_requests.size());
+
+      const auto sender_id_canceled = trace.deferred_transaction_requests[0].get<deferred_reference>().sender_id;
+      BOOST_REQUIRE_EQUAL(std::string(uint128(sender_id_to_cancel)), std::string(uint128(sender_id_canceled)));
+
+      chain.produce_blocks(10);
+
+      liquid_balance = get_currency_balance(chain, N(tester));
+      BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
+      liquid_balance = get_currency_balance(chain, N(tester2));
+      BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
+   }
+} FC_LOG_AND_RETHROW() }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This PR fixes #1994, #2437, and #2438. 

It also refactors `check_authorization` to make it a little cleaner and easier to understand.

Outcomes achieved through this PR:
1. When it comes to checking authorizations in actions of a transaction, five of the native actions are treated as special cases compared to the remaining native actions and any of the non-native actions. These five actions are: `eosio::updateauth`, `eosio::deleteauth`, `eosio::linkauth`, `eosio::unlinkauth`, and `eosio::canceldelay`.
2. None of these five actions can have a user-defined minimum permission set for them via `eosio::linkauth` (see #2438).
3. All five of these actions must have exactly one authorization declared.
4. A minimum permission that must be satisfied by that one declared authorization is automatically determined by `check_authorization` based on the contents of these five native actions.
5. The minimum permission for `eosio::updateauth` is the permission that is to be modified (if the permission already exists) or the parent permission of permission to be created. This is the same behavior as before. However, what has changed is that there is no minimum delay imposed due to this action if a new permission is being created.
6. The minimum permission for `eosio::deleteauth` is the permission that is to be deleted. This behavior has been changed in this PR to be consistent with the behavior of `eosio::updateauth` (see #2437).
7. The minimum permission for `eosio::linkauth` and `eosio::unlinkauth` is the current minimum permission (prior to any modifications) for the `code::action` (with `action` optionally allowed to be empty) that is chosen to be linked to / unlinked from a permission.
8. The minimum permission for `eosio::canceldelay` is the explicit `permission_level` (the `canceling_auth` field in the `canceldelay` action) that now needs to be included in the `eosio::canceldelay` action (see #1994). During execution of the `eosio::canceldelay` action, the handler checks that the specified `permission_level` actually exists as an authorization in the delayed transaction to be canceled. Also, no minimum delay is imposed due to this action.