### PR TITLE
Amazon: installing/upgrading boost removed build directory

### DIFF
--- a/scripts/eosio_build_amazon.sh
+++ b/scripts/eosio_build_amazon.sh
@@ -272,6 +272,14 @@
 			printf "\\n\\tExiting now.\\n"
 			exit 1
 		fi
+		if [ -d "$BUILD_DIR" ]; then
+			if ! rm -rf "$BUILD_DIR"
+			then
+			printf "\\tUnable to remove directory %s. Please remove this directory and run this script %s again. 0\\n" "$BUILD_DIR" "${BASH_SOURCE[0]}"
+			printf "\\tExiting now.\\n\\n"
+			exit 1;
+			fi
+		fi
 		printf "\\tBoost successfully installed @ %s/opt/boost_1_67_0.\\n" "${HOME}"
 	else
 		printf "\\tBoost 1.67.0 found at %s/opt/boost_1_67_0.\\n" "${HOME}"


### PR DESCRIPTION
Amazon: installing/upgrading boost removed build directory