### PR TITLE
Minor cleanup of system contract

### DIFF
--- a/contracts/eosio.system/delegate_bandwidth.cpp
+++ b/contracts/eosio.system/delegate_bandwidth.cpp
@@ -108,9 +108,14 @@ namespace eosiosystem {
       eosio_assert( quant.amount > 0, "must purchase a positive amount" );
 
       auto fee = quant;
-      fee.amount = ( fee.amount + 199 ) / 200; /// .5% fee
+      fee.amount = ( fee.amount + 199 ) / 200; /// .5% fee (round up)
+      // fee.amount cannot be 0 since that is only possible if quant.amount is 0 which is not allowed by the assert above.
+      // If quant.amount == 1, then fee.amount == 1,
+      // otherwise if quant.amount > 1, then 0 < fee.amount < quant.amount.
       auto quant_after_fee = quant;
       quant_after_fee.amount -= fee.amount;
+      // quant_after_fee.amount should be > 0 if quant.amount > 1.
+      // If quant.amount == 1, then quant_after_fee.amount == 0 and the next inline transfer will fail causing the buyram action to fail.
 
       INLINE_ACTION_SENDER(eosio::token, transfer)( N(eosio.token), {payer,N(active)},
          { payer, N(eosio.ram), quant_after_fee, std::string("buy ram") } );

--- a/contracts/eosio.system/eosio.system.abi
+++ b/contracts/eosio.system/eosio.system.abi
@@ -319,10 +319,7 @@
         {"name":"staked",               "type":"int64"},
         {"name":"last_vote_weight",     "type":"float64"},
         {"name":"proxied_vote_weight",  "type":"float64"},
-        {"name":"is_proxy",             "type":"bool"},
-        {"name":"deferred_trx_id",      "type":"uint32"},
-        {"name":"last_unstake_time",    "type":"time_point_sec"},
-        {"name":"unstaking",            "type":"asset"}
+        {"name":"is_proxy",             "type":"bool"}
       ]
     },{
       "name": "claimrewards",

--- a/contracts/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/eosio.system.hpp
@@ -102,14 +102,14 @@ namespace eosiosystem {
       bool                        is_proxy = 0; /// whether the voter is a proxy for others
 
 
-      uint32_t                    deferred_trx_id = 0; /// the ID of the 3-day delay deferred transaction
-      time                        last_unstake_time = 0; /// the time when the deferred_trx_id was sent
-      eosio::asset                unstaking; /// the total unstaking (pending 3 day delay)
+      uint32_t                    reserved1 = 0;
+      time                        reserved2 = 0;
+      eosio::asset                reserved3;
 
       uint64_t primary_key()const { return owner; }
 
       // explicit serialization macro is not necessary, used here only to improve compilation time
-      EOSLIB_SERIALIZE( voter_info, (owner)(proxy)(producers)(staked)(last_vote_weight)(proxied_vote_weight)(is_proxy)(deferred_trx_id)(last_unstake_time)(unstaking) )
+      EOSLIB_SERIALIZE( voter_info, (owner)(proxy)(producers)(staked)(last_vote_weight)(proxied_vote_weight)(is_proxy)(reserved1)(reserved2)(reserved3) )
    };
 
    typedef eosio::multi_index< N(voters), voter_info>  voters_table;

--- a/unittests/eosio_system_tester.hpp
+++ b/unittests/eosio_system_tester.hpp
@@ -552,9 +552,6 @@ inline fc::mutable_variant_object voter( account_name acct ) {
       //("last_vote_weight", double(0))
       ("proxied_vote_weight", double(0))
       ("is_proxy", 0)
-      ("deferred_trx_id", 0)
-      ("last_unstake_time", fc::time_point_sec() )
-      ("unstaking", asset() )
       ;
 }
 


### PR DESCRIPTION
Remove unused (but reserved) fields in `eosiosystem::voter_info` from ABI.

Added clarifying comments to `system_contract::buyram` fee logic.

None of these changes are breaking changes to the system contract. And both old and new cleos version work just fine with these changes to the system contract ABI.