### PR TITLE
Secure entry for cleos wallet import

### DIFF
--- a/libraries/chain/include/eosio/chain/exceptions.hpp
+++ b/libraries/chain/include/eosio/chain/exceptions.hpp
@@ -283,6 +283,12 @@ namespace eosio { namespace chain {
                                     3120006, "No available wallet" )
       FC_DECLARE_DERIVED_EXCEPTION( wallet_unlocked_exception,         wallet_exception,
                                     3120007, "Already unlocked" )
+      FC_DECLARE_DERIVED_EXCEPTION( key_exist_exception,               wallet_exception,
+                                    3120008, "Key already exists" )
+      FC_DECLARE_DERIVED_EXCEPTION( key_nonexistent_exception,         wallet_exception,
+                                    3120009, "Nonexistent key" )
+      FC_DECLARE_DERIVED_EXCEPTION( unsupported_key_type_exception,    wallet_exception,
+                                    3120009, "Unsupported key type" )
 
    FC_DECLARE_DERIVED_EXCEPTION( whitelist_blacklist_exception,   chain_exception,
                                  3130000, "actor or contract whitelist/blacklist exception" )

--- a/plugins/wallet_plugin/wallet.cpp
+++ b/plugins/wallet_plugin/wallet.cpp
@@ -138,7 +138,7 @@ public:
    private_key_type get_private_key(const public_key_type& id)const
    {
       auto has_key = try_get_private_key( id );
-      FC_ASSERT( has_key );
+      EOS_ASSERT( has_key, chain::key_nonexistent_exception, "Key doesn't exist!" );
       return *has_key;
    }
 
@@ -157,7 +157,7 @@ public:
          _keys[wif_pub_key] = priv;
          return true;
       }
-      FC_ASSERT( !"Key already in wallet" );
+      EOS_THROW( chain::key_exist_exception, "Key already in wallet" );
    }
 
    // Removes a key from the wallet
@@ -171,7 +171,7 @@ public:
          _keys.erase(pub);
          return true;
       }
-      FC_ASSERT( !"Key not in wallet" );
+      EOS_THROW( chain::key_nonexistent_exception, "Key not in wallet" );
    }
 
    string create_key(string key_type)
@@ -185,7 +185,7 @@ public:
       else if(key_type == "R1")
          priv_key = fc::crypto::private_key::generate<fc::crypto::r1::private_key_shim>();
       else
-         FC_THROW_EXCEPTION(chain::wallet_exception, "Key type \"${kt}\" not supported by software wallet", ("kt", key_type));
+         EOS_THROW(chain::unsupported_key_type_exception, "Key type \"${kt}\" not supported by software wallet", ("kt", key_type));
 
       import_key((string)priv_key);
       return (string)priv_key.get_public_key();

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -2204,13 +2204,20 @@ int main( int argc, char** argv ) {
    string wallet_key_str;
    auto importWallet = wallet->add_subcommand("import", localized("Import private key into wallet"), false);
    importWallet->add_option("-n,--name", wallet_name, localized("The name of the wallet to import key into"));
-   importWallet->add_option("key", wallet_key_str, localized("Private key in WIF format to import"))->required();
+   importWallet->add_option("--private-key", wallet_key_str, localized("Private key in WIF format to import"));
    importWallet->set_callback([&wallet_name, &wallet_key_str] {
+      if( wallet_key_str.size() == 0 ) {
+         std::cout << localized("password: ");
+         fc::set_console_echo(false);
+         std::getline( std::cin, wallet_key_str, '\n' );
+         fc::set_console_echo(true);
+      }
+
       private_key_type wallet_key;
       try {
          wallet_key = private_key_type( wallet_key_str );
       } catch (...) {
-          EOS_THROW(private_key_type_exception, "Invalid private key: ${private_key}", ("private_key", wallet_key_str))
+         EOS_THROW(private_key_type_exception, "Invalid private key: ${private_key}", ("private_key", wallet_key_str))
       }
       public_key_type pubkey = wallet_key.get_public_key();
 

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -2207,7 +2207,7 @@ int main( int argc, char** argv ) {
    importWallet->add_option("--private-key", wallet_key_str, localized("Private key in WIF format to import"));
    importWallet->set_callback([&wallet_name, &wallet_key_str] {
       if( wallet_key_str.size() == 0 ) {
-         std::cout << localized("password: ");
+         std::cout << localized("private key: ");
          fc::set_console_echo(false);
          std::getline( std::cin, wallet_key_str, '\n' );
          fc::set_console_echo(true);

--- a/tests/WalletMgr.py
+++ b/tests/WalletMgr.py
@@ -76,7 +76,7 @@ class WalletMgr(object):
 
     def importKey(self, account, wallet):
         warningMsg="Key already in wallet"
-        cmd="%s %s wallet import --name %s %s" % (
+        cmd="%s %s wallet import --name %s --private-key %s" % (
             Utils.EosClientPath, self.endpointArgs, wallet.name, account.ownerPrivateKey)
         if Utils.Debug: Utils.Print("cmd: %s" % (cmd))
         try:
@@ -92,7 +92,7 @@ class WalletMgr(object):
         if account.activePrivateKey is None:
             Utils.Print("WARNING: Active private key is not defined for account \"%s\"" % (account.name))
         else:
-            cmd="%s %s wallet import --name %s %s" % (
+            cmd="%s %s wallet import --name %s  --private-key %s" % (
                 Utils.EosClientPath, self.endpointArgs, wallet.name, account.activePrivateKey)
             if Utils.Debug: Utils.Print("cmd: %s" % (cmd))
             try:

--- a/tests/trans_sync_across_mixed_cluster_test.sh
+++ b/tests/trans_sync_across_mixed_cluster_test.sh
@@ -157,13 +157,13 @@ PASSWORD_INITA="$(echo "$PASSWORD_INITA" | awk '/PW/ {print $1}')"
 # remove leading/trailing quotes
 PASSWORD_INITA=${PASSWORD_INITA#\"}
 PASSWORD_INITA=${PASSWORD_INITA%\"}
-programs/cleos/cleos wallet import --name inita $INITA_PRV_KEY
+programs/cleos/cleos wallet import --name inita --private-key $INITA_PRV_KEY
 verifyErrorCode "cleos wallet import"
-programs/cleos/cleos wallet import --name inita $PRV_KEY1
+programs/cleos/cleos wallet import --name inita --private-key $PRV_KEY1
 verifyErrorCode "cleos wallet import"
-programs/cleos/cleos wallet import --name inita $PRV_KEY2
+programs/cleos/cleos wallet import --name inita --private-key $PRV_KEY2
 verifyErrorCode "cleos wallet import"
-programs/cleos/cleos wallet import --name inita $PRV_KEY3
+programs/cleos/cleos wallet import --name inita --private-key $PRV_KEY3
 verifyErrorCode "cleos wallet import"
 
 #

--- a/tutorials/bios-boot-tutorial/bios-boot-tutorial.py
+++ b/tutorials/bios-boot-tutorial/bios-boot-tutorial.py
@@ -77,7 +77,7 @@ def startWallet():
     run(args.cleos + 'wallet create')
 
 def importKeys():
-    run(args.cleos + 'wallet import ' + args.private_key)
+    run(args.cleos + 'wallet import --private-key ' + args.private_key)
     keys = {}
     for a in accounts:
         key = a['pvt']
@@ -85,13 +85,13 @@ def importKeys():
             if len(keys) >= args.max_user_keys:
                 break
             keys[key] = True
-            run(args.cleos + 'wallet import ' + key)
+            run(args.cleos + 'wallet import --private-key ' + key)
     for i in range(firstProducer, firstProducer + numProducers):
         a = accounts[i]
         key = a['pvt']
         if not key in keys:
             keys[key] = True
-            run(args.cleos + 'wallet import ' + key)
+            run(args.cleos + 'wallet import --private-key ' + key)
 
 def startNode(nodeIndex, account):
     dir = args.nodes_dir + ('%02d-' % nodeIndex) + account['name'] + '/'

--- a/tutorials/exchange-tutorial-python/README.md
+++ b/tutorials/exchange-tutorial-python/README.md
@@ -20,9 +20,9 @@ Deleting the `transactions.txt` file will prevent replay from working.
 
 `cleos create key`
 
-`cleos wallet import <private key from step 1>`
+`cleos wallet import  --private-key <private key from step 1>`
 
-`cleos wallet import <private key from step 2>`
+`cleos wallet import  --private-key <private key from step 2>`
 
 `cleos create account eosio <account_name> <public key from step 1> <public key from step 2>`
 


### PR DESCRIPTION
- Add secure entry for `cleos wallet import` if `--private-key` option is not used
- Add some additional error message to make it clear when key already exists in the wallet