### PR TITLE
Set default HTTP port for user specified http:// urls in cleos to :80

### DIFF
--- a/programs/cleos/httpc.cpp
+++ b/programs/cleos/httpc.cpp
@@ -95,7 +95,7 @@ namespace eosio { namespace client { namespace http {
       if(res.server.empty())
          FC_THROW("No server parsed from URL \"${u}\"", ("u", server_url));
       if(res.port.empty())
-         res.port = res.scheme == "http" ? "8888" : "443";
+         res.port = res.scheme == "http" ? "80" : "443";
       boost::trim_right_if(res.path_prefix, boost::is_any_of("/"));
       return res;
    }


### PR DESCRIPTION
Change the default HTTP port used by cleos for http:// URLs to port 80. This doesn't change the default URL of http://localhost:8888, just the port number if someone were to use http://foo.bar/ for example

Requested from community users (note issue #3141) and probably makes sense for more realistically deployed API endpoints