### PR TITLE
Draft of eosio.unregd to keep unreg'd Ethereum addr + EOS balances on chain

### DIFF
--- a/contracts/eosio.unregd/eosio.unregd.abi
+++ b/contracts/eosio.unregd/eosio.unregd.abi
@@ -1,0 +1,52 @@
+{
+  "types": [{
+    "new_type_name": "ethereum_account",
+    "type": "string"
+  }],
+  "structs": [{
+      "name": "account",
+      "base": "",
+      "fields": [{
+          "name": "id",
+          "type": "uint64"
+        }, {
+          "name": "ethereum_account",
+          "type": "ethereum_account"
+        }, {
+          "name": "balance",
+          "type": "asset"
+        }
+      ]
+    },
+
+    {
+      "name": "add",
+      "base": "",
+      "fields": [{
+          "name": "ethereum_account",
+          "type": "ethereum_account"
+        }, {
+          "name": "balance",
+          "type": "asset"
+        }
+      ]
+    }
+  ],
+  "actions": [{
+      "name": "add",
+      "type": "add"
+    }
+  ],
+  "tables": [{
+      "name": "accounts",
+      "index_type": "i64",
+      "key_names": [
+        "id"
+      ],
+      "key_types": [
+        "uint64"
+      ],
+      "type": "account"
+    }
+  ]
+}

--- a/contracts/eosio.unregd/eosio.unregd.cpp
+++ b/contracts/eosio.unregd/eosio.unregd.cpp
@@ -1,0 +1,46 @@
+#include <algorithm>
+
+#include "eosio.unregd.hpp"
+
+using eosio::unregd;
+
+EOSIO_ABI(eosio::unregd, (add))
+
+/**
+ * Add a mapping betwen an ethereum_account and an initial EOS token balance.
+ */
+void unregd::add(const ethereum_account& ethereum_account, const asset& balance) {
+  require_auth(_self);
+
+  auto symbol = balance.symbol;
+  eosio_assert(symbol.is_valid() && symbol == EOS_SYMBOL, "balance must be EOS token");
+
+  // TODO: What to do with existing mapping? Replace? Error?
+  auto itr = find_ethereum_account(ethereum_account);
+  if (itr == accounts.end()) {
+    accounts.emplace(_self, [&](auto& account) {
+      account.id = accounts.available_primary_key();
+      account.ethereum_account = ethereum_account;
+      account.balance = balance;
+    });
+  } else {
+    accounts.modify(itr, _self, [&](auto& account) {
+      account.ethereum_account = ethereum_account;
+      account.balance = balance;
+    });
+  }
+}
+
+/**
+ * For now, in `multi_index`, there is no possibility to create a secondary index
+ * based on a `std::string` or a fixed sized array (unless a key256). As such,
+ * for now, let's do a poor man search to find a matching account.
+ *
+ * TODO: Use a key256 type instead. The `ethereum_account` (40 hex characters,
+ * 80 bytes) would then be the 80 first bytes of the key and the rest would be
+ * padded with zeros creating a key256 from an ethereum account.
+ */
+unregd::accounts_index::const_iterator unregd::find_ethereum_account(const ethereum_account& ethereum_account) const {
+  return std::find_if(accounts.cbegin(), accounts.cend(),
+                      [&](auto& account) { return account.ethereum_account == ethereum_account; });
+}

--- a/contracts/eosio.unregd/eosio.unregd.hpp
+++ b/contracts/eosio.unregd/eosio.unregd.hpp
@@ -1,0 +1,51 @@
+#include <string>
+
+#include <eosiolib/asset.hpp>
+#include <eosiolib/eosio.hpp>
+#include <eosiolib/fixed_key.hpp>
+
+// Macro
+#define TABLE(X) ::eosio::string_to_name(#X)
+
+// Typedefs
+typedef std::string ethereum_account;
+
+// Namespaces
+using eosio::const_mem_fun;
+using eosio::indexed_by;
+using eosio::key256;
+using std::string;
+
+namespace eosio {
+
+class unregd : public contract {
+ public:
+  unregd(account_name contract_account)
+      : eosio::contract(contract_account), accounts(contract_account, contract_account) {}
+
+  // Actions
+  void add(const ethereum_account& ethereum_account, const asset& balance);
+
+ private:
+  static const uint64_t EOS_PRECISION = 4;
+  static const asset_symbol EOS_SYMBOL = S(EOS_PRECISION, EOS);
+
+  //@abi table accounts i64
+  struct account {
+    uint64_t id;
+    ethereum_account ethereum_account;
+    asset balance;
+
+    uint64_t primary_key() const { return id; }
+
+    EOSLIB_SERIALIZE(account, (id)(ethereum_account)(balance))
+  };
+
+  typedef eosio::multi_index<TABLE(accounts), account> accounts_index;
+
+  accounts_index::const_iterator find_ethereum_account(const ethereum_account& ethereum_account) const;
+
+  accounts_index accounts;
+};
+
+}  // namespace eosio


### PR DESCRIPTION
The goal would be to all the community to inject the unregistered snapshot, left on chain.. destroy the authority for the `eosio.unregd` account, and leave that for the future.

Maybe later, a worker proposal and some technical hiccups are alleviated and we can have the owners of the Ethereum address come prove their ownership and release their balance from the `eosio.unregd` contract (which would hold the funds in the interim).

