### PR TITLE
Gh#3542 empty abi

### DIFF
--- a/libraries/chain/include/eosio/chain/exceptions.hpp
+++ b/libraries/chain/include/eosio/chain/exceptions.hpp
@@ -105,14 +105,16 @@ namespace eosio { namespace chain {
                                     3010006, "Invalid transaction" )
       FC_DECLARE_DERIVED_EXCEPTION( abi_type_exception,                chain_type_exception,
                                     3010007, "Invalid ABI" )
+      FC_DECLARE_DERIVED_EXCEPTION( abi_not_found_exception,           chain_type_exception,
+                                    3010008, "No ABI found" )
       FC_DECLARE_DERIVED_EXCEPTION( block_id_type_exception,           chain_type_exception,
-                                    3010008, "Invalid block ID" )
+                                    3010009, "Invalid block ID" )
       FC_DECLARE_DERIVED_EXCEPTION( transaction_id_type_exception,     chain_type_exception,
-                                    3010009, "Invalid transaction ID" )
+                                    3010010, "Invalid transaction ID" )
       FC_DECLARE_DERIVED_EXCEPTION( packed_transaction_type_exception, chain_type_exception,
-                                    3010010, "Invalid packed transaction" )
+                                    3010011, "Invalid packed transaction" )
       FC_DECLARE_DERIVED_EXCEPTION( asset_type_exception,              chain_type_exception,
-                                    3010011, "Invalid asset" )
+                                    3010012, "Invalid asset" )
 
 
    FC_DECLARE_DERIVED_EXCEPTION( fork_database_exception, chain_exception,

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -916,6 +916,8 @@ read_only::abi_json_to_bin_result read_only::abi_json_to_bin( const read_only::a
       } EOS_RETHROW_EXCEPTIONS(chain::invalid_action_args_exception,
                                 "'${args}' is invalid args for action '${action}' code '${code}'. expected '${proto}'",
                                 ("args", params.args)("action", params.action)("code", params.code)("proto", action_abi_to_variant(abi, action_type)))
+   } else {
+      EOS_ASSERT(false, abi_type_exception, "No ABI found for ${contract}", ("contract", params.code));
    }
    return result;
 } FC_CAPTURE_AND_RETHROW( (params.code)(params.action)(params.args) )
@@ -927,6 +929,8 @@ read_only::abi_bin_to_json_result read_only::abi_bin_to_json( const read_only::a
    if( abi_serializer::to_abi(code_account.abi, abi) ) {
       abi_serializer abis( abi );
       result.args = abis.binary_to_variant( abis.get_action_type( params.action ), params.binargs );
+   } else {
+      EOS_ASSERT(false, abi_type_exception, "No ABI found for ${contract}", ("contract", params.code));
    }
    return result;
 }

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -917,7 +917,7 @@ read_only::abi_json_to_bin_result read_only::abi_json_to_bin( const read_only::a
                                 "'${args}' is invalid args for action '${action}' code '${code}'. expected '${proto}'",
                                 ("args", params.args)("action", params.action)("code", params.code)("proto", action_abi_to_variant(abi, action_type)))
    } else {
-      EOS_ASSERT(false, abi_type_exception, "No ABI found for ${contract}", ("contract", params.code));
+      EOS_ASSERT(false, abi_not_found_exception, "No ABI found for ${contract}", ("contract", params.code));
    }
    return result;
 } FC_CAPTURE_AND_RETHROW( (params.code)(params.action)(params.args) )
@@ -930,7 +930,7 @@ read_only::abi_bin_to_json_result read_only::abi_bin_to_json( const read_only::a
       abi_serializer abis( abi );
       result.args = abis.binary_to_variant( abis.get_action_type( params.action ), params.binargs );
    } else {
-      EOS_ASSERT(false, abi_type_exception, "No ABI found for ${contract}", ("contract", params.code));
+      EOS_ASSERT(false, abi_not_found_exception, "No ABI found for ${contract}", ("contract", params.code));
    }
    return result;
 }

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -149,8 +149,6 @@ public:
    };
    struct abi_bin_to_json_result {
       fc::variant    args;
-      vector<name>   required_scope;
-      vector<name>   required_auth;
    };
 
    abi_bin_to_json_result abi_bin_to_json( const abi_bin_to_json_params& params )const;
@@ -416,6 +414,6 @@ FC_REFLECT( eosio::chain_apis::read_only::producer_info, (producer_name) )
 FC_REFLECT( eosio::chain_apis::read_only::abi_json_to_bin_params, (code)(action)(args) )
 FC_REFLECT( eosio::chain_apis::read_only::abi_json_to_bin_result, (binargs) )
 FC_REFLECT( eosio::chain_apis::read_only::abi_bin_to_json_params, (code)(action)(binargs) )
-FC_REFLECT( eosio::chain_apis::read_only::abi_bin_to_json_result, (args)(required_scope)(required_auth) )
+FC_REFLECT( eosio::chain_apis::read_only::abi_bin_to_json_result, (args) )
 FC_REFLECT( eosio::chain_apis::read_only::get_required_keys_params, (transaction)(available_keys) )
 FC_REFLECT( eosio::chain_apis::read_only::get_required_keys_result, (required_keys) )


### PR DESCRIPTION
Resolves #3542 

chain_plugin methods abi_json_to_bin and abi_bin_to_json now throw if there is no ABI for the given account instead of returning an empty result.