### PR TITLE
Generate .wasm files alongside .wast

### DIFF
--- a/CMakeModules/wasm.cmake
+++ b/CMakeModules/wasm.cmake
@@ -157,6 +157,16 @@ macro(add_wast_executable)
     VERBATIM
   )
   set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_MAKE_CLEAN_FILES ${target}.wast)
+
+  add_custom_command(OUTPUT ${DESTINATION_FOLDER}/${target}.wasm
+    DEPENDS ${target}.wast
+    COMMAND $<TARGET_FILE:eosio-wast2wasm> ${DESTINATION_FOLDER}/${target}.wast ${DESTINATION_FOLDER}/${target}.wasm -n
+    COMMENT "Generating WASM ${target}.wasm"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    VERBATIM
+  )
+  set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_MAKE_CLEAN_FILES ${target}.wasm)
+
   STRING (REPLACE "." "_" TARGET_VARIABLE "${target}")
 
   add_custom_command(OUTPUT ${DESTINATION_FOLDER}/${target}.wast.hpp
@@ -183,6 +193,7 @@ macro(add_wast_executable)
   endif()
   
   add_custom_target(${target} ALL DEPENDS ${DESTINATION_FOLDER}/${target}.wast.hpp ${extra_target_dependency})
+  add_custom_target(${target}_wasm ALL DEPENDS ${DESTINATION_FOLDER}/${target}.wasm)
   
   set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_MAKE_CLEAN_FILES ${DESTINATION_FOLDER}/${target}.wast.hpp)
 

--- a/CMakeModules/wasm.cmake
+++ b/CMakeModules/wasm.cmake
@@ -192,8 +192,7 @@ macro(add_wast_executable)
   else()
   endif()
   
-  add_custom_target(${target} ALL DEPENDS ${DESTINATION_FOLDER}/${target}.wast.hpp ${extra_target_dependency})
-  add_custom_target(${target}_wasm ALL DEPENDS ${DESTINATION_FOLDER}/${target}.wasm)
+  add_custom_target(${target} ALL DEPENDS ${DESTINATION_FOLDER}/${target}.wast.hpp ${extra_target_dependency} ${DESTINATION_FOLDER}/${target}.wasm)
   
   set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_MAKE_CLEAN_FILES ${DESTINATION_FOLDER}/${target}.wast.hpp)
 

--- a/libraries/wasm-jit/Source/Programs/Assemble.cpp
+++ b/libraries/wasm-jit/Source/Programs/Assemble.cpp
@@ -7,7 +7,7 @@ int commandMain(int argc,char** argv)
 {
 	if(argc < 3)
 	{
-		std::cerr << "Usage: Assemble in.wast out.wasm [switches]" << std::endl;
+		std::cerr << "Usage: eosio-wast2wasm in.wast out.wasm [switches]" << std::endl;
 		std::cerr << "  -n|--omit-names\t\tOmits WAST function and local names from the output" << std::endl;
 		return EXIT_FAILURE;
 	}

--- a/libraries/wasm-jit/Source/Programs/CMakeLists.txt
+++ b/libraries/wasm-jit/Source/Programs/CMakeLists.txt
@@ -1,6 +1,7 @@
-add_executable(Assemble Assemble.cpp CLI.h)
-target_link_libraries(Assemble Logging IR WAST WASM)
-set_target_properties(Assemble PROPERTIES FOLDER Programs)
+add_executable(eosio-wast2wasm Assemble.cpp CLI.h)
+target_link_libraries(eosio-wast2wasm Logging IR WAST WASM)
+set_target_properties(eosio-wast2wasm PROPERTIES FOLDER Programs)
+INSTALL(TARGETS eosio-wast2wasm DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 add_executable(Disassemble Disassemble.cpp CLI.h)
 target_link_libraries(Disassemble Logging IR WAST WASM)

--- a/tools/eosiocpp.in
+++ b/tools/eosiocpp.in
@@ -28,12 +28,12 @@ function copy_skeleton {
 function build_contract {
     set -e
     workdir=`mktemp -d`
-#    echo mkdir $workdir/built
-    mkdir $workdir/built
 
     if [[ ${VERBOSE} == "1" ]]; then
        PRINT_CMDS="set -x"
     fi
+
+    ($PRINT_CMDS; mkdir $workdir/built)
 
     for file in $@; do
         name=`basename $file`
@@ -60,9 +60,9 @@ function build_contract {
     )
     ($PRINT_CMDS; @WASM_LLC@ -thread-model=single --asm-verbose=false -o $workdir/assembly.s $workdir/linked.bc)
     ($PRINT_CMDS; ${EOSIO_INSTALL_DIR}/bin/eosio-s2wasm -o $outname -s 16384 $workdir/assembly.s)
+    ($PRINT_CMDS; ${EOSIO_INSTALL_DIR}/bin/eosio-wast2wasm $outname ${outname%.*}.wasm -n)
 
-#    echo rm -rf $workdir
-    rm -rf $workdir
+    ($PRINT_CMDS; rm -rf $workdir)
     set +e
 }
 
@@ -104,6 +104,7 @@ function print_help {
     echo "   OR"
     echo "   -o | --outname [output.wast] [input.cpp ...]"
     echo "      Generate the wast output file based on input cpp files"
+    echo "      The wasm output will also be created as output.wasm"
     echo "   OR"
     echo "   -g | --genabi contract.abi types.hpp"
     echo "      Generate the ABI specification file [EXPERIMENTAL]"


### PR DESCRIPTION
Generate binary .wasm files alongside the .wast files. The binary files are a little more... "canonical" (for lack of a better term) than the text files and this also this allows one to easily see actual size of the wasm. cleos already prefers .wasm over .wast.

I was certain there was an issue about this but I can't seem to find it.