### PR TITLE
Fix for failing validate-dirty-db.py test

### DIFF
--- a/plugins/mongo_db_plugin/mongo_db_plugin.cpp
+++ b/plugins/mongo_db_plugin/mongo_db_plugin.cpp
@@ -866,10 +866,17 @@ mongo_db_plugin_impl::mongo_db_plugin_impl()
 }
 
 mongo_db_plugin_impl::~mongo_db_plugin_impl() {
-   done = true;
-   condition.notify_one();
+   if (!startup) {
+      try {
+         ilog( "mongo_db_plugin shutdown in process please be patient this can take a few minutes" );
+         done = true;
+         condition.notify_one();
 
-   consume_thread.join();
+         consume_thread.join();
+      } catch( std::exception& e ) {
+         elog( "Exception on mongo_db_plugin shutdown of consume thread: ${e}", ("e", e.what()));
+      }
+   }
 }
 
 void mongo_db_plugin_impl::wipe_database() {

--- a/plugins/mongo_db_plugin/mongo_db_plugin.cpp
+++ b/plugins/mongo_db_plugin/mongo_db_plugin.cpp
@@ -866,15 +866,10 @@ mongo_db_plugin_impl::mongo_db_plugin_impl()
 }
 
 mongo_db_plugin_impl::~mongo_db_plugin_impl() {
-   try {
-      ilog("mongo_db_plugin shutdown in process please be patient this can take a few minutes");
-      done = true;
-      condition.notify_one();
+   done = true;
+   condition.notify_one();
 
-      consume_thread.join();
-   } catch (std::exception& e) {
-      elog("Exception on mongo_db_plugin shutdown of consume thread: ${e}", ("e", e.what()));
-   }
+   consume_thread.join();
 }
 
 void mongo_db_plugin_impl::wipe_database() {


### PR DESCRIPTION
Remove destructor log statements as logs may not be available here under some circumstance.