### PR TITLE
Gh#2738 buyram newaccount

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 *.dot
 *.abi.hpp
 *.cmake
+*.ninja
 \#*
 \.#*
 CMakeCache.txt
@@ -29,6 +30,9 @@ libraries/egenesis/egenesis_full.cpp
 libraries/egenesis/embed_genesis
 libraries/types/type_generator
 libraries/types/types_test
+libraries/fc/test/crypto/test_cypher_suites
+libraries/testing/chain_tester
+
 
 libraries/wallet/Doxyfile
 libraries/wallet/api_documentation.cpp
@@ -39,26 +43,24 @@ libraries/wasm-jit/Source/Programs/Disassemble
 libraries/wasm-jit/Source/Programs/Test
 libraries/wasm-jit/Source/Programs/wavm
 
-programs/cli_wallet/cli_wallet
 programs/cleos/cleos
 programs/js_operation_serializer/js_operation_serializer
-programs/witness_node/witness_node
 programs/data-dir
-programs/eos-walletd/eos-walletd
-programs/eosiod/eosiod
-programs/eosioc/eosioc
-programs/launcher/launcher
 programs/eosio-abigen/eosio-abigen
+programs/cleos/config.hpp
+programs/eosio-applesedemo/eosio-applesedemo
+programs/eosio-launcher/config.hpp
+programs/eosio-launcher/eosio-launcher
+programs/keosd/keosd
+programs/nodeos/config.hpp
+programs/nodeos/nodeos
 
 scripts/tn_init.sh
 
-tests/app_test
-tests/chain_bench
-tests/chain_test
-tests/intense_test
-tests/performance_test
+tests/plugin_test
 tests/config.hpp
 unittests/config.hpp
+unittests/unit_test
 
 doxygen
 
@@ -66,10 +68,6 @@ wallet.json
 witness_node_data_dir
 
 *.wallet
-
-programs/witness_node/object_database/*
-
-object_database/*
 
 *.pyc
 *.pyo

--- a/libraries/chain/include/eosio/chain/symbol.hpp
+++ b/libraries/chain/include/eosio/chain/symbol.hpp
@@ -63,10 +63,10 @@ namespace eosio {
             static constexpr uint8_t max_precision = 18;
 
             explicit symbol(uint8_t p, const char* s): m_value(string_to_symbol(p, s)) {
-               FC_ASSERT(valid(), "invalid symbol", ("s",s));
+               FC_ASSERT(valid(), "invalid symbol: ${s}", ("s",s));
             }
             explicit symbol(uint64_t v = SY(4, EOS)): m_value(v) {
-               FC_ASSERT(valid(), "invalid symbol", ("name",name()));
+               FC_ASSERT(valid(), "invalid symbol: ${name}", ("name",name()));
             }
             static symbol from_string(const string& from)
             {

--- a/tests/testUtils.py
+++ b/tests/testUtils.py
@@ -488,7 +488,7 @@ class Node(object):
     # Create account and return creation transactions. Return transaction json object
     # waitForTransBlock: wait on creation transaction id to appear in a block
     def createAccount(self, account, creatorAccount, stakedDeposit=1000, waitForTransBlock=False):
-        cmd="%s %s create account -j %s %s %s %s" % (
+        cmd="%s %s create account -j --buy-ram-bytes 0 %s %s %s %s" % (
             Utils.EosClientPath, self.endpointArgs, creatorAccount.name, account.name,
             account.ownerPublicKey, account.activePublicKey)
 

--- a/unittests/currency_tests.cpp
+++ b/unittests/currency_tests.cpp
@@ -43,6 +43,7 @@ class currency_tester : public TESTER {
 
          signed_transaction trx;
          trx.actions.emplace_back(std::move(act));
+
          set_transaction_headers(trx);
          trx.sign(get_private_key(signer, "active"), chain_id_type());
          return push_transaction(trx);
@@ -316,7 +317,7 @@ BOOST_FIXTURE_TEST_CASE(test_symbol, TESTER) try {
    // invalid - contains lower case characters, no validation
    {
       BOOST_CHECK_EXCEPTION(symbol malformed(SY(6,EoS)),
-                            fc::assert_exception, fc_assert_exception_message_is("invalid symbol"));
+                            fc::assert_exception, fc_assert_exception_message_is("invalid symbol: EoS"));
    }
 
    // invalid - contains lower case characters, exception thrown


### PR DESCRIPTION
Add buyram or buyrambytes to newaccount transaction in cleos.
Specifying a buyram of 0 will skip the addition of buyram to the newaccount transaction so that create account can be used without the eosio.system and eosio.token account being loaded. Otherwise eosio.system and eosio.token (created and issued) must be loaded.