### PR TITLE
Changes to Docker builder [skip-ci]

### DIFF
--- a/Docker/README.md
+++ b/Docker/README.md
@@ -78,6 +78,31 @@ If you don't need keosd afterwards, you can stop the keosd service using
 docker-compose stop keosd
 ```
 
+### Develop/Build custom contracts
+
+Due to the fact that the eosio/eos image does not contain the required dependencies for contract development (this is by design, to keep the image size small), you will need to utilize eosio/builder. However, eosio/builder does not contain eosiocpp. As such, you will need to run eosio/builder interactively, and clone, build and install EOS. Once this is complete, you can then utilize eosiocpp to compile your contracts.
+
+You can also create a Dockerfile that will do this for you.
+
+```
+FROM eosio/builder
+
+RUN git clone -b master --depth 1 https://github.com/EOSIO/eos.git --recursive \
+    && cd eos \
+    && cmake -H. -B"/tmp/build" -GNinja -DCMAKE_BUILD_TYPE=Release -DWASM_ROOT=/opt/wasm -DCMAKE_CXX_COMPILER=clang++ \
+       -DCMAKE_C_COMPILER=clang -DSecp256k1_ROOT_DIR=/usr/local -DBUILD_MONGO_DB_PLUGIN=true \
+    && cmake --build /tmp/build --target install && rm -rf /tmp/build /eos
+```
+
+Then, from the same directory as the Dockerfile, simply run:
+
+```bash
+docker build -t eosio/contracts .
+docker run -it -v /path/to/custom/contracts:/contracts eosio/contracts /bin/bash
+```
+
+At this time you should be at a bash shell. You can navigate into the /contracts directory and use eosiocpp to compile your custom contracts.
+
 ### Change default configuration
 
 You can use docker compose override file to change the default configurations. For example, create an alternate config file `config2.ini` and a `docker-compose.override.yml` with the following content.

--- a/Docker/builder/Dockerfile
+++ b/Docker/builder/Dockerfile
@@ -73,9 +73,3 @@ RUN git clone --depth 1 --single-branch --branch master https://github.com/ucb-b
     && mv ../../source/include /opt/berkeley-softfloat-3/include && cd - && rm -rf berkeley-softfloat-3
 
 ENV SOFTFLOAT_ROOT /opt/berkeley-softfloat-3
-
-RUN git clone -b master --depth 1 https://github.com/EOSIO/eos.git --recursive \
-    && cd eos \
-    && cmake -H. -B"/tmp/build" -GNinja -DCMAKE_BUILD_TYPE=Release -DWASM_ROOT=/opt/wasm -DCMAKE_CXX_COMPILER=clang++ \
-       -DCMAKE_C_COMPILER=clang -DSecp256k1_ROOT_DIR=/usr/local -DBUILD_MONGO_DB_PLUGIN=true \
-    && cmake --build /tmp/build --target install && rm -rf /tmp/build /eos


### PR DESCRIPTION
Revert the builder Dockerfile, and provide instructions on how to build contracts within Docker.