### PR TITLE
Gh#3916 cleos no params

### DIFF
--- a/programs/cleos/httpc.cpp
+++ b/programs/cleos/httpc.cpp
@@ -102,7 +102,8 @@ namespace eosio { namespace client { namespace http {
 
    fc::variant do_http_call( const connection_param& cp,
                              const fc::variant& postdata,
-                             bool print_request ) {
+                             bool print_request,
+                             bool print_response ) {
    std::string postjson;
    if( !postdata.is_null() ) {
       postjson = print_request ? fc::json::to_pretty_string( postdata ) : fc::json::to_string( postdata );
@@ -170,6 +171,12 @@ namespace eosio { namespace client { namespace http {
    }
 
    const auto response_result = fc::json::from_string(re);
+   if( print_response ) {
+      std::cerr << "RESPONSE:" << std::endl
+                << "---------------------" << std::endl
+                << fc::json::to_pretty_string( response_result ) << std::endl
+                << "---------------------" << std::endl;
+   }
    if( status_code == 200 || status_code == 201 || status_code == 202 ) {
       return response_result;
    } else if( status_code == 404 ) {

--- a/programs/cleos/httpc.hpp
+++ b/programs/cleos/httpc.hpp
@@ -31,7 +31,8 @@ namespace eosio { namespace client { namespace http {
 
    fc::variant do_http_call( const connection_param& cp,
                              const fc::variant& postdata = fc::variant(),
-                             bool print_request = false );
+                             bool print_request = false,
+                             bool print_response = false);
 
    const string chain_func_base = "/v1/chain";
    const string get_info_func = chain_func_base + "/get_info";

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -2304,9 +2304,11 @@ int main( int argc, char** argv ) {
    add_standard_transaction_options(actionsSubcommand);
    actionsSubcommand->set_callback([&] {
       fc::variant action_args_var;
-      try {
-         action_args_var = json_from_file_or_string(data, fc::json::relaxed_parser);
-      } EOS_RETHROW_EXCEPTIONS(action_type_exception, "Fail to parse action JSON data='${data}'", ("data",data))
+      if( !data.empty() ) {
+         try {
+            action_args_var = json_from_file_or_string(data, fc::json::relaxed_parser);
+         } EOS_RETHROW_EXCEPTIONS(action_type_exception, "Fail to parse action JSON data='${data}'", ("data", data))
+      }
 
       auto arg= fc::mutable_variant_object
                 ("code", contract_account)

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -162,6 +162,7 @@ bool   tx_dont_broadcast = false;
 bool   tx_skip_sign = false;
 bool   tx_print_json = false;
 bool   print_request = false;
+bool   print_response = false;
 
 uint8_t  tx_max_cpu_usage = 0;
 uint32_t tx_max_net_usage = 0;
@@ -215,7 +216,7 @@ fc::variant call( const std::string& url,
       eosio::client::http::connection_param *cp = new eosio::client::http::connection_param((std::string&)url, (std::string&)path,
               no_verify ? false : true, headers);
 
-      return eosio::client::http::do_http_call( *cp, fc::variant(v), print_request );
+      return eosio::client::http::do_http_call( *cp, fc::variant(v), print_request, print_response );
    }
    catch(boost::system::system_error& e) {
       if(url == ::url)
@@ -1550,6 +1551,7 @@ int main( int argc, char** argv ) {
    bool verbose_errors = false;
    app.add_flag( "-v,--verbose", verbose_errors, localized("output verbose actions on error"));
    app.add_flag("--print-request", print_request, localized("print HTTP request to STDERR"));
+   app.add_flag("--print-response", print_response, localized("print HTTP response to STDERR"));
 
    auto version = app.add_subcommand("version", localized("Retrieve version information"), false);
    version->require_subcommand();

--- a/unittests/payloadless_tests.cpp
+++ b/unittests/payloadless_tests.cpp
@@ -42,4 +42,38 @@ BOOST_FIXTURE_TEST_CASE( test_doit, payloadless_tester ) {
    BOOST_CHECK_EQUAL(msg == "Im a payloadless action", true);
 }
 
+// test GH#3916 - contract api action with no parameters fails when called from cleos
+// abi_serializer was failing when action data was empty.
+BOOST_FIXTURE_TEST_CASE( test_abi_serializer, payloadless_tester ) {
+
+   create_accounts( {N(payloadless)} );
+   set_code( N(payloadless), payloadless_wast );
+   set_abi( N(payloadless), payloadless_abi );
+
+   variant pretty_trx = fc::mutable_variant_object()
+      ("actions", fc::variants({
+         fc::mutable_variant_object()
+            ("account", name(N(payloadless)))
+            ("name", "doit")
+            ("authorization", fc::variants({
+               fc::mutable_variant_object()
+                  ("actor", name(N(payloadless)))
+                  ("permission", name(config::active_name))
+            }))
+            ("data", fc::mutable_variant_object()
+            )
+         })
+     );
+
+   signed_transaction trx;
+   // from_variant is key to this test as abi_serializer was explicitly not allowing empty "data"
+   abi_serializer::from_variant(pretty_trx, trx, get_resolver());
+   set_transaction_headers(trx);
+
+   trx.sign( get_private_key( N(payloadless), "active" ), control->get_chain_id() );
+   auto trace = push_transaction( trx );
+   auto msg = trace->action_traces.front().console;
+   BOOST_CHECK_EQUAL(msg == "Im a payloadless action", true);
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
- Explicitly allow empty action data in abi_serializer
- Explicitly allow empty action data on push data cleos command line
- Also includes a new cleos option: `--print-response` which is similar to newly added `--print-request` only prints the http response.

Resolves #3916 