### PR TITLE
fix showing stakes in cleos get account, unit-test for delegatebw transfer

### DIFF
--- a/libraries/chain/resource_limits.cpp
+++ b/libraries/chain/resource_limits.cpp
@@ -345,7 +345,7 @@ int64_t resource_limits_manager::get_account_cpu_limit( const account_name& name
    uint128_t user_weight     = cpu_weight;
    uint128_t all_user_weight = state.total_cpu_weight;
 
-   auto max_user_use_in_window = (virtual_cpu_capacity_in_window * user_weight) / all_user_weight;
+   auto max_user_use_in_window = all_user_weight > 0 ? (uint128_t(virtual_cpu_capacity_in_window) * user_weight) / all_user_weight : uint128_t(virtual_cpu_capacity_in_window);
    auto cpu_used_in_window  = (usage.cpu_usage.value_ex * window_size) / config::rate_limiting_precision;
 
    if( max_user_use_in_window <= cpu_used_in_window ) return 0;
@@ -403,7 +403,7 @@ account_resource_limit resource_limits_manager::get_account_cpu_limit_ex( const 
 
    wdump((cpu_weight));
 
-   auto max_user_use_in_window = (uint128_t(virtual_cpu_capacity_in_window) * user_weight) / all_user_weight;
+   auto max_user_use_in_window = all_user_weight > 0 ? (uint128_t(virtual_cpu_capacity_in_window) * user_weight) / all_user_weight : uint128_t(virtual_cpu_capacity_in_window);
    auto cpu_used_in_window  = (usage.cpu_usage.value_ex * window_size) / config::rate_limiting_precision;
 
    if( max_user_use_in_window <= cpu_used_in_window ) 
@@ -436,7 +436,7 @@ int64_t resource_limits_manager::get_account_net_limit( const account_name& name
    uint128_t user_weight     = net_weight;
    uint128_t all_user_weight = state.total_net_weight;
 
-   auto max_user_use_in_window = (virtual_network_capacity_in_window * user_weight) / all_user_weight;
+   auto max_user_use_in_window = all_user_weight > 0 ? (virtual_network_capacity_in_window * user_weight) / all_user_weight : virtual_network_capacity_in_window;
    auto net_used_in_window  = (usage.net_usage.value_ex * window_size) / config::rate_limiting_precision;
 
    if( max_user_use_in_window <= net_used_in_window ) return 0;
@@ -466,7 +466,7 @@ account_resource_limit resource_limits_manager::get_account_net_limit_ex( const 
    uint128_t all_user_weight = state.total_net_weight;
 
 
-   auto max_user_use_in_window = (virtual_network_capacity_in_window * user_weight) / all_user_weight;
+   auto max_user_use_in_window = all_user_weight > 0 ? (virtual_network_capacity_in_window * user_weight) / all_user_weight : virtual_network_capacity_in_window;
    auto net_used_in_window  = (usage.net_usage.value_ex * window_size) / config::rate_limiting_precision;
 
    if( max_user_use_in_window <= net_used_in_window ) 

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -833,7 +833,7 @@ struct create_account_subcommand {
          createAccount->add_option("--buy-ram-EOS", buy_ram_eos,
                                    (localized("The amount of RAM bytes to purchase for the new account in EOS")));
          createAccount->add_flag("--transfer", transfer,
-                                 (localized("Transfer?")));
+                                 (localized("Transfer voting power and right to unstake EOS to receiver")));
       }
 
       add_standard_transaction_options(createAccount);
@@ -988,7 +988,7 @@ struct delegate_bandwidth_subcommand {
       delegate_bandwidth->add_option("receiver", receiver_str, localized("The account to receive the delegated bandwidth"))->required();
       delegate_bandwidth->add_option("stake_net_quantity", stake_net_amount, localized("The amount of EOS to stake for network bandwidth"))->required();
       delegate_bandwidth->add_option("stake_cpu_quantity", stake_cpu_amount, localized("The amount of EOS to stake for CPU bandwidth"))->required();
-      delegate_bandwidth->add_flag("--transfer", transfer, localized("specify to stake in name of receiver rather than in name of from"))->required();
+      delegate_bandwidth->add_flag("--transfer", transfer, localized("Transfer voting power and right to unstake EOS to receiver"));
       add_standard_transaction_options(delegate_bandwidth);
 
       delegate_bandwidth->set_callback([this] {
@@ -1223,7 +1223,7 @@ void get_account( const string& accountName, bool json_format ) {
 
       std::cout << "net bandwidth: (averaged over 3 days)" << std::endl;
       if ( res.total_resources.is_object() ) {
-         asset net_own( res.delegated_bandwidth.is_object() ? stoll( res.delegated_bandwidth.get_object()["net_weight"].as_string() ) : 0 );
+         asset net_own = res.delegated_bandwidth.is_object() ? asset::from_string( res.delegated_bandwidth.get_object()["net_weight"].as_string() ) : asset(0) ;
          auto net_others = to_asset(res.total_resources.get_object()["net_weight"].as_string()) - net_own;
          std::cout << indent << "staked:" << std::setw(20) << net_own
                    << std::string(11, ' ') << "(total stake delegated from account to self)" << std::endl
@@ -1269,7 +1269,7 @@ void get_account( const string& accountName, bool json_format ) {
 
 
       if ( res.total_resources.is_object() ) {
-         asset cpu_own( res.delegated_bandwidth.is_object() ? stoll( res.delegated_bandwidth.get_object()["cpu_weight"].as_string() ) : 0 );
+         asset cpu_own = res.delegated_bandwidth.is_object() ? asset::from_string( res.delegated_bandwidth.get_object()["cpu_weight"].as_string() ) : asset(0) ;
          auto cpu_others = to_asset(res.total_resources.get_object()["cpu_weight"].as_string()) - cpu_own;
          std::cout << indent << "staked:" << std::setw(20) << cpu_own
                    << std::string(11, ' ') << "(total stake delegated from account to self)" << std::endl


### PR DESCRIPTION
1. update cleos to get account response format (seems like it changed recently)
2. unit-test for delegatebw with transfer
3. avoid devision by 0 in resource_limits.cpp (I did hit it once)