### PR TITLE
#2791 - Add additional unit test for Boot Sequence

### DIFF
--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -85,6 +85,9 @@ namespace eosio { namespace testing {
          virtual signed_block_ptr produce_empty_block( fc::microseconds skip_time = fc::milliseconds(config::block_interval_ms), uint32_t skip_flag = 0/*skip_missed_block_penalty*/ ) = 0;
          void                 produce_blocks( uint32_t n = 1, bool empty = false );
          void                 produce_blocks_until_end_of_round();
+         void                 produce_blocks_for_n_rounds(const uint32_t num_of_rounds = 1);
+         // Produce minimal number of blocks as possible to spend the given time without having any producer become inactive
+         void                 produce_min_num_of_blocks_to_spend_time_wo_inactive_prod(const fc::microseconds target_elapsed_time = fc::microseconds()); 
          signed_block_ptr     push_block(signed_block_ptr b);
 
          transaction_trace_ptr    push_transaction( packed_transaction& trx, fc::time_point deadline = fc::time_point::maximum(), uint32_t billed_cpu_time_us = DEFAULT_BILLED_CPU_TIME_US );

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -180,9 +180,34 @@ namespace eosio { namespace testing {
 
 
    void base_tester::produce_blocks_until_end_of_round() {
-      while( control->pending_block_state()->has_pending_producers() ) {
+      uint64_t blocks_per_round;
+      while(true) {
+         blocks_per_round = control->active_producers().producers.size() * config::producer_repetitions;
          produce_block();
+         if (control->head_block_num() % blocks_per_round == (blocks_per_round - 1)) break;
       }
+   }
+
+   void base_tester::produce_blocks_for_n_rounds(const uint32_t num_of_rounds) {
+      for(uint32_t i = 0; i < num_of_rounds; i++) {
+         produce_blocks_until_end_of_round();
+      }
+   }
+
+   void base_tester::produce_min_num_of_blocks_to_spend_time_wo_inactive_prod(const fc::microseconds target_elapsed_time) {
+      fc::microseconds elapsed_time;
+      while (elapsed_time < target_elapsed_time) {
+         for(uint32_t i = 0; i < control->head_block_state()->active_schedule.producers.size(); i++) {
+            const auto time_to_skip = fc::milliseconds(config::producer_repetitions * config::block_interval_ms);
+            produce_block(time_to_skip);
+            elapsed_time += time_to_skip;
+         }
+         // if it is more than 24 hours, producer will be marked as inactive
+         const auto time_to_skip = fc::seconds(23 * 60 * 60);
+         produce_block(time_to_skip);
+         elapsed_time += time_to_skip;
+      }
+
    }
 
 

--- a/unittests/bootseq_tests.cpp
+++ b/unittests/bootseq_tests.cpp
@@ -40,58 +40,67 @@ std::vector<genesis_account> test_genesis( {
   {N(whale4), 40'000'000'0000ll},
   {N(whale3), 30'000'000'0000ll},
   {N(whale2), 20'000'000'0000ll},
-  {N(p1),      1'000'000'0000ll},
-  {N(p2),      1'000'000'0000ll},
-  {N(p3),      1'000'000'0000ll},
-  {N(p4),      1'000'000'0000ll},
-  {N(p5),      1'000'000'0000ll},
+  {N(proda),      1'000'000'0000ll},
+  {N(prodb),      1'000'000'0000ll},
+  {N(prodc),      1'000'000'0000ll},
+  {N(prodd),      1'000'000'0000ll},
+  {N(prode),      1'000'000'0000ll},
+  {N(prodf),      1'000'000'0000ll},
+  {N(prodg),      1'000'000'0000ll},
+  {N(prodh),      1'000'000'0000ll},
+  {N(prodi),      1'000'000'0000ll},
+  {N(prodj),      1'000'000'0000ll},
+  {N(prodk),      1'000'000'0000ll},
+  {N(prodl),      1'000'000'0000ll},
+  {N(prodm),      1'000'000'0000ll},
+  {N(prodn),      1'000'000'0000ll},
+  {N(prodo),      1'000'000'0000ll},
+  {N(prodp),      1'000'000'0000ll},
+  {N(prodq),      1'000'000'0000ll},
+  {N(prodr),      1'000'000'0000ll},
+  {N(prods),      1'000'000'0000ll},
+  {N(prodt),      1'000'000'0000ll},
+  {N(produ),      1'000'000'0000ll},
+  {N(runnerup1),1'000'000'0000ll},
+  {N(runnerup2),1'000'000'0000ll},
+  {N(runnerup3),1'000'000'0000ll},
   {N(minow1),        100'0000ll},
   {N(minow2),          1'0000ll},
   {N(minow3),          1'0000ll},
   {N(masses),800'000'000'0000ll}
 });
 
-class bootseq_tester : public TESTER
-{
+class bootseq_tester : public TESTER {
 public:
 
-    static fc::variant_object producer_parameters_example( int n ) {
-        return mutable_variant_object()
-                ("target_block_size", 1024 * 1024 + n)
-                ("max_block_size", 10 * 1024 + n)
-                ("target_block_acts_per_scope", 1000 + n)
-                ("max_block_acts_per_scope", 10000 + n)
-                ("target_block_acts", 1100 + n)
-                ("max_block_acts", 11000 + n)
-                ("max_storage_size", 2000 + n)
-                ("max_transaction_lifetime", 3600 + n)
-                ("max_transaction_exec_time", 9900 + n)
-                ("max_authority_depth", 6 + n)
-                ("max_inline_depth", 4 + n)
-                ("max_inline_action_size", 4096 + n)
-                ("max_generated_transaction_size", 64*1024 + n)
-                ("percent_of_max_inflation_rate", 50 + n)
-                ("storage_reserve_ratio", 100 + n);
+   fc::variant get_global_state() {
+      vector<char> data = get_row_by_account( N(eosio), N(eosio), N(global), N(global) );
+      if (data.empty()) std::cout << "\nData is empty\n" << std::endl;
+      return data.empty() ? fc::variant() : abi_ser.binary_to_variant( "eosio_global_state", data );
+
+   }
+  
+    auto buyram( name payer, name receiver, asset ram ) {
+       auto r = base_tester::push_action(N(eosio), N(buyram), payer, mvo()
+                    ("payer", payer)
+                    ("receiver", receiver)
+                    ("quant", ram) 
+                    );
+       produce_block();
+       return r;
     }
 
-    bootseq_tester() {
-        const auto &accnt = control->db().get<account_object, by_name>(config::system_account_name);
-        abi_def abi;
-        BOOST_REQUIRE_EQUAL(abi_serializer::to_abi(accnt.abi, abi), true);
-        abi_ser.set_abi(abi);
+    auto delegate_bandwidth( name from, name receiver, asset net, asset cpu, uint8_t transfer = 1) {
+       auto r = base_tester::push_action(N(eosio), N(delegatebw), from, mvo()
+                    ("from", "eosio" )
+                    ("receiver", receiver)
+                    ("stake_net_quantity", net) 
+                    ("stake_cpu_quantity", cpu) 
+                    ("transfer", transfer) 
+                    );
+       produce_block();
+       return r;
     }
-
-    action_result push_action( const account_name& account, const account_name& signer, const action_name &name, const variant_object &data, bool auth = true ) {
-        string action_type_name = abi_ser.get_action_type(name);
-
-        action act;
-        act.account = account;
-        act.name = name;
-        act.data = abi_ser.variant_to_binary( action_type_name, data );
-
-        return base_tester::push_action( std::move(act), auth ? uint64_t(signer) : 0 );
-    }
-
 
     void create_currency( name contract, name manager, asset maxsupply, const private_key_type* signer = nullptr ) {
         auto act =  mutable_variant_object()
@@ -101,59 +110,64 @@ public:
         base_tester::push_action(contract, N(create), contract, act );
     }
 
-    void issue( name contract, name manager, name to, asset amount ) {
-       base_tester::push_action( contract, N(issue), manager, mutable_variant_object()
+    auto issue( name contract, name manager, name to, asset amount ) {
+       auto r = base_tester::push_action( contract, N(issue), manager, mutable_variant_object()
                 ("to",      to )
                 ("quantity", amount )
                 ("memo", "")
         );
+        produce_block();
+        return r;
     }
 
-
-/*
-    action_result stake(const account_name& from, const account_name& to, const string& net, const string& cpu, const string& ) {
-        return push_action( name(from), name(from), N(delegatebw), mvo()
-                ("from",     from)
-                ("receiver", to)
-                ("stake_net_quantity", net)
-                ("stake_cpu_quantity", cpu)
-                ("stake_storage_quantity", storage)
-                ("transfer", storage)
-        );
+    auto claim_rewards( name owner ) {
+       auto r = base_tester::push_action( config::system_account_name, N(claimrewards), owner, mvo()("owner",  owner ));
+       produce_block();
+       return r;
     }
-    */
-#if _READY
-    fc::variant get_total_stake( const account_name& act )
-    {
-        vector<char> data = get_row_by_account( config::system_account_name, act, N(totalband), act );
-        return data.empty() ? fc::variant() : abi_ser.binary_to_variant( "total_resources", data );
-    }
-#endif
 
-    /*
-    action_result stake( const account_name& acnt, const string& net, const string& cpu, const string& storage ) {
-        return stake( acnt, acnt, net, cpu, storage );
+    auto set_privileged( name account ) {
+       auto r = base_tester::push_action(config::system_account_name, N(setpriv), config::system_account_name,  mvo()("account", account)("is_priv", 1));
+       produce_block();
+       return r;
     }
-    */
 
-    asset get_balance( const account_name& act )
-    {
+    auto register_producer(name producer) {
+       auto r = base_tester::push_action(N(eosio), N(regproducer), producer, mvo()
+                       ("producer",  name(producer))
+                       ("producer_key", get_public_key( producer, "active" ) )
+                       ("url", "" )
+                       ("location", 0 )
+                    );
+       produce_block();
+       return r;
+    }
+    
+    auto undelegate_bandwidth( name from, name receiver, asset net, asset cpu ) {
+       auto r = base_tester::push_action(N(eosio), N(undelegatebw), from, mvo()
+                    ("from", from )
+                    ("receiver", receiver)
+                    ("unstake_net_quantity", net) 
+                    ("unstake_cpu_quantity", cpu) 
+                    );
+       produce_block();
+       return r;              
+    }
+
+    asset get_balance( const account_name& act ) {
          return get_currency_balance(N(eosio.token), symbol(SY(4,EOS)), act);
     }
 
-    action_result regproducer( const account_name& acnt, int params_fixture = 1 ) {
-        return push_action( acnt, acnt, N(regproducer), mvo()
-                ("producer",  name(acnt).to_string() )
-                ("producer_key", fc::raw::pack( get_public_key( acnt, "active" ) ) )
-                ("prefs", producer_parameters_example( params_fixture ) )
-        );
-    }
-
-    void set_code_abi(const account_name& account, const char* wast, const char* abi, const private_key_type* signer = nullptr)
-    {
+    void set_code_abi(const account_name& account, const char* wast, const char* abi, const private_key_type* signer = nullptr) {
        wdump((account));
         set_code(account, wast, signer);
         set_abi(account, abi, signer);
+        if (account == N(eosio)) {
+           const auto& accnt = control->db().get<account_object,by_name>( account );
+           abi_def abi_definition;
+           BOOST_REQUIRE_EQUAL(abi_serializer::to_abi(accnt.abi, abi_definition), true);
+           abi_ser.set_abi(abi_definition);
+        }
         produce_blocks();
     }
 
@@ -165,121 +179,72 @@ BOOST_AUTO_TEST_SUITE(bootseq_tests)
 
 BOOST_FIXTURE_TEST_CASE( bootseq_test, bootseq_tester ) {
     try {
-        //set_code_abi(config::system_account_name, eosio_bios_wast, eosio_bios_abi);
 
-        // Create the following accounts:
-        //  eosio.msig
-        //  eosio.token
+        // Create eosio.msig and eosio.token
         create_accounts({N(eosio.msig), N(eosio.token)});
-        /*
-        auto eosio_active = authority( 1, {}, {{{N(eosio),N(active)},1}} );
-        auto eosio_active_pk = get_private_key( N(eosio), "active" );
-
-        base_tester::push_action(  N(eosio), N(newaccount), vector<permission_level>{{N(eosio),config::active_name}},
-                                   fc::variant(newaccount{
-                                      .creator  = N(eosio),
-                                      .name     = N(eosio.msig),
-                                      .owner    = eosio_active,
-                                      .active   = eosio_active,
-                                      .recovery = eosio_active 
-                                   }).get_object() );
-
-        base_tester::push_action(  N(eosio), N(newaccount), vector<permission_level>{{N(eosio),config::active_name}},
-                                   fc::variant(newaccount{
-                                      .creator  = N(eosio),
-                                      .name     = N(eosio.token),
-                                      .owner    = eosio_active,
-                                      .active   = eosio_active,
-                                      .recovery = eosio_active 
-                                   }).get_object() );
-                                   */
 
         // Set code for the following accounts:
-        //  eosio.system  (code: eosio.bios)
-        //  eosio.msig (code: eosio.msig)
-        //  eosio.token    (code: eosio.token)
+        //  - eosio (code: eosio.bios) (already set by tester constructor)
+        //  - eosio.msig (code: eosio.msig)
+        //  - eosio.token (code: eosio.token)
         set_code_abi(N(eosio.msig), eosio_msig_wast, eosio_msig_abi);//, &eosio_active_pk);
         set_code_abi(N(eosio.token), eosio_token_wast, eosio_token_abi); //, &eosio_active_pk);
 
-        ilog(".");
-        // Set privileges for eosio.msig
-        auto trace = base_tester::push_action(config::system_account_name, N(setpriv),
-                                              config::system_account_name,  mutable_variant_object()
-                ("account", "eosio.msig")
-                ("is_priv", 1)
-        );
+        // Set privileged for eosio.msig and eosio.token
+        set_privileged(N(eosio.msig));
+        set_privileged(N(eosio.token));
 
-        ilog(".");
-        // Todo : how to check the privilege is set? (use is_priv action)
+        // Verify eosio.msig and eosio.token is privileged
+        const auto& eosio_msig_acc = get<account_object, by_name>(N(eosio.msig));
+        BOOST_TEST(eosio_msig_acc.privileged == true);
+        const auto& eosio_token_acc = get<account_object, by_name>(N(eosio.token));
+        BOOST_TEST(eosio_token_acc.privileged == true);
 
-
+        // Create EOS tokens in eosio.token, set its manager as eosio
         auto max_supply = asset::from_string("10000000000.0000 EOS"); /// 1x larger than 1B initial tokens
         auto initial_supply = asset::from_string("1000000000.0000 EOS"); /// 1x larger than 1B initial tokens
-
-        // Create EOS tokens in eosio.token, set its manager as eosio.system
-        create_currency(N(eosio.token), config::system_account_name, max_supply );
-
-
-        // Issue the genesis supply of 1 billion EOS tokens to eosio.system
+        create_currency(N(eosio.token), config::system_account_name, max_supply);
         // Issue the genesis supply of 1 billion EOS tokens to eosio.system
         issue(N(eosio.token), config::system_account_name, config::system_account_name, initial_supply);
-
 
         auto actual = get_balance(config::system_account_name);
         BOOST_REQUIRE_EQUAL(initial_supply, actual);
 
-        // Create a few genesis accounts
-        //std::vector<account_name> gen_accounts{N(inita), N(initb), N(initc)};
-        //create_accounts(gen_accounts);
-
+        // Create genesis accounts
         for( const auto& a : test_genesis ) {
            create_account( a.aname, N(eosio) );
-           /*
-           base_tester::push_action(N(eosio.token), N(transfer), config::system_account_name, mutable_variant_object()
-                    ("from", name(config::system_account_name))
-                    ("to", name(a.aname))
-                    ("quantity", asset(a.initial_balance))
-                    ("memo", "" ) );
-                    */
         }
-        set_code_abi(N(eosio), eosio_system_wast, eosio_system_abi); //, &eosio_active_pk);
 
+        // Set eosio.system to eosio
+        set_code_abi(N(eosio), eosio_system_wast, eosio_system_abi);
+
+        // Buy ram and stake cpu and net for each genesis accounts 
         for( const auto& a : test_genesis ) {
            auto ib = a.initial_balance;
            auto ram = 1000;
            auto net = (ib - ram) / 2;
            auto cpu = ib - net - ram;
 
-           auto r =  base_tester::push_action(N(eosio), N(buyram), N(eosio), mutable_variant_object()
-                    ("payer", "eosio")
-                    ("receiver", name(a.aname))
-                    ("quant", asset(ram)) 
-                    );
+           auto r = buyram(N(eosio), a.aname, asset(ram));
            BOOST_REQUIRE( !r->except_ptr );
 
-           r = base_tester::push_action(N(eosio), N(delegatebw), N(eosio), mutable_variant_object()
-                    ("from", "eosio" )
-                    ("receiver", name(a.aname))
-                    ("stake_net_quantity", asset(net)) 
-                    ("stake_cpu_quantity", asset(cpu)) 
-                    ("transfer", 1) 
-                    );
-
+           r = delegate_bandwidth(N(eosio), a.aname, asset(net), asset(cpu));
            BOOST_REQUIRE( !r->except_ptr );
         }
 
-        produce_blocks(10000);
+        auto producer_candidates = {
+                N(proda), N(prodb), N(prodc), N(prodd), N(prode), N(prodf), N(prodg),
+                N(prodh), N(prodi), N(prodj), N(prodk), N(prodl), N(prodm), N(prodn),
+                N(prodo), N(prodp), N(prodq), N(prodr), N(prods), N(prodt), N(produ), 
+                N(runnerup1), N(runnerup2), N(runnerup3)
+        };
 
-        for( auto pro : { N(p1), N(p2), N(p3), N(p4), N(p5) } ) {
-           base_tester::push_action(N(eosio), N(regproducer), pro, mutable_variant_object()
-                       ("producer",  name(pro))
-                       ("producer_key", get_public_key( pro, "active" ) )
-                       ("url", "" )
-                       ("location", 0 )
-                    );
+        // Register producers
+        for( auto pro : producer_candidates ) {
+           register_producer(pro);
         }
-        produce_blocks(10);
 
+        // Vote for producers
         auto votepro = [&]( account_name voter, vector<account_name> producers ) {
           std::sort( producers.begin(), producers.end() );
           base_tester::push_action(N(eosio), N(voteproducer), voter, mvo()
@@ -288,63 +253,89 @@ BOOST_FIXTURE_TEST_CASE( bootseq_test, bootseq_tester ) {
                                 ("producers", producers) 
                      );
         };
+        votepro( N(b1), { N(proda), N(prodb), N(prodc), N(prodd), N(prode), N(prodf), N(prodg),
+                           N(prodh), N(prodi), N(prodj), N(prodk), N(prodl), N(prodm), N(prodn),
+                           N(prodo), N(prodp), N(prodq), N(prodr), N(prods), N(prodt), N(produ)} );
+        votepro( N(whale2), {N(runnerup1), N(runnerup2), N(runnerup3)} );
+        votepro( N(whale3), {N(proda), N(prodb), N(prodc), N(prodd), N(prode)} );
 
-        produce_blocks(100);
+        // Total Stakes = b1 + whale2 + whale3 stake = (100,000,000 - 1,000) + (20,000,000 - 1,000) + (30,000,000 - 1,000)
+        BOOST_TEST(get_global_state()["total_activated_stake"].as<int64_t>() == 1499999997000);
 
-        votepro( N(b1), {N(p1), N(p2)} );
-        votepro( N(whale2), {N(p2), N(p3)} );
-        votepro( N(whale3), {N(p2), N(p4), N(p5)} );
+        // No producers will be set, since the total activated stake is less than 150,000,000
+        produce_blocks_for_n_rounds(2); // 2 rounds since new producer schedule is set when the first block of next round is irreversible
+        auto active_schedule = control->head_block_state()->active_schedule;
+        BOOST_TEST(active_schedule.producers.size() == 1);
+        BOOST_TEST(active_schedule.producers.front().producer_name == "eosio");
 
-        wlog("pb" );
-        produce_blocks(10);
-        wdump((control->head_block_state()->active_schedule));
+        // Spend some time so the producer pay pool is filled by the inflation rate
+        // Since the total activated stake is less than 150,000,000, reward should remain zero
+        produce_min_num_of_blocks_to_spend_time_wo_inactive_prod(fc::seconds(30 * 24 * 3600)); // 30 days
+        // #warning TODO: now claiming rewards when the pool is empty will throw div by 0 error, fix this as separate issue
+        //   claim_rewards(N(runnerup1)); 
+        produce_block();
+        BOOST_TEST(get_balance(N(runnerup1)).amount == 0);
+
+        // This will increase the total vote stake by (40,000,000 - 1,000)
+        votepro( N(whale4), {N(prodq), N(prodr), N(prods), N(prodt), N(produ)} );
+        BOOST_TEST(get_global_state()["total_activated_stake"].as<int64_t>() == 1899999996000);
+
+        // Since the total vote stake is more than 150,000,000, the new producer set will be set
+        produce_blocks_for_n_rounds(2); // 2 rounds since new producer schedule is set when the first block of next round is irreversible
+        active_schedule = control->head_block_state()->active_schedule;
+        BOOST_REQUIRE(active_schedule.producers.size() == 21);
+        BOOST_TEST(active_schedule.producers.at(0).producer_name == "proda");
+        BOOST_TEST(active_schedule.producers.at(1).producer_name == "prodb");
+        BOOST_TEST(active_schedule.producers.at(2).producer_name == "prodc");
+        BOOST_TEST(active_schedule.producers.at(3).producer_name == "prodd");
+        BOOST_TEST(active_schedule.producers.at(4).producer_name == "prode");
+        BOOST_TEST(active_schedule.producers.at(5).producer_name == "prodf");
+        BOOST_TEST(active_schedule.producers.at(6).producer_name == "prodg");
+        BOOST_TEST(active_schedule.producers.at(7).producer_name == "prodh");
+        BOOST_TEST(active_schedule.producers.at(8).producer_name == "prodi");
+        BOOST_TEST(active_schedule.producers.at(9).producer_name == "prodj");
+        BOOST_TEST(active_schedule.producers.at(10).producer_name == "prodk");
+        BOOST_TEST(active_schedule.producers.at(11).producer_name == "prodl");
+        BOOST_TEST(active_schedule.producers.at(12).producer_name == "prodm");
+        BOOST_TEST(active_schedule.producers.at(13).producer_name == "prodn");
+        BOOST_TEST(active_schedule.producers.at(14).producer_name == "prodo");
+        BOOST_TEST(active_schedule.producers.at(15).producer_name == "prodp");
+        BOOST_TEST(active_schedule.producers.at(16).producer_name == "prodq");
+        BOOST_TEST(active_schedule.producers.at(17).producer_name == "prodr");
+        BOOST_TEST(active_schedule.producers.at(18).producer_name == "prods");
+        BOOST_TEST(active_schedule.producers.at(19).producer_name == "prodt");
+        BOOST_TEST(active_schedule.producers.at(20).producer_name == "produ");
+
+        // Spend some time so the producer pay pool is filled by the inflation rate
+        produce_min_num_of_blocks_to_spend_time_wo_inactive_prod(fc::seconds(30 * 24 * 3600)); // 30 days
+        // Since the total activated stake is larger than 150,000,000, pool should be filled reward should be bigger than zero
+        claim_rewards(N(runnerup1));
+        produce_block();
+        BOOST_TEST(get_balance(N(runnerup1)).amount > 0);
+  
+        const auto first_june_2018 = fc::seconds(1527811200); // 2018-06-01
+        const auto first_june_2028 = fc::seconds(1843430400); // 2028-06-01
+        // Ensure that now is yet 10 years after 2018-06-01 yet
+        BOOST_REQUIRE(control->head_block_time().time_since_epoch() < first_june_2028);
+
+        // This should thrown an error, since block one can only unstake all his stake after 10 years
+        BOOST_REQUIRE_THROW(undelegate_bandwidth(N(b1), N(b1), asset::from_string("49999500.0000 EOS"), asset::from_string("49999500.0000 EOS")), assert_exception); 
+
+        // Skip 10 years
+        produce_block(first_june_2028 - control->head_block_time().time_since_epoch());
+        // Register back producers after 10 years of inactivity
+        for( auto pro : producer_candidates ) {
+           register_producer(pro);
+        }
+        // Block one should be able to unstake all his stake now
+        undelegate_bandwidth(N(b1), N(b1), asset::from_string("49999500.0000 EOS"), asset::from_string("49999500.0000 EOS"));
+       
         return;
         produce_blocks(7000); /// produce blocks until virutal bandwidth can acomadate a small user
         wlog("minow" );
         votepro( N(minow1), {N(p1), N(p2)} );
 
-
-
-        // Transfer EOS to genesis accounts
-        /*for (auto gen_acc : gen_accounts) {
-            auto quantity = "10000.0000 EOS";
-            auto stake_quantity = "5000.0000 EOS";
-
-            ilog(".");
-            auto trace = base_tester::push_action(N(eosio.token), N(transfer), config::system_account_name, mutable_variant_object()
-                    ("from", name(config::system_account_name))
-                    ("to", gen_acc)
-                    ("quantity", quantity)
-                    ("memo", gen_acc)
-            );
-            ilog( "." );
-
-            auto balance = get_balance(gen_acc);
-            BOOST_REQUIRE_EQUAL(asset::from_string(quantity), balance);
-#if _READY
-            // Stake 50% of balance to CPU and other 50% to bandwidth
-            BOOST_REQUIRE_EQUAL(success(),
-                                stake(config::system_account_name, gen_acc, stake_quantity, stake_quantity, ""));
-            auto total = get_total_stake(gen_acc);
-            BOOST_REQUIRE_EQUAL(asset::from_string(stake_quantity).amount, total["net_weight"].as_uint64());
-            BOOST_REQUIRE_EQUAL(asset::from_string(stake_quantity).amount, total["cpu_weight"].as_uint64());
-#endif
-        }
-        */
-        ilog(".");
-
 #warning Complete this test
-/*
-        // Set code eosio.system from eosio.bios to eosio.system
-        set_code_abi(config::system_account_name, eosio_system_wast, eosio_system_abi);
-
-
-        ilog(".");
-        // Register these genesis accts as producer account
-        for (auto gen_acc : gen_accounts) {
-        //    BOOST_REQUIRE_EQUAL(success(), regproducer(gen_acc));
-        }
-*/
     } FC_LOG_AND_RETHROW()
 }
 


### PR DESCRIPTION
For 2791, the following tests are added

1. verify that B1 account can only unstake at the rate of 10M EOS per year starting June 1, 2018
2. verify that no new tokens are created for producer or runner-up pay until at least 150M of stake has cast their first vote.
3. verify that no new producers are set until after 150M stake has voted.

This PR verify point 1 and point 3. Point 2 is currently commented out in this PR (line 274 bootseq_tests.cpp) as it throws out a division by 0 error (I'm going to open a new issue for it).

Furthermore, another point that is found out through this PR is undelegate_bandwidth will fail in case the producer that the user previously voted has unregistered himself as producer (or become inactive producer). I'm going to open another issue for it too.