### PR TITLE
Added setprods to `eosio.system`.

### DIFF
--- a/contracts/eosio.system/eosio.system.cpp
+++ b/contracts/eosio.system/eosio.system.cpp
@@ -77,8 +77,16 @@ namespace eosiosystem {
       set_privileged( account, ispriv );
    }
 
+   void system_contract::setprods( std::vector<eosio::producer_key> schedule ) {
+      (void)schedule; // schedule argument just forces the deserialization of the action data into vector<producer_key> (necessary check)
+      require_auth( _self );
+      char buffer[action_data_size()];
+      read_action_data( buffer, sizeof(buffer) ); // should be the same data as eosio::pack(schedule)
+      set_active_producers(buffer, sizeof(buffer));
+   }
+
 } /// eosio.system
- 
+
 
 EOSIO_ABI( eosiosystem::system_contract,
      (setram)
@@ -93,5 +101,5 @@ EOSIO_ABI( eosiosystem::system_contract,
      (onblock)
      (newaccount)(updateauth)(deleteauth)(linkauth)(unlinkauth)(postrecovery)(passrecovery)(vetorecovery)(onerror)(canceldelay)
      //this file
-     (setpriv)
+     (setpriv)(setprods)
 )

--- a/contracts/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/eosio.system.hpp
@@ -135,7 +135,7 @@ namespace eosiosystem {
          // functions defined in delegate_bandwidth.cpp
 
          /**
-          *  Stakes SYS from the balance of 'from' for the benfit of 'receiver'. 
+          *  Stakes SYS from the balance of 'from' for the benfit of 'receiver'.
           *  If transfer == true, then 'receiver' can unstake to their account
           *  Else 'from' can unstake at any time.
           */
@@ -149,7 +149,7 @@ namespace eosiosystem {
           *  left to delegate.
           *
           *  This will cause an immediate reduction in net/cpu bandwidth of the
-          *  receiver. 
+          *  receiver.
           *
           *  A transaction is scheduled to send the tokens back to 'from' after
           *  the staking period has passed. If existing transaction is scheduled, it
@@ -199,6 +199,8 @@ namespace eosiosystem {
          void claimrewards( const account_name& owner );
 
          void setpriv( account_name account, uint8_t ispriv );
+
+         void setprods( std::vector<eosio::producer_key> schedule );
 
       private:
          void update_elected_producers( block_timestamp timestamp );


### PR DESCRIPTION
Solves the bootstrapping problem of a new network. Otherwise, there is
no way to delegate to the ABPs, and it makes the boot more brittle.