### PR TITLE
Raise chain_api get_table_rows_result time limit

### DIFF
--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -309,7 +309,7 @@ public:
 
          vector<char> data;
 
-         auto end = fc::time_point::now() + fc::microseconds(1000 * 10); /// 10ms max time
+         auto end = fc::time_point::now() + fc::microseconds(1000 * 100); /// 100ms max time TODO fix?
 
          unsigned int count = 0;
          auto itr = lower;


### PR DESCRIPTION
Hotfixes issue #3965. Careful, since this might increase DDoS possibilities.

Credits for @ScottSallinen who first commented on GH what might be the issue.