### PR TITLE
Fix CMake include directories of unit_test build target

### DIFF
--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -14,12 +14,6 @@ set( CMAKE_CXX_STANDARD 14 )
 
 add_subdirectory(contracts)
 
-include_directories("${CMAKE_BINARY_DIR}/contracts")
-include_directories("${CMAKE_SOURCE_DIR}/contracts")
-include_directories("${CMAKE_BINARY_DIR}/unittests/contracts")
-include_directories("${CMAKE_SOURCE_DIR}/unittests/contracts")
-include_directories("${CMAKE_SOURCE_DIR}/libraries/testing/include")
-
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/include/config.hpp.in ${CMAKE_CURRENT_BINARY_DIR}/include/config.hpp ESCAPE_QUOTES)
 
 file(GLOB UNIT_TESTS "*.cpp")
@@ -27,10 +21,14 @@ file(GLOB UNIT_TESTS "*.cpp")
 add_executable( unit_test ${UNIT_TESTS} ${WASM_UNIT_TESTS} )
 target_link_libraries( unit_test eosio_chain chainbase eosio_testing eos_utilities abi_generator fc ${PLATFORM_SPECIFIC_LIBS} )
 
-target_include_directories( unit_test PUBLIC ${CMAKE_BINARY_DIR}/contracts ${CMAKE_CURRENT_BINARY_DIR}/tests/contracts )
-target_include_directories( unit_test PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/wasm_tests )
-target_include_directories( unit_test PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/include )
-add_dependencies(unit_test asserter test_api test_api_mem test_api_db test_ram_limit test_api_multi_index exchange eosio.token proxy identity identity_test stltest infinite eosio.system eosio.token eosio.bios test.inline multi_index_test noop dice eosio.msig payloadless tic_tac_toe)
+target_include_directories( unit_test PUBLIC
+                            ${CMAKE_SOURCE_DIR}/libraries/testing/include
+                            ${CMAKE_SOURCE_DIR}/contracts
+                            ${CMAKE_BINARY_DIR}/contracts
+                            ${CMAKE_CURRENT_SOURCE_DIR}/contracts
+                            ${CMAKE_CURRENT_BINARY_DIR}/contracts
+                            ${CMAKE_CURRENT_BINARY_DIR}/include )
+add_dependencies(unit_test asserter test_api test_api_mem test_api_db test_ram_limit test_api_multi_index exchange eosio.token proxy identity identity_test stltest infinite eosio.system eosio.token eosio.bios test.inline multi_index_test noop dice eosio.msig payloadless tic_tac_toe deferred_test)
 
 #Manually run unit_test for all supported runtimes
 #To run unit_test with all log from blockchain displayed, put --verbose after --, i.e. unit_test -- --verbose


### PR DESCRIPTION
I think these changes to CMakeLists.txt should resolve the build issues users are reporting in #3968, #3969, and #3985.

Although it is hard to say for sure since I couldn't replicate the build issues in the first place on my machines or on Buildkite.