### PR TITLE
Install Scripts: fixed missing bzip2 for CentOS, Fedora

### DIFF
--- a/scripts/eosio_build_centos.sh
+++ b/scripts/eosio_build_centos.sh
@@ -125,7 +125,7 @@
 
 	printf "\\n\\tYUM repository successfully updated.\\n\\n"
 
-	DEP_ARRAY=( git autoconf automake libtool ocaml.x86_64 doxygen graphviz-devel.x86_64 libicu-devel.x86_64 \
+	DEP_ARRAY=( git autoconf automake bzip2 libtool ocaml.x86_64 doxygen graphviz-devel.x86_64 libicu-devel.x86_64 \
 	bzip2-devel.x86_64 openssl-devel.x86_64 gmp-devel.x86_64 python-devel.x86_64 gettext-devel.x86_64)
 	COUNT=1
 	DISPLAY=""

--- a/scripts/eosio_build_fedora.sh
+++ b/scripts/eosio_build_fedora.sh
@@ -57,7 +57,7 @@
 		exit 1;
 	fi
 	
-	DEP_ARRAY=( git gcc.x86_64 gcc-c++.x86_64 autoconf automake libtool make cmake.x86_64 \
+	DEP_ARRAY=( git gcc.x86_64 gcc-c++.x86_64 autoconf automake bzip2 libtool make cmake.x86_64 \
 	bzip2-devel.x86_64 openssl-devel.x86_64 gmp-devel.x86_64 libstdc++-devel.x86_64 \
 	python3-devel.x86_64 mongodb.x86_64 mongodb-server.x86_64 libedit.x86_64 \
 	graphviz.x86_64 doxygen.x86_64 )


### PR DESCRIPTION
Install Scripts: fixed missing bzip2 for CentOS, Fedora, this fails during boost install since it cant unarchive from fresh os.

