### PR TITLE
fixes to get smoke tests working again; improvements to --genesis-timestamp handling

### DIFF
--- a/tests/testUtils.py
+++ b/tests/testUtils.py
@@ -448,7 +448,7 @@ class Node(object):
             Utils.Print("transaction parsing failed. Transaction: %s" % (trans))
             raise
 
-        headBlockNum=self.getIrreversibleBlockNum()
+        headBlockNum=self.getHeadBlockNum()
         assert(headBlockNum)
         try:
             headBlockNum=int(headBlockNum)
@@ -706,8 +706,8 @@ class Node(object):
         return ret
 
     def waitForNextBlock(self, timeout=None):
-        num=self.getIrreversibleBlockNum()
-        lam = lambda: self.getIrreversibleBlockNum() > num
+        num=self.getHeadBlockNum()
+        lam = lambda: self.getHeadBlockNum() > num
         ret=Utils.waitForBool(lam, timeout)
         return ret
 
@@ -833,7 +833,7 @@ class Node(object):
             msg=ex.output.decode("utf-8")
             Utils.Print("ERROR: Exception during actions by account retrieval. %s" % (msg))
             return None
-        
+
     # Gets accounts mapped to key. Returns array
     def getAccountsArrByKey(self, key):
         trans=self.getAccountsByKey(key)
@@ -1032,6 +1032,7 @@ class Node(object):
                 headBlockNumTag="head_block_num"
                 return info[headBlockNumTag]
         else:
+            # Either this implementation or the one in getIrreversibleBlockNum are likely wrong.
             block=self.getBlockFromDb(-1)
             if block is not None:
                 blockNum=block["block_num"]
@@ -1044,6 +1045,7 @@ class Node(object):
             if info is not None:
                 return info["last_irreversible_block_num"]
         else:
+            # Either this implementation or the one in getHeadBlockNum are likely wrong.
             block=self.getBlockFromDb(-1)
             if block is not None:
                 blockNum=block["block_num"]
@@ -1104,7 +1106,7 @@ class Node(object):
         self.killed=False
         return True
 
-    
+
 ###########################################################################################
 
 Wallet=namedtuple("Wallet", "name password host port")
@@ -1291,7 +1293,7 @@ class Cluster(object):
     __localHost="localhost"
     __BiosHost="localhost"
     __BiosPort=8788
-    
+
     # pylint: disable=too-many-arguments
     # walletd [True|False] Is keosd running. If not load the wallet plugin
     def __init__(self, walletd=False, localCluster=True, host="localhost", port=8888, walletHost="localhost", walletPort=8899, enableMongo=False, mongoHost="localhost", mongoPort=27017, mongoDb="EOStest", defproduceraPrvtKey=None, defproducerbPrvtKey=None, staging=False):
@@ -1370,8 +1372,8 @@ class Cluster(object):
         if len(self.nodes) > 0:
             raise RuntimeError("Cluster already running.")
 
-        cmd="%s -p %s -n %s -s %s -d %s -f --p2p-plugin bnet" % (
-            Utils.EosLauncherPath, pnodes, totalNodes, topo, delay)
+        cmd="%s -p %s -n %s -s %s -d %s -i %s -f --p2p-plugin bnet" % (
+            Utils.EosLauncherPath, pnodes, totalNodes, topo, delay, datetime.datetime.utcnow().isoformat(timespec='milliseconds') )
         cmdArr=cmd.split()
         if self.staging:
             cmdArr.append("--nogen")
@@ -1782,7 +1784,7 @@ class Cluster(object):
         m=re.search(r"node_([\d]+)", name)
         return int(m.group(1))
 
-        
+
     @staticmethod
     def parseProducerKeys(configFile, nodeName):
         """Parse node config file for producer keys. Returns dictionary. (Keys: account name; Values: dictionary objects (Keys: ["name", "node", "private","public"]; Values: account name, node id returned by nodeNameToId(nodeName), private key(string)and public key(string)))."""
@@ -1975,7 +1977,7 @@ class Cluster(object):
             if trans is None:
                 Utils.Print("ERROR: Failed to create account %s" % (eosioTokenAccount.name))
                 return False
-            
+
             eosioRamAccount=copy.deepcopy(eosioAccount)
             eosioRamAccount.name="eosio.ram"
             trans=biosNode.createAccount(eosioRamAccount, eosioAccount, 0)
@@ -2010,7 +2012,7 @@ class Cluster(object):
             if trans is None:
                 Utils.Print("ERROR: Failed to publish contract %s." % (contract))
                 return False
-            
+
             # Create currency0000, followed by issue currency0000
             contract=eosioTokenAccount.name
             Utils.Print("push create action to %s contract" % (contract))
@@ -2089,7 +2091,7 @@ class Cluster(object):
 
         return True
 
-    
+
     # Populates list of EosInstanceInfo objects, matched to actual running instances
     def discoverLocalNodes(self, totalNodes, timeout=0):
         nodes=[]


### PR DESCRIPTION
Fixes smoke tests.

This PR also has changes with `--genesis-timestamp` handling in chain_plugin:
 * `--genesis-timestamp` can only be specified on chain initialization just like `--genesis-json`.
 * `--genesis-timestamp` is respected during chain initialization to override the genesis timestamp, even if `--genesis-json` is not passed in as well.
 * The genesis timestamp passed in via `--genesis-timestamp` will always be adjusted to nearest block interval, not just when the string is "now".

While trying to fix the smoke tests, I realized that eosio-launcher is still operating under the old model where the "genesis.json" would be provided every time through config.ini. Updating this to work with the new model is a bigger change that needs to be left for another task (#3575).