### PR TITLE
Producer pay divide-by-zero and min stake checks

### DIFF
--- a/contracts/eosio.system/producer_pay.cpp
+++ b/contracts/eosio.system/producer_pay.cpp
@@ -4,8 +4,8 @@
 
 namespace eosiosystem {
 
-   const int64_t  min_daily_tokens = 100;
-
+   const int64_t  min_daily_tokens    = 100;
+   const int64_t  min_activated_stake = 150'000'000'0000;
    const double   continuous_rate     = 0.04879;          // 5% annual rate
    const double   perblock_rate       = 0.0025;           // 0.25%
    const double   standby_rate        = 0.0075;           // 0.75%
@@ -23,7 +23,7 @@ namespace eosiosystem {
       require_auth(N(eosio));
 
       /** until activated stake crosses this threshold no new rewards are paid */
-      if( _gstate.total_activated_stake < 150'000'000'0000 )
+      if( _gstate.total_activated_stake < min_activated_stake )
          return;
 
       if( _gstate.last_pervote_bucket_fill == 0 )  /// start the presses
@@ -55,6 +55,8 @@ namespace eosiosystem {
 
       const auto& prod = _producers.get( owner );
       eosio_assert( prod.active(), "producer does not have an active key" );
+      
+      eosio_assert( _gstate.total_activated_stake >= min_activated_stake, "not enough has been staked for producers to claim rewards" );
 
       auto ct = current_time();
 
@@ -81,8 +83,14 @@ namespace eosiosystem {
          _gstate.last_pervote_bucket_fill = ct;
       }
 
-      int64_t producer_per_block_pay = (_gstate.perblock_bucket * prod.unpaid_blocks) / _gstate.total_unpaid_blocks;
-      int64_t producer_per_vote_pay  = int64_t((_gstate.pervote_bucket * prod.total_votes ) / _gstate.total_producer_vote_weight);
+      int64_t producer_per_block_pay = 0;
+      if( _gstate.total_unpaid_blocks > 0 ) {
+         producer_per_block_pay = (_gstate.perblock_bucket * prod.unpaid_blocks) / _gstate.total_unpaid_blocks;
+      }
+      int64_t producer_per_vote_pay = 0;
+      if( _gstate.total_producer_vote_weight > 0 ) { 
+         producer_per_vote_pay  = int64_t((_gstate.pervote_bucket * prod.total_votes ) / _gstate.total_producer_vote_weight);
+      }
       if( producer_per_vote_pay < 100'0000 ) {
          producer_per_vote_pay = 0;
       }

--- a/unittests/eosio.system_tests.cpp
+++ b/unittests/eosio.system_tests.cpp
@@ -2120,6 +2120,16 @@ BOOST_FIXTURE_TEST_CASE(producer_onblock_check, eosio_system_tester) try {
       BOOST_REQUIRE_EQUAL(true, rest_didnt_produce);
    }
 
+   {
+      BOOST_CHECK_EQUAL(0, get_global_state()["total_unpaid_blocks"].as<uint32_t>());
+      BOOST_REQUIRE_EQUAL(error("condition: assertion failed: not enough has been staked for producers to claim rewards"),
+                          push_action(producer_names.front(), N(claimrewards), mvo()("owner", producer_names.front())));
+      BOOST_REQUIRE_EQUAL(0, get_balance(producer_names.front()).amount);
+      BOOST_REQUIRE_EQUAL(error("condition: assertion failed: not enough has been staked for producers to claim rewards"),
+                          push_action(producer_names.back(), N(claimrewards), mvo()("owner", producer_names.back())));
+      BOOST_REQUIRE_EQUAL(0, get_balance(producer_names.back()).amount);
+   }
+
    // stake across 15% boundary
    transfer(config::system_account_name, "producvoterb", "100000000.0000 EOS", config::system_account_name);
    BOOST_REQUIRE_EQUAL(success(), stake("producvoterb", "4000000.0000 EOS", "4000000.0000 EOS"));
@@ -2157,6 +2167,9 @@ BOOST_FIXTURE_TEST_CASE(producer_onblock_check, eosio_system_tester) try {
       }
       BOOST_REQUIRE_EQUAL(true, all_21_produced);
       BOOST_REQUIRE_EQUAL(true, rest_didnt_produce);
+      BOOST_REQUIRE_EQUAL(success(),
+                          push_action(producer_names.front(), N(claimrewards), mvo()("owner", producer_names.front())));
+      BOOST_REQUIRE(0 < get_balance(producer_names.front()).amount);
    }
 
 } FC_LOG_AND_RETHROW()


### PR DESCRIPTION
* Added checks against dividing by zero in claimrewards.
* Added threshold stake check in claimrewards. Without this check, a producer would be able to claim pervote pay.