### PR TITLE
Docker fixes for #2672 #2480 [skip-ci]

### DIFF
--- a/Docker/builder/Dockerfile
+++ b/Docker/builder/Dockerfile
@@ -73,3 +73,9 @@ RUN git clone --depth 1 --single-branch --branch master https://github.com/ucb-b
     && mv ../../source/include /opt/berkeley-softfloat-3/include && cd - && rm -rf berkeley-softfloat-3
 
 ENV SOFTFLOAT_ROOT /opt/berkeley-softfloat-3
+
+RUN git clone -b master --depth 1 https://github.com/EOSIO/eos.git --recursive \
+    && cd eos \
+    && cmake -H. -B"/tmp/build" -GNinja -DCMAKE_BUILD_TYPE=Release -DWASM_ROOT=/opt/wasm -DCMAKE_CXX_COMPILER=clang++ \
+       -DCMAKE_C_COMPILER=clang -DSecp256k1_ROOT_DIR=/usr/local -DBUILD_MONGO_DB_PLUGIN=true \
+    && cmake --build /tmp/build --target install && rm -rf /tmp/build /eos

--- a/Docker/nodeosd.sh
+++ b/Docker/nodeosd.sh
@@ -7,12 +7,6 @@ if [ -f '/opt/eosio/bin/data-dir/config.ini' ]; then
     cp /config.ini /opt/eosio/bin/data-dir
 fi
 
-if [ -f '/opt/eosio/bin/data-dir/genesis.json' ]; then
-    echo
-  else
-    cp /genesis.json /opt/eosio/bin/data-dir
-fi
-
 if [ -d '/opt/eosio/bin/data-dir/contracts' ]; then
     echo
   else


### PR DESCRIPTION
Fixes issues with eosiocpp (#2480, #2387, #2320)  and nodeosd.sh (#2672)

*Skipping CI as no buildable code has been modified.