### PR TITLE
Remove nonce from system contracts; use nonce on nobody

### DIFF
--- a/contracts/eosio.bios/eosio.bios.abi
+++ b/contracts/eosio.bios/eosio.bios.abi
@@ -41,12 +41,6 @@
       "fields": [
         {"name":"from", "type":"account_name"}
       ]
-    },{
-      "name": "nonce",
-      "base": "",
-      "fields": [
-        {"name":"value", "type":"string"}
-      ]
     }],
   "actions": [{
       "name": "setalimits",
@@ -67,10 +61,6 @@
     },{
       "name": "reqauth",
       "type": "require_auth",
-      "ricardian_contract": ""
-    },{
-      "name": "nonce",
-      "type": "nonce",
       "ricardian_contract": ""
     }
   ],

--- a/contracts/eosio.system/eosio.system.abi
+++ b/contracts/eosio.system/eosio.system.abi
@@ -1,12 +1,6 @@
 {
   "types": [],
   "structs": [{
-      "name": "nonce",
-       "base": "",
-       "fields": [
-          {"name":"value", "type":"string"}
-      ]
-    },{
       "name": "buyrambytes",
       "base": "",
       "fields": [
@@ -242,10 +236,6 @@
     },{
       "name": "claimrewards",
       "type": "claimrewards",
-      "ricardian_contract": ""
-    },{
-      "name": "nonce",
-      "type": "nonce",
       "ricardian_contract": ""
     }
   ],

--- a/contracts/eosio.system/eosio.system.cpp
+++ b/contracts/eosio.system/eosio.system.cpp
@@ -65,6 +65,4 @@ EOSIO_ABI( eosiosystem::system_contract,
      //XXX
      (onblock)
      (newaccount)(updateauth)(deleteauth)(linkauth)(unlinkauth)(postrecovery)(passrecovery)(vetorecovery)(onerror)(canceldelay)
-     // defined in eosio.system.hpp
-     (nonce)
 )

--- a/contracts/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/eosio.system.hpp
@@ -184,8 +184,6 @@ namespace eosiosystem {
 
          void regproxy( const account_name proxy, bool isproxy );
 
-         void nonce( const std::string& /*value*/ ) {}
-
          // functions defined in producer_pay.cpp
          void claimrewards( const account_name& owner );
 

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -373,11 +373,9 @@ namespace eosio { namespace testing {
         // lets also push a context free action, the multi chain test will then also include a context free action
         ("context_free_actions", fc::variants({
             fc::mutable_variant_object()
-               ("account", name(config::system_account_name))
+               ("account", name(config::nobody_account_name))
                ("name", "nonce")
-               ("data", fc::mutable_variant_object()
-                  ("value", v)
-               )
+               ("data", fc::raw::pack(v))
             })
          );
 

--- a/plugins/txn_test_gen_plugin/txn_test_gen_plugin.cpp
+++ b/plugins/txn_test_gen_plugin/txn_test_gen_plugin.cpp
@@ -252,9 +252,6 @@ struct txn_test_gen_plugin_impl {
       fc::crypto::private_key a_priv_key = fc::crypto::private_key::regenerate(fc::sha256(std::string(64, 'a')));
       fc::crypto::private_key b_priv_key = fc::crypto::private_key::regenerate(fc::sha256(std::string(64, 'b')));
 
-      static uint64_t nonce = static_cast<uint64_t>(fc::time_point::now().sec_since_epoch()) << 32;
-      abi_serializer eosio_serializer(cc.get_database().find<account_object, by_name>(config::system_account_name)->get_abi());
-
       uint32_t reference_block_num = cc.last_irreversible_block_num();
       if (txn_reference_block_lag >= 0) {
          reference_block_num = cc.head_block_num();
@@ -269,11 +266,9 @@ struct txn_test_gen_plugin_impl {
 
       for(unsigned int i = 0; i < batch; ++i) {
       {
-      variant nonce_vo = fc::mutable_variant_object()
-         ("value", fc::to_string(nonce++));
       signed_transaction trx;
       trx.actions.push_back(act_a_to_b);
-      trx.context_free_actions.emplace_back(action({}, config::system_account_name, "nonce", eosio_serializer.variant_to_binary("nonce", nonce_vo)));
+      trx.context_free_actions.emplace_back(action({}, config::nobody_account_name, "nonce", fc::raw::pack(nonce++)));
       trx.set_reference_block(reference_block_id);
       trx.expiration = cc.head_block_time() + fc::seconds(30);
       trx.max_net_usage_words = 100;
@@ -282,11 +277,9 @@ struct txn_test_gen_plugin_impl {
       }
 
       {
-      variant nonce_vo = fc::mutable_variant_object()
-         ("value", fc::to_string(nonce++));
       signed_transaction trx;
       trx.actions.push_back(act_b_to_a);
-      trx.context_free_actions.emplace_back(action({}, config::system_account_name, "nonce", eosio_serializer.variant_to_binary("nonce", nonce_vo)));
+      trx.context_free_actions.emplace_back(action({}, config::nobody_account_name, "nonce", fc::raw::pack(nonce++)));
       trx.set_reference_block(reference_block_id);
       trx.expiration = cc.head_block_time() + fc::seconds(30);
       trx.max_net_usage_words = 100;
@@ -313,7 +306,9 @@ struct txn_test_gen_plugin_impl {
    action act_a_to_b;
    action act_b_to_a;
 
-   abi_serializer currency_serializer = fc::json::from_string(eosio_token_abi).as<abi_def>();
+   uint64_t nonce = static_cast<uint64_t>(fc::time_point::now().sec_since_epoch()) << 32;
+
+   abi_serializer eosio_token_serializer = fc::json::from_string(eosio_token_abi).as<contracts::abi_def>();
 };
 
 txn_test_gen_plugin::txn_test_gen_plugin() {}

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -214,23 +214,12 @@ eosio::chain_apis::read_only::get_info_results get_info() {
    return ::call(url, get_info_func, fc::variant()).as<eosio::chain_apis::read_only::get_info_results>();
 }
 
-string generate_nonce_value() {
+string generate_nonce_string() {
    return fc::to_string(fc::time_point::now().time_since_epoch().count());
 }
 
-chain::action generate_nonce() {
-   auto v = generate_nonce_value();
-   variant nonce = fc::mutable_variant_object()
-         ("value", v);
-
-   try {
-      auto result = call(get_code_func, fc::mutable_variant_object("account_name", name(config::system_account_name)));
-      abi_serializer eosio_serializer(result["abi"].as<abi_def>());
-      return chain::action( {}, config::system_account_name, "nonce", eosio_serializer.variant_to_binary("nonce", nonce));
-   }
-   catch (...) {
-      EOS_THROW(account_query_exception, "A system contract is required to use nonce");
-   }
+chain::action generate_nonce_action() {
+   return chain::action( {}, config::nobody_account_name, "nonce", fc::raw::pack(fc::time_point::now().time_since_epoch().count()));
 }
 
 fc::variant determine_required_keys(const signed_transaction& trx) {
@@ -267,7 +256,7 @@ fc::variant push_transaction( signed_transaction& trx, int32_t extra_kcpu = 1000
    trx.set_reference_block(ref_block_id);
 
    if (tx_force_unique) {
-      trx.context_free_actions.emplace_back( generate_nonce() );
+      trx.context_free_actions.emplace_back( generate_nonce_action() );
    }
 
    auto required_keys = determine_required_keys(trx);
@@ -1386,7 +1375,7 @@ int main( int argc, char** argv ) {
       signed_transaction trx;
       if (tx_force_unique && memo.size() == 0) {
          // use the memo to add a nonce
-         memo = generate_nonce_value();
+         memo = generate_nonce_string();
          tx_force_unique = false;
       }
 


### PR DESCRIPTION
Remove the concept of a noop nonce action on the system contracts. cleos (and the tester and txn_test_gen_plugin) will now execute a non existent action on the nobody account.

Issue #2423 