### PR TITLE
Fix coverage reports [skip-ci]

### DIFF
--- a/.buildkite/coverage.yml
+++ b/.buildkite/coverage.yml
@@ -4,13 +4,13 @@ steps:
         /usr/bin/cmake -GNinja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=clang++-4.0 -DCMAKE_C_COMPILER=clang-4.0 -DWASM_ROOT=/root/opt/wasm -DOPENSSL_ROOT_DIR=/usr/include/openssl -DBUILD_MONGO_DB_PLUGIN=true -DENABLE_COVERAGE_TESTING=true -DBUILD_DOXYGEN=false && \
         /usr/bin/ninja
         echo "--- :spiral_note_pad: Generating Code Coverage Report" && \
-        /usr/bin/ninja EOS_ut_coverage && \
+        /usr/bin/ninja EOSIO_ut_coverage && \
         echo "--- :arrow_up: Publishing Code Coverage Report" && \
-        buildkite-agent artifact upload "EOS_ut_coverage/**/*" s3://eosio-coverage/$BUILDKITE_JOB_ID && \
+        buildkite-agent artifact upload "EOSIO_ut_coverage/**/*" s3://eosio-coverage/$BUILDKITE_JOB_ID && \
         cp /config/.coveralls.yml . && \
-        /usr/local/bin/coveralls-lcov EOS_ut_coverage_filtered.info && \
+        /usr/local/bin/coveralls-lcov EOSIO_ut_coverage_filtered.info && \
         echo "+++ View Report" && \
-        printf "\033]1339;url=https://eosio-coverage.s3-us-west-2.amazonaws.com/$BUILDKITE_JOB_ID/EOS_ut_coverage/index.html;content=View Full Coverage Report\a\n"
+        printf "\033]1339;url=https://eosio-coverage.s3-us-west-2.amazonaws.com/$BUILDKITE_JOB_ID/EOSIO_ut_coverage/index.html;content=View Full Coverage Report\a\n"
     label: ":spiral_note_pad: Generate Report"
     agents:
       - "role=linux-coverage"


### PR DESCRIPTION
PR #3730 caused the buildkite coverage reports to stop functioning due to the renaming of the project from EOS to EOSIO. As a result, the coverage report was renamed from `EOS_ut_coverage` to `EOSIO_ut_coverage`. This PR updates the coverage pipeline to account for these changes.