### PR TITLE
Contract destructor call

### DIFF
--- a/contracts/eosiolib/dispatcher.hpp
+++ b/contracts/eosiolib/dispatcher.hpp
@@ -66,7 +66,7 @@ namespace eosio {
 #define EOSIO_API_CALL( r, OP, elem ) \
    case ::eosio::string_to_name( BOOST_PP_STRINGIZE(elem) ): \
       eosio::execute_action( &thiscontract, &OP::elem ); \
-      return;
+      break;
 
 #define EOSIO_API( TYPE,  MEMBERS ) \
    BOOST_PP_SEQ_FOR_EACH( EOSIO_API_CALL, TYPE, MEMBERS )
@@ -80,7 +80,7 @@ extern "C" { \
          switch( action ) { \
             EOSIO_API( TYPE, MEMBERS ) \
          } \
-         eosio_exit(0); \
+         /* does not allow destructor of thiscontract to run: eosio_exit(0); */ \
       } \
    } \
 } \


### PR DESCRIPTION
Spent some time being confused why the `eosio_exit(0)` in `EOSIO_ABI` was allowing the destructor of the contract to still run. The return in `EOSIO_API_CALL` was skipping the `eosio_exit`. Since the eosio.system contract expects the destructor to run, removing the return and the eosio_exit so that the  eosio.system contract destructor can run.