### PR TITLE
p2p explicit notify/request feature - issue #2475

### DIFF
--- a/libraries/chain/include/eosio/chain/config.hpp
+++ b/libraries/chain/include/eosio/chain/config.hpp
@@ -15,7 +15,7 @@ typedef __uint128_t uint128_t;
 
 const static auto default_block_log_dir     = "block_log";
 const static auto default_shared_memory_dir = "shared_mem";
-const static auto default_shared_memory_size = 1024*1024*1024ll;
+const static auto default_shared_memory_size = 32*1024*1024*1024ll;
 
 const static uint64_t system_account_name    = N(eosio);
 const static uint64_t nobody_account_name    = N(nobody);

--- a/plugins/net_plugin/include/eosio/net_plugin/protocol.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/protocol.hpp
@@ -15,7 +15,7 @@ namespace eosio {
    typedef std::chrono::system_clock::duration::rep tstamp;
 
    struct handshake_message {
-      int16_t                    network_version = 0; ///< derived from git commit hash, not sequential
+      int16_t                    network_version = 0; ///< incremental value above a computed base
       chain_id_type              chain_id; ///< used to identify chain
       fc::sha256                 node_id; ///< used to identify peers and prevent self-connect
       chain::public_key_type     key; ///< authentication key; may be a producer or peer key, or empty

--- a/plugins/net_plugin/include/eosio/net_plugin/protocol.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/protocol.hpp
@@ -15,7 +15,7 @@ namespace eosio {
    typedef std::chrono::system_clock::duration::rep tstamp;
 
    struct handshake_message {
-      int16_t                    network_version = 0; ///< incremental value above a computed base
+      uint16_t                   network_version = 0; ///< incremental value above a computed base
       chain_id_type              chain_id; ///< used to identify chain
       fc::sha256                 node_id; ///< used to identify peers and prevent self-connect
       chain::public_key_type     key; ///< authentication key; may be a producer or peer key, or empty

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -269,7 +269,7 @@ namespace eosio {
        */
       chain::signature_type sign_compact(const chain::public_key_type& signer, const fc::sha256& digest) const;
 
-      int16_t to_protocol_version(int16_t v);
+      uint16_t to_protocol_version(uint16_t v);
    };
 
    const fc::string logger_name("net_plugin_impl");
@@ -305,21 +305,21 @@ namespace eosio {
     *  between ajacent commit id values is shown below.
     *  these numbers were found with the following commands on the master branch:
     *
-    *  git log | grep "^commit" | awk '{print substr($2,4,4)}' | sort -u > sorted.txt
+    *  git log | grep "^commit" | awk '{print substr($2,5,4)}' | sort -u > sorted.txt
     *  rm -f gap.txt; prev=0; for a in $(cat sorted.txt); do echo $prev $((0x$a - 0x$prev)) $a >> gap.txt; prev=$a; done; sort -k2 -n gap.txt | tail
     *
     *  DO NOT EDIT net_version_base OR net_version_range!
     */
-   constexpr int16_t net_version_base = 0xb1d4;
-   constexpr int16_t net_version_range = 133;
+   constexpr uint16_t net_version_base = 0x04b5;
+   constexpr uint16_t net_version_range = 106;
    /**
     *  If there is a change to network protocol or behavior, increment net version to identify
     *  the need for compatibility hooks
     */
-   constexpr int16_t proto_base = 0;
-   constexpr int16_t proto_explicit_sync = 1;
+   constexpr uint16_t proto_base = 0;
+   constexpr uint16_t proto_explicit_sync = 1;
 
-   constexpr int16_t net_version = proto_explicit_sync;
+   constexpr uint16_t net_version = proto_explicit_sync;
 
    /**
     *  Index by id
@@ -449,7 +449,7 @@ namespace eosio {
       int16_t                 sent_handshake_count;
       bool                    connecting;
       bool                    syncing;
-      int16_t                 protocol_version;
+      uint16_t                protocol_version;
       int                     write_depth;
       string                  peer_addr;
       unique_ptr<boost::asio::steady_timer> response_expected;
@@ -2984,7 +2984,7 @@ namespace eosio {
       return connection_ptr();
    }
 
-   int16_t net_plugin_impl::to_protocol_version (int16_t v) {
+   uint16_t net_plugin_impl::to_protocol_version (uint16_t v) {
       if (v >= net_version_base) {
          v -= net_version_base;
          return (v > net_version_range) ? 0 : v;

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -177,14 +177,12 @@ namespace eosio {
 
       const std::chrono::system_clock::duration peer_authentication_interval{std::chrono::seconds{1}}; ///< Peer clock may be no more than 1 second skewed from our clock, including network latency.
 
-      int16_t                       network_version = 0;
       bool                          network_version_match = false;
       chain_id_type                 chain_id;
       fc::sha256                    node_id;
 
       string                        user_agent_name;
       chain_plugin*                 chain_plug;
-      bool                          send_whole_blocks = false;
       int                           started_sessions = 0;
 
       node_transaction_index        local_txns;
@@ -271,7 +269,7 @@ namespace eosio {
        */
       chain::signature_type sign_compact(const chain::public_key_type& signer, const fc::sha256& digest) const;
 
-      int16_t to_net_version(int16_t v);
+      int16_t to_protocol_version(int16_t v);
    };
 
    const fc::string logger_name("net_plugin_impl");
@@ -296,8 +294,7 @@ namespace eosio {
    constexpr auto     def_txn_expire_wait = std::chrono::seconds(3);
    constexpr auto     def_resp_expected_wait = std::chrono::seconds(5);
    constexpr auto     def_sync_fetch_span = 100;
-   constexpr uint32_t    def_max_just_send = 0xFFFFFFFF; //1500; // "mtu" * 1
-   constexpr auto     def_send_whole_blocks = true;
+   constexpr uint32_t  def_max_just_send = 1500; // roughly 1 "mtu"
 
    constexpr auto     message_header_size = 4;
 
@@ -319,7 +316,10 @@ namespace eosio {
     *  If there is a change to network protocol or behavior, increment net version to identify
     *  the need for compatibility hooks
     */
-   constexpr int16_t net_version = 1;
+   constexpr int16_t proto_base = 0;
+   constexpr int16_t proto_explicit_sync = 1;
+
+   constexpr int16_t net_version = proto_explicit_sync;
 
    /**
     *  Index by id
@@ -449,7 +449,7 @@ namespace eosio {
       int16_t                 sent_handshake_count;
       bool                    connecting;
       bool                    syncing;
-      bool                    backwards_compatibility;
+      int16_t                 protocol_version;
       int                     write_depth;
       string                  peer_addr;
       unique_ptr<boost::asio::steady_timer> response_expected;
@@ -457,6 +457,7 @@ namespace eosio {
       go_away_reason         no_retry;
       block_id_type          fork_head;
       uint32_t               fork_head_num;
+      optional<request_message> last_req;
 
       connection_status get_status()const {
          connection_status stat;
@@ -622,7 +623,7 @@ namespace eosio {
                               const packed_transaction& msg);
       void rejected_transaction (const packed_transaction& msg);
       void recv_block (connection_ptr conn, const signed_block_summary& msg);
-      void recv_transaction(connection_ptr c);
+      void recv_transaction(connection_ptr c, const transaction_id_type& id);
       void recv_notice (connection_ptr conn, const notice_message& msg, bool generated);
 
       void retry_fetch (connection_ptr conn);
@@ -641,14 +642,15 @@ namespace eosio {
         sent_handshake_count(0),
         connecting(false),
         syncing(false),
-        backwards_compatibility(false),
+        protocol_version(0),
         write_depth(0),
         peer_addr(endpoint),
         response_expected(),
         pending_fetch(),
         no_retry(no_reason),
         fork_head(),
-        fork_head_num()
+        fork_head_num(0),
+        last_req()
    {
       wlog( "created connection to ${n}", ("n", endpoint) );
       initialize();
@@ -665,14 +667,15 @@ namespace eosio {
         sent_handshake_count(0),
         connecting(true),
         syncing(false),
-        backwards_compatibility(false),
+        protocol_version(0),
         write_depth(0),
         peer_addr(),
         response_expected(),
         pending_fetch(),
         no_retry(no_reason),
         fork_head(),
-        fork_head_num(0)
+        fork_head_num(0),
+        last_req()
    {
       wlog( "accepted network connection" );
       initialize();
@@ -725,6 +728,9 @@ namespace eosio {
       flush_queues();
       connecting = false;
       syncing = false;
+      if( last_req ) {
+         my_impl->big_msg_master->retry_fetch (shared_from_this());
+      }
       reset();
       sent_handshake_count = 0;
       last_handshake_recv = handshake_message();
@@ -838,8 +844,16 @@ namespace eosio {
          try {
             optional<signed_block> b = cc.fetch_block_by_id(blkid);
             if(b) {
-               fc_dlog(logger,"found block for id at num ${n}",("n",b->block_num()));
-               enqueue(*b);
+               uint32_t bnum = b->block_num();
+               bool send_whole = bnum <= cc.last_irreversible_block_num();
+               fc_dlog(logger,"found block for id at num ${n}",("n",bnum));
+               if (send_whole) {
+                  enqueue(net_message(*b));
+               }
+               else {
+                  signed_block_summary &sbs = *b;
+                  enqueue(net_message(sbs));
+               }
             }
             else {
                ilog("fetch block by id returned null, id ${id} on block ${c} of ${s} for ${p}",
@@ -1350,14 +1364,14 @@ namespace eosio {
       if (head < peer_lib) {
          fc_dlog(logger, "sync check state 1");
          // wait for receipt of a notice message before initiating sync
-         if (c->backwards_compatibility) {
+         if (c->protocol_version < proto_explicit_sync) {
             start_sync( c, peer_lib);
          }
          return;
       }
       if (lib_num > msg.head_num ) {
          fc_dlog(logger, "sync check state 2");
-         if (msg.generation > 1 || !c->backwards_compatibility) {
+         if (msg.generation > 1 || c->protocol_version > proto_base) {
             notice_message note;
             note.known_trx.pending = lib_num;
             note.known_trx.mode = last_irr_catch_up;
@@ -1376,7 +1390,7 @@ namespace eosio {
       }
       else {
          fc_dlog(logger, "sync check state 4");
-         if (msg.generation > 1 || !c->backwards_compatibility) {
+         if (msg.generation > 1 ||  c->protocol_version > proto_base) {
             notice_message note;
             note.known_trx.mode = none;
             note.known_blocks.mode = catch_up;
@@ -1502,7 +1516,8 @@ namespace eosio {
       pending_notify.known_blocks.mode = normal;
       pending_notify.known_blocks.ids.push_back( bid );
       pending_notify.known_trx.mode = none;
-      if (msgsiz > just_send_it_max) {
+      // skip will be empty if our producer emitted this block so just send it
+      if (msgsiz > just_send_it_max && skip) {
          fc_ilog(logger, "block size is ${ms}, sending notify",("ms", msgsiz));
          my_impl->send_all(pending_notify, [skip, bid, bnum](connection_ptr c) -> bool {
                if (c == skip || !c->current())
@@ -1615,22 +1630,30 @@ namespace eosio {
    void big_msg_manager::recv_block (connection_ptr c, const signed_block_summary& msg) {
       block_id_type blk_id = msg.id();
       uint32_t num = msg.block_num();
+      const auto& blkstate = c->blk_state.get<by_id>().find(blk_id);
+      if (blkstate != c->blk_state.end()) {
+         c->blk_state.modify(blkstate, set_is_known);
+      }
+      if (c->last_req &&
+          c->last_req->req_blocks.mode != none &&
+          c->last_req->req_blocks.ids.back() == blk_id) {
+         c->last_req.reset();
+      }
       for (auto ref = req_blks.begin(); ref != req_blks.end(); ++ref) {
-         if (ref->id != blk_id)
-            continue;
-         bool is_retry = ref->local_retry;
-         req_blks.erase(ref);
-         fc_dlog(logger, "received a requested block");
+         if (ref->id == blk_id) {
+            bool is_retry = ref->local_retry;
+            req_blks.erase(ref);
+            fc_dlog(logger, "received a requested block");
 
-         if (is_retry) {
-            bcast_block(msg);
-         }
-         else {
-            notice_message note;
-            note.known_blocks.mode = normal;
-            note.known_blocks.ids.push_back( blk_id );
-            note.known_trx.mode = none;
-            my_impl->send_all(note, [blk_id, num](connection_ptr conn) -> bool {
+            if (is_retry) {
+               bcast_block(msg);
+            }
+            else {
+               notice_message note;
+               note.known_blocks.mode = normal;
+               note.known_blocks.ids.push_back( blk_id );
+               note.known_trx.mode = none;
+               my_impl->send_all(note, [blk_id, num](connection_ptr conn) -> bool {
                   const auto& bs = conn->blk_state.find(blk_id);
                   bool unknown = bs == conn->blk_state.end();
                   if (unknown) {
@@ -1638,6 +1661,7 @@ namespace eosio {
                   }
                   return unknown;
                });
+            }
             return;
          }
       }
@@ -1652,7 +1676,7 @@ namespace eosio {
                   if( c != conn && !conn->syncing ) {
                      auto b = conn->blk_state.get<by_id>().find(blk_id);
                      if(b == conn->blk_state.end()) {
-                        conn->blk_state.insert( (block_state){blk_id,num,true,true,fc::time_point()});
+                        conn->blk_state.insert({blk_id,num,true,true,fc::time_point()});
                         sendit = true;
                      } else if (!b->is_known) {
                         conn->blk_state.modify(b,set_is_known);
@@ -1686,8 +1710,15 @@ namespace eosio {
       }
    }
 
-   void big_msg_manager::recv_transaction (connection_ptr c) {
+   void big_msg_manager::recv_transaction (connection_ptr c, const transaction_id_type& tid) {
       pending_txn_source = c;
+      if (c &&
+          c->last_req &&
+          c->last_req->req_trx.mode != none &&
+          c->last_req->req_trx.ids.back() == tid) {
+         c->last_req.reset();
+      }
+
       fc_dlog(logger, "canceling wait on ${p}", ("p",c->peer_name()));
       c->cancel_wait();
    }
@@ -1751,11 +1782,56 @@ namespace eosio {
       if( send_req) {
          c->enqueue(req);
          c->fetch_wait();
+         c->last_req = std::move(req);
       }
-
    }
 
    void big_msg_manager::retry_fetch( connection_ptr c ) {
+      if (!c->last_req) {
+         return;
+      }
+      fc_wlog( logger, "failed to fetch from ${p}",("p",c->peer_name()));
+      transaction_id_type tid;
+      block_id_type bid;
+      bool is_txn = false;
+      if( c->last_req->req_trx.mode == normal ) {
+         is_txn = true;
+         tid = c->last_req->req_trx.ids.back();
+      }
+      else if( c->last_req->req_blocks.mode == normal ) {
+         bid = c->last_req->req_blocks.ids.back();
+      }
+      else {
+         fc_wlog( logger,"no retry, block mpde = ${b} trx mode = ${t}",
+                  ("b",modes_str(c->last_req->req_blocks.mode))("t",modes_str(c->last_req->req_trx.mode)));
+         return;
+      }
+      for (auto conn : my_impl->connections) {
+         if (conn == c || conn->last_req) {
+            continue;
+         }
+         bool sendit = false;
+         if (is_txn) {
+            auto trx = conn->trx_state.get<by_id>().find(tid);
+            sendit = trx != conn->trx_state.end() && trx->is_known_by_peer;
+         }
+         else {
+            auto blk = conn->blk_state.get<by_id>().find(bid);
+            sendit = blk != conn->blk_state.end() && blk->is_known;
+         }
+         if (sendit) {
+            conn->enqueue(*c->last_req);
+            conn->fetch_wait();
+            conn->last_req = c->last_req;
+            return;
+         }
+      }
+
+      // at this point no other peer has it, re-request or do nothing?
+      if( c->connected() ) {
+         c->enqueue(*c->last_req);
+         c->fetch_wait();
+      }
    }
 
    //------------------------------------------------------------------------
@@ -2033,17 +2109,16 @@ namespace eosio {
             c->enqueue( go_away_message(go_away_reason::wrong_chain) );
             return;
          }
-         if( msg.network_version != network_version) {
-            int16_t mnv = to_net_version(msg.network_version);
-            c->backwards_compatibility = mnv < net_version;
+         c->protocol_version = to_protocol_version(msg.network_version);
+         if(c->protocol_version != net_version) {
             if (network_version_match) {
                elog("Peer network version does not match expected ${nv} but got ${mnv}",
-                    ("nv", net_version)("mnv", mnv));
+                    ("nv", net_version)("mnv", c->protocol_version));
                c->enqueue(go_away_message(wrong_version));
                return;
             } else {
                ilog("Local network version: ${nv} Remote version: ${mnv}",
-                    ("nv", net_version)("mnv", mnv));
+                    ("nv", net_version)("mnv", c->protocol_version));
             }
          }
 
@@ -2246,12 +2321,13 @@ namespace eosio {
          fc_dlog(logger, "got a txn during sync - dropping");
          return;
       }
+      transaction_id_type tid = msg.id();
       c->cancel_wait();
-      if(local_txns.get<by_id>().find(msg.id()) != local_txns.end()) {
+      if(local_txns.get<by_id>().find(tid) != local_txns.end()) {
          fc_dlog(logger, "got a duplicate transaction - dropping");
          return;
       }
-      big_msg_master->recv_transaction(c);
+      big_msg_master->recv_transaction(c, tid);
       uint64_t code = 0;
       try {
          chain_plug->accept_transaction( msg);
@@ -2270,7 +2346,7 @@ namespace eosio {
    }
 
    void net_plugin_impl::handle_message( connection_ptr c, const signed_transaction &msg) {
-      ilog("Got a signed transaction from ${p} cancel wait",("p",c->peer_name()));
+      fc_dlog(logger, "Got a signed transaction from ${p} cancel wait",("p",c->peer_name()));
       c->cancel_wait();
    }
 
@@ -2278,7 +2354,6 @@ namespace eosio {
       chain_controller &cc = chain_plug->chain();
       block_id_type blk_id = msg.id();
       uint32_t blk_num = msg.block_num();
-      fc_dlog(logger, "canceling wait on ${p}", ("p",c->peer_name()));
       c->cancel_wait();
 
       try {
@@ -2340,11 +2415,10 @@ namespace eosio {
          }
       }
 
+      bool accepted = false;
       try {
          chain_plug->accept_block(sb, sync_master->is_active(c));
-         big_msg_master->recv_block(c, msg);
-         sync_master->recv_block(c, blk_id, blk_num, true);
-         return;
+         accepted = true;
       } catch( const unlinkable_block_exception &ex) {
          elog( "unlinkable_block_exception accept block #${n} syncing from ${p}",("n",blk_num)("p",c->peer_name()));
       } catch( const block_validate_exception &ex) {
@@ -2356,11 +2430,18 @@ namespace eosio {
       } catch( ...) {
          elog( "handle sync block caught something else from ${p}",("num",blk_num)("p",c->peer_name()));
       }
+#if 0 // after reviewing my conversaion with Bart, I believe this to be improper.
+      // as he explained, if the the block is deemed invalid by the local chain, then this implies a
+      // fork by the sender.
       notice_message pending_notify;
       pending_notify.known_blocks.mode = normal;
       pending_notify.known_blocks.ids.push_back( blk_id );
       pending_notify.known_trx.mode = none;
       big_msg_master->recv_notice (c, pending_notify, true);
+#endif
+      big_msg_master->recv_block(c, msg);
+      sync_master->recv_block(c, blk_id, blk_num, accepted);
+
    }
 
    void net_plugin_impl::handle_message( connection_ptr c, const signed_block &msg) {
@@ -2623,7 +2704,7 @@ namespace eosio {
 
    void
    handshake_initializer::populate( handshake_message &hello) {
-      hello.network_version = my_impl->network_version;
+      hello.network_version = net_version_base + net_version;
       hello.chain_id = my_impl->chain_id;
       hello.node_id = my_impl->node_id;
       hello.key = my_impl->get_authentication_key();
@@ -2685,9 +2766,6 @@ namespace eosio {
          ( "p2p-server-address", bpo::value<string>(), "An externally accessible host:port for identifying this node. Defaults to p2p-listen-endpoint.")
          ( "p2p-peer-address", bpo::value< vector<string> >()->composing(), "The public endpoint of a peer node to connect to. Use multiple p2p-peer-address options as needed to compose a network.")
          ( "agent-name", bpo::value<string>()->default_value("\"EOS Test Agent\""), "The name supplied to identify this node amongst the peers.")
-#if 0 //disabling block summary support
-         ( "send-whole-blocks", bpo::value<bool>()->default_value(def_send_whole_blocks), "True to always send full blocks, false to send block summaries" )
-#endif
          ( "allowed-connection", bpo::value<vector<string>>()->multitoken()->default_value({"any"}, "any"), "Can be 'any' or 'producers' or 'specified' or 'none'. If 'specified', peer-key must be specified at least once. If only 'producers', peer-key is not required. 'producers' and 'specified' may be combined.")
          ( "peer-key", bpo::value<vector<string>>()->composing()->multitoken(), "Optional public key of peer allowed to connect.  May be used multiple times.")
          ( "peer-private-key", boost::program_options::value<vector<string>>()->composing()->multitoken(),
@@ -2698,7 +2776,7 @@ namespace eosio {
          ( "network-version-match", bpo::value<bool>()->default_value(false),
            "True to require exact match of peer network version.")
          ( "sync-fetch-span", bpo::value<uint32_t>()->default_value(def_sync_fetch_span), "number of blocks to retrieve in a chunk from any individual peer during synchronization")
-         ( "max-implicit-request", bpo::value<uint32_t>()->default_value(def_max_just_send), "maximum sizes of transaction or block messages that are set wothout first sending a notice")
+         ( "max-implicit-request", bpo::value<uint32_t>()->default_value(def_max_just_send), "maximum sizes of transaction or block messages that are sent without first sending a notice")
          ;
    }
 
@@ -2710,9 +2788,7 @@ namespace eosio {
    void net_plugin::plugin_initialize( const variables_map& options ) {
       ilog("Initialize net plugin");
 
-      my->network_version = net_version_base + net_version;
       my->network_version_match = options.at("network-version-match").as<bool>();
-      my->send_whole_blocks = def_send_whole_blocks;
 
       my->sync_master.reset( new sync_manager(options.at("sync-fetch-span").as<uint32_t>() ) );
       my->big_msg_master.reset( new big_msg_manager );
@@ -2799,10 +2875,6 @@ namespace eosio {
                   my->private_keys[key_id_to_wif_pair.first] = fc::crypto::private_key(key_id_to_wif_pair.second);
                }
          }
-
-      if( options.count( "send-whole-blocks")) {
-         my->send_whole_blocks = options.at( "send-whole-blocks" ).as<bool>();
-      }
 
       my->chain_plug = app().find_plugin<chain_plugin>();
       my->chain_plug->get_chain_id(my->chain_id);
@@ -2912,7 +2984,7 @@ namespace eosio {
       return connection_ptr();
    }
 
-   int16_t net_plugin_impl::to_net_version (int16_t v) {
+   int16_t net_plugin_impl::to_protocol_version (int16_t v) {
       if (v >= net_version_base) {
          v -= net_version_base;
          return (v > net_version_range) ? 0 : v;


### PR DESCRIPTION
adding in the rest of the notice/request code. Adding in some fixes for preceding prs as well. 
In this commit - I added code to handle a failed fetch, and also to ensure the is_known table is updated correctly for transactions and blocks.  I also returned the default implicit request ("just send it") size.

bonus patches include typo fixes in config option, and replacement of backwards_compatibility with a per-connection network protocol number that is checked as needed.