### PR TITLE
Gh#3030 enable mongodb

### DIFF
--- a/Docker/builder/Dockerfile
+++ b/Docker/builder/Dockerfile
@@ -34,12 +34,6 @@ RUN wget https://dl.bintray.com/boostorg/release/1.67.0/source/boost_1_67_0.tar.
        --with-signals --with-serialization --with-chrono --with-test --with-context --with-locale --with-coroutine --with-iostreams toolset=clang link=static install \
     && cd .. && rm -rf boost_1_67_0
 
-# RUN wget https://github.com/mongodb/mongo-c-driver/releases/download/1.9.3/mongo-c-driver-1.9.3.tar.gz -O - | tar -xz \
-#     && cd mongo-c-driver-1.9.3 \
-#     && ./configure --enable-static --with-libbson=bundled --enable-ssl=openssl --disable-automatic-init-and-cleanup --prefix=/usr/local \
-#     && make -j$(nproc) install \
-#     && cd .. && rm -rf mongo-c-driver-1.9.3
-
 RUN wget https://github.com/mongodb/mongo-c-driver/releases/download/1.10.2/mongo-c-driver-1.10.2.tar.gz -O - | tar -xz \
     && cd mongo-c-driver-1.10.2 \
     && mkdir cmake-build && cd cmake-build \
@@ -68,12 +62,6 @@ RUN git clone --depth 1 https://github.com/cryptonomex/secp256k1-zkp \
     && ./configure --prefix=/usr/local \
     && make -j$(nproc) install \
     && cd .. && rm -rf secp256k1-zkp
-
-# RUN git clone --depth 1 -b releases/v3.2 https://github.com/mongodb/mongo-cxx-driver \
-#     && cd mongo-cxx-driver \
-#     && cmake -H. -Bbuild -G Ninja -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release  -DCMAKE_INSTALL_PREFIX=/usr/local\
-#     && cmake --build build --target install \
-#     && cd .. && rm -rf mongo-cxx-driver
 
 RUN git clone --depth 1 -b releases/v3.3 https://github.com/mongodb/mongo-cxx-driver \
     && cd mongo-cxx-driver/build \

--- a/Docker/builder/Dockerfile
+++ b/Docker/builder/Dockerfile
@@ -34,6 +34,12 @@ RUN wget https://dl.bintray.com/boostorg/release/1.67.0/source/boost_1_67_0.tar.
        --with-signals --with-serialization --with-chrono --with-test --with-context --with-locale --with-coroutine --with-iostreams toolset=clang link=static install \
     && cd .. && rm -rf boost_1_67_0
 
+# RUN wget https://github.com/mongodb/mongo-c-driver/releases/download/1.9.3/mongo-c-driver-1.9.3.tar.gz -O - | tar -xz \
+#     && cd mongo-c-driver-1.9.3 \
+#     && ./configure --enable-static --with-libbson=bundled --enable-ssl=openssl --disable-automatic-init-and-cleanup --prefix=/usr/local \
+#     && make -j$(nproc) install \
+#     && cd .. && rm -rf mongo-c-driver-1.9.3
+
 RUN wget https://github.com/mongodb/mongo-c-driver/releases/download/1.10.2/mongo-c-driver-1.10.2.tar.gz -O - | tar -xz \
     && cd mongo-c-driver-1.10.2 \
     && mkdir cmake-build && cd cmake-build \
@@ -62,6 +68,12 @@ RUN git clone --depth 1 https://github.com/cryptonomex/secp256k1-zkp \
     && ./configure --prefix=/usr/local \
     && make -j$(nproc) install \
     && cd .. && rm -rf secp256k1-zkp
+
+# RUN git clone --depth 1 -b releases/v3.2 https://github.com/mongodb/mongo-cxx-driver \
+#     && cd mongo-cxx-driver \
+#     && cmake -H. -Bbuild -G Ninja -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release  -DCMAKE_INSTALL_PREFIX=/usr/local\
+#     && cmake --build build --target install \
+#     && cd .. && rm -rf mongo-cxx-driver
 
 RUN git clone --depth 1 -b releases/v3.3 https://github.com/mongodb/mongo-cxx-driver \
     && cd mongo-cxx-driver/build \

--- a/Docker/builder/Dockerfile
+++ b/Docker/builder/Dockerfile
@@ -34,11 +34,20 @@ RUN wget https://dl.bintray.com/boostorg/release/1.67.0/source/boost_1_67_0.tar.
        --with-signals --with-serialization --with-chrono --with-test --with-context --with-locale --with-coroutine --with-iostreams toolset=clang link=static install \
     && cd .. && rm -rf boost_1_67_0
 
-RUN wget https://github.com/mongodb/mongo-c-driver/releases/download/1.9.3/mongo-c-driver-1.9.3.tar.gz -O - | tar -xz \
-    && cd mongo-c-driver-1.9.3 \
-    && ./configure --enable-static --with-libbson=bundled --enable-ssl=openssl --disable-automatic-init-and-cleanup --prefix=/usr/local \
-    && make -j$(nproc) install \
-    && cd .. && rm -rf mongo-c-driver-1.9.3
+# RUN wget https://github.com/mongodb/mongo-c-driver/releases/download/1.9.3/mongo-c-driver-1.9.3.tar.gz -O - | tar -xz \
+#     && cd mongo-c-driver-1.9.3 \
+#     && ./configure --enable-static --with-libbson=bundled --enable-ssl=openssl --disable-automatic-init-and-cleanup --prefix=/usr/local \
+#     && make -j$(nproc) install \
+#     && cd .. && rm -rf mongo-c-driver-1.9.3
+
+RUN wget https://github.com/mongodb/mongo-c-driver/releases/download/1.10.2/mongo-c-driver-1.10.2.tar.gz -O - | tar -xz \
+    && cd mongo-c-driver-1.10.2 \
+    && mkdir cmake-build && cd cmake-build \
+    && cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local -DENABLE_BSON=ON \
+		-DENABLE_SSL=OPENSSL -DENABLE_AUTOMATIC_INIT_AND_CLEANUP=OFF -DENABLE_STATIC=ON .. \
+    && make -j$(nproc) \
+    && make install \
+    && cd ../../ && rm -rf mongo-c-driver-1.10.2
 
 RUN git clone --depth 1 --single-branch --branch release_40 https://github.com/llvm-mirror/llvm.git \
     && git clone --depth 1 --single-branch --branch release_40 https://github.com/llvm-mirror/clang.git llvm/tools/clang \
@@ -60,11 +69,18 @@ RUN git clone --depth 1 https://github.com/cryptonomex/secp256k1-zkp \
     && make -j$(nproc) install \
     && cd .. && rm -rf secp256k1-zkp
 
-RUN git clone --depth 1 -b releases/v3.2 https://github.com/mongodb/mongo-cxx-driver \
-    && cd mongo-cxx-driver \
-    && cmake -H. -Bbuild -G Ninja -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release  -DCMAKE_INSTALL_PREFIX=/usr/local\
-    && cmake --build build --target install \
-    && cd .. && rm -rf mongo-cxx-driver
+# RUN git clone --depth 1 -b releases/v3.2 https://github.com/mongodb/mongo-cxx-driver \
+#     && cd mongo-cxx-driver \
+#     && cmake -H. -Bbuild -G Ninja -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release  -DCMAKE_INSTALL_PREFIX=/usr/local\
+#     && cmake --build build --target install \
+#     && cd .. && rm -rf mongo-cxx-driver
+
+RUN git clone --depth 1 -b releases/v3.3 https://github.com/mongodb/mongo-cxx-driver \
+    && cd mongo-cxx-driver/build \
+    && cmake -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local .. \
+    && make -j$(nproc) \
+    && make install \
+    && cd ../../ && rm -rf mongo-cxx-driver
 
 RUN git clone --depth 1 --single-branch --branch master https://github.com/ucb-bar/berkeley-softfloat-3.git \
     && cd berkeley-softfloat-3/build/Linux-x86_64-GCC \

--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -35,31 +35,30 @@ action_trace apply_context::exec_one()
 
    const auto& cfg = control.get_global_properties().configuration;
    try {
-      const auto &a = control.get_account(receiver);
+      const auto& a = control.get_account( receiver );
       privileged = a.privileged;
-      auto native = control.find_apply_handler(receiver, act.account, act.name);
+      auto native = control.find_apply_handler( receiver, act.account, act.name );
       if( native ) {
-         if( trx_context.can_subjectively_fail && control.is_producing_block() ) {
+         if( trx_context.can_subjectively_fail && control.is_producing_block()) {
             control.check_contract_list( receiver );
             control.check_action_list( act.account, act.name );
          }
-         (*native)(*this);
+         (*native)( *this );
       }
 
       if( a.code.size() > 0
-          && !(act.account == config::system_account_name && act.name == N(setcode) && receiver == config::system_account_name) )
-      {
-         if( trx_context.can_subjectively_fail && control.is_producing_block() ) {
+          && !(act.account == config::system_account_name && act.name == N( setcode ) &&
+               receiver == config::system_account_name)) {
+         if( trx_context.can_subjectively_fail && control.is_producing_block()) {
             control.check_contract_list( receiver );
             control.check_action_list( act.account, act.name );
          }
          try {
-            control.get_wasm_interface().apply(a.code_version, a.code, *this);
-         } catch ( const wasm_exit& ){}
+            control.get_wasm_interface().apply( a.code_version, a.code, *this );
+         } catch( const wasm_exit& ) {}
       }
 
-
-   } FC_CAPTURE_AND_RETHROW((_pending_console_output.str()));
+   } FC_RETHROW_EXCEPTIONS(warn, "pending console output: ${console}", ("console", _pending_console_output.str()))
 
    action_receipt r;
    r.receiver         = receiver;

--- a/libraries/chain/include/eosio/chain/transaction.hpp
+++ b/libraries/chain/include/eosio/chain/transaction.hpp
@@ -61,7 +61,8 @@ namespace eosio { namespace chain {
       flat_set<public_key_type>  get_signature_keys( const vector<signature_type>& signatures,
                                                      const chain_id_type& chain_id,
                                                      const vector<bytes>& cfd = vector<bytes>(),
-                                                     bool allow_duplicate_keys = false )const;
+                                                     bool allow_duplicate_keys = false,
+                                                     bool use_cache = true )const;
 
       uint32_t total_actions()const { return context_free_actions.size() + actions.size(); }
       account_name first_authorizor()const {
@@ -91,7 +92,7 @@ namespace eosio { namespace chain {
 
       const signature_type&     sign(const private_key_type& key, const chain_id_type& chain_id);
       signature_type            sign(const private_key_type& key, const chain_id_type& chain_id)const;
-      flat_set<public_key_type> get_signature_keys( const chain_id_type& chain_id, bool allow_duplicate_keys = false )const;
+      flat_set<public_key_type> get_signature_keys( const chain_id_type& chain_id, bool allow_duplicate_keys = false, bool use_cache = true )const;
    };
 
    struct packed_transaction {

--- a/libraries/chain/wasm_interface.cpp
+++ b/libraries/chain/wasm_interface.cpp
@@ -1323,7 +1323,7 @@ class transaction_api : public context_aware_api {
             transaction trx;
             fc::raw::unpack<transaction>(data, data_len, trx);
             context.schedule_deferred_transaction(sender_id, payer, std::move(trx), replace_existing);
-         } FC_CAPTURE_AND_RETHROW((fc::to_hex(data, data_len)));
+         } FC_RETHROW_EXCEPTIONS(warn, "data as hex: ${data}", ("data", fc::to_hex(data, data_len)))
       }
 
       bool cancel_deferred( const unsigned __int128& val ) {

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -286,7 +286,7 @@ namespace eosio { namespace testing {
       if( r->except_ptr ) std::rethrow_exception( r->except_ptr );
       if( r->except ) throw *r->except;
       return r;
-   } FC_CAPTURE_AND_RETHROW( (transaction_header(trx.get_transaction())) ) }
+   } FC_RETHROW_EXCEPTIONS( warn, "transaction_header: ${header}", ("header", transaction_header(trx.get_transaction()) )) }
 
    transaction_trace_ptr base_tester::push_transaction( signed_transaction& trx,
                                                         fc::time_point deadline,
@@ -305,7 +305,9 @@ namespace eosio { namespace testing {
       if( r->except_ptr ) std::rethrow_exception( r->except_ptr );
       if( r->except)  throw *r->except;
       return r;
-   } FC_CAPTURE_AND_RETHROW( (transaction_header(trx))(billed_cpu_time_us) ) }
+   } FC_RETHROW_EXCEPTIONS( warn, "transaction_header: ${header}, billed_cpu_time_us: ${billed}",
+                            ("header", transaction_header(trx) ) ("billed", billed_cpu_time_us))
+   }
 
    typename base_tester::action_result base_tester::push_action(action&& act, uint64_t authorizer) {
       signed_transaction trx;

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -16,7 +16,7 @@ add_subdirectory(wallet_api_plugin)
 add_subdirectory(txn_test_gen_plugin)
 add_subdirectory(db_size_api_plugin)
 #add_subdirectory(faucet_testnet_plugin)
-#add_subdirectory(mongo_db_plugin)
+add_subdirectory(mongo_db_plugin)
 #add_subdirectory(sql_db_plugin)
 add_subdirectory(login_plugin)
 

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1193,7 +1193,8 @@ read_only::abi_json_to_bin_result read_only::abi_json_to_bin( const read_only::a
       EOS_ASSERT(false, abi_not_found_exception, "No ABI found for ${contract}", ("contract", params.code));
    }
    return result;
-} FC_CAPTURE_AND_RETHROW( (params.code)(params.action)(params.args) )
+} FC_RETHROW_EXCEPTIONS( warn, "code: ${code}, action: ${action}, args: ${args}",
+                         ("code", params.code)( "action", params.action )( "args", params.args ))
 
 read_only::abi_bin_to_json_result read_only::abi_bin_to_json( const read_only::abi_bin_to_json_params& params )const {
    abi_bin_to_json_result result;

--- a/plugins/mongo_db_plugin/include/eosio/mongo_db_plugin/mongo_db_plugin.hpp
+++ b/plugins/mongo_db_plugin/include/eosio/mongo_db_plugin/mongo_db_plugin.hpp
@@ -14,20 +14,16 @@ using mongo_db_plugin_impl_ptr = std::shared_ptr<class mongo_db_plugin_impl>;
 
 /**
  * Provides persistence to MongoDB for:
- *   Blocks
- *   Transactions
- *   Actions
- *   Accounts
+ * accounts
+ * actions
+ * block_states
+ * blocks
+ * transaction_traces
+ * transactions
  *
  *   See data dictionary (DB Schema Definition - EOS API) for description of MongoDB schema.
  *
- *   The goal ultimately is for all chainbase data to be mirrored in MongoDB via a delayed node processing
- *   irreversible blocks. Currently, only Blocks, Transactions, Messages, and Account balance it mirrored.
- *   Chainbase is being rewritten to be multi-threaded. Once chainbase is stable, integration directly with
- *   a mirror database approach can be followed removing the need for the direct processing of Blocks employed
- *   with this implementation.
- *
- *   If MongoDB env not available (#ifndef MONGODB) this plugin is a no-op.
+ *   If cmake -DBUILD_MONGO_DB_PLUGIN=true  not specified then this plugin not compiled/included.
  */
 class mongo_db_plugin : public plugin<mongo_db_plugin> {
 public:

--- a/plugins/mongo_db_plugin/mongo_db_plugin.cpp
+++ b/plugins/mongo_db_plugin/mongo_db_plugin.cpp
@@ -360,13 +360,19 @@ namespace {
         auto from_account = find_account(accounts, act.account);
         abi_def abi;
         if (from_account.view().find("abi") != from_account.view().end()) {
-           abi = fc::json::from_string(bsoncxx::to_json(from_account.view()["abi"].get_document())).as<abi_def>();
+           try {
+              abi = fc::json::from_string( bsoncxx::to_json( from_account.view()["abi"].get_document())).as<abi_def>();
+           } catch(...) {
+              ilog( "Unable to convert account abi to abi_def for ${s}::${n}", ("s", act.account)( "n", act.name ) );
+           }
         }
-        abi_serializer abis;
-        abis.set_abi(abi);
-        auto v = abis.binary_to_variant(abis.get_action_type(act.name), act.data);
-        auto json = fc::json::to_string(v);
+        string json;
         try {
+           abi_serializer abis;
+           abis.set_abi( abi );
+           auto v = abis.binary_to_variant( abis.get_action_type( act.name ), act.data );
+           json = fc::json::to_string( v );
+
            const auto& value = bsoncxx::from_json(json);
            act_doc.append(kvp("data", value));
            return;

--- a/plugins/mongo_db_plugin/mongo_db_plugin.cpp
+++ b/plugins/mongo_db_plugin/mongo_db_plugin.cpp
@@ -353,7 +353,6 @@ namespace {
       return *block;
    }
 
-
    void update_account(bsoncxx::builder::basic::document& act_doc, mongocxx::collection& accounts, const chain::action& act) {
       using bsoncxx::builder::basic::kvp;
       using bsoncxx::builder::basic::make_document;
@@ -1000,10 +999,6 @@ void mongo_db_plugin_impl::_process_irreversible_block(const chain::block_state_
    const auto block_id = bs->block->id();
    const auto block_id_str = block_id.str();
    const auto block_num = bs->block->block_num();
-
-   if (block_num == 1153) {
-      std::cout << fc::json::to_pretty_string(bs) << std::endl;
-   }
 
    // genesis block 1 is not signaled to accepted_block
    if (block_num < 2) return;

--- a/plugins/mongo_db_plugin/mongo_db_plugin.cpp
+++ b/plugins/mongo_db_plugin/mongo_db_plugin.cpp
@@ -736,6 +736,10 @@ void mongo_db_plugin_impl::_process_block(const chain::block_state_ptr& bs) {
    auto blocks = mongo_conn[db_name][blocks_col];
    auto trans = mongo_conn[db_name][trans_col];
 
+   if (bs->block->transactions.size() > 1) {
+      std::cout << fc::json::to_pretty_string( *bs ) << std::endl;
+   }
+
    auto block_doc = bsoncxx::builder::basic::document{};
    auto block_state_doc = bsoncxx::builder::basic::document{};
    const auto block_id = bs->id;

--- a/plugins/mongo_db_plugin/mongo_db_plugin.cpp
+++ b/plugins/mongo_db_plugin/mongo_db_plugin.cpp
@@ -456,18 +456,18 @@ namespace {
       act_doc.append( kvp( "hex_data", fc::variant( act.data ).as_string()));
    }
 
-void verify_last_block(mongocxx::collection& blocks, const std::string& prev_block_id) {
-     mongocxx::options::find opts;
-     opts.sort(bsoncxx::from_json(R"xxx({ "_id" : -1 })xxx"));
-     auto last_block = blocks.find_one({}, opts);
-     if (!last_block) {
-        FC_THROW("No blocks found in database");
-     }
-     const auto id = last_block->view()["block_id"].get_utf8().value.to_string();
-     if (id != prev_block_id) {
-        FC_THROW("Did not find expected block ${pid}, instead found ${id}", ("pid", prev_block_id)("id", id));
-     }
-  }
+   void verify_last_block(mongocxx::collection& blocks, const std::string& prev_block_id) {
+      mongocxx::options::find opts;
+      opts.sort( bsoncxx::from_json( R"xxx({ "_id" : -1 })xxx" ));
+      auto last_block = blocks.find_one( {}, opts );
+      if( !last_block ) {
+         FC_THROW( "No blocks found in database" );
+      }
+      const auto id = last_block->view()["block_id"].get_utf8().value.to_string();
+      if( id != prev_block_id ) {
+         FC_THROW( "Did not find expected block ${pid}, instead found ${id}", ("pid", prev_block_id)( "id", id ));
+      }
+   }
 
    void verify_no_blocks(mongocxx::collection& blocks) {
       if (blocks.count(bsoncxx::from_json("{}")) > 0) {

--- a/plugins/mongo_db_plugin/mongo_db_plugin.cpp
+++ b/plugins/mongo_db_plugin/mongo_db_plugin.cpp
@@ -823,7 +823,7 @@ void mongo_db_plugin_impl::_process_block(const chain::block_state_ptr& bs) {
                                    const chain::action_trace& act,
                                    const auto& msg_oid)
    {
-      auto act_oid = bsoncxx::oid{};
+//      auto act_oid = bsoncxx::oid{};
       auto act_doc = bsoncxx::builder::basic::document{};
       act_doc.append(kvp("_id", b_oid{act_oid}),
                      kvp("transaction_id", trans_id_str),

--- a/plugins/mongo_db_plugin/mongo_db_plugin.cpp
+++ b/plugins/mongo_db_plugin/mongo_db_plugin.cpp
@@ -901,7 +901,7 @@ void mongo_db_plugin_impl::_process_block(const chain::block_state_ptr& bs) {
                                         "unknown";
                trx_status_map[trx_trace.id] = trx_status;
 
-               for (const auto& req : trx_trace.deferred_transaction_requests) {
+ //              for (const auto& req : trx_trace.deferred_transaction_requests) {
                   if ( req.contains<chain::deferred_transaction>() ) {
                      auto trx = req.get<chain::deferred_transaction>();
                      auto doc = process_trx(trx);

--- a/plugins/mongo_db_plugin/mongo_db_plugin.cpp
+++ b/plugins/mongo_db_plugin/mongo_db_plugin.cpp
@@ -1001,6 +1001,10 @@ void mongo_db_plugin_impl::_process_irreversible_block(const chain::block_state_
    const auto block_id_str = block_id.str();
    const auto block_num = bs->block->block_num();
 
+   if (block_num == 1153) {
+      std::cout << fc::json::to_pretty_string(bs) << std::endl;
+   }
+
    // genesis block 1 is not signaled to accepted_block
    if (block_num < 2) return;
 

--- a/plugins/mongo_db_plugin/mongo_db_plugin.cpp
+++ b/plugins/mongo_db_plugin/mongo_db_plugin.cpp
@@ -1023,7 +1023,7 @@ void mongo_db_plugin::plugin_initialize(const variables_map& options)
             if( options.at( "mongodb-wipe" ).as<bool>()) {
                ilog( "Wiping mongo database on startup" );
                my->wipe_database_on_startup = true;
-            } else {
+            } else if( options.count( "mongodb-block-start" ) == 0 ) {
                FC_ASSERT( false, "--mongodb-wipe required with --replay-blockchain, --hard-replay-blockchain, or --delete-all-blocks"
                                  " --mongodb-wipe will remove all EOS collections from mongodb." );
             }

--- a/plugins/mongo_db_plugin/mongo_db_plugin.cpp
+++ b/plugins/mongo_db_plugin/mongo_db_plugin.cpp
@@ -171,16 +171,7 @@ void mongo_db_plugin_impl::accepted_transaction( const chain::transaction_metada
          // on startup we don't want to queue, instead push back on caller
          process_accepted_transaction(t);
       } else {
-         boost::mutex::scoped_lock lock(mtx);
-         if (transaction_metadata_queue.size() > queue_size) {
-            lock.unlock();
-            condition.notify_one();
-            boost::this_thread::sleep_for(boost::chrono::milliseconds(100));
-            lock.lock();
-         }
-         transaction_metadata_queue.emplace_back(t);
-         lock.unlock();
-         condition.notify_one();
+         queue(mtx, condition, transaction_metadata_queue, t, queue_size);
       }
    } catch (fc::exception& e) {
       elog("FC Exception while accepted_transaction ${e}", ("e", e.to_string()));

--- a/plugins/mongo_db_plugin/mongo_db_plugin.cpp
+++ b/plugins/mongo_db_plugin/mongo_db_plugin.cpp
@@ -1107,6 +1107,10 @@ void mongo_db_plugin::plugin_initialize(const variables_map& options)
             }
          }
 
+         if( options.count( "abi-serializer-max-time-ms") == 0 ) {
+            FC_ASSERT(false, "--abi-serializer-max-time-ms required as default value not appropriate for parsing full blocks");
+         }
+
          if( options.count( "mongodb-queue-size" )) {
             my->queue_size = options.at( "mongodb-queue-size" ).as<uint32_t>();
          }

--- a/plugins/mongo_db_plugin/mongo_db_plugin.cpp
+++ b/plugins/mongo_db_plugin/mongo_db_plugin.cpp
@@ -340,7 +340,7 @@ namespace {
       return pretty_output;
    }
 
-void handle_mongo_exception( const char* desc, int line_num ) {
+void handle_mongo_exception( const std::string& desc, int line_num ) {
    bool shutdown = true;
    try {
       try {
@@ -791,7 +791,7 @@ void mongo_db_plugin_impl::_process_applied_transaction( const chain::transactio
          FC_ASSERT( false, "Failed to insert trans ${id}", ("id", t->id));
       }
    } catch(...) {
-      handle_mongo_exception("trans_traces insert: ", __LINE__);
+      handle_mongo_exception("trans_traces insert: " + json, __LINE__);
    }
 }
 
@@ -839,7 +839,7 @@ void mongo_db_plugin_impl::_process_accepted_block( const chain::block_state_ptr
          FC_ASSERT( false, "Failed to insert block_state ${bid}", ("bid", block_id));
       }
    } catch(...) {
-      handle_mongo_exception("block_states insert", __LINE__);
+      handle_mongo_exception("block_states insert: " + json, __LINE__);
    }
 
    auto blocks = mongo_conn[db_name][blocks_col];
@@ -871,7 +871,7 @@ void mongo_db_plugin_impl::_process_accepted_block( const chain::block_state_ptr
          FC_ASSERT( false, "Failed to insert block ${bid}", ("bid", block_id));
       }
    } catch(...) {
-      handle_mongo_exception("blocks insert", __LINE__);
+      handle_mongo_exception("blocks insert: " + json, __LINE__);
    }
 }
 

--- a/plugins/mongo_db_plugin/mongo_db_plugin.cpp
+++ b/plugins/mongo_db_plugin/mongo_db_plugin.cpp
@@ -638,7 +638,7 @@ void mongo_db_plugin_impl::_process_accepted_transaction( const chain::transacti
    bool actions_to_write = false;
    mongocxx::options::bulk_write bulk_opts;
    bulk_opts.ordered(false);
-   mongocxx::bulk_write bulk_actions{bulk_opts};
+   mongocxx::bulk_write bulk_actions = actions.create_bulk_write(bulk_opts);
 
    int32_t act_num = 0;
    auto process_action = [&](const std::string& trx_id_str, const chain::action& act, bbb::array& act_array, bool cfa) -> auto {
@@ -768,9 +768,9 @@ void mongo_db_plugin_impl::_process_accepted_transaction( const chain::transacti
       }
 
       if (actions_to_write) {
-         auto result = actions.bulk_write(bulk_actions);
+         auto result = bulk_actions.execute();
          if (!result) {
-            elog("Bulk actions insert failed for transaction: ${id}", ("id", trans_id_str));
+            elog("Bulk actions insert failed for transaction: ${id}", ("id", trx_id_str));
          }
       }
 

--- a/plugins/mongo_db_plugin/mongo_db_plugin.cpp
+++ b/plugins/mongo_db_plugin/mongo_db_plugin.cpp
@@ -513,7 +513,18 @@ namespace {
       act_doc.append( kvp( "hex_data", fc::variant( act.data ).as_string()));
    }
 
-}
+   void verify_last_block(mongocxx::collection& blocks, const std::string& prev_block_id) {
+      mongocxx::options::find opts;
+      opts.sort( bsoncxx::from_json( R"xxx({ "_id" : -1 })xxx" ));
+      auto last_block = blocks.find_one( {}, opts );
+      if( !last_block ) {
+         FC_THROW( "No blocks found in database" );
+      }
+      const auto id = last_block->view()["block_id"].get_utf8().value.to_string();
+      if( id != prev_block_id ) {
+         FC_THROW( "Did not find expected block ${pid}, instead found ${id}", ("pid", prev_block_id)( "id", id ));
+      }
+   }
 
 void mongo_db_plugin_impl::process_accepted_transaction( const chain::transaction_metadata_ptr& t ) {
    try {

--- a/plugins/mongo_db_plugin/mongo_db_plugin.cpp
+++ b/plugins/mongo_db_plugin/mongo_db_plugin.cpp
@@ -862,10 +862,6 @@ void mongo_db_plugin_impl::_process_irreversible_block(const chain::block_state_
    const auto block_id_str = block_id.str();
    const auto block_num = bs->block->block_num();
 
-   if (block_num == 1153) {
-      std::cout << fc::json::to_pretty_string(bs) << std::endl;
-   }
-
    // genesis block 1 is not signaled to accepted_block
    if (block_num < 2) return;
 

--- a/plugins/mongo_db_plugin/mongo_db_plugin.cpp
+++ b/plugins/mongo_db_plugin/mongo_db_plugin.cpp
@@ -169,7 +169,7 @@ void mongo_db_plugin_impl::accepted_transaction( const chain::transaction_metada
    try {
       if (startup) {
          // on startup we don't want to queue, instead push back on caller
-         process_transaction(t);
+         process_accepted_transaction(t);
       } else {
          boost::mutex::scoped_lock lock(mtx);
          if (transaction_metadata_queue.size() > queue_size) {
@@ -542,9 +542,9 @@ void mongo_db_plugin_impl::process_applied_transaction( const chain::transaction
    }
 }
 
-void mongo_db_plugin_impl::process_transaction( const chain::transaction_metadata_ptr& t ) {
+void mongo_db_plugin_impl::process_accepted_transaction( const chain::transaction_metadata_ptr& t ) {
    try {
-      _process_transaction(t);
+      _process_accepted_transaction(t);
    } catch (fc::exception& e) {
       elog("FC Exception while processing transaction metadata: ${e}", ("e", e.to_detail_string()));
    } catch (std::exception& e) {
@@ -554,9 +554,9 @@ void mongo_db_plugin_impl::process_transaction( const chain::transaction_metadat
    }
 }
 
-void mongo_db_plugin_impl::process_transaction( const chain::transaction_trace_ptr& t ) {
+void mongo_db_plugin_impl::process_applied_transaction( const chain::transaction_trace_ptr& t ) {
    try {
-      _process_transaction(t);
+      _process_applied_transaction(t);
    } catch (fc::exception& e) {
       elog("FC Exception while processing transaction trace: ${e}", ("e", e.to_detail_string()));
    } catch (std::exception& e) {
@@ -832,7 +832,6 @@ void mongo_db_plugin_impl::_process_accepted_block( const chain::block_state_ptr
    if (!blocks.insert_one(block_doc.view())) {
       elog("Failed to insert block ${bid}", ("bid", block_id));
    }
-    */
 }
 
 void mongo_db_plugin_impl::_process_irreversible_block(const chain::block_state_ptr& bs)
@@ -848,10 +847,6 @@ void mongo_db_plugin_impl::_process_irreversible_block(const chain::block_state_
    const auto block_id = bs->block->id();
    const auto block_id_str = block_id.str();
    const auto block_num = bs->block->block_num();
-
-   if (block_num == 1153) {
-      std::cout << fc::json::to_pretty_string(bs) << std::endl;
-   }
 
    // genesis block 1 is not signaled to accepted_block
    if (block_num < 2) return;

--- a/plugins/mongo_db_plugin/mongo_db_plugin.cpp
+++ b/plugins/mongo_db_plugin/mongo_db_plugin.cpp
@@ -516,6 +516,19 @@ void mongo_db_plugin_impl::process_applied_transaction( const chain::transaction
    }
 }
 
+void mongo_db_plugin_impl::process_transaction( const eosio::chain::transaction_trace_ptr& t ) {
+   try {
+      _process_transaction(t);
+   } catch (fc::exception& e) {
+      elog("FC Exception while processing transaction trace: ${e}", ("e", e.to_detail_string()));
+   } catch (std::exception& e) {
+      elog("STD Exception while processing tranasction trace: ${e}", ("e", e.what()));
+   } catch (...) {
+      elog("Unknown exception while processing transaction trace");
+   }
+}
+
+
 void mongo_db_plugin_impl::process_irreversible_block(const chain::block_state_ptr& bs) {
   try {
      if( start_block_reached ) {
@@ -782,6 +795,7 @@ void mongo_db_plugin_impl::_process_accepted_block( const chain::block_state_ptr
    if (!blocks.insert_one(block_doc.view())) {
       elog("Failed to insert block ${bid}", ("bid", block_id));
    }
+    */
 }
 
 void mongo_db_plugin_impl::_process_irreversible_block(const chain::block_state_ptr& bs)
@@ -797,6 +811,10 @@ void mongo_db_plugin_impl::_process_irreversible_block(const chain::block_state_
    const auto block_id = bs->block->id();
    const auto block_id_str = block_id.str();
    const auto block_num = bs->block->block_num();
+
+   if (block_num == 1153) {
+      std::cout << fc::json::to_pretty_string(bs) << std::endl;
+   }
 
    // genesis block 1 is not signaled to accepted_block
    if (block_num < 2) return;

--- a/plugins/mongo_db_plugin/mongo_db_plugin.cpp
+++ b/plugins/mongo_db_plugin/mongo_db_plugin.cpp
@@ -10,6 +10,7 @@
 #include <eosio/chain/types.hpp>
 
 #include <fc/io/json.hpp>
+#include <fc/utf8.hpp>
 #include <fc/variant.hpp>
 
 #include <boost/chrono.hpp>
@@ -434,20 +435,25 @@ void handle_mongo_exception( const char* desc, int line_num ) {
                from_account = find_account( accounts, setabi.account );
             }
             if( from_account ) {
-               try {
-                  const abi_def& abi_def = fc::raw::unpack<chain::abi_def>( setabi.abi );
-                  const string json_str = fc::json::to_string( abi_def );
+               const abi_def& abi_def = fc::raw::unpack<chain::abi_def>( setabi.abi );
+               const string json_str = fc::json::to_string( abi_def );
 
+               try{
                   auto update_from = make_document(
                         kvp( "$set", make_document( kvp( "abi", bsoncxx::from_json( json_str )),
                                                     kvp( "updatedAt", b_date{now} ))));
 
-                  if( !accounts.update_one( make_document( kvp( "_id", from_account->view()["_id"].get_oid())), update_from.view()) ) {
-                     elog( "Failed to udpdate account ${n}", ("n", setabi.account));
+                  try {
+                     if( !accounts.update_one( make_document( kvp( "_id", from_account->view()["_id"].get_oid())),
+                                               update_from.view())) {
+                        FC_ASSERT( false, "Failed to udpdate account ${n}", ("n", setabi.account));
+                     }
+                  } catch( ... ) {
+                     handle_mongo_exception( "account update", __LINE__ );
                   }
-               } catch( fc::exception& e ) {
-                  // if unable to unpack abi_def then just don't save the abi
-                  // users are not required to use abi_def as their abi
+               } catch( bsoncxx::exception& e ) {
+                  elog( "Unable to convert abi JSON to MongoDB JSON: ${e}", ("e", e.what()));
+                  elog( "  JSON: ${j}", ("j", json_str));
                }
             }
          }
@@ -456,78 +462,65 @@ void handle_mongo_exception( const char* desc, int line_num ) {
       }
    }
 
-   void add_data(bsoncxx::builder::basic::document& act_doc, mongocxx::collection& accounts, const chain::action& act) {
-      using bsoncxx::builder::basic::kvp;
-      using bsoncxx::builder::basic::make_document;
-      try {
-         if( act.account == chain::config::system_account_name ) {
-            if( act.name == mongo_db_plugin_impl::newaccount ) {
-               auto newaccount = act.data_as<chain::newaccount>();
-               try {
-                  auto json = fc::json::to_string( newaccount );
-                  const auto& value = bsoncxx::from_json( json );
-                  act_doc.append( kvp( "data", value ));
-                  return;
-               } catch (...) {
-                  ilog( "Unable to convert action newaccount to json for ${n}", ( "n", newaccount.name.to_string() ));
-               }
-            } else if( act.name == mongo_db_plugin_impl::setabi ) {
-               auto setabi = act.data_as<chain::setabi>();
-               try {
-                  const abi_def& abi_def = fc::raw::unpack<chain::abi_def>( setabi.abi );
-                  const string json_str = fc::json::to_string( abi_def );
-
-                  // the original keys from document 'view' are kept, "data" here is not replaced by "data" of add_data
-                  act_doc.append(
-                        kvp( "data", make_document( kvp( "account", setabi.account.to_string()),
-                                                    kvp( "abi_def", bsoncxx::from_json( json_str )))));
-                  return;
-               } catch( fc::exception& e ) {
-                  ilog( "Unable to convert action abi_def to json for ${n}", ( "n", setabi.account.to_string() ));
-               }
-            }
-         }
-         auto account = find_account( accounts, act.account );
-         if (account) {
-            auto from_account = *account;
-            abi_def abi;
-            if( from_account.view().find( "abi" ) != from_account.view().end()) {
-               try {
-                  abi = fc::json::from_string( bsoncxx::to_json( from_account.view()["abi"].get_document())).as<abi_def>();
-               } catch( ... ) {
-                  ilog( "Unable to convert account abi to abi_def for ${s}::${n}", ("s", act.account)( "n", act.name ));
-               }
-            }
-            string json;
+void add_data( bsoncxx::builder::basic::document& act_doc, mongocxx::collection& accounts, const chain::action& act ) {
+   using bsoncxx::builder::basic::kvp;
+   using bsoncxx::builder::basic::make_document;
+   try {
+      if( act.account == chain::config::system_account_name ) {
+         if( act.name == mongo_db_plugin_impl::setabi ) {
+            auto setabi = act.data_as<chain::setabi>();
             try {
-               abi_serializer abis;
-               abis.set_abi( abi );
-               auto v = abis.binary_to_variant( abis.get_action_type( act.name ), act.data );
-               json = fc::json::to_string( v );
+               const abi_def& abi_def = fc::raw::unpack<chain::abi_def>( setabi.abi );
+               const string json_str = fc::json::to_string( abi_def );
 
-               const auto& value = bsoncxx::from_json( json );
-               act_doc.append( kvp( "data", value ));
+               act_doc.append(
+                     kvp( "data", make_document( kvp( "account", setabi.account.to_string()),
+                                                 kvp( "abi_def", bsoncxx::from_json( json_str )))));
                return;
-            } catch( std::exception& e ) {
-               elog( "Unable to convert EOS JSON to MongoDB JSON: ${e}", ("e", e.what()));
-               elog( "  EOS JSON: ${j}", ("j", json));
+            } catch( bsoncxx::exception& ) {
+               // better error handling below
+            } catch( fc::exception& e ) {
+               ilog( "Unable to convert action abi_def to json for ${n}", ("n", setabi.account.to_string()));
             }
          }
-      } catch (fc::exception& e) {
-         if( act.name != "onblock" ) { // onblock not in original eosio.system contract abi
-            dlog( "Unable to convert action.data to ABI: ${s}::${n}, what: ${e}",
-                  ("s", act.account)( "n", act.name )( "e", e.to_detail_string()));
-         }
-      } catch (std::exception& e) {
-         ilog( "Unable to convert action.data to ABI: ${s}::${n}, std what: ${e}",
-               ("s", act.account)( "n", act.name )( "e", e.what()));
-      } catch (...) {
-         ilog( "Unable to convert action.data to ABI: ${s}::${n}, unknown exception",
-               ("s", act.account)( "n", act.name ));
       }
-      // if anything went wrong just store raw hex_data
-      act_doc.append( kvp( "hex_data", fc::variant( act.data ).as_string()));
+      auto account = find_account( accounts, act.account );
+      if( account ) {
+         auto from_account = *account;
+         abi_def abi;
+         if( from_account.view().find( "abi" ) != from_account.view().end()) {
+            try {
+               abi = fc::json::from_string( bsoncxx::to_json( from_account.view()["abi"].get_document())).as<abi_def>();
+            } catch( ... ) {
+               ilog( "Unable to convert account abi to abi_def for ${s}::${n}", ("s", act.account)( "n", act.name ));
+            }
+         }
+         string json;
+         try {
+            abi_serializer abis;
+            abis.set_abi( abi );
+            auto v = abis.binary_to_variant( abis.get_action_type( act.name ), act.data );
+            json = fc::json::to_string( v );
+
+            const auto& value = bsoncxx::from_json( json );
+            act_doc.append( kvp( "data", value ));
+            return;
+         } catch( bsoncxx::exception& e ) {
+            ilog( "Unable to convert EOS JSON to MongoDB JSON: ${e}", ("e", e.what()));
+            ilog( "  EOS JSON: ${j}", ("j", json));
+            ilog( "  Storing data has hex." );
+         }
+      }
+   } catch( std::exception& e ) {
+      ilog( "Unable to convert action.data to ABI: ${s}::${n}, std what: ${e}",
+            ("s", act.account)( "n", act.name )( "e", e.what()));
+   } catch( ... ) {
+      ilog( "Unable to convert action.data to ABI: ${s}::${n}, unknown exception",
+            ("s", act.account)( "n", act.name ));
    }
+   // if anything went wrong just store raw hex_data
+   act_doc.append( kvp( "hex_data", fc::variant( act.data ).as_string()));
+}
 
 }
 
@@ -668,14 +661,26 @@ void mongo_db_plugin_impl::_process_accepted_transaction( const chain::transacti
       try {
          const auto& trx_header_value = bsoncxx::from_json( trx_header_json );
          trans_doc.append( kvp( "transaction_header", trx_header_value ));
-         if( !signing_keys_json.empty()) {
+      } catch( bsoncxx::exception& ) {
+         try {
+            trx_header_json = fc::prune_invalid_utf8( trx_header_json );
+            const auto& trx_header_value = bsoncxx::from_json( trx_header_json );
+            trans_doc.append( kvp( "transaction_header", trx_header_value ));
+            trans_doc.append( kvp( "non-utf8-purged", b_bool{true}));
+         } catch( bsoncxx::exception& e ) {
+            elog( "Unable to convert transaction header JSON to MongoDB JSON: ${e}", ("e", e.what()));
+            elog( "  JSON: ${j}", ("j", trx_header_json));
+         }
+      }
+      if( !signing_keys_json.empty()) {
+         try {
             const auto& keys_value = bsoncxx::from_json( signing_keys_json );
             trans_doc.append( kvp( "signing_keys", keys_value ));
+         } catch( bsoncxx::exception& e ) {
+            // should never fail, so don't attempt to remove invalid utf8
+            elog( "Unable to convert signing keys JSON to MongoDB JSON: ${e}", ("e", e.what()));
+            elog( "  JSON: ${j}", ("j", signing_keys_json));
          }
-      } catch( std::exception& e ) {
-         elog( "Unable to convert transaction JSON to MongoDB JSON: ${e}", ("e", e.what()));
-         elog( "  JSON: ${j}", ("j", trx_header_json));
-         elog( "  JSON: ${j}", ("j", signing_keys_json));
       }
    }
 
@@ -703,13 +708,22 @@ void mongo_db_plugin_impl::_process_accepted_transaction( const chain::transacti
 
       try {
          if( !trx_extensions_json.empty()) {
-            const auto& trx_extensions_value = bsoncxx::from_json( trx_extensions_json );
-            trans_doc.append( kvp( "transaction_extensions", trx_extensions_value ));
+            try {
+               const auto& trx_extensions_value = bsoncxx::from_json( trx_extensions_json );
+               trans_doc.append( kvp( "transaction_extensions", trx_extensions_value ));
+            } catch( bsoncxx::exception& ) {
+               static_assert( sizeof(std::remove_pointer<decltype(b_binary::bytes)>::type) == sizeof(std::string::value_type), "string type not storable as b_binary" );
+               trans_doc.append( kvp( "transaction_extensions",
+                                      b_binary{bsoncxx::binary_sub_type::k_binary,
+                                               static_cast<uint32_t>(trx_extensions_json.size()),
+                                               reinterpret_cast<const u_int8_t*>(trx_extensions_json.data())} ));
+            }
          } else {
             trans_doc.append( kvp( "transaction_extensions", make_array()));
          }
 
          if( !trx_signatures_json.empty()) {
+            // signatures contain only utf8
             const auto& trx_signatures_value = bsoncxx::from_json( trx_signatures_json );
             trans_doc.append( kvp( "signatures", trx_signatures_value ));
          } else {
@@ -717,8 +731,21 @@ void mongo_db_plugin_impl::_process_accepted_transaction( const chain::transacti
          }
 
          if( !trx_context_free_data_json.empty()) {
-            const auto& trx_context_free_data_value = bsoncxx::from_json( trx_context_free_data_json );
-            trans_doc.append( kvp( "context_free_data", trx_context_free_data_value ));
+            try {
+               const auto& trx_context_free_data_value = bsoncxx::from_json( trx_context_free_data_json );
+               trans_doc.append( kvp( "context_free_data", trx_context_free_data_value ));
+            } catch( bsoncxx::exception& ) {
+               static_assert( sizeof(std::remove_pointer<decltype(b_binary::bytes)>::type) ==
+                              sizeof(std::remove_pointer<decltype(trx.context_free_data[0].data())>::type), "context_free_data not storable as b_binary" );
+               bsoncxx::builder::basic::array data_array;
+               for (auto& cfd : trx.context_free_data) {
+                  data_array.append(
+                        b_binary{bsoncxx::binary_sub_type::k_binary,
+                                 static_cast<uint32_t>(cfd.size()),
+                                 reinterpret_cast<const u_int8_t*>(cfd.data())} );
+               }
+               trans_doc.append( kvp( "context_free_data", data_array.view() ));
+            }
          } else {
             trans_doc.append( kvp( "context_free_data", make_array()));
          }
@@ -766,18 +793,25 @@ void mongo_db_plugin_impl::_process_applied_transaction( const chain::transactio
    try {
       const auto& value = bsoncxx::from_json( json );
       trans_traces_doc.append( bsoncxx::builder::concatenate_doc{value.view()} );
-      trans_traces_doc.append( kvp( "createdAt", b_date{now} ));
-   } catch( std::exception& e ) {
-      elog( "Unable to convert transaction JSON to MongoDB JSON: ${e}", ("e", e.what()));
-      elog( "  JSON: ${j}", ("j", json));
+   } catch( bsoncxx::exception& ) {
+      try {
+         json = fc::prune_invalid_utf8( json );
+         const auto& value = bsoncxx::from_json( json );
+         trans_traces_doc.append( bsoncxx::builder::concatenate_doc{value.view()} );
+         trans_traces_doc.append( kvp( "non-utf8-purged", b_bool{true} ));
+      } catch( bsoncxx::exception& e ) {
+         elog( "Unable to convert transaction JSON to MongoDB JSON: ${e}", ("e", e.what()));
+         elog( "  JSON: ${j}", ("j", json));
+      }
    }
+   trans_traces_doc.append( kvp( "createdAt", b_date{now} ));
 
    try {
       if( !trans_traces.insert_one( trans_traces_doc.view())) {
          FC_ASSERT( false, "Failed to insert trans ${id}", ("id", t->id));
       }
    } catch(...) {
-      handle_mongo_exception("trans_traces insert", __LINE__);
+      handle_mongo_exception("trans_traces insert: ", __LINE__);
    }
 }
 
@@ -798,19 +832,27 @@ void mongo_db_plugin_impl::_process_accepted_block( const chain::block_state_ptr
 
    auto block_states = mongo_conn[db_name][block_states_col];
    auto block_state_doc = bsoncxx::builder::basic::document{};
+   block_state_doc.append(kvp( "block_num", b_int32{static_cast<int32_t>(block_num)} ),
+                          kvp( "block_id", block_id_str ),
+                          kvp( "validated", b_bool{bs->validated} ),
+                          kvp( "in_current_chain", b_bool{bs->in_current_chain} ));
+
    auto json = fc::json::to_string( bhs );
    try {
-      const auto& value = bsoncxx::from_json(json);
-      block_state_doc.append(kvp( "block_num", b_int32{static_cast<int32_t>(block_num)} ),
-                             kvp( "block_id", block_id_str ),
-                             kvp( "block_header_state", value ),
-                             kvp( "validated", b_bool{bs->validated} ),
-                             kvp( "in_current_chain", b_bool{bs->in_current_chain} ),
-                             kvp( "createdAt", b_date{now} ));
-   } catch (std::exception& e) {
-      elog("Unable to convert block_state JSON to MongoDB JSON: ${e}", ("e", e.what()));
-      elog("  JSON: ${j}", ("j", json));
+      const auto& value = bsoncxx::from_json( json );
+      block_state_doc.append( kvp( "block_header_state", value ));
+   } catch( bsoncxx::exception& ) {
+      try {
+         json = fc::prune_invalid_utf8(json);
+         const auto& value = bsoncxx::from_json( json );
+         block_state_doc.append( kvp( "block_header_state", value ));
+         block_state_doc.append( kvp( "non-utf8-purged", b_bool{true}));
+      } catch( bsoncxx::exception& e ) {
+         elog( "Unable to convert block_header_state JSON to MongoDB JSON: ${e}", ("e", e.what()));
+         elog( "  JSON: ${j}", ("j", json));
+      }
    }
+   block_state_doc.append(kvp( "createdAt", b_date{now} ));
 
    try {
       if( !block_states.insert_one( block_state_doc.view())) {
@@ -822,19 +864,27 @@ void mongo_db_plugin_impl::_process_accepted_block( const chain::block_state_ptr
 
    auto blocks = mongo_conn[db_name][blocks_col];
    auto block_doc = bsoncxx::builder::basic::document{};
+   block_doc.append(kvp( "block_num", b_int32{static_cast<int32_t>(block_num)} ),
+                    kvp( "block_id", block_id_str ),
+                    kvp( "irreversible", b_bool{false} ));
+
    auto v = to_variant_with_abi( *bs->block, accounts );
    json = fc::json::to_string( v );
    try {
-      const auto& value = bsoncxx::from_json(json);
-      block_doc.append(kvp( "block_num", b_int32{static_cast<int32_t>(block_num)} ),
-                       kvp( "block_id", block_id_str ),
-                       kvp( "irreversible", b_bool{false} ),
-                       kvp( "block", value ),
-                       kvp( "createdAt", b_date{now} ));
-   } catch (std::exception& e) {
-      elog("Unable to convert block JSON to MongoDB JSON: ${e}", ("e", e.what()));
-      elog("  JSON: ${j}", ("j", json));
+      const auto& value = bsoncxx::from_json( json );
+      block_doc.append( kvp( "block", value ));
+   } catch( bsoncxx::exception& ) {
+      try {
+         json = fc::prune_invalid_utf8(json);
+         const auto& value = bsoncxx::from_json( json );
+         block_doc.append( kvp( "block", value ));
+         block_doc.append( kvp( "non-utf8-purged", b_bool{true}));
+      } catch( bsoncxx::exception& e ) {
+         elog( "Unable to convert block JSON to MongoDB JSON: ${e}", ("e", e.what()));
+         elog( "  JSON: ${j}", ("j", json));
+      }
    }
+   block_doc.append(kvp( "createdAt", b_date{now} ));
 
    try {
       if( !blocks.insert_one( block_doc.view())) {

--- a/plugins/mongo_db_plugin/mongo_db_plugin.cpp
+++ b/plugins/mongo_db_plugin/mongo_db_plugin.cpp
@@ -862,6 +862,10 @@ void mongo_db_plugin_impl::_process_irreversible_block(const chain::block_state_
    const auto block_id_str = block_id.str();
    const auto block_num = bs->block->block_num();
 
+   if (block_num == 1153) {
+      std::cout << fc::json::to_pretty_string(bs) << std::endl;
+   }
+
    // genesis block 1 is not signaled to accepted_block
    if (block_num < 2) return;
 

--- a/plugins/mongo_db_plugin/mongo_db_plugin.cpp
+++ b/plugins/mongo_db_plugin/mongo_db_plugin.cpp
@@ -866,10 +866,17 @@ mongo_db_plugin_impl::mongo_db_plugin_impl()
 }
 
 mongo_db_plugin_impl::~mongo_db_plugin_impl() {
-   done = true;
-   condition.notify_one();
+   if (!startup) {
+      try {
+         ilog( "mongo_db_plugin shutdown in process please be patient this can take a few minutes" );
+         done = true;
+         condition.notify_one();
 
-   consume_thread.join();
+         consume_thread.join();
+      } catch( std::exception& e ) {
+         elog( "Exception on mongo_db_plugin shutdown of consume thread: ${e}", ("e", e.what()));
+      }
+   }
 }
 
 void mongo_db_plugin_impl::wipe_database() {

--- a/plugins/mongo_db_plugin/mongo_db_plugin.cpp
+++ b/plugins/mongo_db_plugin/mongo_db_plugin.cpp
@@ -798,10 +798,6 @@ void mongo_db_plugin_impl::_process_irreversible_block(const chain::block_state_
    const auto block_id_str = block_id.str();
    const auto block_num = bs->block->block_num();
 
-   if (block_num == 1153) {
-      std::cout << fc::json::to_pretty_string(bs) << std::endl;
-   }
-
    // genesis block 1 is not signaled to accepted_block
    if (block_num < 2) return;
 

--- a/plugins/mongo_db_plugin/mongo_db_plugin.cpp
+++ b/plugins/mongo_db_plugin/mongo_db_plugin.cpp
@@ -866,15 +866,10 @@ mongo_db_plugin_impl::mongo_db_plugin_impl()
 }
 
 mongo_db_plugin_impl::~mongo_db_plugin_impl() {
-   try {
-      ilog("mongo_db_plugin shutdown in process please be patient this can take a few minutes");
-      done = true;
-      condition.notify_one();
+   done = true;
+   condition.notify_one();
 
-      consume_thread.join();
-   } catch (std::exception& e) {
-      elog("Exception on mongo_db_plugin shutdown of consume thread: ${e}", ("e", e.what()));
-   }
+   consume_thread.join();
 }
 
 void mongo_db_plugin_impl::wipe_database() {

--- a/plugins/mongo_db_plugin/mongo_db_plugin.cpp
+++ b/plugins/mongo_db_plugin/mongo_db_plugin.cpp
@@ -798,6 +798,10 @@ void mongo_db_plugin_impl::_process_irreversible_block(const chain::block_state_
    const auto block_id_str = block_id.str();
    const auto block_num = bs->block->block_num();
 
+   if (block_num == 1153) {
+      std::cout << fc::json::to_pretty_string(bs) << std::endl;
+   }
+
    // genesis block 1 is not signaled to accepted_block
    if (block_num < 2) return;
 

--- a/programs/nodeos/CMakeLists.txt
+++ b/programs/nodeos/CMakeLists.txt
@@ -64,10 +64,9 @@ if(TARGET sql_db_plugin)
   target_link_libraries( nodeos PRIVATE -Wl,${whole_archive_flag} sql_db_plugin -Wl,${no_whole_archive_flag} )
 endif()
 
-#if(BUILD_MONGO_DB_PLUGIN)
-#  target_link_libraries( nodeos
-#    PRIVATE -Wl,${whole_archive_flag} mongo_db_plugin -Wl,${no_whole_archive_flag} )
-#endif()
+if(BUILD_MONGO_DB_PLUGIN)
+  target_link_libraries( nodeos PRIVATE -Wl,${whole_archive_flag} mongo_db_plugin -Wl,${no_whole_archive_flag} )
+endif()
 
 install( TARGETS
    nodeos

--- a/programs/nodeos/main.cpp
+++ b/programs/nodeos/main.cpp
@@ -119,7 +119,7 @@ int main(int argc, char** argv)
             return DATABASE_DIRTY;
          }
       }
-      elog("${e}", ("e",e.to_detail_string()));
+      elog( "${e}", ("e", e.to_detail_string()));
       return OTHER_FAIL;
    } catch( const boost::interprocess::bad_alloc& e ) {
       elog("bad alloc");

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -46,9 +46,9 @@ add_test(NAME nodeos_sanity_test COMMAND tests/nodeos_run_test.py -v --sanity-te
 add_test(NAME nodeos_run_test COMMAND tests/nodeos_run_test.py -v --clean-run --dump-error-detail WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 
 add_test(NAME p2p_dawn515_test COMMAND tests/p2p_tests/dawn_515/test.sh WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-#if(BUILD_MONGO_DB_PLUGIN)
-#   add_test(NAME nodeos_run_test-mongodb COMMAND tests/nodeos_run_test.py --mongodb -v --dump-error-detail WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-#endif()
+if(BUILD_MONGO_DB_PLUGIN)
+  add_test(NAME nodeos_run_test-mongodb COMMAND tests/nodeos_run_test.py --mongodb -v --clean-run --dump-error-detail WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+endif()
 
 add_test(NAME distributed-transactions-test COMMAND tests/distributed-transactions-test.py -d 2 -p 1 -n 4 -v --clean-run --dump-error-detail WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 add_test(NAME restart-scenarios-test-resync COMMAND tests/restart-scenarios-test.py -c resync -p4 -v --clean-run --dump-error-details WORKING_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/tests/Cluster.py
+++ b/tests/Cluster.py
@@ -133,7 +133,7 @@ class Cluster(object):
         if not self.walletd:
             nodeosArgs += " --plugin eosio::wallet_api_plugin"
         if self.enableMongo:
-            nodeosArgs += " --plugin eosio::mongo_db_plugin --delete-all-blocks --mongodb-uri %s" % self.mongoUri
+            nodeosArgs += " --plugin eosio::mongo_db_plugin --mongodb-wipe --delete-all-blocks --mongodb-uri %s" % self.mongoUri
 
         if nodeosArgs:
             cmdArr.append("--nodeos")

--- a/tests/Cluster.py
+++ b/tests/Cluster.py
@@ -129,7 +129,7 @@ class Cluster(object):
         if self.staging:
             cmdArr.append("--nogen")
 
-        nodeosArgs="--max-transaction-time 5000 --filter-on * --p2p-max-nodes-per-host %d" % (totalNodes)
+        nodeosArgs="--max-transaction-time 5000 --abi-serializer-max-time-ms 5000 --filter-on * --p2p-max-nodes-per-host %d" % (totalNodes)
         if not self.walletd:
             nodeosArgs += " --plugin eosio::wallet_api_plugin"
         if self.enableMongo:

--- a/tests/nodeos_run_test.py
+++ b/tests/nodeos_run_test.py
@@ -56,7 +56,8 @@ dontBootstrap=sanityTest
 
 WalletdName="keosd"
 ClientName="cleos"
-# Utils.setMongoSyncTime(50)
+timeout = .5 * 12 * 2 + 60 # time for finalization with 1 producer + 60 seconds padding
+Utils.setIrreversibleTimeout(timeout)
 
 try:
     TestHelper.printSystemInfo("BEGIN")
@@ -305,62 +306,17 @@ try:
     actions=node.getActions(testeraAccount, -1, -1)
     assert(actions)
     try:
-        assert(actions["actions"][0]["action_trace"]["act"]["name"] == "transfer")
+        if not enableMongo:
+            assert(actions["actions"][0]["action_trace"]["act"]["name"] == "transfer")
+        else:
+            assert(actions["name"] == "transfer")
     except (AssertionError, TypeError, KeyError) as _:
-        Print("Last action validation failed. Actions: %s" % (actions))
+        Print("Action validation failed. Actions: %s" % (actions))
         raise
-
-    # This API (get accounts) is no longer supported (Issue 2876)
-    # expectedAccounts=[testeraAccount.name, currencyAccount.name, exchangeAccount.name]
-    # Print("Get accounts by key %s, Expected: %s" % (PUB_KEY3, expectedAccounts))
-    # actualAccounts=node.getAccountsArrByKey(PUB_KEY3)
-    # if actualAccounts is None:
-    #     cmdError("%s get accounts pub_key3" % (ClientName))
-    #     errorExit("Failed to retrieve accounts by key %s" % (PUB_KEY3))
-    # noMatch=list(set(expectedAccounts) - set(actualAccounts))
-    # if len(noMatch) > 0:
-    #     errorExit("FAILURE - Accounts lookup by key %s. Expected: %s, Actual: %s" % (
-    #         PUB_KEY3, expectedAccounts, actualAccounts), raw=True)
-    #
-    # expectedAccounts=[testeraAccount.name]
-    # Print("Get accounts by key %s, Expected: %s" % (PUB_KEY1, expectedAccounts))
-    # actualAccounts=node.getAccountsArrByKey(PUB_KEY1)
-    # if actualAccounts is None:
-    #     cmdError("%s get accounts pub_key1" % (ClientName))
-    #     errorExit("Failed to retrieve accounts by key %s" % (PUB_KEY1))
-    # noMatch=list(set(expectedAccounts) - set(actualAccounts))
-    # if len(noMatch) > 0:
-    #     errorExit("FAILURE - Accounts lookup by key %s. Expected: %s, Actual: %s" % (
-    #         PUB_KEY1, expectedAccounts, actualAccounts), raw=True)
-
-    # This API (get servants) is no longer supported. (Issue 3160)
-    # expectedServants=[testeraAccount.name, currencyAccount.name]
-    # Print("Get %s servants, Expected: %s" % (defproduceraAccount.name, expectedServants))
-    # actualServants=node.getServantsArr(defproduceraAccount.name)
-    # if actualServants is None:
-    #     cmdError("%s get servants testera11111" % (ClientName))
-    #     errorExit("Failed to retrieve %s servants" % (defproduceraAccount.name))
-    # noMatch=list(set(expectedAccounts) - set(actualAccounts))
-    # if len(noMatch) > 0:
-    #     errorExit("FAILURE - %s servants. Expected: %s, Actual: %s" % (
-    #         defproduceraAccount.name, expectedServants, actualServants), raw=True)
-    #
-    # Print("Get %s servants, Expected: []" % (testeraAccount.name))
-    # actualServants=node.getServantsArr(testeraAccount.name)
-    # if actualServants is None:
-    #     cmdError("%s get servants testera11111" % (ClientName))
-    #     errorExit("Failed to retrieve %s servants" % (testeraAccount.name))
-    # if len(actualServants) > 0:
-    #     errorExit("FAILURE - %s servants. Expected: [], Actual: %s" % (
-    #         testeraAccount.name, actualServants), raw=True)
 
     node.waitForTransInBlock(transId)
 
-    transaction=None
-    if not enableMongo:
-        transaction=node.getTransaction(transId)
-    else:
-        transaction=node.getActionFromDb(transId)
+    transaction=node.getTransaction(transId)
     if transaction is None:
         cmdError("%s get transaction trans_id" % (ClientName))
         errorExit("Failed to retrieve transaction details %s" % (transId))
@@ -368,17 +324,22 @@ try:
     typeVal=None
     amountVal=None
     assert(transaction)
+    key=""
     try:
         if not enableMongo:
+            key="[traces][0][act][name]"
             typeVal=  transaction["traces"][0]["act"]["name"]
+            key="[traces][0][act][data][quantity]"
             amountVal=transaction["traces"][0]["act"]["data"]["quantity"]
             amountVal=int(decimal.Decimal(amountVal.split()[0])*10000)
         else:
-            typeVal=  transaction["name"]
-            amountVal=transaction["data"]["quantity"]
+            key="[actions][0][name]"
+            typeVal=  transaction["actions"][0]["name"]
+            key="[actions][0][data][quantity]"
+            amountVal=transaction["actions"][0]["data"]["quantity"]
             amountVal=int(decimal.Decimal(amountVal.split()[0])*10000)
     except (TypeError, KeyError) as e:
-        Print("Transaction validation parsing failed. Transaction: %s" % (transaction))
+        Print("transaction%s not found. Transaction: %s" % (key, transaction))
         raise
 
     if typeVal != "transfer" or amountVal != 975311:
@@ -534,7 +495,10 @@ try:
     assert(block)
     transactions=None
     try:
-        transactions=block["transactions"]
+        if not enableMongo:
+            transactions=block["transactions"]
+        else:
+            transactions=block["block"]["transactions"]
         assert(transactions)
     except (AssertionError, TypeError, KeyError) as _:
         Print("FAILURE - Failed to parse block. %s" % (block))
@@ -718,38 +682,33 @@ try:
         cmdError("%s get account" % (ClientName))
         errorExit("Failed to get account %s" % (defproduceraAccount.name))
 
-    #
-    # Proxy
-    #
-    # not implemented
+    Print("Unlocking wallet \"%s\"." % (defproduceraWallet.name))
+    if not walletMgr.unlockWallet(testWallet):
+        cmdError("%s wallet unlock test" % (ClientName))
+        errorExit("Failed to unlock wallet %s" % (testWallet.name))
+
 
     Print("Get head block num.")
     currentBlockNum=node.getHeadBlockNum()
     Print("CurrentBlockNum: %d" % (currentBlockNum))
     Print("Request blocks 1-%d" % (currentBlockNum))
-    for blockNum in range(1, currentBlockNum+1):
-        block=node.getBlock(blockNum, retry=False, silentErrors=False)
+    start=1
+    if enableMongo:
+        start=2 # block 1 (genesis block) is not signaled to the plugins, so not available in DB
+    for blockNum in range(start, currentBlockNum+1):
+        block=node.getBlock(blockNum, silentErrors=False)
         if block is None:
             cmdError("%s get block" % (ClientName))
             errorExit("get block by num %d" % blockNum)
 
         if enableMongo:
             blockId=block["block_id"]
-            block2=node.getBlockById(blockId, retry=False)
+            block2=node.getBlockById(blockId)
             if block2 is None:
                 errorExit("mongo get block by id %s" % blockId)
 
-            # TBD: getTransByBlockId() needs to handle multiple returned transactions
-            # trans=node.getTransByBlockId(blockId, retry=False)
-            # if trans is not None:
-            #     transId=Node.getTransId(trans)
-            #     trans2=node.getMessageFromDb(transId)
-            #     if trans2 is None:
-            #         errorExit("mongo get messages by transaction id %s" % (transId))
-
-
     Print("Request invalid block numbered %d. This will generate an expected error message." % (currentBlockNum+1000))
-    block=node.getBlock(currentBlockNum+1000, silentErrors=True, retry=False)
+    block=node.getBlock(currentBlockNum+1000, silentErrors=True)
     if block is not None:
         errorExit("ERROR: Received block where not expected")
     else:

--- a/tests/testUtils.py
+++ b/tests/testUtils.py
@@ -41,14 +41,11 @@ class Utils:
     SigTermTag="term"
 
     systemWaitTimeout=90
-
-    # mongoSyncTime: nodeos mongodb plugin seems to sync with a 10-15 seconds delay. This will inject
-    #  a wait period before the 2nd DB check (if first check fails)
-    mongoSyncTime=25
+    irreversibleTimeout=60
 
     @staticmethod
-    def setMongoSyncTime(syncTime):
-        Utils.mongoSyncTime=syncTime
+    def setIrreversibleTimeout(timeout):
+        Utils.irreversibleTimeout=timeout
 
     @staticmethod
     def setSystemWaitTimeout(timeout):

--- a/tests/validate-dirty-db.py
+++ b/tests/validate-dirty-db.py
@@ -38,9 +38,9 @@ seed=1
 Utils.Debug=debug
 testSuccessful=False
 
-def runNodeosAndGetOutput(myNodeId, myTimeout=3):
+def runNodeosAndGetOutput(myTimeout=3):
     """Startup nodeos, wait for timeout (before forced shutdown) and collect output. Stdout, stderr and return code are returned in a dictionary."""
-    Print("Launching nodeos process id: %d" % (myNodeId))
+    Print("Launching nodeos process.")
     cmd="programs/nodeos/nodeos --config-dir etc/eosio/node_bios --data-dir var/lib/node_bios --verbose-http-errors"
     Print("cmd: %s" % (cmd))
     proc=subprocess.Popen(cmd.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -84,17 +84,14 @@ try:
     cluster.killall(allInstances=killAll)
     
     Print("Restart nodeos repeatedly to ensure dirty database flag sticks.")
-    nodeId=0
     timeout=3
     
-    for i in range(0,3):
+    for i in range(1,4):
         Print("Attempt %d." % (i))
-        ret = runNodeosAndGetOutput(nodeId, timeout)
+        ret = runNodeosAndGetOutput(timeout)
         assert(ret)
         assert(isinstance(ret, tuple))
-        if not ret or not ret[0]:
-            exit(1)
-
+        assert(ret[0])
         assert(ret[1])
         assert(isinstance(ret[1], dict))
         # pylint: disable=unsubscriptable-object

--- a/tests/validate-dirty-db.py
+++ b/tests/validate-dirty-db.py
@@ -59,7 +59,7 @@ def runNodeosAndGetOutput(myTimeout=3):
         proc.send_signal(signal.SIGKILL)
         return (False, None)
 
-    if debug: Print("Returning success status.")
+    if debug: Print("Returning success.")
     return (True, output)
 
 random.seed(seed) # Use a fixed seed for repeatability.
@@ -101,10 +101,10 @@ try:
         # pylint: disable=unsubscriptable-object
         stderr= ret[1]["stderr"]
         retCode=ret[1]["returncode"]
-        assert retCode == 2, "actual return code: %d" % (retCode)
+        assert retCode == 2, "actual return code: %s" % str(retCode)
         assert("database dirty flag set" in stderr)
 
-    if debug: Print("Setting test success state.")
+    if debug: Print("Setting test result to success.")
     testSuccessful=True
 finally:
     if debug: Print("Cleanup in finally block.")

--- a/tests/validate-dirty-db.py
+++ b/tests/validate-dirty-db.py
@@ -44,10 +44,13 @@ def runNodeosAndGetOutput(myTimeout=3):
     cmd="programs/nodeos/nodeos --config-dir etc/eosio/node_bios --data-dir var/lib/node_bios --verbose-http-errors"
     Print("cmd: %s" % (cmd))
     proc=subprocess.Popen(cmd.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    if debug: Print("Nodeos process launched.")
 
     output={}
     try:
+        if debug: Print("Setting nodeos process timeout.")
         outs,errs = proc.communicate(timeout=myTimeout)
+        if debug: Print("Nodeos process has exited.")
         output["stdout"] = outs.decode("utf-8")
         output["stderr"] = errs.decode("utf-8")
         output["returncode"] = proc.returncode
@@ -56,6 +59,7 @@ def runNodeosAndGetOutput(myTimeout=3):
         proc.send_signal(signal.SIGKILL)
         return (False, None)
 
+    if debug: Print("Returning success status.")
     return (True, output)
 
 random.seed(seed) # Use a fixed seed for repeatability.
@@ -97,11 +101,14 @@ try:
         # pylint: disable=unsubscriptable-object
         stderr= ret[1]["stderr"]
         retCode=ret[1]["returncode"]
-        assert(retCode == 2)
+        assert retCode == 2, "actual return code: %d" % (retCode)
         assert("database dirty flag set" in stderr)
 
+    if debug: Print("Setting test success state.")
     testSuccessful=True
 finally:
+    if debug: Print("Cleanup in finally block.")
     TestHelper.shutdown(cluster, None, testSuccessful, killEosInstances, False, keepLogs, killAll, dumpErrorDetails)
 
+if debug: Print("Exiting test, exit value 0.")
 exit(0)


### PR DESCRIPTION
Resolves #3030 

The mongo db plugin has been updated to work with 1.1 release.

It is recommended that a large `--abi-serializer-max-time-ms` value be passed into the nodeos running the mongo_db_plugin as the default abi serializer time limit may not be large enough to serialize large blocks.

It will create the following collections:
- accounts - created on accepted transaction
-- Currently limited to just name and ABI if contract on account

- actions - created on accepted transaction
-- action_num - the # of the action in its transaction
-- trx_id
-- account
-- name
-- authorization
--- actor
--- permission
-- data
-- hex_data

- block_states - created on accepted block
-- block_num
-- block_id
-- block_header_state
-- validated
-- in_current_chain

- blocks - created on accepted block
-- block_num
-- block_id
-- irreversible - updated to true on irreversible block
-- block

- transaction_traces - created on applied transaction
-- transaction_trace

- transactions - created on accepted transaction
-- trx_id
-- irreversible - updated to true on irreversible block
-- transaction_header
-- signing_keys
-- actions
-- context_free_actions
-- transaction_extensions
-- signatures
-- context_free_data
