### PR TITLE
Add branch argument to Dockerfile [skip-ci]

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,7 +1,8 @@
 FROM eosio/builder as builder
+ARG branch=master
 
-RUN git clone -b master --depth 1 https://github.com/EOSIO/eos.git --recursive \
-    && cd eos \
+RUN git clone -b $branch --depth 1 https://github.com/EOSIO/eos.git --recursive \
+    && cd eos && echo "$branch:$(git rev-parse HEAD)" > /etc/eosio-version \
     && cmake -H. -B"/tmp/build" -GNinja -DCMAKE_BUILD_TYPE=Release -DWASM_ROOT=/opt/wasm -DCMAKE_CXX_COMPILER=clang++ \
        -DCMAKE_C_COMPILER=clang -DCMAKE_INSTALL_PREFIX=/tmp/build  -DSecp256k1_ROOT_DIR=/usr/local -DBUILD_MONGO_DB_PLUGIN=true \
     && cmake --build /tmp/build --target install
@@ -14,6 +15,7 @@ COPY --from=builder /usr/local/lib/* /usr/local/lib/
 COPY --from=builder /tmp/build/bin /opt/eosio/bin
 COPY --from=builder /tmp/build/contracts /contracts
 COPY --from=builder /eos/Docker/config.ini /
+COPY --from=builder /etc/eosio-version /etc
 COPY nodeosd.sh /opt/eosio/bin/nodeosd.sh
 ENV EOSIO_ROOT=/opt/eosio
 RUN chmod +x /opt/eosio/bin/nodeosd.sh

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -20,6 +20,12 @@ cd eos/Docker
 docker build . -t eosio/eos
 ```
 
+The above will build off the most recent commit to the master branch by default. If you would like to target a specific branch/tag, you may use a build argument. For example, if you wished to generate a docker image based off of the dawn-v4.0.0 tag, you could do the following:
+
+```bash
+docker build -t eosio/eos:dawn-v4.0.0 --build-arg branch=dawn-v4.0.0 .
+```
+
 ## Start nodeos docker container only
 
 ```bash


### PR DESCRIPTION
This implements an argument (branch) in the Dockerfile that can be used to specify which branch/tag you would like to build against when generating a docker image.

For example, if you wanted to generate a docker image using the dawn-v4.0.0 tag:
```bash
docker build -t eosio/eos:dawn-v4.0.0 --build-arg branch=dawn-v4.0.0 .
```

This also generates a file that can be found at /etc/eosio-version that contains the branch name, and the commit id. This can be useful for determining the exact commit on which the docker image is based.

```
root@c79d420bbdf1:/# cat /etc/eosio-version
dawn-v4.0.0:9be89106da1d6a1543eb19dd0f3b96a53e286088
```