### PR TITLE
delete unneccesary assert

### DIFF
--- a/libraries/fc/src/crypto/private_key.cpp
+++ b/libraries/fc/src/crypto/private_key.cpp
@@ -90,14 +90,14 @@ namespace fc { namespace crypto {
 
    static private_key::storage_type parse_base58(const string& base58str)
    {
-      if (base58str.find('_') == std::string::npos) {
+      const auto pivot = base58str.find('_');
+
+      if (pivot == std::string::npos) {
          // wif import
          using default_type = private_key::storage_type::template type_at<0>;
          return private_key::storage_type(from_wif<default_type>(base58str));
       } else {
          constexpr auto prefix = config::private_key_base_prefix;
-
-         const auto pivot = base58str.find('_');
 
          const auto prefix_str = base58str.substr(0, pivot);
          FC_ASSERT(prefix == prefix_str, "Private Key has invalid prefix: ${str}", ("str", base58str)("prefix_str", prefix_str));

--- a/libraries/fc/src/crypto/private_key.cpp
+++ b/libraries/fc/src/crypto/private_key.cpp
@@ -98,7 +98,6 @@ namespace fc { namespace crypto {
          return private_key::storage_type(from_wif<default_type>(base58str));
       } else {
          constexpr auto prefix = config::private_key_base_prefix;
-
          const auto prefix_str = base58str.substr(0, pivot);
          FC_ASSERT(prefix == prefix_str, "Private Key has invalid prefix: ${str}", ("str", base58str)("prefix_str", prefix_str));
 

--- a/libraries/fc/src/crypto/private_key.cpp
+++ b/libraries/fc/src/crypto/private_key.cpp
@@ -98,7 +98,6 @@ namespace fc { namespace crypto {
          constexpr auto prefix = config::private_key_base_prefix;
 
          const auto pivot = base58str.find('_');
-         FC_ASSERT(pivot != std::string::npos, "No delimiter in string, cannot determine type: ${str}", ("str", base58str));
 
          const auto prefix_str = base58str.substr(0, pivot);
          FC_ASSERT(prefix == prefix_str, "Private Key has invalid prefix: ${str}", ("str", base58str)("prefix_str", prefix_str));


### PR DESCRIPTION
The case `pivot != std::string::npos` will never happen in `else` block.