### PR TITLE
Support two new options in 'cleos'

### DIFF
--- a/programs/cleos/httpc.cpp
+++ b/programs/cleos/httpc.cpp
@@ -114,7 +114,13 @@ namespace eosio { namespace client { namespace http {
    request_stream << "Host: " << server << "\r\n";
    request_stream << "content-length: " << postjson.size() << "\r\n";
    request_stream << "Accept: */*\r\n";
-   request_stream << "Connection: close\r\n\r\n";
+   request_stream << "Connection: close\r\n";
+   // append more customized headers
+   std::vector<string>::iterator itr;
+   for (itr = cp.headers.begin(); itr != cp.headers.end(); itr++) {
+      request_stream << *itr << "\r\n";
+   }
+   request_stream << "\r\n";
    request_stream << postjson;
 
    unsigned int status_code;

--- a/programs/cleos/httpc.cpp
+++ b/programs/cleos/httpc.cpp
@@ -77,8 +77,7 @@ namespace eosio { namespace client { namespace http {
       return re.str();
    }
 
-   fc::variant call( const std::string& server_url,
-                     const std::string& path,
+   fc::variant call( const connection_param& cp,
                      const fc::variant& postdata ) {
    std::string postjson;
    if( !postdata.is_null() )
@@ -87,6 +86,9 @@ namespace eosio { namespace client { namespace http {
    boost::asio::io_service io_service;
 
    string scheme, server, port, path_prefix;
+
+   const string& server_url = cp.url;
+   const string& path = cp.path;
 
    //via rfc3986 and modified a bit to suck out the port number
    //Sadly this doesn't work for ipv6 addresses
@@ -135,7 +137,8 @@ namespace eosio { namespace client { namespace http {
 #endif
 
       boost::asio::ssl::stream<boost::asio::ip::tcp::socket> socket(io_service, ssl_context);
-      socket.set_verify_mode(boost::asio::ssl::verify_peer);
+      if(cp.verify_cert)
+         socket.set_verify_mode(boost::asio::ssl::verify_peer);
 
       do_connect(socket.next_layer(), server, port);
       socket.handshake(boost::asio::ssl::stream_base::client);

--- a/programs/cleos/httpc.hpp
+++ b/programs/cleos/httpc.hpp
@@ -10,10 +10,12 @@ namespace eosio { namespace client { namespace http {
        string& url;
        string& path;
        bool verify_cert;
+       std::vector<string>& headers;
 
        connection_param( std::string& u,
                          std::string& p,
-                         bool verify) : url(u), path(p){
+                         bool verify,
+                         std::vector<string>& h) : url(u), path(p), headers(h) {
            verify_cert = verify;
        }
    };

--- a/programs/cleos/httpc.hpp
+++ b/programs/cleos/httpc.hpp
@@ -5,8 +5,20 @@
 #pragma once
 
 namespace eosio { namespace client { namespace http {
-   fc::variant call( const std::string& server_url,
-                     const std::string& path,
+
+   struct connection_param {
+       string& url;
+       string& path;
+       bool verify_cert;
+
+       connection_param( std::string& u,
+                         std::string& p,
+                         bool verify) : url(u), path(p){
+           verify_cert = verify;
+       }
+   };
+
+   fc::variant call( const connection_param& cp,
                      const fc::variant& postdata = fc::variant() );
 
    const string chain_func_base = "/v1/chain";

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -26,6 +26,7 @@ Options:
                               the http/https URL where nodeos is running
   --wallet-url TEXT=http://localhost:8888/
                               the http/https URL where keosd is running
+  -n,--no-verify              don't verify peer certificate when using HTTPS
   -v,--verbose                output verbose actions on error
 
 Subcommands:
@@ -137,6 +138,7 @@ FC_DECLARE_EXCEPTION( localized_exception, 10000000, "an error occured" );
 
 string url = "http://localhost:8888/";
 string wallet_url = "http://localhost:8888/";
+bool no_verify = false;
 
 auto   tx_expiration = fc::seconds(30);
 string tx_ref_block_num_or_id;
@@ -194,7 +196,9 @@ fc::variant call( const std::string& url,
                   const std::string& path,
                   const T& v ) {
    try {
-      return eosio::client::http::call( url, path, fc::variant(v) );
+      eosio::client::http::connection_param *cp = new eosio::client::http::connection_param((std::string&)url, (std::string&)path, no_verify ? false : true);
+
+      return eosio::client::http::call( *cp, fc::variant(v) );
    }
    catch(boost::system::system_error& e) {
       if(url == ::url)
@@ -866,6 +870,8 @@ int main( int argc, char** argv ) {
 
    app.add_option( "-u,--url", url, localized("the http/https URL where nodeos is running"), true );
    app.add_option( "--wallet-url", wallet_url, localized("the http/https URL where keosd is running"), true );
+
+   app.add_flag( "-n,--no-verify", no_verify, localized("don't verify peer certificate when using HTTPS"));
 
    bool verbose_errors = false;
    app.add_flag( "-v,--verbose", verbose_errors, localized("output verbose actions on error"));


### PR DESCRIPTION
In some scenarios, 'nodeos' runs remotely from where 'cleos' locates, that implies the communication between the two parties should go across the network. So a new option '-r,--header' is proposed in this PR to allow user to customized the HTTP request headers sent by 'cleos' in case that some 'middle' devices may require for specific headers to contain some 'token'.

And also, if 'nodeos' is set up to provide HTTPS APIs, say by placing a reverse proxy in front, in many cases, especially for some testing environments, there might not be domains assigned with the 'nodeos' - so 'cleos' needs a way to 'tolerate' with the invalid certificates. To address this, a new option '-n,--no-verify' is proposed in this PR too, to disable the peer verification for current secure connection.