### PR TITLE
Fixed typo parmeters -> parameters in "hello"

### DIFF
--- a/contracts/hello/hello.hi_rc.md
+++ b/contracts/hello/hello.hi_rc.md
@@ -3,7 +3,7 @@
 ## ACTION NAME: hi
 
 ### Parameters
-Input paramters:
+Input parameters:
 
 * `user` (string to include in the output)
 


### PR DESCRIPTION
The Ricardian contract "hello.hi_rc.md" of "Hello" example smart contract had a typo, fixed that.