### PR TITLE
Better get_table_rows upper/lower bounds support

### DIFF
--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -52,7 +52,7 @@ template<typename Type>
 Type convert_to_type(const string& str, const string& desc) {
    try {
       return fc::variant(str).as<Type>();
-   } FC_RETHROW_EXCEPTIONS(warn, "Could not convert {desc} string '${str}' to key type.", ("desc", desc)("str",str) )
+   } FC_RETHROW_EXCEPTIONS(warn, "Could not convert ${desc} string '${str}' to key type.", ("desc", desc)("str",str) )
 }
 
 template<>

--- a/programs/cleos/httpc.cpp
+++ b/programs/cleos/httpc.cpp
@@ -13,6 +13,7 @@
 #include <ostream>
 #include <string>
 #include <regex>
+#include <boost/algorithm/string.hpp>
 #include <boost/asio.hpp>
 #include <boost/asio/ssl.hpp>
 #include <fc/variant.hpp>


### PR DESCRIPTION
- Add support for name and symbol values passed to lower/upper bound

It is now possible to use account names in lower/upper bound for tables with account_name as primary key:
` ./cleos get table eosio eosio voters -L kevinh -U kevini`

Resolves #3948 