### PR TITLE
Increase --abi-serializer-max-time-ms for slow test machines

### DIFF
--- a/tests/testUtils.py
+++ b/tests/testUtils.py
@@ -1492,7 +1492,7 @@ class Cluster(object):
         if self.staging:
             cmdArr.append("--nogen")
 
-        nodeosArgs="--max-transaction-time 5000 --filter-on * --p2p-max-nodes-per-host %d" % (totalNodes)
+        nodeosArgs="--max-transaction-time 5000 --abi-serializer-max-time-ms 5000 --filter-on * --p2p-max-nodes-per-host %d" % (totalNodes)
         if not self.walletd:
             nodeosArgs += " --plugin eosio::wallet_api_plugin"
         if self.enableMongo:


### PR DESCRIPTION
Resolves #4503 

Fix for failing "smoke tests". 
Increase the allowed abi serialization time.