### PR TITLE
Update launcher boot script support

### DIFF
--- a/testnet.template
+++ b/testnet.template
@@ -56,23 +56,56 @@ wcmd () {
 }
 
 cacmd () {
-    ecmd create account eosio $*
+    programs/cleos/cleos  --wallet-url $wdurl --url http://$bioshost:$biosport system newaccount --transfer --stake-net "10000000.0000 SYS" --stake-cpu "10000000.0000 SYS"  --buy-ram "10000000.0000 SYS" eosio $* >> $logfile 2>&1
+    ecmd system regproducer $1 $2
+    ecmd system voteproducer prods $1 $1
 }
 
 sleep 2
 ecmd get info
 
-
 wcmd create -n ignition
+
 # Manual deployers, add a line below this block that looks like:
 #    wcmd import -n ignition $PRODKEY[0]
 #    wcmd import -n ignition $PRODKEY[1]
 #    ...
 #    wcmd import -n ignition $PRODKEY[20]
-
 # where $BIOSKEY is replaced by the private key for the bios node
 # ------ DO NOT ALTER THE NEXT LINE -------
 ###INSERT prodkeys
+
+ecmd set contract eosio contracts/eosio.bios contracts/eosio.bios/eosio.bios.wast contracts/eosio.bios/eosio.bios.abi
+
+# Create required system accounts
+ecmd create key
+pubsyskey=`grep "^Public key:" $logfile | tail -1 | sed "s/^Public key://"`
+prisyskey=`grep "^Private key:" $logfile | tail -1 | sed "s/^Private key://"`
+echo eosio.* keys: $prisyskey $pubsyskey >> $logfile
+wcmd import -n ignition $prisyskey
+ecmd create account eosio eosio.bpay $pubsyskey $pubsyskey
+ecmd create account eosio eosio.msig $pubsyskey $pubsyskey
+ecmd create account eosio eosio.names $pubsyskey $pubsyskey
+ecmd create account eosio eosio.ram $pubsyskey $pubsyskey
+ecmd create account eosio eosio.ramfee $pubsyskey $pubsyskey
+ecmd create account eosio eosio.saving $pubsyskey $pubsyskey
+ecmd create account eosio eosio.stake $pubsyskey $pubsyskey
+ecmd create account eosio eosio.token $pubsyskey $pubsyskey
+ecmd create account eosio eosio.vpay $pubsyskey $pubsyskey
+
+ecmd set contract eosio.token contracts/eosio.token contracts/eosio.token/eosio.token.wast contracts/eosio.token/eosio.token.abi
+ecmd set contract eosio.msig contracts/eosio.msig contracts/eosio.msig/eosio.msig.wast contracts/eosio.msig/eosio.msig.abi
+
+echo ===== Start: $step ============ >> $logfile
+echo executing: cleos --wallet-url $wdurl --url http://$bioshost:$biosport push action eosio.token create '[ "eosio", "10000000000.0000 SYS" ]' -p eosio.token | tee -a $logfile
+echo executing: cleos --wallet-url $wdurl --url http://$bioshost:$biosport push action eosio.token issue '[ "eosio", "1000000000.0000 SYS", "memo" ]' -p eosio | tee -a $logfile
+echo ----------------------- >> $logfile
+programs/cleos/cleos --wallet-url $wdurl --url http://$bioshost:$biosport push action eosio.token create '[ "eosio", "10000000000.0000 SYS" ]' -p eosio.token >> $logfile 2>&1
+programs/cleos/cleos --wallet-url $wdurl --url http://$bioshost:$biosport push action eosio.token issue '[ "eosio", "1000000000.0000 SYS", "memo" ]' -p eosio >> $logfile 2>&1
+echo ==== End: $step ============== >> $logfile
+step=$(($step + 1))
+
+ecmd set contract eosio contracts/eosio.system contracts/eosio.system/eosio.system.wast contracts/eosio.system/eosio.system.abi
 
 # Manual deployers, add a series of lines below this block that looks like:
 #    cacmd $PRODNAME[0] $OWNERKEY[0] $ACTIVEKEY[0]
@@ -83,27 +116,5 @@ wcmd create -n ignition
 # public key
 # ------ DO NOT ALTER THE NEXT LINE -------
 ###INSERT cacmd
-
-
-ecmd set contract eosio contracts/eosio.bios contracts/eosio.bios/eosio.bios.wast contracts/eosio.bios/eosio.bios.abi
-
-#the setprods.json argument cannot pass through the function call due to embedded quotes
-echo ===== Start: $step ============ >> $logfile
-echo executing: cleos  --wallet-url $wdurl --url http://$bioshost:$biosport push action eosio setprods setprods.json -p eosio@active | tee -a $logfile
-echo ----------------------- >> $logfile
-programs/cleos/cleos  --wallet-url $wdurl --url http://$bioshost:$biosport push action eosio setprods setprods.json -p eosio@active >> $logfile 2>&1
-echo ==== End: $step ============== >> $logfile
-step=$(($step + 1))
-
-ecmd set contract eosio contracts/eosio.system contracts/eosio.system/eosio.system.wast contracts/eosio.system/eosio.system.abi
-
-echo ===== Start: $step ============ >> $logfile
-echo executing: cleos  --wallet-url $wdurl --url http://$bioshost:$biosport push action eosio issue '{"to":"eosio","quantity":"1000000000.0000 EOS","memo":"init"}' -p eosio@active | tee -a $logfile
-echo ----------------------- >> $logfile
-programs/cleos/cleos  --wallet-url $wdurl --url http://$bioshost:$biosport push action eosio issue '{"to":"eosio","quantity":"1000000000.0000 EOS","memo":"init"}' -p eosio@active >> $logfile 2>&1
-echo ==== End: $step ============== >> $logfile
-step=$(($step + 1))
-
-for a in {a..u}; do ecmd transfer eosio init$a 1000000.0000 "\"fund_producer_init$a\""; done
 
 pkill -15 keosd


### PR DESCRIPTION
Update the launcher to support full set of eosio.* contracts, voting, etc.
After running bios_boot.sh, the resulting network should be fully functioning.