### PR TITLE
Add code insight for contracts to Clion via EXCLUDE_FROM_ALL target.

### DIFF
--- a/CMakeModules/wasm.cmake
+++ b/CMakeModules/wasm.cmake
@@ -190,6 +190,14 @@ macro(add_wast_executable)
 
   set(extra_target_dependency)
 
+  # For CLion code insight
+  include_directories(..)
+  if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${target}.hpp)
+    set(HEADER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${target}.hpp)
+  endif()
+  file(GLOB HEADER_FILES ${ARG_INCLUDE_FOLDERS}/*.hpp ${SYSTEM_INCLUDE_FOLDERS}/*.hpp)
+  add_executable(${target}.tmp EXCLUDE_FROM_ALL ${SOURCE_FILES} ${HEADER_FILE} ${HEADER_FILES})
+
   add_test(NAME "validate_${target}_abi"
            COMMAND ${CMAKE_BINARY_DIR}/scripts/abi_is_json.py ${ABI_FILES})
 


### PR DESCRIPTION
This appears to work for adding code insight to CLion. However, I'm no cmake expert.