### PR TITLE
Fix mismatch error code with cleos error advice on DAWN 4.0

### DIFF
--- a/libraries/chain/include/eosio/chain/exceptions.hpp
+++ b/libraries/chain/include/eosio/chain/exceptions.hpp
@@ -249,8 +249,8 @@ namespace eosio { namespace chain {
                                     3110001, "Missing Chain API Plugin" )
       FC_DECLARE_DERIVED_EXCEPTION( missing_wallet_api_plugin_exception,          missing_plugin_exception,
                                     3110002, "Missing Wallet API Plugin" )
-      FC_DECLARE_DERIVED_EXCEPTION( missing_account_history_api_plugin_exception, missing_plugin_exception,
-                                    3110003, "Missing Account History API Plugin" )
+      FC_DECLARE_DERIVED_EXCEPTION( missing_history_api_plugin_exception, missing_plugin_exception,
+                                    3110003, "Missing History API Plugin" )
       FC_DECLARE_DERIVED_EXCEPTION( missing_net_api_plugin_exception,             missing_plugin_exception,
                                     3110004, "Missing Net API Plugin" )
 

--- a/programs/cleos/help_text.cpp
+++ b/programs/cleos/help_text.cpp
@@ -100,55 +100,11 @@ auto smatch_to_variant(const std::smatch& smatch) {
 const char* error_advice_3010001 = R"=====(Name should be less than 13 characters and only contains the following symbol .12345abcdefghijklmnopqrstuvwxyz)=====";
 const char* error_advice_3010002 = R"=====(Public key should be encoded in base58 and starts with EOS prefix)=====";
 const char* error_advice_3010003 = R"=====(Private key should be encoded in base58 WIF)=====";
-const char* error_advice_3010004 = R"=====(Ensure that your authority JSON follows the following format!
-{
-  "threshold":"uint32_t",
-  "keys":[{ "key":"public_key", "weight":"uint16_t" }],
-  "accounts":[{
-    "permission":{ "actor":"account_name", "permission":"permission_name" },
-    "weight":"uint16_t"
-  }]
-}
-e.g.
-{
-  "threshold":"1",
-  "keys":[{ "key":"EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV", "weight":"1" }],
-  "accounts":[{
-    "permission":{ "actor":"initb", "permission":"social" },
-    "weight":"1
-  }]
-})=====";
+const char* error_advice_3010004 = R"=====(Ensure that your authority JSON follows the right authority structure!
+You can refer to contracts/eosiolib/native.hpp for reference)=====";
 const char* error_advice_3010005 = R"=====(Ensure that your action JSON follows the contract's abi!)=====";
-const char* error_advice_3010006 = R"=====(Ensure that your transaction JSON follows the following format!\n"
-{
-  "ref_block_num":"uint16_t",
-  "ref_block_prefix":"uint32_t",
-  "expiration":"YYYY-MM-DDThh:mm",
-  "region": "uint16_t",
-  "read_scope":[ "account_name" ],
-  "write_scope":[ "account_name" ],
-  "actions":[{
-    "account":"account_name",
-    "name":"action_name",
-    "authorization":[{ "actor":"account_name","permission":"permission_name" }],
-    "data":"bytes"
-  }]
-}"
-e.g.
-{
-  "ref_block_num":"1000",
-  "ref_block_prefix":"3463702842",
-  "expiration":"2018-01-23T01:51:05",
-  "region": "0",
-  "read_scope":[ "initb", "initc" ],
-  "write_scope":[ "initb", "initc" ],
-  "actions":[{
-    "account":"eosio",
-    "name":"transfer",
-    "authorization":[{ "actor":"initb","permission":"active" }],
-    "data":"000000008093dd74000000000094dd74e80300000000000000"
-  }]
-})=====";
+const char* error_advice_3010006 = R"=====(Ensure that your transaction JSON follows the right transaction format!
+You can refer to contracts/eosiolib/transaction.hpp for reference)=====";
 const char* error_advice_3010007 =  R"=====(Ensure that your abi JSON follows the following format!
 {
   "types" : [{ "new_type_name":"type_name", "type":"type_name" }],
@@ -160,13 +116,14 @@ const char* error_advice_3010007 =  R"=====(Ensure that your abi JSON follows th
     "key_names":[ "field_name" ],
     "key_types":[ "type_name" ],
     "type":"type_name" "
-  }]
+  }],
+  "ricardian_clauses": [{ "id": "string", "body": "string" }]
 }
 e.g.
 {
   "types" : [{ "new_type_name":"account_name", "type":"name" }],
   "structs" : [
-    { "name":"foo", "base":"", "fields": [{ "name":"by", "type": "account_name" }] },\n "
+    { "name":"foo", "base":"", "fields": [{ "name":"by", "type": "account_name" }] },
     { "name":"foobar", "base":"", "fields": [{ "name":"by", "type": "account_name" }] }
   ],
   "actions" : [{ "name":"foo","type":"foo"}],
@@ -175,8 +132,9 @@ e.g.
     "index_type":"i64",
     "key_names":[ "by" ],
     "key_types":[ "account_name" ],
-    "type":"foobar" "
-  }]
+    "type":"foobar"
+  }],
+  "ricardian_clauses": [{ "id": "foo", "body": "bar" }]
 })=====";
 const char* error_advice_3010008 =  "Ensure that the block ID is a SHA-256 hexadecimal string!";
 const char* error_advice_3010009 =  "Ensure that the transaction ID is a SHA-256 hexadecimal string!";
@@ -184,15 +142,16 @@ const char* error_advice_3010010 =  R"=====(Ensure that your packed transaction 
 {
   "signatures" : [ "signature" ],
   "compression" : enum("none", "zlib"),
-  "hex_transaction" : "bytes"
+  "packed_context_free_data" : "bytes",
+  "packed_trx" : "bytes";
 }
 e.g.
 {
   "signatures" : [ "SIG_K1_Jze4m1ZHQ4UjuHpBcX6uHPN4Xyggv52raQMTBZJghzDLepaPcSGCNYTxaP2NiaF4yRF5RaYwqsQYAwBwFtfuTJr34Z5GJX" ],
   "compression" : "none",
-  "hex_transaction" : "6c36a25a00002602626c5e7f0000000000010000001e4d75af460000000000a53176010000000000ea305500000000a8ed3232180000001e4d75af4680969800000000000443555200000000"
+  "packed_context_free_data" : "6c36a25a00002602626c5e7f0000000000010000001e4d75af460000000000a53176010000000000ea305500000000a8ed3232180000001e4d75af4680969800000000000443555200000000",
+  "packed_trx" : "6c36a25a00002602626c5e7f0000000000010000001e4d75af460000000000a53176010000000000ea305500000000a8ed3232180000001e4d75af4680969800000000000443555200000000"
 })=====";
-
 
 const char* error_advice_3040000 =  "Ensure that your transaction satisfy the contract's constraint!";
 const char* error_advice_3040005 =  "Please increase the expiration time of your transaction!";

--- a/programs/cleos/help_text.cpp
+++ b/programs/cleos/help_text.cpp
@@ -97,29 +97,10 @@ auto smatch_to_variant(const std::smatch& smatch) {
    return result;
 };
 
-const char* error_advice_3010001 =  "Most likely, the given account/ permission doesn't exist in the blockchain.";
-const char* error_advice_3010002 =  "Most likely, the given account doesn't exist in the blockchain.";
-const char* error_advice_3010003 =  "Most likely, the given table doesnt' exist in the blockchain.";
-const char* error_advice_3010004 =  "Most likely, the given contract doesnt' exist in the blockchain.";
-
-const char* error_advice_3030000 =  "Ensure that your transaction satisfy the contract's constraint!";
-const char* error_advice_3030001 =  R"=====(Ensure that you have the related authority inside your transaction!;
-If you are currently using 'cleos push action' command, try to add the relevant authority using -p option.)=====";
-const char* error_advice_3030002 =  "Ensure that you have the related private keys inside your wallet and your wallet is unlocked.";
-const char* error_advice_3030003 =  "Please remove the unnecessary authority from your action!";
-const char* error_advice_3030004 =  "Please remove the unnecessary signature from your transaction!";
-const char* error_advice_3030011 =  "You can try embedding eosio nonce action inside your transaction to ensure uniqueness.";
-const char* error_advice_3030022 =  "Please increase the expiration time of your transaction!";
-const char* error_advice_3030023 =  "Please decrease the expiration time of your transaction!";
-const char* error_advice_3030024 =  "Ensure that the reference block exist in the blockchain!";
-
-const char* error_advice_3040002 = R"=====(Ensure that your arguments follow the contract abi!
-You can check the contract's abi by using 'cleos get code' command.)=====";
-
-const char* error_advice_3120001 = R"=====(Name should be less than 13 characters and only contains the following symbol .12345abcdefghijklmnopqrstuvwxyz)=====";
-const char* error_advice_3120002 = R"=====(Public key should be encoded in base58 and starts with EOS prefix)=====";
-const char* error_advice_3120003 = R"=====(Private key should be encoded in base58 WIF)=====";
-const char* error_advice_3120004 = R"=====(Ensure that your authority JSON follows the following format!
+const char* error_advice_3010001 = R"=====(Name should be less than 13 characters and only contains the following symbol .12345abcdefghijklmnopqrstuvwxyz)=====";
+const char* error_advice_3010002 = R"=====(Public key should be encoded in base58 and starts with EOS prefix)=====";
+const char* error_advice_3010003 = R"=====(Private key should be encoded in base58 WIF)=====";
+const char* error_advice_3010004 = R"=====(Ensure that your authority JSON follows the following format!
 {
   "threshold":"uint32_t",
   "keys":[{ "key":"public_key", "weight":"uint16_t" }],
@@ -137,8 +118,8 @@ e.g.
     "weight":"1
   }]
 })=====";
-const char* error_advice_3120005 = R"=====(Ensure that your action JSON follows the contract's abi!)=====";
-const char* error_advice_3120006 = R"=====(Ensure that your transaction JSON follows the following format!\n"
+const char* error_advice_3010005 = R"=====(Ensure that your action JSON follows the contract's abi!)=====";
+const char* error_advice_3010006 = R"=====(Ensure that your transaction JSON follows the following format!\n"
 {
   "ref_block_num":"uint16_t",
   "ref_block_prefix":"uint32_t",
@@ -168,7 +149,7 @@ e.g.
     "data":"000000008093dd74000000000094dd74e80300000000000000"
   }]
 })=====";
-const char* error_advice_3120007 =  R"=====(Ensure that your abi JSON follows the following format!
+const char* error_advice_3010007 =  R"=====(Ensure that your abi JSON follows the following format!
 {
   "types" : [{ "new_type_name":"type_name", "type":"type_name" }],
   "structs" : [{ "name":"type_name", "base":"type_name", "fields": [{ "name":"field_name", "type": "type_name" }] }],
@@ -197,9 +178,9 @@ e.g.
     "type":"foobar" "
   }]
 })=====";
-const char* error_advice_3120008 =  "Ensure that the block ID is a SHA-256 hexadecimal string!";
-const char* error_advice_3120009 =  "Ensure that the transaction ID is a SHA-256 hexadecimal string!";
-const char* error_advice_3120010 =  R"=====(Ensure that your packed transaction JSON follows the following format!
+const char* error_advice_3010008 =  "Ensure that the block ID is a SHA-256 hexadecimal string!";
+const char* error_advice_3010009 =  "Ensure that the transaction ID is a SHA-256 hexadecimal string!";
+const char* error_advice_3010010 =  R"=====(Ensure that your packed transaction JSON follows the following format!
 {
   "signatures" : [ "signature" ],
   "compression" : enum("none", "zlib"),
@@ -212,18 +193,39 @@ e.g.
   "hex_transaction" : "6c36a25a00002602626c5e7f0000000000010000001e4d75af460000000000a53176010000000000ea305500000000a8ed3232180000001e4d75af4680969800000000000443555200000000"
 })=====";
 
-const char* error_advice_3130001 =  "Ensure that you have \033[2meosio::chain_api_plugin\033[0m\033[32m added to your node's configuration!";
-const char* error_advice_3130002 =  "Ensure that you have \033[2meosio::wallet_api_plugin\033[0m\033[32m added to your node's configuration!\n"\
-                                    "Otherwise specify your wallet location with \033[2m--wallet-url\033[0m\033[32m argument!";
-const char* error_advice_3130003 =  "Ensure that you have \033[2meosio::account_history_api_plugin\033[0m\033[32m added to your node's configuration!";
-const char* error_advice_3130004 =  "Ensure that you have \033[2meosio::net_api_plugin\033[0m\033[32m added to your node's configuration!";
 
-const char* error_advice_3140001 =  "Try to use different wallet name.";
-const char* error_advice_3140002 =  "Are you sure you typed the wallet name correctly?";
-const char* error_advice_3140003 =  "Ensure that your wallet is unlocked before using it!";
-const char* error_advice_3140004 =  "Ensure that you have the relevant private key imported!";
-const char* error_advice_3140005 =  "Are you sure you are using the right password?";
-const char* error_advice_3140006 =  "Ensure that you have created a wallet and have it open";
+const char* error_advice_3040000 =  "Ensure that your transaction satisfy the contract's constraint!";
+const char* error_advice_3040005 =  "Please increase the expiration time of your transaction!";
+const char* error_advice_3040006 =  "Please decrease the expiration time of your transaction!";
+const char* error_advice_3040007 =  "Ensure that the reference block exist in the blockchain!";
+const char* error_advice_3040008 =  "You can try embedding eosio nonce action inside your transaction to ensure uniqueness.";
+
+const char* error_advice_3050002 = R"=====(Ensure that your arguments follow the contract abi!
+You can check the contract's abi by using 'cleos get code' command.)=====";
+
+const char* error_advice_3060001 =  "Most likely, the given account/ permission doesn't exist in the blockchain.";
+const char* error_advice_3060002 =  "Most likely, the given account doesn't exist in the blockchain.";
+const char* error_advice_3060003 =  "Most likely, the given table doesnt' exist in the blockchain.";
+const char* error_advice_3060004 =  "Most likely, the given contract doesnt' exist in the blockchain.";
+
+const char* error_advice_3090002 =  "Please remove the unnecessary signature from your transaction!";
+const char* error_advice_3090003 =  "Ensure that you have the related private keys inside your wallet and your wallet is unlocked.";
+const char* error_advice_3090004 =  R"=====(Ensure that you have the related authority inside your transaction!;
+If you are currently using 'cleos push action' command, try to add the relevant authority using -p option.)=====";
+const char* error_advice_3090005 =  "Please remove the unnecessary authority from your action!";
+
+const char* error_advice_3110001 =  "Ensure that you have \033[2meosio::chain_api_plugin\033[0m\033[32m added to your node's configuration!";
+const char* error_advice_3110002 =  "Ensure that you have \033[2meosio::wallet_api_plugin\033[0m\033[32m added to your node's configuration!\n"\
+                                    "Otherwise specify your wallet location with \033[2m--wallet-url\033[0m\033[32m argument!";
+const char* error_advice_3110003 =  "Ensure that you have \033[2meosio::account_history_api_plugin\033[0m\033[32m added to your node's configuration!";
+const char* error_advice_3110004 =  "Ensure that you have \033[2meosio::net_api_plugin\033[0m\033[32m added to your node's configuration!";
+
+const char* error_advice_3120001 =  "Try to use different wallet name.";
+const char* error_advice_3120002 =  "Are you sure you typed the wallet name correctly?";
+const char* error_advice_3120003 =  "Ensure that your wallet is unlocked before using it!";
+const char* error_advice_3120004 =  "Ensure that you have the relevant private key imported!";
+const char* error_advice_3120005 =  "Are you sure you are using the right password?";
+const char* error_advice_3120006 =  "Ensure that you have created a wallet and have it open";
 
 
 const std::map<int64_t, std::string> error_advice = {
@@ -231,42 +233,42 @@ const std::map<int64_t, std::string> error_advice = {
    { 3010002, error_advice_3010002 },
    { 3010003, error_advice_3010003 },
    { 3010004, error_advice_3010004 },
+   { 3010005, error_advice_3010005 },
+   { 3010006, error_advice_3010006 },
+   { 3010007, error_advice_3010007 },
+   { 3010008, error_advice_3010008 },
+   { 3010009, error_advice_3010009 },
+   { 3010010, error_advice_3010010 },
 
-   { 3030000, error_advice_3030000 },
-   { 3030001, error_advice_3030001 },
-   { 3030002, error_advice_3030002 },
-   { 3030003, error_advice_3030003 },
-   { 3030004, error_advice_3030004 },
-   { 3030011, error_advice_3030011 },
-   { 3030022, error_advice_3030022 },
-   { 3030023, error_advice_3030023 },
-   { 3030024, error_advice_3030024 },
+   { 3040000, error_advice_3040000 },
+   { 3040008, error_advice_3040008 },
+   { 3040005, error_advice_3040005 },
+   { 3040006, error_advice_3040006 },
+   { 3040007, error_advice_3040007 },
 
+   { 3050002, error_advice_3050002 },
 
-   { 3040002, error_advice_3040002 },
+   { 3060001, error_advice_3060001 },
+   { 3060002, error_advice_3060002 },
+   { 3060003, error_advice_3060003 },
+   { 3060004, error_advice_3060004 },
+   
+   { 3090002, error_advice_3090002 },
+   { 3090003, error_advice_3090003 },
+   { 3090004, error_advice_3090004 },
+   { 3090005, error_advice_3090005 },
+   
+   { 3110001, error_advice_3110001 },
+   { 3110002, error_advice_3110002 },
+   { 3110003, error_advice_3110003 },
+   { 3110004, error_advice_3110004 },
 
    { 3120001, error_advice_3120001 },
    { 3120002, error_advice_3120002 },
    { 3120003, error_advice_3120003 },
    { 3120004, error_advice_3120004 },
    { 3120005, error_advice_3120005 },
-   { 3120006, error_advice_3120006 },
-   { 3120007, error_advice_3120007 },
-   { 3120008, error_advice_3120008 },
-   { 3120009, error_advice_3120009 },
-   { 3120010, error_advice_3120010 },
-
-   { 3130001, error_advice_3130001 },
-   { 3130002, error_advice_3130002 },
-   { 3130003, error_advice_3130003 },
-   { 3130004, error_advice_3130004 },
-
-   { 3140001, error_advice_3140001 },
-   { 3140002, error_advice_3140002 },
-   { 3140003, error_advice_3140003 },
-   { 3140004, error_advice_3140004 },
-   { 3140005, error_advice_3140005 },
-   { 3140006, error_advice_3140006 }
+   { 3120006, error_advice_3120006 }
 };
 
 

--- a/programs/cleos/help_text.cpp
+++ b/programs/cleos/help_text.cpp
@@ -176,7 +176,7 @@ const char* error_advice_3090005 =  "Please remove the unnecessary authority fro
 const char* error_advice_3110001 =  "Ensure that you have \033[2meosio::chain_api_plugin\033[0m\033[32m added to your node's configuration!";
 const char* error_advice_3110002 =  "Ensure that you have \033[2meosio::wallet_api_plugin\033[0m\033[32m added to your node's configuration!\n"\
                                     "Otherwise specify your wallet location with \033[2m--wallet-url\033[0m\033[32m argument!";
-const char* error_advice_3110003 =  "Ensure that you have \033[2meosio::account_history_api_plugin\033[0m\033[32m added to your node's configuration!";
+const char* error_advice_3110003 =  "Ensure that you have \033[2meosio::history_api_plugin\033[0m\033[32m added to your node's configuration!";
 const char* error_advice_3110004 =  "Ensure that you have \033[2meosio::net_api_plugin\033[0m\033[32m added to your node's configuration!";
 
 const char* error_advice_3120001 =  "Try to use different wallet name.";

--- a/programs/cleos/httpc.cpp
+++ b/programs/cleos/httpc.cpp
@@ -159,7 +159,7 @@ namespace eosio { namespace client { namespace http {
       } else if (path.compare(0, wallet_func_base.size(), wallet_func_base) == 0) {
          throw chain::missing_wallet_api_plugin_exception(FC_LOG_MESSAGE(error, "Wallet is not available"));
       } else if (path.compare(0, account_history_func_base.size(), account_history_func_base) == 0) {
-         throw chain::missing_account_history_api_plugin_exception(FC_LOG_MESSAGE(error, "Account History API plugin is not enabled"));
+         throw chain::missing_history_api_plugin_exception(FC_LOG_MESSAGE(error, "History API plugin is not enabled"));
       } else if (path.compare(0, net_func_base.size(), net_func_base) == 0) {
          throw chain::missing_net_api_plugin_exception(FC_LOG_MESSAGE(error, "Net API plugin is not enabled"));
       }


### PR DESCRIPTION
Dawn 4.0 changes the code of the existing exceptions and this causes a mismatch with the error advice given by cleos. This causes confusion when understanding the given error advice. This PR rematch the error code with the error advice. 

At the same time, this PR also changes the reference from account_history_api_plugin in cleos to history_api_plugin since the former is obsolete.

#3067