### PR TITLE
Allow printing non-const references

### DIFF
--- a/contracts/eosiolib/print.hpp
+++ b/contracts/eosiolib/print.hpp
@@ -26,6 +26,10 @@ namespace eosio {
       prints_l( s.c_str(), s.size() );
    }
 
+   inline void print( std::string& s) {
+      prints_l( s.c_str(), s.size() );
+   }
+
    inline void print( const char c ) {
       prints_l( &c, 1 );
    }

--- a/contracts/test_api/test_api.hpp
+++ b/contracts/test_api/test_api.hpp
@@ -53,6 +53,7 @@ struct test_print {
   static void test_printsf();
   static void test_printdf();
   static void test_printqf();
+  static void test_print_simple();
 };
 
 struct test_action {

--- a/contracts/test_api/test_print.cpp
+++ b/contracts/test_api/test_print.cpp
@@ -113,3 +113,10 @@ void test_print::test_printqf() {
    printqf(&z);
    prints("\n");
 }
+
+void test_print::test_print_simple() {
+    std::string const cvalue = "cvalue";
+    eosio::print(cvalue);
+    std::string value = "value";
+    eosio::print(value);
+}


### PR DESCRIPTION
Currently, if you try to print non-const string with `eosio::print` you will get a following error:
`
include/eosiolib/print.hpp:162:9: error: no member named 'print' in 'std::__1::basic_string<char>'
      t.print();
      ~ ^
users.cpp:99:16: note: in instantiation of function template specialization 'eosio::print<std::__1::basic_string<char> &>' requested here
        eosio::print(currentUser.m_email);
               ^
`
Because type match is not exact, compiler tries to deduce from function template on line 162. 