### PR TITLE
Add key-blacklist

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -497,7 +497,8 @@ struct controller_impl {
              || (code == actor_blacklist_exception::code_value)
              || (code == contract_whitelist_exception::code_value)
              || (code == contract_blacklist_exception::code_value)
-             || (code == action_blacklist_exception::code_value);
+             || (code == action_blacklist_exception::code_value)
+             || (code == key_blacklist_exception::code_value);
    }
 
    transaction_trace_ptr push_scheduled_transaction( const transaction_id_type& trxid, fc::time_point deadline, uint32_t billed_cpu_time_us ) {
@@ -1102,6 +1103,16 @@ struct controller_impl {
       }
    }
 
+   void check_key_list( const public_key_type& key )const {
+      if( conf.key_blacklist.size() > 0 ) {
+         EOS_ASSERT( conf.key_blacklist.find( key ) == conf.key_blacklist.end(),
+                     key_blacklist_exception,
+                     "public key '${key}' is on the key blacklist",
+                     ("key", key)
+                   );
+      }
+   }
+
    /*
    bool should_check_tapos()const { return true; }
 
@@ -1446,6 +1457,10 @@ void controller::check_contract_list( account_name code )const {
 
 void controller::check_action_list( account_name code, action_name action )const {
    my->check_action_list( code, action );
+}
+
+void controller::check_key_list( const public_key_type& key )const {
+   my->check_key_list( key );
 }
 
 bool controller::is_producing_block()const {

--- a/libraries/chain/eosio_contract.cpp
+++ b/libraries/chain/eosio_contract.cpp
@@ -56,6 +56,12 @@ void validate_authority_precondition( const apply_context& context, const author
                   );
       }
    }
+
+   if( context.control.is_producing_block() ) {
+      for( const auto& p : auth.keys ) {
+         context.control.check_key_list( p.key );
+      }
+   }
 }
 
 /**
@@ -130,7 +136,7 @@ void apply_eosio_setcode(apply_context& context) {
    FC_ASSERT( act.vmversion == 0 );
 
    fc::sha256 code_id; /// default ID == 0
-   
+
    if( act.code.size() > 0 ) {
      code_id = fc::sha256::hash( act.code.data(), (uint32_t)act.code.size() );
      wasm_interface::validate(context.control, act.code);

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -41,6 +41,7 @@ namespace eosio { namespace chain {
             flat_set<account_name>   contract_whitelist;
             flat_set<account_name>   contract_blacklist;
             flat_set< pair<account_name, action_name> > action_blacklist;
+            flat_set<public_key_type> key_blacklist;
             path                     blocks_dir             =  chain::config::default_blocks_dir_name;
             path                     state_dir              =  chain::config::default_state_dir_name;
             uint64_t                 state_size             =  chain::config::default_state_size;
@@ -160,6 +161,7 @@ namespace eosio { namespace chain {
 
          void check_contract_list( account_name code )const;
          void check_action_list( account_name code, action_name action )const;
+         void check_key_list( const public_key_type& key )const;
          bool is_producing_block()const;
 
 

--- a/libraries/chain/include/eosio/chain/exceptions.hpp
+++ b/libraries/chain/include/eosio/chain/exceptions.hpp
@@ -295,5 +295,7 @@ namespace eosio { namespace chain {
                                     3130004, "Contract to execute is on the blacklist" )
       FC_DECLARE_DERIVED_EXCEPTION( action_blacklist_exception, chain_exception,
                                     3130005, "Action to execute is on the blacklist" )
+      FC_DECLARE_DERIVED_EXCEPTION( key_blacklist_exception, chain_exception,
+                                    3130006, "Public key in authority is on the blacklist" )
 
 } } // eosio::chain

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -142,6 +142,8 @@ void chain_plugin::set_program_options(options_description& cli, options_descrip
           "Contract account added to contract blacklist (may specify multiple times)")
          ("action-blacklist", boost::program_options::value<vector<string>>()->composing()->multitoken(),
           "Action (in the form code::action) added to action blacklist (may specify multiple times)")
+         ("key-blacklist", boost::program_options::value<vector<string>>()->composing()->multitoken(),
+          "Public key added to blacklist of keys that should not be included in authorities (may specify multiple times)")
          ;
 
 // TODO: rate limiting
@@ -215,8 +217,8 @@ void chain_plugin::plugin_initialize(const variables_map& options) {
 
    my->chain_config = controller::config();
 
-   LOAD_VALUE_SET(options, "actor-whitelist", my->chain_config->actor_whitelist);
-   LOAD_VALUE_SET(options, "actor-blacklist", my->chain_config->actor_blacklist);
+   LOAD_VALUE_SET(options, "actor-whitelist",    my->chain_config->actor_whitelist);
+   LOAD_VALUE_SET(options, "actor-blacklist",    my->chain_config->actor_blacklist);
    LOAD_VALUE_SET(options, "contract-whitelist", my->chain_config->contract_whitelist);
    LOAD_VALUE_SET(options, "contract-blacklist", my->chain_config->contract_blacklist);
 
@@ -229,6 +231,14 @@ void chain_plugin::plugin_initialize(const variables_map& options) {
          account_name code(a.substr(0, pos));
          action_name  act(a.substr(pos+2));
          list.emplace( code.value, act.value );
+      }
+   }
+
+   if( options.count("key-blacklist") ) {
+      const std::vector<std::string>& keys = options["key-blacklist"].as<std::vector<std::string>>();
+      auto& list = my->chain_config->key_blacklist;
+      for( const auto& key_str : keys ) {
+         list.emplace( key_str );
       }
    }
 


### PR DESCRIPTION
This PR adds another subjective blacklist feature to the whitelist/blacklist toolbox already provided to block producers.

This feature (`key-blacklist`) allows producers to add public keys to their config.ini which are disallowed from being used in the authorities of account permissions. Any transaction that tries to add/modify a permission authority (for example through `eosio::newaccount` or `eosio::updateauth`) to contain a blacklisted public key is subjectively rejected by the producer. As usual, a node is forced to accept such transactions even if they contain keys on the node's local blacklist if the transaction is part of a completed block signed by a producer.

The `key-blacklist` feature is intended to be used by the top 21 producers as a way to protect users from mistakenly using public keys that have publicly-known private keys (for example, public/private key pairs provided in tutorials) as part of the permission authority for their account.