### PR TITLE
Expose runtime options in the producer api plugin

### DIFF
--- a/plugins/producer_api_plugin/producer_api_plugin.cpp
+++ b/plugins/producer_api_plugin/producer_api_plugin.cpp
@@ -72,6 +72,10 @@ void producer_api_plugin::plugin_startup() {
             INVOKE_V_V(producer, resume), 201),
        CALL(producer, producer, paused,
             INVOKE_R_V(producer, paused), 201),
+       CALL(producer, producer, get_runtime_options,
+            INVOKE_R_V(producer, get_runtime_options), 201),
+       CALL(producer, producer, update_runtime_options,
+            INVOKE_V_R(producer, update_runtime_options, producer_plugin::runtime_options), 201),
    });
 }
 

--- a/plugins/producer_plugin/include/eosio/producer_plugin/producer_plugin.hpp
+++ b/plugins/producer_plugin/include/eosio/producer_plugin/producer_plugin.hpp
@@ -17,6 +17,11 @@ class producer_plugin : public appbase::plugin<producer_plugin> {
 public:
    APPBASE_PLUGIN_REQUIRES((chain_plugin))
 
+   struct runtime_options {
+      fc::optional<int32_t> max_transaction_time;
+      fc::optional<int32_t> max_irreversible_block_age;
+   };
+
    producer_plugin();
    virtual ~producer_plugin();
 
@@ -35,10 +40,14 @@ public:
    void pause();
    void resume();
    bool paused() const;
+   void update_runtime_options(const runtime_options& options);
+   runtime_options get_runtime_options() const;
 
    signal<void(const chain::producer_confirmation&)> confirmed_block;
 private:
    std::shared_ptr<class producer_plugin_impl> my;
 };
 
-} //eosiio
+} //eosio
+
+FC_REFLECT(eosio::producer_plugin::runtime_options, (max_transaction_time)(max_irreversible_block_age));

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -119,7 +119,6 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
       boost::program_options::variables_map _options;
       bool     _production_enabled                 = false;
       bool     _pause_production                   = false;
-      uint32_t _required_producer_participation    = uint32_t(config::required_producer_participation);
       uint32_t _production_skip_flags              = 0; //eosio::chain::skip_nothing;
 
       std::map<chain::public_key_type, chain::private_key_type> _private_keys;
@@ -319,7 +318,7 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
 
          auto deadline = fc::time_point::now() + fc::milliseconds(_max_transaction_time_ms);
          bool deadline_is_subjective = false;
-         if (_pending_block_mode == pending_block_mode::producing && block_time < deadline) {
+         if (_max_transaction_time_ms < 0 || (_pending_block_mode == pending_block_mode::producing && block_time < deadline) ) {
             deadline_is_subjective = true;
             deadline = block_time;
          }
@@ -358,7 +357,7 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
       }
 
       bool production_disabled_by_policy() {
-         return !_production_enabled || _pause_production || get_irreversible_block_age() >= _max_irreversible_block_age_us;
+         return !_production_enabled || _pause_production || (_max_irreversible_block_age_us.count() >= 0 && get_irreversible_block_age() >= _max_irreversible_block_age_us);
       }
 
       enum class start_block_result {
@@ -415,12 +414,6 @@ void producer_plugin::set_program_options(
           "Limits the maximum time (in milliseconds) that is allowed a pushed transaction's code to execute before being considered invalid")
          ("max-irreversible-block-age", bpo::value<int32_t>()->default_value( 30 * 60 ),
           "Limits the maximum age (in seconds) of the DPOS Irreversible Block for a chain this node will produce blocks on")
-         ("required-participation", boost::program_options::value<uint32_t>()
-                                       ->default_value(uint32_t(config::required_producer_participation/config::percent_1))
-                                       ->notifier([this](uint32_t e) {
-                                          my->_required_producer_participation = std::min(e, 100u) * config::percent_1;
-                                       }),
-                                       "Percent of producers (0-100) that must be participating in order to produce blocks")
          ("producer-name,p", boost::program_options::value<vector<string>>()->composing()->multitoken(),
           "ID of producer controlled by this node (e.g. inita; may specify multiple times)")
          ("private-key", boost::program_options::value<vector<string>>()->composing()->multitoken()->default_value({fc::json::to_string(private_key_default)},
@@ -574,6 +567,33 @@ bool producer_plugin::paused() const {
    return my->_pause_production;
 }
 
+void producer_plugin::update_runtime_options(const runtime_options& options) {
+   bool check_speculating = false;
+
+   if (options.max_transaction_time) {
+      my->_max_transaction_time_ms = *options.max_transaction_time;
+   }
+
+   if (options.max_irreversible_block_age) {
+      my->_max_irreversible_block_age_us =  fc::seconds(*options.max_irreversible_block_age);
+      check_speculating = true;
+   }
+
+   if (check_speculating && my->_pending_block_mode == pending_block_mode::speculating) {
+      chain::controller& chain = app().get_plugin<chain_plugin>().chain();
+      chain.abort_block();
+      my->schedule_production_loop();
+   }
+}
+
+producer_plugin::runtime_options producer_plugin::get_runtime_options() const {
+   return {
+      my->_max_transaction_time_ms,
+      my->_max_irreversible_block_age_us.count() < 0 ? -1 : my->_max_irreversible_block_age_us.count() / 1'000'000
+   };
+}
+
+
 
 optional<fc::time_point> producer_plugin_impl::calculate_next_block_time(const account_name& producer_name) const {
    chain::controller& chain = app().get_plugin<chain_plugin>().chain();
@@ -664,6 +684,9 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block() {
       _pending_block_mode = pending_block_mode::speculating;
    } else if ( _pause_production ) {
       elog("Not producing block because production is explicitly paused");
+      _pending_block_mode = pending_block_mode::speculating;
+   } else if ( irreversible_block_age >= _max_irreversible_block_age_us ) {
+      elog("Not producing block because the irreversible block is too old [age:${age}s, max:${max}s]", ("age", irreversible_block_age.count() / 1'000'000)( "max", _max_irreversible_block_age_us.count() / 1'000'000 ));
       _pending_block_mode = pending_block_mode::speculating;
    }
 
@@ -756,7 +779,7 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block() {
             try {
                auto deadline = fc::time_point::now() + fc::milliseconds(_max_transaction_time_ms);
                bool deadline_is_subjective = false;
-               if (_pending_block_mode == pending_block_mode::producing && block_time < deadline) {
+               if (_max_transaction_time_ms < 0 || ( _pending_block_mode == pending_block_mode::producing && block_time < deadline ) ) {
                   deadline_is_subjective = true;
                   deadline = block_time;
                }
@@ -793,7 +816,7 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block() {
             try {
                auto deadline = fc::time_point::now() + fc::milliseconds(_max_transaction_time_ms);
                bool deadline_is_subjective = false;
-               if (_pending_block_mode == pending_block_mode::producing && block_time < deadline) {
+               if (_max_transaction_time_ms < 0 || ( _pending_block_mode == pending_block_mode::producing && block_time < deadline ) ) {
                   deadline_is_subjective = true;
                   deadline = block_time;
                }


### PR DESCRIPTION
This resolves #3487 and restores functionality regarding #3299 that was removed ineb8f4c4a1e5a77ec38dd2dbb40ed4826631b0dd6

This adds 2 new HTTP endpoints:

`POST /v1/producers/get_runtime_options` - takes no payload and produces a JSON in the form:

```
{"max_transaction_time":400,"max_irreversible_block_age":1800}
```

which contains the values for the corresponding config.ini/command-line parameters in use.

`POST /v1/producers/update_runtime_options` - takes a JSON formed as above (each field is optional so you don't have to set _all_ options, you may use it sparsely.

These settings will take effect immediately.

