### PR TITLE
fix multiple bugs that were only exercised with malicious blocks

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -871,13 +871,14 @@ struct controller_impl {
             if (except) {
                elog("exception thrown while switching forks ${e}", ("e",except->to_detail_string()));
 
-               while (ritr != branches.first.rend() ) {
-                  fork_db.set_validity( *ritr, false );
-                  ++ritr;
-               }
+               // ritr currently points to the block that threw
+               // if we mark it invalid it will automatically remove all forks built off it.
+               fork_db.set_validity( *ritr, false );
 
                // pop all blocks from the bad fork
-               for( auto itr = (ritr + 1).base(); itr != branches.second.end(); ++itr ) {
+               // ritr base is a forward itr to the last block successfully applied
+               auto applied_itr = ritr.base();
+               for( auto itr = applied_itr; itr != branches.first.end(); ++itr ) {
                   fork_db.mark_in_current_chain( *itr , false );
                   pop_block();
                }

--- a/libraries/chain/fork_database.cpp
+++ b/libraries/chain/fork_database.cpp
@@ -209,14 +209,14 @@ namespace eosio { namespace chain {
             my->index.erase(itr);
 
          auto& previdx = my->index.get<by_prev>();
-         auto  previtr = previdx.find(id);
-         while( previtr != previdx.end() ) {
+         auto  previtr = previdx.lower_bound(remove_queue[i]);
+         while( previtr != previdx.end() && (*previtr)->header.previous == remove_queue[i] ) {
             remove_queue.push_back( (*previtr)->id );
-            previdx.erase(previtr);
-            previtr = previdx.find(id);
+            ++previtr;
          }
       }
       //wdump((my->index.size()));
+      my->head = *my->index.get<by_lib_block_num>().begin();
    }
 
    void fork_database::set_validity( const block_state_ptr& h, bool valid ) {

--- a/libraries/chain/include/eosio/chain/incremental_merkle.hpp
+++ b/libraries/chain/include/eosio/chain/incremental_merkle.hpp
@@ -98,7 +98,12 @@ class incremental_merkle_impl {
       :_node_count(0)
       {}
 
-      template<typename Allocator>
+      incremental_merkle_impl( const incremental_merkle_impl& ) = default;
+      incremental_merkle_impl( incremental_merkle_impl&& ) = default;
+      incremental_merkle_impl& operator= (const incremental_merkle_impl& ) = default;
+      incremental_merkle_impl& operator= ( incremental_merkle_impl&& ) = default;
+
+      template<typename Allocator, std::enable_if_t<!std::is_same<std::decay_t<Allocator>, incremental_merkle_impl>::value, int> = 0>
       incremental_merkle_impl( Allocator&& alloc ):_active_nodes(forward<Allocator>(alloc)){}
 
       /*


### PR DESCRIPTION
resolves #3725 
resolves #3711 

- `maybe_switch_forks` had several bugs, while handling an exception when switching forks
  - using the wrong vector's iterator when popping blocks
  - popping too many blocks due to the mutation of the iterator above
  - off by one error when popping blocks
- `fork_database::remove` intended to remove all forks which shared a common ancestor of the removed block however, the logic was faulty and only removing direct children potentially leaving many disconnected children of children in the multi index container
- the state of `fork_db::head()` was inconsistent after a failed fork swap as `fork_database::remove()` could have removed the `head` or mutated the multi-index to chain the head block and wasn't recalculating that 

We now have a test case which creates a valid fork of length 6 and 7x invalid forks of length 7 which all pick a different block_number in their respective chains to maliciously corrupt.  These forks are then pushed to the valid node and we ensure that the forks are rejected AND that the state of the valid chain is such that the LIB can advance once producers stop being malicious. 
