### PR TITLE
Fix invalid bind address for http-server-address [skip-ci]

### DIFF
--- a/Docker/config.ini
+++ b/Docker/config.ini
@@ -51,7 +51,7 @@ contracts-console = false
 https-client-validate-peers = 1
 
 # The local IP and port to listen for incoming http connections; set blank to disable. (eosio::http_plugin)
-http-server-address = 127.0.0.1:8888
+http-server-address = 0.0.0.0:8888
 
 # The local IP and port to listen for incoming https connections; leave blank to disable. (eosio::http_plugin)
 # https-server-address =


### PR DESCRIPTION
- Fixes issue with updated config.ini for Docker that has nodeos binding to 127.0.0.1:8888 instead of 0.0.0.0:8888