### PR TITLE
Require wallet password when revealing private keys

### DIFF
--- a/plugins/wallet_api_plugin/wallet_api_plugin.cpp
+++ b/plugins/wallet_api_plugin/wallet_api_plugin.cpp
@@ -91,7 +91,7 @@ void wallet_api_plugin::plugin_startup() {
        CALL(wallet, wallet_mgr, list_wallets,
             INVOKE_R_V(wallet_mgr, list_wallets), 200),
        CALL(wallet, wallet_mgr, list_keys,
-            INVOKE_R_V(wallet_mgr, list_keys), 200),
+            INVOKE_R_R_R(wallet_mgr, list_keys, std::string, std::string), 200),
        CALL(wallet, wallet_mgr, get_public_keys,
             INVOKE_R_V(wallet_mgr, get_public_keys), 200)
    });

--- a/plugins/wallet_plugin/include/eosio/wallet_plugin/wallet.hpp
+++ b/plugins/wallet_plugin/include/eosio/wallet_plugin/wallet.hpp
@@ -91,6 +91,15 @@ class wallet_api
        */
       void    unlock(string password);
 
+      /** Checks the password of the wallet
+       *
+       * Validates the password on a wallet even if the wallet is already unlocked,
+       * throws if bad password given.
+       * @param password the password previously set with \c set_password()
+       * @ingroup Wallet Management
+       */
+      void    check_password(string password);
+
       /** Sets a new password on the wallet.
        *
        * The wallet must be either 'new' or 'unlocked' to

--- a/plugins/wallet_plugin/include/eosio/wallet_plugin/wallet_manager.hpp
+++ b/plugins/wallet_plugin/include/eosio/wallet_plugin/wallet_manager.hpp
@@ -69,8 +69,8 @@ public:
    /// @return A list of wallet names with " *" appended if the wallet is unlocked.
    std::vector<std::string> list_wallets();
 
-   /// @return A list of private keys from all unlocked wallets in wif format.
-   map<public_key_type,private_key_type> list_keys();
+   /// @return A list of private keys from a wallet provided password is correct to said wallet
+   map<public_key_type,private_key_type> list_keys(const string& name, const string& pw);
 
    /// @return A set of public keys from all unlocked wallets, use with chain_controller::get_required_keys.
    flat_set<public_key_type> get_public_keys();

--- a/plugins/wallet_plugin/wallet.cpp
+++ b/plugins/wallet_plugin/wallet.cpp
@@ -327,6 +327,16 @@ void wallet_api::unlock(string password)
 } EOS_RETHROW_EXCEPTIONS(chain::wallet_invalid_password_exception,
                           "Invalid password for wallet: \"${wallet_name}\"", ("wallet_name", get_wallet_filename())) }
 
+void wallet_api::check_password(string password)
+{ try {
+   FC_ASSERT(password.size() > 0);
+   auto pw = fc::sha512::hash(password.c_str(), password.size());
+   vector<char> decrypted = fc::aes_decrypt(pw, my->_wallet.cipher_keys);
+   auto pk = fc::raw::unpack<plain_keys>(decrypted);
+   FC_ASSERT(pk.checksum == pw);
+} EOS_RETHROW_EXCEPTIONS(chain::wallet_invalid_password_exception,
+                          "Invalid password for wallet: \"${wallet_name}\"", ("wallet_name", get_wallet_filename())) }
+
 void wallet_api::set_password( string password )
 {
    if( !is_new() )

--- a/plugins/wallet_plugin/wallet_manager.cpp
+++ b/plugins/wallet_plugin/wallet_manager.cpp
@@ -95,18 +95,16 @@ std::vector<std::string> wallet_manager::list_wallets() {
    return result;
 }
 
-map<public_key_type,private_key_type> wallet_manager::list_keys() {
+map<public_key_type,private_key_type> wallet_manager::list_keys(const string& name, const string& pw) {
    check_timeout();
-   map<public_key_type,private_key_type> result;
-   for (const auto& i : wallets) {
-      if (!i.second->is_locked()) {
-         const auto& keys = i.second->list_keys();
-         for (const auto& i : keys) {
-            result[i.first] = i.second;
-         }
-      }
-   }
-   return result;
+
+   if (wallets.count(name) == 0)
+      EOS_THROW(chain::wallet_nonexistent_exception, "Wallet not found: ${w}", ("w", name));
+   auto& w = wallets.at(name);
+   if (w->is_locked())
+      EOS_THROW(chain::wallet_locked_exception, "Wallet is locked: ${w}", ("w", name));
+   w->check_password(pw); //throws if bad password
+   return w->list_keys();
 }
 
 flat_set<public_key_type> wallet_manager::get_public_keys() {

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -2115,12 +2115,31 @@ int main( int argc, char** argv ) {
    });
 
    // list keys
-   auto listKeys = wallet->add_subcommand("keys", localized("List of private keys from all unlocked wallets in wif format."), false);
+   auto listKeys = wallet->add_subcommand("keys", localized("List of public keys from all unlocked wallets."), false);
    listKeys->set_callback([] {
       // wait for keosd to come up
       try_port(uint16_t(std::stoi(parse_url(wallet_url).port)), 2000);
 
-      const auto& v = call(wallet_url, wallet_list_keys);
+      const auto& v = call(wallet_url, wallet_public_keys);
+      std::cout << fc::json::to_pretty_string(v) << std::endl;
+   });
+
+   // list private keys
+   auto listPrivKeys = wallet->add_subcommand("private_keys", localized("List of private keys from an unlocked wallet in wif or PVT_R1 format."), false);
+   listPrivKeys->add_option("-n,--name", wallet_name, localized("The name of the wallet to list keys from"), true);
+   listPrivKeys->add_option("--password", wallet_pw, localized("The password returned by wallet create"));
+   listPrivKeys->set_callback([&wallet_name, &wallet_pw] {
+      if( wallet_pw.size() == 0 ) {
+         std::cout << localized("password: ");
+         fc::set_console_echo(false);
+         std::getline( std::cin, wallet_pw, '\n' );
+         fc::set_console_echo(true);
+      }
+      // wait for keosd to come up
+      try_port(uint16_t(std::stoi(parse_url(wallet_url).port)), 2000);
+
+      fc::variants vs = {fc::variant(wallet_name), fc::variant(wallet_pw)};
+      const auto& v = call(wallet_url, wallet_list_keys, vs);
       std::cout << fc::json::to_pretty_string(v) << std::endl;
    });
 

--- a/tests/nodeos_run_test.py
+++ b/tests/nodeos_run_test.py
@@ -192,7 +192,7 @@ try:
         errorExit("Unexpected wallet list: %s" % (wallets))
 
     Print("Getting wallet keys.")
-    actualKeys=walletMgr.getKeys()
+    actualKeys=walletMgr.getKeys(testWallet)
     expectedkeys=[]
     for account in accounts:
         expectedkeys.append(account.ownerPrivateKey)
@@ -217,7 +217,7 @@ try:
         errorExit("Failed to unlock wallet %s" % (testWallet.name))
 
     Print("Getting wallet keys.")
-    actualKeys=walletMgr.getKeys()
+    actualKeys=walletMgr.getKeys(defproduceraWallet)
     expectedkeys=[defproduceraAccount.ownerPrivateKey]
     noMatch=list(set(expectedkeys) - set(actualKeys))
     if len(noMatch) > 0:

--- a/tests/testUtils.py
+++ b/tests/testUtils.py
@@ -1272,17 +1272,17 @@ class WalletMgr(object):
 
         return wallets
 
-    def getKeys(self):
+    def getKeys(self, wallet):
         keys=[]
 
         p = re.compile(r'\n\s+\"(\w+)\"\n', re.MULTILINE)
-        cmd="%s %s wallet keys" % (Utils.EosClientPath, self.endpointArgs)
+        cmd="%s %s wallet private_keys --name %s --password %s " % (Utils.EosClientPath, self.endpointArgs, wallet.name, wallet.password)
         if Utils.Debug: Utils.Print("cmd: %s" % (cmd))
         retStr=subprocess.check_output(cmd.split()).decode("utf-8")
         #Utils.Print("retStr: %s" % (retStr))
         m=p.findall(retStr)
         if m is None:
-            Utils.Print("ERROR: wallet keys parser failure")
+            Utils.Print("ERROR: wallet private_keys parser failure")
             return None
         keys=m
 


### PR DESCRIPTION
In addition to being unlocked, wallets now require their password to reveal their private keys.

🚨🚨RPC & cleos changes in here

RPC endpoint changes:
`/v1/wallet/get_public_keys` -- No change. This endpoint prints all public keys from all unlocked wallets.
`/v1/wallet/list_keys` -- This endpoint now requires two strings: the name of an unlocked wallet and its password. It will then reveal the public and private key pairs of that wallet. Be aware this means a slight change in behavior in that it is now impossible to query private keys from all unlocked wallets.

cleos changes:
`wallet keys` -- This command has been changed to print all public keys from unlocked wallets (corresponds to the get_public_keys endpoint). Be aware that there is a change in behavior due to different behavior in how get_public_keys works vs previous behavior: if there is no open wallet or all wallets are locked, wallet keys will now return a "no available wallet" or "locked wallet" error. Previously an empty list would be returned.
`wallet private_keys` -- This is a new command that maps to the list_keys endpoint. It will take the wallet name and password as arguments before printing the public/private key pairs.

Issue #3596 