### PR TITLE
Fixes EOSIO/eos#2803

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -839,15 +839,19 @@ namespace eosio {
          }
       }
       size_t count = 0;
-      if (bstack.back()->previous == lib_id) {
-         count = bstack.size();
-         while (bstack.size()) {
-            enqueue (*bstack.back());
-            bstack.pop_back();
+      if (!bstack.empty()) {
+         if (bstack.back()->previous == lib_id) {
+            count = bstack.size();
+            while (bstack.size()) {
+               enqueue(*bstack.back());
+               bstack.pop_back();
+            }
          }
+         fc_ilog(logger, "Sent ${n} blocks on my fork",("n",count));
+      } else {
+         fc_ilog(logger, "Nothing to send on fork request");
       }
 
-      fc_ilog(logger, "Sent ${n} blocks on my fork",("n",count));
       syncing = false;
    }
 

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -301,7 +301,7 @@ bool producer_plugin_impl::start_block() {
    // If we would wait less than 50ms (1/10 of block_interval), wait for the whole block interval.
    fc::time_point now = fc::time_point::now();
    fc::time_point base = std::max<fc::time_point>(now, chain.head_block_time());
-   int64_t min_time_to_next_block = (config::block_interval_us) - (now.time_since_epoch().count() % (config::block_interval_us) );
+   int64_t min_time_to_next_block = (config::block_interval_us) - (base.time_since_epoch().count() % (config::block_interval_us) );
    fc::time_point block_time = base + fc::microseconds(min_time_to_next_block);
 
 


### PR DESCRIPTION
- use the correct base time when calculating the minimum time to the next block
- prevent bad access of members of `pending` if `start_block` throws by cleaning up `pending` on the way out
- prevent bad access of vector when fulfilling a fork request results in no blocks to send

resolves EOSIO/eos#2803