### PR TITLE
Add verify of socket open

### DIFF
--- a/plugins/bnet_plugin/bnet_plugin.cpp
+++ b/plugins/bnet_plugin/bnet_plugin.cpp
@@ -356,6 +356,7 @@ namespace eosio {
 
         void on_connect( boost::system::error_code ec ) {
            if( ec ) return on_fail( ec, "connect" );
+           if( !_ws->is_open() ) return on_fail( ec, "connect, not open");
 
            set_socket_options();
 


### PR DESCRIPTION
Resolves #3612 

bnet has one of the unusual Boost conditions which crashed net_plugin, see #3610.

