### PR TITLE
Include bios node logs among nodes error details.

### DIFF
--- a/tests/testUtils.py
+++ b/tests/testUtils.py
@@ -1884,6 +1884,9 @@ class Cluster(object):
             shutil.copyfileobj(f, sys.stdout)
 
     def dumpErrorDetails(self):
+        self.dumpErrorDetailImpl("etc/eosio/node_bios/config.ini")
+        self.dumpErrorDetailImpl("var/lib/node_bios/stderr.txt")
+
         for i in range(0, len(self.nodes)):
             fileName="etc/eosio/node_%02d/config.ini" % (i)
             self.dumpErrorDetailImpl(fileName)

--- a/tests/testUtils.py
+++ b/tests/testUtils.py
@@ -1880,12 +1880,17 @@ class Cluster(object):
     def dumpErrorDetailImpl(self,fileName):
         Utils.Print("=================================================================")
         Utils.Print("Contents of %s:" % (fileName))
-        with open(fileName, "r") as f:
-            shutil.copyfileobj(f, sys.stdout)
+        if os.path.exists(fileName):
+            with open(fileName, "r") as f:
+                shutil.copyfileobj(f, sys.stdout)
+        else:
+            Utils.Print("File %s not found." % (fileName))
 
     def dumpErrorDetails(self):
-        self.dumpErrorDetailImpl("etc/eosio/node_bios/config.ini")
-        self.dumpErrorDetailImpl("var/lib/node_bios/stderr.txt")
+        fileName="etc/eosio/node_bios/config.ini"
+        self.dumpErrorDetailImpl(fileName)
+        fileName="var/lib/node_bios/stderr.txt"
+        self.dumpErrorDetailImpl(fileName)
 
         for i in range(0, len(self.nodes)):
             fileName="etc/eosio/node_%02d/config.ini" % (i)


### PR DESCRIPTION
This info is required for debugging errors in Jenkins builds.