### PR TITLE
consolidated security omnibus for 1.0.9

### DIFF
--- a/programs/cleos/httpc.cpp
+++ b/programs/cleos/httpc.cpp
@@ -150,6 +150,18 @@ namespace eosio { namespace client { namespace http {
       return resolved_url(url, std::move(resolved_addresses), *resolved_port, is_loopback);
    }
 
+   string format_host_header(const resolved_url& url) {
+      // common practice is to only make the port explicit when it is the non-default port
+      if (
+         (url.scheme == "https" && url.resolved_port == 443) ||
+         (url.scheme == "http" && url.resolved_port == 80)
+      ) {
+         return url.server;
+      } else {
+         return url.server + ":" + url.port;
+      }
+   }
+
    fc::variant do_http_call( const connection_param& cp,
                              const fc::variant& postdata,
                              bool print_request,
@@ -163,8 +175,9 @@ namespace eosio { namespace client { namespace http {
 
    boost::asio::streambuf request;
    std::ostream request_stream(&request);
+   auto host_header_value = format_host_header(url);
    request_stream << "POST " << url.path << " HTTP/1.0\r\n";
-   request_stream << "Host: " << url.server << "\r\n";
+   request_stream << "Host: " << host_header_value << "\r\n";
    request_stream << "content-length: " << postjson.size() << "\r\n";
    request_stream << "Accept: */*\r\n";
    request_stream << "Connection: close\r\n";

--- a/programs/eosio-launcher/main.cpp
+++ b/programs/eosio-launcher/main.cpp
@@ -1026,6 +1026,7 @@ launcher_def::write_config_file (tn_node_def &node) {
    cfg << "readonly = 0\n";
    cfg << "send-whole-blocks = true\n";
    cfg << "http-server-address = " << host->host_name << ":" << instance.http_port << "\n";
+   cfg << "http-validate-host = false\n";
    if (p2p == p2p_plugin::NET) {
       cfg << "p2p-listen-endpoint = " << host->listen_addr << ":" << instance.p2p_port << "\n";
       cfg << "p2p-server-address = " << host->public_name << ":" << instance.p2p_port << "\n";

--- a/tests/p2p_tests/pump/run_test.pl
+++ b/tests/p2p_tests/pump/run_test.pl
@@ -202,7 +202,8 @@ sub launch_nodes {
         my @cmdline = ($eosd,
                        $gtsarg,
                        "--data-dir=$data_dir[$i]",
-                       "--verbose-http-errors");
+                       "--verbose-http-errors",
+                       "--http-validate-host=false");
         $pid[$i] = fork;
         if ($pid[$i] > 0) {
             my $pause = $i == 0 ? $first_pause : $launch_pause;

--- a/tests/testUtils.py
+++ b/tests/testUtils.py
@@ -1232,7 +1232,7 @@ class WalletMgr(object):
             Utils.Print("ERROR: Wallet Manager wasn't configured to launch keosd")
             return False
 
-        cmd="%s --data-dir %s --config-dir %s --http-server-address=%s:%d --verbose-http-errors" % (
+        cmd="%s --data-dir %s --config-dir %s --http-server-address=%s:%d --verbose-http-errors --http-validate-host=false" % (
             Utils.EosWalletPath, WalletMgr.__walletDataDir, WalletMgr.__walletDataDir, self.host, self.port)
         if Utils.Debug: Utils.Print("cmd: %s" % (cmd))
         with open(WalletMgr.__walletLogFile, 'w') as sout, open(WalletMgr.__walletLogFile, 'w') as serr:

--- a/tests/validate-dirty-db.py
+++ b/tests/validate-dirty-db.py
@@ -40,7 +40,7 @@ testSuccessful=False
 def runNodeosAndGetOutput(myNodeId, myTimeout=3):
     """Startup nodeos, wait for timeout (before forced shutdown) and collect output. Stdout, stderr and return code are returned in a dictionary."""
     Print("Launching nodeos process id: %d" % (myNodeId))
-    cmd="programs/nodeos/nodeos --config-dir etc/eosio/node_bios --data-dir var/lib/node_bios --verbose-http-errors"
+    cmd="programs/nodeos/nodeos --config-dir etc/eosio/node_bios --data-dir var/lib/node_bios --verbose-http-errors --http-validate-host=false"
     Print("cmd: %s" % (cmd))
     proc=subprocess.Popen(cmd.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 


### PR DESCRIPTION
- Handle running out of fds on bnet accept
- add basic validation to http `Host` headers on incoming requests
  * the header must exactly match an expected server[:port]
  * missing ports are assumed defaulted based on scheme to 80/443
- add new configuration option `http-alias` to add additional acceptable hosts
  * the host:port present in the http(s) addresses is automatically acceptable but must be exact (localhost === localhost,  localhost !== 127.0.0.1, etc)
- add new configuration option `http-validate-host` which defaults to true, if false these checks are not performed and any `Host` header is acceptable
- correct cleos behavior which was not sending correct `Host` headers when the urls indicated non-default ports

Co-authored-by: Bart Wyatt <bart.wyatt@block.one>
Co-authored-by: Matt Witherspoon <32485495+spoonincode@users.noreply.github.com>