### PR TITLE
Fedora: when installing/upgrading boost removed build directory

### DIFF
--- a/scripts/eosio_build_darwin.sh
+++ b/scripts/eosio_build_darwin.sh
@@ -222,7 +222,6 @@
 			printf "\\tExiting now.\\n\\n"
 			exit 1;
 		fi
-		
 		if [ -d "$BUILD_DIR" ]; then
 			if ! rm -rf "$BUILD_DIR"
 			then

--- a/scripts/eosio_build_fedora.sh
+++ b/scripts/eosio_build_fedora.sh
@@ -215,6 +215,14 @@
 			printf "\\tExiting now.\\n\\n"
 			exit 1;
 		fi
+		if [ -d "$BUILD_DIR" ]; then
+			if ! rm -rf "$BUILD_DIR"
+			then
+			printf "\\tUnable to remove directory %s. Please remove this directory and run this script %s again. 0\\n" "$BUILD_DIR" "${BASH_SOURCE[0]}"
+			printf "\\tExiting now.\\n\\n"
+			exit 1;
+			fi
+		fi
 		printf "\\n\\tBoost 1.67.0 successfully installed at %s/opt/boost_1_67_0.\\n\\n" "${HOME}"
 	else
 		printf "\\tBoost 1.67.0 found at %s/opt/boost_1_67_0.\\n" "${HOME}"


### PR DESCRIPTION
Fedora: when installing/upgrading boost removed build directory