### PR TITLE
.gitignore updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,4 +78,6 @@ build-debug/*
 etc/eosio/node_*
 var/lib/node_*
 .vscode
+.idea/
+*.iws
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@
 CMakeCache.txt
 CMakeFiles
 cmake_install.cmake
+cmake-build-debug/
+cmake-build-release/
 Makefile
 compile_commands.json
 moc_*


### PR DESCRIPTION
By default JetBrains CLion IDE is using `cmake-build-debug/` and `.idea/` directories.
This PR ignores this and related to this IDE directories.