### PR TITLE
When building with high parallelism, we get a failure on `eosio.token.wast.hpp`

### DIFF
--- a/plugins/txn_test_gen_plugin/CMakeLists.txt
+++ b/plugins/txn_test_gen_plugin/CMakeLists.txt
@@ -3,6 +3,8 @@ add_library( txn_test_gen_plugin
              txn_test_gen_plugin.cpp
              ${HEADERS} )
 
+add_dependencies(txn_test_gen_plugin eosio.token)
+
 target_link_libraries( txn_test_gen_plugin appbase fc http_plugin chain_plugin )
 target_include_directories( txn_test_gen_plugin PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" )
 target_include_directories( txn_test_gen_plugin PUBLIC ${CMAKE_BINARY_DIR}/contracts )


### PR DESCRIPTION
because the dep isn't defined.