### PR TITLE
Eosio build lcov

### DIFF
--- a/eosio_build.sh
+++ b/eosio_build.sh
@@ -45,7 +45,7 @@
 	txtrst=$(tput sgr0)
 
 	if [ ! -d .git ]; then
-		printf "\nThis build script only works with sources cloned from git\n"
+		printf "\n\tThis build script only works with sources cloned from git\n"
 		printf "\tPlease clone a new eos directory with 'git clone https://github.com/EOSIO/eos --recursive'\n"
 		printf "\tSee the wiki for instructions: https://github.com/EOSIO/eos/wiki\n"
 		exit 1

--- a/eosio_build.sh
+++ b/eosio_build.sh
@@ -153,10 +153,17 @@
 	COMPILE_EOS=1
 	COMPILE_CONTRACTS=1
 
-# 	export EOS_BUILD_TYPE=[Debug|Release|RelWithDebInfo|MinSizeRel] to enable
+# 	export EOS_BUILD_TYPE=[Debug|Release|RelWithDebInfo|MinSizeRel|CodeCoverage] to enable
 	CMAKE_BUILD_TYPE=Release
+	CODE_COVERAGE_OPTS=
+	export ENABLE_CODE_COVERAGE=false
 	if [ ! -z $EOS_BUILD_TYPE ]; then
-		CMAKE_BUILD_TYPE=$EOS_BUILD_TYPE
+            if [[ $EOS_BUILD_TYPE == "CodeCoverage" ]]; then
+                ENABLE_CODE_COVERAGE=true
+                EOS_BUILD_TYPE=Debug
+            fi
+
+	    CMAKE_BUILD_TYPE=$EOS_BUILD_TYPE
 	fi
 
 	cd ${WORK_DIR}
@@ -170,7 +177,7 @@
 	$CMAKE -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DCMAKE_CXX_COMPILER=${CXX_COMPILER} \
 	-DCMAKE_C_COMPILER=${C_COMPILER} -DWASM_ROOT=${WASM_ROOT} \
 	-DOPENSSL_ROOT_DIR=${OPENSSL_ROOT_DIR} -DBUILD_MONGO_DB_PLUGIN=true \
-	-DBUILD_DOXYGEN=${DOXYGEN} \
+	-DENABLE_COVERAGE_TESTING=${ENABLE_CODE_COVERAGE} -DBUILD_DOXYGEN=${DOXYGEN} \
 	..
 	
 	if [ $? -ne 0 ]; then

--- a/scripts/eosio_build_amazon.sh
+++ b/scripts/eosio_build_amazon.sh
@@ -103,6 +103,32 @@
 		printf "\n\tNo required YUM dependencies to install.\n"
 	fi
 
+	if [[ $ENABLE_CODE_COVERAGE == true ]]; then
+		printf "\n\tChecking LCOV installation.\n"
+		if [ ! -e /usr/local/bin/lcov ]; then
+			printf "\n\tLCOV installation not found.\n"
+			printf "\tInstalling LCOV.\n"
+			cd ${TEMP_DIR}
+			git clone https://github.com/linux-test-project/lcov.git
+			if [ $? -ne 0 ]; then
+				printf "\tUnable to clone LCOV at this time.\n"
+				printf "\tExiting now.\n\n"
+				exit;
+			fi
+			cd lcov
+			sudo make install
+			if [ $? -ne 0 ]; then
+				printf "\tUnable to install LCOV at this time.\n"
+				printf "\tExiting now.\n\n"
+				exit;
+			fi
+			rm -rf ${TEMP_DIR}/lcov
+			printf "\tSuccessfully installed LCOV.\n"
+		else
+			printf "\n\tLCOV installation found @ /usr/local/bin/lcov.\n"
+		fi
+	fi
+	exit
 	printf "\n\tChecking CMAKE installation.\n"
     if [ ! -e ${CMAKE} ]; then
 		printf "\tInstalling CMAKE\n"

--- a/scripts/eosio_build_amazon.sh
+++ b/scripts/eosio_build_amazon.sh
@@ -104,7 +104,19 @@
 	fi
 
 	if [[ $ENABLE_CODE_COVERAGE == true ]]; then
-		printf "\n\tChecking LCOV installation.\n"
+		printf "\n\tChecking perl installation."
+		perl_bin=$( which perl 2>/dev/null )
+		if [ $? -ne 0 ]; then
+			printf "\n\tInstalling perl."
+			yum -y install perl
+			if [ $? -ne 0 ]; then
+				printf "\n\tUnable to install perl at this time.\n"
+				printf "\n\tExiting now.\n"
+			fi
+		else
+			printf "\n\tPerl installation found at ${perl_bin}."
+		fi
+		printf "\n\tChecking LCOV installation."
 		if [ ! -e /usr/local/bin/lcov ]; then
 			printf "\n\tLCOV installation not found.\n"
 			printf "\tInstalling LCOV.\n"
@@ -128,7 +140,7 @@
 			printf "\n\tLCOV installation found @ /usr/local/bin/lcov.\n"
 		fi
 	fi
-	exit
+
 	printf "\n\tChecking CMAKE installation.\n"
     if [ ! -e ${CMAKE} ]; then
 		printf "\tInstalling CMAKE\n"

--- a/scripts/eosio_build_dep
+++ b/scripts/eosio_build_dep
@@ -10,3 +10,4 @@ gettext,-x,/usr/local/opt/gettext/bin/gettext,gettext,https://ftp.gnu.org/pub/gn
 MongoDB,-x,/usr/local/opt/mongodb/bin/mongod,mongodb,https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-3.6.3.tgz
 Doxygen,-x,/usr/local/bin/doxygen,doxygen,http://ftp.stack.nl/pub/users/dimitri/doxygen-1.8.14.src.tar.gz
 Graphviz,-x,/usr/local/bin/dot,graphviz,https://graphviz.gitlab.io/pub/graphviz/stable/SOURCES/graphviz.tar.gz
+LCOV,-f,/usr/local/bin/lcov,lcov,http://downloads.sourceforge.net/ltp/lcov-1.13.tar.gz

--- a/scripts/eosio_build_ubuntu.sh
+++ b/scripts/eosio_build_ubuntu.sh
@@ -59,6 +59,10 @@
 	DISPLAY=""
 	DEP=""
 
+	if [[ $ENABLE_CODE_COVERAGE == true ]]; then
+		DEP_ARRAY+=(lcov)
+	fi
+
 	printf "\n\tChecking for installed dependencies.\n\n"
 
 	for (( i=0; i<${#DEP_ARRAY[@]}; i++ ));


### PR DESCRIPTION
Added installation of lcov (& perl if needed) to Amazon, Ubuntu and Darwin.
Set env var export ENABLE_CODE_COVERAGE=true to enable html debugging.
I add this to Centos and Fedora in my next PR, but I wanted to get this PR in so Ciju
and company can start using it.