### PR TITLE
Added separate release/debug transaction deadlines

### DIFF
--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -81,7 +81,11 @@ namespace eosio { namespace chain {
 
          bool push_next_unapplied_transaction( fc::time_point deadline = fc::time_point::maximum() );
 
+#ifdef NDEBUG
          transaction_trace_ptr sync_push( const transaction_metadata_ptr& trx, fc::time_point deadline = fc::time_point::now() + fc::milliseconds(30) );
+#else
+         transaction_trace_ptr sync_push( const transaction_metadata_ptr& trx, fc::time_point deadline = fc::time_point::now() + fc::milliseconds(120) );
+#endif
 
          /**
           * Attempt to execute a specific transaction in our deferred trx database


### PR DESCRIPTION
Upped the deadline for debug builds to 4x the release deadline to allow transactions to not fail checktime.