### PR TITLE
Update LIB before promoting producer schedule from proposed to pending or pending to active

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -661,11 +661,15 @@ struct controller_impl {
       pending->_pending_block_state = std::make_shared<block_state>( *head, when ); // promotes pending schedule (if any) to active
       pending->_pending_block_state->in_current_chain = true;
 
+      pending->_pending_block_state->set_confirmed(confirm_block_count);
+
+      auto was_pending_promoted = pending->_pending_block_state->maybe_promote_pending();
+
       const auto& gpo = db.get<global_property_object>();
       if( gpo.proposed_schedule_block_num.valid() && // if there is a proposed schedule that was proposed in a block ...
           ( *gpo.proposed_schedule_block_num <= pending->_pending_block_state->dpos_irreversible_blocknum ) && // ... that has now become irreversible ...
           pending->_pending_block_state->pending_schedule.producers.size() == 0 && // ... and there is room for a new pending schedule ...
-          head->pending_schedule.producers.size() == 0 // ... and not just because it was promoted to active at the start of this block, then:
+          !was_pending_promoted // ... and not just because it was promoted to active at the start of this block, then:
         )
       {
          // Promote proposed schedule to pending schedule.
@@ -679,8 +683,6 @@ struct controller_impl {
             gp.proposed_schedule.clear();
          });
       }
-
-      pending->_pending_block_state->set_confirmed(confirm_block_count);
 
       try {
          auto onbtrx = std::make_shared<transaction_metadata>( get_on_block_transaction() );

--- a/libraries/chain/include/eosio/chain/block_header_state.hpp
+++ b/libraries/chain/include/eosio/chain/block_header_state.hpp
@@ -30,6 +30,7 @@ struct block_header_state {
     void set_new_producers( producer_schedule_type next_pending );
     void set_confirmed( uint16_t num_prev_blocks );
     void add_confirmation( const header_confirmation& c );
+    bool maybe_promote_pending();
 
 
     bool                 has_pending_producers()const { return pending_schedule.producers.size(); }


### PR DESCRIPTION
This resolves the off-by-one bug in activating a new producer schedule that we noticed while running a testnet.

A unit test replicating the conditions for the off-by-one bug was added. The unit test demonstrated the bug with the original code in controller.cpp and block_header_state.cpp. With the code changed to fix the bug, the new unit test now passes.