### PR TITLE
Fix for eos #2900

### DIFF
--- a/libraries/chain/authorization_manager.cpp
+++ b/libraries/chain/authorization_manager.cpp
@@ -314,16 +314,16 @@ namespace eosio { namespace chain {
       return (itr->delay_until - itr->published);
    }
 
-   void noop_checktime( uint32_t ) {}
+   void noop_checktime() {}
 
-   std::function<void(uint32_t)> authorization_manager::_noop_checktime{std::bind(&noop_checktime, std::placeholders::_1)};
+   std::function<void()> authorization_manager::_noop_checktime{&noop_checktime};
 
    void
    authorization_manager::check_authorization( const vector<action>&                actions,
                                                const flat_set<public_key_type>&     provided_keys,
                                                const flat_set<permission_level>&    provided_permissions,
                                                fc::microseconds                     provided_delay,
-                                               const std::function<void(uint32_t)>& _checktime,
+                                               const std::function<void()>&         _checktime,
                                                bool                                 allow_unused_keys
                                              )const
    {
@@ -367,7 +367,7 @@ namespace eosio { namespace chain {
 
          for( const auto& declared_auth : act.authorization ) {
 
-            checktime( config::base_check_authorization_cpu_per_authorization );
+            checktime();
 
             if( !special_case ) {
                auto min_permission_name = lookup_minimum_permission(declared_auth.actor, act.account, act.name);
@@ -396,7 +396,7 @@ namespace eosio { namespace chain {
       // The permission_levels are traversed in ascending order, which is:
       // ascending order of the actor name with ties broken by ascending order of the permission name.
       for( const auto& p : permissions_to_satisfy ) {
-         checktime( config::base_authority_checker_cpu_per_permission ); // TODO: this should eventually move into authority_checker instead
+         checktime(); // TODO: this should eventually move into authority_checker instead
          EOS_ASSERT( checker.satisfied( p.first, p.second ), unsatisfied_authorization,
                      "transaction declares authority '${auth}', "
                      "but does not have signatures for it under a provided delay of ${provided_delay} ms",
@@ -419,7 +419,7 @@ namespace eosio { namespace chain {
                                                const flat_set<public_key_type>&     provided_keys,
                                                const flat_set<permission_level>&    provided_permissions,
                                                fc::microseconds                     provided_delay,
-                                               const std::function<void(uint32_t)>& _checktime,
+                                               const std::function<void()>&         _checktime,
                                                bool                                 allow_unused_keys
                                              )const
    {

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -600,7 +600,7 @@ struct controller_impl {
                        trx->recover_keys(),
                        {},
                        trx_context.delay,
-                       [](uint32_t){}
+                       [](){}
                        /*std::bind(&transaction_context::add_cpu_usage_and_check_time, &trx_context,
                                  std::placeholders::_1)*/,
                        false

--- a/libraries/chain/include/eosio/chain/apply_context.hpp
+++ b/libraries/chain/include/eosio/chain/apply_context.hpp
@@ -568,8 +568,6 @@ class apply_context {
       vector<account_name> get_active_producers() const;
       bytes  get_packed_transaction();
 
-      void checktime(uint32_t instruction_count);
-
       uint64_t next_global_sequence();
       uint64_t next_recv_sequence( account_name receiver );
       uint64_t next_auth_sequence( account_name actor );

--- a/libraries/chain/include/eosio/chain/authority_checker.hpp
+++ b/libraries/chain/include/eosio/chain/authority_checker.hpp
@@ -62,7 +62,7 @@ namespace detail {
    class authority_checker {
       private:
          PermissionToAuthorityFunc            permission_to_authority;
-         const std::function<void(uint32_t)>& checktime;
+         const std::function<void()>&         checktime;
          vector<public_key_type>              provided_keys; // Making this a flat_set<public_key_type> causes runtime problems with utilities::filter_data_by_marker for some reason. TODO: Figure out why.
          flat_set<permission_level>           provided_permissions;
          vector<bool>                         _used_keys;
@@ -75,7 +75,7 @@ namespace detail {
                             const flat_set<public_key_type>&     provided_keys,
                             const flat_set<permission_level>&    provided_permissions,
                             fc::microseconds                     provided_delay,
-                            const std::function<void(uint32_t)>& checktime
+                            const std::function<void()>&         checktime
                          )
          :permission_to_authority(permission_to_authority)
          ,checktime( checktime )
@@ -277,10 +277,10 @@ namespace detail {
                            const flat_set<public_key_type>&     provided_keys,
                            const flat_set<permission_level>&    provided_permissions = flat_set<permission_level>(),
                            fc::microseconds                     provided_delay = fc::microseconds(0),
-                           const std::function<void(uint32_t)>& _checktime = std::function<void(uint32_t)>()
+                           const std::function<void()>&         _checktime = std::function<void()>()
                          )
    {
-      auto noop_checktime = []( uint32_t ) {};
+      auto noop_checktime = []() {};
       const auto& checktime = ( static_cast<bool>(_checktime) ? _checktime : noop_checktime );
       return authority_checker< PermissionToAuthorityFunc>( std::forward<PermissionToAuthorityFunc>(pta),
                                                             recursion_depth_limit,

--- a/libraries/chain/include/eosio/chain/authorization_manager.hpp
+++ b/libraries/chain/include/eosio/chain/authorization_manager.hpp
@@ -80,7 +80,7 @@ namespace eosio { namespace chain {
                               const flat_set<public_key_type>&     provided_keys,
                               const flat_set<permission_level>&    provided_permissions = flat_set<permission_level>(),
                               fc::microseconds                     provided_delay = fc::microseconds(0),
-                              const std::function<void(uint32_t)>& checktime = std::function<void(uint32_t)>(),
+                              const std::function<void()>&         checktime = std::function<void()>(),
                               bool                                 allow_unused_keys = false
                             )const;
 
@@ -102,7 +102,7 @@ namespace eosio { namespace chain {
                               const flat_set<public_key_type>&     provided_keys,
                               const flat_set<permission_level>&    provided_permissions = flat_set<permission_level>(),
                               fc::microseconds                     provided_delay = fc::microseconds(0),
-                              const std::function<void(uint32_t)>& checktime = std::function<void(uint32_t)>(),
+                              const std::function<void()>&         checktime = std::function<void()>(),
                               bool                                 allow_unused_keys = false
                             )const;
 
@@ -112,7 +112,7 @@ namespace eosio { namespace chain {
                                                     )const;
 
 
-         static std::function<void(uint32_t)> _noop_checktime;
+         static std::function<void()> _noop_checktime;
 
       private:
          const controller&    _control;

--- a/libraries/chain/include/eosio/chain/transaction_context.hpp
+++ b/libraries/chain/include/eosio/chain/transaction_context.hpp
@@ -30,7 +30,7 @@ namespace eosio { namespace chain {
          inline void add_net_usage( uint64_t u ) { net_usage += u; check_net_usage(); }
 
          void check_net_usage()const;
-         void check_time()const;
+         void checktime()const;
 
          void add_ram_usage( account_name account, int64_t ram_delta );
 

--- a/libraries/chain/include/eosio/chain/wasm_eosio_injection.hpp
+++ b/libraries/chain/include/eosio/chain/wasm_eosio_injection.hpp
@@ -246,11 +246,8 @@ namespace eosio { namespace chain { namespace wasm_injections {
       static void accept( wasm_ops::instr* inst, wasm_ops::visitor_arg& arg ) {
          auto mapped_index = injector_utils::injected_index_mapping.find(chktm_idx);
 
-         wasm_ops::op_types<>::i32_const_t cnt; 
-         cnt.field = checktime_block_type::bcnt_tables.front()[checktime_block_type::orderings.front()[idx++]];
          wasm_ops::op_types<>::call_t chktm; 
          chktm.field = mapped_index->second;
-         cnt.pack(arg.new_code);
          chktm.pack(arg.new_code);
       }
 
@@ -683,202 +680,79 @@ namespace eosio { namespace chain { namespace wasm_injections {
    };
 
    struct pre_op_injectors : wasm_ops::op_types<pass_injector> {
-      using block_t           = wasm_ops::block                   <instruction_counter>;
-      using loop_t            = wasm_ops::loop                    <instruction_counter, checktime_block_type>;
-      using if__t             = wasm_ops::if_                     <instruction_counter>;
-      using else__t           = wasm_ops::else_                   <instruction_counter>;
+      using call_t            = wasm_ops::call                    <call_depth_check>;
+      using call_indirect_t   = wasm_ops::call_indirect           <call_depth_check>;
       
-      using end_t             = wasm_ops::end                     <instruction_counter, checktime_end>;
-      using unreachable_t     = wasm_ops::unreachable             <instruction_counter>;
-      using br_t              = wasm_ops::br                      <instruction_counter>;
-      using br_if_t           = wasm_ops::br_if                   <instruction_counter>;
-      using br_table_t        = wasm_ops::br_table                <instruction_counter>;
-      using return__t         = wasm_ops::return_                 <instruction_counter>;
-      using call_t            = wasm_ops::call                    <instruction_counter, call_depth_check>;
-      using call_indirect_t   = wasm_ops::call_indirect           <instruction_counter, call_depth_check>;
-      using drop_t            = wasm_ops::drop                    <instruction_counter>;
-      using select_t          = wasm_ops::select                  <instruction_counter>;
-
-      using get_local_t       = wasm_ops::get_local               <instruction_counter>;
-      using set_local_t       = wasm_ops::set_local               <instruction_counter>;
-      using tee_local_t       = wasm_ops::tee_local               <instruction_counter>;
-      using get_global_t      = wasm_ops::get_global              <instruction_counter>;
-      using set_global_t      = wasm_ops::set_global              <instruction_counter>;
-
-      using nop_t             = wasm_ops::nop                     <instruction_counter>;
-      using i32_load_t        = wasm_ops::i32_load                <instruction_counter>;
-      using i64_load_t        = wasm_ops::i64_load                <instruction_counter>;
-      using f32_load_t        = wasm_ops::f32_load                <instruction_counter>;
-      using f64_load_t        = wasm_ops::f64_load                <instruction_counter>;
-      using i32_load8_s_t     = wasm_ops::i32_load8_s             <instruction_counter>;
-      using i32_load8_u_t     = wasm_ops::i32_load8_u             <instruction_counter>;
-      using i32_load16_s_t    = wasm_ops::i32_load16_s            <instruction_counter>;
-      using i32_load16_u_t    = wasm_ops::i32_load16_u            <instruction_counter>;
-      using i64_load8_s_t     = wasm_ops::i64_load8_s             <instruction_counter>;
-      using i64_load8_u_t     = wasm_ops::i64_load8_u             <instruction_counter>;
-      using i64_load16_s_t    = wasm_ops::i64_load16_s            <instruction_counter>;
-      using i64_load16_u_t    = wasm_ops::i64_load16_u            <instruction_counter>;
-      using i64_load32_s_t    = wasm_ops::i64_load32_s            <instruction_counter>;
-      using i64_load32_u_t    = wasm_ops::i64_load32_u            <instruction_counter>;
-      using i32_store_t       = wasm_ops::i32_store               <instruction_counter>;
-      using i64_store_t       = wasm_ops::i64_store               <instruction_counter>;
-      using f32_store_t       = wasm_ops::f32_store               <instruction_counter>;
-      using f64_store_t       = wasm_ops::f64_store               <instruction_counter>;
-      using i32_store8_t      = wasm_ops::i32_store8              <instruction_counter>;
-      using i32_store16_t     = wasm_ops::i32_store16             <instruction_counter>;
-      using i64_store8_t      = wasm_ops::i64_store8              <instruction_counter>;
-      using i64_store16_t     = wasm_ops::i64_store16             <instruction_counter>;
-      using i64_store32_t     = wasm_ops::i64_store32             <instruction_counter>;
-
-      using i32_const_t       = wasm_ops::i32_const               <instruction_counter>;
-      using i64_const_t       = wasm_ops::i64_const               <instruction_counter>;
-      using f32_const_t       = wasm_ops::f32_const               <instruction_counter>;
-      using f64_const_t       = wasm_ops::f64_const               <instruction_counter>;
-      
-      using i32_eqz_t         = wasm_ops::i32_eqz                 <instruction_counter>;
-      using i32_eq_t          = wasm_ops::i32_eq                  <instruction_counter>;
-      using i32_ne_t          = wasm_ops::i32_ne                  <instruction_counter>;
-      using i32_lt_s_t        = wasm_ops::i32_lt_s                <instruction_counter>;
-      using i32_lt_u_t        = wasm_ops::i32_lt_u                <instruction_counter>;
-      using i32_gt_s_t        = wasm_ops::i32_gt_s                <instruction_counter>;
-      using i32_gt_u_t        = wasm_ops::i32_gt_u                <instruction_counter>;
-      using i32_le_s_t        = wasm_ops::i32_le_s                <instruction_counter>;
-      using i32_le_u_t        = wasm_ops::i32_le_u                <instruction_counter>;
-      using i32_ge_s_t        = wasm_ops::i32_ge_s                <instruction_counter>;
-      using i32_ge_u_t        = wasm_ops::i32_ge_u                <instruction_counter>;
-
-      using i32_clz_t         = wasm_ops::i32_clz                 <instruction_counter>;
-      using i32_ctz_t         = wasm_ops::i32_ctz                 <instruction_counter>;
-      using i32_popcnt_t      = wasm_ops::i32_popcnt              <instruction_counter>;
-
-      using i32_add_t         = wasm_ops::i32_add                 <instruction_counter>; 
-      using i32_sub_t         = wasm_ops::i32_sub                 <instruction_counter>; 
-      using i32_mul_t         = wasm_ops::i32_mul                 <instruction_counter>; 
-      using i32_div_s_t       = wasm_ops::i32_div_s               <instruction_counter>; 
-      using i32_div_u_t       = wasm_ops::i32_div_u               <instruction_counter>; 
-      using i32_rem_s_t       = wasm_ops::i32_rem_s               <instruction_counter>; 
-      using i32_rem_u_t       = wasm_ops::i32_rem_u               <instruction_counter>; 
-      using i32_and_t         = wasm_ops::i32_and                 <instruction_counter>; 
-      using i32_or_t          = wasm_ops::i32_or                  <instruction_counter>; 
-      using i32_xor_t         = wasm_ops::i32_xor                 <instruction_counter>; 
-      using i32_shl_t         = wasm_ops::i32_shl                 <instruction_counter>; 
-      using i32_shr_s_t       = wasm_ops::i32_shr_s               <instruction_counter>; 
-      using i32_shr_u_t       = wasm_ops::i32_shr_u               <instruction_counter>; 
-      using i32_rotl_t        = wasm_ops::i32_rotl                <instruction_counter>; 
-      using i32_rotr_t        = wasm_ops::i32_rotr                <instruction_counter>; 
-
-      using i64_eqz_t         = wasm_ops::i64_eqz                 <instruction_counter>;
-      using i64_eq_t          = wasm_ops::i64_eq                  <instruction_counter>;
-      using i64_ne_t          = wasm_ops::i64_ne                  <instruction_counter>;
-      using i64_lt_s_t        = wasm_ops::i64_lt_s                <instruction_counter>;
-      using i64_lt_u_t        = wasm_ops::i64_lt_u                <instruction_counter>;
-      using i64_gt_s_t        = wasm_ops::i64_gt_s                <instruction_counter>;
-      using i64_gt_u_t        = wasm_ops::i64_gt_u                <instruction_counter>;
-      using i64_le_s_t        = wasm_ops::i64_le_s                <instruction_counter>;
-      using i64_le_u_t        = wasm_ops::i64_le_u                <instruction_counter>;
-      using i64_ge_s_t        = wasm_ops::i64_ge_s                <instruction_counter>;
-      using i64_ge_u_t        = wasm_ops::i64_ge_u                <instruction_counter>;
-
-      using i64_clz_t         = wasm_ops::i64_clz                 <instruction_counter>;
-      using i64_ctz_t         = wasm_ops::i64_ctz                 <instruction_counter>;
-      using i64_popcnt_t      = wasm_ops::i64_popcnt              <instruction_counter>;
-
-      using i64_add_t         = wasm_ops::i64_add                 <instruction_counter>; 
-      using i64_sub_t         = wasm_ops::i64_sub                 <instruction_counter>; 
-      using i64_mul_t         = wasm_ops::i64_mul                 <instruction_counter>; 
-      using i64_div_s_t       = wasm_ops::i64_div_s               <instruction_counter>; 
-      using i64_div_u_t       = wasm_ops::i64_div_u               <instruction_counter>; 
-      using i64_rem_s_t       = wasm_ops::i64_rem_s               <instruction_counter>; 
-      using i64_rem_u_t       = wasm_ops::i64_rem_u               <instruction_counter>; 
-      using i64_and_t         = wasm_ops::i64_and                 <instruction_counter>; 
-      using i64_or_t          = wasm_ops::i64_or                  <instruction_counter>; 
-      using i64_xor_t         = wasm_ops::i64_xor                 <instruction_counter>; 
-      using i64_shl_t         = wasm_ops::i64_shl                 <instruction_counter>; 
-      using i64_shr_s_t       = wasm_ops::i64_shr_s               <instruction_counter>; 
-      using i64_shr_u_t       = wasm_ops::i64_shr_u               <instruction_counter>; 
-      using i64_rotl_t        = wasm_ops::i64_rotl                <instruction_counter>; 
-      using i64_rotr_t        = wasm_ops::i64_rotr                <instruction_counter>; 
+      // float binops 
+      using f32_add_t         = wasm_ops::f32_add                 <f32_binop_injector<wasm_ops::f32_add_code>>;
+      using f32_sub_t         = wasm_ops::f32_sub                 <f32_binop_injector<wasm_ops::f32_sub_code>>;
+      using f32_div_t         = wasm_ops::f32_div                 <f32_binop_injector<wasm_ops::f32_div_code>>;
+      using f32_mul_t         = wasm_ops::f32_mul                 <f32_binop_injector<wasm_ops::f32_mul_code>>;
+      using f32_min_t         = wasm_ops::f32_min                 <f32_binop_injector<wasm_ops::f32_min_code>>;
+      using f32_max_t         = wasm_ops::f32_max                 <f32_binop_injector<wasm_ops::f32_max_code>>;
+      using f32_copysign_t    = wasm_ops::f32_copysign            <f32_binop_injector<wasm_ops::f32_copysign_code>>;
+      // float unops
+      using f32_abs_t         = wasm_ops::f32_abs                 <f32_unop_injector<wasm_ops::f32_abs_code>>;
+      using f32_neg_t         = wasm_ops::f32_neg                 <f32_unop_injector<wasm_ops::f32_neg_code>>;
+      using f32_sqrt_t        = wasm_ops::f32_sqrt                <f32_unop_injector<wasm_ops::f32_sqrt_code>>;
+      using f32_floor_t       = wasm_ops::f32_floor               <f32_unop_injector<wasm_ops::f32_floor_code>>;
+      using f32_ceil_t        = wasm_ops::f32_ceil                <f32_unop_injector<wasm_ops::f32_ceil_code>>;
+      using f32_trunc_t       = wasm_ops::f32_trunc               <f32_unop_injector<wasm_ops::f32_trunc_code>>;
+      using f32_nearest_t     = wasm_ops::f32_nearest             <f32_unop_injector<wasm_ops::f32_nearest_code>>;
+      // float relops
+      using f32_eq_t          = wasm_ops::f32_eq                  <f32_relop_injector<wasm_ops::f32_eq_code>>;
+      using f32_ne_t          = wasm_ops::f32_ne                  <f32_relop_injector<wasm_ops::f32_ne_code>>;
+      using f32_lt_t          = wasm_ops::f32_lt                  <f32_relop_injector<wasm_ops::f32_lt_code>>;
+      using f32_le_t          = wasm_ops::f32_le                  <f32_relop_injector<wasm_ops::f32_le_code>>;
+      using f32_gt_t          = wasm_ops::f32_gt                  <f32_relop_injector<wasm_ops::f32_gt_code>>;
+      using f32_ge_t          = wasm_ops::f32_ge                  <f32_relop_injector<wasm_ops::f32_ge_code>>;
 
       // float binops 
-      using f32_add_t         = wasm_ops::f32_add                 <instruction_counter, f32_binop_injector<wasm_ops::f32_add_code>>;
-      using f32_sub_t         = wasm_ops::f32_sub                 <instruction_counter, f32_binop_injector<wasm_ops::f32_sub_code>>;
-      using f32_div_t         = wasm_ops::f32_div                 <instruction_counter, f32_binop_injector<wasm_ops::f32_div_code>>;
-      using f32_mul_t         = wasm_ops::f32_mul                 <instruction_counter, f32_binop_injector<wasm_ops::f32_mul_code>>;
-      using f32_min_t         = wasm_ops::f32_min                 <instruction_counter, f32_binop_injector<wasm_ops::f32_min_code>>;
-      using f32_max_t         = wasm_ops::f32_max                 <instruction_counter, f32_binop_injector<wasm_ops::f32_max_code>>;
-      using f32_copysign_t    = wasm_ops::f32_copysign            <instruction_counter, f32_binop_injector<wasm_ops::f32_copysign_code>>;
+      using f64_add_t         = wasm_ops::f64_add                 <f64_binop_injector<wasm_ops::f64_add_code>>;
+      using f64_sub_t         = wasm_ops::f64_sub                 <f64_binop_injector<wasm_ops::f64_sub_code>>;
+      using f64_div_t         = wasm_ops::f64_div                 <f64_binop_injector<wasm_ops::f64_div_code>>;
+      using f64_mul_t         = wasm_ops::f64_mul                 <f64_binop_injector<wasm_ops::f64_mul_code>>;
+      using f64_min_t         = wasm_ops::f64_min                 <f64_binop_injector<wasm_ops::f64_min_code>>;
+      using f64_max_t         = wasm_ops::f64_max                 <f64_binop_injector<wasm_ops::f64_max_code>>;
+      using f64_copysign_t    = wasm_ops::f64_copysign            <f64_binop_injector<wasm_ops::f64_copysign_code>>;
       // float unops
-      using f32_abs_t         = wasm_ops::f32_abs                 <instruction_counter, f32_unop_injector<wasm_ops::f32_abs_code>>;
-      using f32_neg_t         = wasm_ops::f32_neg                 <instruction_counter, f32_unop_injector<wasm_ops::f32_neg_code>>;
-      using f32_sqrt_t        = wasm_ops::f32_sqrt                <instruction_counter, f32_unop_injector<wasm_ops::f32_sqrt_code>>;
-      using f32_floor_t       = wasm_ops::f32_floor               <instruction_counter, f32_unop_injector<wasm_ops::f32_floor_code>>;
-      using f32_ceil_t        = wasm_ops::f32_ceil                <instruction_counter, f32_unop_injector<wasm_ops::f32_ceil_code>>;
-      using f32_trunc_t       = wasm_ops::f32_trunc               <instruction_counter, f32_unop_injector<wasm_ops::f32_trunc_code>>;
-      using f32_nearest_t     = wasm_ops::f32_nearest             <instruction_counter, f32_unop_injector<wasm_ops::f32_nearest_code>>;
+      using f64_abs_t         = wasm_ops::f64_abs                 <f64_unop_injector<wasm_ops::f64_abs_code>>;
+      using f64_neg_t         = wasm_ops::f64_neg                 <f64_unop_injector<wasm_ops::f64_neg_code>>;
+      using f64_sqrt_t        = wasm_ops::f64_sqrt                <f64_unop_injector<wasm_ops::f64_sqrt_code>>;
+      using f64_floor_t       = wasm_ops::f64_floor               <f64_unop_injector<wasm_ops::f64_floor_code>>;
+      using f64_ceil_t        = wasm_ops::f64_ceil                <f64_unop_injector<wasm_ops::f64_ceil_code>>;
+      using f64_trunc_t       = wasm_ops::f64_trunc               <f64_unop_injector<wasm_ops::f64_trunc_code>>;
+      using f64_nearest_t     = wasm_ops::f64_nearest             <f64_unop_injector<wasm_ops::f64_nearest_code>>;
       // float relops
-      using f32_eq_t          = wasm_ops::f32_eq                  <instruction_counter, f32_relop_injector<wasm_ops::f32_eq_code>>;
-      using f32_ne_t          = wasm_ops::f32_ne                  <instruction_counter, f32_relop_injector<wasm_ops::f32_ne_code>>;
-      using f32_lt_t          = wasm_ops::f32_lt                  <instruction_counter, f32_relop_injector<wasm_ops::f32_lt_code>>;
-      using f32_le_t          = wasm_ops::f32_le                  <instruction_counter, f32_relop_injector<wasm_ops::f32_le_code>>;
-      using f32_gt_t          = wasm_ops::f32_gt                  <instruction_counter, f32_relop_injector<wasm_ops::f32_gt_code>>;
-      using f32_ge_t          = wasm_ops::f32_ge                  <instruction_counter, f32_relop_injector<wasm_ops::f32_ge_code>>;
-
-      // float binops 
-      using f64_add_t         = wasm_ops::f64_add                 <instruction_counter, f64_binop_injector<wasm_ops::f64_add_code>>;
-      using f64_sub_t         = wasm_ops::f64_sub                 <instruction_counter, f64_binop_injector<wasm_ops::f64_sub_code>>;
-      using f64_div_t         = wasm_ops::f64_div                 <instruction_counter, f64_binop_injector<wasm_ops::f64_div_code>>;
-      using f64_mul_t         = wasm_ops::f64_mul                 <instruction_counter, f64_binop_injector<wasm_ops::f64_mul_code>>;
-      using f64_min_t         = wasm_ops::f64_min                 <instruction_counter, f64_binop_injector<wasm_ops::f64_min_code>>;
-      using f64_max_t         = wasm_ops::f64_max                 <instruction_counter, f64_binop_injector<wasm_ops::f64_max_code>>;
-      using f64_copysign_t    = wasm_ops::f64_copysign            <instruction_counter, f64_binop_injector<wasm_ops::f64_copysign_code>>;
-      // float unops
-      using f64_abs_t         = wasm_ops::f64_abs                 <instruction_counter, f64_unop_injector<wasm_ops::f64_abs_code>>;
-      using f64_neg_t         = wasm_ops::f64_neg                 <instruction_counter, f64_unop_injector<wasm_ops::f64_neg_code>>;
-      using f64_sqrt_t        = wasm_ops::f64_sqrt                <instruction_counter, f64_unop_injector<wasm_ops::f64_sqrt_code>>;
-      using f64_floor_t       = wasm_ops::f64_floor               <instruction_counter, f64_unop_injector<wasm_ops::f64_floor_code>>;
-      using f64_ceil_t        = wasm_ops::f64_ceil                <instruction_counter, f64_unop_injector<wasm_ops::f64_ceil_code>>;
-      using f64_trunc_t       = wasm_ops::f64_trunc               <instruction_counter, f64_unop_injector<wasm_ops::f64_trunc_code>>;
-      using f64_nearest_t     = wasm_ops::f64_nearest             <instruction_counter, f64_unop_injector<wasm_ops::f64_nearest_code>>;
-      // float relops
-      using f64_eq_t          = wasm_ops::f64_eq                  <instruction_counter, f64_relop_injector<wasm_ops::f64_eq_code>>;
-      using f64_ne_t          = wasm_ops::f64_ne                  <instruction_counter, f64_relop_injector<wasm_ops::f64_ne_code>>;
-      using f64_lt_t          = wasm_ops::f64_lt                  <instruction_counter, f64_relop_injector<wasm_ops::f64_lt_code>>;
-      using f64_le_t          = wasm_ops::f64_le                  <instruction_counter, f64_relop_injector<wasm_ops::f64_le_code>>;
-      using f64_gt_t          = wasm_ops::f64_gt                  <instruction_counter, f64_relop_injector<wasm_ops::f64_gt_code>>;
-      using f64_ge_t          = wasm_ops::f64_ge                  <instruction_counter, f64_relop_injector<wasm_ops::f64_ge_code>>;
+      using f64_eq_t          = wasm_ops::f64_eq                  <f64_relop_injector<wasm_ops::f64_eq_code>>;
+      using f64_ne_t          = wasm_ops::f64_ne                  <f64_relop_injector<wasm_ops::f64_ne_code>>;
+      using f64_lt_t          = wasm_ops::f64_lt                  <f64_relop_injector<wasm_ops::f64_lt_code>>;
+      using f64_le_t          = wasm_ops::f64_le                  <f64_relop_injector<wasm_ops::f64_le_code>>;
+      using f64_gt_t          = wasm_ops::f64_gt                  <f64_relop_injector<wasm_ops::f64_gt_code>>;
+      using f64_ge_t          = wasm_ops::f64_ge                  <f64_relop_injector<wasm_ops::f64_ge_code>>;
 
 
-      using f64_promote_f32_t = wasm_ops::f64_promote_f32         <instruction_counter, f32_promote_injector>;
-      using f32_demote_f64_t  = wasm_ops::f32_demote_f64          <instruction_counter, f64_demote_injector>;
+      using f64_promote_f32_t = wasm_ops::f64_promote_f32         <f32_promote_injector>;
+      using f32_demote_f64_t  = wasm_ops::f32_demote_f64          <f64_demote_injector>;
 
       
-      using i32_trunc_s_f32_t = wasm_ops::i32_trunc_s_f32         <instruction_counter, f32_trunc_i32_injector<wasm_ops::i32_trunc_s_f32_code>>;
-      using i32_trunc_u_f32_t = wasm_ops::i32_trunc_u_f32         <instruction_counter, f32_trunc_i32_injector<wasm_ops::i32_trunc_u_f32_code>>;
-      using i32_trunc_s_f64_t = wasm_ops::i32_trunc_s_f64         <instruction_counter, f64_trunc_i32_injector<wasm_ops::i32_trunc_s_f64_code>>;
-      using i32_trunc_u_f64_t = wasm_ops::i32_trunc_u_f64         <instruction_counter, f64_trunc_i32_injector<wasm_ops::i32_trunc_u_f64_code>>;
-      using i64_trunc_s_f32_t = wasm_ops::i64_trunc_s_f32         <instruction_counter, f32_trunc_i64_injector<wasm_ops::i64_trunc_s_f32_code>>;
-      using i64_trunc_u_f32_t = wasm_ops::i64_trunc_u_f32         <instruction_counter, f32_trunc_i64_injector<wasm_ops::i64_trunc_u_f32_code>>;
-      using i64_trunc_s_f64_t = wasm_ops::i64_trunc_s_f64         <instruction_counter, f64_trunc_i64_injector<wasm_ops::i64_trunc_s_f64_code>>;
-      using i64_trunc_u_f64_t = wasm_ops::i64_trunc_u_f64         <instruction_counter, f64_trunc_i64_injector<wasm_ops::i64_trunc_u_f64_code>>;
+      using i32_trunc_s_f32_t = wasm_ops::i32_trunc_s_f32         <f32_trunc_i32_injector<wasm_ops::i32_trunc_s_f32_code>>;
+      using i32_trunc_u_f32_t = wasm_ops::i32_trunc_u_f32         <f32_trunc_i32_injector<wasm_ops::i32_trunc_u_f32_code>>;
+      using i32_trunc_s_f64_t = wasm_ops::i32_trunc_s_f64         <f64_trunc_i32_injector<wasm_ops::i32_trunc_s_f64_code>>;
+      using i32_trunc_u_f64_t = wasm_ops::i32_trunc_u_f64         <f64_trunc_i32_injector<wasm_ops::i32_trunc_u_f64_code>>;
+      using i64_trunc_s_f32_t = wasm_ops::i64_trunc_s_f32         <f32_trunc_i64_injector<wasm_ops::i64_trunc_s_f32_code>>;
+      using i64_trunc_u_f32_t = wasm_ops::i64_trunc_u_f32         <f32_trunc_i64_injector<wasm_ops::i64_trunc_u_f32_code>>;
+      using i64_trunc_s_f64_t = wasm_ops::i64_trunc_s_f64         <f64_trunc_i64_injector<wasm_ops::i64_trunc_s_f64_code>>;
+      using i64_trunc_u_f64_t = wasm_ops::i64_trunc_u_f64         <f64_trunc_i64_injector<wasm_ops::i64_trunc_u_f64_code>>;
    
-      using f32_convert_s_i32 = wasm_ops::f32_convert_s_i32       <instruction_counter, i32_convert_f32_injector<wasm_ops::f32_convert_s_i32_code>>;
-      using f32_convert_s_i64 = wasm_ops::f32_convert_s_i64       <instruction_counter, i64_convert_f32_injector<wasm_ops::f32_convert_s_i64_code>>;
-      using f32_convert_u_i32 = wasm_ops::f32_convert_u_i32       <instruction_counter, i32_convert_f32_injector<wasm_ops::f32_convert_u_i32_code>>;
-      using f32_convert_u_i64 = wasm_ops::f32_convert_u_i64       <instruction_counter, i64_convert_f32_injector<wasm_ops::f32_convert_u_i64_code>>;
-      using f64_convert_s_i32 = wasm_ops::f64_convert_s_i32       <instruction_counter, i32_convert_f64_injector<wasm_ops::f64_convert_s_i32_code>>;
-      using f64_convert_s_i64 = wasm_ops::f64_convert_s_i64       <instruction_counter, i64_convert_f64_injector<wasm_ops::f64_convert_s_i64_code>>;
-      using f64_convert_u_i32 = wasm_ops::f64_convert_u_i32       <instruction_counter, i32_convert_f64_injector<wasm_ops::f64_convert_u_i32_code>>;
-      using f64_convert_u_i64 = wasm_ops::f64_convert_u_i64       <instruction_counter, i64_convert_f64_injector<wasm_ops::f64_convert_u_i64_code>>;
-
-      using i32_wrap_i64_t     = wasm_ops::i32_wrap_i64           <instruction_counter>;
-      using i64_extend_s_i32_t = wasm_ops::i64_extend_s_i32       <instruction_counter>;
-      using i64_extend_u_i32_t = wasm_ops::i64_extend_u_i32       <instruction_counter>;
-
-      using i32_reinterpret_f32_t = wasm_ops::i32_reinterpret_f32 <instruction_counter>;
-      using f32_reinterpret_i32_t = wasm_ops::f32_reinterpret_i32 <instruction_counter>;
-      using i64_reinterpret_f64_t = wasm_ops::i64_reinterpret_f64 <instruction_counter>;
-      using f64_reinterpret_i64_t = wasm_ops::f64_reinterpret_i64 <instruction_counter>;
-
+      using f32_convert_s_i32 = wasm_ops::f32_convert_s_i32       <i32_convert_f32_injector<wasm_ops::f32_convert_s_i32_code>>;
+      using f32_convert_s_i64 = wasm_ops::f32_convert_s_i64       <i64_convert_f32_injector<wasm_ops::f32_convert_s_i64_code>>;
+      using f32_convert_u_i32 = wasm_ops::f32_convert_u_i32       <i32_convert_f32_injector<wasm_ops::f32_convert_u_i32_code>>;
+      using f32_convert_u_i64 = wasm_ops::f32_convert_u_i64       <i64_convert_f32_injector<wasm_ops::f32_convert_u_i64_code>>;
+      using f64_convert_s_i32 = wasm_ops::f64_convert_s_i32       <i32_convert_f64_injector<wasm_ops::f64_convert_s_i32_code>>;
+      using f64_convert_s_i64 = wasm_ops::f64_convert_s_i64       <i64_convert_f64_injector<wasm_ops::f64_convert_s_i64_code>>;
+      using f64_convert_u_i32 = wasm_ops::f64_convert_u_i32       <i32_convert_f64_injector<wasm_ops::f64_convert_u_i32_code>>;
+      using f64_convert_u_i64 = wasm_ops::f64_convert_u_i64       <i64_convert_f64_injector<wasm_ops::f64_convert_u_i64_code>>;
    }; // pre_op_injectors
 
 
@@ -911,26 +785,19 @@ namespace eosio { namespace chain { namespace wasm_injections {
             _module_injectors.init();
             // initialize static fields of injectors
             injector_utils::init( mod );
-            instruction_counter::init();
             checktime_injection::init();
-            checktime_block_type::init();
-            checktime_function_end::init();
             call_depth_check::init();
          }
 
          void inject() {
             _module_injectors.inject( *_module );
             // inject checktime first
-            injector_utils::add_import<ResultType::none, ValueType::i32>( *_module, u8"checktime", checktime_injection::chktm_idx );
+            injector_utils::add_import<ResultType::none>( *_module, u8"checktime", checktime_injection::chktm_idx );
 
             for ( auto& fd : _module->functions.defs ) {
                wasm_ops::EOSIO_OperatorDecoderStream<pre_op_injectors> pre_decoder(fd.code);
                wasm_ops::instruction_stream pre_code(fd.code.size()*2);
-               checktime_block_type::orderings.emplace();
-               checktime_block_type::bcnt_tables.emplace();
-               instruction_counter::icnt = 0;
-               instruction_counter::tcnt = 0;
-               instruction_counter::bcnt = 0;
+
                while ( pre_decoder ) {
                   auto op = pre_decoder.decodeOp();
                   if (op->is_post()) {
@@ -943,24 +810,18 @@ namespace eosio { namespace chain { namespace wasm_injections {
                         op->pack(&pre_code);
                   }
                }
-               instruction_counter::fcnts.push(instruction_counter::tcnt - instruction_counter::bcnt);
                fd.code = pre_code.get();
             }
             for ( auto& fd : _module->functions.defs ) {
                wasm_ops::EOSIO_OperatorDecoderStream<post_op_injectors> post_decoder(fd.code);
                wasm_ops::instruction_stream post_code(fd.code.size()*2);
-               bool is_start = true;
+
+               wasm_ops::op_types<>::call_t chktm; 
+               chktm.field = injector_utils::injected_index_mapping.find(checktime_injection::chktm_idx)->second;
+               chktm.pack(&post_code);
+
                while ( post_decoder ) {
                   auto op = post_decoder.decodeOp();
-                  if ( is_start ) {
-                     is_start = false;
-                     wasm_ops::op_types<>::i32_const_t cnt; 
-                     cnt.field = instruction_counter::fcnts.front();
-                     wasm_ops::op_types<>::call_t chktm; 
-                     chktm.field = injector_utils::injected_index_mapping.find(checktime_injection::chktm_idx)->second;
-                     cnt.pack(&post_code);
-                     chktm.pack(&post_code);
-                  }
                   if (op->is_post()) {
                      op->pack(&post_code);
                      op->visit( { _module, &post_code, &fd, post_decoder.index() } );
@@ -972,10 +833,6 @@ namespace eosio { namespace chain { namespace wasm_injections {
                   }
                }
                fd.code = post_code.get();
-               instruction_counter::fcnts.pop();
-               checktime_block_type::orderings.pop();
-               checktime_block_type::bcnt_tables.pop();
-               checktime_injection::idx = 0;
             }
          }
       private:

--- a/libraries/chain/include/eosio/chain/webassembly/common.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/common.hpp
@@ -10,6 +10,7 @@ using namespace fc;
 namespace eosio { namespace chain { 
 
    class apply_context;
+   class transaction_context;
 
    template<typename T>
    struct class_from_wasm {
@@ -20,6 +21,19 @@ namespace eosio { namespace chain {
        */
       static auto value(apply_context& ctx) {
          return T(ctx);
+      }
+   };
+   
+   template<>
+   struct class_from_wasm<transaction_context> {
+      /**
+       * by default this is just constructing an object
+       * @param wasm - the wasm_interface to use
+       * @return
+       */
+      template <typename ApplyCtx>
+      static auto &value(ApplyCtx& ctx) {
+         return ctx.trx_context;
       }
    };
 

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -124,7 +124,7 @@ namespace eosio { namespace chain {
       if( billed_cpu_time_us > 0 )
          deadline = original_deadline; // Only change deadline if billed_cpu_time_us is not set
 
-      check_time(); // Fail early if deadline has already been exceeded
+      checktime(); // Fail early if deadline has already been exceeded
 
       is_initialized = true;
    }
@@ -275,7 +275,7 @@ namespace eosio { namespace chain {
       }
    }
 
-   void transaction_context::check_time()const {
+   void transaction_context::checktime()const {
       auto now = fc::time_point::now();
       if( BOOST_UNLIKELY( now > deadline ) ) {
          if( billed_cpu_time_us > 0 || deadline_exception_code == deadline_exception::code_value ) {

--- a/libraries/chain/wasm_interface.cpp
+++ b/libraries/chain/wasm_interface.cpp
@@ -782,7 +782,7 @@ class permission_api : public context_aware_api {
                                          provided_keys,
                                          provided_permissions,
                                          fc::seconds(trx.delay_sec),
-                                         std::bind(&apply_context::checktime, &context, std::placeholders::_1),
+                                         std::bind(&transaction_context::checktime, &context.trx_context),
                                          false
                                        );
             return true;
@@ -814,7 +814,7 @@ class permission_api : public context_aware_api {
                                          provided_keys,
                                          provided_permissions,
                                          fc::microseconds(delay_us),
-                                         std::bind(&apply_context::checktime, &context, std::placeholders::_1),
+                                         std::bind(&transaction_context::checktime, &context.trx_context),
                                          false
                                        );
             return true;
@@ -1630,8 +1630,8 @@ REGISTER_INTRINSICS(privileged_api,
    (set_privileged,                   void(int64_t, int)                    )
 );
 
-REGISTER_INJECTED_INTRINSICS(apply_context,
-   (checktime,      void(int))
+REGISTER_INJECTED_INTRINSICS(transaction_context,
+   (checktime,      void())
 );
 
 REGISTER_INTRINSICS(producer_api,


### PR DESCRIPTION
Removed injection of instruction counting, removed unused checktime args where called explicitly and changed wasm_interface to call transaction_context::checktime directly.