### PR TITLE
feat(eosio.token): add inline_transfer static method

### DIFF
--- a/contracts/eosio.token/eosio.token.hpp
+++ b/contracts/eosio.token/eosio.token.hpp
@@ -33,8 +33,29 @@ namespace eosio {
                         string       memo );
 
          inline asset get_supply( symbol_name sym )const;
-         
+
          inline asset get_balance( account_name owner, symbol_name sym )const;
+
+         static void inline_transfer( account_name from,
+                                      account_name to,
+                                      extended_asset quantity,
+                                      string memo = string(),
+                                      permission_name perm = N(active) ) {
+           action act(permission_level(from, perm),
+                      quantity.contract,
+                      N(transfer),
+                      transfer_t{from, to, quantity, memo});
+           act.send();
+         }
+
+         struct transfer_t {
+           account_name from;
+           account_name to;
+           asset        quantity;
+           string       memo;
+
+           EOSLIB_SERIALIZE(transfer_t, (from)(to)(quantity)(memo))
+         };
 
       private:
          struct account {


### PR DESCRIPTION
Add `inline_transfer` static method to eosio.token.

This method is needed for other contracts to call tranfer action.

It is similar to what old [`currency::inline_transfer`](https://github.com/EOSIO/eos/blob/master/contracts/eosiolib/currency.hpp#L96) did.