### PR TITLE
Interpret uint64_t key string first as number before then trying to interpret it as a name

### DIFF
--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -606,13 +606,13 @@ template<>
 uint64_t convert_to_type(const string& str, const string& desc) {
    uint64_t value = 0;
    try {
-      name s(str);
-      value = s.value;
+      value = boost::lexical_cast<uint64_t>(str.c_str(), str.size());
    } catch( ... ) {
       try {
          auto trimmed_str = str;
          boost::trim(trimmed_str);
-         value = boost::lexical_cast<uint64_t>(trimmed_str.c_str(), trimmed_str.size());
+         name s(trimmed_str);
+         value = s.value;
       } catch( ... ) {
          try {
             auto symb = eosio::chain::symbol::from_string(str);


### PR DESCRIPTION
Resolves #3982.

This reordering of attempts in `convert_to_type<uint64_t>` is more convenient to the user because names consisting of only digits should be rare.

Ambiguity of account names consisting of only digits can still be resolved. It requires the user to add whitespace to the beginning and/or end of the name in the input string.