### PR TITLE
Rename Docker/cleos.sh PREFIX

### DIFF
--- a/Docker/cleos.sh
+++ b/Docker/cleos.sh
@@ -4,7 +4,7 @@
 # Go into cmd loop: sudo ./cleos.sh
 # Run single cmd:  sudo ./cleos.sh <cleos paramers>
 
-PREFIX="docker exec docker_nodeosd_1 cleos"
+PREFIX="docker-compose exec nodeosd cleos"
 if [ -z $1 ] ; then
   while :
   do


### PR DESCRIPTION
Since we are using docker-compose, we can use it in the `cleos.sh` script.
So we can rename the ugly `docker_nodeosd_1` stuff.