### PR TITLE
Fix cleos unhandled exception on wallet connect failure

### DIFF
--- a/programs/cleos/httpc.cpp
+++ b/programs/cleos/httpc.cpp
@@ -77,7 +77,7 @@ namespace eosio { namespace client { namespace http {
       return re.str();
    }
 
-   fc::variant call( const std::string& server_url,
+   fc::variant do_http_call( const std::string& server_url,
                      const std::string& path,
                      const fc::variant& postdata ) {
    std::string postjson;

--- a/programs/cleos/httpc.hpp
+++ b/programs/cleos/httpc.hpp
@@ -5,7 +5,7 @@
 #pragma once
 
 namespace eosio { namespace client { namespace http {
-   fc::variant call( const std::string& server_url,
+   fc::variant do_http_call( const std::string& server_url,
                      const std::string& path,
                      const fc::variant& postdata = fc::variant() );
 

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -194,7 +194,7 @@ fc::variant call( const std::string& url,
                   const std::string& path,
                   const T& v ) {
    try {
-      return eosio::client::http::call( url, path, fc::variant(v) );
+      return eosio::client::http::do_http_call( url, path, fc::variant(v) );
    }
    catch(boost::system::system_error& e) {
       if(url == ::url)
@@ -207,10 +207,10 @@ fc::variant call( const std::string& url,
 
 template<typename T>
 fc::variant call( const std::string& path,
-                  const T& v ) { return ::call( url, path, fc::variant(v) ); }
+                  const T& v ) { return call( url, path, fc::variant(v) ); }
 
 eosio::chain_apis::read_only::get_info_results get_info() {
-   return ::call(url, get_info_func, fc::variant()).as<eosio::chain_apis::read_only::get_info_results>();
+   return call(url, get_info_func, fc::variant()).as<eosio::chain_apis::read_only::get_info_results>();
 }
 
 string generate_nonce_value() {

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -209,8 +209,12 @@ template<typename T>
 fc::variant call( const std::string& path,
                   const T& v ) { return call( url, path, fc::variant(v) ); }
 
+template<>
+fc::variant call( const std::string& url,
+                  const std::string& path) { return call( url, path, fc::variant() ); }
+
 eosio::chain_apis::read_only::get_info_results get_info() {
-   return call(url, get_info_func, fc::variant()).as<eosio::chain_apis::read_only::get_info_results>();
+   return call(url, get_info_func).as<eosio::chain_apis::read_only::get_info_results>();
 }
 
 string generate_nonce_value() {
@@ -1245,27 +1249,27 @@ int main( int argc, char** argv ) {
    auto connect = net->add_subcommand("connect", localized("start a new connection to a peer"), false);
    connect->add_option("host", new_host, localized("The hostname:port to connect to."))->required();
    connect->set_callback([&] {
-      const auto& v = call(net_connect, new_host);
+      const auto& v = call(url, net_connect, new_host);
       std::cout << fc::json::to_pretty_string(v) << std::endl;
    });
 
    auto disconnect = net->add_subcommand("disconnect", localized("close an existing connection"), false);
    disconnect->add_option("host", new_host, localized("The hostname:port to disconnect from."))->required();
    disconnect->set_callback([&] {
-      const auto& v = call(net_disconnect, new_host);
+      const auto& v = call(url, net_disconnect, new_host);
       std::cout << fc::json::to_pretty_string(v) << std::endl;
    });
 
    auto status = net->add_subcommand("status", localized("status of existing connection"), false);
    status->add_option("host", new_host, localized("The hostname:port to query status of connection"))->required();
    status->set_callback([&] {
-      const auto& v = call(net_status, new_host);
+      const auto& v = call(url, net_status, new_host);
       std::cout << fc::json::to_pretty_string(v) << std::endl;
    });
 
    auto connections = net->add_subcommand("peers", localized("status of all existing peers"), false);
    connections->set_callback([&] {
-      const auto& v = call(net_connections, new_host);
+      const auto& v = call(url, net_connections, new_host);
       std::cout << fc::json::to_pretty_string(v) << std::endl;
    });
 


### PR DESCRIPTION
Change the namespace situation w.r.t. making an http::call() request so that all call()s are funneled through the handler that prints a nicer descrption on a connection failure.

(fallout from HTTPS changes)