### PR TITLE
Kill asserts in tests

### DIFF
--- a/contracts/test_api_mem/test_api_mem.cpp
+++ b/contracts/test_api_mem/test_api_mem.cpp
@@ -9,7 +9,7 @@
 #include "test_memory.cpp"
 
 extern "C" {
-   void apply( uint64_t receiver, uint64_t code, uint64_t action ) {
+   void apply( uint64_t /*receiver*/, uint64_t code, uint64_t action ) {
       require_auth(code);
 
       //test_extended_memory

--- a/contracts/test_api_mem/test_memory.cpp
+++ b/contracts/test_api_mem/test_memory.cpp
@@ -344,6 +344,7 @@ template <typename T>
 void test_memory_load() {
     T *ptr = (T *)(8192 * 1024 - 1);
     volatile T tmp = ptr[0];
+    (void)tmp;
 }
 
 void test_memory::test_outofbound_4()
@@ -391,4 +392,5 @@ void test_memory::test_outofbound_13()
     volatile unsigned int a = 0xffffffff;
     double *ptr = (double *)a; // load with memory wrap
     volatile double tmp = ptr[0];
+    (void)tmp;
 }

--- a/contracts/tic_tac_toe/tic_tac_toe.cpp
+++ b/contracts/tic_tac_toe/tic_tac_toe.cpp
@@ -19,8 +19,8 @@ struct impl {
    /**
     * @brief Check for valid movement
     * @detail Movement is considered valid if it is inside the board and done on empty cell
-    * @param movement - the movement made by the player
-    * @param game - the game on which the movement is being made
+    * @param mvt - the movement made by the player
+    * @param game_for_movement - the game on which the movement is being made
     * @return true if movement is valid
     */
    bool is_valid_movement(const movement& mvt, const game& game_for_movement) {
@@ -33,7 +33,7 @@ struct impl {
    /**
     * @brief Get winner of the game
     * @detail Winner of the game is the first player who made three consecutive aligned movement
-    * @param game - the game which we want to determine the winner of
+    * @param current_game - the game which we want to determine the winner of
     * @return winner of the game (can be either none/ draw/ account name of host/ account name of challenger)
     */
    account_name get_winner(const game& current_game) {
@@ -86,7 +86,7 @@ struct impl {
 
    /**
     * @brief Apply create action
-    * @param create - action to be applied
+    * @param c - action to be applied
     */
    void on(const create& c) {
       require_auth(c.host);
@@ -106,7 +106,7 @@ struct impl {
 
    /**
     * @brief Apply restart action
-    * @param restart - action to be applied
+    * @param r - action to be applied
     */
    void on(const restart& r) {
       require_auth(r.by);
@@ -127,7 +127,7 @@ struct impl {
 
    /**
     * @brief Apply close action
-    * @param close - action to be applied
+    * @param c - action to be applied
     */
    void on(const close& c) {
       require_auth(c.host);
@@ -143,7 +143,7 @@ struct impl {
 
    /**
     * @brief Apply move action
-    * @param move - action to be applied
+    * @param m - action to be applied
     */
    void on(const move& m) {
       require_auth(m.by);
@@ -165,7 +165,7 @@ struct impl {
       eosio_assert(is_valid_movement(m.mvt, *itr), "not a valid movement!");
 
       // Fill the cell, 1 for host, 2 for challenger
-      const auto cell_value = itr->turn == itr->host ? 1 : 2;
+      const uint8_t cell_value = itr->turn == itr->host ? 1 : 2;
       const auto turn = itr->turn == itr->host ? itr->challenger : itr->host;
       existing_host_games.modify(itr, itr->host, [&]( auto& g ) {
          g.board[m.mvt.row * 3 + m.mvt.column] = cell_value;
@@ -177,7 +177,7 @@ struct impl {
    }
 
    /// The apply method implements the dispatch of events to this contract
-   void apply( uint64_t receiver, uint64_t code, uint64_t action ) {
+   void apply( uint64_t /*receiver*/, uint64_t code, uint64_t action ) {
 
       if (code == code_account) {
          if (action == N(create)) {

--- a/contracts/tic_tac_toe/tic_tac_toe.hpp
+++ b/contracts/tic_tac_toe/tic_tac_toe.hpp
@@ -10,7 +10,6 @@
  *  @ingroup examplecontract
  *  
  *  @details
- *
  *  For the following tic-tac-toe game:
  *  - Each pair of player can have 2 unique game, one where player_1 become host and player_2 become challenger and vice versa
  *  - The game data is stored in the "host" scope and use the "challenger" as the key
@@ -53,7 +52,8 @@ namespace tic_tac_toe {
    static const uint32_t board_len = 9;
    struct game {
       game() { initialize_board(); }
-      game(account_name challenger, account_name host):challenger(challenger), host(host), turn(host) {
+      game(account_name challenger_account, account_name host_account)
+            : challenger(challenger_account), host(host_account), turn(host_account) {
          // Initialize board
          initialize_board();
       }

--- a/tests/chain_tests/block_tests.cpp
+++ b/tests/chain_tests/block_tests.cpp
@@ -1170,11 +1170,11 @@ BOOST_AUTO_TEST_CASE(account_ram_limit) { try {
 
    transaction_trace trace = chain.create_account(N(acc2), acc1);
    chain.produce_block();
-   BOOST_ASSERT(trace.status == transaction_trace::executed);
+   BOOST_REQUIRE_EQUAL(trace.status, transaction_trace::executed);
 
    trace = chain.create_account(N(acc3), acc1);
    chain.produce_block();
-   BOOST_ASSERT(trace.status == transaction_trace::executed);
+      BOOST_REQUIRE_EQUAL(trace.status, transaction_trace::executed);
    
    BOOST_REQUIRE_EXCEPTION(
       chain.create_account(N(acc4), acc1), 

--- a/tests/chain_tests/block_tests.cpp
+++ b/tests/chain_tests/block_tests.cpp
@@ -1174,7 +1174,7 @@ BOOST_AUTO_TEST_CASE(account_ram_limit) { try {
 
    trace = chain.create_account(N(acc3), acc1);
    chain.produce_block();
-      BOOST_REQUIRE_EQUAL(trace.status, transaction_trace::executed);
+   BOOST_REQUIRE_EQUAL(trace.status, transaction_trace::executed);
    
    BOOST_REQUIRE_EXCEPTION(
       chain.create_account(N(acc4), acc1), 

--- a/tests/wasm_tests/wasm_tests.cpp
+++ b/tests/wasm_tests/wasm_tests.cpp
@@ -573,7 +573,7 @@ BOOST_FIXTURE_TEST_CASE(weighted_cpu_limit_tests, tester ) try {
          pass = true;
          count++;
       } catch (eosio::chain::tx_resource_exhausted &) {
-         BOOST_ASSERT(count == 10);
+         BOOST_REQUIRE_EQUAL(count, 3);
          break;
       } 
       BOOST_REQUIRE_EQUAL(true, validate());
@@ -582,7 +582,7 @@ BOOST_FIXTURE_TEST_CASE(weighted_cpu_limit_tests, tester ) try {
         mgr.set_account_limits(N(acc2), -1, -1, 1000);
       }
    }
-   BOOST_ASSERT(count == 2);
+   BOOST_REQUIRE_EQUAL(count, 3);
 } FC_LOG_AND_RETHROW()
 
 /**


### PR DESCRIPTION
`BOOST_ASSERT(expr)` is defined as `assert(expr)` which is compiled out in debug builds. Switched from `BOOST_ASSERT` to `BOOST_REQUIRE_EQUAL` and fixed broken test.
Also fixed a few misc warnings.