### PR TITLE
Add creation of new keys via the wallet

### DIFF
--- a/plugins/wallet_api_plugin/wallet_api_plugin.cpp
+++ b/plugins/wallet_api_plugin/wallet_api_plugin.cpp
@@ -45,6 +45,10 @@ using namespace eosio;
 #define INVOKE_R_R(api_handle, call_name, in_param) \
      auto result = api_handle.call_name(fc::json::from_string(body).as<in_param>());
 
+#define INVOKE_R_R_R(api_handle, call_name, in_param0, in_param1) \
+     const auto& vs = fc::json::json::from_string(body).as<fc::variants>(); \
+     auto result = api_handle.call_name(vs.at(0).as<in_param0>(), vs.at(1).as<in_param1>());
+
 #define INVOKE_R_R_R_R(api_handle, call_name, in_param0, in_param1, in_param2) \
      const auto& vs = fc::json::json::from_string(body).as<fc::variants>(); \
      auto result = api_handle.call_name(vs.at(0).as<in_param0>(), vs.at(1).as<in_param1>(), vs.at(2).as<in_param2>());
@@ -88,6 +92,8 @@ void wallet_api_plugin::plugin_startup() {
             INVOKE_V_R_R(wallet_mgr, unlock, std::string, std::string), 200),
        CALL(wallet, wallet_mgr, import_key,
             INVOKE_V_R_R(wallet_mgr, import_key, std::string, std::string), 201),
+       CALL(wallet, wallet_mgr, create_key,
+            INVOKE_R_R_R(wallet_mgr, create_key, std::string, std::string), 201),
        CALL(wallet, wallet_mgr, list_wallets,
             INVOKE_R_V(wallet_mgr, list_wallets), 200),
        CALL(wallet, wallet_mgr, list_keys,

--- a/plugins/wallet_plugin/include/eosio/wallet_plugin/wallet.hpp
+++ b/plugins/wallet_plugin/include/eosio/wallet_plugin/wallet.hpp
@@ -151,6 +151,14 @@ class wallet_api
        */
       bool import_key( string wif_key );
 
+       /** Creates a key within the wallet to be used to sign transactions by an account.
+       *
+       * example: create_key K1
+       *
+       * @param key_type the key type to create. May be empty to allow wallet to pick appropriate/"best" key type
+       */
+      string create_key( string key_type );
+
       std::shared_ptr<detail::wallet_api_impl> my;
       void encrypt_keys();
 };

--- a/plugins/wallet_plugin/include/eosio/wallet_plugin/wallet_manager.hpp
+++ b/plugins/wallet_plugin/include/eosio/wallet_plugin/wallet_manager.hpp
@@ -99,6 +99,14 @@ public:
    /// @throws fc::exception if wallet not found or locked.
    void import_key(const std::string& name, const std::string& wif_key);
 
+   /// Creates a key within the specified wallet.
+   /// Wallet must be opened and unlocked
+   /// @param name of the wallet to create key in
+   /// @param type of key to create
+   /// @throws fc::exception if wallet not found or locked, or if the wallet cannot create said type of key
+   /// @return The public key of the created key
+   string create_key(const std::string& name, const std::string& key_type);
+
 private:
    /// Verify timeout has not occurred and reset timeout if not.
    /// Calls lock_all() if timeout has passed.

--- a/plugins/wallet_plugin/wallet_manager.cpp
+++ b/plugins/wallet_plugin/wallet_manager.cpp
@@ -4,6 +4,7 @@
  */
 #include <eosio/wallet_plugin/wallet_manager.hpp>
 #include <eosio/chain/exceptions.hpp>
+#include <boost/algorithm/string.hpp>
 namespace eosio {
 namespace wallet {
 
@@ -171,6 +172,20 @@ void wallet_manager::import_key(const std::string& name, const std::string& wif_
       EOS_THROW(chain::wallet_locked_exception, "Wallet is locked: ${w}", ("w", name));
    }
    w->import_key(wif_key);
+}
+
+string wallet_manager::create_key(const std::string& name, const std::string& key_type) {
+   check_timeout();
+   if (wallets.count(name) == 0) {
+      EOS_THROW(chain::wallet_nonexistent_exception, "Wallet not found: ${w}", ("w", name));
+   }
+   auto& w = wallets.at(name);
+   if (w->is_locked()) {
+      EOS_THROW(chain::wallet_locked_exception, "Wallet is locked: ${w}", ("w", name));
+   }
+
+   string upper_key_type = boost::to_upper_copy<std::string>(key_type);
+   return w->create_key(upper_key_type);
 }
 
 chain::signed_transaction

--- a/programs/cleos/httpc.hpp
+++ b/programs/cleos/httpc.hpp
@@ -59,6 +59,7 @@ namespace eosio { namespace client { namespace http {
    const string wallet_lock_all = wallet_func_base + "/lock_all";
    const string wallet_unlock = wallet_func_base + "/unlock";
    const string wallet_import_key = wallet_func_base + "/import_key";
+   const string wallet_create_key = wallet_func_base + "/create_key";
    const string wallet_sign_trx = wallet_func_base + "/sign_transaction";
    const string keosd_stop = "/v1/keosd/stop";
 

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -1879,6 +1879,18 @@ int main( int argc, char** argv ) {
       std::cout << localized("imported private key for: ${pubkey}", ("pubkey", std::string(pubkey))) << std::endl;
    });
 
+   // create a key within wallet
+   string wallet_create_key_type;
+   auto createKeyInWallet = wallet->add_subcommand("create_key", localized("Create private key within wallet"), false);
+   createKeyInWallet->add_option("-n,--name", wallet_name, localized("The name of the wallet to create key into"), true);
+   createKeyInWallet->add_option("key_type", wallet_create_key_type, localized("Key type to create (K1/R1)"), true)->set_type_name("K1/R1");
+   createKeyInWallet->set_callback([&wallet_name, &wallet_create_key_type] {
+      //an empty key type is allowed -- it will let the underlying wallet pick which type it prefers
+      fc::variants vs = {fc::variant(wallet_name), fc::variant(wallet_create_key_type)};
+      const auto& v = call(wallet_url, wallet_create_key, vs);
+      std::cout << localized("Created new private key with a public key of: ") << fc::json::to_pretty_string(v) << std::endl;
+   });
+
    // list wallets
    auto listWallet = wallet->add_subcommand("list", localized("List opened wallets, * = unlocked"), false);
    listWallet->set_callback([] {


### PR DESCRIPTION
This change adds the concept of a wallet being asked to create a new private/public key pair. It is a precursor to hardware key support in the wallet because hardware key stores don’t always have the concept of “importing” a key. It’s also beneficial as it gives an alternative means to `cleos create key` which if not careful can cause a private key to easily weasel its way in to a user’s shell history.

This is work on #2252.
Kind of resolves #2207 too, since this now gives an official way of creating R1 keys.