### PR TITLE
fixes for transaction re-broadcast and enable-stale-production timing

### DIFF
--- a/plugins/chain_interface/include/eosio/chain/plugin_interface.hpp
+++ b/plugins/chain_interface/include/eosio/chain/plugin_interface.hpp
@@ -26,8 +26,6 @@ namespace eosio { namespace chain { namespace plugin_interface {
       using applied_transaction    = channel_decl<struct applied_transaction_tag,   transaction_trace_ptr>;
       using accepted_confirmation  = channel_decl<struct accepted_confirmation_tag, header_confirmation>;
 
-      using incoming_block         = channel_decl<struct incoming_blocks_tag,       signed_block_ptr>;
-      using incoming_transaction   = channel_decl<struct incoming_transactions_tag, packed_transaction_ptr>;
    }
 
    namespace methods {
@@ -36,10 +34,25 @@ namespace eosio { namespace chain { namespace plugin_interface {
       using get_head_block_id      = method_decl<chain_plugin_interface, block_id_type ()>;
 
       using get_last_irreversible_block_number = method_decl<chain_plugin_interface, uint32_t ()>;
+   }
 
-      // synchronously push a block/trx to a single provider
-      using incoming_block_sync       = method_decl<chain_plugin_interface, void(const signed_block_ptr&), first_provider_policy>;
-      using incoming_transaction_sync = method_decl<chain_plugin_interface, transaction_trace_ptr(const packed_transaction_ptr&), first_provider_policy>;
+   namespace incoming {
+      namespace channels {
+         using block                 = channel_decl<struct block_tag, signed_block_ptr>;
+         using transaction           = channel_decl<struct transaction_tag, packed_transaction_ptr>;
+      }
+
+      namespace methods {
+         // synchronously push a block/trx to a single provider
+         using block_sync            = method_decl<chain_plugin_interface, void(const signed_block_ptr&), first_provider_policy>;
+         using transaction_sync      = method_decl<chain_plugin_interface, transaction_trace_ptr(const packed_transaction_ptr&), first_provider_policy>;
+      }
+   }
+
+   namespace compat {
+      namespace channels {
+         using transaction_ack       = channel_decl<struct accepted_transaction_tag, std::pair<fc::exception_ptr, packed_transaction_ptr>>;
+      }
    }
 
 } } }

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -45,9 +45,9 @@ public:
    ,accepted_transaction_channel(app().get_channel<channels::accepted_transaction>())
    ,applied_transaction_channel(app().get_channel<channels::applied_transaction>())
    ,accepted_confirmation_channel(app().get_channel<channels::accepted_confirmation>())
-   ,incoming_block_channel(app().get_channel<channels::incoming_block>())
-   ,incoming_block_sync_method(app().get_method<methods::incoming_block_sync>())
-   ,incoming_transaction_sync_method(app().get_method<methods::incoming_transaction_sync>())
+   ,incoming_block_channel(app().get_channel<incoming::channels::block>())
+   ,incoming_block_sync_method(app().get_method<incoming::methods::block_sync>())
+   ,incoming_transaction_sync_method(app().get_method<incoming::methods::transaction_sync>())
    {}
    
    bfs::path                        block_log_dir;
@@ -72,11 +72,11 @@ public:
    channels::accepted_transaction::channel_type&   accepted_transaction_channel;
    channels::applied_transaction::channel_type&    applied_transaction_channel;
    channels::accepted_confirmation::channel_type&  accepted_confirmation_channel;
-   channels::incoming_block::channel_type&         incoming_block_channel;
+   incoming::channels::block::channel_type&         incoming_block_channel;
 
    // retained references to methods for easy calling
-   methods::incoming_block_sync::method_type&       incoming_block_sync_method;
-   methods::incoming_transaction_sync::method_type& incoming_transaction_sync_method;
+   incoming::methods::block_sync::method_type&       incoming_block_sync_method;
+   incoming::methods::transaction_sync::method_type& incoming_transaction_sync_method;
 
    // method provider handles
    methods::get_block_by_number::method_type::handle                 get_block_by_number_provider;
@@ -454,7 +454,7 @@ read_write::push_transaction_results read_write::push_transaction(const read_wri
       abi_serializer::from_variant(params, *pretty_input, resolver);
    } EOS_RETHROW_EXCEPTIONS(chain::packed_transaction_type_exception, "Invalid packed transaction")
 
-   auto trx_trace_ptr = app().get_method<methods::incoming_transaction_sync>()(pretty_input);
+   auto trx_trace_ptr = app().get_method<incoming::methods::transaction_sync>()(pretty_input);
 
    fc::variant pretty_output = db.to_variant_with_abi( *trx_trace_ptr );;
    //abi_serializer::to_variant(*trx_trace_ptr, pretty_output, resolver);

--- a/plugins/net_plugin/CMakeLists.txt
+++ b/plugins/net_plugin/CMakeLists.txt
@@ -1,7 +1,7 @@
-file(GLOB HEADERS "include/eosio/net_plugin/*.hpp")
+file(GLOB HEADERS "include/eosio/net_plugin/*.hpp" )
 add_library( net_plugin
              net_plugin.cpp
              ${HEADERS} )
 
 target_link_libraries( net_plugin chain_plugin producer_plugin appbase fc )
-target_include_directories( net_plugin PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include )
+target_include_directories( net_plugin PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include ${CMAKE_CURRENT_SOURCE_DIR}/../chain_interface/include )


### PR DESCRIPTION
- added compat signal which mimics the on_pending_transaction signal from master
  - this signal is fired whenever an incoming signal is accepted or rejected and indicates the result
- moved check for stale_production to the block reception code since that now flows through producer_plugin