### PR TITLE
Consolidated Security Patches for 1.0.8

### DIFF
--- a/libraries/chain/include/eosio/chain/abi_serializer.hpp
+++ b/libraries/chain/include/eosio/chain/abi_serializer.hpp
@@ -43,7 +43,7 @@ struct abi_serializer {
    bool      is_array(const type_name& type)const;
    bool      is_optional(const type_name& type)const;
    bool      is_type(const type_name& type)const {
-      return _is_type(type, 0);
+      return _is_type(type, 0, fc::time_point::now() + max_serialization_time);
    }
    bool      is_builtin_type(const type_name& type)const;
    bool      is_integer(const type_name& type) const;
@@ -126,7 +126,7 @@ private:
    void _binary_to_variant(const type_name& type, fc::datastream<const char*>& stream, fc::mutable_variant_object& obj,
                            size_t recursion_depth, const fc::time_point& deadline)const;
 
-   bool _is_type(const type_name& type, size_t recursion_depth)const;
+   bool _is_type(const type_name& type, size_t recursion_depth, const fc::time_point& deadline)const;
 
    friend struct impl::abi_from_variant;
    friend struct impl::abi_to_variant;

--- a/libraries/chain/include/eosio/chain/wast_to_wasm.hpp
+++ b/libraries/chain/include/eosio/chain/wast_to_wasm.hpp
@@ -9,7 +9,7 @@
 namespace eosio { namespace chain {
 
 std::vector<uint8_t> wast_to_wasm( const std::string& wast );
-std::string  wasm_to_wast( const std::vector<uint8_t>& wasm );
-std::string  wasm_to_wast( const uint8_t* data, uint64_t size );
+std::string  wasm_to_wast( const std::vector<uint8_t>& wasm, bool strip_names );
+std::string  wasm_to_wast( const uint8_t* data, uint64_t size, bool strip_names );
 
 } } /// eosio::chain

--- a/libraries/chain/wast_to_wasm.cpp
+++ b/libraries/chain/wast_to_wasm.cpp
@@ -61,15 +61,17 @@ namespace eosio { namespace chain {
 
    } FC_CAPTURE_AND_RETHROW( (wast) ) }  /// wast_to_wasm
 
-   std::string     wasm_to_wast( const std::vector<uint8_t>& wasm ) {
-      return wasm_to_wast( wasm.data(), wasm.size() );
+   std::string     wasm_to_wast( const std::vector<uint8_t>& wasm, bool strip_names ) {
+      return wasm_to_wast( wasm.data(), wasm.size(), strip_names );
    } /// wasm_to_wast
 
-   std::string     wasm_to_wast( const uint8_t* data, uint64_t size ) 
+   std::string     wasm_to_wast( const uint8_t* data, uint64_t size, bool strip_names ) 
    { try {
        IR::Module module;
        Serialization::MemoryInputStream stream((const U8*)data,size);
        WASM::serialize(stream,module);
+       if(strip_names)
+          module.userSections.clear();
         // Print the module to WAST.
        return WAST::print(module);
    } FC_CAPTURE_AND_RETHROW() } /// wasm_to_wast

--- a/libraries/wasm-jit/Source/WASM/WASMSerialization.cpp
+++ b/libraries/wasm-jit/Source/WASM/WASMSerialization.cpp
@@ -489,19 +489,19 @@ namespace WASM
 		Uptr numLocalSets = 0;
 		serializeVarUInt32(bodyStream,numLocalSets);
 
-      constexpr size_t max_size = eosio::chain::wasm_constraints::maximum_code_size;
-      if (numBodyBytes >= max_size)
-         throw FatalSerializationException(std::string("Function body too large"));
-      if (numLocalSets >= 1024)
-         throw FatalSerializationException(std::string("too many local sets"));
-      size_t locals_accum = numBodyBytes;
+		constexpr size_t max_size = eosio::chain::wasm_constraints::maximum_code_size;
+		if (numBodyBytes >= max_size)
+			throw FatalSerializationException(std::string("Function body too large"));
+		if (numLocalSets >= 1024)
+			throw FatalSerializationException(std::string("too many local sets"));
+		size_t locals_accum = 0;
 
 		for(Uptr setIndex = 0;setIndex < numLocalSets;++setIndex)
 		{
 			LocalSet localSet;
 			serialize(bodyStream,localSet);
-         locals_accum += localSet.num*4;
-			if( locals_accum >= max_size )
+			locals_accum += localSet.num*4;
+			if( locals_accum > eosio::chain::wasm_constraints::maximum_func_local_bytes )
 				throw FatalSerializationException( "too many locals" );
 
 			for(Uptr index = 0;index < localSet.num;++index) { functionDef.nonParameterLocalTypes.push_back(localSet.type); }
@@ -569,7 +569,7 @@ namespace WASM
 				+ module.memories.imports.size()
 				+ module.globals.imports.size();
 			serializeVarUInt32(sectionStream,size);
-         constexpr size_t max_size = eosio::chain::wasm_constraints::maximum_section_elements;
+			constexpr size_t max_size = eosio::chain::wasm_constraints::maximum_section_elements;
 			if(Stream::isInput)
 			{
 				for(Uptr index = 0;index < size;++index)
@@ -593,8 +593,8 @@ namespace WASM
 							throw FatalSerializationException("invalid import function type index");
 						}
 						module.functions.imports.push_back({{functionTypeIndex},std::move(moduleName),std::move(exportName)});
-                  if (module.functions.imports.size() >= max_size)
-                     throw FatalSerializationException(std::string("Too many function imports"));
+						if (module.functions.imports.size() >= max_size)
+							throw FatalSerializationException(std::string("Too many function imports"));
 						break;
 					}
 					case ObjectKind::table:
@@ -602,8 +602,8 @@ namespace WASM
 						TableType tableType;
 						serialize(sectionStream,tableType);
 						module.tables.imports.push_back({tableType,std::move(moduleName),std::move(exportName)});
-                  if (module.functions.imports.size() >= max_size)
-                     throw FatalSerializationException(std::string("Too many table imports"));
+						if (module.functions.imports.size() >= max_size)
+							throw FatalSerializationException(std::string("Too many table imports"));
 						break;
 					}
 					case ObjectKind::memory:
@@ -611,8 +611,8 @@ namespace WASM
 						MemoryType memoryType;
 						serialize(sectionStream,memoryType);
 						module.memories.imports.push_back({memoryType,std::move(moduleName),std::move(exportName)});
-                  if (module.functions.imports.size() >= max_size)
-                     throw FatalSerializationException(std::string("Too many memory imports"));
+						if (module.functions.imports.size() >= max_size)
+							throw FatalSerializationException(std::string("Too many memory imports"));
 						break;
 					}
 					case ObjectKind::global:
@@ -620,8 +620,8 @@ namespace WASM
 						GlobalType globalType;
 						serialize(sectionStream,globalType);
 						module.globals.imports.push_back({globalType,std::move(moduleName),std::move(exportName)});
-                  if (module.functions.imports.size() >= max_size)
-                     throw FatalSerializationException(std::string("Too many global imports"));
+						if (module.functions.imports.size() >= max_size)
+							throw FatalSerializationException(std::string("Too many global imports"));
 						break;
 					}
 					default: throw FatalSerializationException("invalid ObjectKind");
@@ -678,9 +678,9 @@ namespace WASM
 				// Grow the vector one element at a time:
 				// try to get a serialization exception before making a huge allocation for malformed input.
 				module.functions.defs.clear();
-            constexpr size_t max_size = eosio::chain::wasm_constraints::maximum_section_elements;
-            if ( numFunctions >= max_size )
-               throw FatalSerializationException(std::string("Too many function defs"));
+				constexpr size_t max_size = eosio::chain::wasm_constraints::maximum_section_elements;
+				if ( numFunctions >= max_size )
+					throw FatalSerializationException(std::string("Too many function defs"));
 				for(Uptr functionIndex = 0;functionIndex < numFunctions;++functionIndex)
 				{
 					U32 functionTypeIndex = 0;

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -963,7 +963,7 @@ read_only::get_code_results read_only::get_code( const get_code_params& params )
       if (params.code_as_wasm) {
          result.wasm = string(accnt.code.begin(), accnt.code.end());
       } else {
-         result.wast = wasm_to_wast( (const uint8_t*)accnt.code.data(), accnt.code.size() );
+         result.wast = wasm_to_wast( (const uint8_t*)accnt.code.data(), accnt.code.size(), true );
       }
       result.code_hash = fc::sha256::hash( accnt.code.data(), accnt.code.size() );
    }


### PR DESCRIPTION
* Correct limit for function local size
* Strip user (name) sections from get_code WASM->WAST conversion
* Add deadline to abi_serializer validate.
* catch bad_allocs and raise the appropriate SIGUSR1 from all points in producer plugin
* add invariant that there is no pending block after the call even if some part of the commit fails to commit_block

Co-authored-by: Matt Witherspoon <32485495+spoonincode@users.noreply.github.com>
Co-authored-by: Kevin Heifner <heifnerk@objectcomputing.com>
Co-authored-by: Bart Wyatt <bart.wyatt@block.one>