### PR TITLE
better network names and standard log messages

### DIFF
--- a/plugins/bnet_plugin/bnet_plugin.cpp
+++ b/plugins/bnet_plugin/bnet_plugin.cpp
@@ -71,6 +71,39 @@ namespace eosio {
 
 } /// namespace eosio
 
+namespace fc {
+   extern std::unordered_map<std::string,logger>& get_logger_map();
+}
+
+const fc::string logger_name("bnet_plugin");
+fc::logger plugin_logger;
+std::string peer_log_format;
+
+#define peer_dlog( PEER, FORMAT, ... ) \
+  FC_MULTILINE_MACRO_BEGIN \
+   if( plugin_logger.is_enabled( fc::log_level::debug ) ) \
+      plugin_logger.log( FC_LOG_MESSAGE( debug, peer_log_format + FORMAT, __VA_ARGS__ (PEER->get_logger_variant()) ) ); \
+  FC_MULTILINE_MACRO_END
+
+#define peer_ilog( PEER, FORMAT, ... ) \
+  FC_MULTILINE_MACRO_BEGIN \
+   if( plugin_logger.is_enabled( fc::log_level::info ) ) \
+      plugin_logger.log( FC_LOG_MESSAGE( info, peer_log_format + FORMAT, __VA_ARGS__ (PEER->get_logger_variant()) ) ); \
+  FC_MULTILINE_MACRO_END
+
+#define peer_wlog( PEER, FORMAT, ... ) \
+  FC_MULTILINE_MACRO_BEGIN \
+   if( plugin_logger.is_enabled( fc::log_level::warn ) ) \
+      plugin_logger.log( FC_LOG_MESSAGE( warn, peer_log_format + FORMAT, __VA_ARGS__ (PEER->get_logger_variant()) ) ); \
+  FC_MULTILINE_MACRO_END
+
+#define peer_elog( PEER, FORMAT, ... ) \
+  FC_MULTILINE_MACRO_BEGIN \
+   if( plugin_logger.is_enabled( fc::log_level::error ) ) \
+      plugin_logger.log( FC_LOG_MESSAGE( error, peer_log_format + FORMAT, __VA_ARGS__ (PEER->get_logger_variant())) ); \
+  FC_MULTILINE_MACRO_END
+
+
 using eosio::public_key_type;
 using eosio::chain_id_type;
 using eosio::block_id_type;
@@ -264,6 +297,8 @@ namespace eosio {
         //boost::beast::multi_buffer                                  _in_buffer;
         boost::beast::flat_buffer                                     _in_buffer;
         flat_set<block_id_type>                                       _block_header_notices;
+        fc::optional<fc::variant_object>                              _logger_variant;
+
 
         int next_session_id()const {
            static int session_count = 0;
@@ -458,6 +493,7 @@ namespace eosio {
               auto itr = _block_status.find( id );
               if( itr == _block_status.end() ) return;
               if( itr->received_from_peer ) {
+                 peer_elog(this, "bad signed_block_ptr : unknown" );
                  elog( "peer sent bad block #${b} ${i}, disconnect", ("b", b->block_num())("i",b->id())  );
                  _ws->next_layer().close();
               }
@@ -892,6 +928,7 @@ namespace eosio {
         }
 
         void on( const block_notice& notice ) {
+           peer_ilog(this, "received block_notice");
            for( const auto& id : notice.block_ids ) {
               status( "received notice " + std::to_string( block_header::num_from_id(id) ) );
               mark_block_known_by_peer( id );
@@ -899,9 +936,11 @@ namespace eosio {
         }
 
         void on( const hello& hi ) {
+           peer_ilog(this, "received hello");
            _recv_remote_hello     = true;
 
            if( hi.chain_id != app().get_plugin<chain_plugin>().get_chain_id() ) { // TODO: Quick fix in a rush. Maybe a better solution is needed.
+              peer_elog(this, "bad hello : wrong chain id");
               return do_goodbye( "disconnecting due to wrong chain id" );
            }
 
@@ -922,13 +961,16 @@ namespace eosio {
 
 
         void on( const ping& p ) {
+           peer_ilog(this, "received ping");
            _last_recv_ping = p;
            _remote_lib     = p.lib;
            _last_recv_ping_time = fc::time_point::now();
         }
 
         void on( const pong& p ) {
+           peer_ilog(this, "received pong");
            if( p.code != _last_sent_ping.code ) {
+              peer_elog(this, "bad ping : invalid pong code");
               return do_goodbye( "invalid pong code" );
            }
            _last_sent_ping.code = fc::sha256();
@@ -946,7 +988,11 @@ namespace eosio {
         void check_for_redundant_connection();
 
         void on( const signed_block_ptr& b ) {
-           FC_ASSERT( b, "bad block" );
+           peer_ilog(this, "received signed_block_ptr");
+           if (!b) {
+              peer_elog(this, "bad signed_block_ptr : null pointer");
+              FC_THROW("bad block" );
+           }
            status( "received block " + std::to_string(b->block_num()) );
            //ilog( "recv block ${n}", ("n", b->block_num()) );
            auto id = b->id();
@@ -987,7 +1033,11 @@ namespace eosio {
         }
 
         void on( const packed_transaction_ptr& p ) {
-           FC_ASSERT( p, "bad transaction" );
+           peer_ilog(this, "received packed_transaction_ptr");
+           if (!p) {
+              peer_elog(this, "bad packed_transaction_ptr : null pointer");
+              FC_THROW("bad transaction");
+           }
 
            auto id = p->id();
           // ilog( "recv trx ${n}", ("n", id) );
@@ -1013,6 +1063,29 @@ namespace eosio {
 
         void status( const string& msg ) {
         //   ilog( "${remote_peer}: ${msg}", ("remote_peer",fc::variant(_remote_peer_id).as_string().substr(3,5) )("msg",msg) );
+        }
+
+        const fc::variant_object& get_logger_variant()  {
+           if (!_logger_variant) {
+              boost::system::error_code ec;
+              auto rep = _ws->lowest_layer().remote_endpoint(ec);
+              string ip = ec ? "<unknown>" : rep.address().to_string();
+              string port = ec ? "<unknown>" : std::to_string(rep.port());
+
+              auto lep = _ws->lowest_layer().local_endpoint(ec);
+              string lip = ec ? "<unknown>" : lep.address().to_string();
+              string lport = ec ? "<unknown>" : std::to_string(lep.port());
+
+              _logger_variant.emplace(fc::mutable_variant_object()
+                 ("_name", _peer)
+                 ("_id", _remote_peer_id)
+                 ("_ip", ip)
+                 ("_port", port)
+                 ("_lip", lip)
+                 ("_lport", lport)
+              );
+           }
+           return *_logger_variant;
         }
   };
 
@@ -1220,11 +1293,22 @@ namespace eosio {
          ("bnet-threads", bpo::value<uint32_t>(), "the number of threads to use to process network messages" )
          ("bnet-connect", bpo::value<vector<string>>()->composing(), "remote endpoint of other node to connect to; Use multiple bnet-connect options as needed to compose a network" )
          ("bnet-no-trx", bpo::bool_switch()->default_value(false), "this peer will request no pending transactions from other nodes" )
+         ("bnet-peer-log-format", bpo::value<string>()->default_value( "[\"${_name}\" ${_ip}:${_port}]" ),
+           "The string used to format peers when logging messages about them.  Variables are escaped with ${<variable name>}.\n"
+           "Available Variables:\n"
+           "   _name  \tself-reported name\n\n"
+           "   _id    \tself-reported ID (Public Key)\n\n"
+           "   _ip    \tremote IP address of peer\n\n"
+           "   _port  \tremote port number of peer\n\n"
+           "   _lip   \tlocal IP address connected to peer\n\n"
+           "   _lport \tlocal port number connected to peer\n\n")
          ;
    }
 
    void bnet_plugin::plugin_initialize(const variables_map& options) {
       ilog( "Initialize bnet plugin" );
+
+      peer_log_format = options.at("bnet-peer-log-format").as<string>();
 
       if( options.count( "bnet-endpoint" ) ) {
          auto ip_port = options.at("bnet-endpoint").as< string >();
@@ -1249,6 +1333,9 @@ namespace eosio {
    }
 
    void bnet_plugin::plugin_startup() {
+      if(fc::get_logger_map().find(logger_name) != fc::get_logger_map().end())
+         plugin_logger = fc::get_logger_map()[logger_name];
+
       wlog( "bnet startup " );
 
       my->_on_appled_trx_handle = app().get_channel<channels::accepted_transaction>()

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -286,6 +286,32 @@ namespace eosio {
 
    const fc::string logger_name("net_plugin_impl");
    fc::logger logger;
+   std::string peer_log_format;
+
+#define peer_dlog( PEER, FORMAT, ... ) \
+  FC_MULTILINE_MACRO_BEGIN \
+   if( logger.is_enabled( fc::log_level::debug ) ) \
+      logger.log( FC_LOG_MESSAGE( debug, peer_log_format + FORMAT, __VA_ARGS__ (PEER->get_logger_variant()) ) ); \
+  FC_MULTILINE_MACRO_END
+
+#define peer_ilog( PEER, FORMAT, ... ) \
+  FC_MULTILINE_MACRO_BEGIN \
+   if( logger.is_enabled( fc::log_level::info ) ) \
+      logger.log( FC_LOG_MESSAGE( info, peer_log_format + FORMAT, __VA_ARGS__ (PEER->get_logger_variant()) ) ); \
+  FC_MULTILINE_MACRO_END
+
+#define peer_wlog( PEER, FORMAT, ... ) \
+  FC_MULTILINE_MACRO_BEGIN \
+   if( logger.is_enabled( fc::log_level::warn ) ) \
+      logger.log( FC_LOG_MESSAGE( warn, peer_log_format + FORMAT, __VA_ARGS__ (PEER->get_logger_variant()) ) ); \
+  FC_MULTILINE_MACRO_END
+
+#define peer_elog( PEER, FORMAT, ... ) \
+  FC_MULTILINE_MACRO_BEGIN \
+   if( logger.is_enabled( fc::log_level::error ) ) \
+      logger.log( FC_LOG_MESSAGE( error, peer_log_format + FORMAT, __VA_ARGS__ (PEER->get_logger_variant())) ); \
+  FC_MULTILINE_MACRO_END
+
 
    template<class enum_type, class=typename std::enable_if<std::is_enum<enum_type>::value>::type>
    inline enum_type& operator|=(enum_type& lhs, const enum_type& rhs)
@@ -583,6 +609,31 @@ namespace eosio {
       bool process_next_message(net_plugin_impl& impl, uint32_t message_length);
 
       bool add_peer_block(const peer_block_state &pbs);
+
+      fc::optional<fc::variant_object> _logger_variant;
+      const fc::variant_object& get_logger_variant()  {
+         if (!_logger_variant) {
+            boost::system::error_code ec;
+            auto rep = socket->remote_endpoint(ec);
+            string ip = ec ? "<unknown>" : rep.address().to_string();
+            string port = ec ? "<unknown>" : std::to_string(rep.port());
+
+            auto lep = socket->local_endpoint(ec);
+            string lip = ec ? "<unknown>" : lep.address().to_string();
+            string lport = ec ? "<unknown>" : std::to_string(lep.port());
+
+            _logger_variant.emplace(fc::mutable_variant_object()
+               ("_name", peer_name())
+               ("_id", node_id)
+               ("_sid", ((string)node_id).substr(0, 7))
+               ("_ip", ip)
+               ("_port", port)
+               ("_lip", lip)
+               ("_lport", lport)
+            );
+         }
+         return *_logger_variant;
+      }
    };
 
    struct msgHandler : public fc::visitor<void> {
@@ -1990,7 +2041,7 @@ namespace eosio {
             if( !ec ) {
                uint32_t visitors = 0;
                uint32_t from_addr = 0;
-               auto paddr = socket->remote_endpoint(ec).address().to_v4();
+               auto paddr = socket->remote_endpoint(ec).address();
                if (ec) {
                   fc_elog(logger,"Error getting remote endpoint: ${m}",("m", ec.message()));
                }
@@ -2000,7 +2051,7 @@ namespace eosio {
                         if (conn->peer_addr.empty()) {
                            visitors++;
                            boost::system::error_code ec;
-                           if (paddr == conn->socket->remote_endpoint(ec).address().to_v4()) {
+                           if (paddr == conn->socket->remote_endpoint(ec).address()) {
                               from_addr++;
                            }
                         }
@@ -2176,14 +2227,14 @@ namespace eosio {
    }
 
    void net_plugin_impl::handle_message( connection_ptr c, const chain_size_message &msg) {
-      fc_dlog( logger, "got a chain_size_message from ${p}", ("p",c->peer_name()));
+      peer_ilog(c, "received chain_size_message");
 
    }
 
    void net_plugin_impl::handle_message( connection_ptr c, const handshake_message &msg) {
-      fc_dlog( logger, "got a handshake_message from ${p} ${h}", ("p",c->peer_addr)("h",msg.p2p_address));
+      peer_ilog(c, "received handshake_message");
       if (!is_valid(msg)) {
-         elog( "Invalid handshake message received from ${p} ${h}", ("p",c->peer_addr)("h",msg.p2p_address));
+         peer_elog( c, "bad handshake message");
          c->enqueue( go_away_message( fatal_other ));
          return;
       }
@@ -2283,11 +2334,13 @@ namespace eosio {
       }
 
       c->last_handshake_recv = msg;
+      c->_logger_variant.reset();
       sync_master->recv_handshake(c,msg);
    }
 
    void net_plugin_impl::handle_message( connection_ptr c, const go_away_message &msg ) {
       string rsn = reason_str( msg.reason );
+      peer_ilog(c, "received go_away_message");
       ilog( "received a go away message from ${p}, reason = ${r}",
             ("p", c->peer_name())("r",rsn));
       c->no_retry = msg.reason;
@@ -2299,6 +2352,7 @@ namespace eosio {
    }
 
    void net_plugin_impl::handle_message(connection_ptr c, const time_message &msg) {
+      peer_ilog(c, "received time_message");
       /* We've already lost however many microseconds it took to dispatch
        * the message, but it can't be helped.
        */
@@ -2334,7 +2388,7 @@ namespace eosio {
       // peer tells us about one or more blocks or txns. When done syncing, forward on
       // notices of previously unknown blocks or txns,
       //
-      fc_dlog(logger, "got a notice_message from ${p}", ("p",c->peer_name()));
+      peer_ilog(c, "received notice_message");
       c->connecting = false;
       request_message req;
       bool send_req = false;
@@ -2388,7 +2442,7 @@ namespace eosio {
          break;
       }
       default: {
-         fc_dlog(logger, "received a bogus known_blocks.mode ${m} from ${p}",("m",static_cast<uint32_t>(msg.known_blocks.mode))("p",c->peer_name()));
+         peer_elog(c, "bad notice_message : invalid known_blocks.mode ${m}",("m",static_cast<uint32_t>(msg.known_blocks.mode)));
       }
       }
       fc_dlog(logger, "send req = ${sr}", ("sr",send_req));
@@ -2400,11 +2454,11 @@ namespace eosio {
    void net_plugin_impl::handle_message( connection_ptr c, const request_message &msg) {
       switch (msg.req_blocks.mode) {
       case catch_up :
-         fc_dlog( logger,  "got a catch_up request_message from ${p}", ("p",c->peer_name()));
+         peer_ilog(c,  "received request_message:catch_up");
          c->blk_send_branch( );
          break;
       case normal :
-         fc_dlog(logger, "got a normal block request_message from ${p}", ("p",c->peer_name()));
+         peer_ilog(c, "received request_message:normal");
          c->blk_send(msg.req_blocks.ids);
          break;
       default:;
@@ -2438,7 +2492,8 @@ namespace eosio {
    }
 
    void net_plugin_impl::handle_message( connection_ptr c, const packed_transaction &msg) {
-      fc_dlog(logger, "got a packed transaction from ${p}, cancel wait", ("p",c->peer_name()));
+      fc_dlog(logger, "got a packed transaction, cancel wait");
+      peer_ilog(c, "received packed_transaction");
       if( sync_master->is_active(c) ) {
          fc_dlog(logger, "got a txn during sync - dropping");
          return;
@@ -2456,6 +2511,7 @@ namespace eosio {
             auto e_ptr = result.get<fc::exception_ptr>();
             if (e_ptr->code() != tx_duplicate::code_value && e_ptr->code() != expired_tx_exception::code_value)
                elog("accept txn threw  ${m}",("m",result.get<fc::exception_ptr>()->to_detail_string()));
+               peer_elog(c, "bad packed_transaction : ${m}", ("m",result.get<fc::exception_ptr>()->what()));
          } else {
             auto trace = result.get<transaction_trace_ptr>();
             if (!trace->except) {
@@ -2463,6 +2519,8 @@ namespace eosio {
                dispatcher->bcast_transaction(msg);
                return;
             }
+
+            peer_elog(c, "bad packed_transaction : ${m}", ("m",trace->except->what()));
          }
 
          dispatcher->rejected_transaction(tid);
@@ -2488,8 +2546,8 @@ namespace eosio {
 
       dispatcher->recv_block(c, blk_id, blk_num);
       fc::microseconds age( fc::time_point::now() - msg.timestamp);
-      fc_dlog(logger, "got signed_block #${n} from ${p} block age in secs = ${age}",
-              ("n",blk_num)("p",c->peer_name())("age",age.to_seconds()));
+      peer_ilog(c, "received signed_block : #${n} block age in secs = ${age}",
+              ("n",blk_num)("age",age.to_seconds()));
 
       go_away_reason reason = fatal_other;
       try {
@@ -2497,16 +2555,21 @@ namespace eosio {
          chain_plug->accept_block(sbp); //, sync_master->is_active(c));
          reason = no_reason;
       } catch( const unlinkable_block_exception &ex) {
+         peer_elog(c, "bad signed_block : ${m}", ("m",ex.what()));
          reason = unlinkable;
       } catch( const block_validate_exception &ex) {
+         peer_elog(c, "bad signed_block : ${m}", ("m",ex.what()));
          elog( "block_validate_exception accept block #${n} syncing from ${p}",("n",blk_num)("p",c->peer_name()));
          reason = validation;
       } catch( const assert_exception &ex) {
+         peer_elog(c, "bad signed_block : ${m}", ("m",ex.what()));
          elog( "unable to accept block on assert exception ${n} from ${p}",("n",ex.to_string())("p",c->peer_name()));
       } catch( const fc::exception &ex) {
+         peer_elog(c, "bad signed_block : ${m}", ("m",ex.what()));
          elog( "accept_block threw a non-assert exception ${x} from ${p}",( "x",ex.to_string())("p",c->peer_name()));
          reason = no_reason;
       } catch( ...) {
+         peer_elog(c, "bad signed_block : unknown exception");
          elog( "handle sync block caught something else from ${p}",("num",blk_num)("p",c->peer_name()));
       }
 
@@ -2828,7 +2891,17 @@ namespace eosio {
            "True to require exact match of peer network version.")
          ( "sync-fetch-span", bpo::value<uint32_t>()->default_value(def_sync_fetch_span), "number of blocks to retrieve in a chunk from any individual peer during synchronization")
          ( "max-implicit-request", bpo::value<uint32_t>()->default_value(def_max_just_send), "maximum sizes of transaction or block messages that are sent without first sending a notice")
-         ;
+         ( "peer-log-format", bpo::value<string>()->default_value( "[\"${_name}\" ${_ip}:${_port}]" ),
+           "The string used to format peers when logging messages about them.  Variables are escaped with ${<variable name>}.\n"
+           "Available Variables:\n"
+           "   _name  \tself-reported name\n\n"
+           "   _id    \tself-reported ID (64 hex characters)\n\n"
+           "   _sid   \tfirst 8 characters of _peer.id\n\n"
+           "   _ip    \tremote IP address of peer\n\n"
+           "   _port  \tremote port number of peer\n\n"
+           "   _lip   \tlocal IP address connected to peer\n\n"
+           "   _lport \tlocal port number connected to peer\n\n")
+        ;
    }
 
    template<typename T>
@@ -2838,6 +2911,7 @@ namespace eosio {
 
    void net_plugin::plugin_initialize( const variables_map& options ) {
       ilog("Initialize net plugin");
+      peer_log_format = options.at("peer-log-format").as<string>();
 
       my->network_version_match = options.at("network-version-match").as<bool>();
 


### PR DESCRIPTION
- made peer identificaton in logs uniform and configurable
- audited messages converting reception logging to info level and rejection logging to error
- ported this to bnet_plugin as well
    - set up the "bnet_plugin" logger for this 

There are probably some other messages that should move to the "peer log" format but right now I made sure to info log reception of network messages and error log rejected messages for easy log-parsing

These are configurable:
```
  --peer-log-format arg (=["${_name}" ${_ip}:${_port}])
                                        The string used to format peers when 
                                        logging messages about them.  Variables
                                        are escaped with ${<variable name>}.
                                        Available Variables:
                                           _name  self-reported name
                                        
                                           _id    self-reported ID (64 hex 
                                                  characters)
                                        
                                           _sid   first 8 characters of 
                                                 _id
                                        
                                           _ip    remote IP address of peer
                                        
                                           _port  remote port number of peer
                                        
                                           _lip   local IP address connected to
                                                  peer
                                        
                                           _lport local port number connected 
                                                  to peer
                                        
                                        
```
there is an equivalent under `bnet-peer-log-format`

resolves #3900 
