### PR TITLE
Gh#3398 abi serializer

### DIFF
--- a/libraries/chain/abi_serializer.cpp
+++ b/libraries/chain/abi_serializer.cpp
@@ -228,7 +228,7 @@ namespace eosio { namespace chain {
    type_name abi_serializer::resolve_type(const type_name& type)const {
       auto itr = typedefs.find(type);
       if( itr != typedefs.end() ) {
-         for( auto i = typedefs.size(); i > 0; --i ) { // avoid infinit recursion
+         for( auto i = typedefs.size(); i > 0; --i ) { // avoid infinite recursion
             const type_name& t = itr->second;
             itr = typedefs.find( t );
             if( itr == typedefs.end() ) return t;

--- a/libraries/chain/abi_serializer.cpp
+++ b/libraries/chain/abi_serializer.cpp
@@ -225,10 +225,15 @@ namespace eosio { namespace chain {
       } FC_CAPTURE_AND_RETHROW( (t)  ) }
    }
 
-   type_name abi_serializer::resolve_type(const type_name& type)const  {
+   type_name abi_serializer::resolve_type(const type_name& type)const {
       auto itr = typedefs.find(type);
-      if( itr != typedefs.end() )
-         return resolve_type(itr->second);
+      if( itr != typedefs.end() ) {
+         for( auto i = typedefs.size(); i > 0; --i ) { // avoid infinit recursion
+            const type_name& t = itr->second;
+            itr = typedefs.find( t );
+            if( itr == typedefs.end() ) return t;
+         }
+      }
       return type;
    }
 

--- a/libraries/chain/abi_serializer.cpp
+++ b/libraries/chain/abi_serializer.cpp
@@ -107,6 +107,7 @@ namespace eosio { namespace chain {
 
       for( const auto& td : abi.types ) {
          FC_ASSERT(is_type(td.type), "invalid type", ("type",td.type));
+         FC_ASSERT(!is_type(td.new_type_name), "type already exists", ("new_type_name",td.new_type_name));
          typedefs[td.new_type_name] = td.type;
       }
 
@@ -128,6 +129,8 @@ namespace eosio { namespace chain {
       FC_ASSERT( actions.size() == abi.actions.size() );
       FC_ASSERT( tables.size() == abi.tables.size() );
       FC_ASSERT( error_messages.size() == abi.error_messages.size() );
+
+      validate();
    }
 
    bool abi_serializer::is_builtin_type(const type_name& type)const {

--- a/libraries/chain/include/eosio/chain/abi_serializer.hpp
+++ b/libraries/chain/include/eosio/chain/abi_serializer.hpp
@@ -37,7 +37,6 @@ struct abi_serializer {
    map<type_name, pair<unpack_function, pack_function>> built_in_types;
    void configure_built_in_types();
 
-   bool has_cycle(const vector<pair<string, string>>& sedges)const;
    void validate()const;
 
    type_name resolve_type(const type_name& t)const;


### PR DESCRIPTION
Resolves #3398 

Verify ABI in abi_serializer set_abi to avoid errors during serialization of malformed abi.  A type_def to the same type was causing unbounded recursion and corrupting the stack. Also refactored the resolve_type to no longer use recursion to be extra safe that unbounded recursion was avoided.