### PR TITLE
Test update to kill nodeos/keos instances conservativily.

### DIFF
--- a/tests/distributed-transactions-remote-test.py
+++ b/tests/distributed-transactions-remote-test.py
@@ -22,6 +22,7 @@ parser.add_argument("--dont-kill", help="Leave cluster running after test finish
 parser.add_argument("--dump-error-details",
                     help="Upon error print etc/eosio/node_*/config.ini and var/lib/node_*/stderr.log to stdout",
                     action='store_true')
+parser.add_argument("--kill-all", help="Kill all nodeos and kleos instances", action='store_true')
 
 args = parser.parse_args()
 pnodes=args.p
@@ -29,6 +30,7 @@ pnodes=args.p
 debug=args.v
 dontKill=args.dont_kill
 dumpErrorDetails=args.dump_error_details
+killAll=args.kill_all
 
 testUtils.Utils.Debug=debug
 
@@ -58,7 +60,7 @@ cluster=testUtils.Cluster()
 (fd, nodesFile) = tempfile.mkstemp()
 try:
     Print("BEGIN")
-    cluster.killall()
+    cluster.killall(allInstances=killAll)
     cluster.cleanup()
 
     Print ("producing nodes: %s, non-producing nodes: %d, topology: %s, delay between nodes launch(seconds): %d" %
@@ -98,7 +100,7 @@ finally:
 
     if killEosInstances:
         Print("Shut down the cluster and cleanup.")
-        cluster.killall()
+        cluster.killall(allInstances=killAll)
         cluster.cleanup()
 
 exit(0)

--- a/tests/distributed-transactions-test.py
+++ b/tests/distributed-transactions-test.py
@@ -25,6 +25,7 @@ parser.add_argument("--dont-kill", help="Leave cluster running after test finish
 parser.add_argument("--dump-error-details",
                     help="Upon error print etc/eosio/node_*/config.ini and var/lib/node_*/stderr.log to stdout",
                     action='store_true')
+parser.add_argument("--kill-all", help="Kill all nodeos and kleos instances", action='store_true')
 
 args = parser.parse_args()
 pnodes=args.p
@@ -36,6 +37,7 @@ nodesFile=args.nodes_file
 seed=args.seed
 dontKill=args.dont_kill
 dumpErrorDetails=args.dump_error_details
+killAll=args.kill_all
 
 killWallet=not dontKill
 killEosInstances=not dontKill
@@ -60,9 +62,9 @@ try:
             errorExit("Failed to initilize nodes from Json string.")
         total_nodes=len(cluster.getNodes())
     else:
-        cluster.killall()
+        cluster.killall(allInstances=killAll)
         cluster.cleanup()
-        walletMgr.killall()
+        walletMgr.killall(allInstances=killAll)
         walletMgr.cleanup()
 
         Print ("producing nodes: %s, non-producing nodes: %d, topology: %s, delay between nodes launch(seconds): %d" %
@@ -78,7 +80,7 @@ try:
             errorExit("Cluster never stabilized")
 
     Print("Stand up EOS wallet keosd")
-    walletMgr.killall()
+    walletMgr.killall(allInstances=killAll)
     walletMgr.cleanup()
     if walletMgr.launch() is False:
         errorExit("Failed to stand up keosd.")
@@ -116,11 +118,11 @@ finally:
 
     if killEosInstances:
         Print("Shut down the cluster and cleanup.")
-        cluster.killall()
+        cluster.killall(allInstances=killAll)
         cluster.cleanup()
     if killWallet:
         Print("Shut down the wallet and cleanup.")
-        walletMgr.killall()
+        walletMgr.killall(allInstances=killAll)
         walletMgr.cleanup()
 
 exit(0)

--- a/tests/nodeos_run_remote_test.py
+++ b/tests/nodeos_run_remote_test.py
@@ -18,12 +18,14 @@ parser.add_argument("--only-bios", help="Limit testing to bios node.", action='s
 parser.add_argument("--dump-error-details",
                     help="Upon error print etc/eosio/node_*/config.ini and var/lib/node_*/stderr.log to stdout",
                     action='store_true')
+parser.add_argument("--kill-all", help="Kill all nodeos and kleos instances", action='store_true')
 
 args = parser.parse_args()
 debug=args.v
 dontKill=args.dont_kill
 dumpErrorDetails=args.dump_error_details
 onlyBios=args.only_bios
+killAll=args.kill_all
 
 testUtils.Utils.Debug=debug
 
@@ -39,7 +41,7 @@ testSuccessful=False
 cluster=testUtils.Cluster()
 try:
     Print("BEGIN")
-    cluster.killall()
+    cluster.killall(allInstances=killAll)
     cluster.cleanup()
 
     Print ("producing nodes: %s, non-producing nodes: %d, topology: %s, delay between nodes launch(seconds): %d" %
@@ -76,7 +78,7 @@ finally:
 
     if killEosInstances:
         Print("Shut down the cluster and cleanup.")
-        cluster.killall()
+        cluster.killall(allInstances=killAll)
         cluster.cleanup()
 
 exit(0)

--- a/tests/nodeos_run_test.py
+++ b/tests/nodeos_run_test.py
@@ -51,6 +51,7 @@ parser.add_argument("--keep-logs", help="Don't delete var/lib/node_* folders upo
 parser.add_argument("-v", help="verbose logging", action='store_true')
 parser.add_argument("--dont-kill", help="Leave cluster running after test finishes", action='store_true')
 parser.add_argument("--only-bios", help="Limit testing to bios node.", action='store_true')
+parser.add_argument("--kill-all", help="Kill all nodeos and kleos instances", action='store_true')
 
 args = parser.parse_args()
 testOutputFile=args.output
@@ -66,6 +67,7 @@ dontLaunch=args.dont_launch
 dontKill=args.dont_kill
 prodCount=args.prod_count
 onlyBios=args.only_bios
+killAll=args.kill_all
 
 testUtils.Utils.Debug=debug
 localTest=True if server == LOCAL_HOST else False
@@ -88,11 +90,11 @@ try:
     if enableMongo and not cluster.isMongodDbRunning():
         errorExit("MongoDb doesn't seem to be running.")
 
-    walletMgr.killall()
+    walletMgr.killall(allInstances=killAll)
     walletMgr.cleanup()
 
     if localTest and not dontLaunch:
-        cluster.killall()
+        cluster.killall(allInstances=killAll)
         cluster.cleanup()
         Print("Stand up cluster")
         if cluster.launch(prodCount=prodCount, onlyBios=onlyBios, dontKill=dontKill) is False:
@@ -129,7 +131,7 @@ try:
     exchangeAccount.ownerPublicKey=PUB_KEY2
 
     Print("Stand up walletd")
-    walletMgr.killall()
+    walletMgr.killall(allInstances=killAll)
     walletMgr.cleanup()
     if walletMgr.launch() is False:
         cmdError("%s" % (WalletdName))
@@ -700,14 +702,14 @@ finally:
 
     if killEosInstances:
         Print("Shut down the cluster.")
-        cluster.killall()
+        cluster.killall(allInstances=killAll)
         if testSuccessful and not keepLogs:
             Print("Cleanup cluster data.")
             cluster.cleanup()
 
     if killWallet:
         Print("Shut down the wallet.")
-        walletMgr.killall()
+        walletMgr.killall(allInstances=killAll)
         if testSuccessful and not keepLogs:
             Print("Cleanup wallet data.")
             walletMgr.cleanup()

--- a/tests/restart-scenarios-test.py
+++ b/tests/restart-scenarios-test.py
@@ -44,6 +44,7 @@ parser.add_argument("--dump-error-details",
                     action='store_true')
 parser.add_argument("--keep-logs", help="Don't delete var/lib/node_* folders upon test completion",
                     action='store_true')
+parser.add_argument("--kill-all", help="Kill all nodeos and kleos instances", action='store_true')
 
 args = parser.parse_args()
 pnodes=args.p
@@ -57,6 +58,7 @@ killSignal=args.kill_sig
 killEosInstances= not args.dont_kill
 dumpErrorDetails=args.dump_error_details
 keepLogs=args.keep_logs
+killAll=args.kill_all
 
 seed=1
 testUtils.Utils.Debug=debug
@@ -71,7 +73,7 @@ try:
     cluster.setChainStrategy(chainSyncStrategyStr)
     cluster.setWalletMgr(walletMgr)
 
-    cluster.killall()
+    cluster.killall(allInstances=killAll)
     cluster.cleanup()
 
     Print ("producing nodes: %d, topology: %s, delay between nodes launch(seconds): %d, chain sync strategy: %s" % (
@@ -87,7 +89,7 @@ try:
         errorExit("Cluster never stabilized")
 
     Print("Stand up EOS wallet keosd")
-    walletMgr.killall()
+    walletMgr.killall(allInstances=killAll)
     walletMgr.cleanup()
     if walletMgr.launch() is False:
         errorExit("Failed to stand up keosd.")
@@ -173,8 +175,8 @@ finally:
 
     if killEosInstances:
         Print("Shut down the cluster%s" % (" and cleanup." if (testSuccessful and not keepLogs) else "."))
-        cluster.killall()
-        walletMgr.killall()
+        cluster.killall(allInstances=killAll)
+        walletMgr.killall(allInstances=killAll)
         if testSuccessful and not keepLogs:
             Print("Cleanup cluster and wallet data.")
             cluster.cleanup()

--- a/tests/testUtils.py
+++ b/tests/testUtils.py
@@ -1297,11 +1297,22 @@ class WalletMgr(object):
             with open(WalletMgr.__walletLogFile, "r") as f:
                 shutil.copyfileobj(f, sys.stdout)
 
-    @staticmethod
-    def killall():
-        cmd="pkill -9 %s" % (Utils.EosWalletName)
-        if Utils.Debug: Utils.Print("cmd: %s" % (cmd))
-        subprocess.call(cmd.split())
+    # @staticmethod
+    # def killall():
+    #     cmd="pkill -9 %s" % (Utils.EosWalletName)
+    #     if Utils.Debug: Utils.Print("cmd: %s" % (cmd))
+    #     subprocess.call(cmd.split())
+
+    def killall(self, allInstances=False):
+        """Kill keos instances. allInstances will kill all keos instances running on the system."""
+        if self.__walletPid:
+            os.kill(self.__walletPid, signal.SIGKILL)
+
+        if allInstances:
+            cmd="pkill -9 %s" % (Utils.EosWalletName)
+            if Utils.Debug: Utils.Print("cmd: %s" % (cmd))
+            subprocess.call(cmd.split())
+
 
     @staticmethod
     def cleanup():
@@ -2210,17 +2221,19 @@ class Cluster(object):
             fileName="var/lib/node_%02d/stderr.txt" % (i)
             Cluster.dumpErrorDetailImpl(fileName)
 
-    def killall(self, silent=True):
-        cmd="%s -k 15" % (Utils.EosLauncherPath)
+    def killall(self, silent=True, allInstances=False):
+        """Kill cluster nodeos instances. allInstances will kill all nodeos instances running on the system."""
+        cmd="%s -k 9" % (Utils.EosLauncherPath)
         if Utils.Debug: Utils.Print("cmd: %s" % (cmd))
         if 0 != subprocess.call(cmd.split(), stdout=Utils.FNull):
             if not silent: Utils.Print("Launcher failed to shut down eos cluster.")
 
-        # ocassionally the launcher cannot kill the eos server
-        cmd="pkill -9 %s" % (Utils.EosServerName)
-        if Utils.Debug: Utils.Print("cmd: %s" % (cmd))
-        if 0 != subprocess.call(cmd.split(), stdout=Utils.FNull):
-            if not silent: Utils.Print("Failed to shut down eos cluster.")
+        if allInstances:
+            # ocassionally the launcher cannot kill the eos server
+            cmd="pkill -9 %s" % (Utils.EosServerName)
+            if Utils.Debug: Utils.Print("cmd: %s" % (cmd))
+            if 0 != subprocess.call(cmd.split(), stdout=Utils.FNull):
+                if not silent: Utils.Print("Failed to shut down eos cluster.")
 
         # another explicit nodes shutdown
         for node in self.nodes:


### PR DESCRIPTION
The test runs will not kill any external nodeos and keos instances. The option "--kill-all" will force kill all external instances.