### PR TITLE
Cleanup of multi_index and a more robust implementation of begin() within multi_index

### DIFF
--- a/contracts/eosiolib/fixed_key.hpp
+++ b/contracts/eosiolib/fixed_key.hpp
@@ -83,7 +83,7 @@ namespace eosio {
          *
          * @details Default constructor to fixed_key object which initializes all bytes to zero
          */
-         fixed_key() : _data() {}
+         constexpr fixed_key() : _data() {}
 
          /**
          * @brief Constructor to fixed_key object from std::array of num_words() words

--- a/contracts/eosiolib/multi_index.hpp
+++ b/contracts/eosiolib/multi_index.hpp
@@ -79,7 +79,7 @@ struct secondary_index_db_functions<TYPE> {\
    static int32_t db_idx_upperbound( uint64_t code, uint64_t scope, uint64_t table, TYPE& secondary, uint64_t& primary ) {\
       return db_##IDX##_upperbound( code, scope, table, secondary.data(), TYPE::num_words(), &primary );\
    }\
-};\
+};
 
 #define MAKE_TRAITS_FOR_ARITHMETIC_SECONDARY_KEY(TYPE)\
 template<>\
@@ -111,6 +111,7 @@ namespace _multi_index_detail {
    struct secondary_key_traits<key256> {
       static key256 lowest() { return key256(); }
    };
+
 }
 
 template<uint64_t IndexName, typename Extractor>
@@ -314,6 +315,7 @@ class multi_index
                return get( secondary );
             }
 
+            // Gets the object with the smallest primary key in the case where the secondary key is not unique.
             const T& get( const secondary_key_type& secondary )const {
                auto result = find( secondary );
                eosio_assert( result != cend(), "unable to find secondary key" );

--- a/contracts/eosiolib/multi_index.hpp
+++ b/contracts/eosiolib/multi_index.hpp
@@ -297,6 +297,10 @@ class multi_index
             const_reverse_iterator rend()const    { return crend(); }
 
             const_iterator find( secondary_key_type&& secondary )const {
+               return find( secondary );
+            }
+
+            const_iterator find( const secondary_key_type& secondary )const {
                auto lb = lower_bound( secondary );
                auto e = cend();
                if( lb == e ) return e;
@@ -304,6 +308,16 @@ class multi_index
                if( secondary != secondary_extractor_type()(*lb) )
                   return e;
                return lb;
+            }
+
+            const T& get( secondary_key_type&& secondary )const {
+               return get( secondary );
+            }
+
+            const T& get( const secondary_key_type& secondary )const {
+               auto result = find( secondary );
+               eosio_assert( result != cend(), "unable to find secondary key" );
+               return *result;
             }
 
             const_iterator lower_bound( secondary_key_type&& secondary )const {
@@ -598,7 +612,7 @@ class multi_index
       template<uint64_t IndexName>
       auto get_index()const {
          using namespace _multi_index_detail;
-         
+
          auto res = hana::find_if( _indices, []( auto&& in ) {
             return std::integral_constant<bool, std::decay<typename decltype(+hana::at_c<1>(in))::type>::type::index_name == IndexName>();
          });
@@ -724,7 +738,7 @@ class multi_index
 
       const T& get( uint64_t primary )const {
          auto result = find( primary );
-         eosio_assert( result != end(), "unable to find key" );
+         eosio_assert( result != cend(), "unable to find key" );
          return *result;
       }
 

--- a/contracts/eosiolib/multi_index.hpp
+++ b/contracts/eosiolib/multi_index.hpp
@@ -84,7 +84,7 @@ struct secondary_index_db_functions<TYPE> {\
 #define MAKE_TRAITS_FOR_ARITHMETIC_SECONDARY_KEY(TYPE)\
 template<>\
 struct secondary_key_traits<TYPE> {\
-   static TYPE lowest() { return std::numeric_limits<TYPE>::lowest(); }\
+   static constexpr  TYPE lowest() { return std::numeric_limits<TYPE>::lowest(); }\
 };
 
 namespace _multi_index_detail {
@@ -109,7 +109,7 @@ namespace _multi_index_detail {
    WRAP_SECONDARY_ARRAY_TYPE(idx256, key256)
    template<>
    struct secondary_key_traits<key256> {
-      static key256 lowest() { return key256(); }
+      static constexpr key256 lowest() { return key256(); }
    };
 
 }

--- a/contracts/eosiolib/print.hpp
+++ b/contracts/eosiolib/print.hpp
@@ -1,4 +1,4 @@
-/** 
+/**
  *  @file
  *  @copyright defined in eos/LICENSE.txt
  */
@@ -96,6 +96,11 @@ namespace eosio {
       auto arr = val.extract_as_byte_array();
       prints("0x");
       printhex(static_cast<const void*>(arr.data()), arr.size());
+   }
+
+   template<size_t Size>
+   inline void print( fixed_key<Size>& val ) {
+      print(static_cast<const fixed_key<Size>&>(val));
    }
 
    /**

--- a/contracts/test_api_multi_index/test_multi_index.cpp
+++ b/contracts/test_api_multi_index/test_multi_index.cpp
@@ -462,11 +462,6 @@ void test_multi_index::idx256_general(uint64_t receiver, uint64_t code, uint64_t
 
    auto e = table.find( 2 );
 
-   key256 default_key256;
-   print("key256() = ", default_key256, "\n");
-   auto lowest =  std::numeric_limits<key256>::lowest();
-   print("numeric_limits<key256>::lowest() = ", lowest, "\n");
-
    print("Items sorted by primary key:\n");
    for( const auto& item : table ) {
       print(" ID=", item.primary_key(), ", secondary=", item.sec, "\n");
@@ -517,6 +512,7 @@ void test_multi_index::idx256_general(uint64_t receiver, uint64_t code, uint64_t
 
    print("First entry with a secondary key greater than 42 has ID=", upper->id, ".\n");
    eosio_assert( upper->id == 2, "idx256_general - upper_bound" );
+   eosio_assert( upper->id == secidx.get(onetwothreefour).id, "idx256_general - secondary index get" );
 
    print("Removed entry with ID=", lower1->id, ".\n");
    secidx.erase( lower1 );

--- a/contracts/test_api_multi_index/test_multi_index.cpp
+++ b/contracts/test_api_multi_index/test_multi_index.cpp
@@ -462,6 +462,11 @@ void test_multi_index::idx256_general(uint64_t receiver, uint64_t code, uint64_t
 
    auto e = table.find( 2 );
 
+   key256 default_key256;
+   print("key256() = ", default_key256, "\n");
+   auto lowest =  std::numeric_limits<key256>::lowest();
+   print("numeric_limits<key256>::lowest() = ", lowest, "\n");
+
    print("Items sorted by primary key:\n");
    for( const auto& item : table ) {
       print(" ID=", item.primary_key(), ", secondary=", item.sec, "\n");
@@ -769,4 +774,3 @@ void test_multi_index::idx64_pk_cache_sk_lookup(uint64_t receiver, uint64_t code
 }
 
 #pragma GCC diagnostic pop
-


### PR DESCRIPTION
Changes include in this PR:
* `multi_index` now uses a more robust way of getting the lowest value of a secondary key (according to the sorting order of the corresponding secondary index) which is needed in the implementations of the `begin()` member functions. See [this comment](https://github.com/EOSIO/eos/issues/2461#issuecomment-382562816) in #2461 for more detail.
* Added a `get` member function in the `index` class within `multi_index` to be consistent with the `get` lookup function available for the primary index.
* Made `find` and `get` member functions in the `index` class within `multi_index` consistent with the other lookup functions (`lower_bound` and `upper_bound`) with regards to accepting const references to the secondary key type.
* Cleanup of multi_index.hpp to not pollute the eosio namespace with classes needed only for the implementation of `multi_index`.