### PR TITLE
resource manager audit

### DIFF
--- a/libraries/chain/include/eosio/chain/resource_limits_private.hpp
+++ b/libraries/chain/include/eosio/chain/resource_limits_private.hpp
@@ -28,7 +28,8 @@ namespace eosio { namespace chain { namespace resource_limits {
       template<typename LesserIntType, typename GreaterIntType>
       constexpr LesserIntType downgrade_cast(GreaterIntType val) {
          const auto max = std::numeric_limits<LesserIntType>::max();
-         EOS_ASSERT( val <= max, rate_limiting_state_inconsistent, "Casting a higher bit integer value ${v} to a lower bit integer value which cannot contain the value, max is ${m}", ("v", val)("m", max) );
+         const auto min = std::numeric_limits<LesserIntType>::min();
+         EOS_ASSERT( val >= min && val <= max, rate_limiting_state_inconsistent, "Casting a higher bit integer value ${v} to a lower bit integer value which cannot contain the value, valid range is [${min}, ${max}]", ("v", val)("min", min)("max",max) );
          return LesserIntType(val);
       };
 

--- a/libraries/chain/resource_limits.cpp
+++ b/libraries/chain/resource_limits.cpp
@@ -109,10 +109,10 @@ void resource_limits_manager::add_transaction_usage(const flat_set<account_name>
 
       if( cpu_weight >= 0 && state.total_cpu_weight > 0 ) {
          uint128_t window_size = config.account_cpu_usage_average_window;
-         auto virtual_network_capacity_in_window = state.virtual_cpu_limit * window_size;
-         auto cpu_used_in_window                 = (usage.cpu_usage.value_ex * window_size) / config::rate_limiting_precision;
+         auto virtual_network_capacity_in_window = (uint128_t)state.virtual_cpu_limit * window_size;
+         auto cpu_used_in_window                 = ((uint128_t)usage.cpu_usage.value_ex * window_size) / (uint128_t)config::rate_limiting_precision;
 
-         uint128_t user_weight     = cpu_weight;
+         uint128_t user_weight     = (uint128_t)cpu_weight;
          uint128_t all_user_weight = state.total_cpu_weight;
 
          auto max_user_use_in_window = (virtual_network_capacity_in_window * user_weight) / all_user_weight;
@@ -128,10 +128,10 @@ void resource_limits_manager::add_transaction_usage(const flat_set<account_name>
       if( net_weight >= 0 && state.total_net_weight > 0) {
 
          uint128_t window_size = config.account_net_usage_average_window;
-         auto virtual_network_capacity_in_window = state.virtual_net_limit * window_size;
-         auto net_used_in_window                 = (usage.net_usage.value_ex * window_size) / config::rate_limiting_precision;
+         auto virtual_network_capacity_in_window = (uint128_t)state.virtual_net_limit * window_size;
+         auto net_used_in_window                 = ((uint128_t)usage.net_usage.value_ex * window_size) / (uint128_t)config::rate_limiting_precision;
 
-         uint128_t user_weight     = net_weight;
+         uint128_t user_weight     = (uint128_t)net_weight;
          uint128_t all_user_weight = state.total_net_weight;
 
          auto max_user_use_in_window = (virtual_network_capacity_in_window * user_weight) / all_user_weight;
@@ -335,6 +335,11 @@ uint64_t resource_limits_manager::get_block_net_limit() const {
 }
 
 int64_t resource_limits_manager::get_account_cpu_limit( const account_name& name ) const {
+   auto arl = get_account_cpu_limit_ex(name);
+   return arl.available;
+}
+
+account_resource_limit resource_limits_manager::get_account_cpu_limit_ex( const account_name& name ) const {
 
    const auto& state = _db.get<resource_limits_state_object>();
    const auto& usage = _db.get<resource_usage_object, by_owner>(name);
@@ -345,59 +350,6 @@ int64_t resource_limits_manager::get_account_cpu_limit( const account_name& name
    get_account_limits( name, unused, unused, cpu_weight );
 
    if( cpu_weight < 0 || state.total_cpu_weight == 0 ) {
-      return -1;
-   }
-
-   uint128_t window_size = config.account_cpu_usage_average_window;
-
-   auto virtual_cpu_capacity_in_window = state.virtual_cpu_limit * window_size;
-   uint128_t user_weight     = cpu_weight;
-   uint128_t all_user_weight = state.total_cpu_weight;
-
-   auto max_user_use_in_window = (virtual_cpu_capacity_in_window * user_weight) / all_user_weight;
-   auto cpu_used_in_window  = (usage.cpu_usage.value_ex * window_size) / config::rate_limiting_precision;
-
-   if( max_user_use_in_window <= cpu_used_in_window ) return 0;
-
-   return max_user_use_in_window - cpu_used_in_window;
-
-/*
-   const auto& state = _db.get<resource_limits_state_object>();
-   const auto& usage = _db.get<resource_usage_object, by_owner>(name);
-
-   int64_t x;
-   int64_t cpu_weight;
-   get_account_limits( name, x, x, cpu_weight );
-
-   if( cpu_weight < 0 ) {
-      return -1;
-   }
-
-   auto total_cpu_weight = state.total_cpu_weight;
-   if( total_cpu_weight == 0 ) total_cpu_weight = 1;
-
-   uint128_t consumed_ex = (uint128_t)usage.cpu_usage.consumed * (uint128_t)config::rate_limiting_precision;
-   uint128_t virtual_capacity_ex = (uint128_t)state.virtual_cpu_limit * (uint128_t)config::rate_limiting_precision;
-
-   uint128_t usable_capacity_ex = (uint128_t)(virtual_capacity_ex * cpu_weight) / (uint128_t)total_cpu_weight;
-
-   if( usable_capacity_ex < consumed_ex ) {
-      return 0;
-   }
-
-   return (int64_t)((usable_capacity_ex - consumed_ex) / (uint128_t)config::rate_limiting_precision);
-   */
-}
-
-account_resource_limit resource_limits_manager::get_account_cpu_limit_ex( const account_name& name ) const {
-   const auto& config = _db.get<resource_limits_config_object>();
-   const auto& state = _db.get<resource_limits_state_object>();
-   const auto& usage = _db.get<resource_usage_object, by_owner>(name);
-
-   int64_t cpu_weight, x, y;
-   get_account_limits( name, x, y, cpu_weight );
-
-   if( cpu_weight < 0 || state.total_cpu_weight == 0 ) {
       return { -1, -1, -1 };
    }
 
@@ -405,49 +357,26 @@ account_resource_limit resource_limits_manager::get_account_cpu_limit_ex( const 
 
    uint128_t window_size = config.account_cpu_usage_average_window;
 
-   auto virtual_cpu_capacity_in_window = state.virtual_cpu_limit * window_size;
-   uint128_t user_weight     = cpu_weight;
-   uint128_t all_user_weight = state.total_cpu_weight;
+   uint128_t virtual_cpu_capacity_in_window = (uint128_t)state.virtual_cpu_limit * window_size;
+   uint128_t user_weight     = (uint128_t)cpu_weight;
+   uint128_t all_user_weight = (uint128_t)state.total_cpu_weight;
 
-   auto max_user_use_in_window = (uint128_t(virtual_cpu_capacity_in_window) * user_weight) / all_user_weight;
-   auto cpu_used_in_window  = (usage.cpu_usage.value_ex * window_size) / config::rate_limiting_precision;
+   auto max_user_use_in_window = (virtual_cpu_capacity_in_window * user_weight) / all_user_weight;
+   auto cpu_used_in_window  = impl::integer_divide_ceil((uint128_t)usage.cpu_usage.value_ex * window_size, (uint128_t)config::rate_limiting_precision);
 
    if( max_user_use_in_window <= cpu_used_in_window )
       arl.available = 0;
    else
-      arl.available = max_user_use_in_window - cpu_used_in_window;
+      arl.available = impl::downgrade_cast<uint64_t>(max_user_use_in_window - cpu_used_in_window);
 
-   arl.used = cpu_used_in_window;
-   arl.max = max_user_use_in_window;
-
+   arl.used = impl::downgrade_cast<uint64_t>(cpu_used_in_window);
+   arl.max = impl::downgrade_cast<uint64_t>(max_user_use_in_window);
    return arl;
 }
 
 int64_t resource_limits_manager::get_account_net_limit( const account_name& name ) const {
-   const auto& state = _db.get<resource_limits_state_object>();
-   const auto& usage = _db.get<resource_usage_object, by_owner>(name);
-   const auto& config = _db.get<resource_limits_config_object>();
-
-   int64_t unused;
-   int64_t net_weight;
-   get_account_limits( name, unused, net_weight, unused );
-
-   if( net_weight < 0 || state.total_net_weight == 0 ) {
-      return -1;
-   }
-
-   uint128_t window_size = config.account_net_usage_average_window;
-
-   auto virtual_network_capacity_in_window = state.virtual_net_limit * window_size;
-   uint128_t user_weight     = net_weight;
-   uint128_t all_user_weight = state.total_net_weight;
-
-   auto max_user_use_in_window = (virtual_network_capacity_in_window * user_weight) / all_user_weight;
-   auto net_used_in_window  = (usage.net_usage.value_ex * window_size) / config::rate_limiting_precision;
-
-   if( max_user_use_in_window <= net_used_in_window ) return 0;
-
-   return max_user_use_in_window - net_used_in_window;
+   auto arl = get_account_net_limit_ex(name);
+   return arl.available;
 }
 
 account_resource_limit resource_limits_manager::get_account_net_limit_ex( const account_name& name ) const {
@@ -466,21 +395,21 @@ account_resource_limit resource_limits_manager::get_account_net_limit_ex( const 
 
    uint128_t window_size = config.account_net_usage_average_window;
 
-   auto virtual_network_capacity_in_window = state.virtual_net_limit * window_size;
-   uint128_t user_weight     = net_weight;
-   uint128_t all_user_weight = state.total_net_weight;
+   uint128_t virtual_network_capacity_in_window = state.virtual_net_limit * window_size;
+   uint128_t user_weight     = (uint128_t)net_weight;
+   uint128_t all_user_weight = (uint128_t)state.total_net_weight;
 
 
    auto max_user_use_in_window = (virtual_network_capacity_in_window * user_weight) / all_user_weight;
-   auto net_used_in_window  = (usage.net_usage.value_ex * window_size) / config::rate_limiting_precision;
+   auto net_used_in_window  = impl::integer_divide_ceil((uint128_t)usage.net_usage.value_ex * window_size, (uint128_t)config::rate_limiting_precision);
 
    if( max_user_use_in_window <= net_used_in_window )
       arl.available = 0;
    else
-      arl.available = max_user_use_in_window - net_used_in_window;
+      arl.available = impl::downgrade_cast<uint64_t>(max_user_use_in_window - net_used_in_window);
 
-   arl.used = net_used_in_window;
-   arl.max = max_user_use_in_window;
+   arl.used = impl::downgrade_cast<uint64_t>(net_used_in_window);
+   arl.max = impl::downgrade_cast<uint64_t>(max_user_use_in_window);
    return arl;
 }
 

--- a/libraries/chain/resource_limits.cpp
+++ b/libraries/chain/resource_limits.cpp
@@ -367,10 +367,10 @@ account_resource_limit resource_limits_manager::get_account_cpu_limit_ex( const 
    if( max_user_use_in_window <= cpu_used_in_window )
       arl.available = 0;
    else
-      arl.available = impl::downgrade_cast<uint64_t>(max_user_use_in_window - cpu_used_in_window);
+      arl.available = impl::downgrade_cast<int64_t>(max_user_use_in_window - cpu_used_in_window);
 
-   arl.used = impl::downgrade_cast<uint64_t>(cpu_used_in_window);
-   arl.max = impl::downgrade_cast<uint64_t>(max_user_use_in_window);
+   arl.used = impl::downgrade_cast<int64_t>(cpu_used_in_window);
+   arl.max = impl::downgrade_cast<int64_t>(max_user_use_in_window);
    return arl;
 }
 
@@ -406,10 +406,10 @@ account_resource_limit resource_limits_manager::get_account_net_limit_ex( const 
    if( max_user_use_in_window <= net_used_in_window )
       arl.available = 0;
    else
-      arl.available = impl::downgrade_cast<uint64_t>(max_user_use_in_window - net_used_in_window);
+      arl.available = impl::downgrade_cast<int64_t>(max_user_use_in_window - net_used_in_window);
 
-   arl.used = impl::downgrade_cast<uint64_t>(net_used_in_window);
-   arl.max = impl::downgrade_cast<uint64_t>(max_user_use_in_window);
+   arl.used = impl::downgrade_cast<int64_t>(net_used_in_window);
+   arl.max = impl::downgrade_cast<int64_t>(max_user_use_in_window);
    return arl;
 }
 


### PR DESCRIPTION
 - doing a ratio<> multiply now checks for overflow conditions.  This is a safe assert to add to any chain with default parameters because:
    - ratio is used for elastic limits, the largest current use being max-block-cpu * max-virtual-cpu-mult * maximum-ratio aka 200,000 * 1000 * 1000 which is well under the 64bit limit
    - ratio is used to maintain an exponential moving average of usage, the largest current use being maximum-single-user-value * precision * window-size aka 200,000 * 1,000,000 * 172,800 which needs 55bits and therfore would not hit this assert
 - doing cast from uint128_t for math to uint64_t for results now asserts that the values are representable, for the same reasons as ratio<> this is safe with the defaults but added to protect against future deployments with significantly higher values
 - fixed a bug in the estimator of available cpu/net usage where our fixed point math ceiling divide was not taken into account.  This would lead to situations where our cpu timers were a few microseconds off but because the final accounting would catch anything there was no ability for this to affect concensus.  It is now just better at setting speculative limits

Also removed repetition between get_account* and get_account*_ex