### PR TITLE
Relax abi_serializer time limit for cleos

### DIFF
--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -1578,6 +1578,8 @@ int main( int argc, char** argv ) {
    textdomain(locale_domain);
    context = eosio::client::http::create_http_context();
 
+   abi_serializer::set_max_serialization_time(fc::seconds(1)); // No risk to client side serialization taking a long time
+
    CLI::App app{"Command Line Interface to EOSIO Client"};
    app.require_subcommand();
    app.add_option( "-H,--host", obsoleted_option_host_port, localized("the host where nodeos is running") )->group("hidden");


### PR DESCRIPTION
Resolves #4395.

The strict limit on ABI (de)serialization time only matters for nodeos since it is responding to requests from untrusted parties; cleos does not require such strict limits.