### PR TITLE
push_transaction bugs

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -553,18 +553,6 @@ struct controller_impl {
       return r;
    }
 
-   void transaction_trace_notify( const transaction_metadata_ptr& trx, const transaction_trace_ptr& trace ) {
-      if( trx->on_result ) {
-         (trx->on_result)(trace);
-         trx->on_result = decltype(trx->on_result)(); //assign empty std::function
-      }
-
-      if (!trx->accepted) {
-         emit( self.accepted_transaction, trx);
-         trx->accepted = true;
-      }
-   }
-
    /**
     *  This is the entry point for new transactions to the block state. It will check authorization and
     *  determine whether to execute it now or to delay it. Lastly it inserts a transaction receipt into
@@ -628,7 +616,11 @@ struct controller_impl {
 
             fc::move_append(pending->_actions, move(trx_context.executed));
 
-            transaction_trace_notify(trx, trace);
+            // call the accept signal but only once for this transaction
+            if (!trx->accepted) {
+               emit( self.accepted_transaction, trx);
+               trx->accepted = true;
+            }
 
             emit(self.applied_transaction, trace);
 
@@ -644,7 +636,10 @@ struct controller_impl {
             trace->except_ptr = std::current_exception();
          }
 
-         transaction_trace_notify(trx, trace);
+         if (!failure_is_subjective(*trace->except)) {
+            unapplied_transactions.erase( trx->signed_id );
+         }
+
          return trace;
       } FC_CAPTURE_AND_RETHROW((trace))
    } /// push_transaction

--- a/libraries/chain/include/eosio/chain/transaction_metadata.hpp
+++ b/libraries/chain/include/eosio/chain/transaction_metadata.hpp
@@ -22,9 +22,6 @@ class transaction_metadata {
       optional<flat_set<public_key_type>>   signing_keys;
       bool                                  accepted = false;
 
-      std::function<void(const transaction_trace_ptr&)>       on_result;
-
-
       transaction_metadata( const signed_transaction& t, packed_transaction::compression_type c = packed_transaction::none )
       :trx(t),packed_trx(t, c) {
          id = trx.id();


### PR DESCRIPTION
Remove unapplied transactions on objective failure.  Dont call "accepted" on failure