### PR TITLE
Rename set_active_producers intrinsic to set_proposed_producers

### DIFF
--- a/contracts/eosio.bios/eosio.bios.hpp
+++ b/contracts/eosio.bios/eosio.bios.hpp
@@ -28,7 +28,7 @@ namespace eosio {
             require_auth( _self );
             char buffer[action_data_size()];
             read_action_data( buffer, sizeof(buffer) ); // should be the same data as eosio::pack(schedule)
-            set_active_producers(buffer, sizeof(buffer));
+            set_proposed_producers(buffer, sizeof(buffer));
          }
 
          void reqauth( action_name from ) {

--- a/contracts/eosio.system/voting.cpp
+++ b/contracts/eosio.system/voting.cpp
@@ -34,7 +34,7 @@ namespace eosiosystem {
     *  @pre authority of producer to register
     *
     */
-   void system_contract::regproducer( const account_name producer, const eosio::public_key& producer_key, const std::string& url, uint16_t location ) { 
+   void system_contract::regproducer( const account_name producer, const eosio::public_key& producer_key, const std::string& url, uint16_t location ) {
       eosio_assert( url.size() < 512, "url too long" );
       require_auth( producer );
 
@@ -96,7 +96,7 @@ namespace eosiosystem {
 
          top_producers.emplace_back( std::pair<eosio::producer_key,uint16_t>({{it->owner, it->producer_key}, it->location}));
       }
-      
+
 
 
       /// sort by producer name
@@ -114,7 +114,7 @@ namespace eosiosystem {
 
       if( new_id != _gstate.last_producer_schedule_id ) {
          _gstate.last_producer_schedule_id = new_id;
-         set_active_producers( packed_schedule.data(),  packed_schedule.size() );
+         set_proposed_producers( packed_schedule.data(),  packed_schedule.size() );
       }
       _gstate.last_producer_schedule_update = block_time;
    }
@@ -133,7 +133,7 @@ namespace eosiosystem {
     *  @pre voter must have previously staked some EOS for voting
     *  @pre voter->staked must be up to date
     *
-    *  @post every producer previously voted for will have vote reduced by previous vote weight 
+    *  @post every producer previously voted for will have vote reduced by previous vote weight
     *  @post every producer newly voted for will have vote increased by new vote amount
     *  @post prior proxy will proxied_vote_weight decremented by previous vote weight
     *  @post new proxy will proxied_vote_weight incremented by new vote weight
@@ -245,7 +245,7 @@ namespace eosiosystem {
    /**
     *  An account marked as a proxy can vote with the weight of other accounts which
     *  have selected it as a proxy. Other accounts must refresh their voteproducer to
-    *  update the proxy's weight.    
+    *  update the proxy's weight.
     *
     *  @param isproxy - true if proxy wishes to vote on behalf of others, false otherwise
     *  @pre proxy must have something staked (existing row in voters table)

--- a/contracts/eosiolib/privileged.h
+++ b/contracts/eosiolib/privileged.h
@@ -20,7 +20,14 @@ extern "C" {
 
    void set_resource_limits( account_name account, int64_t ram_bytes, int64_t net_weight, int64_t cpu_weight );
 
-   bool set_active_producers( char *producer_data, uint32_t producer_data_size );
+   /**
+    * Propose the new active producer schedule
+    * @param producer_data - packed data of produce_keys in the appropriate producer schedule order
+    * @param producer_data_size - size of the data buffer
+    *
+    * @return -1 if setting proposing a new producer schedule was unsuccessful, other returns the version of the new proposed schedule
+    */
+   int64_t set_proposed_producers( char *producer_data, uint32_t producer_data_size );
 
    bool is_privileged( account_name account );
 

--- a/contracts/eosiolib/privileged.h
+++ b/contracts/eosiolib/privileged.h
@@ -25,7 +25,7 @@ extern "C" {
     * @param producer_data - packed data of produce_keys in the appropriate producer schedule order
     * @param producer_data_size - size of the data buffer
     *
-    * @return -1 if setting proposing a new producer schedule was unsuccessful, other returns the version of the new proposed schedule
+    * @return -1 if proposing a new producer schedule was unsuccessful, otherwise returns the version of the new proposed schedule
     */
    int64_t set_proposed_producers( char *producer_data, uint32_t producer_data_size );
 

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1218,17 +1218,17 @@ void controller::pop_block() {
    my->pop_block();
 }
 
-bool controller::set_proposed_producers( vector<producer_key> producers ) {
+int64_t controller::set_proposed_producers( vector<producer_key> producers ) {
    const auto& gpo = get_global_properties();
    auto cur_block_num = head_block_num() + 1;
 
    if( gpo.proposed_schedule_block_num.valid() ) {
       if( *gpo.proposed_schedule_block_num != cur_block_num )
-         return false; // there is already a proposed schedule set in a previous block, wait for it to become pending
+         return -1; // there is already a proposed schedule set in a previous block, wait for it to become pending
 
       if( std::equal( producers.begin(), producers.end(),
                       gpo.proposed_schedule.producers.begin(), gpo.proposed_schedule.producers.end() ) )
-         return false; // the proposed producer schedule does not change
+         return -1; // the proposed producer schedule does not change
    }
 
    producer_schedule_type sch;
@@ -1249,15 +1249,17 @@ bool controller::set_proposed_producers( vector<producer_key> producers ) {
    }
 
    if( std::equal( producers.begin(), producers.end(), begin, end ) )
-      return false; // the producer schedule would not change
+      return -1; // the producer schedule would not change
 
    sch.producers = std::move(producers);
+
+   int64_t version = sch.version;
 
    my->db.modify( gpo, [&]( auto& gp ) {
       gp.proposed_schedule_block_num = cur_block_num;
       gp.proposed_schedule = std::move(sch);
    });
-   return true;
+   return version;
 }
 
 const producer_schedule_type&    controller::active_producers()const {

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -148,7 +148,7 @@ namespace eosio { namespace chain {
          void validate_expiration( const transaction& t )const;
          void validate_tapos( const transaction& t )const;
 
-         bool set_proposed_producers( vector<producer_key> producers );
+         int64_t set_proposed_producers( vector<producer_key> producers );
 
          bool skip_auth_check()const;
 

--- a/libraries/chain/wasm_interface.cpp
+++ b/libraries/chain/wasm_interface.cpp
@@ -145,7 +145,7 @@ class privileged_api : public context_aware_api {
          context.control.get_resource_limits_manager().get_account_limits( account, ram_bytes, net_weight, cpu_weight);
       }
 
-      bool set_active_producers( array_ptr<char> packed_producer_schedule, size_t datalen) {
+      int64_t set_proposed_producers( array_ptr<char> packed_producer_schedule, size_t datalen) {
          datastream<const char*> ds( packed_producer_schedule, datalen );
          vector<producer_key> producers;
          fc::raw::unpack(ds, producers);
@@ -1684,7 +1684,7 @@ REGISTER_INTRINSICS(privileged_api,
    (activate_feature,                 void(int64_t)                         )
    (get_resource_limits,              void(int64_t,int,int,int)             )
    (set_resource_limits,              void(int64_t,int64_t,int64_t,int64_t) )
-   (set_active_producers,             int(int,int)                          )
+   (set_proposed_producers,           int64_t(int,int)                      )
    (get_blockchain_parameters_packed, int(int, int)                         )
    (set_blockchain_parameters_packed, void(int,int)                         )
    (is_privileged,                    int(int64_t)                          )


### PR DESCRIPTION
Renamed `set_active_producers` intrinsic to `set_proposed_producers` and return an `int64_t` instead of a `bool`.

The return value initially indicated whether the intrinsic was successful in proposing a new producer schedule.

Now -1 is returned to indicate failure and a non-negative number is returned to indicate success.
If successful, `set_proposed_producers` returns the version of the new proposed producer schedule.

This is a hard forking change.