### PR TITLE
Add producer name to double-confirm assert

### DIFF
--- a/libraries/chain/block_header_state.cpp
+++ b/libraries/chain/block_header_state.cpp
@@ -155,7 +155,7 @@ namespace eosio { namespace chain {
 
     auto itr = producer_to_last_produced.find(h.producer);
     if( itr != producer_to_last_produced.end() ) {
-       FC_ASSERT( itr->second < result.block_num - h.confirmed, "producer double-confirming known range" );
+       FC_ASSERT( itr->second < result.block_num - h.confirmed, "producer ${prod} double-confirming known range", ("prod", h.producer) );
     }
 
     // FC_ASSERT( result.header.block_mroot == h.block_mroot, "mismatch block merkle root" );


### PR DESCRIPTION
Noticed during testing producer name is not indicated on double-confirm.