### PR TITLE
Use https to fetch deps, remove --no-check-certificate

### DIFF
--- a/Docker/builder/Dockerfile
+++ b/Docker/builder/Dockerfile
@@ -9,7 +9,7 @@ RUN echo 'APT::Install-Recommends 0;' >> /etc/apt/apt.conf.d/01norecommends \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y sudo wget curl net-tools ca-certificates unzip gnupg
 
 RUN echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic main" >> /etc/apt/sources.list.d/llvm.list \
-  && wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add - \
+  && wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add - \
   && apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y git-core automake autoconf libtool build-essential pkg-config libtool \
      mpi-default-dev libicu-dev python-dev python3-dev libbz2-dev zlib1g-dev libssl-dev libgmp-dev \
@@ -19,7 +19,7 @@ RUN echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic main" >> /etc/ap
 RUN update-alternatives --install /usr/bin/clang clang /usr/lib/llvm-4.0/bin/clang 400 \
   && update-alternatives --install /usr/bin/clang++ clang++ /usr/lib/llvm-4.0/bin/clang++ 400
 
-RUN wget --no-check-certificate https://cmake.org/files/v3.9/cmake-3.9.6-Linux-x86_64.sh \
+RUN wget https://cmake.org/files/v3.9/cmake-3.9.6-Linux-x86_64.sh \
     && bash cmake-3.9.6-Linux-x86_64.sh --prefix=/usr/local --exclude-subdir --skip-license \
     && rm cmake-3.9.6-Linux-x86_64.sh
 
@@ -53,14 +53,14 @@ RUN wget https://github.com/WebAssembly/binaryen/archive/1.37.21.tar.gz -O - | t
     && cmake --build build --target install \
     && cd .. && rm -rf binaryen-1.37.21
 
-RUN git clone --depth 1 git://github.com/cryptonomex/secp256k1-zkp \
+RUN git clone --depth 1 https://github.com/cryptonomex/secp256k1-zkp \
     && cd secp256k1-zkp \
     && ./autogen.sh \
     && ./configure --prefix=/usr/local \
     && make -j$(nproc) install \
     && cd .. && rm -rf secp256k1-zkp
 
-RUN git clone --depth 1 -b releases/stable git://github.com/mongodb/mongo-cxx-driver \
+RUN git clone --depth 1 -b releases/stable https://github.com/mongodb/mongo-cxx-driver \
     && cd mongo-cxx-driver \
     && cmake -H. -Bbuild -G Ninja -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release  -DCMAKE_INSTALL_PREFIX=/usr/local\
     && cmake --build build --target install \

--- a/libraries/wasm-jit/travis-build.sh
+++ b/libraries/wasm-jit/travis-build.sh
@@ -6,17 +6,17 @@ $CXX --version
 
 if [[ $TRAVIS_OS_NAME == "osx" ]]; then
   export CMAKE_URL="https://cmake.org/files/v3.7/cmake-3.7.2-Darwin-x86_64.tar.gz";
-  export LLVM_URL="http://releases.llvm.org/4.0.0/clang+llvm-4.0.0-x86_64-apple-darwin.tar.xz";
+  export LLVM_URL="https://releases.llvm.org/4.0.0/clang+llvm-4.0.0-x86_64-apple-darwin.tar.xz";
 else
   export CMAKE_URL="https://cmake.org/files/v3.7/cmake-3.7.2-Linux-x86_64.tar.gz";
-  export LLVM_URL="http://releases.llvm.org/4.0.0/clang+llvm-4.0.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz";
+  export LLVM_URL="https://releases.llvm.org/4.0.0/clang+llvm-4.0.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz";
 fi
 
 
 # Download a newer version of cmake than is available in Travis's whitelisted apt sources.
 mkdir cmake
 cd cmake
-wget --no-check-certificate --quiet -O ./cmake.tar.gz ${CMAKE_URL}
+wget --quiet -O ./cmake.tar.gz ${CMAKE_URL}
 tar --strip-components=1 -xzf ./cmake.tar.gz
 export PATH=`pwd`/bin:${PATH}
 cd ..
@@ -25,7 +25,7 @@ cmake --version
 # Download a binary build of LLVM4 (also not available in Travis's whitelisted apt sources)
 mkdir llvm4
 cd llvm4
-wget --no-check-certificate --quiet -O ./llvm.tar.xz ${LLVM_URL}
+wget --quiet -O ./llvm.tar.xz ${LLVM_URL}
 tar --strip-components=1 -xf ./llvm.tar.xz
 export LLVM_DIR=`pwd`/lib/cmake/llvm
 cd ..


### PR DESCRIPTION
Currently active man-in-the-middle can do anything with docker container in build time because deps fetched with ` --no-check-certificate`. Also we load GPG key with http and don't check fingerprint.

This is not an ideal fix, we should also check signatures and fingerprints, but it's at least something.