### PR TITLE
Silence spurious debug dump

### DIFF
--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -61,7 +61,6 @@ namespace eosio { namespace chain {
       uint64_t block_cpu_limit = rl.get_block_cpu_limit();
 
       if( !billed_cpu_time_us ) {
-         wdump((block_cpu_limit));
          auto potential_deadline = fc::time_point::now() + fc::microseconds(block_cpu_limit);
          if( potential_deadline < deadline ) deadline = potential_deadline;
       }


### PR DESCRIPTION
there was a `wdump` added in c1aa803957f8a9098fab60af328da77fc0459e4b that prints to the log a great deal in normal operation.

It is gone.  

"printf debugging" should probably be something that is removed/commented out before PRs in the future.