### PR TITLE
Fix non-void function return value

### DIFF
--- a/libraries/fc/src/exception.cpp
+++ b/libraries/fc/src/exception.cpp
@@ -219,6 +219,7 @@ namespace fc
       } catch( ... ) {
          ss << "<- exception in to_string.\n";
       }
+      return ss.str();
    }
 
    /**


### PR DESCRIPTION
Since last catch insert exception string to `ss`, it should returns.