### PR TITLE
route all pushes through producer

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -348,6 +348,7 @@ struct controller_impl {
       if( add_to_fork_db ) {
          pending->_pending_block_state->validated = true;
          auto new_bsp = fork_db.add( pending->_pending_block_state );
+         emit( self.accepted_block_header, pending->_pending_block_state );
          head = fork_db.head();
          FC_ASSERT( new_bsp == head, "committed block did not become the new head in fork database" );
       }

--- a/libraries/chain/include/eosio/chain/block.hpp
+++ b/libraries/chain/include/eosio/chain/block.hpp
@@ -57,7 +57,7 @@ namespace eosio { namespace chain {
 
       vector<transaction_receipt>   transactions; /// new or generated transactions
    };
-   typedef std::shared_ptr<signed_block> signed_block_ptr;
+   using signed_block_ptr = std::shared_ptr<signed_block>;
 
    struct producer_confirmation {
       block_id_type   block_id;

--- a/libraries/chain/include/eosio/chain/block_state.hpp
+++ b/libraries/chain/include/eosio/chain/block_state.hpp
@@ -27,7 +27,7 @@ namespace eosio { namespace chain {
       vector<transaction_metadata_ptr>                    trxs;
    };
 
-   typedef std::shared_ptr<block_state> block_state_ptr;
+   using block_state_ptr = std::shared_ptr<block_state>;
 
 } } /// namespace eosio::chain
 

--- a/libraries/chain/include/eosio/chain/block_timestamp.hpp
+++ b/libraries/chain/include/eosio/chain/block_timestamp.hpp
@@ -30,6 +30,17 @@ namespace eosio { namespace chain {
          static block_timestamp maximum() { return block_timestamp( 0xffff ); }
          static block_timestamp min() { return block_timestamp(0); }
 
+         block_timestamp next() const {
+            FC_ASSERT( std::numeric_limits<uint32_t>::max() - slot >= 1, "block timestamp overflow" );
+            auto result = block_timestamp(*this);
+            result.slot += 1;
+            return result;
+         }
+
+         fc::time_point to_time_point() const {
+            return (fc::time_point)(*this);
+         }
+
          operator fc::time_point() const {
             int64_t msec = slot * (int64_t)IntervalMs;
             msec += EpochMs;

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -37,7 +37,6 @@ namespace eosio { namespace chain {
             struct runtime_limits {
                fc::microseconds     max_push_block_us = fc::microseconds(100000);
                fc::microseconds     max_push_transaction_us = fc::microseconds(1000'000);
-               fc::microseconds     max_deferred_transactions_us = fc::microseconds(100000);
             };
 
             path         block_log_dir       =  chain::config::default_block_log_dir;
@@ -196,7 +195,7 @@ namespace eosio { namespace chain {
 
 } }  /// eosio::chain
 
-FC_REFLECT( eosio::chain::controller::config::runtime_limits, (max_push_block_us)(max_push_transaction_us)(max_deferred_transactions_us) )
+FC_REFLECT( eosio::chain::controller::config::runtime_limits, (max_push_block_us)(max_push_transaction_us) )
 FC_REFLECT( eosio::chain::controller::config,
             (block_log_dir)
             (shared_memory_dir)(shared_memory_size)(read_only)

--- a/libraries/chain/include/eosio/chain/trace.hpp
+++ b/libraries/chain/include/eosio/chain/trace.hpp
@@ -31,7 +31,7 @@ namespace eosio { namespace chain {
    };
 
    struct transaction_trace;
-   typedef std::shared_ptr<transaction_trace> transaction_trace_ptr;
+   using transaction_trace_ptr = std::shared_ptr<transaction_trace>;
 
    struct transaction_trace {
       transaction_id_type          id;
@@ -55,7 +55,7 @@ namespace eosio { namespace chain {
       uint64_t                        cpu_usage;
       vector<transaction_trace_ptr>   trx_traces;
    };
-   typedef std::shared_ptr<block_trace> block_trace_ptr;
+   using block_trace_ptr = std::shared_ptr<block_trace>;
 
 } }  /// namespace eosio::chain
 

--- a/libraries/chain/include/eosio/chain/transaction.hpp
+++ b/libraries/chain/include/eosio/chain/transaction.hpp
@@ -137,6 +137,7 @@ namespace eosio { namespace chain {
       void               set_transaction(const transaction& t, const vector<bytes>& cfd, compression_type _compression = none);
    };
 
+   using packed_transaction_ptr = std::shared_ptr<packed_transaction>;
 
    /**
     *  When a transaction is generated it can be scheduled to occur

--- a/libraries/chain/include/eosio/chain/transaction_metadata.hpp
+++ b/libraries/chain/include/eosio/chain/transaction_metadata.hpp
@@ -48,6 +48,6 @@ class transaction_metadata {
       uint32_t total_actions()const { return trx.context_free_actions.size() + trx.actions.size(); }
 };
 
-typedef std::shared_ptr<transaction_metadata> transaction_metadata_ptr;
+using transaction_metadata_ptr = std::shared_ptr<transaction_metadata>;
 
 } } // eosio::chain

--- a/libraries/fc/include/fc/exception/exception.hpp
+++ b/libraries/fc/include/fc/exception/exception.hpp
@@ -444,6 +444,23 @@ namespace fc
       wdump( __VA_ARGS__ ); \
    }
 
+#define FC_LOG_AND_DROP( ... )  \
+   catch( fc::exception& er ) { \
+      wlog( "${details}", ("details",er.to_detail_string()) ); \
+   } catch( const std::exception& e ) {  \
+      fc::exception fce( \
+                FC_LOG_MESSAGE( warn, "rethrow ${what}: ",FC_FORMAT_ARG_PARAMS( __VA_ARGS__  )("what",e.what()) ), \
+                fc::std_exception_code,\
+                BOOST_CORE_TYPEID(e).name(), \
+                e.what() ) ; \
+      wlog( "${details}", ("details",fce.to_detail_string()) ); \
+   } catch( ... ) {  \
+      fc::unhandled_exception e( \
+                FC_LOG_MESSAGE( warn, "rethrow", FC_FORMAT_ARG_PARAMS( __VA_ARGS__) ), \
+                std::current_exception() ); \
+      wlog( "${details}", ("details",e.to_detail_string()) ); \
+   }
+
 
 /**
  *  @def FC_RETHROW_EXCEPTIONS(LOG_LEVEL,FORMAT,...)

--- a/plugins/chain_interface/include/eosio/chain/plugin_interface.hpp
+++ b/plugins/chain_interface/include/eosio/chain/plugin_interface.hpp
@@ -25,11 +25,14 @@ namespace eosio { namespace chain { namespace plugin_interface {
       using accepted_transaction   = channel_decl<struct accepted_transaction_tag,  transaction_metadata_ptr>;
       using applied_transaction    = channel_decl<struct applied_transaction_tag,   transaction_trace_ptr>;
       using accepted_confirmation  = channel_decl<struct accepted_confirmation_tag, header_confirmation>;
+
+      using incoming_block         = channel_decl<struct incoming_blocks_tag,       signed_block_ptr>;
+      using incoming_transaction   = channel_decl<struct incoming_transactions_tag, packed_transaction_ptr>;
    }
 
    namespace methods {
-      using get_block_by_number    = method_decl<chain_plugin_interface, const signed_block_ptr&(uint32_t block_num)>;
-      using get_block_by_id        = method_decl<chain_plugin_interface, const signed_block_ptr&(const block_id_type& block_id)>;
+      using get_block_by_number    = method_decl<chain_plugin_interface, signed_block_ptr(uint32_t block_num)>;
+      using get_block_by_id        = method_decl<chain_plugin_interface, signed_block_ptr(const block_id_type& block_id)>;
       using get_head_block_id      = method_decl<chain_plugin_interface, block_id_type ()>;
 
       using get_last_irreversible_block_number = method_decl<chain_plugin_interface, uint32_t ()>;

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -257,7 +257,9 @@ void chain_plugin::plugin_initialize(const variables_map& options) {
    });
 
    my->incoming_transaction_subscription = app().get_channel<channels::incoming_transaction>().subscribe([this](const packed_transaction_ptr& ptrx){
-      my->chain->push_transaction(std::make_shared<transaction_metadata>(*ptrx), get_transaction_deadline());
+      try {
+         my->chain->push_transaction(std::make_shared<transaction_metadata>(*ptrx), get_transaction_deadline());
+      } FC_LOG_AND_DROP();
    });
 }
 

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -45,6 +45,7 @@ public:
    ,accepted_transaction_channel(app().get_channel<channels::accepted_transaction>())
    ,applied_transaction_channel(app().get_channel<channels::applied_transaction>())
    ,accepted_confirmation_channel(app().get_channel<channels::accepted_confirmation>())
+   ,incoming_block_channel(app().get_channel<channels::incoming_block>())
    {}
    
    bfs::path                        block_log_dir;
@@ -61,7 +62,6 @@ public:
    chain_id_type                    chain_id;
    int32_t                          max_reversible_block_time_ms;
    int32_t                          max_pending_transaction_time_ms;
-   int32_t                          max_deferred_transaction_time_ms;
    //txn_msg_rate_limits              rate_limits;
    fc::optional<vm_type>            wasm_runtime;
 
@@ -72,6 +72,7 @@ public:
    channels::accepted_transaction::channel_type&   accepted_transaction_channel;
    channels::applied_transaction::channel_type&    applied_transaction_channel;
    channels::accepted_confirmation::channel_type&  accepted_confirmation_channel;
+   channels::incoming_block::channel_type&         incoming_block_channel;
 
    // method provider handles
    methods::get_block_by_number::method_type::handle                 get_block_by_number_provider;
@@ -79,6 +80,8 @@ public:
    methods::get_head_block_id::method_type::handle                   get_head_block_id_provider;
    methods::get_last_irreversible_block_number::method_type::handle  get_last_irreversible_block_number_provider;
 
+   // things we subscribe to
+   channels::incoming_transaction::channel_type::handle incoming_transaction_subscription;
 };
 
 chain_plugin::chain_plugin()
@@ -99,8 +102,6 @@ void chain_plugin::set_program_options(options_description& cli, options_descrip
           "Limits the maximum time (in milliseconds) that a reversible block is allowed to run before being considered invalid")
          ("max-pending-transaction-time", bpo::value<int32_t>()->default_value(30),
           "Limits the maximum time (in milliseconds) that is allowed a pushed transaction's code to execute before being considered invalid")
-         ("max-deferred-transaction-time", bpo::value<int32_t>()->default_value(20),
-          "Limits the maximum time (in milliseconds) that is allowed a to push deferred transactions at the start of a block")
          ("wasm-runtime", bpo::value<eosio::chain::wasm_interface::vm_type>()->value_name("wavm/binaryen"), "Override default WASM runtime")
          ("shared-memory-size-mb", bpo::value<uint64_t>()->default_value(config::default_shared_memory_size / (1024  * 1024)), "Maximum size MB of database shared memory file")
 
@@ -182,7 +183,6 @@ void chain_plugin::plugin_initialize(const variables_map& options) {
 
    my->max_reversible_block_time_ms = options.at("max-reversible-block-time").as<int32_t>();
    my->max_pending_transaction_time_ms = options.at("max-pending-transaction-time").as<int32_t>();
-   my->max_deferred_transaction_time_ms = options.at("max-deferred-transaction-time").as<int32_t>();
 
    if(options.count("wasm-runtime"))
       my->wasm_runtime = options.at("wasm-runtime").as<vm_type>();
@@ -209,21 +209,17 @@ void chain_plugin::plugin_initialize(const variables_map& options) {
       my->chain_config->limits.max_push_transaction_us = fc::milliseconds(my->max_pending_transaction_time_ms);
    }
 
-   if (my->max_deferred_transaction_time_ms > 0 ) {
-      my->chain_config->limits.max_deferred_transactions_us = fc::milliseconds(my->max_deferred_transaction_time_ms);
-   }
-
    if(my->wasm_runtime)
       my->chain_config->wasm_runtime = *my->wasm_runtime;
 
    my->chain.emplace(*my->chain_config);
 
    // set up method providers
-   my->get_block_by_number_provider = app().get_method<methods::get_block_by_number>().register_provider([this](uint32_t block_num) -> const signed_block_ptr& {
+   my->get_block_by_number_provider = app().get_method<methods::get_block_by_number>().register_provider([this](uint32_t block_num) -> signed_block_ptr {
       return my->chain->fetch_block_by_number(block_num);
    });
 
-   my->get_block_by_id_provider = app().get_method<methods::get_block_by_id>().register_provider([this](block_id_type id) -> const signed_block_ptr& {
+   my->get_block_by_id_provider = app().get_method<methods::get_block_by_id>().register_provider([this](block_id_type id) -> signed_block_ptr {
       return my->chain->fetch_block_by_id(id);
    });
 
@@ -259,6 +255,10 @@ void chain_plugin::plugin_initialize(const variables_map& options) {
    my->chain->accepted_confirmation.connect([this](const header_confirmation& conf){
       my->accepted_confirmation_channel.publish(conf);
    });
+
+   my->incoming_transaction_subscription = app().get_channel<channels::incoming_transaction>().subscribe([this](const packed_transaction_ptr& ptrx){
+      my->chain->push_transaction(std::make_shared<transaction_metadata>(*ptrx), get_transaction_deadline());
+   });
 }
 
 void chain_plugin::plugin_startup()
@@ -286,7 +286,7 @@ chain_apis::read_write chain_plugin::get_read_write_api() {
 }
 
 void chain_plugin::accept_block(const signed_block_ptr& block ) {
-   chain().push_block( block );
+   my->incoming_block_channel.publish(block);
 }
 
 void chain_plugin::accept_transaction(const packed_transaction& trx) {

--- a/plugins/faucet_testnet_plugin/faucet_testnet_plugin.cpp
+++ b/plugins/faucet_testnet_plugin/faucet_testnet_plugin.cpp
@@ -239,8 +239,6 @@ struct faucet_testnet_plugin_impl {
       trx.sign(_create_account_private_key, chainid);
 
       try {
-         if( !cc.pending_block_state() )
-            cc.start_block();
          cc.push_transaction( std::make_shared<transaction_metadata>(trx) );
       } catch (const account_name_exists_exception& ) {
          // another transaction ended up adding the account, so look for alternates

--- a/plugins/producer_plugin/CMakeLists.txt
+++ b/plugins/producer_plugin/CMakeLists.txt
@@ -7,4 +7,4 @@ add_library( producer_plugin
 
 target_link_libraries( producer_plugin chain_plugin appbase eosio_chain eos_utilities )
 target_include_directories( producer_plugin
-                            PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" )
+                            PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" "${CMAKE_CURRENT_SOURCE_DIR}/../chain_interface/include" )

--- a/plugins/txn_test_gen_plugin/txn_test_gen_plugin.cpp
+++ b/plugins/txn_test_gen_plugin/txn_test_gen_plugin.cpp
@@ -73,8 +73,6 @@ using namespace eosio::chain;
 struct txn_test_gen_plugin_impl {
    transaction_trace_ptr push_transaction( signed_transaction& trx ) { try {
       controller& cc = app().get_plugin<chain_plugin>().chain();
-      if( !cc.pending_block_state() )
-         cc.start_block();
       return cc.push_transaction( std::make_shared<transaction_metadata>(trx) );
    } FC_CAPTURE_AND_RETHROW( (transaction_header(trx)) ) }
 

--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -544,7 +544,7 @@ BOOST_AUTO_TEST_CASE(checktime_fail_tests) { try {
 	//       1) compilation of the smart contract should probably not count towards the CPU time of a transaction that first uses it;
 	//       2) checktime should eventually switch to a deterministic metric which should hopefully fix the inconsistencies
 	//          of this test succeeding/failing on different machines (for example, succeeding on our local dev machines but failing on Jenkins).
-   TESTER t( {fc::milliseconds(5000), fc::milliseconds(5000), fc::milliseconds(-1)} );
+   TESTER t( {fc::milliseconds(5000), fc::milliseconds(5000)} );
    t.produce_blocks(2);
 
    t.create_account( N(testapi) );


### PR DESCRIPTION
 - move the deferred limit to the producer plugin which now controls it
 - route all new blocks through producer so it can maintain invariant that there is always a pending block (whether for speculative execution or future signing)
 - re-apply unapplied transactions and apply deferred transactions on a new block (NOTE: this needs 
 - proper throttling once subjective failures are handled correctly inside controller).  
 - Remove spurious calls to start_block in other plugins
 - fixed producer plugin and changed some logic to respect the notion that we "called our shot" in start_block and should no longer be concerned with other time slots