### PR TITLE
Fixed CPU speed calculation

### DIFF
--- a/scripts/eosio_build_darwin.sh
+++ b/scripts/eosio_build_darwin.sh
@@ -5,7 +5,7 @@
 
 	MEM_GIG=$(bc <<< "($(sysctl -in hw.memsize) / 1024000000)")
 
-	CPU_SPEED=$(bc <<< "scale=2; ($(sysctl -in hw.cpufrequency) / 10^6) / 10")
+	CPU_SPEED=$(bc <<< "scale=2; ($(sysctl -in hw.cpufrequency) / 10^8) / 10")
 	CPU_CORE=$( sysctl -in machdep.cpu.core_count )
 
 	DISK_INSTALL=$(df -h . | tail -1 | tr -s ' ' | cut -d\  -f1 || cut -d' ' -f1)


### PR DESCRIPTION
CPU speed was being displayed incorrectly, this PR fixes it.

> 	ARCHITECTURE: Darwin
> 
> 	OS name: Darwin
> 	OS Version: 10.13.4
> 	**CPU speed: 310.00Ghz**
> 	CPU cores: 4
> 	Physical Memory: 16 Gbytes


is now:

> 	ARCHITECTURE: Darwin
> 
> 	OS name: Darwin
> 	OS Version: 10.13.4
> 	**CPU speed: 3.10Ghz**
> 	CPU cores: 4
> 	Physical Memory: 16 Gbytes
