### PR TITLE
Eager checks for the existence of accounts and permissions in actions

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1302,15 +1302,25 @@ fc::microseconds controller::limit_delay( fc::microseconds delay )const {
 
 void controller::validate_referenced_accounts( const transaction& trx )const {
    for( const auto& a : trx.context_free_actions ) {
-      get_account( a.account );
-      FC_ASSERT( a.authorization.size() == 0 );
+      auto* code = my->db.find<account_object, by_name>(a.account);
+      EOS_ASSERT( code != nullptr, transaction_exception,
+                  "action's code account ${account} does not exist", ("account", a.account) );
+      EOS_ASSERT( a.authorization.size() == 0, transaction_exception,
+                  "context-free actions cannot have authorizations" );
    }
    bool one_auth = false;
    for( const auto& a : trx.actions ) {
-      get_account( a.account );
+      auto* code = my->db.find<account_object, by_name>(a.account);
+      EOS_ASSERT( code != nullptr, transaction_exception,
+                  "action's code account ${account} does not exist", ("account", a.account) );
       for( const auto& auth : a.authorization ) {
          one_auth = true;
-         get_account( auth.actor );
+         auto* actor = my->db.find<account_object, by_name>(auth.actor);
+         EOS_ASSERT( actor  != nullptr, transaction_exception,
+                     "action's authorizing actor ${account} does not exist", ("account", auth.actor) );
+         EOS_ASSERT( my->authorization.find_permission(auth) != nullptr, transaction_exception,
+                     "action's authorizations include a non-existent permission: {permission}",
+                     ("permission", auth) );
       }
    }
    EOS_ASSERT( one_auth, tx_no_auths, "transaction must have at least one authorization" );


### PR DESCRIPTION
Transaction validation now also checks to see if the permissions specified in the authorizations of the actions exist early in the validation process, regardless of whether authorizations end up being checked or not (e.g. for a privileged account). 

The existence of the code accounts of inline actions (context-aware or context-free) are now checked early. The permissions specified in the authorizations of an inline context-aware action are also checked early. 

Also more descriptive exceptions will be thrown for non-existent accounts or permissions.