### PR TITLE
Docker local test net improvements

### DIFF
--- a/Docker/README.md
+++ b/Docker/README.md
@@ -173,27 +173,24 @@ run `docker pull eosio/eos:latest`
 
 run `docker-compose up`
 
-### EOSIO 1.0 Testnet
+### EOSIO Testnet
 
-We can easily set up a EOSIO 1.0 local testnet using docker images. Just run the following commands:
+We can easily set up a EOSIO local testnet using docker images. Just run the following commands:
 
 Note: if you want to use the mongo db plugin, you have to enable it in your `data-dir/config.ini` first.
 
 ```
-# pull images
-docker pull eosio/eos:v1.0.7
-
 # create volume
 docker volume create --name=nodeos-data-volume
 docker volume create --name=keosd-data-volume
-# start containers
-docker-compose -f docker-compose-eosio1.0.yaml up -d
+# pull images and start containers
+docker-compose -f docker-compose-eosio-latest.yaml up -d
 # get chain info
 curl http://127.0.0.1:8888/v1/chain/get_info
 # get logs
 docker-compose logs -f nodeosd
 # stop containers
-docker-compose -f docker-compose-eosio1.0.yaml down
+docker-compose -f docker-compose-eosio-latest.yaml down
 ```
 
 The `blocks` data are stored under `--data-dir` by default, and the wallet files are stored under `--wallet-dir` by default, of course you can change these as you want.

--- a/Docker/docker-compose-eosio-latest.yaml
+++ b/Docker/docker-compose-eosio-latest.yaml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   nodeosd:
-    image: eosio/eos:v1.0.7
+    image: eosio/eos:latest
     command: /opt/eosio/bin/nodeosd.sh --data-dir /opt/eosio/bin/data-dir -e
     hostname: nodeosd
     ports:
@@ -14,7 +14,7 @@ services:
       - nodeos-data-volume:/opt/eosio/bin/data-dir
 
   keosd:
-    image: eosio/eos:v1.0.7
+    image: eosio/eos:latest
     command: /opt/eosio/bin/keosd --wallet-dir /opt/eosio/bin/data-dir --http-server-address=127.0.0.1:8900
     hostname: keosd
     links:


### PR DESCRIPTION
Depending when latest release is uploaded to DockerHub we may encounter following error when the release does not exists yet:

```
$ cd $EOSIO_SOURCE/Docker
$ docker-compose -f docker-compose-eosio1.0.yaml up

Creating network "docker_default" with the default driver
Pulling nodeosd (eosio/eos:v1.0.4)...
ERROR: manifest for eosio/eos:v1.0.4 not found
```

I will suggest to use always `latest` tag and have always `docker-compose-eosio-latest.yaml` as a local test net file for Docker Compose.
Later, when we have another major release like EOSIO v2, we can create `docker-compose-eosio1.0.yaml` for the previous release if needed (probably it will not be necessary anyway).

Resolves #4148