### PR TITLE
Increase timeout for coverage reports [skip-ci]

### DIFF
--- a/.buildkite/coverage.yml
+++ b/.buildkite/coverage.yml
@@ -26,4 +26,4 @@ steps:
           - WASM_ROOT=/root/opt/wasm
           - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/root/opt/wasm/bin
           - CI=true
-    timeout: 30
+    timeout: 60


### PR DESCRIPTION
Latest coverage reports are hitting the timeout threshold causing failures. This increases the allowed time for the job to complete.