### PR TITLE
add support for LetsEncrypt certs

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -11,7 +11,7 @@ RUN git clone -b $branch https://github.com/EOSIO/eos.git --recursive \
 
 FROM ubuntu:18.04
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install openssl && rm -rf /var/lib/apt/lists/*
+RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install openssl ca-certificates && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /usr/local/lib/* /usr/local/lib/
 COPY --from=builder /tmp/build/bin /opt/eosio/bin
 COPY --from=builder /tmp/build/contracts /contracts

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -11,7 +11,7 @@ RUN git clone -b $branch https://github.com/EOSIO/eos.git --recursive \
 
 FROM ubuntu:18.04
 
-RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install openssl ca-certificates && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install openssl ca-certificates && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /usr/local/lib/* /usr/local/lib/
 COPY --from=builder /tmp/build/bin /opt/eosio/bin
 COPY --from=builder /tmp/build/contracts /contracts

--- a/Docker/dev/Dockerfile
+++ b/Docker/dev/Dockerfile
@@ -10,7 +10,7 @@ RUN git clone -b $branch https://github.com/EOSIO/eos.git --recursive \
     && mv /eos/Docker/config.ini / && mv /opt/eosio/contracts /contracts && mv /eos/Docker/nodeosd.sh /opt/eosio/bin/nodeosd.sh && mv tutorials /tutorials \
     && rm -rf /eos
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install openssl vim psmisc python3-pip && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install openssl ca-certificates vim psmisc python3-pip && rm -rf /var/lib/apt/lists/*
 RUN pip3 install numpy
 ENV EOSIO_ROOT=/opt/eosio
 RUN chmod +x /opt/eosio/bin/nodeosd.sh


### PR DESCRIPTION
`cleos` fails when talking to HTTPS APIs backed by LE certs. this fixes that.

closes #4044.