### PR TITLE
fix for eos #2928

### DIFF
--- a/programs/cleos/httpc.cpp
+++ b/programs/cleos/httpc.cpp
@@ -108,7 +108,7 @@ namespace eosio { namespace client { namespace http {
       postjson = fc::json::to_string( postdata );
 
    boost::asio::io_service io_service;
-
+   
    auto url = parse_url( server_url );
        
    boost::asio::streambuf request;

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -1692,27 +1692,27 @@ int main( int argc, char** argv ) {
    auto connect = net->add_subcommand("connect", localized("start a new connection to a peer"), false);
    connect->add_option("host", new_host, localized("The hostname:port to connect to."))->required();
    connect->set_callback([&] {
-      const auto& v = call(net_connect, new_host);
+      const auto& v = call(url, net_connect, new_host);
       std::cout << fc::json::to_pretty_string(v) << std::endl;
    });
 
    auto disconnect = net->add_subcommand("disconnect", localized("close an existing connection"), false);
    disconnect->add_option("host", new_host, localized("The hostname:port to disconnect from."))->required();
    disconnect->set_callback([&] {
-      const auto& v = call(net_disconnect, new_host);
+      const auto& v = call(url, net_disconnect, new_host);
       std::cout << fc::json::to_pretty_string(v) << std::endl;
    });
 
    auto status = net->add_subcommand("status", localized("status of existing connection"), false);
    status->add_option("host", new_host, localized("The hostname:port to query status of connection"))->required();
    status->set_callback([&] {
-      const auto& v = call(net_status, new_host);
-      std::cout << fc::json::to_pretty_string(v) << std::endl;
+      const auto& v = call(url, net_status, new_host);
+      std::cout << "status " << fc::json::to_pretty_string(v) << " status" << std::endl;
    });
 
    auto connections = net->add_subcommand("peers", localized("status of all existing peers"), false);
    connections->set_callback([&] {
-      const auto& v = call(net_connections, new_host);
+      const auto& v = call(url, net_connections, new_host);
       std::cout << fc::json::to_pretty_string(v) << std::endl;
    });
 


### PR DESCRIPTION
This is a simple fix that took entirely too long to pin down because of keosd running in the background at the same port as nodeos.  Hopefully that fix will come in soon to segregate those two.  Another issue that was uncovered by this fix is that ```net status``` always returns null.  I have created another issue for that.