### PR TITLE
Make the default key added to each wallet optional

### DIFF
--- a/plugins/wallet_plugin/wallet_manager.cpp
+++ b/plugins/wallet_plugin/wallet_manager.cpp
@@ -46,7 +46,8 @@ std::string wallet_manager::create(const std::string& name) {
    wallet->set_password(password);
    wallet->set_wallet_filename(wallet_filename.string());
    wallet->unlock(password);
-   wallet->import_key(eosio_key);
+   if(eosio_key.size())
+      wallet->import_key(eosio_key);
    wallet->lock();
    wallet->unlock(password);
    

--- a/plugins/wallet_plugin/wallet_plugin.cpp
+++ b/plugins/wallet_plugin/wallet_plugin.cpp
@@ -54,7 +54,6 @@ void wallet_plugin::plugin_initialize(const variables_map& options) {
    }
    if (options.count("eosio-key")) {
       std::string eosio_wif_key = options.at("eosio-key").as<std::string>();
-      eosio_wif_key = fc::json::from_string(eosio_wif_key).as<std::string>();
       wallet_manager_ptr->set_eosio_key(eosio_wif_key);
    }
 }


### PR DESCRIPTION
By default we add the "root" eosio key to each created wallet. This key is configurable, however it also is always required. Change to code to accept an empty key which is an indicator that no key shall be added to created wallets.

Orginally did this because it makes an incoming unit test a little easier; but I can also see why some users may not want a key placed in every single wallet they create too.