### PR TITLE
fix expired delay txn handling, add test case for 2071

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -463,6 +463,7 @@ struct controller_impl {
          trace->id = gto.trx_id;
          trace->scheduled = false;
          trace->receipt = push_receipt( gto.trx_id, transaction_receipt::expired, billed_cpu_time_us, 0 ); // expire the transaction
+         undo_session.squash();
          return trace;
       }
 

--- a/unittests/delay_tests.cpp
+++ b/unittests/delay_tests.cpp
@@ -2392,4 +2392,44 @@ BOOST_AUTO_TEST_CASE( max_transaction_delay_execute ) { try {
 
 } FC_LOG_AND_RETHROW() }
 
+BOOST_FIXTURE_TEST_CASE( delay_expired, validating_tester) { try {
+
+   produce_blocks(2);
+   signed_transaction trx;
+
+   account_name a = N(newco);
+   account_name creator = config::system_account_name;
+
+   auto owner_auth =  authority( get_public_key( a, "owner" ) );
+   trx.actions.emplace_back( vector<permission_level>{{creator,config::active_name}},
+                             newaccount{
+                                .creator  = creator,
+                                .name     = a,
+                                .owner    = owner_auth,
+                                .active   = authority( get_public_key( a, "active" ) )
+                             });
+   set_transaction_headers(trx);
+   trx.delay_sec = 3;
+   trx.expiration = control->head_block_time() + fc::microseconds(1000000);
+   trx.sign( get_private_key( creator, "active" ), chain_id_type()  );
+
+   auto trace = push_transaction( trx );
+
+   BOOST_REQUIRE_EQUAL(transaction_receipt_header::delayed, trace->receipt->status);
+
+   signed_block_ptr sb = produce_block();
+  
+   sb  = produce_block();
+
+   BOOST_REQUIRE_EQUAL(transaction_receipt_header::delayed, trace->receipt->status);
+   produce_empty_block(fc::milliseconds(610 * 1000));
+   sb  = produce_block();
+   BOOST_REQUIRE_EQUAL(1, sb->transactions.size());
+   BOOST_REQUIRE_EQUAL(transaction_receipt_header::expired, sb->transactions[0].status);
+
+   create_account(a); // account can still be created
+   
+} FC_LOG_AND_RETHROW() }
+
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
add "undo_session.squash()" in the case when scheduled txn is expired, so that the expired scheduled txn will not be added back into the database.

