### PR TITLE
show core token balances (including liquid core token balance) in cleos get account

### DIFF
--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1009,7 +1009,25 @@ read_only::get_account_results read_only::get_account( const get_account_params&
    if( abi_serializer::to_abi(code_account.abi, abi) ) {
       abi_serializer abis( abi );
       //get_table_rows_ex<key_value_index, by_scope_primary>(p,abi);
-      const auto* t_id = d.find<chain::table_id_object, chain::by_code_scope_table>(boost::make_tuple( config::system_account_name, params.account_name, N(userres) ));
+
+      const auto token_code = N(eosio.token);
+
+      const auto* t_id = d.find<chain::table_id_object, chain::by_code_scope_table>(boost::make_tuple( token_code, params.account_name, N(accounts) ));
+      if( t_id != nullptr ) {
+         const auto &idx = d.get_index<key_value_index, by_scope_primary>();
+         auto it = idx.find(boost::make_tuple( t_id->id, symbol().to_symbol_code() ));
+         if( it != idx.end() && it->value.size() >= sizeof(asset) ) {
+            asset bal;
+            fc::datastream<const char *> ds(it->value.data(), it->value.size());
+            fc::raw::unpack(ds, bal);
+
+            if( bal.get_symbol().valid() && bal.get_symbol() == symbol() ) {
+               result.core_liquid_balance = bal;
+            }
+         }
+      }
+
+      t_id = d.find<chain::table_id_object, chain::by_code_scope_table>(boost::make_tuple( config::system_account_name, params.account_name, N(userres) ));
       if (t_id != nullptr) {
          const auto &idx = d.get_index<key_value_index, by_scope_primary>();
          auto it = idx.find(boost::make_tuple( t_id->id, params.account_name ));

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -100,10 +100,11 @@ public:
       uint32_t                   head_block_num = 0;
       fc::time_point             head_block_time;
 
-
       bool                       privileged = false;
       fc::time_point             last_code_update;
       fc::time_point             created;
+
+      optional<asset>            core_liquid_balance;
 
       int64_t                    ram_quota  = 0;
       int64_t                    net_weight = 0;
@@ -423,7 +424,7 @@ FC_REFLECT( eosio::chain_apis::read_only::get_producers_result, (rows)(total_pro
 
 FC_REFLECT( eosio::chain_apis::read_only::get_account_results,
             (account_name)(head_block_num)(head_block_time)(privileged)(last_code_update)(created)
-            (ram_quota)(net_weight)(cpu_weight)(net_limit)(cpu_limit)(ram_usage)(permissions)
+            (core_liquid_balance)(ram_quota)(net_weight)(cpu_weight)(net_limit)(cpu_limit)(ram_usage)(permissions)
             (total_resources)(self_delegated_bandwidth)(refund_request)(voter_info) )
 FC_REFLECT( eosio::chain_apis::read_only::get_code_results, (account_name)(code_hash)(wast)(wasm)(abi) )
 FC_REFLECT( eosio::chain_apis::read_only::get_abi_results, (account_name)(abi) )

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -1323,8 +1323,10 @@ void get_account( const string& accountName, bool json_format ) {
    auto res = json.as<eosio::chain_apis::read_only::get_account_results>();
 
    if (!json_format) {
-      if(res.privileged) std::cout << "privileged: true" << std::endl;
+      asset staked;
+      asset unstaking;
 
+      if(res.privileged) std::cout << "privileged: true" << std::endl;
 
       constexpr size_t indent_size = 5;
       const string indent(indent_size, ' ');
@@ -1410,6 +1412,13 @@ void get_account( const string& accountName, bool json_format ) {
       if ( res.total_resources.is_object() ) {
          if( res.self_delegated_bandwidth.is_object() ) {
             asset net_own =  asset::from_string( res.self_delegated_bandwidth.get_object()["net_weight"].as_string() );
+            staked = net_own;
+
+            if( staked.get_symbol() != unstaking.get_symbol() ) {
+               // Core symbol of nodeos responding to the request is different than core symbol built into cleos
+               unstaking = asset( 0, staked.get_symbol() ); // Correct core symbol for unstaking asset.
+            }
+
             auto net_others = to_asset(res.total_resources.get_object()["net_weight"].as_string()) - net_own;
 
             std::cout << indent << "staked:" << std::setw(20) << net_own
@@ -1470,7 +1479,10 @@ void get_account( const string& accountName, bool json_format ) {
       if ( res.total_resources.is_object() ) {
          if( res.self_delegated_bandwidth.is_object() ) {
             asset cpu_own = asset::from_string( res.self_delegated_bandwidth.get_object()["cpu_weight"].as_string() );
+            staked += cpu_own;
+
             auto cpu_others = to_asset(res.total_resources.get_object()["cpu_weight"].as_string()) - cpu_own;
+
             std::cout << indent << "staked:" << std::setw(20) << cpu_own
                       << std::string(11, ' ') << "(total stake delegated from account to self)" << std::endl
                       << indent << "delegated:" << std::setw(17) << cpu_others
@@ -1495,7 +1507,7 @@ void get_account( const string& accountName, bool json_format ) {
          fc::time_point refund_time = request_time + fc::days(3);
          auto now = res.head_block_time;
          std::cout << std::fixed << setprecision(3);
-         std::cout << "unstaked tokens:" << std::endl;
+         std::cout << "unstaking tokens:" << std::endl;
          std::cout << indent << std::left << std::setw(25) << "time of unstake request:" << std::right << std::setw(20) << string(request_time);
          if( now >= refund_time ) {
             std::cout << " (available to claim now with 'eosio::refund' action)\n";
@@ -1504,10 +1516,24 @@ void get_account( const string& accountName, bool json_format ) {
 
             asset net = asset::from_string( obj["net_amount"].as_string() );
             asset cpu = asset::from_string( obj["cpu_amount"].as_string() );
+            unstaking = net + cpu;
+
             std::cout << indent << std::left << std::setw(25) << "from net bandwidth:" << std::right << std::setw(18) << net << std::endl;
             std::cout << indent << std::left << std::setw(25) << "from cpu bandwidth:" << std::right << std::setw(18) << cpu << std::endl;
-            std::cout << indent << std::left << std::setw(25) << "total:" << std::right << std::setw(18) << (cpu + net) << std::endl;
+            std::cout << indent << std::left << std::setw(25) << "total:" << std::right << std::setw(18) << unstaking << std::endl;
          }
+         std::cout << std::endl;
+      }
+
+      if( res.core_liquid_balance.valid() ) {
+         std::cout << res.core_liquid_balance->get_symbol().name() << " balances: " << std::endl;
+         std::cout << indent << std::left << std::setw(11)
+                   << "liquid:" << std::right << std::setw(18) << *res.core_liquid_balance << std::endl;
+         std::cout << indent << std::left << std::setw(11)
+                   << "staked:" << std::right << std::setw(18) << staked << std::endl;
+         std::cout << indent << std::left << std::setw(11)
+                   << "unstaking:" << std::right << std::setw(18) << unstaking << std::endl;
+         std::cout << indent << std::left << std::setw(11) << "total:" << std::right << std::setw(18) << (*res.core_liquid_balance + staked + unstaking) << std::endl;
          std::cout << std::endl;
       }
 


### PR DESCRIPTION
Resolves #4066.

Example outputs:
```
$ programs/cleos/cleos get account alice
permissions: 
     owner     1:    1 EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV
        active     1:    1 EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV
memory: 
     quota:     5.971 KiB    used:     4.158 KiB  

net bandwidth: 
     staked:          5.0000 SYS           (total stake delegated from account to self)
     delegated:      13.0000 SYS           (total staked delegated to account from others)
     used:               157 bytes
     available:        41.47 MiB  
     limit:            41.47 MiB  

cpu bandwidth:
     staked:          5.0000 SYS           (total stake delegated from account to self)
     delegated:       0.0000 SYS           (total staked delegated to account from others)
     used:             1.619 ms   
     available:        2.302 sec  
     limit:            2.304 sec  

SYS balances: 
     liquid:         4960.0000 SYS
     staked:           10.0000 SYS
     unstaking:         0.0000 SYS
     total:          4970.0000 SYS

producers:     <not voted>
```
and
```
$ programs/cleos/cleos get account eosio
privileged: true
permissions: 
     owner     1:    1 EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV
        active     1:    1 EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV
memory: 
     quota:     324.4 MiB    used:     1.113 MiB  

net bandwidth: 
     staked:   74999999.5000 SYS           (total stake delegated from account to self)
     delegated:       0.0000 SYS           (total staked delegated to account from others)
     used:             10.33 KiB  
     available:        164.8 TiB  
     limit:            164.8 TiB  

cpu bandwidth:
     staked:   74999997.5000 SYS           (total stake delegated from account to self)
     delegated:       0.0000 SYS           (total staked delegated to account from others)
     used:             499.2 ms   
     available:         9600 hr   
     limit:             9600 hr   

unstaking tokens:
     time of unstake request:  2018-06-12T22:08:15 (funds will be available in 50.39 hr)
     from net bandwidth:              0.0000 SYS
     from cpu bandwidth:              2.5000 SYS
     total:                           2.5000 SYS

SYS balances: 
     liquid:    849989947.2914 SYS
     staked:    149999997.0000 SYS
     unstaking:         2.5000 SYS
     total:     999989946.7914 SYS

producers:
     eosio       
```

v1.0.3 cleos should still be able to work as it used to with a chain_plugin version running with these changes.

A cleos version with these changes should still be able to work (granted without displaying the core token balances) with a v1.0.3 chain_plugin.

However, these changes do technically change the JSON structure of `get_account_results`. In particular, a new optional field `core_liquid_balance` is added in.