### PR TITLE
Fix #3315 - unable to create 12 char names (by non-eosio accounts)

### DIFF
--- a/contracts/eosio.system/eosio.system.cpp
+++ b/contracts/eosio.system/eosio.system.cpp
@@ -134,11 +134,12 @@ namespace eosiosystem {
                             const authority& active*/ ) {
 
       if( creator != _self ) {
-         auto tmp = newact;
+         auto tmp = newact >> 4;
          bool has_dot = false;
-         for( uint32_t i = 0; i < 13; ++i ) {
-           has_dot |= (tmp >> 59);
-           tmp <<= 5;
+
+         for( uint32_t i = 0; i < 12; ++i ) {
+           has_dot |= !(tmp & 0x1f);
+           tmp >>= 5;
          }
          auto suffix = eosio::name_suffix(newact);
          if( has_dot ) {

--- a/contracts/eosiolib/print.hpp
+++ b/contracts/eosiolib/print.hpp
@@ -26,6 +26,10 @@ namespace eosio {
       prints_l( s.c_str(), s.size() );
    }
 
+   inline void print( const char c ) {
+      prints_l( &c, 1 );
+   }
+
    /**
     * Prints signed integer
     * @brief Prints signed integer as a 64 bit signed integer

--- a/unittests/eosio.system_tests.cpp
+++ b/unittests/eosio.system_tests.cpp
@@ -1763,6 +1763,8 @@ BOOST_FIXTURE_TEST_CASE(producer_onblock_check, eosio_system_tester) try {
    create_account_with_resources( N(producvoterb), config::system_account_name, core_from_string("1.0000"), false, large_asset, large_asset );
    create_account_with_resources( N(producvoterc), config::system_account_name, core_from_string("1.0000"), false, large_asset, large_asset );
 
+
+
    // create accounts {defproducera, defproducerb, ..., defproducerz} and register as producers
    std::vector<account_name> producer_names;
    producer_names.reserve('z' - 'a' + 1);
@@ -2262,6 +2264,7 @@ BOOST_FIXTURE_TEST_CASE( buyname, eosio_system_tester ) try {
    //wlog( "verify dan cannot create test.fail" );
    BOOST_REQUIRE_THROW( create_accounts_with_resources( { N(test.fail) }, N(dan) ), fc::exception ); // dan shouldn't be able to do this
 
+   create_accounts_with_resources( { N(goodgoodgood) }, N(dan) ); /// 12 char names should succeed 
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( multiple_namebids, eosio_system_tester ) try {

--- a/unittests/misc_tests.cpp
+++ b/unittests/misc_tests.cpp
@@ -532,51 +532,6 @@ BOOST_AUTO_TEST_CASE(alphabetic_sort)
 
 } FC_LOG_AND_RETHROW() }
 
-BOOST_AUTO_TEST_CASE( suffix_test ) try {
-   uint64_t com = name( "com" );
-   uint64_t order = com;
-
-   uint64_t name_com = name("name.com");
-   uint64_t name_com_au = name("name.com.au");
-
-   //std::string str(13,'.');
-
-   uint64_t tmp = com;
-   auto print = []( uint64_t tmp ) {
-      static const char* charmap = ".12345abcdefghijklmnopqrstuvwxyz";
-
-      uint64_t suffix = 0;
-      bool endsuffix = false;
-      uint32_t offset = 0;
-      for( uint32_t i = 0; i <= 12; ++i, ++offset ) {
-         auto p = tmp >> 59;
-         char c = charmap[p];
-
-         if( !p ) {
-            endsuffix = true;
-         } else {
-            if( !endsuffix ) {
-               suffix |= uint64_t(p) << (59-(5*offset));
-            }
-         }
-         if( endsuffix && p ) {
-            endsuffix = false;
-            offset = 0;
-            suffix = uint64_t(p) << (59-(5*offset));
-         }
-         std::cerr << c;
-       //  str[12-i] = c;
-         tmp <<= 5;
-      }
-   //   std::cerr << "  suffix: " << name(suffix) <<"\n";
-   };
-
-   print( com );
-   //std::cerr <<"\n";
-   print( name_com );
-   print( name_com_au );
-
-} FC_LOG_AND_RETHROW() 
 
 BOOST_AUTO_TEST_CASE(transaction_test) { try {
 


### PR DESCRIPTION
   - added print(char) API
   - added unit test to validate create 12