### PR TITLE
Verify definition exists to prevent SEGFAULT

### DIFF
--- a/libraries/abi_generator/abi_generator.cpp
+++ b/libraries/abi_generator/abi_generator.cpp
@@ -555,6 +555,7 @@ clang::CXXRecordDecl::base_class_range abi_generator::get_struct_bases(const cla
   auto cxxrecord_decl = clang::dyn_cast<CXXRecordDecl>(record_type->getDecl());
   ABI_ASSERT(cxxrecord_decl != nullptr);
   //record_type->getCanonicalTypeInternal().dump();
+  ABI_ASSERT(cxxrecord_decl->hasDefinition(), "No definition for ${t}", ("t", qt.getAsString()));
 
   auto bases = cxxrecord_decl->bases();
 


### PR DESCRIPTION
Resolves #3728

Added assert for definition of type to avoid SEGFAULT. The particular type `tuple<uint64_t, uint64_t>` uses multiple inheritance and is not supported. Now exits with error message of the unsupported type.