### PR TITLE
genabi actually accepts a cpp file instead of a header file

### DIFF
--- a/tools/eosiocpp.in
+++ b/tools/eosiocpp.in
@@ -96,7 +96,7 @@ function print_help {
     echo "       OR"
     echo "       $0 -n mycontract"
     echo "       OR"
-    echo "       $0 -g contract.abi types.hpp"
+    echo "       $0 -g contract.abi contract.cpp"
     echo
     echo "Options:"
     echo "   -n | --newcontract [name]"
@@ -106,7 +106,7 @@ function print_help {
     echo "      Generate the wast output file based on input cpp files"
     echo "      The wasm output will also be created as output.wasm"
     echo "   OR"
-    echo "   -g | --genabi contract.abi types.hpp"
+    echo "   -g | --genabi contract.abi contract.cpp"
     echo "      Generate the ABI specification file [EXPERIMENTAL]"
 }
 


### PR DESCRIPTION
Follow the same convention in '-o' that cpp contains the contract code.