### PR TITLE
Fix validate_b1_vesting

### DIFF
--- a/contracts/eosio.system/delegate_bandwidth.cpp
+++ b/contracts/eosio.system/delegate_bandwidth.cpp
@@ -205,7 +205,7 @@ namespace eosiosystem {
       const int64_t max_claimable = 100'000'000'0000ll;
       const int64_t claimable = int64_t(max_claimable * double(now()-base_time) / (10*seconds_per_year) );
 
-      eosio_assert( max_claimable - claimable <= stake, "b1 can only claim their tokens over 10 years" );
+      eosio_assert( max_claimable - claimable >= stake, "b1 can only claim their tokens over 10 years" );
    }
 
    void system_contract::changebw( account_name from, account_name receiver,


### PR DESCRIPTION
Since "stake for voting cannot be negative", after 10 years later, `claimable` is bigger than `max_claimable`, `max_claimable - claimable` is negative which is <= `stake`, which means assert never crash, b1 can claim their tokens forever.

I do not know if I understand the right, please correct me if i am wrong.