### PR TITLE
Add SNI to HTTPS requests in cleos

### DIFF
--- a/programs/cleos/httpc.cpp
+++ b/programs/cleos/httpc.cpp
@@ -161,6 +161,7 @@ namespace eosio { namespace client { namespace http {
 #endif
 
       boost::asio::ssl::stream<boost::asio::ip::tcp::socket> socket(io_service, ssl_context);
+      SSL_set_tlsext_host_name(socket.native_handle(), url.server.c_str());
       if(cp.verify_cert)
          socket.set_verify_mode(boost::asio::ssl::verify_peer);
 


### PR DESCRIPTION
Many https servers/proxies require this

Sorry, no issue number. Problem reported from users & it's a quick fix