### PR TITLE
add --data-dir in the docker-compose file to easily find wallet and blocks in the mount dir

### DIFF
--- a/Docker/README.md
+++ b/Docker/README.md
@@ -167,3 +167,4 @@ curl http://127.0.0.1:8888/v1/chain/get_info
 docker-compose logs nodeosd
 ```
 
+The `blocks` data are stored under `--data-dir` by default, and the wallet files are stored under `--wallet-dir` by default, of course you can change these as you want.

--- a/Docker/docker-compose-dawn3.0.yaml
+++ b/Docker/docker-compose-dawn3.0.yaml
@@ -3,7 +3,7 @@ version: "3"
 services:
   nodeosd:
     image: eosio/eos:dawn3x
-    command: /opt/eosio/bin/nodeosd.sh
+    command: /opt/eosio/bin/nodeosd.sh --data-dir /opt/eosio/bin/data-dir
     hostname: nodeosd
     ports:
       - 8888:8888

--- a/Docker/docker-compose-dawn3.0.yaml
+++ b/Docker/docker-compose-dawn3.0.yaml
@@ -15,7 +15,7 @@ services:
 
   keosd:
     image: eosio/eos:dawn3x
-    command: /opt/eosio/bin/keosd
+    command: /opt/eosio/bin/keosd --wallet-dir /opt/eosio/bin/data-dir
     hostname: keosd
     links:
       - nodeosd

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     build:
       context: .
     image: eosio/eos
-    command: /opt/eosio/bin/nodeosd.sh
+    command: /opt/eosio/bin/nodeosd.sh --data-dir /opt/eosio/bin/data-dir
     hostname: nodeosd
     ports:
       - 8888:8888

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -22,7 +22,7 @@ services:
 
   keosd:
     image: eosio/eos
-    command: /opt/eosio/bin/keosd
+    command: /opt/eosio/bin/keosd --wallet-dir /opt/eosio/bin/data-dir
     hostname: keosd
     links:
       - nodeosd


### PR DESCRIPTION
Related about [#2495](https://github.com/EOSIO/eos/issues/2495)
Add --data-dir in the docker-compose file to easily find wallet and blocks in the mount dir