### PR TITLE
Optimize compiled contract for size

### DIFF
--- a/tools/eosiocpp.in
+++ b/tools/eosiocpp.in
@@ -39,7 +39,7 @@ function build_contract {
         name=`basename $file`
         filePath=`dirname $file`
 
-        ($PRINT_CMDS; @WASM_CLANG@ -emit-llvm -O3 --std=c++14 --target=wasm32 -nostdinc \
+        ($PRINT_CMDS; @WASM_CLANG@ -emit-llvm -Os --std=c++14 --target=wasm32 -nostdinc \
                                    -DBOOST_DISABLE_ASSERTS -DBOOST_EXCEPTION_DISABLE \
                                    -nostdlib -nostdlibinc -ffreestanding -nostdlib -fno-threadsafe-statics -fno-rtti \
                                    -fno-exceptions -I ${EOSIO_INSTALL_DIR}/include \


### PR DESCRIPTION
With the recent increase in ram usage, the use of `-Os` instead of `-O3` as the default optimization mode makes sense.

This way we will save on the consumption of the most scarce resource on the network at the moment and help the network as a whole.

- Some experiments show a reduction of the file size of 1/3. Effectively reducing the cost to deploy 33%