### PR TITLE
add DPOS confirmations to producer plugin

### DIFF
--- a/libraries/chain/block_header_state.cpp
+++ b/libraries/chain/block_header_state.cpp
@@ -114,7 +114,9 @@ namespace eosio { namespace chain {
 
     /// grow the confirmed count
     static_assert(std::numeric_limits<uint8_t>::max() >= (config::max_producers * 2 / 3) + 1, "8bit confirmations may not be able to hold all of the needed confirmations");
-    auto num_active_producers = result.active_schedule.producers.size();
+
+    // This uses the previous block active_schedule because thats the "schedule" that signs and therefore confirms _this_ block
+    auto num_active_producers = active_schedule.producers.size();
     uint32_t required_confs = (uint32_t)(num_active_producers * 2 / 3) + 1;
 
     if( confirm_count.size() < config::maximum_tracked_dpos_confirmations ) {

--- a/plugins/producer_plugin/include/eosio/producer_plugin/producer_plugin.hpp
+++ b/plugins/producer_plugin/include/eosio/producer_plugin/producer_plugin.hpp
@@ -21,7 +21,8 @@ namespace block_production_condition {
       no_private_key = 4,
       low_participation = 5,
       lag = 6,
-      exception_producing_block = 7
+      exception_producing_block = 7,
+      fork_below_watermark = 8,
    };
 }
 

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -474,7 +474,8 @@ block_production_condition::block_production_condition_enum producer_plugin_impl
       flat_set<account_name> new_producers;
       new_producers.reserve(new_bs->active_schedule.producers.size());
       for( const auto& p: new_bs->active_schedule.producers) {
-         new_producers.insert(p.producer_name);
+         if (_producers.count(p.producer_name) > 0)
+            new_producers.insert(p.producer_name);
       }
 
       for( const auto& p: hbs->active_schedule.producers) {


### PR DESCRIPTION
Producer plugin now tracks watermarks

- it is conservative-ish when it does not know about a producer: it will only confirm the block itself, no priors
 - it also squelches broadcasts of blocks where it knows it would double sign due to a shorter fork being more irreversible HOWEVER,
 - as it has no durable store of this information, crashes after switching from a longer fork to a shorter but more irreversible forks may lead to a double confirmed block height