### PR TITLE
Gh#3853 wallet name

### DIFF
--- a/plugins/wallet_plugin/wallet_manager.cpp
+++ b/plugins/wallet_plugin/wallet_manager.cpp
@@ -17,6 +17,12 @@ std::string gen_password() {
 
 }
 
+bool valid_filename(const string& name) {
+   if (name.empty()) return false;
+   if (std::find_if(name.begin(), name.end(), !boost::algorithm::is_alnum() && !boost::algorithm::is_any_of("._")) != name.end()) return false;
+   return boost::filesystem::path(name).filename().string() == name;
+}
+
 void wallet_manager::set_timeout(const std::chrono::seconds& t) {
    timeout = t;
    timeout_time = std::chrono::system_clock::now() + timeout;
@@ -34,14 +40,16 @@ void wallet_manager::check_timeout() {
 
 std::string wallet_manager::create(const std::string& name) {
    check_timeout();
-   std::string password = gen_password();
+
+   EOS_ASSERT(valid_filename(name), wallet_exception, "Invalid filename, path not allowed in wallet name ${n}", ("n", name));
 
    auto wallet_filename = dir / (name + file_ext);
 
    if (fc::exists(wallet_filename)) {
       EOS_THROW(chain::wallet_exist_exception, "Wallet with name: '${n}' already exists at ${path}", ("n", name)("path",fc::path(wallet_filename)));
    }
-   
+
+   std::string password = gen_password();
    wallet_data d;
    auto wallet = make_unique<wallet_api>(d);
    wallet->set_password(password);
@@ -51,7 +59,7 @@ std::string wallet_manager::create(const std::string& name) {
       wallet->import_key(eosio_key);
    wallet->lock();
    wallet->unlock(password);
-   
+
    // If we have name in our map then remove it since we want the emplace below to replace.
    // This can happen if the wallet file is removed while eos-walletd is running.
    auto it = wallets.find(name);
@@ -65,6 +73,9 @@ std::string wallet_manager::create(const std::string& name) {
 
 void wallet_manager::open(const std::string& name) {
    check_timeout();
+
+   EOS_ASSERT(valid_filename(name), wallet_exception, "Invalid filename, path not allowed in wallet name ${n}", ("n", name));
+
    wallet_data d;
    auto wallet = std::make_unique<wallet_api>(d);
    auto wallet_filename = dir / (name + file_ext);

--- a/plugins/wallet_plugin/wallet_manager.cpp
+++ b/plugins/wallet_plugin/wallet_manager.cpp
@@ -19,7 +19,7 @@ std::string gen_password() {
 
 bool valid_filename(const string& name) {
    if (name.empty()) return false;
-   if (std::find_if(name.begin(), name.end(), !boost::algorithm::is_alnum() && !boost::algorithm::is_any_of("._")) != name.end()) return false;
+   if (std::find_if(name.begin(), name.end(), !boost::algorithm::is_alnum() && !boost::algorithm::is_any_of("._-")) != name.end()) return false;
    return boost::filesystem::path(name).filename().string() == name;
 }
 

--- a/tests/wallet_tests.cpp
+++ b/tests/wallet_tests.cpp
@@ -51,6 +51,7 @@ BOOST_AUTO_TEST_CASE(wallet_test)
    wallet.unlock("pass");
    BOOST_CHECK_EQUAL(1, wallet.list_keys().size());
    wallet.save_wallet_file("wallet_test.json");
+   BOOST_CHECK(fc::exists("wallet_test.json"));
 
    wallet_data d2;
    wallet_api wallet2(d2);
@@ -64,6 +65,8 @@ BOOST_AUTO_TEST_CASE(wallet_test)
 
    auto privCopy2 = wallet2.get_private_key(pub);
    BOOST_CHECK_EQUAL(wif, (std::string)privCopy2);
+
+   fc::remove("wallet_test.json");
 } FC_LOG_AND_RETHROW() }
 
 /// Test wallet manager
@@ -174,6 +177,10 @@ BOOST_AUTO_TEST_CASE(wallet_manager_test)
 
    wm.set_eosio_key("");
 
+   wm.create("testgen");
+   BOOST_CHECK_THROW(wm.create_key("testgen", "xxx"), chain::wallet_exception);
+   wm.lock("testgen");
+
    const string test_key_create_types[] = {"K1", "R1", "k1", ""};
    for(const string& key_type_to_create : test_key_create_types) {
       string pw = wm.create("testgen");
@@ -192,16 +199,57 @@ BOOST_AUTO_TEST_CASE(wallet_manager_test)
       fc::remove("testgen.wallet");
    }
 
-   wm.create("testgen");
-   BOOST_CHECK_THROW(wm.create_key("testgen", "xxx"), chain::wallet_exception);
-   wm.lock("testgen");
-
    BOOST_CHECK(fc::exists("test.wallet"));
    BOOST_CHECK(fc::exists("test2.wallet"));
    fc::remove("test.wallet");
    fc::remove("test2.wallet");
 
 } FC_LOG_AND_RETHROW() }
+
+/// Test wallet manager
+BOOST_AUTO_TEST_CASE(wallet_manager_create_test) {
+   try {
+      using namespace eosio::wallet;
+
+      if (fc::exists("test.wallet")) fc::remove("test.wallet");
+
+      wallet_manager wm;
+      wm.create("test");
+      BOOST_CHECK_THROW(wm.create("test"), wallet_exist_exception);
+
+      BOOST_CHECK_THROW(wm.create("./test"), wallet_exception);
+      BOOST_CHECK_THROW(wm.create("../../test"), wallet_exception);
+      BOOST_CHECK_THROW(wm.create("/tmp/test"), wallet_exception);
+      BOOST_CHECK_THROW(wm.create("/tmp/"), wallet_exception);
+      BOOST_CHECK_THROW(wm.create("/"), wallet_exception);
+      BOOST_CHECK_THROW(wm.create(",/"), wallet_exception);
+      BOOST_CHECK_THROW(wm.create(","), wallet_exception);
+      BOOST_CHECK_THROW(wm.create("<<"), wallet_exception);
+      BOOST_CHECK_THROW(wm.create("<"), wallet_exception);
+      BOOST_CHECK_THROW(wm.create(",<"), wallet_exception);
+      BOOST_CHECK_THROW(wm.create(",<<"), wallet_exception);
+      BOOST_CHECK_THROW(wm.create(""), wallet_exception);
+
+      fc::remove("test.wallet");
+
+      wm.create(".test");
+      BOOST_CHECK(fc::exists(".test.wallet"));
+      fc::remove(".test.wallet");
+      wm.create("..test");
+      BOOST_CHECK(fc::exists("..test.wallet"));
+      fc::remove("..test.wallet");
+      wm.create("...test");
+      BOOST_CHECK(fc::exists("...test.wallet"));
+      fc::remove("...test.wallet");
+      wm.create(".");
+      BOOST_CHECK(fc::exists("..wallet"));
+      fc::remove("..wallet");
+      wm.create("__test_test");
+      BOOST_CHECK(fc::exists("__test_test.wallet"));
+      fc::remove("__test_test.wallet");
+
+   } FC_LOG_AND_RETHROW()
+}
 
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/wallet_tests.cpp
+++ b/tests/wallet_tests.cpp
@@ -247,6 +247,9 @@ BOOST_AUTO_TEST_CASE(wallet_manager_create_test) {
       wm.create("__test_test");
       BOOST_CHECK(fc::exists("__test_test.wallet"));
       fc::remove("__test_test.wallet");
+      wm.create("t-t");
+      BOOST_CHECK(fc::exists("t-t.wallet"));
+      fc::remove("t-t.wallet");
 
    } FC_LOG_AND_RETHROW()
 }


### PR DESCRIPTION
Add verification of valid wallet filenames where valid is:
- Does not include a path, so that wallet files can only be created in keosd data-dir.
- Includes only alphanumeric, `_`, `-`,and `.` characters.

Resolves #3853 and #3779.