### PR TITLE
replace usage of boost::ipc::vector<char> with boost::ipc::basic_string

### DIFF
--- a/libraries/chain/eosio_contract.cpp
+++ b/libraries/chain/eosio_contract.cpp
@@ -133,8 +133,6 @@ void apply_eosio_setcode(apply_context& context) {
       /** TODO: consider whether a microsecond level local timestamp is sufficient to detect code version changes*/
       #warning TODO: update setcode message to include the hash, then validate it in validate
       a.code_version = code_id;
-      // Added resize(0) here to avoid bug in boost vector container
-      a.code.resize( 0 );
       a.code.resize( code_size );
       a.last_code_update = context.control.pending_block_time();
       memcpy( a.code.data(), act.code.data(), code_size );

--- a/libraries/chain/include/eosio/chain/account_object.hpp
+++ b/libraries/chain/include/eosio/chain/account_object.hpp
@@ -25,12 +25,10 @@ namespace eosio { namespace chain {
       digest_type          code_version;
       block_timestamp_type creation_date;
 
-      shared_vector<char>  code;
-      shared_vector<char>  abi;
+      shared_string  code;
+      shared_string  abi;
 
       void set_abi( const eosio::chain::abi_def& a ) {
-         // Added resize(0) here to avoid bug in boost vector container
-         abi.resize( 0 );
          abi.resize( fc::raw::pack_size( a ) );
          fc::datastream<char*> ds( abi.data(), abi.size() );
          fc::raw::pack( ds, a );

--- a/libraries/chain/include/eosio/chain/contract_table_objects.hpp
+++ b/libraries/chain/include/eosio/chain/contract_table_objects.hpp
@@ -64,7 +64,7 @@ namespace eosio { namespace chain {
       table_id              t_id;
       uint64_t              primary_key;
       account_name          payer = 0;
-      shared_vector<char>   value;
+      shared_string         value;
    };
 
    using key_value_index = chainbase::shared_multi_index_container<

--- a/libraries/chain/include/eosio/chain/generated_transaction_object.hpp
+++ b/libraries/chain/include/eosio/chain/generated_transaction_object.hpp
@@ -34,7 +34,7 @@ namespace eosio { namespace chain {
          time_point                    delay_until; /// this generated transaction will not be applied until the specified time
          time_point                    expiration; /// this generated transaction will not be applied after this time
          time_point                    published;
-         shared_vector<char>           packed_trx;
+         shared_string                 packed_trx;
 
          uint32_t set( const transaction& trx ) {
             auto trxsize = fc::raw::pack_size( trx );

--- a/libraries/chain/include/eosio/chain/wasm_interface.hpp
+++ b/libraries/chain/include/eosio/chain/wasm_interface.hpp
@@ -61,7 +61,7 @@ namespace eosio { namespace chain {
          static void validate(const bytes& code);
 
          //Calls apply or error on a given code
-         void apply(const digest_type& code_id, const shared_vector<char>& code, apply_context& context);
+         void apply(const digest_type& code_id, const shared_string& code, apply_context& context);
 
       private:
          unique_ptr<struct wasm_interface_impl> my;

--- a/libraries/chain/include/eosio/chain/wasm_interface_private.hpp
+++ b/libraries/chain/include/eosio/chain/wasm_interface_private.hpp
@@ -47,7 +47,7 @@ namespace eosio { namespace chain {
          return mem_image;
       }
 
-      std::unique_ptr<wasm_instantiated_module_interface>& get_instantiated_module(const digest_type& code_id, const shared_vector<char>& code) {
+      std::unique_ptr<wasm_instantiated_module_interface>& get_instantiated_module(const digest_type& code_id, const shared_string& code) {
          auto it = instantiation_cache.find(code_id);
          if(it == instantiation_cache.end()) {
             IR::Module module;

--- a/libraries/chain/wasm_interface.cpp
+++ b/libraries/chain/wasm_interface.cpp
@@ -52,7 +52,7 @@ namespace eosio { namespace chain {
       //Hard: Kick off instantiation in a separate thread at this location
 	   }
 
-   void wasm_interface::apply( const digest_type& code_id, const shared_vector<char>& code, apply_context& context ) {
+   void wasm_interface::apply( const digest_type& code_id, const shared_string& code, apply_context& context ) {
       my->get_instantiated_module(code_id, code)->apply(context);
    }
 

--- a/plugins/history_plugin/history_plugin.cpp
+++ b/plugins/history_plugin/history_plugin.cpp
@@ -27,7 +27,7 @@ namespace eosio {
       id_type      id;
       uint64_t     action_sequence_num; ///< the sequence number of the relevant action
 
-      shared_vector<char>  packed_action_trace;
+      shared_string        packed_action_trace;
       uint32_t             block_num;
       block_timestamp_type block_time;
       transaction_id_type  trx_id;


### PR DESCRIPTION
boost::interprocess:vector has problems when POD are used; see boost ticket 13533. We've been struggling with this for a good while and it's even worse on boost 1.67. Since the fix in boost's ticket 13533 won't be available until boost 1.68, replace instances off `boost::ipc::vector<char>` with boost::ipc::basic_string