### PR TITLE
Fix for eos #2890

### DIFF
--- a/contracts/dice/dice.abi
+++ b/contracts/dice/dice.abi
@@ -43,7 +43,7 @@
           "type": "asset"
         },{
           "name": "deadline",
-          "type": "time"
+          "type": "time_point_sec"
         },{
           "name": "player1",
           "type": "player"

--- a/contracts/dice/dice.cpp
+++ b/contracts/dice/dice.cpp
@@ -6,6 +6,7 @@
 #include <vector>
 #include <string>
 #include <eosiolib/eosio.hpp>
+#include <eosiolib/time.hpp>
 #include <eosiolib/asset.hpp>
 #include <eosiolib/contract.hpp>
 #include <eosiolib/crypto.h>
@@ -86,7 +87,7 @@ class dice : public eosio::contract {
             auto game_itr = games.emplace(_self, [&](auto& new_game){
                new_game.id       = gdice_itr->nextgameid;
                new_game.bet      = new_offer_itr->bet;
-               new_game.deadline = 0;
+               new_game.deadline = eosio::time_point_sec(0);
 
                new_game.player1.commitment = matched_offer_itr->commitment;
                memset(&new_game.player1.reveal, 0, sizeof(checksum256));
@@ -184,7 +185,7 @@ class dice : public eosio::contract {
                else
                   game.player2.reveal = source;
 
-               game.deadline = now() + FIVE_MINUTES;
+               game.deadline = eosio::time_point_sec(now() + FIVE_MINUTES);
             });
          }
       }
@@ -195,7 +196,7 @@ class dice : public eosio::contract {
          auto game_itr = games.find(gameid);
 
          eosio_assert(game_itr != games.end(), "game not found");
-         eosio_assert(game_itr->deadline != 0 && now() > game_itr->deadline, "game not expired");
+         eosio_assert(game_itr->deadline != eosio::time_point_sec(0) && eosio::time_point_sec(now()) > game_itr->deadline, "game not expired");
 
          auto idx = offers.template get_index<N(commitment)>();
          auto player1_offer = idx.find( offer::get_commitment(game_itr->player1.commitment) );
@@ -300,7 +301,7 @@ class dice : public eosio::contract {
       struct game {
          uint64_t id;
          asset    bet;
-         time     deadline;
+         eosio::time_point_sec deadline;
          player   player1;
          player   player2;
 

--- a/contracts/eosio.msig/eosio.msig.abi
+++ b/contracts/eosio.msig/eosio.msig.abi
@@ -2,10 +2,7 @@
   "types": [{
       "new_type_name": "account_name",
       "type": "name"
-    },{
-      "new_type_name": "time_point_sec",
-      "type": "time"
-    }
+    }  
   ],
   "structs": [{
       "name": "permission_level",

--- a/contracts/eosio.msig/eosio.msig.cpp
+++ b/contracts/eosio.msig/eosio.msig.cpp
@@ -34,7 +34,7 @@ void multisig::propose() {
    ds >> trx_header;
 
    require_auth( proposer );
-   eosio_assert( trx_header.expiration >= now(), "transaction expired" );
+   eosio_assert( trx_header.expiration >= eosio::time_point_sec(now()), "transaction expired" );
    //eosio_assert( trx_header.actions.size() > 0, "transaction must have at least one action" );
 
    proposals proptable( _self, proposer );
@@ -93,7 +93,7 @@ void multisig::cancel( account_name proposer, name proposal_name, account_name c
    eosio_assert( prop_it != proptable.end(), "proposal not found" );
 
    if( canceler != proposer ) {
-      eosio_assert( unpack<transaction_header>( prop_it->packed_transaction ).expiration < now(), "cannot cancel until expiration" );
+      eosio_assert( unpack<transaction_header>( prop_it->packed_transaction ).expiration < eosio::time_point_sec(now()), "cannot cancel until expiration" );
    }
 
    proptable.erase(prop_it);
@@ -109,7 +109,7 @@ void multisig::exec( account_name proposer, name proposal_name, account_name exe
    transaction_header trx_header;
    datastream<const char*> ds( prop_it->packed_transaction.data(), prop_it->packed_transaction.size() );
    ds >> trx_header;
-   eosio_assert( trx_header.expiration >= now(), "transaction expired" );
+   eosio_assert( trx_header.expiration >= eosio::time_point_sec(now()), "transaction expired" );
 
    bytes packed_provided_approvals = pack(prop_it->provided_approvals);
    auto res = ::check_transaction_authorization( prop_it->packed_transaction.data(), prop_it->packed_transaction.size(),

--- a/contracts/eosio.system/eosio.system.abi
+++ b/contracts/eosio.system/eosio.system.abi
@@ -80,7 +80,7 @@
       "base": "",
       "fields": [
          {"name":"owner", "type":"account_name"},
-         {"name":"request_time", "type":"time"},
+         {"name":"request_time", "type":"time_point_sec"},
          {"name":"amount", "type":"uint64"}
       ]
     },{
@@ -124,7 +124,7 @@
       "fields": [
          {"name":"total_ram_bytes_reserved",      "type":"uint64"},
          {"name":"total_ram_stake",               "type":"asset"},
-         {"name":"last_producer_schedule_update", "type":"time"},
+         {"name":"last_producer_schedule_update", "type":"time_point_sec"},
          {"name":"last_pervote_bucket_fill",      "type":"uint64"},
          {"name":"pervote_bucket",                "type":"asset"},
          {"name":"savings",                       "type":"asset"},
@@ -192,7 +192,7 @@
         {"name":"proxied_vote_weight",  "type":"float64"},
         {"name":"is_proxy",             "type":"bool"},
         {"name":"deferred_trx_id",      "type":"uint32"},
-        {"name":"last_unstake_time",    "type":"time"},
+        {"name":"last_unstake_time",    "type":"time_point_sec"},
         {"name":"unstaking",            "type":"asset"}
       ]
     },{

--- a/contracts/eosiolib/time.hpp
+++ b/contracts/eosiolib/time.hpp
@@ -1,0 +1,172 @@
+#pragma once
+#include <stdint.h>
+#include <string>
+#include <eosiolib/eosio.hpp>
+
+namespace eosio {
+  class microseconds {
+    public:
+        explicit microseconds( int64_t c = 0) :_count(c){}
+        static microseconds maximum() { return microseconds(0x7fffffffffffffffll); }
+        friend microseconds operator + (const  microseconds& l, const microseconds& r ) { return microseconds(l._count+r._count); }
+        friend microseconds operator - (const  microseconds& l, const microseconds& r ) { return microseconds(l._count-r._count); }
+
+
+        bool operator==(const microseconds& c)const { return _count == c._count; }
+        bool operator!=(const microseconds& c)const { return _count != c._count; }
+        friend bool operator>(const microseconds& a, const microseconds& b){ return a._count > b._count; }
+        friend bool operator>=(const microseconds& a, const microseconds& b){ return a._count >= b._count; }
+        friend bool operator<(const microseconds& a, const microseconds& b){ return a._count < b._count; }
+        friend bool operator<=(const microseconds& a, const microseconds& b){ return a._count <= b._count; }
+        microseconds& operator+=(const microseconds& c) { _count += c._count; return *this; }
+        microseconds& operator-=(const microseconds& c) { _count -= c._count; return *this; }
+        int64_t count()const { return _count; }
+        int64_t to_seconds()const { return _count/1000000; }
+    private:
+        int64_t _count;
+        friend class time_point;
+  };
+
+  inline microseconds seconds( int64_t s ) { return microseconds( s * 1000000 ); }
+  inline microseconds milliseconds( int64_t s ) { return microseconds( s * 1000 ); }
+  inline microseconds minutes(int64_t m) { return seconds(60*m); }
+  inline microseconds hours(int64_t h) { return minutes(60*h); }
+  inline microseconds days(int64_t d) { return hours(24*d); }
+
+  class time_point {
+    public:
+        explicit time_point( microseconds e = microseconds() ) :elapsed(e){}
+        operator std::string()const;
+        static time_point from_iso_string( const std::string& s );
+        const microseconds& time_since_epoch()const { return elapsed; }
+        uint32_t            sec_since_epoch()const  { return elapsed.count() / 1000000; }
+        bool   operator > ( const time_point& t )const                              { return elapsed._count > t.elapsed._count; }
+        bool   operator >=( const time_point& t )const                              { return elapsed._count >=t.elapsed._count; }
+        bool   operator < ( const time_point& t )const                              { return elapsed._count < t.elapsed._count; }
+        bool   operator <=( const time_point& t )const                              { return elapsed._count <=t.elapsed._count; }
+        bool   operator ==( const time_point& t )const                              { return elapsed._count ==t.elapsed._count; }
+        bool   operator !=( const time_point& t )const                              { return elapsed._count !=t.elapsed._count; }
+        time_point&  operator += ( const microseconds& m)                           { elapsed+=m; return *this;                 }
+        time_point&  operator -= ( const microseconds& m)                           { elapsed-=m; return *this;                 }
+        time_point   operator + (const microseconds& m) const { return time_point(elapsed+m); }
+        time_point   operator + (const time_point& m) const { return time_point(elapsed+m.elapsed); }
+        time_point   operator - (const microseconds& m) const { return time_point(elapsed-m); }
+        microseconds operator - (const time_point& m) const { return microseconds(elapsed.count() - m.elapsed.count()); }
+        microseconds elapsed;
+  };
+
+  /**
+   *  A lower resolution time_point accurate only to seconds from 1970
+   */
+  class time_point_sec
+  {
+    public:
+        time_point_sec()
+        :utc_seconds(0){}
+
+        explicit time_point_sec(uint32_t seconds )
+        :utc_seconds(seconds){}
+
+        time_point_sec( const time_point& t )
+        :utc_seconds( t.time_since_epoch().count() / 1000000ll ){}
+
+        static time_point_sec maximum() { return time_point_sec(0xffffffff); }
+        static time_point_sec min() { return time_point_sec(0); }
+
+        operator time_point()const { return time_point( eosio::seconds( utc_seconds) ); }
+        uint32_t sec_since_epoch()const { return utc_seconds; }
+
+        time_point_sec operator = ( const eosio::time_point& t )
+        {
+          utc_seconds = t.time_since_epoch().count() / 1000000ll;
+          return *this;
+        }
+        friend bool      operator < ( const time_point_sec& a, const time_point_sec& b )  { return a.utc_seconds < b.utc_seconds; }
+        friend bool      operator > ( const time_point_sec& a, const time_point_sec& b )  { return a.utc_seconds > b.utc_seconds; }
+        friend bool      operator <= ( const time_point_sec& a, const time_point_sec& b )  { return a.utc_seconds <= b.utc_seconds; }
+        friend bool      operator >= ( const time_point_sec& a, const time_point_sec& b )  { return a.utc_seconds >= b.utc_seconds; }
+        friend bool      operator == ( const time_point_sec& a, const time_point_sec& b ) { return a.utc_seconds == b.utc_seconds; }
+        friend bool      operator != ( const time_point_sec& a, const time_point_sec& b ) { return a.utc_seconds != b.utc_seconds; }
+        time_point_sec&  operator += ( uint32_t m ) { utc_seconds+=m; return *this; }
+        time_point_sec&  operator += ( microseconds m ) { utc_seconds+=m.to_seconds(); return *this; }
+        time_point_sec&  operator += ( time_point_sec m ) { utc_seconds+=m.utc_seconds; return *this; }
+        time_point_sec&  operator -= ( uint32_t m ) { utc_seconds-=m; return *this; }
+        time_point_sec&  operator -= ( microseconds m ) { utc_seconds-=m.to_seconds(); return *this; }
+        time_point_sec&  operator -= ( time_point_sec m ) { utc_seconds-=m.utc_seconds; return *this; }
+        time_point_sec   operator +( uint32_t offset )const { return time_point_sec(utc_seconds + offset); }
+        time_point_sec   operator -( uint32_t offset )const { return time_point_sec(utc_seconds - offset); }
+
+        friend time_point   operator + ( const time_point_sec& t, const microseconds& m )   { return time_point(t) + m;             }
+        friend time_point   operator - ( const time_point_sec& t, const microseconds& m )   { return time_point(t) - m;             }
+        friend microseconds operator - ( const time_point_sec& t, const time_point_sec& m ) { return time_point(t) - time_point(m); }
+        friend microseconds operator - ( const time_point& t, const time_point_sec& m ) { return time_point(t) - time_point(m); }
+        uint32_t utc_seconds;
+  };
+
+   /**
+   * This class is used in the block headers to represent the block time
+   * It is a parameterised class that takes an Epoch in milliseconds and
+   * and an interval in milliseconds and computes the number of slots.
+   **/
+   template<uint16_t IntervalMs, uint64_t EpochMs>
+   class block_timestamp {
+      public:
+         explicit block_timestamp( uint32_t s=0 ) :slot(s){}
+
+         block_timestamp(const time_point& t) {
+            set_time_point(t);
+         }
+
+         block_timestamp(const time_point_sec& t) {
+            set_time_point(t);
+         }
+
+         static block_timestamp maximum() { return block_timestamp( 0xffff ); }
+         static block_timestamp min() { return block_timestamp(0); }
+
+         block_timestamp next() const {
+            FC_ASSERT( std::numeric_limits<uint32_t>::max() - slot >= 1, "block timestamp overflow" );
+            auto result = block_timestamp(*this);
+            result.slot += 1;
+            return result;
+         }
+
+         time_point to_time_point() const {
+            return (time_point)(*this);
+         }
+
+         operator time_point() const {
+            int64_t msec = slot * (int64_t)IntervalMs;
+            msec += EpochMs;
+            return time_point(milliseconds(msec));
+         }
+
+         void operator = (const time_point& t ) {
+            set_time_point(t);
+         }
+
+         bool   operator > ( const block_timestamp& t )const   { return slot >  t.slot; }
+         bool   operator >=( const block_timestamp& t )const   { return slot >= t.slot; }
+         bool   operator < ( const block_timestamp& t )const   { return slot <  t.slot; }
+         bool   operator <=( const block_timestamp& t )const   { return slot <= t.slot; }
+         bool   operator ==( const block_timestamp& t )const   { return slot == t.slot; }
+         bool   operator !=( const block_timestamp& t )const   { return slot != t.slot; }
+         uint32_t slot;
+
+      private:
+      void set_time_point(const time_point& t) {
+         auto micro_since_epoch = t.time_since_epoch();
+         auto msec_since_epoch  = micro_since_epoch.count() / 1000;
+         slot = ( msec_since_epoch - EpochMs ) / IntervalMs;
+      }
+
+      void set_time_point(const time_point_sec& t) {
+         uint64_t  sec_since_epoch = t.sec_since_epoch();
+         slot = (sec_since_epoch * 1000 - EpochMs) / IntervalMs;
+      }
+   }; // block_timestamp
+   static constexpr uint32_t block_interval_ms = 500;
+   static constexpr uint64_t block_timestamp_epoch = 946684800000ll;  // epoch is year 2000
+   typedef block_timestamp<block_interval_ms, block_timestamp_epoch> block_timestamp_type; 
+
+} // namespace eosio

--- a/contracts/eosiolib/transaction.hpp
+++ b/contracts/eosiolib/transaction.hpp
@@ -5,8 +5,8 @@
 #pragma once
 #include <eosiolib/transaction.h>
 #include <eosiolib/action.hpp>
-#include <eosiolib/print.hpp>
 #include <eosiolib/types.hpp>
+#include <eosiolib/time.hpp>
 #include <eosiolib/serialize.hpp>
 #include <vector>
 
@@ -24,11 +24,11 @@ namespace eosio {
 
    class transaction_header {
    public:
-      transaction_header( time exp = now() + 60 )
+      transaction_header( time_point_sec exp = time_point_sec(now() + 60) )
          :expiration(exp)
-      { eosio::print("now=", now(), " exp=", expiration, "\n"); }
+      {}
 
-      time            expiration;
+      time_point_sec  expiration;
       uint16_t        ref_block_num;
       uint32_t        ref_block_prefix;
       unsigned_int    net_usage_words = 0UL; /// number of 8 byte words this transaction can serialize into after compressions
@@ -40,7 +40,7 @@ namespace eosio {
 
    class transaction : public transaction_header {
    public:
-      transaction(time exp = now() + 60) : transaction_header( exp ) {}
+      transaction(time_point_sec exp = time_point_sec(now() + 60)) : transaction_header( exp ) {}
 
       void send(uint64_t sender_id, account_name payer, bool replace_existing = false) const {
          auto serialize = pack(*this);

--- a/libraries/chain/abi_serializer.cpp
+++ b/libraries/chain/abi_serializer.cpp
@@ -68,7 +68,9 @@ namespace eosio { namespace chain {
       //native.hpp
       built_in_types.emplace("string",                    pack_unpack<string>());
       built_in_types.emplace("clause_pair",               pack_unpack<clause_pair>());
-      built_in_types.emplace("time",                      pack_unpack<fc::time_point_sec>());
+      built_in_types.emplace("time_point",                pack_unpack<fc::time_point>());
+      built_in_types.emplace("time_point_sec",            pack_unpack<fc::time_point_sec>());
+      built_in_types.emplace("block_timestamp_type",      pack_unpack<block_timestamp_type>());
       built_in_types.emplace("signature",                 pack_unpack<signature_type>());
       built_in_types.emplace("checksum160",               pack_unpack<checksum160_type>());
       built_in_types.emplace("checksum256",               pack_unpack<checksum256_type>());

--- a/libraries/chain/eosio_contract_abi.cpp
+++ b/libraries/chain/eosio_contract_abi.cpp
@@ -11,7 +11,6 @@ abi_def eosio_contract_abi(const abi_def& eosio_system_abi)
    eos_abi.types.push_back( type_def{"context_free_type","bytes"} );
    eos_abi.types.push_back( type_def{"weight_type","uint16"} );
    eos_abi.types.push_back( type_def{"fields","field[]"} );
-   eos_abi.types.push_back( type_def{"time_point_sec","time"} );
 
    // TODO add ricardian contracts
    eos_abi.actions.push_back( action_def{name("setcode"), "setcode",""} );

--- a/unittests/abi_tests.cpp
+++ b/unittests/abi_tests.cpp
@@ -112,11 +112,20 @@ fc::variant verify_type_round_trip_conversion( const abi_serializer& abis, const
          "name": "string_arr",
          "type": "string[]"
       },{
-         "name": "time",
-         "type": "time"
+         "name": "block_timestamp_type",
+         "type": "block_timestamp_type"
       },{
-         "name": "time_arr",
-         "type": "time[]"
+         "name": "time_point",
+         "type": "time_point"
+      },{
+         "name": "time_point_arr",
+         "type": "time_point[]"
+      },{
+         "name": "time_point_sec",
+         "type": "time_point_sec"
+      },{
+         "name": "time_point_sec_arr",
+         "type": "time_point_sec[]"
       },{
          "name": "signature",
          "type": "signature"
@@ -464,6 +473,7 @@ BOOST_FIXTURE_TEST_CASE(abigen_all_types, abi_gen_helper)
    #include <eosiolib/types.hpp>
    #include <eosiolib/asset.hpp>
    #include <eosiolib/action.hpp>
+   #include <eosiolib/time.hpp>
    #include <string>
 
    typedef eosio::symbol_type symbol;
@@ -471,7 +481,7 @@ BOOST_FIXTURE_TEST_CASE(abigen_all_types, abi_gen_helper)
    //@abi action
    struct test_struct {
      std::string             field1;
-     time                    field2;
+     eosio::time_point_sec   field2;
      signature               field3;
      checksum256             field4;
      field_name              field5;
@@ -497,6 +507,8 @@ BOOST_FIXTURE_TEST_CASE(abigen_all_types, abi_gen_helper)
      eosio::asset            field40;
      eosio::extended_asset   field41;
      symbol                  field42;
+     eosio::time_point       field43;
+     eosio::block_timestamp_type  field44;
    };
    )=====";
 
@@ -511,7 +523,7 @@ BOOST_FIXTURE_TEST_CASE(abigen_all_types, abi_gen_helper)
              "type": "string"
            },{
              "name": "field2",
-             "type": "time"
+             "type": "time_point_sec"
            },{
              "name": "field3",
              "type": "signature"
@@ -587,6 +599,12 @@ BOOST_FIXTURE_TEST_CASE(abigen_all_types, abi_gen_helper)
            },{
              "name": "field42",
              "type": "symbol"
+           },{
+             "name": "field43",
+             "type": "time_point"
+           },{
+             "name": "field44",
+             "type": "block_timestamp_type"
            }
          ]
        }
@@ -1742,8 +1760,11 @@ BOOST_AUTO_TEST_CASE(general)
 
       "string"            : "ola ke ase",
       "string_arr"        : ["ola ke ase","ola ke desi"],
-      "time"              : "2021-12-20T15:30",
-      "time_arr"          : ["2021-12-20T15:30","2021-12-20T15:31"],
+      "block_timestamp_type" : "2021-12-20T15",
+      "time_point"        : "2021-12-20T15:30",
+      "time_point_arr"    : ["2021-12-20T15:30","2021-12-20T15:31"],
+      "time_point_sec"    : "2021-12-20T15:30:21",
+      "time_point_sec_arr": ["2021-12-20T15:30:21","2021-12-20T15:31:21"],
       "signature"         : "SIG_K1_Jzdpi5RCzHLGsQbpGhndXBzcFs8vT5LHAtWLMxPzBdwRHSmJkcCdVu6oqPUQn1hbGUdErHvxtdSTS1YA73BThQFwV1v4G5",
       "signature_arr"     : ["SIG_K1_Jzdpi5RCzHLGsQbpGhndXBzcFs8vT5LHAtWLMxPzBdwRHSmJkcCdVu6oqPUQn1hbGUdErHvxtdSTS1YA73BThQFwV1v4G5","SIG_K1_Jzdpi5RCzHLGsQbpGhndXBzcFs8vT5LHAtWLMxPzBdwRHSmJkcCdVu6oqPUQn1hbGUdErHvxtdSTS1YA73BThQFwV1v4G5"],
       "checksum256"       : "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",


### PR DESCRIPTION
Added native time types (time_point, time_point_sec and block_timestamp_type) to contract side and abi.