### PR TITLE
Broadcast transactions immediately upon chain acceptance

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2437,6 +2437,7 @@ namespace eosio {
       try {
          chain_plug->accept_transaction( msg);
          fc_dlog(logger, "chain accepted transaction" );
+         dispatcher->bcast_transaction(msg);
          return;
       }
       catch( const fc::exception &ex) {


### PR DESCRIPTION
The net code previously expected that accept_transaction() would fire a signal indicated the chain accepted a transaction. This signal would then cause bcast_transaction to 1) mark in local_txns that this node has seen said transaction and 2) broadcast the transactions to the other peers

The problem is that post-slim accept_transaction() no longer fires a signal for acceptance but instead an app channel message that is wired up to transaction_ack() in the net code. There is a subtle breakage here that app channels are dispatched via the event queue — not immediately like signals. This would sometimes cause transactions to enter the event queue more than once before transaction_ack() was called. This would then cause chain::controller to fire exceptions of duplicate transactions that bleed all over the log output.

By calling bcast_transaction() immediately after accept_transaction(), local_txns will be populated with the accepted transaction before returned to event loop.

Issue #3139