### PR TITLE
Easily setup a dawn3.0 local testnet using docker

### DIFF
--- a/Docker/README.md
+++ b/Docker/README.md
@@ -149,3 +149,21 @@ run `docker pull eosio/eos:latest`
 
 run `docker-compose up`
 
+### Dawn3.0 Testnet
+
+We can easliy set up a dawn3.0 local testnet using docker images. Just run the following commands:
+
+```
+# pull images
+docker pull eosio/eos:dawn3x
+# create volume
+docker volume create --name=nodeos-data-volume
+docker volume create --name=keosd-data-volume
+# start containers
+docker-compose -f docker-compose-dawn3.0.yml up -d
+# get chain info
+curl http://127.0.0.1:8888/v1/chain/get_info
+# get logs
+docker-compose logs nodeosd
+```
+

--- a/Docker/docker-compose-dawn3.0.yaml
+++ b/Docker/docker-compose-dawn3.0.yaml
@@ -1,0 +1,29 @@
+version: "3"
+
+services:
+  nodeosd:
+    image: eosio/eos:dawn3x
+    command: /opt/eosio/bin/nodeosd.sh
+    hostname: nodeosd
+    ports:
+      - 8888:8888
+      - 9876:9876
+    expose:
+      - "8888"
+    volumes:
+      - nodeos-data-volume:/opt/eosio/bin/data-dir
+
+  keosd:
+    image: eosio/eos:dawn3x
+    command: /opt/eosio/bin/keosd
+    hostname: keosd
+    links:
+      - nodeosd
+    volumes:
+      - keosd-data-volume:/opt/eosio/bin/data-dir
+
+volumes:
+ nodeos-data-volume:
+   external: true
+ keosd-data-volume:
+   external: true


### PR DESCRIPTION
1. Add a docker-compose-dawn3.0.yml file to easily setup a local dawn3.0 testnet.
2. Add document in READMD.md for this change.