### PR TITLE
fixes to contract whitelist/blacklist

### DIFF
--- a/contracts/eosiolib/transaction.hpp
+++ b/contracts/eosiolib/transaction.hpp
@@ -42,14 +42,14 @@ namespace eosio {
    public:
       transaction(time_point_sec exp = time_point_sec(now() + 60)) : transaction_header( exp ) {}
 
-      void send(uint64_t sender_id, account_name payer, bool replace_existing = false) const {
+      void send(const uint128_t& sender_id, account_name payer, bool replace_existing = false) const {
          auto serialize = pack(*this);
          send_deferred(sender_id, payer, serialize.data(), serialize.size(), replace_existing);
       }
 
       vector<action>  context_free_actions;
       vector<action>  actions;
-      extensions_type transaction_extensions; 
+      extensions_type transaction_extensions;
 
       EOSLIB_SERIALIZE_DERIVED( transaction, transaction_header, (context_free_actions)(actions)(transaction_extensions) )
    };

--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -39,7 +39,7 @@ action_trace apply_context::exec_one()
       privileged = a.privileged;
       auto native = control.find_apply_handler(receiver, act.account, act.name);
       if( native ) {
-         if( control.is_producing_block() ) {
+         if( !trx_context.cannot_subjectively_fail && control.is_producing_block() ) {
             control.check_contract_list( receiver );
          }
          (*native)(*this);
@@ -48,7 +48,7 @@ action_trace apply_context::exec_one()
       if( a.code.size() > 0
           && !(act.account == config::system_account_name && act.name == N(setcode) && receiver == config::system_account_name) )
       {
-         if( control.is_producing_block() ) {
+         if( !trx_context.cannot_subjectively_fail && control.is_producing_block() ) {
             control.check_contract_list( receiver );
          }
          try {
@@ -375,8 +375,8 @@ int apply_context::get_action( uint32_t type, uint32_t index, char* buffer, size
          return -1;
       act_ptr = &trx.actions[index];
    }
-   
-   FC_ASSERT(act_ptr, "action is not found" ); 
+
+   FC_ASSERT(act_ptr, "action is not found" );
 
    auto ps = fc::raw::pack_size( *act_ptr );
    if( ps <= buffer_size ) {

--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -39,7 +39,7 @@ action_trace apply_context::exec_one()
       privileged = a.privileged;
       auto native = control.find_apply_handler(receiver, act.account, act.name);
       if( native ) {
-         if( !trx_context.cannot_subjectively_fail && control.is_producing_block() ) {
+         if( trx_context.can_subjectively_fail && control.is_producing_block() ) {
             control.check_contract_list( receiver );
          }
          (*native)(*this);
@@ -48,7 +48,7 @@ action_trace apply_context::exec_one()
       if( a.code.size() > 0
           && !(act.account == config::system_account_name && act.name == N(setcode) && receiver == config::system_account_name) )
       {
-         if( !trx_context.cannot_subjectively_fail && control.is_producing_block() ) {
+         if( trx_context.can_subjectively_fail && control.is_producing_block() ) {
             control.check_contract_list( receiver );
          }
          try {

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -637,14 +637,14 @@ struct controller_impl {
          try {
             if( implicit ) {
                trx_context.init_for_implicit_trx();
-               trx_context.cannot_subjectively_fail = true;
+               trx_context.can_subjectively_fail = false;
             } else {
                trx_context.init_for_input_trx( trx->packed_trx.get_unprunable_size(),
                                                trx->packed_trx.get_prunable_size(),
                                                trx->trx.signatures.size() );
             }
 
-            if( !trx_context.cannot_subjectively_fail && pending->_block_status == controller::block_status::incomplete ) {
+            if( trx_context.can_subjectively_fail && pending->_block_status == controller::block_status::incomplete ) {
                check_actor_list( trx_context.bill_to_accounts ); // Assumes bill_to_accounts is the set of actors authorizing the transaction
             }
 
@@ -800,9 +800,9 @@ struct controller_impl {
                push_scheduled_transaction( receipt.trx.get<transaction_id_type>(), fc::time_point::maximum(), receipt.cpu_usage_us );
             }
             const transaction_receipt_header& r = pending->_pending_block_state->block->transactions.back();
-            FC_ASSERT( r == static_cast<const transaction_receipt_header&>(receipt),
-                       "receipt does not match",
-                       ("producer_receipt", receipt)("validator_receipt", pending->_pending_block_state->block->transactions.back()) );
+            EOS_ASSERT( r == static_cast<const transaction_receipt_header&>(receipt),
+                        block_validate_exception, "receipt does not match",
+                        ("producer_receipt", receipt)("validator_receipt", pending->_pending_block_state->block->transactions.back()) );
          }
 
          finalize_block();

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -492,10 +492,14 @@ struct controller_impl {
 
    bool failure_is_subjective( const fc::exception& e ) {
       auto code = e.code();
-      return (code == block_net_usage_exceeded::code_value) ||
-             (code == block_cpu_usage_exceeded::code_value) ||
-             (code == deadline_exception::code_value)       ||
-             (code == leeway_deadline_exception::code_value);
+      return    (code == block_net_usage_exceeded::code_value)
+             || (code == block_cpu_usage_exceeded::code_value)
+             || (code == deadline_exception::code_value)
+             || (code == leeway_deadline_exception::code_value)
+             || (code == actor_whitelist_exception::code_value)
+             || (code == actor_blacklist_exception::code_value)
+             || (code == contract_whitelist_exception::code_value)
+             || (code == contract_blacklist_exception::code_value);
    }
 
    transaction_trace_ptr push_scheduled_transaction( const transaction_id_type& trxid, fc::time_point deadline, uint32_t billed_cpu_time_us ) {

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -633,13 +633,14 @@ struct controller_impl {
          try {
             if( implicit ) {
                trx_context.init_for_implicit_trx();
+               trx_context.cannot_subjectively_fail = true;
             } else {
                trx_context.init_for_input_trx( trx->packed_trx.get_unprunable_size(),
                                                trx->packed_trx.get_prunable_size(),
                                                trx->trx.signatures.size() );
             }
 
-            if( !implicit && pending->_block_status == controller::block_status::incomplete ) {
+            if( !trx_context.cannot_subjectively_fail && pending->_block_status == controller::block_status::incomplete ) {
                check_actor_list( trx_context.bill_to_accounts ); // Assumes bill_to_accounts is the set of actors authorizing the transaction
             }
 

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -791,10 +791,13 @@ struct controller_impl {
                auto& pt = receipt.trx.get<packed_transaction>();
                auto mtrx = std::make_shared<transaction_metadata>(pt);
                push_transaction( mtrx, fc::time_point::maximum(), false, receipt.cpu_usage_us );
-            }
-            else if( receipt.trx.contains<transaction_id_type>() ) {
+            } else if( receipt.trx.contains<transaction_id_type>() ) {
                push_scheduled_transaction( receipt.trx.get<transaction_id_type>(), fc::time_point::maximum(), receipt.cpu_usage_us );
             }
+            const transaction_receipt_header& r = pending->_pending_block_state->block->transactions.back();
+            FC_ASSERT( r == static_cast<const transaction_receipt_header&>(receipt),
+                       "receipt does not match",
+                       ("producer_receipt", receipt)("validator_receipt", pending->_pending_block_state->block->transactions.back()) );
          }
 
          finalize_block();

--- a/libraries/chain/include/eosio/chain/block.hpp
+++ b/libraries/chain/include/eosio/chain/block.hpp
@@ -21,6 +21,10 @@ namespace eosio { namespace chain {
       transaction_receipt_header():status(hard_fail){}
       transaction_receipt_header( status_enum s ):status(s){}
 
+      friend inline bool operator ==( const transaction_receipt_header& lhs, const transaction_receipt_header& rhs ) {
+         return std::tie(lhs.status, lhs.cpu_usage_us, lhs.net_usage_words) == std::tie(rhs.status, rhs.cpu_usage_us, rhs.net_usage_words);
+      }
+
       fc::enum_type<uint8_t,status_enum>   status;
       uint32_t                             cpu_usage_us; ///< total billed CPU usage (microseconds)
       fc::unsigned_int                     net_usage_words; ///<  total billed NET usage, so we can reconstruct resource state when skipping context free data... hard failures...

--- a/libraries/chain/include/eosio/chain/transaction_context.hpp
+++ b/libraries/chain/include/eosio/chain/transaction_context.hpp
@@ -75,7 +75,7 @@ namespace eosio { namespace chain {
          fc::microseconds              delay;
          bool                          is_input           = false;
          bool                          apply_context_free = true;
-         bool                          cannot_subjectively_fail = false;
+         bool                          can_subjectively_fail = true;
 
          fc::time_point                deadline = fc::time_point::maximum();
          fc::microseconds              leeway = fc::microseconds(3000);

--- a/libraries/chain/include/eosio/chain/transaction_context.hpp
+++ b/libraries/chain/include/eosio/chain/transaction_context.hpp
@@ -75,6 +75,7 @@ namespace eosio { namespace chain {
          fc::microseconds              delay;
          bool                          is_input           = false;
          bool                          apply_context_free = true;
+         bool                          cannot_subjectively_fail = false;
 
          fc::time_point                deadline = fc::time_point::maximum();
          fc::microseconds              leeway = fc::microseconds(3000);

--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -201,6 +201,9 @@ namespace eosio { namespace testing {
 
          vector<char> get_row_by_account( uint64_t code, uint64_t scope, uint64_t table, const account_name& act );
 
+         map<account_name, block_id_type> get_last_produced_block_map()const { return last_produced_block; };
+         void set_last_produced_block_map( const map<account_name, block_id_type>& lpb ) { last_produced_block = lpb; }
+
          static vector<uint8_t> to_uint8_vector(const string& s);
 
          static vector<uint8_t> to_uint8_vector(uint64_t x);
@@ -303,7 +306,8 @@ namespace eosio { namespace testing {
    public:
       virtual ~validating_tester() {
          try {
-            produce_block();
+            if( num_blocks_to_producer_before_shutdown > 0 )
+               produce_blocks( num_blocks_to_producer_before_shutdown );
             BOOST_REQUIRE_EQUAL( validate(), true );
          } catch( const fc::exception& e ) {
             wdump((e.to_detail_string()));
@@ -385,7 +389,8 @@ namespace eosio { namespace testing {
         return ok;
       }
 
-      unique_ptr<controller>                  validating_node;
+      unique_ptr<controller>   validating_node;
+      uint32_t                 num_blocks_to_producer_before_shutdown = 0;
    };
 
    /**

--- a/scripts/abigen.sh
+++ b/scripts/abigen.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+if (( $# < 3 )); then
+   echo "$0 SOURCE_DIR BUILD_DIR ARGS..."
+   exit 0
+fi
+
+function get_absolute_dir_path() {
+  pushd $1 > /dev/null
+  echo $PWD
+  popd > /dev/null
+}
+
+SOURCE_DIR=$(get_absolute_dir_path $1)
+
+BUILD_DIR=$2
+
+shift; shift
+
+#echo "Source directory: ${SOURCE_DIR}"
+
+eval "${BUILD_DIR}/programs/eosio-abigen/eosio-abigen -extra-arg=--std=c++14 -extra-arg=--target=wasm32 -extra-arg=\"-I${SOURCE_DIR}/contracts/libc++/upstream/include\" -extra-arg=\"-I${SOURCE_DIR}/contracts/musl/upstream/include\" -extra-arg=\"-I${SOURCE_DIR}/externals/magic_get/include\" -extra-arg=\"-I${SOURCE_DIR}/contracts\" $@"

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -12,8 +12,11 @@ link_directories(${LLVM_LIBRARY_DIR})
 
 set( CMAKE_CXX_STANDARD 14 )
 
+add_subdirectory(contracts)
+
 include_directories("${CMAKE_BINARY_DIR}/contracts")
 include_directories("${CMAKE_SOURCE_DIR}/contracts")
+include_directories("${CMAKE_BINARY_DIR}/unittests/contracts")
 include_directories("${CMAKE_SOURCE_DIR}/unittests/contracts")
 include_directories("${CMAKE_SOURCE_DIR}/libraries/testing/include")
 

--- a/unittests/contracts/CMakeLists.txt
+++ b/unittests/contracts/CMakeLists.txt
@@ -1,0 +1,7 @@
+# will be implictly used for any compilation unit if not overrided by SYSTEM_INCLUDE_FOLDERS parameter
+# these directories go as -isystem <dir> to avoid warnings from code of third-party libraries
+set(DEFAULT_SYSTEM_INCLUDE_FOLDERS ${CMAKE_SOURCE_DIR}/contracts/libc++/upstream/include ${CMAKE_SOURCE_DIR}/contracts/musl/upstream/include ${Boost_INCLUDE_DIR})
+
+set(STANDARD_INCLUDE_FOLDERS ${CMAKE_SOURCE_DIR}/contracts ${CMAKE_SOURCE_DIR}/unittests/contracts ${CMAKE_SOURCE_DIR}/externals/magic_get/include)
+
+add_subdirectory(deferred_test)

--- a/unittests/contracts/deferred_test/CMakeLists.txt
+++ b/unittests/contracts/deferred_test/CMakeLists.txt
@@ -1,0 +1,8 @@
+file(GLOB ABI_FILES "*.abi")
+configure_file("${ABI_FILES}" "${CMAKE_CURRENT_BINARY_DIR}" COPYONLY)
+
+add_wast_executable(TARGET deferred_test
+  INCLUDE_FOLDERS "${STANDARD_INCLUDE_FOLDERS}" ${Boost_INCLUDE_DIR}
+  LIBRARIES libc++ libc eosiolib
+  DESTINATION_FOLDER ${CMAKE_CURRENT_BINARY_DIR}
+)

--- a/unittests/contracts/deferred_test/deferred_test.abi
+++ b/unittests/contracts/deferred_test/deferred_test.abi
@@ -1,0 +1,45 @@
+{
+  "version": "eosio::abi/1.0",
+  "types": [],
+  "structs": [{
+      "name": "defercall",
+      "base": "",
+      "fields": [{
+          "name": "payer",
+          "type": "name"
+        },{
+           "name": "sender_id",
+           "type": "uint64"
+         },{
+          "name": "contract",
+          "type": "name"
+        },{
+          "name": "payload",
+          "type": "uint64"
+        }
+      ]
+    },{
+      "name": "deferfunc",
+      "base": "",
+      "fields": [{
+          "name": "payload",
+          "type": "uint64"
+        }
+      ]
+    }
+  ],
+  "actions": [{
+      "name": "defercall",
+      "type": "defercall",
+      "ricardian_contract": ""
+    },{
+      "name": "deferfunc",
+      "type": "deferfunc",
+      "ricardian_contract": ""
+    }
+  ],
+  "tables": [],
+  "ricardian_clauses": [],
+  "error_messages": [],
+  "abi_extensions": []
+}

--- a/unittests/contracts/deferred_test/deferred_test.cpp
+++ b/unittests/contracts/deferred_test/deferred_test.cpp
@@ -1,0 +1,60 @@
+/**
+ *  @file
+ *  @copyright defined in eos/LICENSE.txt
+ */
+
+#include <eosiolib/eosio.hpp>
+#include <eosiolib/transaction.hpp>
+#include <eosiolib/dispatcher.hpp>
+
+using namespace eosio;
+
+class deferred_test : public eosio::contract {
+   public:
+      using contract::contract;
+
+      struct deferfunc_args {
+         uint64_t payload;
+      };
+
+      //@abi action
+      void defercall( account_name payer, uint64_t sender_id, account_name contract, uint64_t payload ) {
+         print( "defercall called on ", name{_self}, "\n" );
+         require_auth( payer );
+
+         print( "deferred send of deferfunc action to ", name{contract}, " by ", name{payer}, " with sender id ", sender_id );
+         transaction trx;
+         deferfunc_args a = {.payload = payload};
+         trx.actions.emplace_back(permission_level{_self, N(active)}, contract, N(deferfunc), a);
+         trx.send( (static_cast<uint128_t>(payer) << 64) | sender_id, payer);
+      }
+
+      //@abi action
+      void deferfunc( uint64_t payload ) {
+         print("deferfunc called on ", name{_self}, "\n");
+      }
+
+   private:
+};
+
+void apply_onerror(uint64_t receiver, const onerror& error ) {
+   print("onerror called on ", name{receiver}, "\n");
+}
+
+extern "C" {
+    /// The apply method implements the dispatch of events to this contract
+    void apply( uint64_t receiver, uint64_t code, uint64_t action ) {
+      if( code == N(eosio) && action == N(onerror) ) {
+         apply_onerror( receiver, onerror::from_current_action() );
+      } else if( code == receiver ) {
+         deferred_test thiscontract(receiver);
+         if( action == N(defercall) ) {
+            execute_action( &thiscontract, &deferred_test::defercall );
+         } else if( action == N(deferfunc) ) {
+            execute_action( &thiscontract, &deferred_test::deferfunc );
+         }
+      }
+   }
+}
+
+//EOSIO_ABI( deferred_test, (defercall)(deferfunc) )

--- a/unittests/whitelist_blacklist_tests.cpp
+++ b/unittests/whitelist_blacklist_tests.cpp
@@ -347,15 +347,15 @@ BOOST_AUTO_TEST_CASE( deferred_blacklist_failure ) { try {
       ( "payload", 10 )
    );
 
-   tester1.chain->produce_blocks(2);
+   BOOST_CHECK_EXCEPTION( tester1.chain->produce_blocks(), fc::exception,
+                          fc_exception_message_is("account 'charlie' is on the contract blacklist")
+                        );
+   tester1.chain->produce_blocks(2, true); // Produce 2 empty blocks (other than onblock of course).
 
-   // Comment out to trigger bug
-   /*
    while( tester2.chain->control->head_block_num() < tester1.chain->control->head_block_num() ) {
       auto b = tester1.chain->control->fetch_block_by_number( tester2.chain->control->head_block_num()+1 );
       tester2.chain->push_block( b );
    }
-   */
 } FC_LOG_AND_RETHROW() }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/unittests/whitelist_blacklist_tests.cpp
+++ b/unittests/whitelist_blacklist_tests.cpp
@@ -299,13 +299,10 @@ BOOST_AUTO_TEST_CASE( blacklist_eosio ) { try {
 
    tester1.chain->produce_blocks(2);
 
-   // Comment out to trigger bug
-   /*
    while( tester2.chain->control->head_block_num() < tester1.chain->control->head_block_num() ) {
       auto b = tester1.chain->control->fetch_block_by_number( tester2.chain->control->head_block_num()+1 );
       tester2.chain->push_block( b );
    }
-   */
 
 } FC_LOG_AND_RETHROW() }
 

--- a/unittests/whitelist_blacklist_tests.cpp
+++ b/unittests/whitelist_blacklist_tests.cpp
@@ -19,6 +19,7 @@ using namespace eosio::testing;
 
 using mvo = fc::mutable_variant_object;
 
+template<class Tester = TESTER>
 class whitelist_blacklist_tester {
    public:
       whitelist_blacklist_tester() {}
@@ -46,7 +47,9 @@ class whitelist_blacklist_tester {
          return cfg;
       }
 
-      void init() {
+      void init( bool bootstrap = true ) {
+         FC_ASSERT( !chain, "chain is already up" );
+
          auto cfg = get_default_chain_configuration( tempdir.path() );
          cfg.actor_whitelist = actor_whitelist;
          cfg.actor_blacklist = actor_blacklist;
@@ -54,6 +57,11 @@ class whitelist_blacklist_tester {
          cfg.contract_blacklist = contract_blacklist;
 
          chain.emplace(cfg);
+         wdump((last_produced_block));
+         chain->set_last_produced_block_map( last_produced_block );
+
+         if( !bootstrap ) return;
+
          chain->create_accounts({N(eosio.token), N(alice), N(bob), N(charlie)});
          chain->set_code(N(eosio.token), eosio_token_wast);
          chain->set_abi(N(eosio.token), eosio_token_abi);
@@ -69,6 +77,13 @@ class whitelist_blacklist_tester {
          chain->produce_blocks();
       }
 
+      void shutdown() {
+         FC_ASSERT( chain.valid(), "chain is not up" );
+         last_produced_block = chain->get_last_produced_block_map();
+         wdump((last_produced_block));
+         chain.reset();
+      }
+
       transaction_trace_ptr transfer( account_name from, account_name to, string quantity = "1.00 TOK" ) {
          return chain->push_action( N(eosio.token), N(transfer), from, mvo()
             ( "from", from )
@@ -78,12 +93,13 @@ class whitelist_blacklist_tester {
          );
       }
 
-      fc::temp_directory       tempdir; // Must come before chain
-      fc::optional<TESTER>     chain;
-      flat_set<account_name>   actor_whitelist;
-      flat_set<account_name>   actor_blacklist;
-      flat_set<account_name>   contract_whitelist;
-      flat_set<account_name>   contract_blacklist;
+      fc::temp_directory                tempdir; // Must come before chain
+      fc::optional<Tester>              chain;
+      flat_set<account_name>            actor_whitelist;
+      flat_set<account_name>            actor_blacklist;
+      flat_set<account_name>            contract_whitelist;
+      flat_set<account_name>            contract_blacklist;
+      map<account_name, block_id_type>  last_produced_block;
 };
 
 struct transfer_args {
@@ -99,7 +115,7 @@ FC_REFLECT( transfer_args, (from)(to)(quantity)(memo) )
 BOOST_AUTO_TEST_SUITE(whitelist_blacklist_tests)
 
 BOOST_AUTO_TEST_CASE( actor_whitelist ) { try {
-   whitelist_blacklist_tester test;
+   whitelist_blacklist_tester<> test;
    test.actor_whitelist = {N(eosio), N(eosio.token), N(alice)};
    test.init();
 
@@ -132,7 +148,7 @@ BOOST_AUTO_TEST_CASE( actor_whitelist ) { try {
 } FC_LOG_AND_RETHROW() }
 
 BOOST_AUTO_TEST_CASE( actor_blacklist ) { try {
-   whitelist_blacklist_tester test;
+   whitelist_blacklist_tester<> test;
    test.actor_blacklist = {N(bob)};
    test.init();
 
@@ -166,7 +182,7 @@ BOOST_AUTO_TEST_CASE( actor_blacklist ) { try {
 } FC_LOG_AND_RETHROW() }
 
 BOOST_AUTO_TEST_CASE( contract_whitelist ) { try {
-   whitelist_blacklist_tester test;
+   whitelist_blacklist_tester<> test;
    test.contract_whitelist = {N(eosio), N(eosio.token), N(bob)};
    test.init();
 
@@ -215,7 +231,7 @@ BOOST_AUTO_TEST_CASE( contract_whitelist ) { try {
 } FC_LOG_AND_RETHROW() }
 
 BOOST_AUTO_TEST_CASE( contract_blacklist ) { try {
-   whitelist_blacklist_tester test;
+   whitelist_blacklist_tester<> test;
    test.contract_blacklist = {N(charlie)};
    test.init();
 
@@ -261,6 +277,36 @@ BOOST_AUTO_TEST_CASE( contract_blacklist ) { try {
                           fc_exception_message_starts_with("account 'charlie' is on the contract blacklist")
                         );
    test.chain->produce_blocks();
+} FC_LOG_AND_RETHROW() }
+
+BOOST_AUTO_TEST_CASE( blacklist_eosio ) { try {
+   whitelist_blacklist_tester<tester> tester1;
+   tester1.init();
+   tester1.chain->produce_blocks();
+   tester1.chain->set_code(N(eosio), eosio_token_wast);
+   tester1.chain->produce_blocks();
+   tester1.shutdown();
+   tester1.contract_blacklist = {N(eosio)};
+   tester1.init(false);
+
+   whitelist_blacklist_tester<tester> tester2;
+   tester2.init(false);
+
+   while( tester2.chain->control->head_block_num() < tester1.chain->control->head_block_num() ) {
+      auto b = tester1.chain->control->fetch_block_by_number( tester2.chain->control->head_block_num()+1 );
+      tester2.chain->push_block( b );
+   }
+
+   tester1.chain->produce_blocks(2);
+
+   // Comment out to trigger bug
+   /*
+   while( tester2.chain->control->head_block_num() < tester1.chain->control->head_block_num() ) {
+      auto b = tester1.chain->control->fetch_block_by_number( tester2.chain->control->head_block_num()+1 );
+      tester2.chain->push_block( b );
+   }
+   */
+
 } FC_LOG_AND_RETHROW() }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Resolves #3814.

Whitelisting/blacklisting exceptions are subjective failures. They depend on the particular configuration of the block producer considering transactions for inclusion in a block. A subjective failure should never lead to a block being produced that relies on that subjective decision making (which is not made objective by including it in the block structure as an official part of the protocol, e.g. with the CPU billing amount) because the validators would not in general able to recreate that subjective decision making.

At the moment, there are a couple places where this rule is broken in the current code. 

First, since the onblock transaction is implicit which means it is not recorded as successful or not within the block, any subjective failure of the onblock action should not be allowed. However, the contract whitelist/blacklist was not respecting this rule. This means a producer who configured their whitelist/blacklists to effectively ban the `eosio` contract from executing would produce blocks that would be considered objectively invalid by all other validators. This was the issue described in #3814.

Second, the whitelist/blacklist exceptions were not treated as subjective failures in `controller`. This meant that whitelist/blacklist failures encountered while processing a deferred transaction would have incorrectly elevated the status of the retired transaction to `soft_fail` or `hard_fail`. A validator would have expected a different receipt status and again considered that block to be objectively invalid.

These bugs are fixed in this PR.

These bugs did not affect correct validation of a chain. All validators would still correctly accept or reject blocks according to the intended protocol on v1.0.1. The problem is with the block producers potentially producing objectively bad blocks due to these bugs. However, if block producers do not use the `contract-whitelist` and `contract-blacklist` options on v1.0.1, they are still safe from producing objectively bad blocks.

Since these bugs do not affect correct validation of a chain, the bug fixes in this PR (which do not modify validation logic†) are not consensus-breaking changes. 

With the changes in this PR (intended to be included in v1.0.2), the contract whitelist/blacklist features should be safe for block producers to use.

This PR also includes the following changes:
* Fail early on mismatching receipts with more meaningful error message (see footnote† below).
* Correct the C++ signature of `transaction::send` in eosiolib to accept a `uint128_t` sender ID rather than a `uint64_t` one. The signature of the C intrinsic (`send_deferred`) that `transaction::send` wraps was already correct, so once again this is not a consensus-breaking change.
* Added a helper script "scripts/abigen.sh" to make ABI generation from source code more convenient.
* Added two additional tests to whitelist_blacklist_tests related to the two bug fixes described earlier.
* Avoid producing the unnecessary additional block when deconstructing `validating_tester`. 

Footnotes:
† There is an immaterial change in the validation logic within this PR. The `transaction_receipt_header`s generated during the validation step are now compared against those in the signed block to ensure they are identical. This change is immaterial from the perspective of following the same protocol as before because any differences in the bits of these `transaction_receipt_header`s would have led to a very different block-signing digest used to recover the producer public key. So the block would still fail anyway due to a signature mismatch. The changes in this PR just make the validation fail earlier with a more meaningful error message.