### PR TITLE
name_suffix and eosio.system_tests improvements

### DIFF
--- a/unittests/eosio.system_tests.cpp
+++ b/unittests/eosio.system_tests.cpp
@@ -2229,22 +2229,24 @@ BOOST_FIXTURE_TEST_CASE( buyname, eosio_system_tester ) try {
    produce_block( fc::days(14) );
    produce_block();
 
-   BOOST_REQUIRE_THROW( create_accounts_with_resources( { N(fail) }, N(dan) ), fc::exception ); // dan shouldn't be able to create fail
-
+   BOOST_REQUIRE_EXCEPTION( create_accounts_with_resources( { N(fail) }, N(dan) ), // dan shouldn't be able to create fail
+                            eosio_assert_message_exception, eosio_assert_message_is( "no active bid for name" ) );
    bidname( "dan", "nofail", core_from_string( "1.0000" ) );
    BOOST_REQUIRE_EQUAL( "assertion failure with message: must increase bid by 10%", bidname( "sam", "nofail", core_from_string( "1.0000" ) )); // didn't increase bid by 10%
    BOOST_REQUIRE_EQUAL( success(), bidname( "sam", "nofail", core_from_string( "2.0000" ) )); // didn't increase bid by 10%
    produce_block( fc::days(1) );
    produce_block();
 
-   BOOST_REQUIRE_THROW( create_accounts_with_resources( { N(nofail) }, N(dan) ), fc::exception); // dan shoudn't be able to do this, sam won
+   BOOST_REQUIRE_EXCEPTION( create_accounts_with_resources( { N(nofail) }, N(dan) ), // dan shoudn't be able to do this, sam won
+                            eosio_assert_message_exception, eosio_assert_message_is( "only highest bidder can claim" ) );
    //wlog( "verify sam can create nofail" );
    create_accounts_with_resources( { N(nofail) }, N(sam) ); // sam should be able to do this, he won the bid
    //wlog( "verify nofail can create test.nofail" );
    transfer( "eosio", "nofail", core_from_string( "1000.0000" ) );
    create_accounts_with_resources( { N(test.nofail) }, N(nofail) ); // only nofail can create test.nofail
    //wlog( "verify dan cannot create test.fail" );
-   BOOST_REQUIRE_THROW( create_accounts_with_resources( { N(test.fail) }, N(dan) ), fc::exception ); // dan shouldn't be able to do this
+   BOOST_REQUIRE_EXCEPTION( create_accounts_with_resources( { N(test.fail) }, N(dan) ), // dan shouldn't be able to do this
+                            eosio_assert_message_exception, eosio_assert_message_is( "only suffix may create this account" ) );
 
    create_accounts_with_resources( { N(goodgoodgood) }, N(dan) ); /// 12 char names should succeed
 } FC_LOG_AND_RETHROW()
@@ -2290,7 +2292,7 @@ BOOST_FIXTURE_TEST_CASE( multiple_namebids, eosio_system_tester ) try {
    bidname( "carl", "prefe", core_from_string("1.0000") );
    BOOST_REQUIRE_EQUAL( core_from_string( "9998.0000" ), get_balance("carl") );
 
-   BOOST_REQUIRE_EQUAL( error("assertion failure with message: account is already high bidder"),
+   BOOST_REQUIRE_EQUAL( error("assertion failure with message: account is already highest bidder"),
                         bidname( "bob", "prefb", core_from_string("1.1001") ) );
    BOOST_REQUIRE_EQUAL( error("assertion failure with message: must increase bid by 10%"),
                         bidname( "alice", "prefb", core_from_string("1.0999") ) );
@@ -2379,9 +2381,9 @@ BOOST_FIXTURE_TEST_CASE( multiple_namebids, eosio_system_tester ) try {
    produce_blocks(2);
    // bid for prefb has closed, only highest bidder can claim
    BOOST_REQUIRE_EXCEPTION( create_account_with_resources( N(prefb), N(alice) ),
-                            fc::exception, fc_assert_exception_message_is("only high bidder can claim") );
+                            eosio_assert_message_exception, eosio_assert_message_is( "only highest bidder can claim" ) );
    BOOST_REQUIRE_EXCEPTION( create_account_with_resources( N(prefb), N(carl) ),
-                            fc::exception, fc_assert_exception_message_is("only high bidder can claim") );
+                            eosio_assert_message_exception, eosio_assert_message_is( "only highest bidder can claim" ) );
    create_account_with_resources( N(prefb), N(eve) );
 
    BOOST_REQUIRE_EXCEPTION( create_account_with_resources( N(prefe), N(carl) ),


### PR DESCRIPTION
Resolves #3701

Changes in this PR:
* Grammatical fixes in name bidding assert messages.
* Improvement to eosio.system tests.
* Reimplemented name_suffix to be a little easier to understand (also now support 13 character names).
* Added unit tests for name_suffix (keep in mind the unit tests only test a copy of the function from contracts/eosiolib/types.hpp so they have to be kept in sync).

I verified that the old name_suffix implementation and new name_suffix implementation behave identically for randomly generated names less than 13 characters long. The following code was used to do that:
```
boost::random::mt19937 rng;
boost::random::uniform_int_distribution<uint64_t> r(0, std::numeric_limits<uint64_t>::max());
for( uint32_t i = 0; i < 1000000; ++i ) {
   uint64_t n = r(rng);
   if( n & 0x0Full ) continue; // Skip names that are 13 characters long
   FC_ASSERT( name_suffix(n) == old_name_suffix(n), "mismatch" );
}
```