### PR TITLE
zero wasm linear memory on memory growth

### DIFF
--- a/libraries/chain/include/eosio/chain/webassembly/binaryen.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/binaryen.hpp
@@ -114,6 +114,7 @@ struct interpreter_interface : ModuleInstance::ExternalInterface {
    }
 
    void growMemory(Address old_size, Address new_size) override {
+      memset(memory.data + old_size.addr, 0, new_size.addr - old_size.addr);
       current_memory_size += new_size.addr - old_size.addr;
    }
 

--- a/libraries/wasm-jit/Source/Runtime/Memory.cpp
+++ b/libraries/wasm-jit/Source/Runtime/Memory.cpp
@@ -114,6 +114,7 @@ namespace Runtime
 			{
 				return -1;
 			}
+			memset(memory->baseAddress + (memory->numPages << IR::numBytesPerPageLog2), 0, numNewPages << IR::numBytesPerPageLog2);
 			memory->numPages += numNewPages;
 		}
 		return previousNumPages;

--- a/unittests/contracts/test_wasts.hpp
+++ b/unittests/contracts/test_wasts.hpp
@@ -563,3 +563,40 @@ static const char import_injected_wast[] =                                      
 " (import \"" EOSIO_INJECTED_MODULE_NAME "\" \"checktime\" (func $inj (param i32)))"  \
 " (func $apply (param $0 i64) (param $1 i64) (param $2 i64))"                         \
 ")";
+
+static const char memory_growth_memset_store[] = R"=====(
+(module
+ (export "apply" (func $apply))
+ (memory $0 1)
+ (func $apply (param $0 i64)(param $1 i64)(param $2 i64)
+    (drop (grow_memory (i32.const 2)))
+    (i32.store (i32.const 80000) (i32.const 2))
+    (i32.store (i32.const 140000) (i32.const 3))
+ )
+)
+)=====";
+
+static const char memory_growth_memset_test[] = R"=====(
+(module
+ (export "apply" (func $apply))
+ (import "env" "eosio_assert" (func $eosio_assert (param i32 i32)))
+ (memory $0 1)
+ (func $apply (param $0 i64)(param $1 i64)(param $2 i64)
+   (drop (grow_memory (i32.const 2)))
+   (call $eosio_assert
+     (i32.eq
+       (i32.load offset=80000 (i32.const 0))
+       (i32.const 0)
+     )
+     (i32.const 0)
+   )
+   (call $eosio_assert
+     (i32.eq
+       (i32.load offset=140000 (i32.const 0))
+       (i32.const 0)
+     )
+     (i32.const 0)
+   )
+ )
+)
+)=====";

--- a/unittests/wasm_tests.cpp
+++ b/unittests/wasm_tests.cpp
@@ -1558,6 +1558,37 @@ BOOST_FIXTURE_TEST_CASE( protect_injected, TESTER ) try {
    produce_blocks(1);
 } FC_LOG_AND_RETHROW()
 
+BOOST_FIXTURE_TEST_CASE( mem_growth_memset, TESTER ) try {
+   produce_blocks(2);
+
+   create_accounts( {N(grower)} );
+   produce_block();
+
+   action act;
+   act.account = N(grower);
+   act.name = N();
+   act.authorization = vector<permission_level>{{N(grower),config::active_name}};
+
+   set_code(N(grower), memory_growth_memset_store);
+   {
+      signed_transaction trx;
+      trx.actions.push_back(act);
+      set_transaction_headers(trx);
+      trx.sign(get_private_key( N(grower), "active" ), control->get_chain_id());
+      push_transaction(trx);
+   }
+
+   produce_blocks(1);
+   set_code(N(grower), memory_growth_memset_test);
+   {
+      signed_transaction trx;
+      trx.actions.push_back(act);
+      set_transaction_headers(trx);
+      trx.sign(get_private_key( N(grower), "active" ), control->get_chain_id());
+      push_transaction(trx);
+   }
+} FC_LOG_AND_RETHROW()
+
 INCBIN(fuzz1, "fuzz1.wasm");
 INCBIN(fuzz2, "fuzz2.wasm");
 INCBIN(fuzz3, "fuzz3.wasm");


### PR DESCRIPTION
When a WASM grows its linear memory (via the grow_memory opcode) the new freshly accessible memory is required to be zeroed out.

Our binaryen implementation needs a fix for this.

WAVM is more interesting. It relies on a madvise(MADV_DONTNEED) to mark pages such that a subsequent access to those pages would be zero. This works on Linux.. but does not on macOS. It doesn't appear like this zero behavior that Linux performs is anything to do with what POSIX allows so macOS is probably within its rights to not zero memory.

Change the WAVM memory growth to simply memset() on growth. This is a little undesirable because it means the memory will get zeroed twice on Linux (once in the memset and once in the kernel due to the madvise)

Issue #3731 