### PR TITLE
Allow squelching of debugging output over HTTP

### DIFF
--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -806,8 +806,9 @@ auto make_resolver(const Api *api) {
 
 fc::variant read_only::get_block(const read_only::get_block_params& params) const {
    signed_block_ptr block;
+   EOS_ASSERT(!params.block_num_or_id.empty() && params.block_num_or_id.size() <= 64, chain::block_id_type_exception, "Invalid Block number or ID, must be greater than 0 and less than 64 characters" );
    try {
-      block = db.fetch_block_by_id(fc::json::from_string(params.block_num_or_id).as<block_id_type>());
+      block = db.fetch_block_by_id(fc::variant(params.block_num_or_id).as<block_id_type>());
       if (!block) {
          block = db.fetch_block_by_number(fc::to_uint64(params.block_num_or_id));
       }
@@ -839,7 +840,7 @@ fc::variant read_only::get_block_header_state(const get_block_header_state_param
       b = db.fetch_block_state_by_number(*block_num);
    } else {
       try {
-         b = db.fetch_block_state_by_id(fc::json::from_string(params.block_num_or_id).as<block_id_type>());
+         b = db.fetch_block_state_by_id(fc::variant(params.block_num_or_id).as<block_id_type>());
       } EOS_RETHROW_EXCEPTIONS(chain::block_id_type_exception, "Invalid block ID: ${block_num_or_id}", ("block_num_or_id", params.block_num_or_id))
    }
 

--- a/plugins/http_plugin/http_plugin.cpp
+++ b/plugins/http_plugin/http_plugin.cpp
@@ -79,6 +79,8 @@ namespace eosio {
    using websocket_server_tls_type =  websocketpp::server<detail::asio_with_stub_log<websocketpp::transport::asio::tls_socket::endpoint>>;
    using ssl_context_ptr =  websocketpp::lib::shared_ptr<websocketpp::lib::asio::ssl::context>;
 
+   static bool verbose_http_errors = false;
+
    class http_plugin_impl {
       public:
          map<string,url_handler>  url_handlers;
@@ -87,6 +89,7 @@ namespace eosio {
          string                   access_control_allow_headers;
          string                   access_control_max_age;
          bool                     access_control_allow_credentials = false;
+         size_t                   max_body_size;
 
          websocket_server_type    server;
 
@@ -142,19 +145,19 @@ namespace eosio {
                   err += e.to_detail_string();
                   elog( "${e}", ("e", err));
                   error_results results{websocketpp::http::status_code::internal_server_error,
-                                        "Internal Service Error", e};
+                                        "Internal Service Error", error_results::error_info(e, verbose_http_errors )};
                   con->set_body( fc::json::to_string( results ));
                } catch (const std::exception& e) {
                   err += e.what();
                   elog( "${e}", ("e", err));
                   error_results results{websocketpp::http::status_code::internal_server_error,
-                                        "Internal Service Error", fc::exception( FC_LOG_MESSAGE( error, e.what()))};
+                                        "Internal Service Error", error_results::error_info(fc::exception( FC_LOG_MESSAGE( error, e.what())), verbose_http_errors )};
                   con->set_body( fc::json::to_string( results ));
                } catch (...) {
                   err += "Unknown Exception";
                   error_results results{websocketpp::http::status_code::internal_server_error,
                                         "Internal Service Error",
-                                        fc::exception( FC_LOG_MESSAGE( error, "Unknown Exception" ))};
+                                        error_results::error_info(fc::exception( FC_LOG_MESSAGE( error, "Unknown Exception" )), verbose_http_errors )};
                   con->set_body( fc::json::to_string( results ));
                }
             } catch (...) {
@@ -200,7 +203,7 @@ namespace eosio {
                } else {
                   wlog( "404 - not found: ${ep}", ("ep", resource));
                   error_results results{websocketpp::http::status_code::not_found,
-                                        "Not Found", fc::exception( FC_LOG_MESSAGE( error, "Unknown Endpoint" ))};
+                                        "Not Found", error_results::error_info(fc::exception( FC_LOG_MESSAGE( error, "Unknown Endpoint" )), verbose_http_errors )};
                   con->set_body( fc::json::to_string( results ));
                   con->set_status( websocketpp::http::status_code::not_found );
                }
@@ -215,7 +218,7 @@ namespace eosio {
                ws.clear_access_channels(websocketpp::log::alevel::all);
                ws.init_asio(&app().get_io_service());
                ws.set_reuse_addr(true);
-
+               ws.set_max_http_body_size(max_body_size);
                ws.set_http_handler([&](connection_hdl hdl) {
                   handle_http_request<T>(ws.get_con_from_hdl(hdl));
                });
@@ -270,6 +273,8 @@ namespace eosio {
                 if (v) ilog("configured http with Access-Control-Allow-Credentials: true");
              })->default_value(false),
              "Specify if Access-Control-Allow-Credentials: true should be returned on each request.")
+            ("max-body-size", bpo::value<uint32_t>()->default_value(1024*1024), "The maximum body size in bytes allowed for incoming RPC requests")
+            ("verbose-http-errors", bpo::bool_switch()->default_value(false), "Append the error log to HTTP responses")
             ;
    }
 
@@ -311,6 +316,9 @@ namespace eosio {
             elog("failed to configure https to listen on ${h}:${p} (${m})", ("h",host)("p",port)("m", ec.what()));
          }
       }
+
+      my->max_body_size = options.at("max-body-size").as<uint32_t>();
+      verbose_http_errors = options.at("verbose-http-errors").as<bool>();
 
       //watch out for the returns above when adding new code here
    }
@@ -377,31 +385,34 @@ namespace eosio {
          try {
             throw;
          } catch (chain::unsatisfied_authorization& e) {
-            error_results results{401, "UnAuthorized", e};
+            error_results results{401, "UnAuthorized", error_results::error_info(e, verbose_http_errors)};
             cb( 401, fc::json::to_string( results ));
          } catch (chain::tx_duplicate& e) {
-            error_results results{409, "Conflict", e};
+            error_results results{409, "Conflict", error_results::error_info(e, verbose_http_errors)};
             cb( 409, fc::json::to_string( results ));
          } catch (chain::transaction_exception& e) {
-            error_results results{400, "Bad Request", e};
+            error_results results{400, "Bad Request", error_results::error_info(e, verbose_http_errors)};
             cb( 400, fc::json::to_string( results ));
          } catch (fc::eof_exception& e) {
-            error_results results{400, "Bad Request", e};
+            error_results results{400, "Bad Request", error_results::error_info(e, verbose_http_errors)};
             cb( 400, fc::json::to_string( results ));
-            elog( "Unable to parse arguments: ${args}", ("args", body));
+            elog( "Unable to parse arguments to ${api}.${call}", ("api", api_name)( "call", call_name ));
+            dlog("Bad arguments: ${args}", ("args", body));
          } catch (fc::exception& e) {
-            error_results results{500, "Internal Service Error", e};
+            error_results results{500, "Internal Service Error", error_results::error_info(e, verbose_http_errors)};
             cb( 500, fc::json::to_string( results ));
-            elog( "FC Exception encountered while processing ${api}.${call}: ${e}",
-                  ("api", api_name)( "call", call_name )( "e", e.to_detail_string()));
+            elog( "FC Exception encountered while processing ${api}.${call}",
+                  ("api", api_name)( "call", call_name ));
+            dlog( "Exception Details: ${e}", ("e", e.to_detail_string()));
          } catch (std::exception& e) {
-            error_results results{500, "Internal Service Error", fc::exception( FC_LOG_MESSAGE( error, e.what()))};
+            error_results results{500, "Internal Service Error", error_results::error_info(fc::exception( FC_LOG_MESSAGE( error, e.what())), verbose_http_errors)};
             cb( 500, fc::json::to_string( results ));
-            elog( "STD Exception encountered while processing ${api}.${call}: ${e}",
-                  ("api", api_name)( "call", call_name )( "e", e.what()));
+            elog( "STD Exception encountered while processing ${api}.${call}",
+                  ("api", api_name)( "call", call_name ));
+            dlog( "Exception Details: ${e}", ("e", e.what()));
          } catch (...) {
             error_results results{500, "Internal Service Error",
-                                  fc::exception( FC_LOG_MESSAGE( error, "Unknown Exception" ))};
+               error_results::error_info(fc::exception( FC_LOG_MESSAGE( error, "Unknown Exception" )), verbose_http_errors)};
             cb( 500, fc::json::to_string( results ));
             elog( "Unknown Exception encountered while processing ${api}.${call}",
                   ("api", api_name)( "call", call_name ));

--- a/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
@@ -105,19 +105,21 @@ namespace eosio {
 
          error_info() {};
 
-         error_info(const fc::exception& exc) {
+         error_info(const fc::exception& exc, bool include_log) {
             code = exc.code();
             name = exc.name();
             what = exc.what();
-            for (auto itr = exc.get_log().begin(); itr != exc.get_log().end(); ++itr) {
-               // Prevent sending trace that are too big
-               if (details.size() >= details_limit) break;
-               // Append error
-               error_detail detail = {
-                       itr->get_message(), itr->get_context().get_file(),
-                       itr->get_context().get_line_number(), itr->get_context().get_method()
-               };
-               details.emplace_back(detail);
+            if (include_log) {
+               for (auto itr = exc.get_log().begin(); itr != exc.get_log().end(); ++itr) {
+                  // Prevent sending trace that are too big
+                  if (details.size() >= details_limit) break;
+                  // Append error
+                  error_detail detail = {
+                          itr->get_message(), itr->get_context().get_file(),
+                          itr->get_context().get_line_number(), itr->get_context().get_method()
+                  };
+                  details.emplace_back(detail);
+               }
             }
          }
       };

--- a/tests/p2p_tests/pump/run_test.pl
+++ b/tests/p2p_tests/pump/run_test.pl
@@ -201,7 +201,8 @@ sub launch_nodes {
     for (my $i = 0; $i < $nodes;  $i++) {
         my @cmdline = ($eosd,
                        $gtsarg,
-                       "--data-dir=$data_dir[$i]");
+                       "--data-dir=$data_dir[$i]",
+                       "--verbose-http-errors");
         $pid[$i] = fork;
         if ($pid[$i] > 0) {
             my $pause = $i == 0 ? $first_pause : $launch_pause;

--- a/tests/testUtils.py
+++ b/tests/testUtils.py
@@ -1232,7 +1232,7 @@ class WalletMgr(object):
             Utils.Print("ERROR: Wallet Manager wasn't configured to launch keosd")
             return False
 
-        cmd="%s --data-dir %s --config-dir %s --http-server-address=%s:%d" % (
+        cmd="%s --data-dir %s --config-dir %s --http-server-address=%s:%d --verbose-http-errors" % (
             Utils.EosWalletPath, WalletMgr.__walletDataDir, WalletMgr.__walletDataDir, self.host, self.port)
         if Utils.Debug: Utils.Print("cmd: %s" % (cmd))
         with open(WalletMgr.__walletLogFile, 'w') as sout, open(WalletMgr.__walletLogFile, 'w') as serr:

--- a/tests/validate-dirty-db.py
+++ b/tests/validate-dirty-db.py
@@ -40,7 +40,7 @@ testSuccessful=False
 def runNodeosAndGetOutput(myNodeId, myTimeout=3):
     """Startup nodeos, wait for timeout (before forced shutdown) and collect output. Stdout, stderr and return code are returned in a dictionary."""
     Print("Launching nodeos process id: %d" % (myNodeId))
-    cmd="programs/nodeos/nodeos --config-dir etc/eosio/node_bios --data-dir var/lib/node_bios"
+    cmd="programs/nodeos/nodeos --config-dir etc/eosio/node_bios --data-dir var/lib/node_bios --verbose-http-errors"
     Print("cmd: %s" % (cmd))
     proc=subprocess.Popen(cmd.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 


### PR DESCRIPTION
I got tired of seeing a lot of spam from scripts and Curl... thusly:

- add option to enable the inclusion of http details in API responses (defaults to false, enabled via `verbose-http-errors` in config or command line)
  - this works for keosd and nodeos
- add configurable paramter for max payload size (defaults to 1MiB, set via `max-body-size` in bytes in config or command line)