### PR TITLE
Prevent name bidding on invalid names or names that do not require bidding to create

### DIFF
--- a/contracts/eosio.system/eosio.system.cpp
+++ b/contracts/eosio.system/eosio.system.cpp
@@ -97,6 +97,9 @@ namespace eosiosystem {
    void system_contract::bidname( account_name bidder, account_name newname, asset bid ) {
       require_auth( bidder );
       eosio_assert( eosio::name_suffix(newname) == newname, "you can only bid on top-level suffix" );
+      eosio_assert( newname != 0, "the empty name is not a valid account name to bid on" );
+      eosio_assert( (newname & 0xFull) == 0, "13 character names are not valid account names to bid on" );
+      eosio_assert( (newname & 0x1F0ull) == 0, "accounts with 12 character names and no dots can be created without bidding required" );
       eosio_assert( !is_account( newname ), "account already exists" );
       eosio_assert( bid.symbol == asset().symbol, "asset must be system token" );
       eosio_assert( bid.amount > 0, "insufficient bid" );

--- a/unittests/eosio.system_tests.cpp
+++ b/unittests/eosio.system_tests.cpp
@@ -2094,6 +2094,23 @@ BOOST_FIXTURE_TEST_CASE( buyname, eosio_system_tester ) try {
    create_accounts_with_resources( { N(goodgoodgood) }, N(dan) ); /// 12 char names should succeed
 } FC_LOG_AND_RETHROW()
 
+BOOST_FIXTURE_TEST_CASE( bid_invalid_names, eosio_system_tester ) try {
+   create_accounts_with_resources( { N(dan) } );
+
+   BOOST_REQUIRE_EQUAL( wasm_assert_msg( "you can only bid on top-level suffix" ),
+                        bidname( "dan", "abcdefg.12345", core_from_string( "1.0000" ) ) );
+
+   BOOST_REQUIRE_EQUAL( wasm_assert_msg( "the empty name is not a valid account name to bid on" ),
+                        bidname( "dan", "", core_from_string( "1.0000" ) ) );
+
+   BOOST_REQUIRE_EQUAL( wasm_assert_msg( "13 character names are not valid account names to bid on" ),
+                        bidname( "dan", "abcdefgh12345", core_from_string( "1.0000" ) ) );
+
+   BOOST_REQUIRE_EQUAL( wasm_assert_msg( "accounts with 12 character names and no dots can be created without bidding required" ),
+                        bidname( "dan", "abcdefg12345", core_from_string( "1.0000" ) ) );
+
+} FC_LOG_AND_RETHROW()
+
 BOOST_FIXTURE_TEST_CASE( multiple_namebids, eosio_system_tester ) try {
 
    const std::string not_closed_message("auction for name is not closed yet");


### PR DESCRIPTION
Resolves #4263.

This PR introduces further restrictions on the `bidname` action of the system contract to prevent new bids on names which:
 * are 13 characters long (since an account with a 13 character name can never be created);
 * are the empty name (since an account with the empty name can never be created);
 * are 12 characters long with no dots (since these don't require winning bids to create).
