### PR TITLE
Fix to a bug in tester destruction and changes to transaction_metadata to fix wasm_tests

### DIFF
--- a/libraries/chain/include/eosio/chain/transaction_metadata.hpp
+++ b/libraries/chain/include/eosio/chain/transaction_metadata.hpp
@@ -24,8 +24,8 @@ class transaction_metadata {
       std::function<void(const transaction_trace_ptr&)>       on_result;
 
 
-      transaction_metadata( const signed_transaction& t )
-      :trx(t),packed_trx(t,packed_transaction::zlib) {
+      transaction_metadata( const signed_transaction& t, packed_transaction::compression_type c = packed_transaction::none )
+      :trx(t),packed_trx(t, c) {
          id = trx.id();
          //raw_packed = fc::raw::pack( static_cast<const transaction&>(trx) );
          signed_id = digest_type::hash(packed_trx);


### PR DESCRIPTION
This PR has two fixes:

1. It fixes a bug which caused failure on exit of any test:

This bug was due to the fact that the tester was setup in a way that the destructor of the `tempdir` was called (which erased the folder contain the blockchain/database data) prior to the destructor of `controller` which depended on that folder existing (to write the fork_db to disk). Later a more robust change should probably be added in which fork_database checks to see if the directory exists, and if not either logs the error but does not try to write out the fork database, or alternatively creates the needed directories before writing the fork database to the file.

2. It fixes wasm_tests.

The two remaining tests that were failing in wasm_tests had to due with net usage billing. The behavior in tests of generating the `packed_transaction` to push (from a signed_transaction` provided by the tests) changed from master to slim. The change was to always compress the `packed_transaction`. Since net usage billing is based on the size of the `packed_transaction` this broke some of the tests in wasm_tests.

This PR changes the default behavior of constructing a `transaction_metadata` from a `signed_transaction` to not compress the generated `packed_transaction`, which fixes all the tests in wasm_tests. The default behavior can be overridden by passing in an optional argument specifying the `compression_type` explicitly. 


Note: This PR also merged in changes already in slim in order for this PR to be mergeable. Those changes introduced regressions in some of the tests. They are related to existing bugs in resource billing that are being uncovered now (and that is the next task I will be working on). However, the changes in this PR are not the reason for the regressions.