### PR TITLE
Fix ubuntu version check ( OS_MAJ -lt 16 )

### DIFF
--- a/scripts/eosio_build_ubuntu.sh
+++ b/scripts/eosio_build_ubuntu.sh
@@ -39,7 +39,7 @@
 		   fi
 		;;
 		"Ubuntu")
-			if [ "${OS_MIN}" -lt 4 ]; then
+			if [ "${OS_MAJ}" -lt 16 ]; then
 				printf "\\tYou must be running Ubuntu 16.04.x or higher to install EOSIO.\\n"
 				printf "\\tExiting now.\\n"
 				exit 1


### PR DESCRIPTION
There's an if statement which checks ubuntu version is eosio_build_ubuntu.sh in ./scripts directory.

The minimum version which supports at EOS is ubuntu 16.04 or higher, so It should be changed like below.

BEFORE
if [ "${OS_MIN}" -lt 4 ]; then

AFTER 
if [ "${"OS_MAJ}" -lt 16 ]; then