### PR TITLE
Don't spawn keosd for system listproducers or system listbw

### DIFF
--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -711,6 +711,11 @@ void ensure_keosd_running(CLI::App* app) {
         return;
     if (app->get_subcommand("create")->got_subcommand("key")) // create key does not require wallet
        return;
+    if (auto* subapp = app->get_subcommand("system")) {
+       if (subapp->got_subcommand("listproducers") || subapp->get_subcommand("listbw")) // system list* do not require wallet
+         return;
+    }
+
     auto parsed_url = parse_url(wallet_url);
     if (parsed_url.server != "localhost" && parsed_url.server != "127.0.0.1")
         return;


### PR DESCRIPTION
Resolves #4018 

cleos now does not launch keosd for `system listproducers` nor `system listbw`