### PR TITLE
Add Debian build support.

### DIFF
--- a/eosio_build.sh
+++ b/eosio_build.sh
@@ -191,6 +191,13 @@
 				MONGOD_CONF=${HOME}/opt/mongodb/mongod.conf
 				export PATH=${HOME}/opt/mongodb/bin:$PATH
 			;;
+			"Debian GNU/Linux")
+				FILE=${PWD}/scripts/eosio_build_ubuntu.sh
+				CXX_COMPILER=clang++-4.0
+				C_COMPILER=clang-4.0
+				MONGOD_CONF=${HOME}/opt/mongodb/mongod.conf
+				export PATH=${HOME}/opt/mongodb/bin:$PATH
+			;;
 			*)
 				printf "\\n\\tUnsupported Linux Distribution. Exiting now.\\n\\n"
 				exit 1

--- a/scripts/eosio_build_ubuntu.sh
+++ b/scripts/eosio_build_ubuntu.sh
@@ -45,6 +45,13 @@
 				exit 1
 			fi
 		;;
+		"Debian")
+			if [ $OS_MAJ -lt 10 ]; then
+				printf "\tYou must be running Debian 10 to install EOSIO, and resolve missing dependencies from unstable (sid).\n"
+				printf "\tExiting now.\n"
+				exit 1
+		fi
+		;;
 	esac
 
 	if [ "${DISK_AVAIL%.*}" -lt "${DISK_MIN}" ]; then


### PR DESCRIPTION
Building on Debian "testing/buster" is pretty straight forward. A few dependencies are not available, and needs to be complemented with some from "unstable/sid"