### PR TITLE
Update README for docker hub

### DIFF
--- a/Docker/README.md
+++ b/Docker/README.md
@@ -142,7 +142,7 @@ docker volume rm keosd-data-volume
 ### Docker Hub
 
 Docker Hub image available from [docker hub](https://hub.docker.com/r/eosio/eos/).
-Replace the `docker-compose.yaml` file with the content below
+Create a new `docker-compose.yaml` file with the content below
 
 ```bash
 version: "3"


### PR DESCRIPTION
We asked a new person to follow the guide to start the docker using the image from docker hub yesterday, and it seems the word "replace" makes it confusing if the user is not cloning the EOSIO/eos github repo and just want to start the docker container immediately.