### PR TITLE
Add cmake rules for optional MAS style signing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ include( GNUInstallDirs )
 include( VersionMacros )
 include( SetupTargetMacros )
 include( InstallDirectoryPermissions )
+include( MASSigning )
 
 set( BLOCKCHAIN_NAME "EOSIO" )
 set( CMAKE_CXX_STANDARD 14 )

--- a/CMakeModules/MASSigning.cmake
+++ b/CMakeModules/MASSigning.cmake
@@ -1,0 +1,22 @@
+macro(mas_sign target)
+
+#example values:
+# MAS_CERT_FINGERPRINT=C5139C2C4D7FA071EFBFD86CE44B652631C9376A
+# MAS_BASE_APPID=5A4683969Z.com.example.         <<note the trailing period on this
+# MAS_PROVISIONING_PROFILE="/Users/spoon/Library/MobileDevice/Provisioning Profiles/b1d57761-e5b8-4e58-b412-f1cd0f1924a1.provisionprofile"
+# MAS_KEYCHAIN_GROUP=5A4683969Z.com.example.keyz
+#Given the above, the executable will be signed via the certificate in the keystore matching the fingerprint and bundled with the
+# specified provisioning profile. The appid will the base plus the name of the target, 5A4683969Z.com.example.keosd for example. And
+# the entitlements file will have a keychain sharing group of 5A4683969Z.com.example.keyz
+
+if(APPLE AND MAS_CERT_FINGERPRINT AND MAS_BASE_APPID AND MAS_PROVISIONING_PROFILE AND MAS_KEYCHAIN_GROUP)
+
+  add_custom_command(TARGET ${target} POST_BUILD
+                     COMMAND ${CMAKE_SOURCE_DIR}/tools/mas_sign.sh ${MAS_CERT_FINGERPRINT} ${MAS_BASE_APPID}$<TARGET_FILE_NAME:${target}> ${MAS_PROVISIONING_PROFILE} ${MAS_KEYCHAIN_GROUP} $<TARGET_FILE_NAME:${target}>
+                     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+                     VERBATIM
+                     )
+
+endif()
+
+endmacro(mas_sign)

--- a/programs/keosd/CMakeLists.txt
+++ b/programs/keosd/CMakeLists.txt
@@ -15,6 +15,8 @@ target_link_libraries( keosd
         PRIVATE http_plugin
         PRIVATE eosio_chain fc ${CMAKE_DL_LIBS} ${PLATFORM_SPECIFIC_LIBS} )
 
+mas_sign(keosd)
+
 install( TARGETS
    keosd
 

--- a/programs/nodeos/CMakeLists.txt
+++ b/programs/nodeos/CMakeLists.txt
@@ -95,3 +95,5 @@ install(DIRECTORY DESTINATION ${CMAKE_INSTALL_FULL_LOCALSTATEDIR}/lib/eosio
                               WORLD_READ
                               WORLD_EXECUTE
 			)
+
+mas_sign(nodeos)

--- a/tools/mas_sign.sh
+++ b/tools/mas_sign.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+set -eu
+
+if [ $# -ne 5 ]; then
+   echo Usage: $0 certificate-fingerprint appid provisioning-file keychain-group filename
+   exit 1
+fi
+
+CERT=$1
+APPID=$2
+PP=$3
+KCG=$4
+FILENAME=$5
+IFS=. read TEAMID BUNDLEID <<<"${APPID}"
+
+mkdir -p $FILENAME.app/Contents/MacOS
+cp "$3" $FILENAME.app/Contents/embedded.provisionprofile
+cp $FILENAME $FILENAME.app/Contents/MacOS/$FILENAME
+
+cat > $FILENAME.app/Contents/Info.plist <<ENDENDEND
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$FILENAME</string>
+	<key>CFBundleIdentifier</key>
+	<string>$BUNDLEID</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$FILENAME</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>
+ENDENDEND
+
+TMPFILE=$(mktemp /tmp/signscript.XXXXXX)
+trap "rm $TMPFILE" EXIT
+
+cat > $TMPFILE <<ENDENDEND
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.application-identifier</key>
+	<string>$APPID</string>
+	<key>com.apple.developer.team-identifier</key>
+	<string>$TEAMID</string>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$KCG</string>
+	</array>
+</dict>
+</plist>
+ENDENDEND
+
+codesign --force --sign $CERT --timestamp=none --entitlements $TMPFILE $FILENAME.app


### PR DESCRIPTION
Add optional Mac App Store signing for nodeos & keosd. Mac App Store style signing is required to use the Secure Enclave. Four new parameters must be given to cmake to enable this feature (MAS_CERT_FINGERPRINT, MAS_BASE_APPID, MAS_PROVISIONING_PROFILE, and MAS_KEYCHAIN_GROUP)

The final MAS signed app file is not currently included in the cpack configuration (not sure how to best handle this)

Work on #2252