### PR TITLE
Docker fixes, and use Ubuntu 18.04 [skip-ci]

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,14 +1,14 @@
 FROM eosio/builder as builder
 ARG branch=master
 
-RUN git clone -b $branch --depth 1 https://github.com/EOSIO/eos.git --recursive \
+RUN git clone -b $branch https://github.com/EOSIO/eos.git --recursive \
     && cd eos && echo "$branch:$(git rev-parse HEAD)" > /etc/eosio-version \
     && cmake -H. -B"/tmp/build" -GNinja -DCMAKE_BUILD_TYPE=Release -DWASM_ROOT=/opt/wasm -DCMAKE_CXX_COMPILER=clang++ \
        -DCMAKE_C_COMPILER=clang -DCMAKE_INSTALL_PREFIX=/tmp/build  -DSecp256k1_ROOT_DIR=/usr/local -DBUILD_MONGO_DB_PLUGIN=true \
     && cmake --build /tmp/build --target install
 
 
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install openssl && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /usr/local/lib/* /usr/local/lib/
@@ -16,7 +16,7 @@ COPY --from=builder /tmp/build/bin /opt/eosio/bin
 COPY --from=builder /tmp/build/contracts /contracts
 COPY --from=builder /eos/Docker/config.ini /
 COPY --from=builder /etc/eosio-version /etc
-COPY nodeosd.sh /opt/eosio/bin/nodeosd.sh
+COPY --from=builder /eos/Docker/nodeosd.sh /opt/eosio/bin/nodeosd.sh
 ENV EOSIO_ROOT=/opt/eosio
 RUN chmod +x /opt/eosio/bin/nodeosd.sh
 ENV LD_LIBRARY_PATH /usr/local/lib


### PR DESCRIPTION
- Use nodeosd.sh from the branch the Docker image is built against.
- Remove unnecessary --depth 1 from git clone.
- Use Ubuntu 18.04 base image as it is now the current LTS release.