### PR TITLE
Remove snapshot submodule.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,9 +6,6 @@
 	path = libraries/appbase
 	url = https://github.com/eosio/appbase
         ignore = dirty
-[submodule "programs/snapshot"]
-	path = programs/snapshot
-	url = https://github.com/EOSIO/genesis.git
 [submodule "contracts/musl/upstream"]
 	path = contracts/musl/upstream
 	url = https://github.com/EOSIO/musl.git


### PR DESCRIPTION
Note that for existing checkouts, a copy remains in $GIT_DIR/modules so
checkout of previous revisions does not require fetching from a remote
repository.  New checkouts will not have a copy unless an older revision
is checked out, followed by git submodule update --init --recursive.