### PR TITLE
Sanitize the return value of memcmp() to wasm

### DIFF
--- a/libraries/chain/wasm_interface.cpp
+++ b/libraries/chain/wasm_interface.cpp
@@ -1281,7 +1281,12 @@ class memory_api : public context_aware_api {
       }
 
       int memcmp( array_ptr<const char> dest, array_ptr<const char> src, size_t length) {
-         return ::memcmp(dest, src, length);
+         int ret = ::memcmp(dest, src, length);
+         if(ret < 0)
+            return -1;
+         if(ret > 0)
+            return 1;
+         return 0;
       }
 
       char* memset( array_ptr<char> dest, int value, size_t length ) {


### PR DESCRIPTION
For wasm’s memcmp, we farm it out to the system's memcmp, however the c specification states that memcmp only needs to return less than 0, 0, or greater than 0. It's implementation specific _how_ much less than or greater than 0 it is. So, sanitize the return value to only ever be -1, 0, 1.

Issue #3706