### PR TITLE
scripts/eosio_build_darwin.sh: fix typo

### DIFF
--- a/scripts/eosio_build_darwin.sh
+++ b/scripts/eosio_build_darwin.sh
@@ -188,7 +188,7 @@
 						if brew list | grep "boost"
 						then 
 							printf "\\tUnlinking Boost Version %s.\\n" "${BVERSION}"
-							printff "\\tunlinking boost %s\\n" "${BVERSION}"				
+							printf "\\tunlinking boost %s\\n" "${BVERSION}"
 							if ! "${BREW}" unlink boost
 							then
 								printf "\\tUnable to remove boost libraries at this time. 0\\n"


### PR DESCRIPTION
fixes 2 `f`s in `printf`.
A warning on my MBP. :)
