### PR TITLE
Update mongo-c-driver 1.10.1 for MongoDB 3.3.0

### DIFF
--- a/Docker/builder/Dockerfile
+++ b/Docker/builder/Dockerfile
@@ -34,11 +34,11 @@ RUN wget https://dl.bintray.com/boostorg/release/1.67.0/source/boost_1_67_0.tar.
        --with-signals --with-serialization --with-chrono --with-test --with-context --with-locale --with-coroutine --with-iostreams toolset=clang link=static install \
     && cd .. && rm -rf boost_1_67_0
 
-RUN wget https://github.com/mongodb/mongo-c-driver/releases/download/1.9.3/mongo-c-driver-1.9.3.tar.gz -O - | tar -xz \
-    && cd mongo-c-driver-1.9.3 \
+RUN wget https://github.com/mongodb/mongo-c-driver/releases/download/1.10.1/mongo-c-driver-1.10.1.tar.gz -O - | tar -xz \
+    && cd mongo-c-driver-1.10.1 \
     && ./configure --enable-static --with-libbson=bundled --enable-ssl=openssl --disable-automatic-init-and-cleanup --prefix=/usr/local \
     && make -j$(nproc) install \
-    && cd .. && rm -rf mongo-c-driver-1.9.3
+    && cd .. && rm -rf mongo-c-driver-1.10.1
 
 RUN git clone --depth 1 --single-branch --branch release_40 https://github.com/llvm-mirror/llvm.git \
     && git clone --depth 1 --single-branch --branch release_40 https://github.com/llvm-mirror/clang.git llvm/tools/clang \

--- a/scripts/eosio_build_amazon.sh
+++ b/scripts/eosio_build_amazon.sh
@@ -389,28 +389,28 @@ fi
 			exit 1;
 		fi
 		STATUS=$(curl -LO -w '%{http_code}' --connect-timeout 30 \
-		"https://github.com/mongodb/mongo-c-driver/releases/download/1.9.3/mongo-c-driver-1.9.3.tar.gz" )
+		"https://github.com/mongodb/mongo-c-driver/releases/download/1.10.1/mongo-c-driver-1.10.1.tar.gz" )
 		if [ "${STATUS}" -ne 200 ]; then
-			rm -f "${TEMP_DIR}/mongo-c-driver-1.9.3.tar.gz"
+			rm -f "${TEMP_DIR}/mongo-c-driver-1.10.1.tar.gz"
 			printf "\\tUnable to download MongoDB C driver at this time.\\n"
 			printf "\\tExiting now.\\n\\n"
 			exit 1;
 		fi
-		if ! tar xf "${TEMP_DIR}/mongo-c-driver-1.9.3.tar.gz"
+		if ! tar xf "${TEMP_DIR}/mongo-c-driver-1.10.1.tar.gz"
 		then
-			printf "\\n\\tUnable to decompress file  %s/mongo-c-driver-1.9.3.tar.gz.\\n" "${TEMP_DIR}"
+			printf "\\n\\tUnable to decompress file  %s/mongo-c-driver-1.10.1.tar.gz.\\n" "${TEMP_DIR}"
 			printf "\\n\\tExiting now.\\n"
 			exit 1;
 		fi
-		if ! rm -f "${TEMP_DIR}/mongo-c-driver-1.9.3.tar.gz"
+		if ! rm -f "${TEMP_DIR}/mongo-c-driver-1.10.1.tar.gz"
 		then
-			printf "\\n\\tUnable to remove file  %s/mongo-c-driver-1.9.3.tar.gz.\\n" "${TEMP_DIR}"
+			printf "\\n\\tUnable to remove file  %s/mongo-c-driver-1.10.1.tar.gz.\\n" "${TEMP_DIR}"
 			printf "\\n\\tExiting now.\\n"
 			exit 1;
 		fi
-		if ! cd "${TEMP_DIR}/mongo-c-driver-1.9.3"
+		if ! cd "${TEMP_DIR}/mongo-c-driver-1.10.1"
 		then
-			printf "\\n\\tUnable to change directory info  %s/mongo-c-driver-1.9.3.\\n" "${TEMP_DIR}"
+			printf "\\n\\tUnable to change directory info  %s/mongo-c-driver-1.10.1.\\n" "${TEMP_DIR}"
 			printf "\\n\\tExiting now.\\n"
 			exit 1;
 		fi
@@ -438,9 +438,9 @@ fi
 			printf "\\n\\tExiting now.\\n"
 			exit 1;
 		fi
-		if ! rm -rf "${TEMP_DIR}/mongo-c-driver-1.9.3"
+		if ! rm -rf "${TEMP_DIR}/mongo-c-driver-1.10.1"
 		then
-			printf "\\n\\tUnable to remove  directory %s/mongo-c-driver-1.9.3.\\n" "${TEMP_DIR}"
+			printf "\\n\\tUnable to remove  directory %s/mongo-c-driver-1.10.1.\\n" "${TEMP_DIR}"
 			printf "\\n\\tExiting now.\\n"
 			exit 1;
 		fi

--- a/scripts/eosio_build_centos.sh
+++ b/scripts/eosio_build_centos.sh
@@ -479,28 +479,28 @@ mongodconf
 			exit 1;
 		fi
 		STATUS=$(curl -LO -w '%{http_code}' --connect-timeout 30 \
-		"https://github.com/mongodb/mongo-c-driver/releases/download/1.9.3/mongo-c-driver-1.9.3.tar.gz" )
+		"https://github.com/mongodb/mongo-c-driver/releases/download/1.10.1/mongo-c-driver-1.10.1.tar.gz" )
 		if [ "${STATUS}" -ne 200 ]; then
-			rm -f "${TEMP_DIR}/mongo-c-driver-1.9.3.tar.gz"
+			rm -f "${TEMP_DIR}/mongo-c-driver-1.10.1.tar.gz"
 			printf "\\tUnable to download MongoDB C driver at this time.\\n"
 			printf "\\tExiting now.\\n\\n"
 			exit 1;
 		fi
-		if ! tar xf "${TEMP_DIR}/mongo-c-driver-1.9.3.tar.gz"
+		if ! tar xf "${TEMP_DIR}/mongo-c-driver-1.10.1.tar.gz"
 		then
-			printf "\\n\\tUnable to unarchive file  %s/mongo-c-driver-1.9.3.tar.gz.\\n" "${TEMP_DIR}"
+			printf "\\n\\tUnable to unarchive file  %s/mongo-c-driver-1.10.1.tar.gz.\\n" "${TEMP_DIR}"
 			printf "\\n\\tExiting now.\\n"
 			exit 1;
 		fi
-		if ! rm -f "${TEMP_DIR}/mongo-c-driver-1.9.3.tar.gz"
+		if ! rm -f "${TEMP_DIR}/mongo-c-driver-1.10.1.tar.gz"
 		then
-			printf "\\n\\tUnable to remove file  %s/mongo-c-driver-1.9.3.tar.gz.\\n" "${TEMP_DIR}"
+			printf "\\n\\tUnable to remove file  %s/mongo-c-driver-1.10.1.tar.gz.\\n" "${TEMP_DIR}"
 			printf "\\n\\tExiting now.\\n"
 			exit 1;
 		fi
-		if ! cd "${TEMP_DIR}/mongo-c-driver-1.9.3"
+		if ! cd "${TEMP_DIR}/mongo-c-driver-1.10.1"
 		then
-			printf "\\n\\tUnable to enter directory %s/mongo-c-driver-1.9.3.\\n" "${TEMP_DIR}"
+			printf "\\n\\tUnable to enter directory %s/mongo-c-driver-1.10.1.\\n" "${TEMP_DIR}"
 			printf "\\n\\tExiting now.\\n"
 			exit 1;
 		fi
@@ -528,9 +528,9 @@ mongodconf
 			printf "\\n\\tExiting now.\\n"
 			exit 1;
 		fi
-		if ! rm -rf "${TEMP_DIR}/mongo-c-driver-1.9.3"
+		if ! rm -rf "${TEMP_DIR}/mongo-c-driver-1.10.1"
 		then
-			printf "\\n\\tUnable to remove  directory %s/mongo-c-driver-1.9.3.\\n" "${TEMP_DIR}"
+			printf "\\n\\tUnable to remove  directory %s/mongo-c-driver-1.10.1.\\n" "${TEMP_DIR}"
 			printf "\\n\\tExiting now.\\n"
 			exit 1;
 		fi

--- a/scripts/eosio_build_darwin.sh
+++ b/scripts/eosio_build_darwin.sh
@@ -258,31 +258,31 @@
 				exit 1;
 			fi
 		fi
-		STATUS=$(curl -LO -w '%{http_code}' --connect-timeout 30 https://github.com/mongodb/mongo-c-driver/releases/download/1.9.3/mongo-c-driver-1.9.3.tar.gz)
+		STATUS=$(curl -LO -w '%{http_code}' --connect-timeout 30 https://github.com/mongodb/mongo-c-driver/releases/download/1.10.1/mongo-c-driver-1.10.1.tar.gz)
 		if [ "${STATUS}" -ne 200 ]; then
-			if ! rm -f "${TEMP_DIR}/mongo-c-driver-1.9.3.tar.gz"
+			if ! rm -f "${TEMP_DIR}/mongo-c-driver-1.10.1.tar.gz"
 			then
-				printf "\\tUnable to remove file %s/mongo-c-driver-1.9.3.tar.gz.\\n" "${TEMP_DIR}"
+				printf "\\tUnable to remove file %s/mongo-c-driver-1.10.1.tar.gz.\\n" "${TEMP_DIR}"
 			fi
 			printf "\\tUnable to download MongoDB C driver at this time.\\n"
 			printf "\\tExiting now.\\n\\n"
 			exit 1;
 		fi
-		if ! tar xf mongo-c-driver-1.9.3.tar.gz
+		if ! tar xf mongo-c-driver-1.10.1.tar.gz
 		then
-			printf "\\tUnable to unarchive file mongo-c-driver-1.9.3.tar.gz.\\n"
+			printf "\\tUnable to unarchive file mongo-c-driver-1.10.1.tar.gz.\\n"
 			printf "\\tExiting now.\\n\\n"
 			exit 1;
 		fi
-		if ! rm -f "${TEMP_DIR}/mongo-c-driver-1.9.3.tar.gz"
+		if ! rm -f "${TEMP_DIR}/mongo-c-driver-1.10.1.tar.gz"
 		then
-			printf "\\tUnable to remove file mongo-c-driver-1.9.3.tar.gz.\\n"
+			printf "\\tUnable to remove file mongo-c-driver-1.10.1.tar.gz.\\n"
 			printf "\\tExiting now.\\n\\n"
 			exit 1;
 		fi
-		if ! cd mongo-c-driver-1.9.3
+		if ! cd mongo-c-driver-1.10.1
 		then
-			printf "\\tUnable to cd into directory %s/mongo-c-driver-1.9.3.\\n" "${TEMP_DIR}"
+			printf "\\tUnable to cd into directory %s/mongo-c-driver-1.10.1.\\n" "${TEMP_DIR}"
 			printf "\\tExiting now.\\n\\n"
 			exit 1;
 		fi
@@ -310,9 +310,9 @@
 			printf "\\tExiting now.\\n\\n"
 			exit 1;
 		fi
-		if ! rm -rf "${TEMP_DIR}/mongo-c-driver-1.9.3"
+		if ! rm -rf "${TEMP_DIR}/mongo-c-driver-1.10.1"
 		then
-			printf "\\tUnable to remove directory %s/mongo-c-driver-1.9.3.\\n" "${TEMP_DIR}"
+			printf "\\tUnable to remove directory %s/mongo-c-driver-1.10.1.\\n" "${TEMP_DIR}"
 			printf "\\tExiting now.\\n\\n"
 			exit 1;
 		fi

--- a/scripts/eosio_build_fedora.sh
+++ b/scripts/eosio_build_fedora.sh
@@ -254,28 +254,28 @@
 			printf "\\tExiting now.\\n\\n"
 			exit 1;
 		fi
-		STATUS=$(curl -LO -w '%{http_code}' --connect-timeout 30 https://github.com/mongodb/mongo-c-driver/releases/download/1.9.3/mongo-c-driver-1.9.3.tar.gz)
+		STATUS=$(curl -LO -w '%{http_code}' --connect-timeout 30 https://github.com/mongodb/mongo-c-driver/releases/download/1.10.1/mongo-c-driver-1.10.1.tar.gz)
 		if [ "${STATUS}" -ne 200 ]; then
-			rm -f "${TEMP_DIR}/mongo-c-driver-1.9.3.tar.gz" 2>/dev/null
+			rm -f "${TEMP_DIR}/mongo-c-driver-1.10.1.tar.gz" 2>/dev/null
 			printf "\\tUnable to download MongoDB C driver at this time.\\n"
 			printf "\\tExiting now.\\n\\n"
 			exit 1;
 		fi
-		if ! tar xf "${TEMP_DIR}/mongo-c-driver-1.9.3.tar.gz"
+		if ! tar xf "${TEMP_DIR}/mongo-c-driver-1.10.1.tar.gz"
 		then
-			printf "\\tUnable to unarchive file %s/mongo-c-driver-1.9.3.tar.gz.\\n" "${TEMP_DIR}"
+			printf "\\tUnable to unarchive file %s/mongo-c-driver-1.10.1.tar.gz.\\n" "${TEMP_DIR}"
 			printf "\\tExiting now.\\n\\n"
 			exit 1;
 		fi
-		if ! rm -f "${TEMP_DIR}/mongo-c-driver-1.9.3.tar.gz"
+		if ! rm -f "${TEMP_DIR}/mongo-c-driver-1.10.1.tar.gz"
 		then
-			printf "\\tUnable to remove file %s/mongo-c-driver-1.9.3.tar.gz.\\n" "${TEMP_DIR}"
+			printf "\\tUnable to remove file %s/mongo-c-driver-1.10.1.tar.gz.\\n" "${TEMP_DIR}"
 			printf "\\tExiting now.\\n\\n"
 			exit 1;
 		fi
-		if ! cd "${TEMP_DIR}/mongo-c-driver-1.9.3"
+		if ! cd "${TEMP_DIR}/mongo-c-driver-1.10.1"
 		then
-			printf "\\tUnable to enter directory %s/mongo-c-driver-1.9.3.\\n" "${TEMP_DIR}"
+			printf "\\tUnable to enter directory %s/mongo-c-driver-1.10.1.\\n" "${TEMP_DIR}"
 			printf "\\tExiting now.\\n\\n"
 			exit 1;
 		fi
@@ -303,9 +303,9 @@
 			printf "\\tExiting now.\\n\\n"
 			exit 1;
 		fi
-		if ! rm -rf "${TEMP_DIR}/mongo-c-driver-1.9.3"
+		if ! rm -rf "${TEMP_DIR}/mongo-c-driver-1.10.1"
 		then
-			printf "\\tUnable to remove directory %s/mongo-c-driver-1.9.3.\\n" "${TEMP_DIR}"
+			printf "\\tUnable to remove directory %s/mongo-c-driver-1.10.1.\\n" "${TEMP_DIR}"
 			printf "\\tExiting now.\\n\\n"
 			exit 1;
 		fi

--- a/scripts/eosio_build_ubuntu.sh
+++ b/scripts/eosio_build_ubuntu.sh
@@ -278,31 +278,31 @@ mongodconf
 			printf "\\n\\tExiting now.\\n\\n"
 			exit 1;
 		fi
-		STATUS=$(curl -LO -w '%{http_code}' --connect-timeout 30 https://github.com/mongodb/mongo-c-driver/releases/download/1.9.3/mongo-c-driver-1.9.3.tar.gz)
+		STATUS=$(curl -LO -w '%{http_code}' --connect-timeout 30 https://github.com/mongodb/mongo-c-driver/releases/download/1.10.1/mongo-c-driver-1.10.1.tar.gz)
 		if [ "${STATUS}" -ne 200 ]; then
-			if ! rm -f "${TEMP_DIR}/mongo-c-driver-1.9.3.tar.gz"
+			if ! rm -f "${TEMP_DIR}/mongo-c-driver-1.10.1.tar.gz"
 			then
-				printf "\\n\\tUnable to remove file %s/mongo-c-driver-1.9.3.tar.gz.\\n" "${TEMP_DIR}"
+				printf "\\n\\tUnable to remove file %s/mongo-c-driver-1.10.1.tar.gz.\\n" "${TEMP_DIR}"
 			fi
 			printf "\\tUnable to download MongoDB C driver at this time.\\n"
 			printf "\\tExiting now.\\n\\n"
 			exit 1;
 		fi
-		if ! tar xf "${TEMP_DIR}/mongo-c-driver-1.9.3.tar.gz"
+		if ! tar xf "${TEMP_DIR}/mongo-c-driver-1.10.1.tar.gz"
 		then
-			printf "\\n\\tUnable to unarchive file %s/mongo-c-driver-1.9.3.tar.gz.\\n" "${TEMP_DIR}"
+			printf "\\n\\tUnable to unarchive file %s/mongo-c-driver-1.10.1.tar.gz.\\n" "${TEMP_DIR}"
 			printf "\\n\\tExiting now.\\n\\n"
 			exit 1;
 		fi
-		if ! rm -f "${TEMP_DIR}/mongo-c-driver-1.9.3.tar.gz"
+		if ! rm -f "${TEMP_DIR}/mongo-c-driver-1.10.1.tar.gz"
 		then
-			printf "\\n\\tUnable to remove file %s/mongo-c-driver-1.9.3.tar.gz.\\n" "${TEMP_DIR}"
+			printf "\\n\\tUnable to remove file %s/mongo-c-driver-1.10.1.tar.gz.\\n" "${TEMP_DIR}"
 			printf "\\n\\tExiting now.\\n\\n"
 			exit 1;
 		fi
-		if ! cd "${TEMP_DIR}/mongo-c-driver-1.9.3"
+		if ! cd "${TEMP_DIR}/mongo-c-driver-1.10.1"
 		then
-			printf "\\n\\tUnable to enter directory %s/mongo-c-driver-1.9.3.\\n" "${TEMP_DIR}"
+			printf "\\n\\tUnable to enter directory %s/mongo-c-driver-1.10.1.\\n" "${TEMP_DIR}"
 			printf "\\n\\tExiting now.\\n\\n"
 			exit 1;
 		fi
@@ -330,9 +330,9 @@ mongodconf
 			printf "\\n\\tExiting now.\\n\\n"
 			exit 1;
 		fi
-		if ! rm -rf "${TEMP_DIR}/mongo-c-driver-1.9.3"
+		if ! rm -rf "${TEMP_DIR}/mongo-c-driver-1.10.1"
 		then
-			printf "\\n\\tUnable to remove directory %s/mongo-c-driver-1.9.3.\\n" "${TEMP_DIR}"
+			printf "\\n\\tUnable to remove directory %s/mongo-c-driver-1.10.1.\\n" "${TEMP_DIR}"
 			printf "\\n\\tExiting now.\\n\\n"
 			exit 1;
 		fi


### PR DESCRIPTION
MongoDB C++11 Driver 3.3.0 this version of mongocxx requires the MongoDB
C driver 1.10.1.