### PR TITLE
explicitly remove implicit calls

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -708,8 +708,8 @@ struct controller_impl {
 
 
    void push_block( const signed_block_ptr& b ) {
+      FC_ASSERT(!pending, "it is not valid to push a block when there is a pending block");
       try {
-         if( pending ) abort_block();
          FC_ASSERT( b );
          auto new_header_state = fork_db.add( b );
          emit( self.accepted_block_header, new_header_state );
@@ -718,6 +718,7 @@ struct controller_impl {
    }
 
    void push_confirmation( const header_confirmation& c ) {
+      FC_ASSERT(!pending, "it is not valid to push a confirmation when there is a pending block");
       fork_db.add( c );
       emit( self.accepted_confirmation, c );
       maybe_switch_forks();
@@ -728,7 +729,6 @@ struct controller_impl {
 
       if( new_head->header.previous == head->id ) {
          try {
-            abort_block();
             apply_block( new_head->block );
             fork_db.mark_in_current_chain( new_head, true );
             fork_db.set_validity( new_head, true );
@@ -820,8 +820,10 @@ struct controller_impl {
 
 
    void finalize_block()
-   { try {
-      if( !pending ) self.start_block();
+   {
+      FC_ASSERT(pending, "it is not valid to finalize when there is no pending block");
+      try {
+
 
       /*
       ilog( "finalize block ${n} (${id}) at ${t} by ${p} (${signing_key}); schedule_version: ${v} lib: ${lib} #dtrxs: ${ndtrxs} ${np}",

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -82,6 +82,7 @@ namespace eosio { namespace testing {
    }
 
    signed_block_ptr base_tester::push_block(signed_block_ptr b) {
+      control->abort_block();
       control->push_block(b);
       return b;
    }
@@ -639,6 +640,7 @@ namespace eosio { namespace testing {
          for( int i = 1; i <= a.control->head_block_num(); ++i ) {
             auto block = a.control->fetch_block_by_number(i);
             if( block ) { //&& !b.control->is_known_block(block->id()) ) {
+               b.control->abort_block();
                b.control->push_block(block); //, eosio::chain::validation_steps::created_block);
             }
          }

--- a/unittests/forked_tests.cpp
+++ b/unittests/forked_tests.cpp
@@ -67,6 +67,7 @@ BOOST_AUTO_TEST_CASE( forking ) try {
    wlog( "push c1 blocks to c2" );
    while( c2.control->head_block_num() < c.control->head_block_num() ) {
       auto fb = c.control->fetch_block_by_number( c2.control->head_block_num()+1 );
+      c2.control->abort_block();
       c2.control->push_block( fb );
    }
    wlog( "end push c1 blocks to c2" );
@@ -92,6 +93,7 @@ BOOST_AUTO_TEST_CASE( forking ) try {
    wlog( "push c1 blocks to c2" );
    while( c2.control->head_block_num() < c.control->head_block_num() ) {
       auto fb = c.control->fetch_block_by_number( c2.control->head_block_num()+1 );
+      c2.control->abort_block();
       c2.control->push_block( fb );
    }
    wlog( "end push c1 blocks to c2" );
@@ -119,6 +121,7 @@ BOOST_AUTO_TEST_CASE( forking ) try {
    wlog( "push c2 blocks to c1" );
    for( uint32_t start = fork_block_num + 1, end = c2.control->head_block_num(); start <= end; ++start ) {
       auto fb = c2.control->fetch_block_by_number( start );
+      c.control->abort_block();
       c.control->push_block( fb );
    }
    wlog( "end push c2 blocks to c1" );
@@ -138,6 +141,7 @@ BOOST_AUTO_TEST_CASE( forking ) try {
    wlog( "push c1 blocks to c2" );
    while( c2.control->head_block_num() < c.control->head_block_num() ) {
       auto fb = c.control->fetch_block_by_number( c2.control->head_block_num()+1 );
+      c2.control->abort_block();
       c2.control->push_block( fb );
    }
    wlog( "end push c1 blocks to c2" );
@@ -165,12 +169,14 @@ BOOST_AUTO_TEST_CASE( forking ) try {
    wlog( "push c2 blocks (except for the last block by dan) to c1" );
    for( uint32_t start = fork_block_num + 1, end = c2.control->head_block_num() - 1; start <= end; ++start ) {
       auto fb = c2.control->fetch_block_by_number( start );
+      c.control->abort_block();
       c.control->push_block( fb );
    }
    wlog( "end push c2 blocks to c1" );
    wlog( "now push dan's block to c1 but first corrupt it so it is a bad block" );
    auto bad_block = *b;
    bad_block.transaction_mroot = bad_block.previous;
+   c.control->abort_block();
    BOOST_REQUIRE_EXCEPTION(c.control->push_block( std::make_shared<signed_block>(bad_block) ), fc::exception,
       [] (const fc::exception &ex)->bool {
          return ex.to_detail_string().find("block not signed by expected key") != std::string::npos;


### PR DESCRIPTION
enforce that there is/is-not a pending block when it is expected