### PR TITLE
Add unstaking info to get account of cleos and chain_plugin

### DIFF
--- a/libraries/chain/include/eosio/chain/resource_limits_private.hpp
+++ b/libraries/chain/include/eosio/chain/resource_limits_private.hpp
@@ -54,6 +54,9 @@ namespace eosio { namespace chain { namespace resource_limits {
       {
          const GreaterIntType max = std::numeric_limits<LesserIntType>::max();
          const GreaterIntType min = 0;
+         if( !(val >= min && val <= max) ) {
+            wlog("downgrade_cast higher to lower");
+         }
          EOS_ASSERT( val >= min && val <= max, rate_limiting_state_inconsistent, "Casting a higher bit integer value ${v} to a lower bit integer value which cannot contain the value, valid range is [${min}, ${max}]", ("v", val)("min", min)("max",max) );
          return LesserIntType(val);
       };

--- a/libraries/chain/include/eosio/chain/resource_limits_private.hpp
+++ b/libraries/chain/include/eosio/chain/resource_limits_private.hpp
@@ -54,9 +54,6 @@ namespace eosio { namespace chain { namespace resource_limits {
       {
          const GreaterIntType max = std::numeric_limits<LesserIntType>::max();
          const GreaterIntType min = 0;
-         if( !(val >= min && val <= max) ) {
-            wlog("downgrade_cast higher to lower");
-         }
          EOS_ASSERT( val >= min && val <= max, rate_limiting_state_inconsistent, "Casting a higher bit integer value ${v} to a lower bit integer value which cannot contain the value, valid range is [${min}, ${max}]", ("v", val)("min", min)("max",max) );
          return LesserIntType(val);
       };

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -969,6 +969,9 @@ read_only::get_account_results read_only::get_account( const get_account_params&
    const auto& d = db.db();
    const auto& rm = db.get_resource_limits_manager();
 
+   result.head_block_num  = db.head_block_num();
+   result.head_block_time = db.head_block_time();
+
    rm.get_account_limits( result.account_name, result.ram_quota, result.net_weight, result.cpu_weight );
 
    const auto& a = db.get_account(result.account_name);

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1028,6 +1028,17 @@ read_only::get_account_results read_only::get_account( const get_account_params&
          }
       }
 
+      t_id = d.find<chain::table_id_object, chain::by_code_scope_table>(boost::make_tuple( config::system_account_name, params.account_name, N(refunds) ));
+      if (t_id != nullptr) {
+         const auto &idx = d.get_index<key_value_index, by_scope_primary>();
+         auto it = idx.find(boost::make_tuple( t_id->id, params.account_name ));
+         if ( it != idx.end() ) {
+            vector<char> data;
+            copy_inline_row(*it, data);
+            result.refund_request = abis.binary_to_variant( "refund_request", data );
+         }
+      }
+
       t_id = d.find<chain::table_id_object, chain::by_code_scope_table>(boost::make_tuple( config::system_account_name, config::system_account_name, N(voters) ));
       if (t_id != nullptr) {
          const auto &idx = d.get_index<key_value_index, by_scope_primary>();

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -113,6 +113,7 @@ public:
 
       fc::variant                total_resources;
       fc::variant                self_delegated_bandwidth;
+      fc::variant                refund_request;
       fc::variant                voter_info;
    };
 
@@ -416,7 +417,7 @@ FC_REFLECT( eosio::chain_apis::read_only::get_currency_stats_result, (supply)(ma
 FC_REFLECT( eosio::chain_apis::read_only::get_producers_params, (json)(lower_bound)(limit) )
 FC_REFLECT( eosio::chain_apis::read_only::get_producers_result, (rows)(total_producer_vote_weight)(more) );
 
-FC_REFLECT( eosio::chain_apis::read_only::get_account_results, (account_name)(privileged)(last_code_update)(created)(ram_quota)(net_weight)(cpu_weight)(net_limit)(cpu_limit)(ram_usage)(permissions)(total_resources)(self_delegated_bandwidth)(voter_info) )
+FC_REFLECT( eosio::chain_apis::read_only::get_account_results, (account_name)(privileged)(last_code_update)(created)(ram_quota)(net_weight)(cpu_weight)(net_limit)(cpu_limit)(ram_usage)(permissions)(total_resources)(self_delegated_bandwidth)(refund_request)(voter_info) )
 FC_REFLECT( eosio::chain_apis::read_only::get_code_results, (account_name)(code_hash)(wast)(wasm)(abi) )
 FC_REFLECT( eosio::chain_apis::read_only::get_abi_results, (account_name)(abi) )
 FC_REFLECT( eosio::chain_apis::read_only::get_account_params, (account_name) )

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -76,7 +76,7 @@ public:
       uint32_t                last_irreversible_block_num = 0;
       chain::block_id_type    last_irreversible_block_id;
       chain::block_id_type    head_block_id;
-      fc::time_point_sec      head_block_time;
+      fc::time_point          head_block_time;
       account_name            head_block_producer;
 
       uint64_t                virtual_block_cpu_limit = 0;
@@ -97,6 +97,10 @@ public:
 
    struct get_account_results {
       name                       account_name;
+      uint32_t                   head_block_num = 0;
+      fc::time_point             head_block_time;
+
+
       bool                       privileged = false;
       fc::time_point             last_code_update;
       fc::time_point             created;
@@ -417,7 +421,10 @@ FC_REFLECT( eosio::chain_apis::read_only::get_currency_stats_result, (supply)(ma
 FC_REFLECT( eosio::chain_apis::read_only::get_producers_params, (json)(lower_bound)(limit) )
 FC_REFLECT( eosio::chain_apis::read_only::get_producers_result, (rows)(total_producer_vote_weight)(more) );
 
-FC_REFLECT( eosio::chain_apis::read_only::get_account_results, (account_name)(privileged)(last_code_update)(created)(ram_quota)(net_weight)(cpu_weight)(net_limit)(cpu_limit)(ram_usage)(permissions)(total_resources)(self_delegated_bandwidth)(refund_request)(voter_info) )
+FC_REFLECT( eosio::chain_apis::read_only::get_account_results,
+            (account_name)(head_block_num)(head_block_time)(privileged)(last_code_update)(created)
+            (ram_quota)(net_weight)(cpu_weight)(net_limit)(cpu_limit)(ram_usage)(permissions)
+            (total_resources)(self_delegated_bandwidth)(refund_request)(voter_info) )
 FC_REFLECT( eosio::chain_apis::read_only::get_code_results, (account_name)(code_hash)(wast)(wasm)(abi) )
 FC_REFLECT( eosio::chain_apis::read_only::get_abi_results, (account_name)(abi) )
 FC_REFLECT( eosio::chain_apis::read_only::get_account_params, (account_name) )

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -1366,7 +1366,7 @@ void get_account( const string& accountName, bool json_format ) {
          dfs_print( r, 0 );
       }
 
-      auto to_pretty_net = []( int64_t nbytes ) {
+      auto to_pretty_net = []( int64_t nbytes, uint8_t width_for_units = 5 ) {
          if(nbytes == -1) {
              // special case. Treat it as unlimited
              return std::string("unlimited");
@@ -1389,7 +1389,10 @@ void get_account( const string& accountName, bool json_format ) {
          }
          std::stringstream ss;
          ss << setprecision(4);
-         ss << bytes << " " << std::left << setw(5) << unit;
+         ss << bytes << " ";
+         if( width_for_units > 0 )
+            ss << std::left << setw( width_for_units );
+         ss << unit;
          return ss.str();
       };
 
@@ -1417,7 +1420,7 @@ void get_account( const string& accountName, bool json_format ) {
       }
 
 
-      auto to_pretty_time = []( int64_t nmicro ) {
+      auto to_pretty_time = []( int64_t nmicro, uint8_t width_for_units = 5 ) {
          if(nmicro == -1) {
              // special case. Treat it as unlimited
              return std::string("unlimited");
@@ -1425,7 +1428,7 @@ void get_account( const string& accountName, bool json_format ) {
          string unit = "us";
          double micro = static_cast<double>(nmicro);
 
-         if( micro > 1000000*60 ) {
+         if( micro > 1000000*60*60ll ) {
             micro /= 1000000*60*60ll;
             unit = "hr";
          }
@@ -1443,7 +1446,10 @@ void get_account( const string& accountName, bool json_format ) {
          }
          std::stringstream ss;
          ss << setprecision(4);
-         ss << micro<< " " << std::left << setw(5) << unit;
+         ss << micro << " ";
+         if( width_for_units > 0 )
+            ss << std::left << setw( width_for_units );
+         ss << unit;
          return ss.str();
       };
 
@@ -1478,6 +1484,27 @@ void get_account( const string& accountName, bool json_format ) {
       std::cout << indent << std::left << std::setw(11) << "limit:"     << std::right << std::setw(18) << to_pretty_time( res.cpu_limit.max ) << "\n";
       std::cout << std::endl;
 
+      if( res.refund_request.is_object() ) {
+         auto obj = res.refund_request.get_object();
+         auto request_time = fc::time_point_sec::from_iso_string( obj["request_time"].as_string() );
+         fc::time_point refund_time = request_time + fc::days(3);
+         auto now = fc::time_point::now();
+         std::cout << std::fixed << setprecision(3);
+         std::cout << "unstaked tokens:" << std::endl;
+         std::cout << indent << std::left << std::setw(25) << "time of unstake request:" << std::right << std::setw(20) << string(request_time);
+         if( now >= refund_time ) {
+            std::cout << " (available to claim now with 'eosio::refund' action)\n";
+         } else {
+            std::cout << " (funds will be available in " << to_pretty_time( (refund_time - now).count(), 0 ) << ")\n";
+
+            asset net = asset::from_string( obj["net_amount"].as_string() );
+            asset cpu = asset::from_string( obj["cpu_amount"].as_string() );
+            std::cout << indent << std::left << std::setw(25) << "from net bandwidth:" << std::right << std::setw(18) << net << std::endl;
+            std::cout << indent << std::left << std::setw(25) << "from cpu bandwidth:" << std::right << std::setw(18) << cpu << std::endl;
+            std::cout << indent << std::left << std::setw(25) << "total:" << std::right << std::setw(18) << (cpu + net) << std::endl;
+         }
+         std::cout << std::endl;
+      }
 
       if ( res.voter_info.is_object() ) {
          auto& obj = res.voter_info.get_object();

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -1493,7 +1493,7 @@ void get_account( const string& accountName, bool json_format ) {
          auto obj = res.refund_request.get_object();
          auto request_time = fc::time_point_sec::from_iso_string( obj["request_time"].as_string() );
          fc::time_point refund_time = request_time + fc::days(3);
-         auto now = fc::time_point::now();
+         auto now = res.head_block_time;
          std::cout << std::fixed << setprecision(3);
          std::cout << "unstaked tokens:" << std::endl;
          std::cout << indent << std::left << std::setw(25) << "time of unstake request:" << std::right << std::setw(20) << string(request_time);

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -822,7 +822,7 @@ struct create_account_subcommand {
          createAccount->add_option("--stake-cpu", stake_cpu,
                                    (localized("The amount of EOS delegated for CPU bandwidth")))->required();
          createAccount->add_option("--buy-ram-kbytes", buy_ram_bytes_in_kbytes,
-                                   (localized("The amount of RAM bytes to purchase for the new account in kilobytes KiB, default is 8 KiB")));
+                                   (localized("The amount of RAM bytes to purchase for the new account in kibibytes (KiB), default is 8 KiB")));
          createAccount->add_option("--buy-ram", buy_ram_eos,
                                    (localized("The amount of RAM bytes to purchase for the new account in EOS")));
          createAccount->add_flag("--transfer", transfer,
@@ -1375,16 +1375,16 @@ void get_account( const string& accountName, bool json_format ) {
          string unit = "bytes";
          double bytes = static_cast<double> (nbytes);
          if (bytes >= 1024 * 1024 * 1024 * 1024ll) {
-             unit = "Tb";
+             unit = "TiB";
              bytes /= 1024 * 1024 * 1024 * 1024ll;
          } else if (bytes >= 1024 * 1024 * 1024) {
-             unit = "Gb";
+             unit = "GiB";
              bytes /= 1024 * 1024 * 1024;
          } else if (bytes >= 1024 * 1024) {
-             unit = "Mb";
+             unit = "MiB";
              bytes /= 1024 * 1024;
          } else if (bytes >= 1024) {
-             unit = "Kb";
+             unit = "KiB";
              bytes /= 1024;
          }
          std::stringstream ss;


### PR DESCRIPTION
Resolves #4059.

Added `refund_request` to `get_account_results` of chain_plugin which is populated with the data of the corresponding table row from the system contract for the requested user if such row exists.

Cleos will now use the information in  `refund_request` of  `get_account_results` (if it exists) to display unstaking information for the `cleos get account` command.

Also, changed the display of various units for bytes (`Kb` -> `KiB`, `Mb` -> `MiB`, etc.) to clearly reflect that the values are multiples of 1024 rather than multiples of 1000.

Also, `head_block_time` returned from get info is now a `time_point` rather than `time_point_sec` (displays the millisecond resolution necessary with sub-second block times).