### PR TITLE
accurate resource billing and estimates

### DIFF
--- a/libraries/chain/include/eosio/chain/resource_limits.hpp
+++ b/libraries/chain/include/eosio/chain/resource_limits.hpp
@@ -45,7 +45,6 @@ namespace eosio { namespace chain { namespace resource_limits {
          void initialize_account( const account_name& account );
          void set_block_parameters( const elastic_limit_parameters& cpu_limit_parameters, const elastic_limit_parameters& net_limit_parameters );
 
-         void update_account_usage( const flat_set<account_name>& accounts, uint32_t ordinal );
          void add_transaction_usage( const flat_set<account_name>& accounts, uint64_t cpu_usage, uint64_t net_usage, uint32_t ordinal );
 
          void add_pending_ram_usage( const account_name account, int64_t ram_delta );
@@ -65,11 +64,11 @@ namespace eosio { namespace chain { namespace resource_limits {
          uint64_t get_block_cpu_limit() const;
          uint64_t get_block_net_limit() const;
 
-         int64_t get_account_cpu_limit( const account_name& name ) const;
-         int64_t get_account_net_limit( const account_name& name ) const;
+         int64_t get_account_cpu_limit( const account_name& name, uint32_t time_slot ) const;
+         int64_t get_account_net_limit( const account_name& name, uint32_t time_slot ) const;
 
-         account_resource_limit get_account_cpu_limit_ex( const account_name& name ) const;
-         account_resource_limit get_account_net_limit_ex( const account_name& name ) const;
+         account_resource_limit get_account_cpu_limit_ex( const account_name& name, uint32_t time_slot ) const;
+         account_resource_limit get_account_net_limit_ex( const account_name& name, uint32_t time_slot ) const;
 
          int64_t get_account_ram_usage( const account_name& name ) const;
 

--- a/libraries/chain/include/eosio/chain/resource_limits_private.hpp
+++ b/libraries/chain/include/eosio/chain/resource_limits_private.hpp
@@ -69,6 +69,7 @@ namespace eosio { namespace chain { namespace resource_limits {
       {
          static_assert( Precision > 0, "Precision must be positive" );
          static constexpr uint64_t max_raw_value = std::numeric_limits<uint64_t>::max() / Precision;
+         static constexpr uint64_t precision = Precision;
 
          exponential_moving_average_accumulator()
          : last_ordinal(0)

--- a/libraries/chain/resource_limits.cpp
+++ b/libraries/chain/resource_limits.cpp
@@ -357,7 +357,7 @@ account_resource_limit resource_limits_manager::get_account_cpu_limit_ex( const 
       arl.available = 0;
    } else {
       auto delta_ex = max_usage_ex - current_usage_ex;
-      arl.available = impl::downgrade_cast<int64_t>(delta_ex * (uint128_t)window_size);
+      arl.available = impl::downgrade_cast<int64_t>(delta_ex * (uint128_t)window_size  / (uint128_t)usage_accumulator::precision );
    }
 
    arl.used = impl::downgrade_cast<int64_t>(current_usage_ex * (uint128_t)window_size / (uint128_t)usage_accumulator::precision);
@@ -400,7 +400,7 @@ account_resource_limit resource_limits_manager::get_account_net_limit_ex( const 
       arl.available = 0;
    } else {
       auto delta_ex = max_usage_ex - current_usage_ex;
-      arl.available = impl::downgrade_cast<int64_t>(delta_ex * (uint128_t)window_size);
+      arl.available = impl::downgrade_cast<int64_t>(delta_ex * (uint128_t)window_size / (uint128_t)usage_accumulator::precision);
    }
 
    arl.used = impl::downgrade_cast<int64_t>(current_usage_ex * (uint128_t)window_size / (uint128_t)usage_accumulator::precision);

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -82,16 +82,16 @@ namespace eosio { namespace chain {
       validate_ram_usage.reserve( bill_to_accounts.size() );
 
       // Update usage values of accounts to reflect new time
-      rl.update_account_usage( bill_to_accounts, block_timestamp_type(control.pending_block_time()).slot );
-
+      auto time_slot = block_timestamp_type(control.pending_block_time()).slot;
+      
       // Calculate the highest network usage and CPU time that all of the billed accounts can afford to be billed
       int64_t account_net_limit = large_number_no_overflow;
       int64_t account_cpu_limit = large_number_no_overflow;
       for( const auto& a : bill_to_accounts ) {
-         auto net_limit = rl.get_account_net_limit(a);
+         auto net_limit = rl.get_account_net_limit(a, time_slot);
          if( net_limit >= 0 )
             account_net_limit = std::min( account_net_limit, net_limit );
-         auto cpu_limit = rl.get_account_cpu_limit(a);
+         auto cpu_limit = rl.get_account_cpu_limit(a, time_slot);
          if( cpu_limit >= 0 )
             account_cpu_limit = std::min( account_cpu_limit, cpu_limit );
       }
@@ -219,13 +219,14 @@ namespace eosio { namespace chain {
       }
 
       // Calculate the new highest network usage and CPU time that all of the billed accounts can afford to be billed
+      auto time_slot = block_timestamp_type(control.pending_block_time()).slot;
       int64_t account_net_limit = large_number_no_overflow;
       int64_t account_cpu_limit = large_number_no_overflow;
       for( const auto& a : bill_to_accounts ) {
-         auto net_limit = rl.get_account_net_limit(a);
+         auto net_limit = rl.get_account_net_limit(a, time_slot);
          if( net_limit >= 0 )
             account_net_limit = std::min( account_net_limit, net_limit );
-         auto cpu_limit = rl.get_account_cpu_limit(a);
+         auto cpu_limit = rl.get_account_cpu_limit(a, time_slot);
          if( cpu_limit >= 0 )
             account_cpu_limit = std::min( account_cpu_limit, cpu_limit );
       }

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -946,8 +946,9 @@ read_only::get_account_results read_only::get_account( const get_account_params&
    result.last_code_update = a.last_code_update;
    result.created          = a.creation_date;
 
-   result.net_limit = rm.get_account_net_limit_ex( result.account_name );
-   result.cpu_limit = rm.get_account_cpu_limit_ex( result.account_name );
+   auto time_slot = block_timestamp_type(db.pending_block_time()).slot;
+   result.net_limit = rm.get_account_net_limit_ex( result.account_name, time_slot );
+   result.cpu_limit = rm.get_account_cpu_limit_ex( result.account_name, time_slot );
    result.ram_usage = rm.get_account_ram_usage( result.account_name );
 
    const auto& permissions = d.get_index<permission_index,by_owner>();


### PR DESCRIPTION
 - fix innacuracy caused by order of multiplies and divides in add_transaction_usage. This is techincally a concensus-affecting change
   - math and comparison is now done in the higher precision format to avoid divides etc
- with the accounting fixed the calculation of available resources can be made precise without a lot of fuss
- added tests to prove that the calculation of available resources is precise
- additionally, handled decaying logic in the calculation instead of ad-hoc in transaction_context