### PR TITLE
Use s3 bucket to publish coverage reports [skip-ci]

### DIFF
--- a/.buildkite/coverage.yml
+++ b/.buildkite/coverage.yml
@@ -6,7 +6,8 @@ steps:
         echo "+++ :spiral_note_pad: Generating Code Coverage Report" && \
         /usr/bin/ninja EOS_ut_coverage && \
         echo "--- :arrow_up: Publishing Code Coverage Report" && \
-        buildkite-agent artifact upload "EOS_ut_coverage/**/*" s3://eosio-coverage/$BUILDKITE_JOB_ID
+        buildkite-agent artifact upload "EOS_ut_coverage/**/*" s3://eosio-coverage/$BUILDKITE_JOB_ID && \
+        printf "\033]1339;url=https://eosio-coverage.s3-us-west-2.amazonaws.com/$BUILDKITE_JOB_ID/EOS_ut_coverage/index.html;content=View Full Coverage Report\a\n"
     label: ":spiral_note_pad: Generate Report"
     agents:
       - "role=linux-coverage"

--- a/.buildkite/coverage.yml
+++ b/.buildkite/coverage.yml
@@ -3,10 +3,11 @@ steps:
         echo "--- :hammer: Building" && \
         /usr/bin/cmake -GNinja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=clang++-4.0 -DCMAKE_C_COMPILER=clang-4.0 -DWASM_ROOT=/root/opt/wasm -DOPENSSL_ROOT_DIR=/usr/include/openssl -DBUILD_MONGO_DB_PLUGIN=true -DENABLE_COVERAGE_TESTING=true -DBUILD_DOXYGEN=false && \
         /usr/bin/ninja
-        echo "+++ :spiral_note_pad: Generating Code Coverage Report" && \
+        echo "--- :spiral_note_pad: Generating Code Coverage Report" && \
         /usr/bin/ninja EOS_ut_coverage && \
         echo "--- :arrow_up: Publishing Code Coverage Report" && \
         buildkite-agent artifact upload "EOS_ut_coverage/**/*" s3://eosio-coverage/$BUILDKITE_JOB_ID && \
+        echo "+++ View Report" && \
         printf "\033]1339;url=https://eosio-coverage.s3-us-west-2.amazonaws.com/$BUILDKITE_JOB_ID/EOS_ut_coverage/index.html;content=View Full Coverage Report\a\n"
     label: ":spiral_note_pad: Generate Report"
     agents:

--- a/.buildkite/coverage.yml
+++ b/.buildkite/coverage.yml
@@ -1,15 +1,15 @@
 steps:
   - command: |
-        echo "+++ :hammer: Building" && \
+        echo "--- :hammer: Building" && \
         /usr/bin/cmake -GNinja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=clang++-4.0 -DCMAKE_C_COMPILER=clang-4.0 -DWASM_ROOT=/root/opt/wasm -DOPENSSL_ROOT_DIR=/usr/include/openssl -DBUILD_MONGO_DB_PLUGIN=true -DENABLE_COVERAGE_TESTING=true -DBUILD_DOXYGEN=false && \
         /usr/bin/ninja
-        echo "--- :spiral_note_pad: Generating Code Coverage Report" && \
+        echo "+++ :spiral_note_pad: Generating Code Coverage Report" && \
         /usr/bin/ninja EOS_ut_coverage && \
-        tar -pzcf report.tar.gz EOS_ut_coverage/
+        echo "--- :arrow_up: Publishing Code Coverage Report" && \
+        buildkite-agent artifact upload "EOS_ut_coverage/**/*" s3://eosio-coverage/$BUILDKITE_JOB_ID
     label: ":spiral_note_pad: Generate Report"
     agents:
       - "role=linux-coverage"
-    artifact_paths: "report.tar.gz"
     plugins:
       docker#v1.1.1:
         image: "eosio/ci:ubuntu18"


### PR DESCRIPTION
Publish coverage reports to our s3 bucket  in order to view reports within browser.