### PR TITLE
chain ID is now handled at runtime and is the hash of the genesis state; also the genesis state is included at the start of blocks.log

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,7 +190,13 @@ if (CORE_SYMBOL_NAME_LENGTH GREATER 7)
   message(FATAL_ERROR "CORE_SYMBOL_NAME lenght must be a between 1 and 7 characters")
 endif()
 
-message( STATUS "Using ${CORE_SYMBOL_NAME} as CORE symbol name")
+message( STATUS "Using '${CORE_SYMBOL_NAME}' as CORE symbol name" )
+
+if ("${EOSIO_ROOT_KEY}" STREQUAL "")
+   set(EOSIO_ROOT_KEY "EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV")
+endif()
+
+message( STATUS "Using '${EOSIO_ROOT_KEY}' as public key for eosio account" )
 
 include(wasm)
 

--- a/libraries/chain/CMakeLists.txt
+++ b/libraries/chain/CMakeLists.txt
@@ -1,16 +1,9 @@
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/include/eosio/chain/core_symbol.hpp.in ${CMAKE_CURRENT_SOURCE_DIR}/include/eosio/chain/core_symbol.hpp)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/include/eosio/chain/core_symbol.hpp.in ${CMAKE_CURRENT_BINARY_DIR}/include/eosio/chain/core_symbol.hpp)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/genesis_state_root_key.cpp.in ${CMAKE_CURRENT_BINARY_DIR}/genesis_state_root_key.cpp)
 
-# set the chain id
-if (NOT "${CHAIN_ID}" STREQUAL "")
-   set(eosio_CHAIN_ID "${CHAIN_ID}")
-else()
-   ## sha256("eosio::chain version 1.0")
-   set(eosio_CHAIN_ID "144B6AB7924EA47BAE7A5846B4494A35563AE816E2ED5AFFA7A9C990C2B3CFB3")
-endif()
-
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/chain_id.cpp.in ${CMAKE_CURRENT_SOURCE_DIR}/chain_id.cpp)
-
-file(GLOB HEADERS "include/eosio/chain/*.hpp" "include/eosio/chain/contracts/*.hpp")
+file(GLOB HEADERS "include/eosio/chain/*.hpp"
+                  "include/eosio/chain/contracts/*.hpp"
+                  "${CMAKE_CURRENT_BINARY_DIR}/include/eosio/chain/core_symbol.hpp" )
 
 ## SORT .cpp by most likely to change / break compile
 add_library( eosio_chain
@@ -25,12 +18,12 @@ add_library( eosio_chain
              authorization_manager.cpp
              resource_limits.cpp
              block_log.cpp
-             genesis_state.cpp
              transaction_context.cpp
              eosio_contract.cpp
              eosio_contract_abi.cpp
              chain_config.cpp
-             chain_id.cpp
+             genesis_state.cpp
+             ${CMAKE_CURRENT_BINARY_DIR}/genesis_state_root_key.cpp
 
 #             chain_config.cpp
 #             block_trace.cpp

--- a/libraries/chain/CMakeLists.txt
+++ b/libraries/chain/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library( eosio_chain
              eosio_contract.cpp
              eosio_contract_abi.cpp
              chain_config.cpp
+             chain_id_type.cpp
              genesis_state.cpp
              ${CMAKE_CURRENT_BINARY_DIR}/genesis_state_root_key.cpp
 

--- a/libraries/chain/chain_id.cpp.in
+++ b/libraries/chain/chain_id.cpp.in
@@ -1,6 +1,0 @@
-#include <eosio/chain/types.hpp>
-
-namespace eosio { namespace chain {
-   chain_id_type::chain_id_type( const fc::string& s ) { id = fc::sha256(s); }
-   chain_id_type::chain_id_type() { id = fc::sha256("${eosio_CHAIN_ID}"); }
-}} // namespace eosio::chain

--- a/libraries/chain/chain_id_type.cpp
+++ b/libraries/chain/chain_id_type.cpp
@@ -1,0 +1,27 @@
+/**
+ *  @file
+ *  @copyright defined in eos/LICENSE.txt
+ */
+
+#include <eosio/chain/chain_id_type.hpp>
+#include <eosio/chain/exceptions.hpp>
+
+namespace eosio { namespace chain {
+
+   void chain_id_type::reflector_verify()const {
+      FC_ASSERT( *reinterpret_cast<const fc::sha256*>(this) != fc::sha256(), "chain_id_type cannot be zero" );
+   }
+
+} }  // namespace eosio::chain
+
+namespace fc {
+
+   void to_variant(const eosio::chain::chain_id_type& cid, fc::variant& v) {
+      to_variant( static_cast<const fc::sha256&>(cid), v);
+   }
+
+   void from_variant(const fc::variant& v, eosio::chain::chain_id_type& cid) {
+      from_variant( v, static_cast<fc::sha256&>(cid) );
+   }
+
+} // fc

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -224,7 +224,7 @@ struct controller_impl {
             replaying = false;
 
          } else if( !end ) {
-            blog.append( head->block );
+            blog.reset_to_genesis( conf.genesis, head->block );
          }
       }
 

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -56,6 +56,7 @@ struct controller_impl {
    resource_limits_manager        resource_limits;
    authorization_manager          authorization;
    controller::config             conf;
+   chain_id_type                  chain_id;
    bool                           replaying = false;
    bool                           replaying_irreversible = false;
 
@@ -103,7 +104,8 @@ struct controller_impl {
     wasmif( cfg.wasm_runtime ),
     resource_limits( db ),
     authorization( s, db ),
-    conf( cfg )
+    conf( cfg ),
+    chain_id( cfg.genesis.compute_chain_id() )
    {
 
 #define SET_APP_HANDLER( receiver, contract, action) \
@@ -645,7 +647,7 @@ struct controller_impl {
             if( !self.skip_auth_check() && !implicit ) {
                authorization.check_authorization(
                        trx->trx.actions,
-                       trx->recover_keys(),
+                       trx->recover_keys( chain_id ),
                        {},
                        trx_context.delay,
                        [](){}
@@ -1288,6 +1290,10 @@ bool controller::skip_auth_check()const {
 
 bool controller::contracts_console()const {
    return my->conf.contracts_console;
+}
+
+chain_id_type controller::get_chain_id()const {
+   return my->chain_id;
 }
 
 const apply_handler* controller::find_apply_handler( account_name receiver, account_name scope, action_name act ) const

--- a/libraries/chain/genesis_state.cpp
+++ b/libraries/chain/genesis_state.cpp
@@ -10,9 +10,15 @@
 
 namespace eosio { namespace chain {
 
+genesis_state::genesis_state() {
+   initial_timestamp = fc::time_point::from_iso_string( "2018-03-02T12:00:00" );
+   initial_key = fc::variant(eosio_root_key).as<public_key_type>();
+}
 
 chain::chain_id_type genesis_state::compute_chain_id() const {
-   return config::chain_id;
+   digest_type::encoder enc;
+   fc::raw::pack( enc, *this );
+   return enc.result();
 }
 
 } } // namespace eosio::chain

--- a/libraries/chain/genesis_state.cpp
+++ b/libraries/chain/genesis_state.cpp
@@ -18,7 +18,7 @@ genesis_state::genesis_state() {
 chain::chain_id_type genesis_state::compute_chain_id() const {
    digest_type::encoder enc;
    fc::raw::pack( enc, *this );
-   return enc.result();
+   return chain_id_type{enc.result()};
 }
 
 } } // namespace eosio::chain

--- a/libraries/chain/genesis_state_root_key.cpp.in
+++ b/libraries/chain/genesis_state_root_key.cpp.in
@@ -1,0 +1,12 @@
+/**
+ *  @file
+ *  @copyright defined in eos/LICENSE.txt
+ */
+
+#include <eosio/chain/genesis_state.hpp>
+
+namespace eosio { namespace chain {
+
+const string genesis_state::eosio_root_key = "${EOSIO_ROOT_KEY}";
+
+} } // namespace eosio::chain

--- a/libraries/chain/include/eosio/chain/block_log.hpp
+++ b/libraries/chain/include/eosio/chain/block_log.hpp
@@ -5,6 +5,7 @@
 #pragma once
 #include <fc/filesystem.hpp>
 #include <eosio/chain/block.hpp>
+#include <eosio/chain/genesis_state.hpp>
 
 namespace eosio { namespace chain {
 
@@ -43,6 +44,8 @@ namespace eosio { namespace chain {
 
          uint64_t append(const signed_block_ptr& b);
          void flush();
+         uint64_t reset_to_genesis( const genesis_state& gs, const signed_block_ptr& genesis_block );
+
          std::pair<signed_block_ptr, uint64_t> read_block(uint64_t file_pos)const;
          signed_block_ptr read_block_by_num(uint32_t block_num)const;
          signed_block_ptr read_block_by_id(const block_id_type& id)const {
@@ -58,7 +61,11 @@ namespace eosio { namespace chain {
 
          static const uint64_t npos = std::numeric_limits<uint64_t>::max();
 
+         static const uint32_t supported_version;
+
          static fc::path repair_log( const fc::path& data_dir );
+
+         static genesis_state extract_genesis_state( const fc::path& data_dir );
 
       private:
          void open(const fc::path& data_dir);

--- a/libraries/chain/include/eosio/chain/chain_id_type.hpp
+++ b/libraries/chain/include/eosio/chain/chain_id_type.hpp
@@ -1,0 +1,56 @@
+/**
+ *  @file
+ *  @copyright defined in eos/LICENSE.txt
+ */
+#pragma once
+
+#include <fc/crypto/sha256.hpp>
+
+namespace eosio {
+
+   class net_plugin_impl;
+   struct handshake_message;
+
+   namespace chain_apis {
+      class read_only;
+   }
+
+namespace chain {
+
+   struct chain_id_type : public fc::sha256 {
+      using fc::sha256::sha256;
+
+      template<typename T>
+      inline friend T& operator<<( T& ds, const chain_id_type& cid ) {
+        ds.write( cid.data(), cid.data_size() );
+        return ds;
+      }
+
+      template<typename T>
+      inline friend T& operator>>( T& ds, chain_id_type& cid ) {
+        ds.read( cid.data(), cid.data_size() );
+        return ds;
+      }
+
+      void reflector_verify()const;
+
+      private:
+         chain_id_type() = default;
+
+         template<typename T>
+         friend T fc::variant::as()const;
+
+         friend class eosio::chain_apis::read_only;
+
+         // Eventually net_plugin should be updated to not default construct chain_id. Then these two lines can be removed.
+         friend class eosio::net_plugin_impl;
+         friend struct eosio::handshake_message;
+   };
+
+} }  // namespace eosio::chain
+
+namespace fc {
+  class variant;
+  void to_variant(const eosio::chain::chain_id_type& cid, fc::variant& v);
+  void from_variant(const fc::variant& v, eosio::chain::chain_id_type& cid);
+} // fc

--- a/libraries/chain/include/eosio/chain/chain_id_type.hpp
+++ b/libraries/chain/include/eosio/chain/chain_id_type.hpp
@@ -37,12 +37,12 @@ namespace chain {
       private:
          chain_id_type() = default;
 
+         // Some exceptions are unfortunately necessary:
          template<typename T>
          friend T fc::variant::as()const;
 
          friend class eosio::chain_apis::read_only;
 
-         // Eventually net_plugin should be updated to not default construct chain_id. Then these two lines can be removed.
          friend class eosio::net_plugin_impl;
          friend struct eosio::handshake_message;
    };

--- a/libraries/chain/include/eosio/chain/config.hpp
+++ b/libraries/chain/include/eosio/chain/config.hpp
@@ -115,8 +115,6 @@ const static int irreversible_threshold_percent= 70 * percent_1;
 
 const static uint64_t billable_alignment = 16;
 
-const static chain_id_type chain_id = chain_id_type();
-
 template<typename T>
 struct billable_size;
 

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -154,6 +154,8 @@ namespace eosio { namespace chain {
 
          bool contracts_console()const;
 
+         chain_id_type get_chain_id()const;
+
          signal<void(const block_state_ptr&)>          accepted_block_header;
          signal<void(const block_state_ptr&)>          accepted_block;
          signal<void(const block_state_ptr&)>          irreversible_block;

--- a/libraries/chain/include/eosio/chain/core_symbol.hpp
+++ b/libraries/chain/include/eosio/chain/core_symbol.hpp
@@ -1,8 +1,0 @@
-/** @file 
- *    @copyright defined in eos/LICENSE.txt 
- *
- * \warning This file is machine generated. DO NOT EDIT.  See core_symbol.hpp.in for changes.
- */
-
-#define CORE_SYMBOL SY(4,SYS)
-#define CORE_SYMBOL_NAME "SYS"

--- a/libraries/chain/include/eosio/chain/exceptions.hpp
+++ b/libraries/chain/include/eosio/chain/exceptions.hpp
@@ -246,6 +246,8 @@ namespace eosio { namespace chain {
                                     3100003, "unknown transaction" )
       FC_DECLARE_DERIVED_EXCEPTION( fixed_reversible_db_exception,    misc_exception,
                                     3100004, "corrupted reversible block database was fixed" )
+      FC_DECLARE_DERIVED_EXCEPTION( extract_genesis_state_exception,    misc_exception,
+                                    3100005, "extracted genesis state from blocks.log" )
 
    FC_DECLARE_DERIVED_EXCEPTION( missing_plugin_exception, chain_exception,
                                  3110000, "missing plugin exception" )

--- a/libraries/chain/include/eosio/chain/genesis_state.hpp
+++ b/libraries/chain/include/eosio/chain/genesis_state.hpp
@@ -16,6 +16,10 @@
 namespace eosio { namespace chain {
 
 struct genesis_state {
+   genesis_state();
+
+   static const string eosio_root_key;
+
    chain_config   initial_configuration = {
       .max_block_net_usage                  = config::default_max_block_net_usage,
       .target_block_net_usage_pct           = config::default_target_block_net_usage_pct,
@@ -38,8 +42,8 @@ struct genesis_state {
       .max_authority_depth                  = config::default_max_auth_depth,
    };
 
-   time_point                               initial_timestamp = fc::time_point::from_iso_string( "2018-03-02T12:00:00" );
-   public_key_type                          initial_key = fc::variant("EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV").as<public_key_type>();
+   time_point                               initial_timestamp;
+   public_key_type                          initial_key;
 
    /**
     * Get the chain_id corresponding to this genesis state.

--- a/libraries/chain/include/eosio/chain/types.hpp
+++ b/libraries/chain/include/eosio/chain/types.hpp
@@ -88,12 +88,19 @@ namespace eosio { namespace chain {
 
    struct void_t{};
 
+   using chain_id_type = fc::sha256;
+   /*
+   struct genesis_state;
+
    struct chain_id_type {
       chain_id_type(const fc::string& s);
+      //chain_id_type( const genesis_state& gs );
       chain_id_type();
       operator fc::sha256() { return id; }
       fc::sha256 id;
    };
+   */
+
 
    using chainbase::allocator;
    using shared_string = boost::interprocess::basic_string<char, std::char_traits<char>, allocator<char>>;
@@ -228,4 +235,3 @@ FC_REFLECT_ENUM(eosio::chain::object_type,
                 (OBJECT_TYPE_COUNT)
                )
 FC_REFLECT( eosio::chain::void_t, )
-FC_REFLECT(eosio::chain::chain_id_type, (id) )

--- a/libraries/chain/include/eosio/chain/types.hpp
+++ b/libraries/chain/include/eosio/chain/types.hpp
@@ -4,6 +4,7 @@
  */
 #pragma once
 #include <eosio/chain/name.hpp>
+#include <eosio/chain/chain_id_type.hpp>
 
 #include <chainbase/chainbase.hpp>
 
@@ -87,19 +88,6 @@ namespace eosio { namespace chain {
    using signature_type   = fc::crypto::signature;
 
    struct void_t{};
-
-   using chain_id_type = fc::sha256;
-   /*
-   struct genesis_state;
-
-   struct chain_id_type {
-      chain_id_type(const fc::string& s);
-      //chain_id_type( const genesis_state& gs );
-      chain_id_type();
-      operator fc::sha256() { return id; }
-      fc::sha256 id;
-   };
-   */
 
 
    using chainbase::allocator;

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -268,7 +268,7 @@ namespace eosio { namespace testing {
                                 });
 
       set_transaction_headers(trx);
-      trx.sign( get_private_key( creator, "active" ), chain_id_type()  );
+      trx.sign( get_private_key( creator, "active" ), control->get_chain_id()  );
       return push_transaction( trx );
    }
 
@@ -312,7 +312,7 @@ namespace eosio { namespace testing {
       trx.actions.emplace_back(std::move(act));
       set_transaction_headers(trx);
       if (authorizer) {
-         trx.sign(get_private_key(authorizer, "active"), chain_id_type());
+         trx.sign(get_private_key(authorizer, "active"), control->get_chain_id());
       }
       try {
          push_transaction(trx);
@@ -369,7 +369,7 @@ namespace eosio { namespace testing {
       trx.actions.emplace_back( get_action( code, acttype, auths, data ) );
       set_transaction_headers( trx, expiration, delay_sec );
       for (const auto& auth : auths) {
-         trx.sign( get_private_key( auth.actor, auth.permission.to_string() ), chain_id_type() );
+         trx.sign( get_private_key( auth.actor, auth.permission.to_string() ), control->get_chain_id() );
       }
 
       return push_transaction( trx );
@@ -411,7 +411,7 @@ namespace eosio { namespace testing {
       abi_serializer::from_variant(pretty_trx, trx, get_resolver());
       set_transaction_headers(trx);
       for(auto iter = keys.begin(); iter != keys.end(); iter++)
-         trx.sign( *iter, chain_id_type() );
+         trx.sign( *iter, control->get_chain_id() );
       return push_transaction( trx );
    }
 
@@ -457,7 +457,7 @@ namespace eosio { namespace testing {
       abi_serializer::from_variant(pretty_trx, trx, get_resolver());
       set_transaction_headers(trx);
 
-      trx.sign( get_private_key( from, "active" ), chain_id_type() );
+      trx.sign( get_private_key( from, "active" ), control->get_chain_id() );
       return push_transaction( trx, fc::time_point::maximum(), billed_cpu_time_us );
    }
 
@@ -491,7 +491,7 @@ namespace eosio { namespace testing {
       abi_serializer::from_variant(pretty_trx, trx, get_resolver());
       set_transaction_headers(trx);
 
-      trx.sign( get_private_key( from, name(config::active_name).to_string() ), chain_id_type()  );
+      trx.sign( get_private_key( from, name(config::active_name).to_string() ), control->get_chain_id()  );
       return push_transaction( trx );
    }
 
@@ -518,7 +518,7 @@ namespace eosio { namespace testing {
       abi_serializer::from_variant(pretty_trx, trx, get_resolver());
       set_transaction_headers(trx);
 
-      trx.sign( get_private_key( currency, name(config::active_name).to_string() ), chain_id_type()  );
+      trx.sign( get_private_key( currency, name(config::active_name).to_string() ), control->get_chain_id()  );
       return push_transaction( trx );
    }
 
@@ -529,7 +529,7 @@ namespace eosio { namespace testing {
       trx.actions.emplace_back( vector<permission_level>{{account, config::active_name}},
                                 linkauth(account, code, type, req));
       set_transaction_headers(trx);
-      trx.sign( get_private_key( account, "active" ), chain_id_type()  );
+      trx.sign( get_private_key( account, "active" ), control->get_chain_id()  );
 
       push_transaction( trx );
    }
@@ -541,7 +541,7 @@ namespace eosio { namespace testing {
       trx.actions.emplace_back( vector<permission_level>{{account, config::active_name}},
                                 unlinkauth(account, code, type ));
       set_transaction_headers(trx);
-      trx.sign( get_private_key( account, "active" ), chain_id_type()  );
+      trx.sign( get_private_key( account, "active" ), control->get_chain_id()  );
 
       push_transaction( trx );
    }
@@ -565,7 +565,7 @@ namespace eosio { namespace testing {
 
          set_transaction_headers(trx);
       for (const auto& key: keys) {
-         trx.sign( key, chain_id_type()  );
+         trx.sign( key, control->get_chain_id()  );
       }
 
       push_transaction( trx );
@@ -591,7 +591,7 @@ namespace eosio { namespace testing {
 
          set_transaction_headers(trx);
          for (const auto& key: keys) {
-            trx.sign( key, chain_id_type()  );
+            trx.sign( key, control->get_chain_id()  );
          }
 
          push_transaction( trx );
@@ -621,9 +621,9 @@ namespace eosio { namespace testing {
 
       set_transaction_headers(trx);
       if( signer ) {
-         trx.sign( *signer, chain_id_type()  );
+         trx.sign( *signer, control->get_chain_id()  );
       } else {
-         trx.sign( get_private_key( account, "active" ), chain_id_type()  );
+         trx.sign( get_private_key( account, "active" ), control->get_chain_id()  );
       }
       push_transaction( trx );
    } FC_CAPTURE_AND_RETHROW( (account) )
@@ -640,9 +640,9 @@ namespace eosio { namespace testing {
 
       set_transaction_headers(trx);
       if( signer ) {
-         trx.sign( *signer, chain_id_type()  );
+         trx.sign( *signer, control->get_chain_id()  );
       } else {
-         trx.sign( get_private_key( account, "active" ), chain_id_type()  );
+         trx.sign( get_private_key( account, "active" ), control->get_chain_id()  );
       }
       push_transaction( trx );
    }

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -64,7 +64,7 @@ public:
    fc::optional<block_log>          block_logger;
    fc::optional<controller::config> chain_config;
    fc::optional<controller>         chain;
-   chain_id_type                    chain_id;
+   fc::optional<chain_id_type>      chain_id;
    //txn_msg_rate_limits              rate_limits;
    fc::optional<vm_type>            wasm_runtime;
 
@@ -304,7 +304,7 @@ void chain_plugin::plugin_initialize(const variables_map& options) {
    }
 
    my->chain.emplace(*my->chain_config);
-   my->chain_id = my->chain->get_chain_id();
+   my->chain_id.emplace(my->chain->get_chain_id());
 
    // set up method providers
    my->get_block_by_number_provider = app().get_method<methods::get_block_by_number>().register_provider([this](uint32_t block_num) -> signed_block_ptr {
@@ -476,7 +476,8 @@ controller& chain_plugin::chain() { return *my->chain; }
 const controller& chain_plugin::chain() const { return *my->chain; }
 
 chain::chain_id_type chain_plugin::get_chain_id()const {
-   return my->chain_id;
+   FC_ASSERT( my->chain_id.valid(), "chain ID has not been initialized yet" );
+   return *my->chain_id;
 }
 
 namespace chain_apis {

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -295,6 +295,12 @@ void chain_plugin::plugin_initialize(const variables_map& options) {
         }
         ilog( "Adjusting genesis timestamp to ${timestamp}", ("timestamp", my->chain_config->genesis.initial_timestamp) );
       }
+
+      wlog( "Starting up fresh blockchain with provided genesis state." );
+   } else if( fc::is_regular_file( my->blocks_dir / "blocks.log" ) ) {
+      my->chain_config->genesis = block_log::extract_genesis_state( my->blocks_dir );
+   } else {
+      wlog( "Starting up fresh blockchain with default genesis state." );
    }
 
    my->chain.emplace(*my->chain_config);

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -298,6 +298,7 @@ void chain_plugin::plugin_initialize(const variables_map& options) {
    }
 
    my->chain.emplace(*my->chain_config);
+   my->chain_id = my->chain->get_chain_id();
 
    // set up method providers
    my->get_block_by_number_provider = app().get_method<methods::get_block_by_number>().register_provider([this](uint32_t block_num) -> signed_block_ptr {

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -60,6 +60,7 @@ public:
 
    struct get_info_results {
       string                  server_version;
+      chain::chain_id_type    chain_id;
       uint32_t                head_block_num = 0;
       uint32_t                last_irreversible_block_num = 0;
       chain::block_id_type    last_irreversible_block_id;
@@ -378,7 +379,7 @@ public:
    // Only call this after plugin_startup()!
    const controller& chain() const;
 
-   void get_chain_id(chain::chain_id_type& cid) const;
+   chain::chain_id_type get_chain_id() const;
 
 private:
    unique_ptr<class chain_plugin_impl> my;
@@ -389,7 +390,7 @@ private:
 FC_REFLECT( eosio::chain_apis::permission, (perm_name)(parent)(required_auth) )
 FC_REFLECT(eosio::chain_apis::empty, )
 FC_REFLECT(eosio::chain_apis::read_only::get_info_results,
-(server_version)(head_block_num)(last_irreversible_block_num)(last_irreversible_block_id)(head_block_id)(head_block_time)(head_block_producer)(virtual_block_cpu_limit)(virtual_block_net_limit)(block_cpu_limit)(block_net_limit) )
+(server_version)(chain_id)(head_block_num)(last_irreversible_block_num)(last_irreversible_block_id)(head_block_id)(head_block_time)(head_block_producer)(virtual_block_cpu_limit)(virtual_block_net_limit)(block_cpu_limit)(block_net_limit) )
 FC_REFLECT(eosio::chain_apis::read_only::get_block_params, (block_num_or_id))
 
 FC_REFLECT( eosio::chain_apis::read_write::push_transaction_results, (transaction_id)(processed) )

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -52,7 +52,7 @@ namespace eosio {
    namespace bip = boost::interprocess;
 
    class connection;
-   
+
    class sync_manager;
    class dispatch_manager;
 
@@ -409,7 +409,7 @@ namespace eosio {
       }
    } set_is_known;
 
-   
+
    struct update_block_num {
       uint32_t new_bnum;
       update_block_num(uint32_t bnum) : new_bnum(bnum) {}
@@ -579,7 +579,7 @@ namespace eosio {
        * encountered unpacking or processing the message.
        */
       bool process_next_message(net_plugin_impl& impl, uint32_t message_length);
-      
+
       bool add_peer_block(const peer_block_state &pbs);
    };
 
@@ -1607,7 +1607,7 @@ namespace eosio {
       pending_notify.known_blocks.mode = normal;
       pending_notify.known_blocks.ids.push_back( bid );
       pending_notify.known_trx.mode = none;
-      
+
       peer_block_state pbstate = {bid, bnum, false,true,time_point()};
       // skip will be empty if our producer emitted this block so just send it
       if (( large_msg_notify && msgsiz > just_send_it_max) && skip) {
@@ -1644,11 +1644,11 @@ namespace eosio {
          c->last_req.reset();
       }
       c->add_peer_block({id, bnum, false,true,time_point()});
-      
+
       fc_dlog(logger, "canceling wait on ${p}", ("p",c->peer_name()));
       c->cancel_wait();
    }
-   
+
    void dispatch_manager::rejected_block (const block_id_type& id) {
       fc_dlog(logger,"not sending rejected transaction ${tid}",("tid",id));
       for (auto org = received_blocks.begin(); org != received_blocks.end(); org++) {
@@ -1743,7 +1743,7 @@ namespace eosio {
       }
 
    }
-   
+
    void dispatch_manager::recv_transaction (connection_ptr c, const transaction_id_type& id) {
       received_transactions.emplace_back((transaction_origin){id, c});
       if (c &&
@@ -1766,7 +1766,7 @@ namespace eosio {
          }
       }
    }
-   
+
    void dispatch_manager::recv_notice (connection_ptr c, const notice_message& msg, bool generated) {
       request_message req;
       req.req_trx.mode = none;
@@ -2180,7 +2180,7 @@ namespace eosio {
             fc_dlog(logger, "skipping duplicate check, addr == ${pa}, id = ${ni}",("pa",c->peer_addr)("ni",c->last_handshake_recv.node_id));
          }
 
-         if( msg.chain_id.id != chain_id.id) {
+         if( msg.chain_id != chain_id) {
             elog( "Peer on a different chain. Closing connection");
             c->enqueue( go_away_message(go_away_reason::wrong_chain) );
             return;
@@ -2886,7 +2886,7 @@ namespace eosio {
          }
 
       my->chain_plug = app().find_plugin<chain_plugin>();
-      my->chain_plug->get_chain_id(my->chain_id);
+      my->chain_id = app().get_plugin<chain_plugin>().get_chain_id();
       fc::rand_pseudo_bytes(my->node_id.data(), my->node_id.data_size());
       ilog("my node_id is ${id}",("id",my->node_id));
 

--- a/plugins/txn_test_gen_plugin/txn_test_gen_plugin.cpp
+++ b/plugins/txn_test_gen_plugin/txn_test_gen_plugin.cpp
@@ -79,8 +79,7 @@ struct txn_test_gen_plugin_impl {
       abi_def currency_abi_def = fc::json::from_string(eosio_token_abi).as<abi_def>();
 
       controller& cc = app().get_plugin<chain_plugin>().chain();
-      chain::chain_id_type chainid;
-      app().get_plugin<chain_plugin>().get_chain_id(chainid);
+      auto chainid = app().get_plugin<chain_plugin>().get_chain_id();
 
       fc::crypto::private_key txn_test_receiver_A_priv_key = fc::crypto::private_key::regenerate(fc::sha256(std::string(64, 'a')));
       fc::crypto::private_key txn_test_receiver_B_priv_key = fc::crypto::private_key::regenerate(fc::sha256(std::string(64, 'b')));
@@ -233,8 +232,7 @@ struct txn_test_gen_plugin_impl {
 
    void send_transaction() {
       controller& cc = app().get_plugin<chain_plugin>().chain();
-      chain::chain_id_type chainid;
-      app().get_plugin<chain_plugin>().get_chain_id(chainid);
+      auto chainid = app().get_plugin<chain_plugin>().get_chain_id();
 
       name sender("txn.test.a");
       name recipient("txn.test.b");

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -2149,7 +2149,8 @@ int main( int argc, char** argv ) {
 
    sign->set_callback([&] {
       signed_transaction trx = json_from_file_or_string(trx_json_to_sign).as<signed_transaction>();
-      chain_id_type chain_id;
+
+      fc::optional<chain_id_type> chain_id;
 
       if( str_chain_id.size() == 0 ) {
          ilog( "grabbing chain_id from nodeos" );
@@ -2167,7 +2168,7 @@ int main( int argc, char** argv ) {
       }
 
       auto priv_key = fc::crypto::private_key::regenerate(*utilities::wif_to_key(str_private_key));
-      trx.sign(priv_key, chain_id);
+      trx.sign(priv_key, *chain_id);
 
       if(push_trx) {
          auto trx_result = call(push_txn_func, packed_transaction(trx, packed_transaction::none));

--- a/programs/nodeos/main.cpp
+++ b/programs/nodeos/main.cpp
@@ -80,11 +80,13 @@ void initialize_logging()
 }
 
 enum return_codes {
-   OTHER_FAIL      = -2,
-   INITIALIZE_FAIL = -1,
-   SUCCESS         = 0,
-   BAD_ALLOC       = 1,
-   FIXED_REVERSIBLE = 2
+   OTHER_FAIL        = -2,
+   INITIALIZE_FAIL   = -1,
+   SUCCESS           = 0,
+   BAD_ALLOC         = 1,
+   DATABASE_DIRTY    = 2,
+   FIXED_REVERSIBLE  = 3,
+   EXTRACTED_GENESIS = 4
 };
 
 int main(int argc, char** argv)
@@ -103,6 +105,8 @@ int main(int argc, char** argv)
       ilog("eosio root is ${root}", ("root", root.string()));
       app().startup();
       app().exec();
+   } catch( const extract_genesis_state_exception& e ) {
+      return EXTRACTED_GENESIS;
    } catch( const fixed_reversible_db_exception& e ) {
       return FIXED_REVERSIBLE;
    } catch( const fc::exception& e ) {
@@ -117,11 +121,14 @@ int main(int argc, char** argv)
    } catch( const std::runtime_error& e ) {
       if( std::string(e.what()) == "database dirty flag set" ) {
          elog( "database dirty flag set (likely due to unclean shutdown): replay required" );
+         return DATABASE_DIRTY;
       } else if( std::string(e.what()) == "database metadata dirty flag set" ) {
          elog( "database metadata dirty flag set (likely due to unclean shutdown): replay required" );
+         return DATABASE_DIRTY;
       } else {
          elog( "${e}", ("e",e.what()));
       }
+      return OTHER_FAIL;
    } catch( const std::exception& e ) {
       elog("${e}", ("e",e.what()));
       return OTHER_FAIL;

--- a/tests/chain_tests/block_tests.cpp
+++ b/tests/chain_tests/block_tests.cpp
@@ -324,7 +324,7 @@ BOOST_AUTO_TEST_CASE(trx_uniqueness) {
                                .active   = authority(chain.get_public_key(new_account_name, "active"))
                             });
    chain.set_transaction_headers(trx, 90);
-   trx.sign(chain.get_private_key(config::system_account_name, "active"), chain_id_type());
+   trx.sign(chain.get_private_key(config::system_account_name, "active"), chain.control->get_chain_id());
    chain.push_transaction(trx);
 
    BOOST_CHECK_THROW(chain.push_transaction(trx), tx_duplicate);
@@ -346,12 +346,12 @@ BOOST_AUTO_TEST_CASE(invalid_expiration) {
                             });
    trx.ref_block_num = static_cast<uint16_t>(chain.control->head_block_num());
    trx.ref_block_prefix = static_cast<uint32_t>(chain.control->head_block_id()._hash[1]);
-   trx.sign(chain.get_private_key(config::system_account_name, "active"), chain_id_type());
+   trx.sign(chain.get_private_key(config::system_account_name, "active"), chain.control->get_chain_id());
    // Unset expiration should throw
    BOOST_CHECK_THROW(chain.push_transaction(trx), transaction_exception);
 
    memset(&trx.expiration, 0, sizeof(trx.expiration)); // currently redundant, as default is all zeros, but may not always be.
-   trx.sign(chain.get_private_key(config::system_account_name, "active"), chain_id_type());
+   trx.sign(chain.get_private_key(config::system_account_name, "active"), chain.control->get_chain_id());
    // Expired transaction (January 1970) should throw
    BOOST_CHECK_THROW(chain.push_transaction(trx), transaction_exception);
    BOOST_REQUIRE_EQUAL( chain.validate(), true );
@@ -374,7 +374,7 @@ BOOST_AUTO_TEST_CASE(transaction_expiration) {
       trx.ref_block_num = static_cast<uint16_t>(chain.control->head_block_num());
       trx.ref_block_prefix = static_cast<uint32_t>(chain.control->head_block_id()._hash[1]);
       trx.expiration = chain.control->head_block_time() + fc::microseconds(i * 1000000);
-      trx.sign(chain.get_private_key(config::system_account_name, "active"), chain_id_type());
+      trx.sign(chain.get_private_key(config::system_account_name, "active"), chain.control->get_chain_id());
 
       // expire in 1st time, pass in 2nd time
       if (i == 0)
@@ -401,7 +401,7 @@ BOOST_AUTO_TEST_CASE(invalid_tapos) {
    trx.ref_block_num = static_cast<uint16_t>(chain.control->head_block_num() + 1);
    trx.ref_block_prefix = static_cast<uint32_t>(chain.control->head_block_id()._hash[1]);
    trx.expiration = chain.control->head_block_time() + fc::microseconds(1000000);
-   trx.sign(chain.get_private_key(config::system_account_name, "active"), chain_id_type());
+   trx.sign(chain.get_private_key(config::system_account_name, "active"), chain.control->get_chain_id());
 
    BOOST_CHECK_THROW(chain.push_transaction(trx), invalid_ref_block_exception);
 
@@ -427,13 +427,13 @@ BOOST_AUTO_TEST_CASE(irrelevant_auth) {
                                         .active   = authority( chain.get_public_key( new_account_name, "active" ) )
                                 });
       chain.set_transaction_headers(trx);
-      trx.sign( chain.get_private_key( config::system_account_name, "active" ), chain_id_type()  );
+      trx.sign( chain.get_private_key( config::system_account_name, "active" ), chain.control->get_chain_id()  );
 
       chain.push_transaction(trx, skip_transaction_signatures);
       chain.control->clear_pending();
 
       // Add unneeded signature
-      trx.sign( chain.get_private_key( name("random"), "active" ), chain_id_type()  );
+      trx.sign( chain.get_private_key( name("random"), "active" ), chain.control->get_chain_id()  );
 
       // Check that it throws for irrelevant signatures
       BOOST_CHECK_THROW(chain.push_transaction( trx ), tx_irrelevant_sig);
@@ -460,7 +460,7 @@ BOOST_AUTO_TEST_CASE(no_auth) {
                                       .active   = authority()
                                 });
       chain.set_transaction_headers(trx);
-      trx.sign( chain.get_private_key( config::system_account_name, "active" ), chain_id_type()  );
+      trx.sign( chain.get_private_key( config::system_account_name, "active" ), chain.control->get_chain_id()  );
 
       // Check that it throws for no auth
       BOOST_CHECK_THROW(chain.push_transaction( trx ), action_validate_exception);
@@ -954,21 +954,21 @@ BOOST_AUTO_TEST_CASE(irrelevant_sig_soft_check) {
                                         .active   = authority( chain.get_public_key( new_account_name, "active" ) )
                                 });
       chain.set_transaction_headers(trx);
-      trx.sign( chain.get_private_key( config::system_account_name, "active" ), chain_id_type()  );
-      trx.sign( chain.get_private_key( name("random"), "active" ), chain_id_type()  );
+      trx.sign( chain.get_private_key( config::system_account_name, "active" ), chain.control->get_chain_id()  );
+      trx.sign( chain.get_private_key( name("random"), "active" ), chain.control->get_chain_id()  );
 
       // Check that it throws for irrelevant signatures
       BOOST_REQUIRE_THROW(chain.push_transaction( trx ), tx_irrelevant_sig);
 
       // Check that it throws for multiple signatures by the same key
       trx.signatures.clear();
-      trx.sign( chain.get_private_key( config::system_account_name, "active" ), chain_id_type() );
-      trx.sign( chain.get_private_key( config::system_account_name, "active" ), chain_id_type() );
+      trx.sign( chain.get_private_key( config::system_account_name, "active" ), chain.control->get_chain_id() );
+      trx.sign( chain.get_private_key( config::system_account_name, "active" ), chain.control->get_chain_id() );
       BOOST_REQUIRE_THROW(chain.push_transaction( trx ), tx_duplicate_sig);
 
       // Sign the transaction properly and push to the block
       trx.signatures.clear();
-      trx.sign( chain.get_private_key( config::system_account_name, "active" ), chain_id_type() );
+      trx.sign( chain.get_private_key( config::system_account_name, "active" ), chain.control->get_chain_id() );
       chain.push_transaction( trx );
 
       // Produce block so the transaction gets included in the block
@@ -1003,8 +1003,8 @@ BOOST_AUTO_TEST_CASE(irrelevant_sig_hard_check) {
                                            .active   = authority( chain.get_public_key( new_account_name, "active" ) )
                                    });
          chain.set_transaction_headers(trx);
-         trx.sign( chain.get_private_key( config::system_account_name, "active" ), chain_id_type()  );
-         trx.sign( chain.get_private_key( name("random"), "active" ), chain_id_type()  );
+         trx.sign( chain.get_private_key( config::system_account_name, "active" ), chain.control->get_chain_id()  );
+         trx.sign( chain.get_private_key( name("random"), "active" ), chain.control->get_chain_id()  );
 
          // Force push transaction with irrelevant signatures using a skip flag
          chain.push_transaction( trx, skip_transaction_signatures );
@@ -1035,8 +1035,8 @@ BOOST_AUTO_TEST_CASE(irrelevant_sig_hard_check) {
                                            .active   = authority( chain.get_public_key( new_account_name, "active" ) )
                                    });
          chain.set_transaction_headers(trx);
-         trx.sign( chain.get_private_key( config::system_account_name, "active" ), chain_id_type() );
-         trx.sign( chain.get_private_key( config::system_account_name, "active" ), chain_id_type() );
+         trx.sign( chain.get_private_key( config::system_account_name, "active" ), chain.control->get_chain_id() );
+         trx.sign( chain.get_private_key( config::system_account_name, "active" ), chain.control->get_chain_id() );
 
          // Force push transaction with multiple signatures by the same key using a skip flag
          chain.push_transaction( trx, skip_transaction_signatures );
@@ -1129,7 +1129,7 @@ BOOST_AUTO_TEST_CASE(get_required_keys)
       auto required_keys = chain.validating_node->get_required_keys(trx, available_keys);
       BOOST_TEST( required_keys.size() == 1 );
       BOOST_TEST( *required_keys.begin() == priv_key_needed.get_public_key() );
-      trx.sign( priv_key_needed, chain_id_type() );
+      trx.sign( priv_key_needed, chain.control->get_chain_id() );
       chain.push_transaction(trx);
 
       chain.produce_blocks();

--- a/tests/wallet_tests.cpp
+++ b/tests/wallet_tests.cpp
@@ -4,6 +4,7 @@
  */
 #include <eosio/utilities/key_conversion.hpp>
 #include <eosio/utilities/rand.hpp>
+#include <eosio/chain/genesis_state.hpp>
 #include <eosio/wallet_plugin/wallet.hpp>
 #include <eosio/wallet_plugin/wallet_manager.hpp>
 
@@ -103,7 +104,7 @@ BOOST_AUTO_TEST_CASE(wallet_manager_test)
    wm.import_key("test", key1);
    BOOST_CHECK_EQUAL(2, wm.list_keys().size());
    auto keys = wm.list_keys();
-   
+
    auto pub_pri_pair = [](const char *key) -> auto {
        private_key_type prikey = private_key_type(std::string(key));
        return std::pair<const public_key_type, private_key_type>(prikey.get_public_key(), prikey);
@@ -145,12 +146,13 @@ BOOST_AUTO_TEST_CASE(wallet_manager_test)
    private_key_type pkey3{std::string(key3)};
 
    chain::signed_transaction trx;
+   auto chain_id = genesis_state().compute_chain_id();
    flat_set<public_key_type> pubkeys;
    pubkeys.emplace(pkey1.get_public_key());
    pubkeys.emplace(pkey2.get_public_key());
    pubkeys.emplace(pkey3.get_public_key());
-   trx = wm.sign_transaction(trx, pubkeys, chain_id_type{});
-   const auto& pks = trx.get_signature_keys(chain_id_type{});
+   trx = wm.sign_transaction(trx, pubkeys, chain_id );
+   const auto& pks = trx.get_signature_keys(chain_id);
    BOOST_CHECK_EQUAL(3, pks.size());
    BOOST_CHECK(find(pks.cbegin(), pks.cend(), pkey1.get_public_key()) != pks.cend());
    BOOST_CHECK(find(pks.cbegin(), pks.cend(), pkey2.get_public_key()) != pks.cend());

--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -148,8 +148,8 @@ transaction_trace_ptr CallAction(TESTER& test, T ac, const vector<account_name>&
    trx.actions.push_back(act);
 
    test.set_transaction_headers(trx);
-   auto sigs = trx.sign(test.get_private_key(scope[0], "active"), chain_id_type());
-   trx.get_signature_keys(chain_id_type());
+   auto sigs = trx.sign(test.get_private_key(scope[0], "active"), test.control->get_chain_id());
+   trx.get_signature_keys(test.control->get_chain_id());
    auto res = test.push_transaction(trx);
    BOOST_CHECK_EQUAL(res->receipt->status, transaction_receipt::executed);
    test.produce_block();
@@ -172,8 +172,8 @@ transaction_trace_ptr CallFunction(TESTER& test, T ac, const vector<char>& data,
       trx.actions.push_back(act);
 
       test.set_transaction_headers(trx, test.DEFAULT_EXPIRATION_DELTA);
-      auto sigs = trx.sign(test.get_private_key(scope[0], "active"), chain_id_type());
-      trx.get_signature_keys(chain_id_type() );
+      auto sigs = trx.sign(test.get_private_key(scope[0], "active"), test.control->get_chain_id());
+      trx.get_signature_keys(test.control->get_chain_id() );
       auto res = test.push_transaction(trx);
       BOOST_CHECK_EQUAL(res->receipt->status, transaction_receipt::executed);
       test.produce_block();
@@ -265,8 +265,8 @@ BOOST_FIXTURE_TEST_CASE(action_receipt_tests, TESTER) { try {
       act.authorization = {{config::system_account_name, config::active_name}};
       trx.actions.push_back(act);
       this->set_transaction_headers(trx, this->DEFAULT_EXPIRATION_DELTA);
-      trx.sign(this->get_private_key(config::system_account_name, "active"), chain_id_type());
-      trx.get_signature_keys(chain_id_type() );
+      trx.sign(this->get_private_key(config::system_account_name, "active"), control->get_chain_id());
+      trx.get_signature_keys(control->get_chain_id() );
       auto res = this->push_transaction(trx);
       BOOST_CHECK_EQUAL(res->receipt->status, transaction_receipt::executed);
       this->produce_block();
@@ -335,7 +335,7 @@ BOOST_FIXTURE_TEST_CASE(action_tests, TESTER) { try {
 
    // test require_notice
    auto scope = std::vector<account_name>{N(testapi)};
-   auto test_require_notice = [](auto& test, std::vector<char>& data, std::vector<account_name>& scope){
+   auto test_require_notice = [this](auto& test, std::vector<char>& data, std::vector<account_name>& scope){
       signed_transaction trx;
       auto tm = test_api_action<TEST_METHOD("test_action", "require_notice")>{};
 
@@ -345,7 +345,7 @@ BOOST_FIXTURE_TEST_CASE(action_tests, TESTER) { try {
       trx.actions.push_back(act);
 
       test.set_transaction_headers(trx);
-      trx.sign(test.get_private_key(N(inita), "active"), chain_id_type());
+      trx.sign(test.get_private_key(N(inita), "active"), control->get_chain_id());
       auto res = test.push_transaction(trx);
       BOOST_CHECK_EQUAL(res->receipt->status, transaction_receipt::executed);
    };
@@ -397,9 +397,9 @@ BOOST_FIXTURE_TEST_CASE(action_tests, TESTER) { try {
       trx.actions.push_back(act);
 
       set_transaction_headers(trx);
-      trx.sign(get_private_key(N(testapi), "active"), chain_id_type());
-      trx.sign(get_private_key(N(acc3), "active"), chain_id_type());
-      trx.sign(get_private_key(N(acc4), "active"), chain_id_type());
+      trx.sign(get_private_key(N(testapi), "active"), control->get_chain_id());
+      trx.sign(get_private_key(N(acc3), "active"), control->get_chain_id());
+      trx.sign(get_private_key(N(acc4), "active"), control->get_chain_id());
       auto res = push_transaction(trx);
       BOOST_CHECK_EQUAL(res->receipt->status, transaction_receipt::executed);
    }
@@ -464,7 +464,7 @@ BOOST_FIXTURE_TEST_CASE(cf_action_tests, TESTER) { try {
       set_transaction_headers(trx);
 
       // signing a transaction with only context_free_actions should not be allowed
-      //      auto sigs = trx.sign(get_private_key(N(testapi), "active"), chain_id_type());
+      //      auto sigs = trx.sign(get_private_key(N(testapi), "active"), control->get_chain_id());
 
       BOOST_CHECK_EXCEPTION(push_transaction(trx), tx_no_auths,
                             [](const fc::exception& e) {
@@ -481,7 +481,7 @@ BOOST_FIXTURE_TEST_CASE(cf_action_tests, TESTER) { try {
       trx.actions.push_back(act1);
       set_transaction_headers(trx);
       // run normal passing case
-      auto sigs = trx.sign(get_private_key(N(testapi), "active"), chain_id_type());
+      auto sigs = trx.sign(get_private_key(N(testapi), "active"), control->get_chain_id());
       auto res = push_transaction(trx);
 
       BOOST_CHECK_EQUAL(res->receipt->status, transaction_receipt::executed);
@@ -495,7 +495,7 @@ BOOST_FIXTURE_TEST_CASE(cf_action_tests, TESTER) { try {
       trx.actions.push_back(act2);
       set_transaction_headers(trx);
       // run (dummy_action.b = 200) case looking for invalid use of context_free api
-      sigs = trx.sign(get_private_key(N(testapi), "active"), chain_id_type());
+      sigs = trx.sign(get_private_key(N(testapi), "active"), control->get_chain_id());
       BOOST_CHECK_EXCEPTION(push_transaction(trx), assert_exception,
                             [](const fc::exception& e) {
                                return expect_assert_message(e, "this API may only be called from context_free apply");
@@ -520,7 +520,7 @@ BOOST_FIXTURE_TEST_CASE(cf_action_tests, TESTER) { try {
             trx.context_free_actions.emplace_back(cfa_act);
             trx.signatures.clear();
             set_transaction_headers(trx);
-            sigs = trx.sign(get_private_key(N(testapi), "active"), chain_id_type());
+            sigs = trx.sign(get_private_key(N(testapi), "active"), control->get_chain_id());
             BOOST_CHECK_EXCEPTION(push_transaction(trx), assert_exception,
                  [](const fc::exception& e) {
                     return expect_assert_message(e, "only context free api's can be used in this context" );
@@ -564,7 +564,7 @@ BOOST_FIXTURE_TEST_CASE(cfa_tx_signature, TESTER)  try {
    set_transaction_headers(tx2);
 
    const private_key_type& priv_key = get_private_key("dummy", "active");
-   BOOST_TEST((std::string)tx1.sign(priv_key, chain_id_type()) != (std::string)tx2.sign(priv_key, chain_id_type()));
+   BOOST_TEST((std::string)tx1.sign(priv_key, control->get_chain_id()) != (std::string)tx2.sign(priv_key, control->get_chain_id()));
 
    BOOST_REQUIRE_EQUAL( validate(), true );
 } FC_LOG_AND_RETHROW()
@@ -590,7 +590,7 @@ BOOST_FIXTURE_TEST_CASE(cfa_stateful_api, TESTER)  try {
    action act({}, test_api_action<TEST_METHOD("test_transaction", "stateful_api")>{});
    trx.context_free_actions.push_back(act);
    set_transaction_headers(trx);
-   trx.sign( get_private_key( creator, "active" ), chain_id_type()  );
+   trx.sign( get_private_key( creator, "active" ), control->get_chain_id()  );
    BOOST_CHECK_EXCEPTION(push_transaction( trx ), fc::exception,
       [&](const fc::exception &e) {
          return expect_assert_message(e, "only context free api's can be used in this context");
@@ -620,7 +620,7 @@ BOOST_FIXTURE_TEST_CASE(deferred_cfa_failed, TESTER)  try {
    action act({}, test_api_action<TEST_METHOD("test_transaction", "stateful_api")>{});
    trx.context_free_actions.push_back(act);
    set_transaction_headers(trx, 10, 2);
-   trx.sign( get_private_key( creator, "active" ), chain_id_type()  );
+   trx.sign( get_private_key( creator, "active" ), control->get_chain_id()  );
 
    BOOST_CHECK_EXCEPTION(push_transaction( trx ), fc::exception,
       [&](const fc::exception &e) {
@@ -656,7 +656,7 @@ BOOST_FIXTURE_TEST_CASE(deferred_cfa_success, TESTER)  try {
    action act({}, test_api_action<TEST_METHOD("test_transaction", "context_free_api")>{});
    trx.context_free_actions.push_back(act);
    set_transaction_headers(trx, 10, 2);
-   trx.sign( get_private_key( creator, "active" ), chain_id_type()  );
+   trx.sign( get_private_key( creator, "active" ), control->get_chain_id()  );
    auto trace = push_transaction( trx );
    BOOST_REQUIRE(trace != nullptr);
    if (trace) {
@@ -699,8 +699,8 @@ void call_test(TESTER& test, T ac, uint32_t billed_cpu_time_us , uint32_t max_cp
    trx.actions.push_back(act);
    test.set_transaction_headers(trx);
    //trx.max_cpu_usage_ms = max_cpu_usage_ms;
-   auto sigs = trx.sign(test.get_private_key(N(testapi), "active"), chain_id_type());
-   trx.get_signature_keys(chain_id_type() );
+   auto sigs = trx.sign(test.get_private_key(N(testapi), "active"), test.control->get_chain_id());
+   trx.get_signature_keys(test.control->get_chain_id() );
    auto res = test.push_transaction( trx, fc::time_point::now() + fc::milliseconds(max_cpu_usage_ms), billed_cpu_time_us );
    BOOST_CHECK_EQUAL(res->receipt->status, transaction_receipt::executed);
    test.produce_block();
@@ -1329,11 +1329,11 @@ BOOST_FIXTURE_TEST_CASE(crypto_tests, TESTER) { try {
       auto pl = vector<permission_level>{{N(testapi), config::active_name}};
 
       action act(pl, test_api_action<TEST_METHOD("test_crypto", "test_recover_key")>{});
-		auto signatures = trx.sign(get_private_key(N(testapi), "active"), chain_id_type());
+		auto signatures = trx.sign(get_private_key(N(testapi), "active"), control->get_chain_id());
 
 		produce_block();
 
-      auto payload   = fc::raw::pack( trx.sig_digest( chain_id_type() ) );
+      auto payload   = fc::raw::pack( trx.sig_digest( control->get_chain_id() ) );
       auto pk     = fc::raw::pack( get_public_key( N(testapi), "active" ) );
       auto sigs   = fc::raw::pack( signatures );
       payload.insert( payload.end(), pk.begin(), pk.end() );
@@ -1769,8 +1769,8 @@ BOOST_FIXTURE_TEST_CASE(privileged_tests, tester) { try {
 
 		set_tapos(trx);
 
-		auto sigs = trx.sign(get_private_key(config::system_account_name, "active"), chain_id_type());
-      trx.get_signature_keys(chain_id_type() );
+		auto sigs = trx.sign(get_private_key(config::system_account_name, "active"), control->get_chain_id());
+      trx.get_signature_keys(control->get_chain_id() );
 		auto res = push_transaction(trx);
 		BOOST_CHECK_EQUAL(res.status, transaction_receipt::executed);
 	}

--- a/unittests/auth_tests.cpp
+++ b/unittests/auth_tests.cpp
@@ -407,9 +407,9 @@ try {
                                 });
 
       chain.set_transaction_headers(trx);
-      trx.sign( chain.get_private_key( acc1, "active" ), chain_id_type()  );
-      trx.sign( chain.get_private_key( acc1, "owner" ), chain_id_type()  );
-      trx.sign( chain.get_private_key( acc1a, "owner" ), chain_id_type()  );
+      trx.sign( chain.get_private_key( acc1, "active" ), chain.control->get_chain_id()  );
+      trx.sign( chain.get_private_key( acc1, "owner" ), chain.control->get_chain_id()  );
+      trx.sign( chain.get_private_key( acc1a, "owner" ), chain.control->get_chain_id()  );
       return chain.push_transaction( trx );
    };
 
@@ -459,7 +459,7 @@ try {
                                 });
 
       chain.set_transaction_headers(trx);
-      trx.sign( chain.get_private_key( creator, "active" ), chain_id_type()  );
+      trx.sign( chain.get_private_key( creator, "active" ), chain.control->get_chain_id()  );
       return chain.push_transaction( trx );
    };
 

--- a/unittests/currency_tests.cpp
+++ b/unittests/currency_tests.cpp
@@ -45,7 +45,7 @@ class currency_tester : public TESTER {
          trx.actions.emplace_back(std::move(act));
 
          set_transaction_headers(trx);
-         trx.sign(get_private_key(signer, "active"), chain_id_type());
+         trx.sign(get_private_key(signer, "active"), control->get_chain_id());
          return push_transaction(trx);
       }
 
@@ -425,7 +425,7 @@ BOOST_FIXTURE_TEST_CASE( test_proxy, currency_tester ) try {
       trx.actions.emplace_back(std::move(setowner_act));
 
       set_transaction_headers(trx);
-      trx.sign(get_private_key(N(alice), "active"), chain_id_type());
+      trx.sign(get_private_key(N(alice), "active"), control->get_chain_id());
       push_transaction(trx);
       produce_block();
       BOOST_REQUIRE_EQUAL(true, chain_has_transaction(trx.id()));
@@ -480,7 +480,7 @@ BOOST_FIXTURE_TEST_CASE( test_deferred_failure, currency_tester ) try {
       trx.actions.emplace_back(std::move(setowner_act));
 
       set_transaction_headers(trx);
-      trx.sign(get_private_key(N(bob), "active"), chain_id_type());
+      trx.sign(get_private_key(N(bob), "active"), control->get_chain_id());
       push_transaction(trx);
       produce_block();
       BOOST_REQUIRE_EQUAL(true, chain_has_transaction(trx.id()));
@@ -531,7 +531,7 @@ BOOST_FIXTURE_TEST_CASE( test_deferred_failure, currency_tester ) try {
       trx.actions.emplace_back(std::move(setowner_act));
 
       set_transaction_headers(trx);
-      trx.sign(get_private_key(N(alice), "active"), chain_id_type());
+      trx.sign(get_private_key(N(alice), "active"), control->get_chain_id());
       push_transaction(trx);
       produce_block();
       BOOST_REQUIRE_EQUAL(true, chain_has_transaction(trx.id()));

--- a/unittests/delay_tests.cpp
+++ b/unittests/delay_tests.cpp
@@ -39,7 +39,7 @@ BOOST_FIXTURE_TEST_CASE( delay_create_account, validating_tester) { try {
                              });
    set_transaction_headers(trx);
    trx.delay_sec = 3;
-   trx.sign( get_private_key( creator, "active" ), chain_id_type()  );
+   trx.sign( get_private_key( creator, "active" ), control->get_chain_id()  );
 
    auto trace = push_transaction( trx );
 
@@ -66,7 +66,7 @@ BOOST_FIXTURE_TEST_CASE( delay_error_create_account, validating_tester) { try {
                              });
    set_transaction_headers(trx);
    trx.delay_sec = 3;
-   trx.sign( get_private_key( creator, "active" ), chain_id_type()  );
+   trx.sign( get_private_key( creator, "active" ), control->get_chain_id()  );
 
    ilog( fc::json::to_pretty_string(trx) );
    auto trace = push_transaction( trx );
@@ -1705,7 +1705,7 @@ BOOST_AUTO_TEST_CASE( mindelay_test ) { try {
    trx.actions.push_back(act);
 
    chain.set_transaction_headers(trx, 30, 10);
-   trx.sign(chain.get_private_key(N(tester), "active"), chain_id_type());
+   trx.sign(chain.get_private_key(N(tester), "active"), chain.control->get_chain_id());
    trace = chain.push_transaction(trx);
    BOOST_REQUIRE_EQUAL(transaction_receipt::delayed, trace->receipt->status);
    gen_size = chain.control->db().get_index<generated_transaction_multi_index,by_trx_id>().size();
@@ -1905,7 +1905,7 @@ BOOST_AUTO_TEST_CASE( canceldelay_test ) { try {
                             chain::canceldelay{{N(tester), config::active_name}, ids[0]});
 
    chain.set_transaction_headers(trx);
-   trx.sign(chain.get_private_key(N(tester), "active"), chain_id_type());
+   trx.sign(chain.get_private_key(N(tester), "active"), chain.control->get_chain_id());
    trace = chain.push_transaction(trx);
    //wdump((fc::json::to_pretty_string(trace)));
    BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace->receipt->status);
@@ -2082,7 +2082,7 @@ BOOST_AUTO_TEST_CASE( canceldelay_test2 ) { try {
          trx.actions.emplace_back(vector<permission_level>{{N(tester), config::active_name}},
                                   chain::canceldelay{{N(tester), config::active_name}, trx_id});
          chain.set_transaction_headers(trx);
-         trx.sign(chain.get_private_key(N(tester), "active"), chain_id_type());
+         trx.sign(chain.get_private_key(N(tester), "active"), chain.control->get_chain_id());
          BOOST_REQUIRE_EXCEPTION( chain.push_transaction(trx), action_validate_exception,
                                   fc_exception_message_is("canceling_auth in canceldelay action was not found as authorization in the original delayed transaction") );
       }
@@ -2093,7 +2093,7 @@ BOOST_AUTO_TEST_CASE( canceldelay_test2 ) { try {
          trx.actions.emplace_back(vector<permission_level>{{N(tester), N(second)}},
                                   chain::canceldelay{{N(tester), N(first)}, trx_id});
          chain.set_transaction_headers(trx);
-         trx.sign(chain.get_private_key(N(tester), "second"), chain_id_type());
+         trx.sign(chain.get_private_key(N(tester), "second"), chain.control->get_chain_id());
          BOOST_REQUIRE_THROW( chain.push_transaction(trx), irrelevant_auth_exception );
          BOOST_REQUIRE_EXCEPTION( chain.push_transaction(trx), irrelevant_auth_exception,
                                   fc_exception_message_starts_with("canceldelay action declares irrelevant authority") );
@@ -2104,7 +2104,7 @@ BOOST_AUTO_TEST_CASE( canceldelay_test2 ) { try {
       trx.actions.emplace_back(vector<permission_level>{{N(tester), config::active_name}},
                                chain::canceldelay{{N(tester), N(first)}, trx_id});
       chain.set_transaction_headers(trx);
-      trx.sign(chain.get_private_key(N(tester), "active"), chain_id_type());
+      trx.sign(chain.get_private_key(N(tester), "active"), chain.control->get_chain_id());
       trace = chain.push_transaction(trx);
 
       BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace->receipt->status);
@@ -2168,7 +2168,7 @@ BOOST_AUTO_TEST_CASE( canceldelay_test2 ) { try {
       trx.actions.emplace_back(vector<permission_level>{{N(tester), N(first)}},
                                chain::canceldelay{{N(tester), N(second)}, trx_id});
       chain.set_transaction_headers(trx);
-      trx.sign(chain.get_private_key(N(tester), "first"), chain_id_type());
+      trx.sign(chain.get_private_key(N(tester), "first"), chain.control->get_chain_id());
       trace = chain.push_transaction(trx);
 
       BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace->receipt->status);
@@ -2221,7 +2221,7 @@ BOOST_AUTO_TEST_CASE( canceldelay_test2 ) { try {
          trx.actions.emplace_back(vector<permission_level>{{N(tester), N(active)}},
                                   chain::canceldelay{{N(tester), config::owner_name}, trx_id});
          chain.set_transaction_headers(trx);
-         trx.sign(chain.get_private_key(N(tester), "active"), chain_id_type());
+         trx.sign(chain.get_private_key(N(tester), "active"), chain.control->get_chain_id());
          BOOST_REQUIRE_THROW( chain.push_transaction(trx), irrelevant_auth_exception );
       }
 
@@ -2230,7 +2230,7 @@ BOOST_AUTO_TEST_CASE( canceldelay_test2 ) { try {
       trx.actions.emplace_back(vector<permission_level>{{N(tester), config::owner_name}},
                                chain::canceldelay{{N(tester), config::owner_name}, trx_id});
       chain.set_transaction_headers(trx);
-      trx.sign(chain.get_private_key(N(tester), "owner"), chain_id_type());
+      trx.sign(chain.get_private_key(N(tester), "owner"), chain.control->get_chain_id());
       trace = chain.push_transaction(trx);
 
       BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace->receipt->status);
@@ -2372,14 +2372,14 @@ BOOST_FIXTURE_TEST_CASE( delay_expired, validating_tester) { try {
    set_transaction_headers(trx);
    trx.delay_sec = 3;
    trx.expiration = control->head_block_time() + fc::microseconds(1000000);
-   trx.sign( get_private_key( creator, "active" ), chain_id_type()  );
+   trx.sign( get_private_key( creator, "active" ), control->get_chain_id()  );
 
    auto trace = push_transaction( trx );
 
    BOOST_REQUIRE_EQUAL(transaction_receipt_header::delayed, trace->receipt->status);
 
    signed_block_ptr sb = produce_block();
-  
+
    sb  = produce_block();
 
    BOOST_REQUIRE_EQUAL(transaction_receipt_header::delayed, trace->receipt->status);
@@ -2389,7 +2389,7 @@ BOOST_FIXTURE_TEST_CASE( delay_expired, validating_tester) { try {
    BOOST_REQUIRE_EQUAL(transaction_receipt_header::expired, sb->transactions[0].status);
 
    create_account(a); // account can still be created
-   
+
 } FC_LOG_AND_RETHROW() }
 
 

--- a/unittests/dice_tests.cpp
+++ b/unittests/dice_tests.cpp
@@ -40,7 +40,7 @@ struct cancel_offer_t {
    checksum256_type commitment;
 
    static account_name get_account() { return N(dice); }
-   static action_name get_name() {return N(canceloffer); } 
+   static action_name get_name() {return N(canceloffer); }
 };
 FC_REFLECT(cancel_offer_t, (commitment));
 
@@ -49,7 +49,7 @@ struct reveal_t {
    checksum256_type source;
 
    static account_name get_account() { return N(dice); }
-   static action_name get_name() {return N(reveal); } 
+   static action_name get_name() {return N(reveal); }
 };
 FC_REFLECT(reveal_t, (commitment)(source));
 
@@ -58,7 +58,7 @@ struct deposit_t {
    asset        amount;
 
    static account_name get_account() { return N(dice); }
-   static action_name get_name() {return N(deposit); } 
+   static action_name get_name() {return N(deposit); }
 };
 FC_REFLECT( deposit_t, (from)(amount) );
 
@@ -67,7 +67,7 @@ struct withdraw_t {
    asset        amount;
 
    static account_name get_account() { return N(dice); }
-   static action_name get_name() {return N(withdraw); } 
+   static action_name get_name() {return N(withdraw); }
 };
 FC_REFLECT( withdraw_t, (to)(amount) );
 
@@ -107,7 +107,7 @@ struct dice_tester : TESTER {
          offer_bet_t{amount, account, commitment} );
       trx.actions.push_back(act);
       set_transaction_headers(trx);
-      trx.sign(get_private_key( account, "active" ), chain_id_type());
+      trx.sign(get_private_key( account, "active" ), control->get_chain_id());
       auto ptrx = packed_transaction(trx,packed_transaction::none);
       push_transaction(ptrx);
    }
@@ -118,7 +118,7 @@ struct dice_tester : TESTER {
          cancel_offer_t{commitment} );
       trx.actions.push_back(act);
       set_transaction_headers(trx);
-      trx.sign(get_private_key( account, "active" ), chain_id_type());
+      trx.sign(get_private_key( account, "active" ), control->get_chain_id());
       auto ptrx = packed_transaction(trx,packed_transaction::none);
       push_transaction(ptrx);
    }
@@ -129,7 +129,7 @@ struct dice_tester : TESTER {
          deposit_t{account, amount} );
       trx.actions.push_back(act);
       set_transaction_headers(trx);
-      trx.sign(get_private_key( account, "active" ), chain_id_type());
+      trx.sign(get_private_key( account, "active" ), control->get_chain_id());
       auto ptrx = packed_transaction(trx,packed_transaction::none);
       push_transaction(ptrx);
    }
@@ -140,7 +140,7 @@ struct dice_tester : TESTER {
          withdraw_t{account, amount} );
       trx.actions.push_back(act);
       set_transaction_headers(trx);
-      trx.sign(get_private_key( account, "active" ), chain_id_type());
+      trx.sign(get_private_key( account, "active" ), control->get_chain_id());
       auto ptrx = packed_transaction(trx,packed_transaction::none);
       push_transaction(ptrx);
    }
@@ -151,7 +151,7 @@ struct dice_tester : TESTER {
          reveal_t{commitment, source} );
       trx.actions.push_back(act);
       set_transaction_headers(trx);
-      trx.sign(get_private_key( account, "active" ), chain_id_type());
+      trx.sign(get_private_key( account, "active" ), control->get_chain_id());
       auto ptrx = packed_transaction(trx,packed_transaction::none);
       push_transaction(ptrx);
    }
@@ -225,12 +225,12 @@ BOOST_AUTO_TEST_SUITE(dice_tests)
 BOOST_FIXTURE_TEST_CASE( dice_test, dice_tester ) try {
 
    create_accounts( {N(eosio.token), N(dice),N(alice),N(bob),N(carol),N(david)}, false);
-   
+
    set_code(N(eosio.token), eosio_token_wast);
    set_abi(N(eosio.token), eosio_token_abi);
 
    produce_block();
-   
+
    add_dice_authority(N(alice));
    add_dice_authority(N(bob));
    add_dice_authority(N(carol));
@@ -258,7 +258,7 @@ BOOST_FIXTURE_TEST_CASE( dice_test, dice_tester ) try {
    produce_block();
 
    // Alice deposits 1000
-   deposit( N(alice), core_from_string("1000.0000")); 
+   deposit( N(alice), core_from_string("1000.0000"));
    produce_block();
 
    BOOST_REQUIRE_EQUAL( balance_of(N(alice)), core_from_string("1000.0000"));
@@ -266,13 +266,13 @@ BOOST_FIXTURE_TEST_CASE( dice_test, dice_tester ) try {
 
    // Alice tries to bet 0 (fail)
    // secret : 9b886346e1351d4144d0b8392a975612eb0f8b6de7eae1cc9bcc55eb52be343c
-   BOOST_CHECK_THROW( offer_bet( N(alice), core_from_string("0.0000"), 
+   BOOST_CHECK_THROW( offer_bet( N(alice), core_from_string("0.0000"),
       commitment_for("9b886346e1351d4144d0b8392a975612eb0f8b6de7eae1cc9bcc55eb52be343c")
    ), fc::exception);
-   
+
    // Alice bets 10 (success)
    // secret : 0ba044d2833758ee2c8f24d8a3f70c82c334abe6ce13219a4cf3b862abb03c46
-   offer_bet( N(alice), core_from_string("10.0000"), 
+   offer_bet( N(alice), core_from_string("10.0000"),
       commitment_for("0ba044d2833758ee2c8f24d8a3f70c82c334abe6ce13219a4cf3b862abb03c46")
    );
    produce_block();
@@ -286,14 +286,14 @@ BOOST_FIXTURE_TEST_CASE( dice_test, dice_tester ) try {
 
    // Alice tries to bet 1000 (fail)
    // secret : a512f6b1b589a8906d574e9de74a529e504a5c53a760f0991a3e00256c027971
-   BOOST_CHECK_THROW( offer_bet( N(alice), core_from_string("1000.0000"), 
+   BOOST_CHECK_THROW( offer_bet( N(alice), core_from_string("1000.0000"),
       commitment_for("a512f6b1b589a8906d574e9de74a529e504a5c53a760f0991a3e00256c027971")
    ), fc::exception);
    produce_block();
 
    // Bob tries to bet 90 without deposit
    // secret : 4facfc98932dde46fdc4403125a16337f6879a842a7ff8b0dc8e1ecddd59f3c8
-   BOOST_CHECK_THROW( offer_bet( N(bob), core_from_string("90.0000"), 
+   BOOST_CHECK_THROW( offer_bet( N(bob), core_from_string("90.0000"),
       commitment_for("4facfc98932dde46fdc4403125a16337f6879a842a7ff8b0dc8e1ecddd59f3c8")
    ), fc::exception);
    produce_block();
@@ -304,7 +304,7 @@ BOOST_FIXTURE_TEST_CASE( dice_test, dice_tester ) try {
 
    // Bob bets 11 (success)
    // secret : eec3272712d974c474a3e7b4028b53081344a5f50008e9ccf918ba0725a8d784
-   offer_bet( N(bob), core_from_string("11.0000"), 
+   offer_bet( N(bob), core_from_string("11.0000"),
       commitment_for("eec3272712d974c474a3e7b4028b53081344a5f50008e9ccf918ba0725a8d784")
    );
    produce_block();
@@ -319,14 +319,14 @@ BOOST_FIXTURE_TEST_CASE( dice_test, dice_tester ) try {
 
    // Carol bets 10 (success)
    // secret : 3efb4bd5e19b780f4980c919330c0306f8157f93db1fc72c7cefec63e0e7f37a
-   offer_bet( N(carol), core_from_string("10.0000"), 
+   offer_bet( N(carol), core_from_string("10.0000"),
       commitment_for("3efb4bd5e19b780f4980c919330c0306f8157f93db1fc72c7cefec63e0e7f37a")
    );
    produce_block();
 
    BOOST_REQUIRE_EQUAL( open_games(N(alice)), 1);
    BOOST_REQUIRE_EQUAL( open_offers(N(alice)), 0);
-   
+
    BOOST_REQUIRE_EQUAL( open_games(N(carol)), 1);
    BOOST_REQUIRE_EQUAL( open_offers(N(carol)), 0);
 
@@ -334,42 +334,42 @@ BOOST_FIXTURE_TEST_CASE( dice_test, dice_tester ) try {
 
 
    // Alice tries to cancel a nonexistent bet (fail)
-   BOOST_CHECK_THROW( cancel_offer( N(alice), 
+   BOOST_CHECK_THROW( cancel_offer( N(alice),
       commitment_for("00000000000000000000000000000000000000000000000000000000abb03c46")
    ), fc::exception);
 
    // Alice tries to cancel an in-game bet (fail)
-   BOOST_CHECK_THROW( cancel_offer( N(alice), 
+   BOOST_CHECK_THROW( cancel_offer( N(alice),
       commitment_for("0ba044d2833758ee2c8f24d8a3f70c82c334abe6ce13219a4cf3b862abb03c46")
    ), fc::exception);
 
    // Alice reveals secret (success)
-   reveal( N(alice), 
+   reveal( N(alice),
       commitment_for("0ba044d2833758ee2c8f24d8a3f70c82c334abe6ce13219a4cf3b862abb03c46"),
       checksum_type("0ba044d2833758ee2c8f24d8a3f70c82c334abe6ce13219a4cf3b862abb03c46")
    );
    produce_block();
 
    // Alice tries to reveal again (fail)
-   BOOST_CHECK_THROW( reveal( N(alice), 
+   BOOST_CHECK_THROW( reveal( N(alice),
       commitment_for("0ba044d2833758ee2c8f24d8a3f70c82c334abe6ce13219a4cf3b862abb03c46"),
       checksum_type("0ba044d2833758ee2c8f24d8a3f70c82c334abe6ce13219a4cf3b862abb03c46")
    ), fc::exception);
 
    // Bob tries to reveal an invalid (secret,commitment) pair (fail)
-   BOOST_CHECK_THROW( reveal( N(bob), 
+   BOOST_CHECK_THROW( reveal( N(bob),
       commitment_for("121344d2833758ee2c8f24d8a3f70c82c334abe6ce13219a4cf3b862abb03c46"),
       checksum_type("141544d2833758ee2c8f24d8a3f70c82c334abe6ce13219a4cf3b862abb03c46")
    ), fc::exception);
 
    // Bob tries to reveal a valid (secret,commitment) pair that has no offer/game (fail)
-   BOOST_CHECK_THROW( reveal( N(bob), 
+   BOOST_CHECK_THROW( reveal( N(bob),
       commitment_for("e48c6884bb97ac5f5951df6012ce79f63bb8549ad0111315ad9ecbaf4c9b1eb8"),
       checksum_type("e48c6884bb97ac5f5951df6012ce79f63bb8549ad0111315ad9ecbaf4c9b1eb8")
    ), fc::exception);
 
    // Bob reveals Carol's secret (success)
-   reveal( N(bob), 
+   reveal( N(bob),
       commitment_for("3efb4bd5e19b780f4980c919330c0306f8157f93db1fc72c7cefec63e0e7f37a"),
       checksum_type("3efb4bd5e19b780f4980c919330c0306f8157f93db1fc72c7cefec63e0e7f37a")
    );
@@ -377,7 +377,7 @@ BOOST_FIXTURE_TEST_CASE( dice_test, dice_tester ) try {
    BOOST_REQUIRE_EQUAL( open_games(N(alice)), 0);
    BOOST_REQUIRE_EQUAL( open_offers(N(alice)), 0);
    BOOST_REQUIRE_EQUAL( balance_of(N(alice)), core_from_string("1010.0000"));
-   
+
    BOOST_REQUIRE_EQUAL( open_games(N(carol)), 0);
    BOOST_REQUIRE_EQUAL( open_offers(N(carol)), 0);
    BOOST_REQUIRE_EQUAL( balance_of(N(carol)), core_from_string("290.0000"));
@@ -386,19 +386,19 @@ BOOST_FIXTURE_TEST_CASE( dice_test, dice_tester ) try {
    withdraw( N(alice), core_from_string("1009.0000"));
    BOOST_REQUIRE_EQUAL( balance_of(N(alice)), core_from_string("1.0000"));
 
-   BOOST_REQUIRE_EQUAL( 
+   BOOST_REQUIRE_EQUAL(
       get_currency_balance(N(eosio.token), symbol(CORE_SYMBOL), N(alice)),
       core_from_string("10009.0000")
    );
 
    // Alice withdraw 2 (fail)
-   BOOST_CHECK_THROW( withdraw( N(alice), core_from_string("2.0000")), 
+   BOOST_CHECK_THROW( withdraw( N(alice), core_from_string("2.0000")),
       fc::exception);
 
    // Alice withdraw 1 (success)
    withdraw( N(alice), core_from_string("1.0000"));
 
-   BOOST_REQUIRE_EQUAL( 
+   BOOST_REQUIRE_EQUAL(
       get_currency_balance(N(eosio.token), symbol(CORE_SYMBOL), N(alice)),
       core_from_string("10010.0000")
    );

--- a/unittests/eosio_system_tester.hpp
+++ b/unittests/eosio_system_tester.hpp
@@ -125,7 +125,7 @@ public:
                                 );
 
       set_transaction_headers(trx);
-      trx.sign( get_private_key( creator, "active" ), chain_id_type()  );
+      trx.sign( get_private_key( creator, "active" ), control->get_chain_id()  );
       return push_transaction( trx );
    }
 
@@ -168,7 +168,7 @@ public:
                                 );
 
       set_transaction_headers(trx);
-      trx.sign( get_private_key( creator, "active" ), chain_id_type()  );
+      trx.sign( get_private_key( creator, "active" ), control->get_chain_id()  );
       return push_transaction( trx );
    }
 
@@ -209,7 +209,7 @@ public:
       }
 
       set_transaction_headers(trx);
-      trx.sign( get_private_key( creator, "active" ), chain_id_type()  );
+      trx.sign( get_private_key( creator, "active" ), control->get_chain_id()  );
       return push_transaction( trx );
    }
 

--- a/unittests/exchange_tests.cpp
+++ b/unittests/exchange_tests.cpp
@@ -70,7 +70,7 @@ class exchange_tester : public TESTER {
          signed_transaction trx;
          trx.actions.emplace_back(std::move(act));
          set_transaction_headers(trx);
-         trx.sign(get_private_key(signer, "active"), chain_id_type());
+         trx.sign(get_private_key(signer, "active"), control->get_chain_id());
          return push_transaction(trx);
       }
 
@@ -153,7 +153,7 @@ class exchange_tester : public TESTER {
                  ("maximum_supply", maxsupply )
                  ("can_freeze", 0)
                  ("can_recall", 0)
-                 ("can_whitelist", 0)                 
+                 ("can_whitelist", 0)
          );
       }
 

--- a/unittests/misc_tests.cpp
+++ b/unittests/misc_tests.cpp
@@ -569,9 +569,9 @@ BOOST_AUTO_TEST_CASE(transaction_test) { try {
    trx.expiration = fc::time_point::now();
    trx.validate();
    BOOST_CHECK_EQUAL(0, trx.signatures.size());
-   ((const signed_transaction &)trx).sign( test.get_private_key( N(eosio), "active" ), chain_id_type());
+   ((const signed_transaction &)trx).sign( test.get_private_key( N(eosio), "active" ), test.control->get_chain_id());
    BOOST_CHECK_EQUAL(0, trx.signatures.size());
-   trx.sign( test.get_private_key( N(eosio), "active" ), chain_id_type()  );
+   trx.sign( test.get_private_key( N(eosio), "active" ), test.control->get_chain_id()  );
    BOOST_CHECK_EQUAL(1, trx.signatures.size());
    trx.validate();
 

--- a/unittests/multi_index_tests.cpp
+++ b/unittests/multi_index_tests.cpp
@@ -44,7 +44,7 @@ BOOST_FIXTURE_TEST_CASE( multi_index_load, TESTER ) try {
       );
       trx.actions.emplace_back(std::move(trigger_act));
       set_transaction_headers(trx);
-      trx.sign(get_private_key(N(multitest), "active"), chain_id_type());
+      trx.sign(get_private_key(N(multitest), "active"), control->get_chain_id());
       push_transaction(trx);
    }
 
@@ -61,7 +61,7 @@ BOOST_FIXTURE_TEST_CASE( multi_index_load, TESTER ) try {
       );
       trx.actions.emplace_back(std::move(trigger_act));
       set_transaction_headers(trx);
-      trx.sign(get_private_key(N(multitest), "active"), chain_id_type());
+      trx.sign(get_private_key(N(multitest), "active"), control->get_chain_id());
       push_transaction(trx);
    }
 

--- a/unittests/multisig_tests.cpp
+++ b/unittests/multisig_tests.cpp
@@ -91,7 +91,7 @@ public:
                                 );
 
       set_transaction_headers(trx);
-      trx.sign( get_private_key( creator, "active" ), chain_id_type()  );
+      trx.sign( get_private_key( creator, "active" ), control->get_chain_id()  );
       return push_transaction( trx );
    }
    void create_currency( name contract, name manager, asset maxsupply ) {

--- a/unittests/wasm_tests.cpp
+++ b/unittests/wasm_tests.cpp
@@ -91,7 +91,7 @@ BOOST_FIXTURE_TEST_CASE( basic_test, TESTER ) try {
       trx.actions[0].authorization = {{N(asserter),config::active_name}};
 
       set_transaction_headers(trx);
-      trx.sign( get_private_key( N(asserter), "active" ), chain_id_type() );
+      trx.sign( get_private_key( N(asserter), "active" ), control->get_chain_id() );
       auto result = push_transaction( trx );
       BOOST_CHECK_EQUAL(result->receipt->status, transaction_receipt::executed);
       BOOST_CHECK_EQUAL(result->action_traces.size(), 1);
@@ -117,7 +117,7 @@ BOOST_FIXTURE_TEST_CASE( basic_test, TESTER ) try {
                                 assertdef {0, "Should Assert!"} );
 
       set_transaction_headers(trx);
-      trx.sign( get_private_key( N(asserter), "active" ), chain_id_type() );
+      trx.sign( get_private_key( N(asserter), "active" ), control->get_chain_id() );
       yes_assert_id = trx.id();
 
       BOOST_CHECK_THROW(push_transaction( trx ), eosio_assert_message_exception);
@@ -150,7 +150,7 @@ BOOST_FIXTURE_TEST_CASE( prove_mem_reset, TESTER ) try {
                                 provereset {} );
 
       set_transaction_headers(trx);
-      trx.sign( get_private_key( N(asserter), "active" ), chain_id_type() );
+      trx.sign( get_private_key( N(asserter), "active" ), control->get_chain_id() );
       push_transaction( trx );
       produce_blocks(1);
       BOOST_REQUIRE_EQUAL(true, chain_has_transaction(trx.id()));
@@ -204,7 +204,7 @@ BOOST_FIXTURE_TEST_CASE( abi_from_variant, TESTER ) try {
    signed_transaction trx;
    abi_serializer::from_variant(pretty_trx, trx, resolver);
    set_transaction_headers(trx);
-   trx.sign( get_private_key( N(asserter), "active" ), chain_id_type() );
+   trx.sign( get_private_key( N(asserter), "active" ), control->get_chain_id() );
    push_transaction( trx );
    produce_blocks(1);
    BOOST_REQUIRE_EQUAL(true, chain_has_transaction(trx.id()));
@@ -230,7 +230,7 @@ BOOST_FIXTURE_TEST_CASE( f32_tests, TESTER ) try {
       trx.actions.push_back(act);
 
       set_transaction_headers(trx);
-      trx.sign(get_private_key( N(f32_tests), "active" ), chain_id_type());
+      trx.sign(get_private_key( N(f32_tests), "active" ), control->get_chain_id());
       push_transaction(trx);
       produce_blocks(1);
       BOOST_REQUIRE_EQUAL(true, chain_has_transaction(trx.id()));
@@ -253,7 +253,7 @@ BOOST_FIXTURE_TEST_CASE( f32_test_bitwise, TESTER ) try {
       trx.actions.push_back(act);
 
       set_transaction_headers(trx);
-      trx.sign(get_private_key( N(f32_tests), "active" ), chain_id_type());
+      trx.sign(get_private_key( N(f32_tests), "active" ), control->get_chain_id());
       push_transaction(trx);
       produce_blocks(1);
       BOOST_REQUIRE_EQUAL(true, chain_has_transaction(trx.id()));
@@ -276,7 +276,7 @@ BOOST_FIXTURE_TEST_CASE( f32_test_cmp, TESTER ) try {
       trx.actions.push_back(act);
 
       set_transaction_headers(trx);
-      trx.sign(get_private_key( N(f32_tests), "active" ), chain_id_type());
+      trx.sign(get_private_key( N(f32_tests), "active" ), control->get_chain_id());
       push_transaction(trx);
       produce_blocks(1);
       BOOST_REQUIRE_EQUAL(true, chain_has_transaction(trx.id()));
@@ -301,7 +301,7 @@ BOOST_FIXTURE_TEST_CASE( f64_tests, TESTER ) try {
       trx.actions.push_back(act);
 
       set_transaction_headers(trx);
-      trx.sign(get_private_key( N(f_tests), "active" ), chain_id_type());
+      trx.sign(get_private_key( N(f_tests), "active" ), control->get_chain_id());
       push_transaction(trx);
       produce_blocks(1);
       BOOST_REQUIRE_EQUAL(true, chain_has_transaction(trx.id()));
@@ -324,7 +324,7 @@ BOOST_FIXTURE_TEST_CASE( f64_test_bitwise, TESTER ) try {
       trx.actions.push_back(act);
 
       set_transaction_headers(trx);
-      trx.sign(get_private_key( N(f_tests), "active" ), chain_id_type());
+      trx.sign(get_private_key( N(f_tests), "active" ), control->get_chain_id());
       push_transaction(trx);
       produce_blocks(1);
       BOOST_REQUIRE_EQUAL(true, chain_has_transaction(trx.id()));
@@ -347,7 +347,7 @@ BOOST_FIXTURE_TEST_CASE( f64_test_cmp, TESTER ) try {
       trx.actions.push_back(act);
 
       set_transaction_headers(trx);
-      trx.sign(get_private_key( N(f_tests), "active" ), chain_id_type());
+      trx.sign(get_private_key( N(f_tests), "active" ), control->get_chain_id());
       push_transaction(trx);
       produce_blocks(1);
       BOOST_REQUIRE_EQUAL(true, chain_has_transaction(trx.id()));
@@ -373,7 +373,7 @@ BOOST_FIXTURE_TEST_CASE( f32_f64_conversion_tests, tester ) try {
       trx.actions.push_back(act);
 
       set_transaction_headers(trx);
-      trx.sign(get_private_key( N(f_tests), "active" ), chain_id_type());
+      trx.sign(get_private_key( N(f_tests), "active" ), control->get_chain_id());
       push_transaction(trx);
       produce_blocks(1);
       BOOST_REQUIRE_EQUAL(true, chain_has_transaction(trx.id()));
@@ -402,7 +402,7 @@ BOOST_FIXTURE_TEST_CASE( f32_f64_overflow_tests, tester ) try {
       trx.actions.push_back(act);
 
       set_transaction_headers(trx);
-      trx.sign(get_private_key( N(f_tests)+count, "active" ), chain_id_type());
+      trx.sign(get_private_key( N(f_tests)+count, "active" ), control->get_chain_id());
 
       try {
          push_transaction(trx);
@@ -500,7 +500,7 @@ BOOST_FIXTURE_TEST_CASE(misaligned_tests, tester ) try {
       trx.actions.push_back(act);
 
       set_transaction_headers(trx);
-      trx.sign(get_private_key( N(aligncheck), "active" ), chain_id_type());
+      trx.sign(get_private_key( N(aligncheck), "active" ), control->get_chain_id());
       push_transaction(trx);
       produce_block();
 
@@ -565,7 +565,7 @@ BOOST_FIXTURE_TEST_CASE(cpu_usage_tests, tester ) try {
 
       set_transaction_headers(trx);
       trx.max_cpu_usage_ms = limit++;
-      trx.sign(get_private_key( N(f_tests), "active" ), chain_id_type());
+      trx.sign(get_private_key( N(f_tests), "active" ), control->get_chain_id());
 
       try {
          push_transaction(trx);
@@ -625,7 +625,7 @@ BOOST_FIXTURE_TEST_CASE(weighted_cpu_limit_tests, tester ) try {
       }
 
       set_transaction_headers(trx);
-      trx.sign(get_private_key( N(f_tests), "active" ), chain_id_type());
+      trx.sign(get_private_key( N(f_tests), "active" ), control->get_chain_id());
 
       try {
          push_transaction(trx, fc::time_point::maximum(), 0);
@@ -665,7 +665,7 @@ BOOST_FIXTURE_TEST_CASE( check_entry_behavior, TESTER ) try {
    trx.actions.push_back(act);
 
    set_transaction_headers(trx);
-   trx.sign(get_private_key( N(entrycheck), "active" ), chain_id_type());
+   trx.sign(get_private_key( N(entrycheck), "active" ), control->get_chain_id());
    push_transaction(trx);
    produce_blocks(1);
    BOOST_REQUIRE_EQUAL(true, chain_has_transaction(trx.id()));
@@ -689,7 +689,7 @@ BOOST_FIXTURE_TEST_CASE( check_entry_behavior_2, TESTER ) try {
    trx.actions.push_back(act);
 
    set_transaction_headers(trx);
-   trx.sign(get_private_key( N(entrycheck), "active" ), chain_id_type());
+   trx.sign(get_private_key( N(entrycheck), "active" ), control->get_chain_id());
    push_transaction(trx);
    produce_blocks(1);
    BOOST_REQUIRE_EQUAL(true, chain_has_transaction(trx.id()));
@@ -719,7 +719,7 @@ BOOST_FIXTURE_TEST_CASE( simple_no_memory_check, TESTER ) try {
    trx.actions.push_back(act);
    trx.expiration = control->head_block_time();
    set_transaction_headers(trx);
-   trx.sign(get_private_key( N(nomem), "active" ), chain_id_type());
+   trx.sign(get_private_key( N(nomem), "active" ), control->get_chain_id());
    BOOST_CHECK_THROW(push_transaction( trx ), wasm_execution_error);
 } FC_LOG_AND_RETHROW()
 
@@ -750,7 +750,7 @@ BOOST_FIXTURE_TEST_CASE( check_global_reset, TESTER ) try {
    }
 
    set_transaction_headers(trx);
-   trx.sign(get_private_key( N(globalreset), "active" ), chain_id_type());
+   trx.sign(get_private_key( N(globalreset), "active" ), control->get_chain_id());
    push_transaction(trx);
    produce_blocks(1);
    BOOST_REQUIRE_EQUAL(true, chain_has_transaction(trx.id()));
@@ -788,7 +788,7 @@ BOOST_FIXTURE_TEST_CASE( stl_test, TESTER ) try {
         trx.actions.push_back(std::move(msg_act));
 
         set_transaction_headers(trx);
-        trx.sign(get_private_key(N(stltest), "active"), chain_id_type());
+        trx.sign(get_private_key(N(stltest), "active"), control->get_chain_id());
         push_transaction(trx);
         produce_block();
 
@@ -818,7 +818,7 @@ BOOST_FIXTURE_TEST_CASE( big_memory, TESTER ) try {
    trx.actions.push_back(act);
 
    set_transaction_headers(trx);
-   trx.sign(get_private_key( N(bigmem), "active" ), chain_id_type());
+   trx.sign(get_private_key( N(bigmem), "active" ), control->get_chain_id());
    //but should not be able to grow beyond largest page
    push_transaction(trx);
 
@@ -998,7 +998,7 @@ BOOST_FIXTURE_TEST_CASE(noop, TESTER) try {
       trx.actions.emplace_back(std::move(act));
 
       set_transaction_headers(trx);
-      trx.sign(get_private_key(N(noop), "active"), chain_id_type());
+      trx.sign(get_private_key(N(noop), "active"), control->get_chain_id());
       push_transaction(trx);
       produce_block();
 
@@ -1022,7 +1022,7 @@ BOOST_FIXTURE_TEST_CASE(noop, TESTER) try {
       trx.actions.emplace_back(std::move(act));
 
       set_transaction_headers(trx);
-      trx.sign(get_private_key(N(alice), "active"), chain_id_type());
+      trx.sign(get_private_key(N(alice), "active"), control->get_chain_id());
       push_transaction(trx);
       produce_block();
 
@@ -1054,7 +1054,7 @@ BOOST_FIXTURE_TEST_CASE(eosio_abi, TESTER) try {
                                    .active   = authority( get_public_key( a, "active" ) )
                              });
    set_transaction_headers(trx);
-   trx.sign( get_private_key( config::system_account_name, "active" ), chain_id_type()  );
+   trx.sign( get_private_key( config::system_account_name, "active" ), control->get_chain_id()  );
    auto result = push_transaction( trx );
 
    fc::variant pretty_output;
@@ -1085,7 +1085,7 @@ BOOST_FIXTURE_TEST_CASE( check_table_maximum, TESTER ) try {
    act.authorization = vector<permission_level>{{N(tbl),config::active_name}};
    trx.actions.push_back(act);
       set_transaction_headers(trx);
-   trx.sign(get_private_key( N(tbl), "active" ), chain_id_type());
+   trx.sign(get_private_key( N(tbl), "active" ), control->get_chain_id());
    push_transaction(trx);
    }
 
@@ -1099,7 +1099,7 @@ BOOST_FIXTURE_TEST_CASE( check_table_maximum, TESTER ) try {
    act.authorization = vector<permission_level>{{N(tbl),config::active_name}};
    trx.actions.push_back(act);
       set_transaction_headers(trx);
-   trx.sign(get_private_key( N(tbl), "active" ), chain_id_type());
+   trx.sign(get_private_key( N(tbl), "active" ), control->get_chain_id());
    push_transaction(trx);
    }
 
@@ -1113,7 +1113,7 @@ BOOST_FIXTURE_TEST_CASE( check_table_maximum, TESTER ) try {
    act.authorization = vector<permission_level>{{N(tbl),config::active_name}};
    trx.actions.push_back(act);
       set_transaction_headers(trx);
-   trx.sign(get_private_key( N(tbl), "active" ), chain_id_type());
+   trx.sign(get_private_key( N(tbl), "active" ), control->get_chain_id());
    push_transaction(trx);
    }
 
@@ -1127,7 +1127,7 @@ BOOST_FIXTURE_TEST_CASE( check_table_maximum, TESTER ) try {
    act.authorization = vector<permission_level>{{N(tbl),config::active_name}};
    trx.actions.push_back(act);
       set_transaction_headers(trx);
-   trx.sign(get_private_key( N(tbl), "active" ), chain_id_type());
+   trx.sign(get_private_key( N(tbl), "active" ), control->get_chain_id());
 
    //should fail, a check to make sure assert() in wasm is being evaluated correctly
    BOOST_CHECK_THROW(push_transaction(trx), eosio_assert_message_exception);
@@ -1143,7 +1143,7 @@ BOOST_FIXTURE_TEST_CASE( check_table_maximum, TESTER ) try {
    act.authorization = vector<permission_level>{{N(tbl),config::active_name}};
    trx.actions.push_back(act);
       set_transaction_headers(trx);
-   trx.sign(get_private_key( N(tbl), "active" ), chain_id_type());
+   trx.sign(get_private_key( N(tbl), "active" ), control->get_chain_id());
 
    //should fail, this element index (5) does not exist
    BOOST_CHECK_THROW(push_transaction(trx), eosio::chain::wasm_execution_error);
@@ -1159,7 +1159,7 @@ BOOST_FIXTURE_TEST_CASE( check_table_maximum, TESTER ) try {
    act.authorization = vector<permission_level>{{N(tbl),config::active_name}};
    trx.actions.push_back(act);
       set_transaction_headers(trx);
-   trx.sign(get_private_key( N(tbl), "active" ), chain_id_type());
+   trx.sign(get_private_key( N(tbl), "active" ), control->get_chain_id());
 
    //should fail, this element index is out of range
    BOOST_CHECK_THROW(push_transaction(trx), eosio::chain::wasm_execution_error);
@@ -1179,7 +1179,7 @@ BOOST_FIXTURE_TEST_CASE( check_table_maximum, TESTER ) try {
    act.authorization = vector<permission_level>{{N(tbl),config::active_name}};
    trx.actions.push_back(act);
       set_transaction_headers(trx);
-   trx.sign(get_private_key( N(tbl), "active" ), chain_id_type());
+   trx.sign(get_private_key( N(tbl), "active" ), control->get_chain_id());
    push_transaction(trx);
    }
 
@@ -1192,7 +1192,7 @@ BOOST_FIXTURE_TEST_CASE( check_table_maximum, TESTER ) try {
    act.authorization = vector<permission_level>{{N(tbl),config::active_name}};
    trx.actions.push_back(act);
    set_transaction_headers(trx);
-   trx.sign(get_private_key( N(tbl), "active" ), chain_id_type());
+   trx.sign(get_private_key( N(tbl), "active" ), control->get_chain_id());
    push_transaction(trx);
    }
    set_code(N(tbl), table_checker_small_wast);
@@ -1206,7 +1206,7 @@ BOOST_FIXTURE_TEST_CASE( check_table_maximum, TESTER ) try {
    act.authorization = vector<permission_level>{{N(tbl),config::active_name}};
    trx.actions.push_back(act);
    set_transaction_headers(trx);
-   trx.sign(get_private_key( N(tbl), "active" ), chain_id_type());
+   trx.sign(get_private_key( N(tbl), "active" ), control->get_chain_id());
 
    //an element that is out of range and has no mmap access permission either (should be a trapped segv)
    BOOST_CHECK_EXCEPTION(push_transaction(trx), eosio::chain::wasm_execution_error, [](const eosio::chain::wasm_execution_error &e) {return true;});
@@ -1306,7 +1306,7 @@ BOOST_FIXTURE_TEST_CASE( lotso_stack_3, TESTER ) try {
    trx.actions.push_back(act);
 
       set_transaction_headers(trx);
-   trx.sign(get_private_key( N(stackz), "active" ), chain_id_type());
+   trx.sign(get_private_key( N(stackz), "active" ), control->get_chain_id());
    push_transaction(trx);
    }
 } FC_LOG_AND_RETHROW()
@@ -1368,7 +1368,7 @@ BOOST_FIXTURE_TEST_CASE( lotso_stack_6, TESTER ) try {
    trx.actions.push_back(act);
 
       set_transaction_headers(trx);
-   trx.sign(get_private_key( N(stackz), "active" ), chain_id_type());
+   trx.sign(get_private_key( N(stackz), "active" ), control->get_chain_id());
    push_transaction(trx);
    }
 } FC_LOG_AND_RETHROW()
@@ -1517,7 +1517,7 @@ BOOST_FIXTURE_TEST_CASE(net_usage_tests, tester ) try {
                               });
       set_transaction_headers(trx);
       if (max_net_usage) trx.max_net_usage_words = max_net_usage;
-      trx.sign( get_private_key( account, "active" ), chain_id_type()  );
+      trx.sign( get_private_key( account, "active" ), control->get_chain_id()  );
       try {
          packed_transaction ptrx(trx);
          push_transaction(ptrx);
@@ -1569,7 +1569,7 @@ BOOST_FIXTURE_TEST_CASE(weighted_net_usage_tests, tester ) try {
                                  .code       = bytes(wasm.begin(), wasm.end())
                               });
       set_transaction_headers(trx);
-      trx.sign( get_private_key( account, "active" ), chain_id_type()  );
+      trx.sign( get_private_key( account, "active" ), control->get_chain_id()  );
       try {
          packed_transaction ptrx(trx);
          push_transaction(ptrx );


### PR DESCRIPTION
Resolves #3415 and includes the genesis state in "blocks/blocks.log" file rather than requiring a "genesis.json" file.

Changes in this PR:
* "blocks/blocks.log" now has a `uint32_t` version number (which cannot be 0) followed by the `genesis_state` used to initialize the chain. The blocks (started with the virtual block 1) follow immediately after as usual. This allows a compatible version of the nodeos to replay the blockchain (up to last irreversible block) generated by another nodeos using only the "blocks/blocks.log" file.
* The genesis state provided to nodeos (via the `--genesis-json` and optionally `--genesis-timestamp` options) can now only be provided via the command line (not config.ini) and can only be provided when starting up a fresh blockchain.
* A bug with `--genesis-timestamp` was fixed. It was not correctly rounding up to the nearest acceptable block time.
* Two new command line options have been added to chain_plugin: `--print-genesis-json` and `--extract-genesis-json`. These extract the genesis state from the start of "blocks/blocks.log" and either print it as JSON to console (`--print-genesis-json`) or write it out as JSON to the specified file (`--extract-genesis-json`), and then nodeos exits with a special error code (`EXTRACTED_GENESIS`). If there is no "blocks/blocks.log", then it will instead use the default genesis state configured with the compiled nodeos and print out an appropriate warning stating so.
* A bug was fixed in nodeos to return the correct error codes when exiting due to a dirty database.
* Chain ID is now the SHA256 hash of the genesis state. Also it is handled dynamically in the code now. This means nodeos can replay the "blocks/blocks.log" generated for a different chain (with different chain ID) as long as it was generated by compatible software (no hard forking protocol rule changes).
* chain_plugin `get_info` now returns the chain ID of the blockchain.
* cleos has been adapted to use the chain ID returned from `get_info` to sign transactions. When using `cleos sign` it is possible to override this behavior by providing the chain ID directly using the `--chain-id` option. This makes it still possible to use cleos to do offline transaction signing.
* The `CHAIN_ID` variable that could have been provided to CMake to override the default has been removed. In its place the `EOSIO_ROOT_KEY` CMake variable has been added. This will change the public key of the root (`eosio`) account set within the default genesis state.