### PR TITLE
Increase pipeline timeouts [skip-ci]

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,7 +10,7 @@ steps:
     agents:
       - "role=macos-builder"
     artifact_paths: "build.tar.gz"
-    timeout: 30
+    timeout: 60
 
   - command: |
         echo "+++ :hammer: Building" && \
@@ -25,7 +25,7 @@ steps:
       docker#v1.1.1:
         image: "eosio/ci:ubuntu"
         workdir: /data/job
-    timeout: 30
+    timeout: 60
     
   - command: |
         echo "+++ :hammer: Building" && \
@@ -40,7 +40,7 @@ steps:
       docker#v1.1.1:
         image: "eosio/ci:ubuntu18"
         workdir: /data/job
-    timeout: 30
+    timeout: 60
 
   - command: |
         echo "+++ :hammer: Building" && \
@@ -55,7 +55,7 @@ steps:
       docker#v1.1.1:
         image: "eosio/ci:fedora"
         workdir: /data/job
-    timeout: 30
+    timeout: 60
  
   - command: |
         echo "+++ :hammer: Building" && \
@@ -70,7 +70,7 @@ steps:
       docker#v1.1.1:
         image: "eosio/ci:centos"
         workdir: /data/job
-    timeout: 30
+    timeout: 60
 
   - command: |
         echo "+++ :hammer: Building" && \
@@ -85,7 +85,7 @@ steps:
       docker#v1.1.1:
         image: "eosio/ci:amazonlinux"
         workdir: /data/job
-    timeout: 30
+    timeout: 60
 
   - wait
 
@@ -107,7 +107,7 @@ steps:
       - "mongod.log"
       - "build/genesis.json"
       - "build/config.ini"
-    timeout: 30
+    timeout: 60
     
   - command: |
         echo "--- :arrow_down: Downloading build directory" && \
@@ -131,7 +131,7 @@ steps:
       docker#v1.1.1:
         image: "eosio/ci:ubuntu"
         workdir: /data/job
-    timeout: 30
+    timeout: 60
   
   - command: |
         echo "--- :arrow_down: Downloading build directory" && \
@@ -155,7 +155,7 @@ steps:
       docker#v1.1.1:
         image: "eosio/ci:ubuntu18"
         workdir: /data/job
-    timeout: 30
+    timeout: 60
 
   - command: |
         echo "--- :arrow_down: Downloading build directory" && \
@@ -179,7 +179,7 @@ steps:
       docker#v1.1.1:
         image: "eosio/ci:fedora"
         workdir: /data/job
-    timeout: 30
+    timeout: 60
 
   - command: |
         echo "--- :arrow_down: Downloading build directory" && \
@@ -203,7 +203,7 @@ steps:
       docker#v1.1.1:
         image: "eosio/ci:centos"
         workdir: /data/job
-    timeout: 30
+    timeout: 60
 
   - command: |
         echo "--- :arrow_down: Downloading build directory" && \
@@ -227,4 +227,4 @@ steps:
       docker#v1.1.1:
         image: "eosio/ci:amazonlinux"
         workdir: /data/job
-    timeout: 30
+    timeout: 60


### PR DESCRIPTION
We periodically bump up against the 30 minute timeout. This increases the timeout to 60 minutes to ensure jobs complete.