### PR TITLE
Add snapshot plugin

### DIFF
--- a/libraries/chain/include/eosio/chain/account_object.hpp
+++ b/libraries/chain/include/eosio/chain/account_object.hpp
@@ -80,5 +80,4 @@ namespace eosio { namespace chain {
 CHAINBASE_SET_INDEX_TYPE(eosio::chain::account_object, eosio::chain::account_index)
 CHAINBASE_SET_INDEX_TYPE(eosio::chain::account_sequence_object, eosio::chain::account_sequence_index)
 
-
-FC_REFLECT(eosio::chain::account_object, (name)(vm_type)(vm_version)(code_version)(code)(creation_date))
+FC_REFLECT(eosio::chain::account_object, (name)(vm_type)(vm_version)(privileged)(last_code_update)(code_version)(creation_date)(code)(abi))

--- a/libraries/chain/include/eosio/chain/contract_table_objects.hpp
+++ b/libraries/chain/include/eosio/chain/contract_table_objects.hpp
@@ -216,5 +216,8 @@ CHAINBASE_SET_INDEX_TYPE(eosio::chain::index256_object, eosio::chain::index256_i
 CHAINBASE_SET_INDEX_TYPE(eosio::chain::index_double_object, eosio::chain::index_double_index)
 CHAINBASE_SET_INDEX_TYPE(eosio::chain::index_long_double_object, eosio::chain::index_long_double_index)
 
-FC_REFLECT(eosio::chain::table_id_object, (id)(code)(scope)(table) )
+FC_REFLECT(chainbase::oid<eosio::chain::table_id_object>, (_id))
+FC_REFLECT(eosio::chain::table_id_object, (id)(code)(scope)(table)(payer)(count) )
+
+FC_REFLECT(chainbase::oid<eosio::chain::key_value_object>, (_id))
 FC_REFLECT(eosio::chain::key_value_object, (id)(t_id)(primary_key)(value)(payer) )

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -18,6 +18,7 @@ add_subdirectory(db_size_api_plugin)
 #add_subdirectory(faucet_testnet_plugin)
 #add_subdirectory(mongo_db_plugin)
 #add_subdirectory(sql_db_plugin)
+add_subdirectory(snapshot_plugin)
 
 # Forward variables to top level so packaging picks them up
 set(CPACK_DEBIAN_PACKAGE_DEPENDS ${CPACK_DEBIAN_PACKAGE_DEPENDS} PARENT_SCOPE)

--- a/plugins/snapshot_plugin/CMakeLists.txt
+++ b/plugins/snapshot_plugin/CMakeLists.txt
@@ -1,0 +1,7 @@
+file(GLOB HEADERS "include/eosio/snapshot_plugin/*.hpp")
+add_library( snapshot_plugin
+             snapshot_plugin.cpp
+             ${HEADERS} )
+
+target_link_libraries( snapshot_plugin appbase fc chain_plugin)
+target_include_directories( snapshot_plugin PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" )

--- a/plugins/snapshot_plugin/include/eosio/snapshot_plugin/snapshot_plugin.hpp
+++ b/plugins/snapshot_plugin/include/eosio/snapshot_plugin/snapshot_plugin.hpp
@@ -24,6 +24,19 @@ public:
    void plugin_startup();
    void plugin_shutdown();
 
+   /**
+    *  snapshot_version must be changed anytime there is a change
+    *  on any of the following types:
+    *  - eosio::types::chain_id_type
+    *  - eosio::chain::genesis_state
+    *  - eosio::chain::block_header_state
+    *  - eosio::chain::account_object
+    *  - eosio::chain::permission_object
+    *  - eosio::chain::table_id_object
+    *  - eosio::chain::key_value_object
+    */
+   uint16_t snapshot_version = 0x0001;
+
 private:
    std::unique_ptr<class snapshot_plugin_impl> my;
    fc::optional<boost::signals2::scoped_connection> m_irreversible_block_connection;

--- a/plugins/snapshot_plugin/include/eosio/snapshot_plugin/snapshot_plugin.hpp
+++ b/plugins/snapshot_plugin/include/eosio/snapshot_plugin/snapshot_plugin.hpp
@@ -1,0 +1,33 @@
+/**
+ *  @file
+ *  @copyright defined in eos/LICENSE.txt
+ */
+#pragma once
+#include <appbase/application.hpp>
+
+#include <eosio/chain_plugin/chain_plugin.hpp>
+#include <boost/signals2/connection.hpp>
+
+namespace eosio {
+
+using namespace appbase;
+
+class snapshot_plugin : public appbase::plugin<snapshot_plugin> {
+public:
+   snapshot_plugin();
+   virtual ~snapshot_plugin();
+ 
+   APPBASE_PLUGIN_REQUIRES((chain_plugin))
+   virtual void set_program_options(options_description&, options_description& cfg) override;
+ 
+   void plugin_initialize(const variables_map& options);
+   void plugin_startup();
+   void plugin_shutdown();
+
+private:
+   std::unique_ptr<class snapshot_plugin_impl> my;
+   fc::optional<boost::signals2::scoped_connection> m_irreversible_block_connection;
+   fc::optional<boost::signals2::scoped_connection> m_accepted_block_connection;
+};
+
+}

--- a/plugins/snapshot_plugin/snapshot_plugin.cpp
+++ b/plugins/snapshot_plugin/snapshot_plugin.cpp
@@ -1,0 +1,273 @@
+/**
+ *  @file
+ *  @copyright defined in eos/LICENSE.txt
+ */
+#include <eosio/chain/asset.hpp>
+#include <eosio/chain/account_object.hpp>
+#include <eosio/chain/permission_object.hpp>
+#include <eosio/chain/block_log.hpp>
+#include <eosio/snapshot_plugin/snapshot_plugin.hpp>
+#include <fc/io/raw.hpp>
+#include <fc/io/json.hpp>
+#include <fc/crypto/hex.hpp>
+#include <fc/optional.hpp>
+#include <fc/reflect/reflect.hpp>
+
+using namespace eosio;
+using namespace eosio::chain;
+using namespace chainbase;
+using namespace fc;
+using namespace std;
+
+struct permission {
+   struct name  perm_name;
+   struct name  parent;
+   authority    required_auth;
+};
+FC_REFLECT( permission, (perm_name)(parent)(required_auth) )
+
+template<typename Function>
+void iterate_all_tables(const database& db, Function f)
+{
+   const auto &idx = db.get_index<table_id_multi_index, by_code_scope_table>();
+   auto lower = idx.begin();
+   auto upper = idx.end();
+
+   for (auto itr = lower; itr != upper; ++itr) {
+      f(*itr);
+   }
+}
+
+template<typename Function>
+void iterate_all_rows(const database& db, const table_id_object& t_id, Function f)
+{
+   const auto &idx = db.get_index<key_value_index, by_scope_primary>();
+   decltype(t_id.id) next_tid(t_id.id._id + 1);
+   auto lower = idx.lower_bound(boost::make_tuple(t_id.id));
+   auto upper = idx.lower_bound(boost::make_tuple(next_tid));
+
+   for (auto itr = lower; itr != upper; ++itr) {
+      f(*itr);
+   }
+}
+
+string get_scope_name(const table_id_object& t_id) {
+   string scope_name;
+   if(t_id.code == N(eosio.token) && t_id.table == N(stat)) {
+      scope_name = symbol(uint64_t(t_id.scope)<<8).name();
+   } else {
+      scope_name = string(t_id.scope);
+   }
+   return scope_name;   
+}
+
+string get_primary_key_name(const table_id_object& t_id, const key_value_object& obj) {
+   string pk;
+   if(t_id.code == N(eosio.token) && ( t_id.table == N(accounts) || t_id.table == N(stat)) ) {
+      pk = symbol(uint64_t(obj.primary_key)<<8).name();
+   } else {
+      pk = fc::to_string(obj.primary_key);
+   }
+   return pk;
+}
+
+namespace eosio {
+   static appbase::abstract_plugin& _snapshot_plugin = app().register_plugin<snapshot_plugin>();
+
+class snapshot_plugin_impl {
+   public:
+};
+
+snapshot_plugin::snapshot_plugin():my(new snapshot_plugin_impl()){}
+snapshot_plugin::~snapshot_plugin(){}
+
+void snapshot_plugin::set_program_options(options_description&, options_description& cfg) {
+   cfg.add_options()
+         ("snapshot-at-block", bpo::value<string>()->default_value(""), "Block hash at which to take the snapshot")
+         ("snapshot-to", bpo::value<string>()->default_value("snapshot.json"), "Pathname of JSON file where to store the snapshot")
+         ;
+}
+
+void snapshot_plugin::plugin_initialize(const variables_map& options) {
+
+   auto snapshot_at_block = fc::json::from_string(options.at("snapshot-at-block").as<string>()).as<block_id_type>();
+   auto snapshot_to = options.at("snapshot-to").as<string>();
+
+   if( snapshot_at_block != block_id_type() ) {
+
+      chain_plugin* chain_plug = app().find_plugin<chain_plugin>();
+      FC_ASSERT(chain_plug);
+      auto& chain = chain_plug->chain();
+      auto& db = chain.db();
+      const auto& config = chain_plug->chain_config();
+
+      // Save snapshot when block is irreversible
+      m_irreversible_block_connection.emplace(chain.irreversible_block.connect([this, snapshot_at_block, snapshot_to, &db](const chain::block_state_ptr& b) {
+         if( b->id == snapshot_at_block ) {
+            try {
+               fc::rename( snapshot_to+".tmp", snapshot_to );
+               ilog("Snapshot saved to ${file}", ("file", snapshot_to));
+            } catch ( fc::exception e ) {
+               wlog( "Failed to save snapshot: ${ex}", ("ex",e) );
+               return;
+            }
+         }
+      }));
+
+      // Take snapshot after block is applied
+      m_accepted_block_connection.emplace(chain.accepted_block.connect([this, snapshot_at_block, snapshot_to, &db, &config, &chain](const chain::block_state_ptr& b) {
+
+         if( b->id == snapshot_at_block ) {
+
+            ilog("Taking snapshot on block ${n} (${h})...",("n",snapshot_at_block)("h",b->block_num));
+
+            std::ofstream out;
+            try {
+               out.open( snapshot_to + ".tmp" );
+               // dump chain id
+               out << "{\"chain_id\":" << fc::json::to_string(chain.get_chain_id());
+
+               // dump gensis
+               out << ",\"genesis\":" << fc::json::to_string(config.genesis);
+
+               // dump accounts with permissions
+               out << ",\"accounts\":{";
+               bool first = true;
+               const auto& account_idx = db.get_index<account_index, by_name>();
+               const auto& permissions_idx = db.get_index<permission_index,by_owner>();
+               for (auto accnt = account_idx.begin(); accnt != account_idx.end(); ++accnt) {
+                  fc::variant v;
+                  fc::to_variant(*accnt, v);
+
+                  fc::mutable_variant_object mvo(v);
+
+                  abi_def abi;
+                  if( abi_serializer::to_abi(accnt->abi, abi) ) {
+                     fc::variant vabi;
+                     fc::to_variant(abi, vabi);
+                     mvo["abi"] = vabi;
+                  }
+
+                  vector<permission> permissions;
+                  auto perm = permissions_idx.lower_bound( boost::make_tuple( accnt->name ) );
+                  while( perm != permissions_idx.end() && perm->owner == accnt->name ) {
+                     struct name parent;
+
+                     // Don't lookup parent if null
+                     if( perm->parent._id ) {
+                        const auto* p = db.template find<permission_object,by_id>( perm->parent );
+                        if( p ) {
+                           FC_ASSERT(perm->owner == p->owner, "Invalid parent");
+                           parent = p->name;
+                        }
+                     }
+
+                     permissions.push_back( permission{ perm->name, parent, perm->auth.to_authority() } );
+                     ++perm;
+                  }
+
+                  mvo["permissions"] = permissions;
+
+                  if(first) { first = false; } else { out << ","; }
+                  out << "\"" << string(accnt->name) << "\":" << fc::json::to_string(mvo);
+               }
+               out << "}";
+
+               // dump all tables
+               out << ",\"tables\":{";
+
+               account_name   last_code(0);
+               scope_name     last_scope(0);
+
+               iterate_all_tables(db, [&](const table_id_object& t_id) {
+
+                  const auto& code_account = db.get<account_object,by_name>( t_id.code );
+                  abi_def abi;
+                  auto valid_abi = abi_serializer::to_abi(code_account.abi, abi);
+
+                  abi_serializer abis(abi);
+
+                  if( last_code != t_id.code ) {
+                     if( last_code != account_name(0) ) {
+                        out << "}},";
+                     }
+                     out << "\"" << string(t_id.code) << "\":{";
+                     out << "\"" << get_scope_name(t_id) << "\":{";
+                     out << "\"" << string(t_id.table) << "\":{";
+                     last_code  = t_id.code;
+                     last_scope = t_id.scope;
+                  }
+                  else
+                  if ( last_scope != t_id.scope ) {
+                     if( last_scope != scope_name(0) ) {
+                        out << "},";
+                     }
+
+                     out << "\"" << get_scope_name(t_id) << "\":{";
+                     out << "\"" << string(t_id.table) << "\":{";
+                     last_scope = t_id.scope;
+                  }
+                  else 
+                  {
+                     if(first) { first = false; } else { out << ","; }
+                     out << "\"" << string(t_id.table) << "\":{";
+                  }
+
+                  bool first_row = true;
+                  vector<char> data;
+
+                  string table_type;
+                  if( valid_abi ) 
+                     table_type = abis.get_table_type(t_id.table);
+
+                  iterate_all_rows(db, t_id, [&](const key_value_object& row) {
+                     if(first_row == true) { first_row = false; } else { out << ","; }
+
+                     auto pk = get_primary_key_name(t_id, row);
+                     out << "\"" << pk << "\":";
+
+                     if( !valid_abi || !table_type.size()) {
+                        out << "{\"hex_data\":\"" << fc::to_hex(row.value.data(), row.value.size()) << "\"}";
+                     } else {
+                        data.resize( row.value.size() );
+                        memcpy(data.data(), row.value.data(), row.value.size());
+                        out << "{\"data\":" 
+                            << fc::json::to_string( abis.binary_to_variant(table_type, data) ) 
+                            << "}";
+                     }
+                  });
+
+                  out << "}";
+
+               });
+
+               // close scope/code
+               out << "}}";
+
+               // close tables
+               out << "}";
+
+               // close main json object
+               out << "}";
+
+               out.close();
+            } catch ( ... ) {
+               try { fc::remove( snapshot_to+".tmp" ); } catch (...) {}
+               wlog( "Failed to take snapshot");
+               return;
+            }
+         }
+
+      }));
+   }
+}
+
+void snapshot_plugin::plugin_startup() {
+   // Make the magic happen
+}
+
+void snapshot_plugin::plugin_shutdown() {
+   // OK, that's enough magic
+}
+
+}

--- a/programs/nodeos/CMakeLists.txt
+++ b/programs/nodeos/CMakeLists.txt
@@ -56,6 +56,7 @@ target_link_libraries( nodeos
         PRIVATE -Wl,${whole_archive_flag} txn_test_gen_plugin        -Wl,${no_whole_archive_flag}
         PRIVATE -Wl,${whole_archive_flag} db_size_api_plugin         -Wl,${no_whole_archive_flag}
         PRIVATE -Wl,${whole_archive_flag} producer_api_plugin        -Wl,${no_whole_archive_flag}
+        PRIVATE -Wl,${whole_archive_flag} snapshot_plugin        -Wl,${no_whole_archive_flag}
         PRIVATE chain_plugin http_plugin producer_plugin http_client_plugin
         PRIVATE eosio_chain fc ${CMAKE_DL_LIBS} ${PLATFORM_SPECIFIC_LIBS} )
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -14,3 +14,14 @@ install( FILES ${CMAKE_CURRENT_BINARY_DIR}/eosiocpp DESTINATION ${CMAKE_INSTALL_
 add_executable( print_floats print_floats.cpp )
 target_include_directories( print_floats PRIVATE ${Boost_INCLUDE_DIR} )
 target_link_libraries( print_floats PRIVATE ${Boost_LIBRARIES} )
+
+add_executable( snap2json snap2json.cpp )
+target_include_directories( snap2json PRIVATE ${Boost_INCLUDE_DIR} )
+target_link_libraries( snap2json PRIVATE eosio_chain fc ${CMAKE_DL_LIBS} ${PLATFORM_SPECIFIC_LIBS} )
+
+install( TARGETS
+   snap2json
+   RUNTIME DESTINATION ${CMAKE_INSTALL_FULL_BINDIR}
+   LIBRARY DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}
+   ARCHIVE DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}
+)

--- a/tools/snap2json.cpp
+++ b/tools/snap2json.cpp
@@ -1,0 +1,184 @@
+/**
+ *  @file
+ *  @copyright defined in eos/LICENSE.txt
+ */
+
+#include <eosio/chain/asset.hpp>
+#include <eosio/chain/block_log.hpp>
+#include <eosio/chain/block_header_state.hpp>
+#include <eosio/chain/abi_serializer.hpp>
+#include <eosio/chain/authority.hpp>
+#include <fc/io/raw.hpp>
+#include <fc/io/json.hpp>
+#include <fc/crypto/hex.hpp>
+#include <fc/optional.hpp>
+#include <fc/reflect/reflect.hpp>
+#include <fc/filesystem.hpp>
+
+// TODO: find a better way to instantiate chainbase objects
+#undef OBJECT_CTOR
+#define OBJECT_CTOR(...) public:
+#define shared_string vector<char>
+#define shared_authority authority
+namespace eosio { namespace chain { namespace config {
+   template<>
+   constexpr uint64_t billable_size_v<authority> = 1;
+}}}
+
+#include <eosio/chain/account_object.hpp>
+#include <eosio/chain/permission_object.hpp>
+#include <eosio/chain/contract_table_objects.hpp>
+
+using namespace eosio;
+using namespace eosio::chain;
+using namespace chainbase;
+using namespace fc;
+using namespace std;
+
+#include <boost/program_options.hpp>
+
+namespace po = boost::program_options;
+
+int main(int argc, const char **argv) {
+
+   try {
+
+   po::options_description desc("Convert a snapshot taken with the snapshot_plugin to json");
+   desc.add_options()
+      ("help,h", "Print this help message and exit")
+      ("in", po::value<string>(), "Pathname of the input binary snapshot")
+      ("out", po::value<string>(), "Pathname of the output JSON file")
+   ;
+
+   po::variables_map vm;
+   po::store(po::parse_command_line(argc, argv, desc), vm);
+   po::notify(vm);
+
+   string in_file;
+   if(vm.count("in")) {
+      in_file = vm.at("in").as<string>();
+   }
+
+   if( vm.count("help") || !in_file.size() ) {
+      std::cout << desc << std::endl;
+      return 1;
+   }
+
+   if(!fc::exists(in_file)) {
+      cout << "Input file does not exists: " << in_file << endl;
+      return 1;
+   }
+
+   std::ifstream ifs(in_file);
+
+   std::streambuf *buf;
+   std::ofstream ofs;
+
+   if(vm.count("out")) {
+       ofs.open(vm.at("out").as<string>());
+       buf = ofs.rdbuf();
+   } else {
+       buf = std::cout.rdbuf();
+   }
+
+   std::ostream out(buf);
+
+   uint16_t version;
+   fc::raw::unpack(ifs, version);
+   out << "{\"version\":" << fc::json::to_string(version);
+
+   chain_id_type chain_id(sha256(""));
+   fc::raw::unpack(ifs, chain_id);
+   out << ",\"chain_id\":" << fc::json::to_string(chain_id);
+
+   genesis_state gs;
+   fc::raw::unpack(ifs, gs);
+   out << ",\"genesis_state\":" << fc::json::to_string(gs);
+
+   block_header_state bhs;
+   fc::raw::unpack(ifs, bhs);
+   out << ",\"block_header_state\":" << fc::json::to_string(bhs);
+
+   uint32_t total_accounts;
+   fc::raw::unpack(ifs, total_accounts);
+
+   map<account_name, abi_def> contract_abi;
+
+   out << ",\"accounts\":[";
+   for(uint32_t i=0; i<total_accounts; ++i) {
+      if(i>0) out << ",";
+      account_object accnt;
+      fc::raw::unpack(ifs, accnt);
+
+      fc::variant v;
+      fc::to_variant(accnt, v);
+      fc::mutable_variant_object mvo(v);
+
+      abi_def abi;
+      if( abi_serializer::to_abi(accnt.abi, abi) ) {
+         contract_abi[accnt.name] = abi;
+         fc::variant vabi;
+         fc::to_variant(abi, vabi);
+         mvo["abi"] = vabi;
+      }
+
+      out << fc::json::to_string(mvo);
+   }
+   out << "]";
+
+   out << ",\"permissions\":[";
+   uint32_t total_perms;
+   fc::raw::unpack(ifs, total_perms);
+   for(uint32_t i=0; i<total_perms; ++i) {
+      if(i>0) out << ",";
+      permission_object perm;
+      fc::raw::unpack(ifs, perm);
+      out << fc::json::to_string(perm);
+   }
+   out << "]";
+
+   out << ",\"tables\":[";
+   uint32_t total_tables;
+   fc::raw::unpack(ifs, total_tables);
+   for(uint32_t i=0; i<total_tables; ++i) {
+      if(i>0) out << ",";
+      table_id_object t_id;
+      fc::raw::unpack(ifs, t_id);
+      out << "{";
+      out << "\"tid\":" << fc::json::to_string(t_id);
+      out << ",\"rows\":{";
+
+      const auto& abi = contract_abi[t_id.code];
+      abi_serializer abis(abi);
+      string table_type = abis.get_table_type(t_id.table);
+      vector<char> data;
+
+      for(int j=0; j<t_id.count; ++j) {
+         if(j>0) out << ",";
+         key_value_object row;
+         fc::raw::unpack(ifs, row);
+         out << "\"" << row.primary_key << "\":";
+         if(!table_type.size()) {
+            out << "{\"hex_data\":\"" << fc::to_hex(row.value.data(), row.value.size()) << "\"}";
+         } else {
+            data.resize( row.value.size() );
+            memcpy(data.data(), row.value.data(), row.value.size());
+            out << "{\"data\":"
+                << fc::json::to_string( abis.binary_to_variant(table_type, data) )
+                << "}";
+         }
+      }
+      out << "}}"; //table
+   }
+   out << "]"; //tables
+
+   out << "}"; //main object
+
+   ifs.close();
+   ofs.close();
+
+   return 0;
+
+   } FC_CAPTURE_AND_LOG(());
+   return 1;
+}


### PR DESCRIPTION
This PR adds a new plugin that allows to take a snapshot of the blockchain state at a determined block.
The snapshot is taken after the block is applied and its saved when that block becomes irreversible.

The generated snapshot contains:
 - The chain id
 - The genesis state
 - All accounts (with permissions)
 - All the tables
