### PR TITLE
Build: fixed option behavior

### DIFF
--- a/eosio_build.sh
+++ b/eosio_build.sh
@@ -62,7 +62,7 @@
 	txtrst=$(tput sgr0)
 
 	if [ $# -ne 0 ]; then
-		while getopts ":cdos:" opt; do
+		while getopts ":cdo:s:" opt; do
 			case "${opt}" in
 				o )
 					options=( "Debug" "Release" "RelWithDebInfo" "MinSizeRel" )


### PR DESCRIPTION
fixed issue where passing in -o without an arg behaved unexpectedly