### PR TITLE
fix(contracts): add pragma once to header files

### DIFF
--- a/contracts/eosio.bios/eosio.bios.hpp
+++ b/contracts/eosio.bios/eosio.bios.hpp
@@ -1,3 +1,4 @@
+#pragma once
 #include <eosiolib/eosio.hpp>
 #include <eosiolib/privileged.h>
 #include <eosiolib/producer_schedule.hpp>

--- a/contracts/eosio.token/eosio.token.hpp
+++ b/contracts/eosio.token/eosio.token.hpp
@@ -3,6 +3,8 @@
  *  @copyright defined in eos/LICENSE.txt
  */
 
+#pragma once
+
 #include <eosiolib/eosio.hpp>
 #include <eosiolib/asset.hpp>
 #include <string>
@@ -18,13 +20,13 @@ namespace eosio {
          void create( account_name issuer,
                       asset        maximum_supply,
                       uint8_t      issuer_can_freeze,
-                      uint8_t      issuer_can_recall,  
+                      uint8_t      issuer_can_recall,
                       uint8_t      issuer_can_whitelist );
 
 
          void issue( account_name to, asset quantity, string memo );
 
-         void transfer( account_name from, 
+         void transfer( account_name from,
                         account_name to,
                         asset        quantity,
                         string       memo );
@@ -56,7 +58,7 @@ namespace eosio {
          typedef eosio::multi_index<N(stat), currency_stats> stats;
 
          void sub_balance( account_name owner, asset value, const currency_stats& st );
-         void add_balance( account_name owner, asset value, const currency_stats& st, 
+         void add_balance( account_name owner, asset value, const currency_stats& st,
                            account_name ram_payer );
    };
 

--- a/contracts/eosiolib/currency.hpp
+++ b/contracts/eosiolib/currency.hpp
@@ -1,3 +1,4 @@
+#pragma once
 #include <eosiolib/eosio.hpp>
 #include <eosiolib/asset.hpp>
 #include <eosiolib/multi_index.hpp>


### PR DESCRIPTION
All header files should have `#pragma once` on the top.

Found this when I include a header file twice.