### PR TITLE
non producing node support

### DIFF
--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -34,18 +34,12 @@ namespace eosio { namespace chain {
    class controller {
       public:
          struct config {
-            struct runtime_limits {
-               fc::microseconds     max_push_block_us = fc::microseconds(100000);
-               fc::microseconds     max_push_transaction_us = fc::microseconds(1000'000);
-            };
-
             path         block_log_dir       =  chain::config::default_block_log_dir;
             path         shared_memory_dir   =  chain::config::default_shared_memory_dir;
             uint64_t     shared_memory_size  =  chain::config::default_shared_memory_size;
             bool         read_only           =  false;
 
             genesis_state                  genesis;
-            runtime_limits                 limits;
             wasm_interface::vm_type        wasm_runtime = chain::config::default_wasm_runtime;
          };
 
@@ -195,10 +189,9 @@ namespace eosio { namespace chain {
 
 } }  /// eosio::chain
 
-FC_REFLECT( eosio::chain::controller::config::runtime_limits, (max_push_block_us)(max_push_transaction_us) )
 FC_REFLECT( eosio::chain::controller::config,
             (block_log_dir)
             (shared_memory_dir)(shared_memory_size)(read_only)
             (genesis)
-            (limits)(wasm_runtime)
+            (wasm_runtime)
           )

--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -72,7 +72,7 @@ namespace eosio { namespace testing {
 
          static const uint32_t DEFAULT_EXPIRATION_DELTA = 6;
 
-         void              init(bool push_genesis = true, controller::config::runtime_limits limits = controller::config::runtime_limits());
+         void              init(bool push_genesis = true);
          void              init(controller::config config);
 
          void              close();
@@ -240,11 +240,11 @@ namespace eosio { namespace testing {
 
    class tester : public base_tester {
    public:
-      tester(bool push_genesis, controller::config::runtime_limits limits = controller::config::runtime_limits()) {
-         init(push_genesis, limits);
+      tester(bool push_genesis) {
+         init(push_genesis);
       }
-      tester(controller::config::runtime_limits limits = controller::config::runtime_limits()) {
-         init(true, limits);
+      tester() {
+         init(true);
       }
 
       tester(controller::config config) {
@@ -273,7 +273,7 @@ namespace eosio { namespace testing {
             wdump((e.to_detail_string()));
          }
       }
-      validating_tester(controller::config::runtime_limits limits = controller::config::runtime_limits()) {
+      validating_tester() {
          controller::config vcfg;
          vcfg.block_log_dir      = tempdir.path() / "vblocklog";
          vcfg.shared_memory_dir  = tempdir.path() / "vshared";
@@ -281,7 +281,6 @@ namespace eosio { namespace testing {
 
          vcfg.genesis.initial_timestamp = fc::time_point::from_iso_string("2020-01-01T00:00:00.000");
          vcfg.genesis.initial_key = get_public_key( config::system_account_name, "active" );
-         vcfg.limits = limits;
 
          for(int i = 0; i < boost::unit_test::framework::master_test_suite().argc; ++i) {
             if(boost::unit_test::framework::master_test_suite().argv[i] == std::string("--binaryen"))
@@ -292,7 +291,7 @@ namespace eosio { namespace testing {
 
          validating_node = std::make_unique<controller>(vcfg);
          validating_node->startup();
-         init(true, limits);
+         init(true);
       }
 
       validating_tester(controller::config config) {

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -32,14 +32,13 @@ namespace eosio { namespace testing {
      return control->head_block_id() == other.control->head_block_id();
    }
 
-   void base_tester::init(bool push_genesis, controller::config::runtime_limits limits) {
+   void base_tester::init(bool push_genesis) {
       cfg.block_log_dir      = tempdir.path() / "blocklog";
       cfg.shared_memory_dir  = tempdir.path() / "shared";
       cfg.shared_memory_size = 1024*1024*8;
 
       cfg.genesis.initial_timestamp = fc::time_point::from_iso_string("2020-01-01T00:00:00.000");
       cfg.genesis.initial_key = get_public_key( config::system_account_name, "active" );
-      cfg.limits = limits;
 
       for(int i = 0; i < boost::unit_test::framework::master_test_suite().argc; ++i) {
          if(boost::unit_test::framework::master_test_suite().argv[i] == std::string("--binaryen"))

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -4,6 +4,7 @@ add_subdirectory(http_plugin)
 add_subdirectory(chain_plugin)
 add_subdirectory(chain_api_plugin)
 add_subdirectory(producer_plugin)
+add_subdirectory(validator_plugin)
 add_subdirectory(history_plugin)
 add_subdirectory(history_api_plugin)
 

--- a/plugins/chain_interface/include/eosio/chain/plugin_interface.hpp
+++ b/plugins/chain_interface/include/eosio/chain/plugin_interface.hpp
@@ -36,6 +36,13 @@ namespace eosio { namespace chain { namespace plugin_interface {
       using get_head_block_id      = method_decl<chain_plugin_interface, block_id_type ()>;
 
       using get_last_irreversible_block_number = method_decl<chain_plugin_interface, uint32_t ()>;
+
+      // synchronously push a block/trx to a single provider
+      using incoming_block_sync       = method_decl<chain_plugin_interface, void(const signed_block_ptr&), first_provider_policy>;
+      using incoming_transaction_sync = method_decl<chain_plugin_interface, transaction_trace_ptr(const packed_transaction_ptr&), first_provider_policy>;
+
+      // start the "best" coordinator
+      using start_coordinator      = method_decl<chain_plugin_interface, void(), first_provider_policy>;
    }
 
 } } }

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -354,9 +354,6 @@ public:
    // Only call this after plugin_startup()!
    const controller& chain() const;
 
-   // Calculate deadline for controller push_transaction
-   fc::time_point get_transaction_deadline()const;
-
    void get_chain_id(chain::chain_id_type& cid) const;
 
 private:

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -8,6 +8,7 @@
 
 #include <fc/io/json.hpp>
 #include <fc/smart_ref_impl.hpp>
+#include <fc/scoped_exit.hpp>
 
 #include <boost/asio.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
@@ -109,13 +110,13 @@ class producer_plugin_impl {
          // abort the pending block
          chain.abort_block();
 
-         try {
-            // push the new block
-            chain.push_block(block);
-         } FC_LOG_AND_DROP();
-
-         // restart our production loop
-         schedule_production_loop();
+         // exceptions throw out, make sure we restart our loop
+         auto ensure = fc::make_scoped_exit([this](){
+            // restart our production loop
+            schedule_production_loop();
+         });
+         // push the new block
+         chain.push_block(block);
       }
 
       transaction_trace_ptr on_incoming_transaction(const packed_transaction_ptr& trx) {
@@ -235,11 +236,15 @@ void producer_plugin::plugin_initialize(const boost::program_options::variables_
 
 
    my->_incoming_block_subscription = app().get_channel<channels::incoming_block>().subscribe([this](const signed_block_ptr& block){
-      my->on_incoming_block(block);
+      try {
+         my->on_incoming_block(block);
+      } FC_LOG_AND_DROP();
    });
 
    my->_incoming_transaction_subscription = app().get_channel<channels::incoming_transaction>().subscribe([this](const packed_transaction_ptr& trx){
-      my->on_incoming_transaction(trx);
+      try {
+         my->on_incoming_transaction(trx);
+      } FC_LOG_AND_DROP();
    });
 
    static const int my_priority = 1;

--- a/plugins/validator_plugin/CMakeLists.txt
+++ b/plugins/validator_plugin/CMakeLists.txt
@@ -1,0 +1,10 @@
+file(GLOB HEADERS "include/eosio/validator_plugin/*.hpp")
+
+add_library( validator_plugin
+        validator_plugin.cpp
+        ${HEADERS}
+        )
+
+target_link_libraries( validator_plugin chain_plugin appbase eosio_chain eos_utilities )
+target_include_directories( validator_plugin
+        PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" "${CMAKE_CURRENT_SOURCE_DIR}/../chain_interface/include" )

--- a/plugins/validator_plugin/include/eosio/validator_plugin/validator_plugin.hpp
+++ b/plugins/validator_plugin/include/eosio/validator_plugin/validator_plugin.hpp
@@ -1,0 +1,34 @@
+/**
+ *  @file
+ *  @copyright defined in eos/LICENSE.txt
+ */
+
+#pragma once
+
+#include <eosio/chain_plugin/chain_plugin.hpp>
+
+#include <appbase/application.hpp>
+
+namespace eosio {
+
+class validator_plugin : public appbase::plugin<validator_plugin> {
+public:
+   APPBASE_PLUGIN_REQUIRES((chain_plugin))
+
+   validator_plugin();
+   virtual ~validator_plugin();
+
+   virtual void set_program_options(
+      boost::program_options::options_description &command_line_options,
+      boost::program_options::options_description &config_file_options
+      ) override;
+
+   virtual void plugin_initialize(const boost::program_options::variables_map& options);
+   virtual void plugin_startup();
+   virtual void plugin_shutdown();
+
+private:
+   std::unique_ptr<class validator_plugin_impl> my;
+};
+
+} //eosio

--- a/plugins/validator_plugin/validator_plugin.cpp
+++ b/plugins/validator_plugin/validator_plugin.cpp
@@ -1,0 +1,132 @@
+/**
+ *  @file
+ *  @copyright defined in eos/LICENSE.txt
+ */
+#include <eosio/validator_plugin/validator_plugin.hpp>
+#include <eosio/chain/plugin_interface.hpp>
+
+using std::string;
+using std::vector;
+
+namespace eosio {
+
+static appbase::abstract_plugin& _producer_plugin = app().register_plugin<validator_plugin>();
+
+using namespace eosio::chain;
+using namespace eosio::chain::plugin_interface;
+
+class validator_plugin_impl {
+   public:
+      validator_plugin_impl()
+      {}
+
+      boost::program_options::variables_map _options;
+
+      int32_t                                                   _max_deferred_transaction_time_ms;
+      int32_t                                                   _max_pending_transaction_time_ms;
+
+      channels::incoming_block::channel_type::handle            _incoming_block_subscription;
+      channels::incoming_transaction::channel_type::handle      _incoming_transaction_subscription;
+
+      methods::incoming_block_sync::method_type::handle         _incoming_block_sync_provider;
+      methods::incoming_transaction_sync::method_type::handle   _incoming_transaction_sync_provider;
+      methods::start_coordinator::method_type::handle           _start_coordinator_provider;
+
+      void start_block();
+
+      void on_incoming_block(const signed_block_ptr& block) {
+         chain::controller& chain = app().get_plugin<chain_plugin>().chain();
+         // abort the pending block
+         chain.abort_block();
+
+         try {
+            // push the new block
+            chain.push_block(block);
+         } FC_LOG_AND_DROP();
+
+         // restart our production loop
+         start_block();
+      }
+
+      transaction_trace_ptr on_incoming_transaction(const packed_transaction_ptr& trx) {
+         chain::controller& chain = app().get_plugin<chain_plugin>().chain();
+         return chain.sync_push(std::make_shared<transaction_metadata>(*trx), fc::time_point::now() + fc::milliseconds(_max_pending_transaction_time_ms));
+      }
+};
+
+validator_plugin::validator_plugin()
+   : my(new validator_plugin_impl()){
+   }
+
+validator_plugin::~validator_plugin() {}
+
+void validator_plugin::set_program_options(
+   boost::program_options::options_description& command_line_options,
+   boost::program_options::options_description& config_file_options)
+{
+   config_file_options.add_options()
+         ("validator-max-pending-transaction-time", bpo::value<int32_t>()->default_value(30),
+          "Limits the maximum time (in milliseconds) that is allowed a pushed transaction's code to execute before being considered invalid")
+         ("validator-max-deferred-transaction-time", bpo::value<int32_t>()->default_value(20),
+          "Limits the maximum time (in milliseconds) that is allowed a to push deferred transactions at the start of a block")
+         ;
+}
+
+void validator_plugin::plugin_initialize(const boost::program_options::variables_map& options)
+{ try {
+   my->_max_deferred_transaction_time_ms = options.at("validator-max-deferred-transaction-time").as<int32_t>();
+   my->_max_pending_transaction_time_ms = options.at("validator-max-pending-transaction-time").as<int32_t>();
+
+
+   my->_incoming_block_subscription = app().get_channel<channels::incoming_block>().subscribe([this](const signed_block_ptr& block){
+      my->on_incoming_block(block);
+   });
+
+   my->_incoming_transaction_subscription = app().get_channel<channels::incoming_transaction>().subscribe([this](const packed_transaction_ptr& trx){
+      my->on_incoming_transaction(trx);
+   });
+
+   // this is a low priority default plugin
+   static const int my_priority = 1000;
+
+   my->_incoming_block_sync_provider = app().get_method<methods::incoming_block_sync>().register_provider([this](const signed_block_ptr& block){
+      my->on_incoming_block(block);
+   }, my_priority);
+
+   my->_incoming_transaction_sync_provider = app().get_method<methods::incoming_transaction_sync>().register_provider([this](const packed_transaction_ptr& trx) -> transaction_trace_ptr {
+      return my->on_incoming_transaction(trx);
+   }, my_priority);
+
+
+   my->_start_coordinator_provider = app().get_method<methods::start_coordinator>().register_provider([this]() {
+      ilog("Launching validating node.");
+      my->start_block();
+   }, my_priority);
+
+
+} FC_LOG_AND_RETHROW() }
+
+void validator_plugin::plugin_startup()
+{
+}
+
+void validator_plugin::plugin_shutdown() {
+
+}
+
+void validator_plugin_impl::start_block() {
+   chain::controller& chain = app().get_plugin<chain_plugin>().chain();
+   chain.abort_block();
+   chain.start_block();
+   // TODO:  BIG BAD WARNING, THIS WILL HAPPILY BLOW PAST DEADLINES BUT CONTROLLER IS NOT YET SAFE FOR DEADLINE USAGE
+   try {
+      while (chain.push_next_unapplied_transaction(fc::time_point::maximum()));
+   } FC_LOG_AND_DROP();
+
+   try {
+      while (chain.push_next_scheduled_transaction(fc::time_point::maximum()));
+   } FC_LOG_AND_DROP();
+
+}
+
+} // namespace eosio

--- a/programs/nodeos/CMakeLists.txt
+++ b/programs/nodeos/CMakeLists.txt
@@ -53,7 +53,7 @@ target_link_libraries( nodeos
 #        PRIVATE -Wl,${whole_archive_flag} faucet_testnet_plugin      -Wl,${no_whole_archive_flag}
 #        PRIVATE -Wl,${whole_archive_flag} txn_test_gen_plugin        -Wl,${no_whole_archive_flag}
         PRIVATE -Wl,${whole_archive_flag} producer_plugin            -Wl,${no_whole_archive_flag}
-        PRIVATE producer_plugin chain_plugin http_plugin validator_plugin
+        PRIVATE chain_plugin http_plugin validator_plugin
         PRIVATE eosio_chain fc ${CMAKE_DL_LIBS} ${PLATFORM_SPECIFIC_LIBS} )
 
 #if(BUILD_MONGO_DB_PLUGIN)

--- a/programs/nodeos/CMakeLists.txt
+++ b/programs/nodeos/CMakeLists.txt
@@ -45,14 +45,15 @@ endif()
 
 target_link_libraries( nodeos
         PRIVATE appbase
-        PRIVATE -Wl,${whole_archive_flag} history_plugin -Wl,${no_whole_archive_flag}
-        PRIVATE -Wl,${whole_archive_flag} history_api_plugin -Wl,${no_whole_archive_flag}
+        PRIVATE -Wl,${whole_archive_flag} history_plugin             -Wl,${no_whole_archive_flag}
+        PRIVATE -Wl,${whole_archive_flag} history_api_plugin         -Wl,${no_whole_archive_flag}
         PRIVATE -Wl,${whole_archive_flag} chain_api_plugin           -Wl,${no_whole_archive_flag}
         PRIVATE -Wl,${whole_archive_flag} wallet_api_plugin          -Wl,${no_whole_archive_flag}
 #        PRIVATE -Wl,${whole_archive_flag} net_api_plugin             -Wl,${no_whole_archive_flag}
 #        PRIVATE -Wl,${whole_archive_flag} faucet_testnet_plugin      -Wl,${no_whole_archive_flag}
 #        PRIVATE -Wl,${whole_archive_flag} txn_test_gen_plugin        -Wl,${no_whole_archive_flag}
-        PRIVATE producer_plugin chain_plugin http_plugin history_api_plugin history_plugin
+        PRIVATE -Wl,${whole_archive_flag} producer_plugin            -Wl,${no_whole_archive_flag}
+        PRIVATE producer_plugin chain_plugin http_plugin validator_plugin
         PRIVATE eosio_chain fc ${CMAKE_DL_LIBS} ${PLATFORM_SPECIFIC_LIBS} )
 
 #if(BUILD_MONGO_DB_PLUGIN)

--- a/programs/nodeos/main.cpp
+++ b/programs/nodeos/main.cpp
@@ -9,6 +9,7 @@
 #include <eosio/history_plugin.hpp>
 //#include <eosio/net_plugin/net_plugin.hpp>
 #include <eosio/producer_plugin/producer_plugin.hpp>
+#include <eosio/validator_plugin/validator_plugin.hpp>
 #include <eosio/utilities/common.hpp>
 
 #include <fc/log/logger_config.hpp>
@@ -88,7 +89,7 @@ int main(int argc, char** argv)
       auto root = fc::app_path(); 
       app().set_default_data_dir(root / "eosio/nodeos/data" );
       app().set_default_config_dir(root / "eosio/nodeos/config" );
-      if(!app().initialize<chain_plugin, http_plugin, producer_plugin>(argc, argv))
+      if(!app().initialize<chain_plugin, http_plugin, validator_plugin>(argc, argv))
          return -1;
       initialize_logging();
       ilog("nodeos version ${ver}", ("ver", eosio::utilities::common::itoh(static_cast<uint32_t>(app().version()))));

--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -646,7 +646,7 @@ BOOST_AUTO_TEST_CASE(checktime_fail_tests) { try {
 	//       1) compilation of the smart contract should probably not count towards the CPU time of a transaction that first uses it;
 	//       2) checktime should eventually switch to a deterministic metric which should hopefully fix the inconsistencies
 	//          of this test succeeding/failing on different machines (for example, succeeding on our local dev machines but failing on Jenkins).
-   TESTER t( {fc::milliseconds(5000), fc::milliseconds(5000)} );
+   TESTER t;
    t.produce_blocks(2);
 
    t.create_account( N(testapi) );


### PR DESCRIPTION
 - removed unused runtime_limits from controller 
 - added 3 new methods for chain::plugin_interface
    - sync incoming trx/block that should be used for legacy applications that need the exceptions/traces
    - a start_coordinator method
 - these new methods will only route to a single provider based on priority
 - migrated producer plugin to provide these 3 methods at a high priority
 - created validator plugin to provide these 3 methods at a low priority
 - validator plugin is default initialized, producer is no longer
 - validator plugin will start blocks and abort/restart as blocks come in