### PR TITLE
Mirror improves http performance

### DIFF
--- a/libraries/fc/vendor/websocketpp/websocketpp/connection.hpp
+++ b/libraries/fc/vendor/websocketpp/websocketpp/connection.hpp
@@ -1041,6 +1041,7 @@ public:
      * @see websocketpp::http::response::set_body
      */
     void set_body(std::string const & value);
+    void set_body(std::string && value);
 
     /// Append a header
     /**

--- a/libraries/fc/vendor/websocketpp/websocketpp/impl/connection_impl.hpp
+++ b/libraries/fc/vendor/websocketpp/websocketpp/impl/connection_impl.hpp
@@ -575,6 +575,16 @@ void connection<config>::set_body(std::string const & value) {
     m_response.set_body(value);
 }
 
+template <typename config>
+void connection<config>::set_body(std::string&& value) {
+    if (m_internal_state != istate::PROCESS_HTTP_REQUEST) {
+        throw exception("Call to set_status from invalid state",
+                      error::make_error_code(error::invalid_state));
+    }
+
+    m_response.set_body(std::move(value));
+}
+
 // TODO: EXCEPTION_FREE
 template <typename config>
 void connection<config>::append_header(std::string const & key,

--- a/plugins/http_plugin/http_plugin.cpp
+++ b/plugins/http_plugin/http_plugin.cpp
@@ -146,8 +146,8 @@ namespace eosio {
                auto resource = con->get_uri()->get_resource();
                auto handler_itr = url_handlers.find(resource);
                if(handler_itr != url_handlers.end()) {
-                  handler_itr->second(resource, body, [con](int code, string body) {
-                     con->set_body(body);
+                  handler_itr->second(resource, body, [con](auto code, auto&& body) {
+                     con->set_body(std::move(body));
                      con->set_status(websocketpp::http::status_code::value(code));
                   });
                } else {


### PR DESCRIPTION
Add move-semantic-version `set_body` function, this improves around 10% performance when load testing http-get function heavily.