### PR TITLE
Fix reversed inequality for expiration checks

### DIFF
--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -838,7 +838,7 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block() {
                continue;
             }
 
-            if (trx->packed_trx.expiration() > pbs->header.timestamp.to_time_point()) {
+            if (trx->packed_trx.expiration() < pbs->header.timestamp.to_time_point()) {
                // expired, drop it
                chain.drop_unapplied_transaction(trx);
                continue;


### PR DESCRIPTION
This would effectively prevent upgrading transactions received during speculative execution into real production blocks.  See the issue below for more details and explanations of scenarios where this lead to actually dropping transactions from the network. 

resolves #4145