### PR TITLE
syncus-interruptus

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -883,7 +883,7 @@ namespace eosio {
       handshake_initializer::populate(last_handshake_sent);
       last_handshake_sent.generation = ++sent_handshake_count;
       fc_dlog(logger, "Sending handshake generation ${g} to ${ep}",
-              ("g",last_handshake_sent.generation)("ep", peer_addr));
+              ("g",last_handshake_sent.generation)("ep", peer_name()));
       enqueue(last_handshake_sent);
    }
 
@@ -1416,6 +1416,9 @@ namespace eosio {
       if( req.req_blocks.mode == catch_up ) {
          c->fork_head = id;
          c->fork_head_num = num;
+         ilog ("got a catch_up notice while in ${s}, fork head num = ${fhn} target LIB = ${lib} next_expected = ${ne}", ("s",stage_str(state))("fhn",num)("lib",sync_known_lib_num)("ne", sync_next_expected_num));
+         if (state == lib_catchup)
+            return;
          set_state(head_catchup);
       }
       else {
@@ -1444,6 +1447,7 @@ namespace eosio {
    }
 
    void sync_manager::recv_block (connection_ptr c, const block_id_type &blk_id, uint32_t blk_num, bool accepted) {
+      fc_dlog(logger," got block ${bn} from ${p}",("bn",blk_num)("p",c->peer_name()));
       if (!accepted) {
          uint32_t head_num = chain_plug->chain().head_block_num();
          if (head_num != last_repeated) {


### PR DESCRIPTION
#2615 what happens is a peer on a fork connects while a node is in "lib_sync" state, retriving a long chain. The peer sends a "catchup head" notice, which incorrectly and prematurely throws the node out of lib_sync  state, but without i notifying the other peers, so the node is left un synched.

Thi pach addresses that case.
