### PR TITLE
Update FC_ASSERT to EOS_ASSERT for a more descriptive concise error message

### DIFF
--- a/libraries/abi_generator/include/eosio/abi_generator/abi_generator.hpp
+++ b/libraries/abi_generator/include/eosio/abi_generator/abi_generator.hpp
@@ -89,7 +89,7 @@ namespace eosio {
          inline string is_clause_decl( string line ) {
             smatch match;
             if ( regex_match( line, match, regex("(###[ ]+CLAUSE[ ]+NAME[ ]*:[ ]*)(.*)", regex_constants::ECMAScript) ) ) {
-               FC_ASSERT( match.size() == 3, "Error, malformed clause declaration" );
+               EOS_ASSERT( match.size() == 3, invalid_ricardian_clause_exception, "Error, malformed clause declaration" );
                return match[2].str();
             }
             return {};
@@ -98,7 +98,7 @@ namespace eosio {
          inline string is_action_decl( string line ) {
             smatch match;
             if ( regex_match( line, match, regex("(##[ ]+ACTION[ ]+NAME[ ]*:[ ]*)(.*)", regex_constants::ECMAScript) ) ) {
-               FC_ASSERT( match.size() == 3, "Error, malformed action declaration" );
+               EOS_ASSERT( match.size() == 3,  invalid_ricardian_action_exception, "Error, malformed action declaration" );
                return match[2].str();
             }
             return {};
@@ -137,7 +137,7 @@ namespace eosio {
                if ( !(_name = is_clause_decl( line )).empty() ) {
                   if ( !first_time ) {
                      if (body.str().empty() ) {
-                        FC_ASSERT( false, "Error, invalid input in ricardian clauses, no body found" );
+                        EOS_ASSERT( false, invalid_ricardian_clause_exception, "Error, invalid input in ricardian clauses, no body found" );
                      }
                      _clauses.emplace_back( name, body.str() );
                      body.str("");

--- a/libraries/chain/authorization_manager.cpp
+++ b/libraries/chain/authorization_manager.cpp
@@ -112,13 +112,13 @@ namespace eosio { namespace chain {
 
    const permission_object*  authorization_manager::find_permission( const permission_level& level )const
    { try {
-      FC_ASSERT( !level.actor.empty() && !level.permission.empty(), "Invalid permission" );
+      EOS_ASSERT( !level.actor.empty() && !level.permission.empty(), invalid_permission, "Invalid permission" );
       return _db.find<permission_object, by_owner>( boost::make_tuple(level.actor,level.permission) );
    } EOS_RETHROW_EXCEPTIONS( chain::permission_query_exception, "Failed to retrieve permission: ${level}", ("level", level) ) }
 
    const permission_object&  authorization_manager::get_permission( const permission_level& level )const
    { try {
-      FC_ASSERT( !level.actor.empty() && !level.permission.empty(), "Invalid permission" );
+      EOS_ASSERT( !level.actor.empty() && !level.permission.empty(), invalid_permission, "Invalid permission" );
       return _db.get<permission_object, by_owner>( boost::make_tuple(level.actor,level.permission) );
    } EOS_RETHROW_EXCEPTIONS( chain::permission_query_exception, "Failed to retrieve permission: ${level}", ("level", level) ) }
 
@@ -154,11 +154,12 @@ namespace eosio { namespace chain {
    {
       // Special case native actions cannot be linked to a minimum permission, so there is no need to check.
       if( scope == config::system_account_name ) {
-          FC_ASSERT( act_name != updateauth::get_name() &&
+          EOS_ASSERT( act_name != updateauth::get_name() &&
                      act_name != deleteauth::get_name() &&
                      act_name != linkauth::get_name() &&
                      act_name != unlinkauth::get_name() &&
                      act_name != canceldelay::get_name(),
+                     unlinkable_min_permission_action,
                      "cannot call lookup_minimum_permission on native actions that are not allowed to be linked to minimum permissions" );
       }
 
@@ -292,7 +293,8 @@ namespace eosio { namespace chain {
       const auto& generated_transaction_idx = _control.db().get_index<generated_transaction_multi_index>();
       const auto& generated_index = generated_transaction_idx.indices().get<by_trx_id>();
       const auto& itr = generated_index.lower_bound(trx_id);
-      FC_ASSERT( itr != generated_index.end() && itr->sender == account_name() && itr->trx_id == trx_id,
+      EOS_ASSERT( itr != generated_index.end() && itr->sender == account_name() && itr->trx_id == trx_id,
+                  tx_not_found,
                  "cannot cancel trx_id=${tid}, there is no deferred transaction with that transaction id",
                  ("tid", trx_id) );
 

--- a/libraries/chain/chain_id_type.cpp
+++ b/libraries/chain/chain_id_type.cpp
@@ -9,7 +9,7 @@
 namespace eosio { namespace chain {
 
    void chain_id_type::reflector_verify()const {
-      FC_ASSERT( *reinterpret_cast<const fc::sha256*>(this) != fc::sha256(), "chain_id_type cannot be zero" );
+      EOS_ASSERT( *reinterpret_cast<const fc::sha256*>(this) != fc::sha256(), chain_id_type_exception, "chain_id_type cannot be zero" );
    }
 
 } }  // namespace eosio::chain

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -72,7 +72,7 @@ struct controller_impl {
 
    void pop_block() {
       auto prev = fork_db.get_block( head->header.previous );
-      FC_ASSERT( prev, "attempt to pop beyond last irreversible block" );
+      EOS_ASSERT( prev, block_validate_exception, "attempt to pop beyond last irreversible block" );
 
       if( const auto* b = reversible_blocks.find<reversible_block_object,by_num>(head->block_num) )
       {
@@ -166,7 +166,7 @@ struct controller_impl {
          blog.read_head();
 
       const auto& log_head = blog.head();
-      FC_ASSERT( log_head );
+      EOS_ASSERT( log_head, block_log_exception, "block log head can not be found" );
       auto lh_block_num = log_head->block_num();
 
       db.commit( s->block_num );
@@ -177,8 +177,8 @@ struct controller_impl {
          return;
       }
 
-      FC_ASSERT( s->block_num - 1  == lh_block_num, "unlinkable block", ("s->block_num",s->block_num)("lh_block_num", lh_block_num) );
-      FC_ASSERT( s->block->previous == log_head->id(), "irreversible doesn't link to block log head" );
+      EOS_ASSERT( s->block_num - 1  == lh_block_num, unlinkable_block_exception, "unlinkable block", ("s->block_num",s->block_num)("lh_block_num", lh_block_num) );
+      EOS_ASSERT( s->block->previous == log_head->id(), unlinkable_block_exception, "irreversible doesn't link to block log head" );
       blog.append(s->block);
 
       const auto& ubi = reversible_blocks.get_index<reversible_block_index,by_num>();
@@ -244,17 +244,17 @@ struct controller_impl {
       const auto& ubi = reversible_blocks.get_index<reversible_block_index,by_num>();
       auto objitr = ubi.rbegin();
       if( objitr != ubi.rend() ) {
-         FC_ASSERT( objitr->blocknum == head->block_num,
+         EOS_ASSERT( objitr->blocknum == head->block_num, fork_database_exception,
                     "reversible block database is inconsistent with fork database, replay blockchain",
                     ("head",head->block_num)("unconfimed", objitr->blocknum)         );
       } else {
          auto end = blog.read_head();
-         FC_ASSERT( end && end->block_num() == head->block_num,
+         EOS_ASSERT( end && end->block_num() == head->block_num, fork_database_exception,
                     "fork database exists but reversible block database does not, replay blockchain",
                     ("blog_head",end->block_num())("head",head->block_num)  );
       }
 
-      FC_ASSERT( db.revision() >= head->block_num, "fork database is inconsistent with shared memory",
+      EOS_ASSERT( db.revision() >= head->block_num, fork_database_exception, "fork database is inconsistent with shared memory",
                  ("db",db.revision())("head",head->block_num) );
 
       if( db.revision() > head->block_num ) {
@@ -422,7 +422,7 @@ struct controller_impl {
             auto new_bsp = fork_db.add(pending->_pending_block_state);
             emit(self.accepted_block_header, pending->_pending_block_state);
             head = fork_db.head();
-            FC_ASSERT(new_bsp == head, "committed block did not become the new head in fork database");
+            EOS_ASSERT(new_bsp == head, fork_database_exception, "committed block did not become the new head in fork database");
          }
 
          if( !replaying ) {
@@ -530,7 +530,7 @@ struct controller_impl {
    transaction_trace_ptr push_scheduled_transaction( const transaction_id_type& trxid, fc::time_point deadline, uint32_t billed_cpu_time_us ) {
       const auto& idx = db.get_index<generated_transaction_multi_index,by_trx_id>();
       auto itr = idx.find( trxid );
-      FC_ASSERT( itr != idx.end(), "unknown transaction" );
+      EOS_ASSERT( itr != idx.end(), unknown_transaction_exception, "unknown transaction" );
       return push_scheduled_transaction( *itr, deadline, billed_cpu_time_us );
    }
 
@@ -543,7 +543,7 @@ struct controller_impl {
          remove_scheduled_transaction(gto);
       });
 
-      FC_ASSERT( gto.delay_until <= self.pending_block_time(), "this transaction isn't ready",
+      EOS_ASSERT( gto.delay_until <= self.pending_block_time(), transaction_exception, "this transaction isn't ready",
                  ("gto.delay_until",gto.delay_until)("pbt",self.pending_block_time())          );
       if( gto.expiration < self.pending_block_time() ) {
          auto trace = std::make_shared<transaction_trace>();
@@ -637,7 +637,7 @@ struct controller_impl {
    const transaction_receipt& push_receipt( const T& trx, transaction_receipt_header::status_enum status,
                                             uint64_t cpu_usage_us, uint64_t net_usage ) {
       uint64_t net_usage_words = net_usage / 8;
-      FC_ASSERT( net_usage_words*8 == net_usage, "net_usage is not divisible by 8" );
+      EOS_ASSERT( net_usage_words*8 == net_usage, transaction_exception, "net_usage is not divisible by 8" );
       pending->_pending_block_state->block->transactions.emplace_back( trx );
       transaction_receipt& r = pending->_pending_block_state->block->transactions.back();
       r.cpu_usage_us         = cpu_usage_us;
@@ -656,7 +656,7 @@ struct controller_impl {
                                            bool implicit,
                                            uint32_t billed_cpu_time_us  )
    {
-      FC_ASSERT(deadline != fc::time_point(), "deadline cannot be uninitialized");
+      EOS_ASSERT(deadline != fc::time_point(), transaction_exception, "deadline cannot be uninitialized");
 
       transaction_trace_ptr trace;
       try {
@@ -751,9 +751,9 @@ struct controller_impl {
 
 
    void start_block( block_timestamp_type when, uint16_t confirm_block_count, controller::block_status s ) {
-      FC_ASSERT( !pending );
+      EOS_ASSERT( !pending, block_validate_exception, "pending block is not available" );
 
-      FC_ASSERT( db.revision() == head->block_num, "",
+      EOS_ASSERT( db.revision() == head->block_num, database_exception, "db revision is not on par with head block", 
                 ("db.revision()", db.revision())("controller_head_block", head->block_num)("fork_db_head_block", fork_db.head()->block_num) );
 
       auto guard_pending = fc::make_scoped_exit([this](){
@@ -830,7 +830,7 @@ struct controller_impl {
 
    void apply_block( const signed_block_ptr& b, controller::block_status s ) { try {
       try {
-         FC_ASSERT( b->block_extensions.size() == 0, "no supported extensions" );
+         EOS_ASSERT( b->block_extensions.size() == 0, block_validate_exception, "no supported extensions" );
          start_block( b->timestamp, b->confirmed, s );
 
          transaction_trace_ptr trace;
@@ -887,10 +887,10 @@ struct controller_impl {
 
    void push_block( const signed_block_ptr& b, controller::block_status s ) {
     //  idump((fc::json::to_pretty_string(*b)));
-      FC_ASSERT(!pending, "it is not valid to push a block when there is a pending block");
+      EOS_ASSERT(!pending, block_validate_exception, "it is not valid to push a block when there is a pending block");
       try {
-         FC_ASSERT( b );
-         FC_ASSERT( s != controller::block_status::incomplete, "invalid block status for a completed block" );
+         EOS_ASSERT( b, block_validate_exception, "trying to push empty block" );
+         EOS_ASSERT( s != controller::block_status::incomplete, block_validate_exception, "invalid block status for a completed block" );
          emit( self.pre_accepted_block, b );
          bool trust = !conf.force_all_checks && (s == controller::block_status::irreversible || s == controller::block_status::validated);
          auto new_header_state = fork_db.add( b, trust );
@@ -903,7 +903,7 @@ struct controller_impl {
    }
 
    void push_confirmation( const header_confirmation& c ) {
-      FC_ASSERT(!pending, "it is not valid to push a confirmation when there is a pending block");
+      EOS_ASSERT(!pending, block_validate_exception, "it is not valid to push a confirmation when there is a pending block");
       fork_db.add( c );
       emit( self.accepted_confirmation, c );
       if ( read_mode != db_read_mode::IRREVERSIBLE ) {
@@ -933,7 +933,7 @@ struct controller_impl {
             fork_db.mark_in_current_chain( *itr , false );
             pop_block();
          }
-         FC_ASSERT( self.head_block_id() == branches.second.back()->header.previous,
+         EOS_ASSERT( self.head_block_id() == branches.second.back()->header.previous, fork_database_exception,
                     "loss of sync between fork_db and chainbase during fork switch" ); // _should_ never fail
 
          for( auto ritr = branches.first.rbegin(); ritr != branches.first.rend(); ++ritr) {
@@ -959,7 +959,7 @@ struct controller_impl {
                   fork_db.mark_in_current_chain( *itr , false );
                   pop_block();
                }
-               FC_ASSERT( self.head_block_id() == branches.second.back()->header.previous,
+               EOS_ASSERT( self.head_block_id() == branches.second.back()->header.previous, fork_database_exception,
                           "loss of sync between fork_db and chainbase during fork switch reversal" ); // _should_ never fail
 
                // re-apply good blocks
@@ -1012,7 +1012,7 @@ struct controller_impl {
 
    void finalize_block()
    {
-      FC_ASSERT(pending, "it is not valid to finalize when there is no pending block");
+      EOS_ASSERT(pending, block_validate_exception, "it is not valid to finalize when there is no pending block");
       try {
 
 
@@ -1329,7 +1329,7 @@ block_state_ptr controller::pending_block_state()const {
    return block_state_ptr();
 }
 time_point controller::pending_block_time()const {
-   FC_ASSERT( my->pending, "no pending block" );
+   EOS_ASSERT( my->pending, block_validate_exception, "no pending block" );
    return my->pending->_pending_block_state->header.timestamp;
 }
 

--- a/libraries/chain/eosio_contract.cpp
+++ b/libraries/chain/eosio_contract.cpp
@@ -132,8 +132,8 @@ void apply_eosio_setcode(apply_context& context) {
    auto  act = context.act.data_as<setcode>();
    context.require_authorization(act.account);
 
-   FC_ASSERT( act.vmtype == 0 );
-   FC_ASSERT( act.vmversion == 0 );
+   EOS_ASSERT( act.vmtype == 0, invalid_contract_vm_type, "code should be 0" );
+   EOS_ASSERT( act.vmversion == 0, invalid_contract_vm_version, "version should be 0" );
 
    fc::sha256 code_id; /// default ID == 0
 
@@ -148,7 +148,7 @@ void apply_eosio_setcode(apply_context& context) {
    int64_t old_size  = (int64_t)account.code.size() * config::setcode_ram_bytes_multiplier;
    int64_t new_size  = code_size * config::setcode_ram_bytes_multiplier;
 
-   FC_ASSERT( account.code_version != code_id, "contract is already running this version of code" );
+   EOS_ASSERT( account.code_version != code_id, set_exact_code, "contract is already running this version of code" );
 
    db.modify( account, [&]( auto& a ) {
       /** TODO: consider whether a microsecond level local timestamp is sufficient to detect code version changes*/

--- a/libraries/chain/fork_database.cpp
+++ b/libraries/chain/fork_database.cpp
@@ -1,5 +1,5 @@
 #include <eosio/chain/fork_database.hpp>
-
+#include <eosio/chain/exceptions.hpp>
 #include <boost/multi_index_container.hpp>
 #include <boost/multi_index/member.hpp>
 #include <boost/multi_index/ordered_index.hpp>
@@ -110,11 +110,12 @@ namespace eosio { namespace chain {
 
    void fork_database::set( block_state_ptr s ) {
       auto result = my->index.insert( s );
-      FC_ASSERT( s->id == s->header.id() );
+      EOS_ASSERT( s->id == s->header.id(), fork_database_exception, 
+                  "block state id (${id}) is different from block state header id (${hid})", ("id", string(s->id))("hid", string(s->header.id())) );
 
          //FC_ASSERT( s->block_num == s->header.block_num() );
 
-      FC_ASSERT( result.second, "unable to insert block state, duplicate state detected" );
+      EOS_ASSERT( result.second, fork_database_exception, "unable to insert block state, duplicate state detected" );
       if( !my->head ) {
          my->head =  s;
       } else if( my->head->block_num < s->block_num ) {
@@ -124,7 +125,7 @@ namespace eosio { namespace chain {
 
    block_state_ptr fork_database::add( block_state_ptr n ) {
       auto inserted = my->index.insert(n);
-      FC_ASSERT( inserted.second, "duplicate block added?" );
+      EOS_ASSERT( inserted.second, fork_database_exception, "duplicate block added?" );
 
       my->head = *my->index.get<by_lib_block_num>().begin();
 
@@ -139,18 +140,18 @@ namespace eosio { namespace chain {
    }
 
    block_state_ptr fork_database::add( signed_block_ptr b, bool trust ) {
-      FC_ASSERT( b, "attempt to add null block" );
-      FC_ASSERT( my->head, "no head block set" );
+      EOS_ASSERT( b, fork_database_exception, "attempt to add null block" );
+      EOS_ASSERT( my->head, fork_db_block_not_found, "no head block set" );
 
       const auto& by_id_idx = my->index.get<by_block_id>();
       auto existing = by_id_idx.find( b->id() );
-      FC_ASSERT( existing == by_id_idx.end(), "we already know about this block" );
+      EOS_ASSERT( existing == by_id_idx.end(), fork_database_exception, "we already know about this block" );
 
       auto prior = by_id_idx.find( b->previous );
-      FC_ASSERT( prior != by_id_idx.end(), "unlinkable block", ("id", b->id())("previous", b->previous) );
+      EOS_ASSERT( prior != by_id_idx.end(), unlinkable_block_exception, "unlinkable block", ("id", string(b->id()))("previous", string(b->previous)) );
 
       auto result = std::make_shared<block_state>( **prior, move(b), trust );
-      FC_ASSERT( result );
+      EOS_ASSERT( result, fork_database_exception , "fail to add new block state" );
       return add(result);
    }
 
@@ -170,14 +171,14 @@ namespace eosio { namespace chain {
       {
          result.first.push_back(first_branch);
          first_branch = get_block( first_branch->header.previous );
-         FC_ASSERT( first_branch );
+         EOS_ASSERT( first_branch, fork_db_block_not_found, "block ${id} does not exist", ("id", string(first_branch->header.previous)) );
       }
 
       while( second_branch->block_num > first_branch->block_num )
       {
          result.second.push_back( second_branch );
          second_branch = get_block( second_branch->header.previous );
-         FC_ASSERT( second_branch );
+         EOS_ASSERT( second_branch, fork_db_block_not_found, "block ${id} does not exist", ("id", string(second_branch->header.previous)) );
       }
 
       while( first_branch->header.previous != second_branch->header.previous )
@@ -186,7 +187,9 @@ namespace eosio { namespace chain {
          result.second.push_back(second_branch);
          first_branch = get_block( first_branch->header.previous );
          second_branch = get_block( second_branch->header.previous );
-         FC_ASSERT( first_branch && second_branch );
+         EOS_ASSERT( first_branch && second_branch, fork_db_block_not_found, 
+                     "either block ${fid} or ${sid} does not exist", 
+                     ("fid", string(first_branch->header.previous))("sid", string(second_branch->header.previous)) );
       }
 
       if( first_branch && second_branch )
@@ -232,7 +235,7 @@ namespace eosio { namespace chain {
 
       auto& by_id_idx = my->index.get<by_block_id>();
       auto itr = by_id_idx.find( h->id );
-      FC_ASSERT( itr != by_id_idx.end(), "could not find block in fork database" );
+      EOS_ASSERT( itr != by_id_idx.end(), fork_db_block_not_found, "could not find block in fork database" );
 
       by_id_idx.modify( itr, [&]( auto& bsp ) { // Need to modify this way rather than directly so that Boost MultiIndex can re-sort
          bsp->in_current_chain = in_current_chain;
@@ -287,7 +290,7 @@ namespace eosio { namespace chain {
 
    void fork_database::add( const header_confirmation& c ) {
       auto b = get_block( c.block_id );
-      FC_ASSERT( b, "unable to find block id ${id}", ("id",c.block_id));
+      EOS_ASSERT( b, fork_db_block_not_found, "unable to find block id ${id}", ("id",c.block_id));
       b->add_confirmation( c );
 
       if( b->bft_irreversible_blocknum < b->block_num &&

--- a/libraries/chain/include/eosio/chain/abi_serializer.hpp
+++ b/libraries/chain/include/eosio/chain/abi_serializer.hpp
@@ -185,8 +185,8 @@ namespace impl {
       static void add( mutable_variant_object &mvo, const char* name, const M& v, Resolver,
                        size_t recursion_depth, const fc::time_point& deadline, const fc::microseconds& max_serialization_time )
       {
-         FC_ASSERT( ++recursion_depth < abi_serializer::max_recursion_depth, "recursive definition, max_recursion_depth ${r} ", ("r", abi_serializer::max_recursion_depth) );
-         FC_ASSERT( fc::time_point::now() < deadline, "serialization time limit ${t}us exceeded", ("t", max_serialization_time) );
+         EOS_ASSERT( ++recursion_depth < abi_serializer::max_recursion_depth, abi_recursion_depth_exception, "recursive definition, max_recursion_depth ${r} ", ("r", abi_serializer::max_recursion_depth) );
+         EOS_ASSERT( fc::time_point::now() < deadline, abi_serialization_deadline_exception, "serialization time limit ${t}us exceeded", ("t", max_serialization_time) );
          mvo(name,v);
       }
 
@@ -206,8 +206,8 @@ namespace impl {
       static void add( mutable_variant_object &mvo, const char* name, const vector<M>& v, Resolver resolver,
                        size_t recursion_depth, const fc::time_point& deadline, const fc::microseconds& max_serialization_time )
       {
-         FC_ASSERT( ++recursion_depth < abi_serializer::max_recursion_depth, "recursive definition, max_recursion_depth ${r} ", ("r", abi_serializer::max_recursion_depth) );
-         FC_ASSERT( fc::time_point::now() < deadline, "serialization time limit ${t}us exceeded", ("t", max_serialization_time) );
+         EOS_ASSERT( ++recursion_depth < abi_serializer::max_recursion_depth, abi_recursion_depth_exception, "recursive definition, max_recursion_depth ${r} ", ("r", abi_serializer::max_recursion_depth) );
+         EOS_ASSERT( fc::time_point::now() < deadline, abi_serialization_deadline_exception, "serialization time limit ${t}us exceeded", ("t", max_serialization_time) );
          vector<variant> array;
          array.reserve(v.size());
 
@@ -227,8 +227,8 @@ namespace impl {
       static void add( mutable_variant_object &mvo, const char* name, const std::shared_ptr<M>& v, Resolver resolver,
                        size_t recursion_depth, const fc::time_point& deadline, const fc::microseconds& max_serialization_time )
       {
-         FC_ASSERT( ++recursion_depth < abi_serializer::max_recursion_depth, "recursive definition, max_recursion_depth ${r} ", ("r", abi_serializer::max_recursion_depth) );
-         FC_ASSERT( fc::time_point::now() < deadline, "serialization time limit ${t}us exceeded", ("t", max_serialization_time) );
+         EOS_ASSERT( ++recursion_depth < abi_serializer::max_recursion_depth, abi_recursion_depth_exception, "recursive definition, max_recursion_depth ${r} ", ("r", abi_serializer::max_recursion_depth) );
+         EOS_ASSERT( fc::time_point::now() < deadline, abi_serialization_deadline_exception, "serialization time limit ${t}us exceeded", ("t", max_serialization_time) );
          if( !v ) return;
          mutable_variant_object obj_mvo;
          add(obj_mvo, "_", *v, resolver, recursion_depth, deadline, max_serialization_time);
@@ -257,8 +257,8 @@ namespace impl {
       static void add( mutable_variant_object &mvo, const char* name, const fc::static_variant<Args...>& v, Resolver resolver,
                        size_t recursion_depth, const fc::time_point& deadline, const fc::microseconds& max_serialization_time )
       {
-         FC_ASSERT( ++recursion_depth < abi_serializer::max_recursion_depth, "recursive definition, max_recursion_depth ${r} ", ("r", abi_serializer::max_recursion_depth) );
-         FC_ASSERT( fc::time_point::now() < deadline, "serialization time limit ${t}us exceeded", ("t", max_serialization_time) );
+         EOS_ASSERT( ++recursion_depth < abi_serializer::max_recursion_depth, abi_recursion_depth_exception, "recursive definition, max_recursion_depth ${r} ", ("r", abi_serializer::max_recursion_depth) );
+         EOS_ASSERT( fc::time_point::now() < deadline, abi_serialization_deadline_exception, "serialization time limit ${t}us exceeded", ("t", max_serialization_time) );
          mutable_variant_object obj_mvo;
          add_static_variant<Resolver> adder(obj_mvo, resolver, recursion_depth, deadline, max_serialization_time);
          v.visit(adder);
@@ -276,8 +276,8 @@ namespace impl {
       static void add( mutable_variant_object &out, const char* name, const action& act, Resolver resolver,
                        size_t recursion_depth, const fc::time_point& deadline, const fc::microseconds& max_serialization_time )
       {
-         FC_ASSERT( ++recursion_depth < abi_serializer::max_recursion_depth, "recursive definition, max_recursion_depth ${r} ", ("r", abi_serializer::max_recursion_depth) );
-         FC_ASSERT( fc::time_point::now() < deadline, "serialization time limit ${t}us exceeded", ("t", max_serialization_time) );
+         EOS_ASSERT( ++recursion_depth < abi_serializer::max_recursion_depth, abi_recursion_depth_exception, "recursive definition, max_recursion_depth ${r} ", ("r", abi_serializer::max_recursion_depth) );
+         EOS_ASSERT( fc::time_point::now() < deadline, abi_serialization_deadline_exception, "serialization time limit ${t}us exceeded", ("t", max_serialization_time) );
          mutable_variant_object mvo;
          mvo("account", act.account);
          mvo("name", act.name);
@@ -314,8 +314,8 @@ namespace impl {
       static void add( mutable_variant_object &out, const char* name, const packed_transaction& ptrx, Resolver resolver,
                        size_t recursion_depth, const fc::time_point& deadline, const fc::microseconds& max_serialization_time )
       {
-         FC_ASSERT( ++recursion_depth < abi_serializer::max_recursion_depth, "recursive definition, max_recursion_depth ${r} ", ("r", abi_serializer::max_recursion_depth) );
-         FC_ASSERT( fc::time_point::now() < deadline, "serialization time limit ${t}us exceeded", ("t", max_serialization_time) );
+         EOS_ASSERT( ++recursion_depth < abi_serializer::max_recursion_depth, abi_recursion_depth_exception, "recursive definition, max_recursion_depth ${r} ", ("r", abi_serializer::max_recursion_depth) );
+         EOS_ASSERT( fc::time_point::now() < deadline, abi_serialization_deadline_exception, "serialization time limit ${t}us exceeded", ("t", max_serialization_time) );
          mutable_variant_object mvo;
          auto trx = ptrx.get_transaction();
          mvo("id", trx.id());
@@ -382,8 +382,8 @@ namespace impl {
       static void extract( const variant& v, M& o, Resolver,
                            size_t recursion_depth, const fc::time_point& deadline, const fc::microseconds& max_serialization_time )
       {
-         FC_ASSERT( ++recursion_depth < abi_serializer::max_recursion_depth, "recursive definition, max_recursion_depth ${r} ", ("r", abi_serializer::max_recursion_depth) );
-         FC_ASSERT( fc::time_point::now() < deadline, "serialization time limit ${t}us exceeded", ("t", max_serialization_time) );
+         EOS_ASSERT( ++recursion_depth < abi_serializer::max_recursion_depth, abi_recursion_depth_exception, "recursive definition, max_recursion_depth ${r} ", ("r", abi_serializer::max_recursion_depth) );
+         EOS_ASSERT( fc::time_point::now() < deadline, abi_serialization_deadline_exception, "serialization time limit ${t}us exceeded", ("t", max_serialization_time) );
          from_variant(v, o);
       }
 
@@ -403,8 +403,8 @@ namespace impl {
       static void extract( const variant& v, vector<M>& o, Resolver resolver,
                            size_t recursion_depth, const fc::time_point& deadline, const fc::microseconds& max_serialization_time )
       {
-         FC_ASSERT( ++recursion_depth < abi_serializer::max_recursion_depth, "recursive definition, max_recursion_depth ${r} ", ("r", abi_serializer::max_recursion_depth) );
-         FC_ASSERT( fc::time_point::now() < deadline, "serialization time limit ${t}us exceeded", ("t", max_serialization_time) );
+         EOS_ASSERT( ++recursion_depth < abi_serializer::max_recursion_depth, abi_recursion_depth_exception, "recursive definition, max_recursion_depth ${r} ", ("r", abi_serializer::max_recursion_depth) );
+         EOS_ASSERT( fc::time_point::now() < deadline, abi_serialization_deadline_exception, "serialization time limit ${t}us exceeded", ("t", max_serialization_time) );
          const variants& array = v.get_array();
          o.clear();
          o.reserve( array.size() );
@@ -423,8 +423,8 @@ namespace impl {
       static void extract( const variant& v, std::shared_ptr<M>& o, Resolver resolver,
                            size_t recursion_depth, const fc::time_point& deadline, const fc::microseconds& max_serialization_time )
       {
-         FC_ASSERT( ++recursion_depth < abi_serializer::max_recursion_depth, "recursive definition, max_recursion_depth ${r} ", ("r", abi_serializer::max_recursion_depth) );
-         FC_ASSERT( fc::time_point::now() < deadline, "serialization time limit ${t}us exceeded", ("t", max_serialization_time) );
+         EOS_ASSERT( ++recursion_depth < abi_serializer::max_recursion_depth, abi_recursion_depth_exception, "recursive definition, max_recursion_depth ${r} ", ("r", abi_serializer::max_recursion_depth) );
+         EOS_ASSERT( fc::time_point::now() < deadline, abi_serialization_deadline_exception, "serialization time limit ${t}us exceeded", ("t", max_serialization_time) );
          const variant_object& vo = v.get_object();
          M obj;
          extract(vo, obj, resolver, recursion_depth, deadline, max_serialization_time);
@@ -440,8 +440,8 @@ namespace impl {
       static void extract( const variant& v, action& act, Resolver resolver,
                            size_t recursion_depth, const fc::time_point& deadline, const fc::microseconds& max_serialization_time )
       {
-         FC_ASSERT( ++recursion_depth < abi_serializer::max_recursion_depth, "recursive definition, max_recursion_depth ${r} ", ("r", abi_serializer::max_recursion_depth) );
-         FC_ASSERT( fc::time_point::now() < deadline, "serialization time limit ${t}us exceeded", ("t", max_serialization_time) );
+         EOS_ASSERT( ++recursion_depth < abi_serializer::max_recursion_depth, abi_recursion_depth_exception, "recursive definition, max_recursion_depth ${r} ", ("r", abi_serializer::max_recursion_depth) );
+         EOS_ASSERT( fc::time_point::now() < deadline, abi_serialization_deadline_exception, "serialization time limit ${t}us exceeded", ("t", max_serialization_time) );
          const variant_object& vo = v.get_object();
          EOS_ASSERT(vo.contains("account"), packed_transaction_type_exception, "Missing account");
          EOS_ASSERT(vo.contains("name"), packed_transaction_type_exception, "Missing name");
@@ -487,8 +487,8 @@ namespace impl {
       static void extract( const variant& v, packed_transaction& ptrx, Resolver resolver,
                            size_t recursion_depth, const fc::time_point& deadline, const fc::microseconds& max_serialization_time )
       {
-         FC_ASSERT( ++recursion_depth < abi_serializer::max_recursion_depth, "recursive definition, max_recursion_depth ${r} ", ("r", abi_serializer::max_recursion_depth) );
-         FC_ASSERT( fc::time_point::now() < deadline, "serialization time limit ${t}us exceeded", ("t", max_serialization_time) );
+         EOS_ASSERT( ++recursion_depth < abi_serializer::max_recursion_depth, abi_recursion_depth_exception, "recursive definition, max_recursion_depth ${r} ", ("r", abi_serializer::max_recursion_depth) );
+         EOS_ASSERT( fc::time_point::now() < deadline, abi_serialization_deadline_exception, "serialization time limit ${t}us exceeded", ("t", max_serialization_time) );
          const variant_object& vo = v.get_object();
          EOS_ASSERT(vo.contains("signatures"), packed_transaction_type_exception, "Missing signatures");
          EOS_ASSERT(vo.contains("compression"), packed_transaction_type_exception, "Missing compression");
@@ -570,8 +570,8 @@ namespace impl {
    void abi_to_variant::add( mutable_variant_object &mvo, const char* name, const M& v, Resolver resolver,
                              size_t recursion_depth, const fc::time_point& deadline, const fc::microseconds& max_serialization_time )
    {
-      FC_ASSERT( ++recursion_depth < abi_serializer::max_recursion_depth, "recursive definition, max_recursion_depth ${r} ", ("r", abi_serializer::max_recursion_depth) );
-      FC_ASSERT( fc::time_point::now() < deadline, "serialization time limit ${t}us exceeded", ("t", max_serialization_time) );
+      EOS_ASSERT( ++recursion_depth < abi_serializer::max_recursion_depth, abi_recursion_depth_exception, "recursive definition, max_recursion_depth ${r} ", ("r", abi_serializer::max_recursion_depth) );
+      EOS_ASSERT( fc::time_point::now() < deadline, abi_serialization_deadline_exception, "serialization time limit ${t}us exceeded", ("t", max_serialization_time) );
       mutable_variant_object member_mvo;
       fc::reflector<M>::visit( impl::abi_to_variant_visitor<M, Resolver>( member_mvo, v, resolver, recursion_depth, deadline, max_serialization_time ) );
       mvo(name, std::move(member_mvo));
@@ -581,8 +581,8 @@ namespace impl {
    void abi_from_variant::extract( const variant& v, M& o, Resolver resolver,
                                    size_t recursion_depth, const fc::time_point& deadline, const fc::microseconds& max_serialization_time )
    {
-      FC_ASSERT( ++recursion_depth < abi_serializer::max_recursion_depth, "recursive definition, max_recursion_depth ${r} ", ("r", abi_serializer::max_recursion_depth) );
-      FC_ASSERT( fc::time_point::now() < deadline, "serialization time limit ${t}us exceeded", ("t", max_serialization_time) );
+      EOS_ASSERT( ++recursion_depth < abi_serializer::max_recursion_depth, abi_recursion_depth_exception, "recursive definition, max_recursion_depth ${r} ", ("r", abi_serializer::max_recursion_depth) );
+      EOS_ASSERT( fc::time_point::now() < deadline, abi_serialization_deadline_exception, "serialization time limit ${t}us exceeded", ("t", max_serialization_time) );
       const variant_object& vo = v.get_object();
       fc::reflector<M>::visit( abi_from_variant_visitor<M, decltype(resolver)>( vo, o, resolver, recursion_depth, deadline, max_serialization_time ) );
    }

--- a/libraries/chain/include/eosio/chain/account_object.hpp
+++ b/libraries/chain/include/eosio/chain/account_object.hpp
@@ -36,7 +36,7 @@ namespace eosio { namespace chain {
 
       eosio::chain::abi_def get_abi()const {
          eosio::chain::abi_def a;
-         FC_ASSERT( abi.size() != 0, "No ABI set on account ${n}", ("n",name) );
+         EOS_ASSERT( abi.size() != 0, abi_not_found_exception, "No ABI set on account ${n}", ("n",name) );
 
          fc::datastream<const char*> ds( abi.data(), abi.size() );
          fc::raw::unpack( ds, a );

--- a/libraries/chain/include/eosio/chain/action.hpp
+++ b/libraries/chain/include/eosio/chain/action.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <eosio/chain/types.hpp>
+#include <eosio/chain/exceptions.hpp>
 
 namespace eosio { namespace chain {
 
@@ -86,8 +87,8 @@ namespace eosio { namespace chain {
 
       template<typename T>
       T data_as()const {
-         FC_ASSERT( account == T::get_account() );
-         FC_ASSERT( name == T::get_name()  );
+         EOS_ASSERT( account == T::get_account(), action_type_exception, "account is not consistent with action struct" );
+         EOS_ASSERT( name == T::get_name(), action_type_exception, "action name is not consistent with action struct"  );
          return fc::raw::unpack<T>(data);
       }
    };

--- a/libraries/chain/include/eosio/chain/apply_context.hpp
+++ b/libraries/chain/include/eosio/chain/apply_context.hpp
@@ -42,36 +42,36 @@ class apply_context {
 
             const table_id_object& get_table( table_id_object::id_type i )const {
                auto itr = _table_cache.find(i);
-               FC_ASSERT( itr != _table_cache.end(), "an invariant was broken, table should be in cache" );
+               EOS_ASSERT( itr != _table_cache.end(), table_not_in_cache, "an invariant was broken, table should be in cache" );
                return *itr->second.first;
             }
 
             int get_end_iterator_by_table_id( table_id_object::id_type i )const {
                auto itr = _table_cache.find(i);
-               FC_ASSERT( itr != _table_cache.end(), "an invariant was broken, table should be in cache" );
+               EOS_ASSERT( itr != _table_cache.end(), table_not_in_cache, "an invariant was broken, table should be in cache" );
                return itr->second.second;
             }
 
             const table_id_object* find_table_by_end_iterator( int ei )const {
-               FC_ASSERT( ei < -1, "not an end iterator" );
+               EOS_ASSERT( ei < -1, invalid_table_iterator, "not an end iterator" );
                auto indx = end_iterator_to_index(ei);
                if( indx >= _end_iterator_to_table.size() ) return nullptr;
                return _end_iterator_to_table[indx];
             }
 
             const T& get( int iterator ) {
-               FC_ASSERT( iterator != -1, "invalid iterator" );
-               FC_ASSERT( iterator >= 0, "dereference of end iterator" );
-               FC_ASSERT( iterator < _iterator_to_object.size(), "iterator out of range" );
+               EOS_ASSERT( iterator != -1, invalid_table_iterator, "invalid iterator" );
+               EOS_ASSERT( iterator >= 0, table_operation_not_permitted, "dereference of end iterator" );
+               EOS_ASSERT( iterator < _iterator_to_object.size(), invalid_table_iterator, "iterator out of range" );
                auto result = _iterator_to_object[iterator];
-               FC_ASSERT( result, "dereference of deleted object" );
+               EOS_ASSERT( result, table_operation_not_permitted, "dereference of deleted object" );
                return *result;
             }
 
             void remove( int iterator ) {
-               FC_ASSERT( iterator != -1, "invalid iterator" );
-               FC_ASSERT( iterator >= 0, "cannot call remove on end iterators" );
-               FC_ASSERT( iterator < _iterator_to_object.size(), "iterator out of range" );
+               EOS_ASSERT( iterator != -1, invalid_table_iterator, "invalid iterator" );
+               EOS_ASSERT( iterator >= 0, table_operation_not_permitted, "cannot call remove on end iterators" );
+               EOS_ASSERT( iterator < _iterator_to_object.size(), invalid_table_iterator, "iterator out of range" );
                auto obj_ptr = _iterator_to_object[iterator];
                if( !obj_ptr ) return;
                _iterator_to_object[iterator] = nullptr;
@@ -179,7 +179,7 @@ class apply_context {
             int store( uint64_t scope, uint64_t table, const account_name& payer,
                        uint64_t id, secondary_key_proxy_const_type value )
             {
-               FC_ASSERT( payer != account_name(), "must specify a valid account to pay for new record" );
+               EOS_ASSERT( payer != account_name(), invalid_table_payer, "must specify a valid account to pay for new record" );
 
 //               context.require_write_lock( scope );
 
@@ -207,7 +207,7 @@ class apply_context {
                context.update_db_usage( obj.payer, -( config::billable_size_v<ObjectType> ) );
 
                const auto& table_obj = itr_cache.get_table( obj.t_id );
-               FC_ASSERT( table_obj.code == context.receiver, "db access violation" );
+               EOS_ASSERT( table_obj.code == context.receiver, table_access_violation, "db access violation" );
 
 //               context.require_write_lock( table_obj.scope );
 
@@ -227,7 +227,7 @@ class apply_context {
                const auto& obj = itr_cache.get( iterator );
 
                const auto& table_obj = itr_cache.get_table( obj.t_id );
-               FC_ASSERT( table_obj.code == context.receiver, "db access violation" );
+               EOS_ASSERT( table_obj.code == context.receiver, table_access_violation, "db access violation" );
 
 //               context.require_write_lock( table_obj.scope );
 
@@ -322,7 +322,7 @@ class apply_context {
                if( iterator < -1 ) // is end iterator
                {
                   auto tab = itr_cache.find_table_by_end_iterator(iterator);
-                  FC_ASSERT( tab, "not a valid end iterator" );
+                  EOS_ASSERT( tab, invalid_table_iterator, "not a valid end iterator" );
 
                   auto itr = idx.upper_bound(tab->id);
                   if( idx.begin() == idx.end() || itr == idx.begin() ) return -1; // Empty index
@@ -411,7 +411,7 @@ class apply_context {
                if( iterator < -1 ) // is end iterator
                {
                   auto tab = itr_cache.find_table_by_end_iterator(iterator);
-                  FC_ASSERT( tab, "not a valid end iterator" );
+                  EOS_ASSERT( tab, invalid_table_iterator, "not a valid end iterator" );
 
                   auto itr = idx.upper_bound(tab->id);
                   if( idx.begin() == idx.end() || itr == idx.begin() ) return -1; // Empty table

--- a/libraries/chain/include/eosio/chain/asset.hpp
+++ b/libraries/chain/include/eosio/chain/asset.hpp
@@ -43,14 +43,14 @@ struct asset
 
    asset& operator += (const asset& o)
    {
-      FC_ASSERT(get_symbol() == o.get_symbol());
+      EOS_ASSERT(get_symbol() == o.get_symbol(), asset_type_exception, "addition between two different asset is not allowed");
       amount += o.amount;
       return *this;
    }
 
    asset& operator -= (const asset& o)
    {
-      FC_ASSERT(get_symbol() == o.get_symbol());
+      EOS_ASSERT(get_symbol() == o.get_symbol(), asset_type_exception, "subtraction between two different asset is not allowed");
       amount -= o.amount;
       return *this;
    }
@@ -62,7 +62,7 @@ struct asset
    }
    friend bool operator < (const asset& a, const asset& b)
    {
-      FC_ASSERT(a.get_symbol() == b.get_symbol());
+      EOS_ASSERT(a.get_symbol() == b.get_symbol(), asset_type_exception, "logical operation between two different asset is not allowed");
       return std::tie(a.amount,a.get_symbol()) < std::tie(b.amount,b.get_symbol());
    }
    friend bool operator <= (const asset& a, const asset& b) { return (a == b) || (a < b); }
@@ -71,12 +71,12 @@ struct asset
    friend bool operator >= (const asset& a, const asset& b) { return !(a < b);  }
 
    friend asset operator - (const asset& a, const asset& b) {
-      FC_ASSERT(a.get_symbol() == b.get_symbol());
+      EOS_ASSERT(a.get_symbol() == b.get_symbol(), asset_type_exception, "subtraction between two different asset is not allowed");
       return asset(a.amount - b.amount, a.get_symbol());
    }
 
    friend asset operator + (const asset& a, const asset& b) {
-      FC_ASSERT(a.get_symbol() == b.get_symbol());
+      EOS_ASSERT(a.get_symbol() == b.get_symbol(), asset_type_exception, "addition between two different asset is not allowed");
       return asset(a.amount + b.amount, a.get_symbol());
    }
 

--- a/libraries/chain/include/eosio/chain/authority_checker.hpp
+++ b/libraries/chain/include/eosio/chain/authority_checker.hpp
@@ -85,7 +85,7 @@ namespace detail {
          ,provided_delay(provided_delay)
          ,recursion_depth_limit(recursion_depth_limit)
          {
-            FC_ASSERT( static_cast<bool>(checktime), "checktime cannot be empty" );
+            EOS_ASSERT( static_cast<bool>(checktime), authorization_exception, "checktime cannot be empty" );
          }
 
          enum permission_cache_status {

--- a/libraries/chain/include/eosio/chain/block_timestamp.hpp
+++ b/libraries/chain/include/eosio/chain/block_timestamp.hpp
@@ -6,6 +6,7 @@
 #include <fc/variant.hpp>
 #include <fc/string.hpp>
 #include <fc/optional.hpp>
+#include <eosio/chain/exceptions.hpp>
 
 namespace eosio { namespace chain {
 
@@ -31,7 +32,7 @@ namespace eosio { namespace chain {
          static block_timestamp min() { return block_timestamp(0); }
 
          block_timestamp next() const {
-            FC_ASSERT( std::numeric_limits<uint32_t>::max() - slot >= 1, "block timestamp overflow" );
+            EOS_ASSERT( std::numeric_limits<uint32_t>::max() - slot >= 1, overflow_exception, "block timestamp overflow" );
             auto result = block_timestamp(*this);
             result.slot += 1;
             return result;

--- a/libraries/chain/include/eosio/chain/block_timestamp.hpp
+++ b/libraries/chain/include/eosio/chain/block_timestamp.hpp
@@ -6,7 +6,7 @@
 #include <fc/variant.hpp>
 #include <fc/string.hpp>
 #include <fc/optional.hpp>
-#include <eosio/chain/exceptions.hpp>
+#include <fc/exception/exception.hpp>
 
 namespace eosio { namespace chain {
 
@@ -32,7 +32,7 @@ namespace eosio { namespace chain {
          static block_timestamp min() { return block_timestamp(0); }
 
          block_timestamp next() const {
-            EOS_ASSERT( std::numeric_limits<uint32_t>::max() - slot >= 1, overflow_exception, "block timestamp overflow" );
+            EOS_ASSERT( std::numeric_limits<uint32_t>::max() - slot >= 1, fc::overflow_exception, "block timestamp overflow" );
             auto result = block_timestamp(*this);
             result.slot += 1;
             return result;

--- a/libraries/chain/include/eosio/chain/exceptions.hpp
+++ b/libraries/chain/include/eosio/chain/exceptions.hpp
@@ -297,12 +297,10 @@ namespace eosio { namespace chain {
                                     3100005, "Extracted genesis state from blocks.log" )
       FC_DECLARE_DERIVED_EXCEPTION( subjective_block_production_exception,    misc_exception,
                                     3100006, "Subjective exception thrown during block production" )
-      FC_DECLARE_DERIVED_EXCEPTION( overflow_exception,    misc_exception,
-                                    3100007, "Oveflow" )
       FC_DECLARE_DERIVED_EXCEPTION( multiple_voter_info,    misc_exception,
-                                    3100008, "Multiple voter info detected" )
+                                    3100007, "Multiple voter info detected" )
       FC_DECLARE_DERIVED_EXCEPTION( unsupported_feature,    misc_exception,
-                                    3100009, "Feature is currently unsupported" )
+                                    3100008, "Feature is currently unsupported" )
       
 
 

--- a/libraries/chain/include/eosio/chain/exceptions.hpp
+++ b/libraries/chain/include/eosio/chain/exceptions.hpp
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <fc/exception/exception.hpp>
-#include <eosio/chain/protocol.hpp>
 #include <boost/core/typeinfo.hpp>
 
 
@@ -84,8 +83,18 @@ namespace eosio { namespace chain {
     *   |- wasm_exception
     *   |- resource_exhausted_exception
     *   |- misc_exception
-    *   |- missing_plugin_exception
+    *   |- plugin_exception
     *   |- wallet_exception
+    *   |- whitelist_blacklist_exception
+    *   |- controller_emit_signal_exception
+    *   |- abi_exception
+    *   |- contract_exception
+    *   |- producer_exception
+    *   |- reversible_blocks_exception
+    *   |- block_log_exception
+    *   |- resource_limit_exception
+    *   |- mongo_db_exception
+    *   |- contract_api_exception
     */
 
     FC_DECLARE_DERIVED_EXCEPTION( chain_type_exception, chain_exception,
@@ -105,51 +114,65 @@ namespace eosio { namespace chain {
                                     3010006, "Invalid transaction" )
       FC_DECLARE_DERIVED_EXCEPTION( abi_type_exception,                chain_type_exception,
                                     3010007, "Invalid ABI" )
-      FC_DECLARE_DERIVED_EXCEPTION( abi_not_found_exception,           chain_type_exception,
-                                    3010008, "No ABI found" )
       FC_DECLARE_DERIVED_EXCEPTION( block_id_type_exception,           chain_type_exception,
-                                    3010009, "Invalid block ID" )
+                                    3010008, "Invalid block ID" )
       FC_DECLARE_DERIVED_EXCEPTION( transaction_id_type_exception,     chain_type_exception,
-                                    3010010, "Invalid transaction ID" )
+                                    3010009, "Invalid transaction ID" )
       FC_DECLARE_DERIVED_EXCEPTION( packed_transaction_type_exception, chain_type_exception,
-                                    3010011, "Invalid packed transaction" )
+                                    3010010, "Invalid packed transaction" )
       FC_DECLARE_DERIVED_EXCEPTION( asset_type_exception,              chain_type_exception,
-                                    3010012, "Invalid asset" )
+                                    3010011, "Invalid asset" )
+      FC_DECLARE_DERIVED_EXCEPTION( chain_id_type_exception,           chain_type_exception,
+                                    3010012, "Invalid chain ID" )
+      FC_DECLARE_DERIVED_EXCEPTION( fixed_key_type_exception,           chain_type_exception,
+                                    3010013, "Invalid fixed key" )
+      FC_DECLARE_DERIVED_EXCEPTION( symbol_type_exception,           chain_type_exception,
+                                    3010014, "Invalid symbol" )
 
 
    FC_DECLARE_DERIVED_EXCEPTION( fork_database_exception, chain_exception,
-                                 3020000, "fork database exception" )
+                                 3020000, "Fork database exception" )
 
-      FC_DECLARE_DERIVED_EXCEPTION( unlinkable_block_exception, chain_exception,
-                                    3020001, "unlinkable block" )
+      FC_DECLARE_DERIVED_EXCEPTION( fork_db_block_not_found, fork_database_exception,
+                                    3020001, "Block can not be found" )
 
 
    FC_DECLARE_DERIVED_EXCEPTION( block_validate_exception, chain_exception,
-                                 3030000, "block exception" )
+                                 3030000, "Block exception" )
 
+      FC_DECLARE_DERIVED_EXCEPTION( unlinkable_block_exception, block_validate_exception,
+                                    3030001, "Unlinkable block" )
       FC_DECLARE_DERIVED_EXCEPTION( block_tx_output_exception,   block_validate_exception,
-                                    3030001, "transaction outputs in block do not match transaction outputs from applying block" )
+                                    3030002, "Transaction outputs in block do not match transaction outputs from applying block" )
       FC_DECLARE_DERIVED_EXCEPTION( block_concurrency_exception, block_validate_exception,
-                                    3030002, "block does not guarantee concurrent execution without conflicts" )
+                                    3030003, "Block does not guarantee concurrent execution without conflicts" )
       FC_DECLARE_DERIVED_EXCEPTION( block_lock_exception,        block_validate_exception,
-                                    3030003, "shard locks in block are incorrect or mal-formed" )
+                                    3030004, "Shard locks in block are incorrect or mal-formed" )
       FC_DECLARE_DERIVED_EXCEPTION( block_resource_exhausted,    block_validate_exception,
-                                    3030004, "block exhausted allowed resources" )
+                                    3030005, "Block exhausted allowed resources" )
       FC_DECLARE_DERIVED_EXCEPTION( block_too_old_exception,     block_validate_exception,
-                                    3030005, "block is too old to push" )
+                                    3030006, "Block is too old to push" )
+      FC_DECLARE_DERIVED_EXCEPTION( block_from_the_future,       block_validate_exception,
+                                    3030007, "Block is from the future" )
+      FC_DECLARE_DERIVED_EXCEPTION( wrong_signing_key,           block_validate_exception,
+                                    3030008, "Block is not signed with expected key" )
+      FC_DECLARE_DERIVED_EXCEPTION( wrong_producer,              block_validate_exception,
+                                    3030009, "Block is not signed by expected producer" )
+                                    
+                                    
 
 
    FC_DECLARE_DERIVED_EXCEPTION( transaction_exception,             chain_exception,
-                                 3040000, "transaction exception" )
+                                 3040000, "Transaction exception" )
 
       FC_DECLARE_DERIVED_EXCEPTION( tx_decompression_error,      transaction_exception,
                                     3040001, "Error decompressing transaction" )
       FC_DECLARE_DERIVED_EXCEPTION( tx_no_action,                transaction_exception,
-                                    3040002, "transaction should have at least one normal action" )
+                                    3040002, "Transaction should have at least one normal action" )
       FC_DECLARE_DERIVED_EXCEPTION( tx_no_auths,                 transaction_exception,
-                                    3040003, "transaction should have at least one required authority" )
+                                    3040003, "Transaction should have at least one required authority" )
       FC_DECLARE_DERIVED_EXCEPTION( cfa_irrelevant_auth,         transaction_exception,
-                                    3040004, "context-free action should have no required authority" )
+                                    3040004, "Context-free action should have no required authority" )
       FC_DECLARE_DERIVED_EXCEPTION( expired_tx_exception,        transaction_exception,
                                     3040005, "Expired Transaction" )
       FC_DECLARE_DERIVED_EXCEPTION( tx_exp_too_far_exception,    transaction_exception,
@@ -157,25 +180,45 @@ namespace eosio { namespace chain {
       FC_DECLARE_DERIVED_EXCEPTION( invalid_ref_block_exception, transaction_exception,
                                     3040007, "Invalid Reference Block" )
       FC_DECLARE_DERIVED_EXCEPTION( tx_duplicate,                transaction_exception,
-                                    3040008, "duplicate transaction" )
+                                    3040008, "Duplicate transaction" )
       FC_DECLARE_DERIVED_EXCEPTION( deferred_tx_duplicate,       transaction_exception,
-                                    3040009, "duplicate deferred transaction" )
+                                    3040009, "Duplicate deferred transaction" )
+      FC_DECLARE_DERIVED_EXCEPTION( cfa_inside_generated_tx,     transaction_exception,
+                                    3040010, "Context free action is not allowed inside generated transaction" )
+      FC_DECLARE_DERIVED_EXCEPTION( tx_not_found,     transaction_exception,
+                                    3040011, "The transaction can not be found" )
+      FC_DECLARE_DERIVED_EXCEPTION( too_many_tx_at_once,          transaction_exception,
+                                    3040012, "Pushing too many transactions at once" )
+      FC_DECLARE_DERIVED_EXCEPTION( tx_too_big,                   transaction_exception,
+                                    3040013, "Transaction is too big" )
+      FC_DECLARE_DERIVED_EXCEPTION( unknown_transaction_compression, transaction_exception,
+                                    3040014, "Unknown transaction compression" )
 
 
    FC_DECLARE_DERIVED_EXCEPTION( action_validate_exception, chain_exception,
-                                 3050000, "action exception" )
+                                 3050000, "Action validate exception" )
 
       FC_DECLARE_DERIVED_EXCEPTION( account_name_exists_exception, action_validate_exception,
-                                    3050001, "account name already exists" )
+                                    3050001, "Account name already exists" )
       FC_DECLARE_DERIVED_EXCEPTION( invalid_action_args_exception, action_validate_exception,
                                     3050002, "Invalid Action Arguments" )
       FC_DECLARE_DERIVED_EXCEPTION( eosio_assert_message_exception, action_validate_exception,
                                     3050003, "eosio_assert_message assertion failure" )
       FC_DECLARE_DERIVED_EXCEPTION( eosio_assert_code_exception, action_validate_exception,
                                     3050004, "eosio_assert_code assertion failure" )
+      FC_DECLARE_DERIVED_EXCEPTION( action_not_found_exception, action_validate_exception,
+                                    3050005, "Action can not be found" )
+      FC_DECLARE_DERIVED_EXCEPTION( action_data_and_struct_mismatch, action_validate_exception,
+                                    3050006, "Mismatch between action data and its struct" )
+      FC_DECLARE_DERIVED_EXCEPTION( unaccessible_api, action_validate_exception,
+                                    3050007, "Attempt to use unaccessible API" )
+      FC_DECLARE_DERIVED_EXCEPTION( abort_called, action_validate_exception,
+                                    3050008, "Abort Called" )
+      FC_DECLARE_DERIVED_EXCEPTION( inline_action_too_big, action_validate_exception,
+                                    3050009, "Inline Action exceeds maximum size limit" )
 
    FC_DECLARE_DERIVED_EXCEPTION( database_exception, chain_exception,
-                                 3060000, "database exception" )
+                                 3060000, "Database exception" )
 
       FC_DECLARE_DERIVED_EXCEPTION( permission_query_exception,     database_exception,
                                     3060001, "Permission Query Exception" )
@@ -185,89 +228,103 @@ namespace eosio { namespace chain {
                                     3060003, "Contract Table Query Exception" )
       FC_DECLARE_DERIVED_EXCEPTION( contract_query_exception,       database_exception,
                                     3060004, "Contract Query Exception" )
-
-
+     
    FC_DECLARE_DERIVED_EXCEPTION( wasm_exception, chain_exception,
                                  3070000, "WASM Exception" )
-
       FC_DECLARE_DERIVED_EXCEPTION( page_memory_error,        wasm_exception,
-                                    3070001, "error in WASM page memory" )
-
+                                    3070001, "Error in WASM page memory" )
       FC_DECLARE_DERIVED_EXCEPTION( wasm_execution_error,     wasm_exception,
                                     3070002, "Runtime Error Processing WASM" )
-
       FC_DECLARE_DERIVED_EXCEPTION( wasm_serialization_error, wasm_exception,
                                     3070003, "Serialization Error Processing WASM" )
-
       FC_DECLARE_DERIVED_EXCEPTION( overlapping_memory_error, wasm_exception,
                                     3070004, "memcpy with overlapping memory" )
-
+      FC_DECLARE_DERIVED_EXCEPTION( binaryen_exception, wasm_exception,
+                                    3070005, "binaryen exception" )
 
 
    FC_DECLARE_DERIVED_EXCEPTION( resource_exhausted_exception, chain_exception,
-                                 3080000, "resource exhausted exception" )
+                                 3080000, "Resource exhausted exception" )
 
       FC_DECLARE_DERIVED_EXCEPTION( ram_usage_exceeded, resource_exhausted_exception,
-                                    3080001, "account using more than allotted RAM usage" )
+                                    3080001, "Account using more than allotted RAM usage" )
       FC_DECLARE_DERIVED_EXCEPTION( tx_net_usage_exceeded, resource_exhausted_exception,
-                                    3080002, "transaction exceeded the current network usage limit imposed on the transaction" )
+                                    3080002, "Transaction exceeded the current network usage limit imposed on the transaction" )
       FC_DECLARE_DERIVED_EXCEPTION( block_net_usage_exceeded, resource_exhausted_exception,
-                                    3080003, "transaction network usage is too much for the remaining allowable usage of the current block" )
+                                    3080003, "Transaction network usage is too much for the remaining allowable usage of the current block" )
       FC_DECLARE_DERIVED_EXCEPTION( tx_cpu_usage_exceeded, resource_exhausted_exception,
-                                    3080004, "transaction exceeded the current CPU usage limit imposed on the transaction" )
+                                    3080004, "Transaction exceeded the current CPU usage limit imposed on the transaction" )
       FC_DECLARE_DERIVED_EXCEPTION( block_cpu_usage_exceeded, resource_exhausted_exception,
-                                    3080005, "transaction CPU usage is too much for the remaining allowable usage of the current block" )
+                                    3080005, "Transaction CPU usage is too much for the remaining allowable usage of the current block" )
       FC_DECLARE_DERIVED_EXCEPTION( deadline_exception, resource_exhausted_exception,
-                                    3080006, "transaction took too long" )
+                                    3080006, "Transaction took too long" )
       FC_DECLARE_DERIVED_EXCEPTION( leeway_deadline_exception, deadline_exception,
-                                    3081001, "transaction reached the deadline set due to leeway on account CPU limits" )
+                                    3081001, "Transaction reached the deadline set due to leeway on account CPU limits" )
 
    FC_DECLARE_DERIVED_EXCEPTION( authorization_exception, chain_exception,
                                  3090000, "Authorization exception" )
       FC_DECLARE_DERIVED_EXCEPTION( tx_duplicate_sig,             authorization_exception,
-                                    3090001, "duplicate signature included" )
+                                    3090001, "Duplicate signature included" )
       FC_DECLARE_DERIVED_EXCEPTION( tx_irrelevant_sig,            authorization_exception,
-                                    3090002, "irrelevant signature included" )
+                                    3090002, "Irrelevant signature included" )
       FC_DECLARE_DERIVED_EXCEPTION( unsatisfied_authorization,    authorization_exception,
-                                    3090003, "provided keys, permissions, and delays do not satisfy declared authorizations" )
+                                    3090003, "Provided keys, permissions, and delays do not satisfy declared authorizations" )
       FC_DECLARE_DERIVED_EXCEPTION( missing_auth_exception,       authorization_exception,
-                                    3090004, "missing required authority" )
+                                    3090004, "Missing required authority" )
       FC_DECLARE_DERIVED_EXCEPTION( irrelevant_auth_exception,    authorization_exception,
-                                    3090005, "irrelevant authority included" )
+                                    3090005, "Irrelevant authority included" )
       FC_DECLARE_DERIVED_EXCEPTION( insufficient_delay_exception, authorization_exception,
-                                    3090006, "insufficient delay" )
+                                    3090006, "Insufficient delay" )
+      FC_DECLARE_DERIVED_EXCEPTION( invalid_permission,           authorization_exception,
+                                    3090007, "Invalid Permission" )
+      FC_DECLARE_DERIVED_EXCEPTION( unlinkable_min_permission_action, authorization_exception,
+                                    3090008, "The action is not allowed to be linked with minimum permission" )
+      FC_DECLARE_DERIVED_EXCEPTION( invalid_parent_permission,           authorization_exception,
+                                    3090009, "The parent permission is invalid" )
 
    FC_DECLARE_DERIVED_EXCEPTION( misc_exception, chain_exception,
                                  3100000, "Miscellaneous exception" )
 
       FC_DECLARE_DERIVED_EXCEPTION( rate_limiting_state_inconsistent, misc_exception,
-                                    3100001, "internal state is no longer consistent" )
+                                    3100001, "Internal state is no longer consistent" )
       FC_DECLARE_DERIVED_EXCEPTION( unknown_block_exception,          misc_exception,
-                                    3100002, "unknown block" )
+                                    3100002, "Unknown block" )
       FC_DECLARE_DERIVED_EXCEPTION( unknown_transaction_exception,    misc_exception,
-                                    3100003, "unknown transaction" )
+                                    3100003, "Unknown transaction" )
       FC_DECLARE_DERIVED_EXCEPTION( fixed_reversible_db_exception,    misc_exception,
-                                    3100004, "corrupted reversible block database was fixed" )
+                                    3100004, "Corrupted reversible block database was fixed" )
       FC_DECLARE_DERIVED_EXCEPTION( extract_genesis_state_exception,    misc_exception,
-                                    3100005, "extracted genesis state from blocks.log" )
+                                    3100005, "Extracted genesis state from blocks.log" )
       FC_DECLARE_DERIVED_EXCEPTION( subjective_block_production_exception,    misc_exception,
-                                    3100006, "subjective exception thrown during block production" )
+                                    3100006, "Subjective exception thrown during block production" )
+      FC_DECLARE_DERIVED_EXCEPTION( overflow_exception,    misc_exception,
+                                    3100007, "Oveflow" )
+      FC_DECLARE_DERIVED_EXCEPTION( multiple_voter_info,    misc_exception,
+                                    3100008, "Multiple voter info detected" )
+      FC_DECLARE_DERIVED_EXCEPTION( unsupported_feature,    misc_exception,
+                                    3100009, "Feature is currently unsupported" )
+      
 
-   FC_DECLARE_DERIVED_EXCEPTION( missing_plugin_exception, chain_exception,
-                                 3110000, "missing plugin exception" )
 
-      FC_DECLARE_DERIVED_EXCEPTION( missing_chain_api_plugin_exception,           missing_plugin_exception,
+   FC_DECLARE_DERIVED_EXCEPTION( plugin_exception, chain_exception,
+                                 3110000, "Plugin exception" )
+
+      FC_DECLARE_DERIVED_EXCEPTION( missing_chain_api_plugin_exception,           plugin_exception,
                                     3110001, "Missing Chain API Plugin" )
-      FC_DECLARE_DERIVED_EXCEPTION( missing_wallet_api_plugin_exception,          missing_plugin_exception,
+      FC_DECLARE_DERIVED_EXCEPTION( missing_wallet_api_plugin_exception,          plugin_exception,
                                     3110002, "Missing Wallet API Plugin" )
-      FC_DECLARE_DERIVED_EXCEPTION( missing_history_api_plugin_exception, missing_plugin_exception,
+      FC_DECLARE_DERIVED_EXCEPTION( missing_history_api_plugin_exception,         plugin_exception,
                                     3110003, "Missing History API Plugin" )
-      FC_DECLARE_DERIVED_EXCEPTION( missing_net_api_plugin_exception,             missing_plugin_exception,
+      FC_DECLARE_DERIVED_EXCEPTION( missing_net_api_plugin_exception,             plugin_exception,
                                     3110004, "Missing Net API Plugin" )
+      FC_DECLARE_DERIVED_EXCEPTION( missing_chain_plugin_exception,               plugin_exception,
+                                    3110005, "Missing Chain Plugin" )
+      FC_DECLARE_DERIVED_EXCEPTION( plugin_config_exception,               plugin_exception,
+                                    3110006, "Incorrect plugin configuration" )
 
 
    FC_DECLARE_DERIVED_EXCEPTION( wallet_exception, chain_exception,
-                                 3120000, "wallet exception" )
+                                 3120000, "Wallet exception" )
 
       FC_DECLARE_DERIVED_EXCEPTION( wallet_exist_exception,            wallet_exception,
                                     3120001, "Wallet already exists" )
@@ -288,10 +345,15 @@ namespace eosio { namespace chain {
       FC_DECLARE_DERIVED_EXCEPTION( key_nonexistent_exception,         wallet_exception,
                                     3120009, "Nonexistent key" )
       FC_DECLARE_DERIVED_EXCEPTION( unsupported_key_type_exception,    wallet_exception,
-                                    3120009, "Unsupported key type" )
+                                    3120010, "Unsupported key type" )
+      FC_DECLARE_DERIVED_EXCEPTION( invalid_lock_timeout_exception,    wallet_exception,
+                                    3120011, "Wallet lock timeout is invalid" )
+      FC_DECLARE_DERIVED_EXCEPTION( secure_enclave_exception,          wallet_exception,
+                                    3120012, "Secure Enclave Exception" )
+ 
 
    FC_DECLARE_DERIVED_EXCEPTION( whitelist_blacklist_exception,   chain_exception,
-                                 3130000, "actor or contract whitelist/blacklist exception" )
+                                 3130000, "Actor or contract whitelist/blacklist exception" )
 
       FC_DECLARE_DERIVED_EXCEPTION( actor_whitelist_exception,    whitelist_blacklist_exception,
                                     3130001, "Authorizing actor of transaction is not on the whitelist" )
@@ -307,8 +369,127 @@ namespace eosio { namespace chain {
                                     3130006, "Public key in authority is on the blacklist" )
 
    FC_DECLARE_DERIVED_EXCEPTION( controller_emit_signal_exception, chain_exception,
-                                 3140000, "exceptions that are allowed to bubble out of emit calls in controller" )
+                                 3140000, "Exceptions that are allowed to bubble out of emit calls in controller" )
       FC_DECLARE_DERIVED_EXCEPTION( checkpoint_exception,          controller_emit_signal_exception,
                                    3140001, "Block does not match checkpoint" )
 
+
+   FC_DECLARE_DERIVED_EXCEPTION( abi_exception,                           chain_exception,
+                                 3015000, "ABI exception" ) 
+      FC_DECLARE_DERIVED_EXCEPTION( abi_not_found_exception,              abi_exception,
+                                    3015001, "No ABI found" )
+      FC_DECLARE_DERIVED_EXCEPTION( invalid_ricardian_clause_exception,   abi_exception,
+                                    3015002, "Invalid Ricardian Clause" )
+      FC_DECLARE_DERIVED_EXCEPTION( invalid_ricardian_action_exception,   abi_exception,
+                                    3015003, "Invalid Ricardian Action" )
+      FC_DECLARE_DERIVED_EXCEPTION( invalid_type_inside_abi,           abi_exception,
+                                    3015004, "The type defined in the ABI is invalid" ) // Not to be confused with abi_type_exception
+      FC_DECLARE_DERIVED_EXCEPTION( duplicate_abi_type_def_exception,     abi_exception,
+                                    3015005, "Duplicate type definition in the ABI" )
+      FC_DECLARE_DERIVED_EXCEPTION( duplicate_abi_struct_def_exception,   abi_exception,
+                                    3015006, "Duplicate struct definition in the ABI" )
+      FC_DECLARE_DERIVED_EXCEPTION( duplicate_abi_action_def_exception,   abi_exception,
+                                    3015007, "Duplicate action definition in the ABI" )
+      FC_DECLARE_DERIVED_EXCEPTION( duplicate_abi_table_def_exception,    abi_exception,
+                                    3015008, "Duplicate table definition in the ABI" )
+      FC_DECLARE_DERIVED_EXCEPTION( duplicate_abi_err_msg_def_exception,  abi_exception,
+                                    3015009, "Duplicate error message definition in the ABI" )
+      FC_DECLARE_DERIVED_EXCEPTION( abi_serialization_deadline_exception, abi_exception,
+                                    3015010, "ABI serialization time has exceeded the deadline" )
+      FC_DECLARE_DERIVED_EXCEPTION( abi_recursion_depth_exception,        abi_exception,
+                                    3015011, "ABI recursive definition has exceeded the max recursion depth" ) 
+      FC_DECLARE_DERIVED_EXCEPTION( abi_circular_def_exception,           abi_exception,
+                                    3015012, "Circular definition is detected in the ABI" ) 
+      FC_DECLARE_DERIVED_EXCEPTION( unpack_exception,                     abi_exception,
+                                    3015013, "Unpack data exception" ) 
+      FC_DECLARE_DERIVED_EXCEPTION( pack_exception,                     abi_exception,
+                                    3015014, "Pack data exception" ) 
+
+   FC_DECLARE_DERIVED_EXCEPTION( contract_exception,           chain_exception,
+                                 3160000, "Contract exception" )
+      FC_DECLARE_DERIVED_EXCEPTION( invalid_table_payer,             contract_exception,
+                                    3160001, "The payer of the table data is invalid" )
+      FC_DECLARE_DERIVED_EXCEPTION( table_access_violation,          contract_exception,
+                                    3160002, "Table access violation" )
+      FC_DECLARE_DERIVED_EXCEPTION( invalid_table_iterator,          contract_exception,
+                                    3160003, "Invalid table iterator" )
+      FC_DECLARE_DERIVED_EXCEPTION( table_not_in_cache,          contract_exception,
+                                    3160004, "Table can not be found inside the cache" )
+      FC_DECLARE_DERIVED_EXCEPTION( table_operation_not_permitted,          contract_exception,
+                                    3160005, "The table operation is not allowed" )
+      FC_DECLARE_DERIVED_EXCEPTION( invalid_contract_vm_type,          contract_exception,
+                                    3160006, "Invalid contract vm type" )
+      FC_DECLARE_DERIVED_EXCEPTION( invalid_contract_vm_version,          contract_exception,
+                                    3160007, "Invalid contract vm version" )
+      FC_DECLARE_DERIVED_EXCEPTION( set_exact_code,          contract_exception,
+                                    3160008, "Contract is already running this version of code" )
+      FC_DECLARE_DERIVED_EXCEPTION( wast_file_not_found,          contract_exception,
+                                    3160009, "No wast file found" )
+      FC_DECLARE_DERIVED_EXCEPTION( abi_file_not_found,          contract_exception,
+                                    3160010, "No abi file found" )
+
+   FC_DECLARE_DERIVED_EXCEPTION( producer_exception,           chain_exception,
+                                 3170000, "Producer exception" )
+      FC_DECLARE_DERIVED_EXCEPTION( producer_priv_key_not_found,   producer_exception,
+                                    3170001, "Producer private key is not available" )
+      FC_DECLARE_DERIVED_EXCEPTION( missing_pending_block_state,   producer_exception,
+                                    3170002, "Pending block state is missing" )
+      FC_DECLARE_DERIVED_EXCEPTION( producer_double_confirm,       producer_exception,
+                                    3170003, "Producer is double confirming known range" )
+      FC_DECLARE_DERIVED_EXCEPTION( producer_schedule_exception,   producer_exception,
+                                    3170004, "Producer schedule exception" )
+      FC_DECLARE_DERIVED_EXCEPTION( producer_not_in_schedule,      producer_exception,
+                                    3170006, "The producer is not part of current schedule" )
+
+   FC_DECLARE_DERIVED_EXCEPTION( reversible_blocks_exception,           chain_exception,
+                                 3180000, "Reversible Blocks exception" )
+      FC_DECLARE_DERIVED_EXCEPTION( invalid_reversible_blocks_dir,             reversible_blocks_exception,
+                                    3180001, "Invalid reversible blocks directory" )
+      FC_DECLARE_DERIVED_EXCEPTION( reversible_blocks_backup_dir_exist,          reversible_blocks_exception,
+                                    3180002, "Backup directory for reversible blocks already existg" )
+      FC_DECLARE_DERIVED_EXCEPTION( gap_in_reversible_blocks_db,          reversible_blocks_exception,
+                                    3180003, "There is gap in reversible blocks database" )
+
+   FC_DECLARE_DERIVED_EXCEPTION( block_log_exception, chain_exception,
+                                 3190000, "Block log exception" )
+      FC_DECLARE_DERIVED_EXCEPTION( block_log_unsupported_version, block_log_exception,
+                                    3190001, "unsupported version of block log" )
+      FC_DECLARE_DERIVED_EXCEPTION( block_log_append_fail, block_log_exception,
+                                    3190002, "fail to append block to the block log" )
+      FC_DECLARE_DERIVED_EXCEPTION( block_log_not_found, block_log_exception,
+                                    3190003, "block log can not be found" )
+      FC_DECLARE_DERIVED_EXCEPTION( block_log_backup_dir_exist, block_log_exception,
+                                    3190004, "block log backup dir already exists" )
+
+   FC_DECLARE_DERIVED_EXCEPTION( http_exception, chain_exception,
+                                 3200000, "http exception" )
+      FC_DECLARE_DERIVED_EXCEPTION( invalid_http_client_root_cert,    http_exception,
+                                    3200001, "invalid http client root certificate" )
+      FC_DECLARE_DERIVED_EXCEPTION( invalid_http_response, http_exception,
+                                    3200002, "invalid http response" )
+      FC_DECLARE_DERIVED_EXCEPTION( resolved_to_multiple_ports, block_log_exception,
+                                    3200003, "service resolved to multiple ports" )
+      FC_DECLARE_DERIVED_EXCEPTION( fail_to_resolve_host, block_log_exception,
+                                    3200004, "fail to resolve host" )
+      FC_DECLARE_DERIVED_EXCEPTION( http_request_fail, block_log_exception,
+                                    3200005, "http request fail" )
+
+   FC_DECLARE_DERIVED_EXCEPTION( resource_limit_exception, chain_exception,
+                                 3210000, "Resource limit exception" )
+   
+   FC_DECLARE_DERIVED_EXCEPTION( mongo_db_exception, chain_exception,
+                                 3220000, "Mongo DB exception" )
+      FC_DECLARE_DERIVED_EXCEPTION( mongo_db_insert_fail, mongo_db_exception,
+                                 3220001, "Fail to insert new data to Mongo DB" )
+      FC_DECLARE_DERIVED_EXCEPTION( mongo_db_update_fail, mongo_db_exception,
+                                 3220002, "Fail to update existing data in Mongo DB" )
+
+   FC_DECLARE_DERIVED_EXCEPTION( contract_api_exception,    chain_exception,
+                                 3230000, "Contract API exception" )
+      FC_DECLARE_DERIVED_EXCEPTION( crypto_api_exception,   contract_api_exception,
+                                    3230001, "Crypto API Exception" )
+      FC_DECLARE_DERIVED_EXCEPTION( db_api_exception,       contract_api_exception,
+                                    3230002, "Database API Exception" )
+      FC_DECLARE_DERIVED_EXCEPTION( arithmetic_exception,   contract_api_exception,
+                                    3230003, "Arithmetic Exception" )
 } } // eosio::chain

--- a/libraries/chain/include/eosio/chain/fixed_key.hpp
+++ b/libraries/chain/include/eosio/chain/fixed_key.hpp
@@ -9,7 +9,7 @@
 #include <type_traits>
 
 #include <fc/exception/exception.hpp>
-
+#include <eosio/chain/exceptions.hpp>
 namespace eosio {
 
    using chain::uint128_t;
@@ -58,7 +58,7 @@ namespace eosio {
                    continue;
                }
 
-               FC_ASSERT( sub_words_left == 1, "unexpected error in fixed_key constructor" );
+               EOS_ASSERT( sub_words_left == 1, chain::fixed_key_type_exception, "unexpected error in fixed_key constructor" );
                temp_word |= static_cast<word_t>(w);
                sub_words_left = num_sub_words;
 

--- a/libraries/chain/include/eosio/chain/resource_limits_private.hpp
+++ b/libraries/chain/include/eosio/chain/resource_limits_private.hpp
@@ -98,7 +98,7 @@ namespace eosio { namespace chain { namespace resource_limits {
             EOS_ASSERT(std::numeric_limits<decltype(value_ex)>::max() - value_ex >= value_ex_contrib, rate_limiting_state_inconsistent, "Overflow in accumulated value when adding usage!");
 
             if( last_ordinal != ordinal ) {
-               FC_ASSERT( ordinal > last_ordinal, "new ordinal cannot be less than the previous ordinal" );
+               EOS_ASSERT( ordinal > last_ordinal, resource_limit_exception, "new ordinal cannot be less than the previous ordinal" );
                if( (uint64_t)last_ordinal + window_size > (uint64_t)ordinal ) {
                   const auto delta = ordinal - last_ordinal; // clearly 0 < delta < window_size
                   const auto decay = make_ratio(

--- a/libraries/chain/include/eosio/chain/symbol.hpp
+++ b/libraries/chain/include/eosio/chain/symbol.hpp
@@ -44,7 +44,7 @@ namespace eosio {
             uint64_t result = 0;
             for (uint32_t i = 0; i < len; ++i) {
                // All characters must be upper case alphabets
-               FC_ASSERT (str[i] >= 'A' && str[i] <= 'Z', "invalid character in symbol name");
+               EOS_ASSERT (str[i] >= 'A' && str[i] <= 'Z', symbol_type_exception, "invalid character in symbol name");
                result |= (uint64_t(str[i]) << (8*(i+1)));
             }
             result |= uint64_t(precision);
@@ -64,22 +64,22 @@ namespace eosio {
             static constexpr uint8_t max_precision = 18;
 
             explicit symbol(uint8_t p, const char* s): m_value(string_to_symbol(p, s)) {
-               FC_ASSERT(valid(), "invalid symbol: ${s}", ("s",s));
+               EOS_ASSERT(valid(), symbol_type_exception, "invalid symbol: ${s}", ("s",s));
             }
             explicit symbol(uint64_t v = CORE_SYMBOL): m_value(v) {
-               FC_ASSERT(valid(), "invalid symbol: ${name}", ("name",name()));
+               EOS_ASSERT(valid(), symbol_type_exception, "invalid symbol: ${name}", ("name",name()));
             }
             static symbol from_string(const string& from)
             {
                try {
                   string s = fc::trim(from);
-                  FC_ASSERT(!s.empty(), "creating symbol from empty string");
+                  EOS_ASSERT(!s.empty(), symbol_type_exception, "creating symbol from empty string");
                   auto comma_pos = s.find(',');
-                  FC_ASSERT(comma_pos != string::npos, "missing comma in symbol");
+                  EOS_ASSERT(comma_pos != string::npos, symbol_type_exception, "missing comma in symbol");
                   auto prec_part = s.substr(0, comma_pos);
                   uint8_t p = fc::to_int64(prec_part);
                   string name_part = s.substr(comma_pos + 1);
-                  FC_ASSERT( p <= max_precision, "precision ${p} should be <= 18", ("p", p));
+                  EOS_ASSERT( p <= max_precision, symbol_type_exception, "precision ${p} should be <= 18", ("p", p));
                   return symbol(string_to_symbol(p, name_part.c_str()));
                } FC_CAPTURE_LOG_AND_RETHROW((from))
             }
@@ -97,7 +97,7 @@ namespace eosio {
             uint8_t decimals() const { return m_value & 0xFF; }
             uint64_t precision() const
             {
-               FC_ASSERT( decimals() <= max_precision, "precision ${p} should be <= 18", ("p", decimals()) );
+               EOS_ASSERT( decimals() <= max_precision, symbol_type_exception, "precision ${p} should be <= 18", ("p", decimals()) );
                uint64_t p10 = 1;
                uint64_t p = decimals();
                while( p > 0  ) {
@@ -138,8 +138,8 @@ namespace eosio {
             }
 
             void reflector_verify()const {
-               FC_ASSERT( decimals() <= max_precision, "precision ${p} should be <= 18", ("p", decimals()) );
-               FC_ASSERT( valid_name(name()), "invalid symbol: ${name}", ("name",name()));
+               EOS_ASSERT( decimals() <= max_precision, symbol_type_exception, "precision ${p} should be <= 18", ("p", decimals()) );
+               EOS_ASSERT( valid_name(name()), symbol_type_exception, "invalid symbol: ${name}", ("name",name()));
             }
 
          private:

--- a/libraries/chain/include/eosio/chain/wasm_eosio_binary_ops.hpp
+++ b/libraries/chain/include/eosio/chain/wasm_eosio_binary_ops.hpp
@@ -5,6 +5,7 @@
 #include <boost/preprocessor/seq/remove.hpp>
 #include <boost/preprocessor/seq/push_back.hpp>
 #include <fc/reflect/reflect.hpp>
+#include <eosio/chain/exceptions.hpp>
 
 #include <cstdint>
 #include <functional>
@@ -663,14 +664,14 @@ struct EOSIO_OperatorDecoderStream
    operator bool() const { return nextByte < end; }
 
    instr* decodeOp() {
-      FC_ASSERT(nextByte + sizeof(IR::Opcode) <= end);
+      EOS_ASSERT(nextByte + sizeof(IR::Opcode) <= end, wasm_exception, "");
       IR::Opcode opcode = *(IR::Opcode*)nextByte;  
       switch(opcode)
       {
       #define VISIT_OPCODE(opcode,name,nameString,Imm,...) \
          case IR::Opcode::name: \
          { \
-            FC_ASSERT(nextByte + sizeof(IR::OpcodeAndImm<IR::Imm>) <= end); \
+            EOS_ASSERT(nextByte + sizeof(IR::OpcodeAndImm<IR::Imm>) <= end, wasm_exception, ""); \
             IR::OpcodeAndImm<IR::Imm>* encodedOperator = (IR::OpcodeAndImm<IR::Imm>*)nextByte; \
             nextByte += sizeof(IR::OpcodeAndImm<IR::Imm>); \
             auto op = _cached_ops->at(BOOST_PP_CAT(name, _code)); \

--- a/libraries/chain/include/eosio/chain/wasm_interface.hpp
+++ b/libraries/chain/include/eosio/chain/wasm_interface.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <eosio/chain/types.hpp>
+#include <eosio/chain/exceptions.hpp>
 #include "Runtime/Linker.h"
 #include "Runtime/Runtime.h"
 
@@ -31,14 +32,14 @@ namespace eosio { namespace chain {
          //protect access to "private" injected functions; so for now just simply allow "env" since injected functions
          //  are in a different module
          if(validating && mod_name != "env")
-            FC_ASSERT( !"importing from module that is not 'env'", "${module}.${export}", ("module",mod_name)("export",export_name) );
+            EOS_ASSERT( false, wasm_exception, "importing from module that is not 'env': ${module}.${export}", ("module",mod_name)("export",export_name) );
 
          // Try to resolve an intrinsic first.
          if(Runtime::IntrinsicResolver::singleton.resolve(mod_name,export_name,type, out)) {
             return true;
          }
 
-         FC_ASSERT( !"unresolvable", "${module}.${export}", ("module",mod_name)("export",export_name) );
+         EOS_ASSERT( false, wasm_exception, "${module}.${export} unresolveable", ("module",mod_name)("export",export_name) );
          return false;
       } FC_CAPTURE_AND_RETHROW( (mod_name)(export_name) ) }
       };

--- a/libraries/chain/include/eosio/chain/wasm_interface_private.hpp
+++ b/libraries/chain/include/eosio/chain/wasm_interface_private.hpp
@@ -6,6 +6,7 @@
 #include <eosio/chain/webassembly/runtime_interface.hpp>
 #include <eosio/chain/wasm_eosio_injection.hpp>
 #include <eosio/chain/transaction_context.hpp>
+#include <eosio/chain/exceptions.hpp>
 #include <fc/scoped_exit.hpp>
 
 #include "IR/Module.h"
@@ -28,15 +29,15 @@ namespace eosio { namespace chain {
          else if(vm == wasm_interface::vm_type::binaryen)
             runtime_interface = std::make_unique<webassembly::binaryen::binaryen_runtime>();
          else
-            FC_THROW("wasm_interface_impl fall through");
+            EOS_THROW(wasm_exception, "wasm_interface_impl fall through");
       }
 
       std::vector<uint8_t> parse_initial_memory(const Module& module) {
          std::vector<uint8_t> mem_image;
 
          for(const DataSegment& data_segment : module.dataSegments) {
-            FC_ASSERT(data_segment.baseOffset.type == InitializerExpression::Type::i32_const);
-            FC_ASSERT(module.memories.defs.size());
+            EOS_ASSERT(data_segment.baseOffset.type == InitializerExpression::Type::i32_const, wasm_exception, "");
+            EOS_ASSERT(module.memories.defs.size(), wasm_exception, "");
             const U32 base_offset = data_segment.baseOffset.i32;
             const Uptr memory_size = (module.memories.defs[0].type.size.min << IR::numBytesPerPageLog2);
             if(base_offset >= memory_size || base_offset + data_segment.data.size() > memory_size)

--- a/libraries/chain/include/eosio/chain/webassembly/binaryen.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/binaryen.hpp
@@ -158,7 +158,7 @@ class binaryen_runtime : public eosio::chain::wasm_runtime_interface {
 template<typename T>
 inline array_ptr<T> array_ptr_impl (interpreter_interface* interface, uint32_t ptr, uint32_t length)
 {
-   FC_ASSERT( length < INT_MAX/(uint32_t)sizeof(T), "length will overflow" );
+   EOS_ASSERT( length < INT_MAX/(uint32_t)sizeof(T), binaryen_exception, "length will overflow" );
    return array_ptr<T>((T*)(interface->get_validated_pointer(ptr, length * (uint32_t)sizeof(T))));
 }
 
@@ -586,7 +586,7 @@ struct intrinsic_invoker_impl<Ret, std::tuple<T &, Inputs...>> {
    static auto translate_one(interpreter_interface* interface, Inputs... rest, LiteralList& args, int offset) -> std::enable_if_t<std::is_const<U>::value, Ret> {
       // references cannot be created for null pointers
       uint32_t ptr = args.at((uint32_t)offset).geti32();
-      FC_ASSERT(ptr != 0);
+      EOS_ASSERT(ptr != 0, binaryen_exception, "references cannot be created for null pointers");
       T* base = array_ptr_impl<T>(interface, ptr, 1);
       if ( reinterpret_cast<uintptr_t>(base) % alignof(T) != 0 ) {
          wlog( "misaligned const reference" );
@@ -602,7 +602,7 @@ struct intrinsic_invoker_impl<Ret, std::tuple<T &, Inputs...>> {
    static auto translate_one(interpreter_interface* interface, Inputs... rest, LiteralList& args, int offset) -> std::enable_if_t<!std::is_const<U>::value, Ret> {
       // references cannot be created for null pointers
       uint32_t ptr = args.at((uint32_t)offset).geti32();
-      FC_ASSERT(ptr != 0);
+      EOS_ASSERT(ptr != 0, binaryen_exception, "references cannot be created for null pointers");
       T* base = array_ptr_impl<T>(interface, ptr, 1);
       if ( reinterpret_cast<uintptr_t>(base) % alignof(T) != 0 ) {
          wlog( "misaligned reference" );

--- a/libraries/chain/include/eosio/chain/webassembly/wavm.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/wavm.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <eosio/chain/webassembly/common.hpp>
+#include <eosio/chain/exceptions.hpp>
 #include <eosio/chain/webassembly/runtime_interface.hpp>
 #include <softfloat.hpp>
 #include "Runtime/Runtime.h"
@@ -580,7 +581,7 @@ struct intrinsic_invoker_impl<Ret, std::tuple<T &, Inputs...>, std::tuple<Transl
    template<then_type Then, typename U=T>
    static auto translate_one(running_instance_context& ctx, Inputs... rest, Translated... translated, I32 ptr) -> std::enable_if_t<std::is_const<U>::value, Ret> {
       // references cannot be created for null pointers
-      FC_ASSERT((U32)ptr != 0);
+      EOS_ASSERT((U32)ptr != 0, wasm_exception, "references cannot be created for null pointers");
       MemoryInstance* mem = ctx.memory;
       if(!mem || (U32)ptr+sizeof(T) >= IR::numBytesPerPage*Runtime::getMemoryNumPages(mem))
          Runtime::causeException(Exception::Cause::accessViolation);
@@ -598,7 +599,7 @@ struct intrinsic_invoker_impl<Ret, std::tuple<T &, Inputs...>, std::tuple<Transl
    template<then_type Then, typename U=T>
    static auto translate_one(running_instance_context& ctx, Inputs... rest, Translated... translated, I32 ptr) -> std::enable_if_t<!std::is_const<U>::value, Ret> {
       // references cannot be created for null pointers
-      FC_ASSERT((U32)ptr != 0);
+      EOS_ASSERT((U32)ptr != 0, wasm_exception, "reference cannot be created for null pointers");
       MemoryInstance* mem = ctx.memory;
       if(!mem || (U32)ptr+sizeof(T) >= IR::numBytesPerPage*Runtime::getMemoryNumPages(mem))
          Runtime::causeException(Exception::Cause::accessViolation);

--- a/libraries/chain/resource_limits.cpp
+++ b/libraries/chain/resource_limits.cpp
@@ -22,9 +22,9 @@ static uint64_t update_elastic_limit(uint64_t current_limit, uint64_t average_us
 void elastic_limit_parameters::validate()const {
    // At the very least ensure parameters are not set to values that will cause divide by zero errors later on.
    // Stricter checks for sensible values can be added later.
-   FC_ASSERT( periods > 0, "elastic limit parameter 'periods' cannot be zero" );
-   FC_ASSERT( contract_rate.denominator > 0, "elastic limit parameter 'contract_rate' is not a well-defined ratio" );
-   FC_ASSERT( expand_rate.denominator > 0,   "elastic limit parameter 'expand_rate' is not a well-defined ratio" );
+   EOS_ASSERT( periods > 0, resource_limit_exception, "elastic limit parameter 'periods' cannot be zero" );
+   EOS_ASSERT( contract_rate.denominator > 0, resource_limit_exception, "elastic limit parameter 'contract_rate' is not a well-defined ratio" );
+   EOS_ASSERT( expand_rate.denominator > 0, resource_limit_exception, "elastic limit parameter 'expand_rate' is not a well-defined ratio" );
 }
 
 

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -24,12 +24,12 @@ namespace eosio { namespace chain {
    {
       trace->id = id;
       executed.reserve( trx.total_actions() );
-      FC_ASSERT( trx.transaction_extensions.size() == 0, "we don't support any extensions yet" );
+      EOS_ASSERT( trx.transaction_extensions.size() == 0, unsupported_feature, "we don't support any extensions yet" );
    }
 
    void transaction_context::init(uint64_t initial_net_usage )
    {
-      FC_ASSERT( !is_initialized, "cannot initialize twice" );
+      EOS_ASSERT( !is_initialized, transaction_exception, "cannot initialize twice" );
       const static int64_t large_number_no_overflow = std::numeric_limits<int64_t>::max()/2;
 
       const auto& cfg = control.get_global_properties().configuration;
@@ -181,7 +181,7 @@ namespace eosio { namespace chain {
    }
 
    void transaction_context::exec() {
-      FC_ASSERT( is_initialized, "must first initialize" );
+      EOS_ASSERT( is_initialized, transaction_exception, "must first initialize" );
 
       if( apply_context_free ) {
          for( const auto& act : trx.context_free_actions ) {
@@ -201,7 +201,7 @@ namespace eosio { namespace chain {
    }
 
    void transaction_context::finalize() {
-      FC_ASSERT( is_initialized, "must first initialize" );
+      EOS_ASSERT( is_initialized, transaction_exception, "must first initialize" );
       const static int64_t large_number_no_overflow = std::numeric_limits<int64_t>::max()/2;
 
       if( is_input ) {
@@ -303,7 +303,7 @@ namespace eosio { namespace chain {
                        "but it is possible it could have succeeded if it were allowed to run to completion",
                        ("now", now)("deadline", _deadline)("start", start)("billing_timer", now - pseudo_start) );
          }
-         FC_ASSERT( false, "unexpected deadline exception code" );
+         EOS_ASSERT( false,  transaction_exception, "unexpected deadline exception code" );
       }
    }
 

--- a/libraries/chain/wasm_interface.cpp
+++ b/libraries/chain/wasm_interface.cpp
@@ -70,7 +70,7 @@ class context_aware_api {
       :context(ctx)
       {
          if( context.context_free )
-            FC_ASSERT( context_free, "only context free api's can be used in this context" );
+            EOS_ASSERT( context_free, unaccessible_api, "only context free api's can be used in this context" );
          context.used_context_free_api |= !context_free;
       }
 
@@ -88,7 +88,7 @@ class context_free_api : public context_aware_api {
       context_free_api( apply_context& ctx )
       :context_aware_api(ctx, true) {
          /* the context_free_data is not available during normal application because it is prunable */
-         FC_ASSERT( context.context_free, "this API may only be called from context_free apply" );
+         EOS_ASSERT( context.context_free, unaccessible_api, "this API may only be called from context_free apply" );
       }
 
       int get_context_free_data( uint32_t index, array_ptr<char> buffer, size_t buffer_size )const {
@@ -101,7 +101,7 @@ class privileged_api : public context_aware_api {
       privileged_api( apply_context& ctx )
       :context_aware_api(ctx)
       {
-         FC_ASSERT( context.privileged, "${code} does not have permission to call this API", ("code",context.receiver) );
+         EOS_ASSERT( context.privileged, unaccessible_api, "${code} does not have permission to call this API", ("code",context.receiver) );
       }
 
       /**
@@ -122,7 +122,7 @@ class privileged_api : public context_aware_api {
        *  Feature name should be base32 encoded name.
        */
       void activate_feature( int64_t feature_name ) {
-         FC_ASSERT( !"Unsupported Hardfork Detected" );
+         EOS_ASSERT( false, unsupported_feature, "Unsupported Hardfork Detected" );
       }
 
       /**
@@ -712,7 +712,7 @@ class crypto_api : public context_aware_api {
          fc::raw::unpack(pubds, p);
 
          auto check = fc::crypto::public_key( s, digest, false );
-         FC_ASSERT( check == p, "Error expected key different than recovered key" );
+         EOS_ASSERT( check == p, crypto_api_exception, "Error expected key different than recovered key" );
       }
 
       int recover_key( const fc::sha256& digest,
@@ -742,22 +742,22 @@ class crypto_api : public context_aware_api {
 
       void assert_sha256(array_ptr<char> data, size_t datalen, const fc::sha256& hash_val) {
          auto result = encode<fc::sha256::encoder>( data, datalen );
-         FC_ASSERT( result == hash_val, "hash mismatch" );
+         EOS_ASSERT( result == hash_val, crypto_api_exception, "hash mismatch" );
       }
 
       void assert_sha1(array_ptr<char> data, size_t datalen, const fc::sha1& hash_val) {
          auto result = encode<fc::sha1::encoder>( data, datalen );
-         FC_ASSERT( result == hash_val, "hash mismatch" );
+         EOS_ASSERT( result == hash_val, crypto_api_exception, "hash mismatch" );
       }
 
       void assert_sha512(array_ptr<char> data, size_t datalen, const fc::sha512& hash_val) {
          auto result = encode<fc::sha512::encoder>( data, datalen );
-         FC_ASSERT( result == hash_val, "hash mismatch" );
+         EOS_ASSERT( result == hash_val, crypto_api_exception, "hash mismatch" );
       }
 
       void assert_ripemd160(array_ptr<char> data, size_t datalen, const fc::ripemd160& hash_val) {
          auto result = encode<fc::ripemd160::encoder>( data, datalen );
-         FC_ASSERT( result == hash_val, "hash mismatch" );
+         EOS_ASSERT( result == hash_val, crypto_api_exception, "hash mismatch" );
       }
 
       void sha1(array_ptr<char> data, size_t datalen, fc::sha1& hash_val) {
@@ -919,7 +919,7 @@ public:
 
    void abort() {
       edump(("abort() called"));
-      FC_ASSERT( false, "abort() called");
+      EOS_ASSERT( false, abort_called, "abort() called");
    }
 
    // Kept as intrinsic rather than implementing on WASM side (using eosio_assert_message and strlen) because strlen is faster on native side.
@@ -1138,13 +1138,15 @@ class console_api : public context_aware_api {
 
 #define DB_API_METHOD_WRAPPERS_ARRAY_SECONDARY(IDX, ARR_SIZE, ARR_ELEMENT_TYPE)\
       int db_##IDX##_store( uint64_t scope, uint64_t table, uint64_t payer, uint64_t id, array_ptr<const ARR_ELEMENT_TYPE> data, size_t data_len) {\
-         FC_ASSERT( data_len == ARR_SIZE,\
+         EOS_ASSERT( data_len == ARR_SIZE,\
+                    db_api_exception,\
                     "invalid size of secondary key array for " #IDX ": given ${given} bytes but expected ${expected} bytes",\
                     ("given",data_len)("expected",ARR_SIZE) );\
          return context.IDX.store(scope, table, payer, id, data.value);\
       }\
       void db_##IDX##_update( int iterator, uint64_t payer, array_ptr<const ARR_ELEMENT_TYPE> data, size_t data_len ) {\
-         FC_ASSERT( data_len == ARR_SIZE,\
+         EOS_ASSERT( data_len == ARR_SIZE,\
+                    db_api_exception,\
                     "invalid size of secondary key array for " #IDX ": given ${given} bytes but expected ${expected} bytes",\
                     ("given",data_len)("expected",ARR_SIZE) );\
          return context.IDX.update(iterator, payer, data.value);\
@@ -1153,25 +1155,29 @@ class console_api : public context_aware_api {
          return context.IDX.remove(iterator);\
       }\
       int db_##IDX##_find_secondary( uint64_t code, uint64_t scope, uint64_t table, array_ptr<const ARR_ELEMENT_TYPE> data, size_t data_len, uint64_t& primary ) {\
-         FC_ASSERT( data_len == ARR_SIZE,\
+         EOS_ASSERT( data_len == ARR_SIZE,\
+                    db_api_exception,\
                     "invalid size of secondary key array for " #IDX ": given ${given} bytes but expected ${expected} bytes",\
                     ("given",data_len)("expected",ARR_SIZE) );\
          return context.IDX.find_secondary(code, scope, table, data, primary);\
       }\
       int db_##IDX##_find_primary( uint64_t code, uint64_t scope, uint64_t table, array_ptr<ARR_ELEMENT_TYPE> data, size_t data_len, uint64_t primary ) {\
-         FC_ASSERT( data_len == ARR_SIZE,\
+         EOS_ASSERT( data_len == ARR_SIZE,\
+                    db_api_exception,\
                     "invalid size of secondary key array for " #IDX ": given ${given} bytes but expected ${expected} bytes",\
                     ("given",data_len)("expected",ARR_SIZE) );\
          return context.IDX.find_primary(code, scope, table, data.value, primary);\
       }\
       int db_##IDX##_lowerbound( uint64_t code, uint64_t scope, uint64_t table, array_ptr<ARR_ELEMENT_TYPE> data, size_t data_len, uint64_t& primary ) {\
-         FC_ASSERT( data_len == ARR_SIZE,\
+         EOS_ASSERT( data_len == ARR_SIZE,\
+                    db_api_exception,\
                     "invalid size of secondary key array for " #IDX ": given ${given} bytes but expected ${expected} bytes",\
                     ("given",data_len)("expected",ARR_SIZE) );\
          return context.IDX.lowerbound_secondary(code, scope, table, data.value, primary);\
       }\
       int db_##IDX##_upperbound( uint64_t code, uint64_t scope, uint64_t table, array_ptr<ARR_ELEMENT_TYPE> data, size_t data_len, uint64_t& primary ) {\
-         FC_ASSERT( data_len == ARR_SIZE,\
+         EOS_ASSERT( data_len == ARR_SIZE,\
+                    db_api_exception,\
                     "invalid size of secondary key array for " #IDX ": given ${given} bytes but expected ${expected} bytes",\
                     ("given",data_len)("expected",ARR_SIZE) );\
          return context.IDX.upperbound_secondary(code, scope, table, data.value, primary);\
@@ -1300,7 +1306,7 @@ class transaction_api : public context_aware_api {
 
       void send_inline( array_ptr<char> data, size_t data_len ) {
          //TODO: Why is this limit even needed? And why is it not consistently checked on actions in input or deferred transactions
-         FC_ASSERT( data_len < context.control.get_global_properties().configuration.max_inline_action_size,
+         EOS_ASSERT( data_len < context.control.get_global_properties().configuration.max_inline_action_size, inline_action_too_big,
                     "inline action too big" );
 
          action act;
@@ -1310,7 +1316,7 @@ class transaction_api : public context_aware_api {
 
       void send_context_free_inline( array_ptr<char> data, size_t data_len ) {
          //TODO: Why is this limit even needed? And why is it not consistently checked on actions in input or deferred transactions
-         FC_ASSERT( data_len < context.control.get_global_properties().configuration.max_inline_action_size,
+         EOS_ASSERT( data_len < context.control.get_global_properties().configuration.max_inline_action_size, inline_action_too_big,
                    "inline action too big" );
 
          action act;
@@ -1411,7 +1417,7 @@ class compiler_builtins : public context_aware_api {
          rhs <<= 64;
          rhs |=  lb;
 
-         FC_ASSERT(rhs != 0, "divide by zero");
+         EOS_ASSERT(rhs != 0, arithmetic_exception, "divide by zero");
 
          lhs /= rhs;
 
@@ -1428,7 +1434,7 @@ class compiler_builtins : public context_aware_api {
          rhs <<= 64;
          rhs |=  lb;
 
-         FC_ASSERT(rhs != 0, "divide by zero");
+         EOS_ASSERT(rhs != 0, arithmetic_exception, "divide by zero");
 
          lhs /= rhs;
          ret = lhs;
@@ -1458,7 +1464,7 @@ class compiler_builtins : public context_aware_api {
          rhs <<= 64;
          rhs |=  lb;
 
-         FC_ASSERT(rhs != 0, "divide by zero");
+         EOS_ASSERT(rhs != 0, arithmetic_exception, "divide by zero");
 
          lhs %= rhs;
          ret = lhs;
@@ -1474,7 +1480,7 @@ class compiler_builtins : public context_aware_api {
          rhs <<= 64;
          rhs |=  lb;
 
-         FC_ASSERT(rhs != 0, "divide by zero");
+         EOS_ASSERT(rhs != 0, arithmetic_exception, "divide by zero");
 
          lhs %= rhs;
          ret = lhs;

--- a/libraries/chain/wast_to_wasm.cpp
+++ b/libraries/chain/wast_to_wasm.cpp
@@ -12,6 +12,7 @@
 #include <sstream>
 #include <iomanip>
 #include <fc/exception/exception.hpp>
+#include <eosio/chain/exceptions.hpp>
 
 namespace eosio { namespace chain {
 
@@ -33,7 +34,7 @@ namespace eosio { namespace chain {
             ss << error.locus.sourceLine << std::endl;
             ss << std::setw(error.locus.column(8)) << "^" << std::endl;
          }
-         FC_ASSERT( !"error parsing wast", "${msg}", ("msg",ss.str()) );
+         EOS_ASSERT( false, wasm_exception, "error parsing wast: ${msg}", ("msg",ss.str()) );
       }
 
       for(auto sectionIt = module.userSections.begin();sectionIt != module.userSections.end();++sectionIt)
@@ -52,11 +53,11 @@ namespace eosio { namespace chain {
       {
          ss << "Error serializing WebAssembly binary file:" << std::endl;
          ss << exception.message << std::endl;
-         FC_ASSERT( !"error converting to wasm", "${msg}", ("msg",ss.get()) );
+         EOS_ASSERT( false, wasm_exception, "error converting to wasm: ${msg}", ("msg",ss.get()) );
       } catch(const IR::ValidationException& e) {
          ss << "Error validating WebAssembly binary file:" << std::endl;
          ss << e.message << std::endl;
-         FC_ASSERT( !"error converting to wasm", "${msg}", ("msg",ss.get()) );
+         EOS_ASSERT( false, wasm_exception, "error converting to wasm: ${msg}", ("msg",ss.get()) );
       }
 
    } FC_CAPTURE_AND_RETHROW( (wast) ) }  /// wast_to_wasm

--- a/libraries/chain/webassembly/binaryen.cpp
+++ b/libraries/chain/webassembly/binaryen.cpp
@@ -61,7 +61,7 @@ std::unique_ptr<wasm_instantiated_module_interface> binaryen_runtime::instantiat
       WasmBinaryBuilder builder(*module, code, false);
       builder.read();
 
-      FC_ASSERT(module->memory.initial * Memory::kPageSize <= wasm_constraints::maximum_linear_memory);
+      EOS_ASSERT(module->memory.initial * Memory::kPageSize <= wasm_constraints::maximum_linear_memory, binaryen_exception, "exceeds maximum linear memory");
 
       // create a temporary globals to  use
       TrivialGlobalManager globals;
@@ -73,7 +73,7 @@ std::unique_ptr<wasm_instantiated_module_interface> binaryen_runtime::instantiat
       table.resize(module->table.initial);
       for (auto& segment : module->table.segments) {
          Address offset = ConstantExpressionRunner<TrivialGlobalManager>(globals).visit(segment.offset).value.geti32();
-         FC_ASSERT( uint64_t(offset) + segment.data.size() <= module->table.initial);
+         EOS_ASSERT( uint64_t(offset) + segment.data.size() <= module->table.initial, binaryen_exception, "");
          for (size_t i = 0; i != segment.data.size(); ++i) {
             table[offset + i] = segment.data[i];
          }
@@ -93,7 +93,7 @@ std::unique_ptr<wasm_instantiated_module_interface> binaryen_runtime::instantiat
             }
          }
 
-         FC_ASSERT( !"unresolvable", "${module}.${export}", ("module",import->module.c_str())("export",import->base.c_str()) );
+         EOS_ASSERT( !"unresolvable", wasm_exception, "${module}.${export} unresolveable", ("module",import->module.c_str())("export",import->base.c_str()) );
       }
 
       return std::make_unique<binaryen_instantiated_module>(_memory, initial_memory, move(table), move(import_lut), move(module));

--- a/libraries/chain/webassembly/wavm.cpp
+++ b/libraries/chain/webassembly/wavm.cpp
@@ -44,7 +44,7 @@ class wavm_instantiated_module : public wasm_instantiated_module_interface {
             if( !call )
                return;
 
-            FC_ASSERT( getFunctionType(call)->parameters.size() == args.size() );
+            EOS_ASSERT( getFunctionType(call)->parameters.size() == args.size(), wasm_exception, "" );
 
             //The memory instance is reused across all wavm_instantiated_modules, but for wasm instances
             // that didn't declare "memory", getDefaultMemory() won't see it
@@ -122,7 +122,7 @@ std::unique_ptr<wasm_instantiated_module_interface> wavm_runtime::instantiate_mo
    eosio::chain::webassembly::common::root_resolver resolver;
    LinkResult link_result = linkModule(*module, resolver);
    ModuleInstance *instance = instantiateModule(*module, std::move(link_result.resolvedImports));
-   FC_ASSERT(instance != nullptr);
+   EOS_ASSERT(instance != nullptr, wasm_exception, "Fail to Instantiate WAVM Module");
 
    return std::make_unique<wavm_instantiated_module>(instance, std::move(module), initial_memory);
 }

--- a/plugins/bnet_plugin/bnet_plugin.cpp
+++ b/plugins/bnet_plugin/bnet_plugin.cpp
@@ -1003,7 +1003,7 @@ namespace eosio {
            peer_ilog(this, "received signed_block_ptr");
            if (!b) {
               peer_elog(this, "bad signed_block_ptr : null pointer");
-              FC_THROW("bad block" );
+              EOS_THROW(block_validate_exception, "bad block" );
            }
            status( "received block " + std::to_string(b->block_num()) );
            //ilog( "recv block ${n}", ("n", b->block_num()) );
@@ -1048,7 +1048,7 @@ namespace eosio {
            peer_ilog(this, "received packed_transaction_ptr");
            if (!p) {
               peer_elog(this, "bad packed_transaction_ptr : null pointer");
-              FC_THROW("bad transaction");
+              EOS_THROW(transaction_exception, "bad transaction");
            }
 
            auto id = p->id();
@@ -1130,7 +1130,7 @@ namespace eosio {
         }
 
         void run() {
-           FC_ASSERT( _acceptor.is_open(), "unable top open listen socket" );
+           EOS_ASSERT( _acceptor.is_open(), plugin_exception, "unable top open listen socket" );
            do_accept();
         }
 
@@ -1360,7 +1360,7 @@ namespace eosio {
       wlog( "bnet startup " );
 
       auto& chain = app().get_plugin<chain_plugin>().chain();
-      FC_ASSERT ( chain.get_read_mode() != chain::db_read_mode::IRREVERSIBLE, "bnet is not compatible with \"irreversible\" read_mode");
+      EOS_ASSERT ( chain.get_read_mode() != chain::db_read_mode::IRREVERSIBLE, plugin_exception, "bnet is not compatible with \"irreversible\" read_mode");
 
       my->_on_appled_trx_handle = app().get_channel<channels::accepted_transaction>()
                                 .subscribe( [this]( transaction_metadata_ptr t ){
@@ -1439,7 +1439,7 @@ namespace eosio {
       wlog( "done joining threads" );
 
       my->for_each_session([](auto ses){
-         FC_ASSERT( false, "session ${ses} still active", ("ses", ses->_session_num) );
+         EOS_ASSERT( false, plugin_exception, "session ${ses} still active", ("ses", ses->_session_num) );
       });
 
       // lifetime of _ioc is guarded by shared_ptr of bnet_plugin_impl

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -286,7 +286,7 @@ void chain_plugin::plugin_initialize(const variables_map& options) {
          auto& list = my->chain_config->action_blacklist;
          for( const auto& a : acts ) {
             auto pos = a.find( "::" );
-            FC_ASSERT( pos != std::string::npos, "Invalid entry in action-blacklist: '${a}'", ("a", a));
+            EOS_ASSERT( pos != std::string::npos, plugin_config_exception, "Invalid entry in action-blacklist: '${a}'", ("a", a));
             account_name code( a.substr( 0, pos ));
             action_name act( a.substr( pos + 2 ));
             list.emplace( code.value, act.value );
@@ -316,7 +316,8 @@ void chain_plugin::plugin_initialize(const variables_map& options) {
             auto item = fc::json::from_string(cp).as<std::pair<uint32_t,block_id_type>>();
             auto itr = my->loaded_checkpoints.find(item.first);
             if( itr != my->loaded_checkpoints.end() ) {
-               FC_ASSERT( itr->second == item.second,
+               EOS_ASSERT( itr->second == item.second,
+                           plugin_config_exception,
                           "redefining existing checkpoint at block number ${num}: original: ${orig} new: ${new}",
                           ("num", item.first)("orig", itr->second)("new", item.second)
                );
@@ -442,7 +443,8 @@ void chain_plugin::plugin_initialize(const variables_map& options) {
       }
 
       if( options.count( "genesis-json" )) {
-         FC_ASSERT( !fc::exists( my->blocks_dir / "blocks.log" ),
+         EOS_ASSERT( !fc::exists( my->blocks_dir / "blocks.log" ),
+                     plugin_config_exception,
                     "Genesis state can only be set on a fresh blockchain." );
 
          auto genesis_file = options.at( "genesis-json" ).as<bfs::path>();
@@ -450,7 +452,8 @@ void chain_plugin::plugin_initialize(const variables_map& options) {
             genesis_file = bfs::current_path() / genesis_file;
          }
 
-         FC_ASSERT( fc::is_regular_file( genesis_file ),
+         EOS_ASSERT( fc::is_regular_file( genesis_file ),
+                     plugin_config_exception,
                     "Specified genesis file '${genesis}' does not exist.",
                     ("genesis", genesis_file.generic_string()));
 
@@ -465,7 +468,8 @@ void chain_plugin::plugin_initialize(const variables_map& options) {
 
          wlog( "Starting up fresh blockchain with provided genesis state." );
       } else if( options.count( "genesis-timestamp" )) {
-         FC_ASSERT( !fc::exists( my->blocks_dir / "blocks.log" ),
+         EOS_ASSERT( !fc::exists( my->blocks_dir / "blocks.log" ),
+                     plugin_config_exception,
                     "Genesis state can only be set on a fresh blockchain." );
 
          my->chain_config->genesis.initial_timestamp = calculate_genesis_timestamp(
@@ -626,10 +630,11 @@ bool chain_plugin::recover_reversible_blocks( const fc::path& db_dir, uint32_t c
       reversible_dir = *new_db_dir;
    } else {
       auto reversible_dir_name = reversible_dir.filename().generic_string();
-      FC_ASSERT( reversible_dir_name != ".", "Invalid path to reversible directory" );
+      EOS_ASSERT( reversible_dir_name != ".", invalid_reversible_blocks_dir, "Invalid path to reversible directory" );
       backup_dir = reversible_dir.parent_path() / reversible_dir_name.append("-").append( now );
 
-      FC_ASSERT( !fc::exists(backup_dir),
+      EOS_ASSERT( !fc::exists(backup_dir),
+                  reversible_blocks_backup_dir_exist,
                  "Cannot move existing reversible directory to already existing directory '${backup_dir}'",
                  ("backup_dir", backup_dir) );
 
@@ -664,7 +669,7 @@ bool chain_plugin::recover_reversible_blocks( const fc::path& db_dir, uint32_t c
          return true;
       }
       for( ; itr != ubi.end(); ++itr ) {
-         FC_ASSERT( itr->blocknum == end + 1, "gap in reversible block database" );
+         EOS_ASSERT( itr->blocknum == end + 1, gap_in_reversible_blocks_db, "gap in reversible block database" );
          reversible_blocks.write( itr->packedblock.data(), itr->packedblock.size() );
          new_reversible.create<reversible_block_object>( [&]( auto& ubo ) {
             ubo.blocknum = itr->blocknum;
@@ -715,7 +720,7 @@ bool chain_plugin::import_reversible_blocks( const fc::path& reversible_dir,
          if( start == 0 ) {
             start = num;
          } else {
-            FC_ASSERT( num == end + 1, "gap in reversible block database" );
+            EOS_ASSERT( num == end + 1, gap_in_reversible_blocks_db, "gap in reversible block database" );
          }
 
          new_reversible.create<reversible_block_object>( [&]( auto& ubo ) {
@@ -743,7 +748,7 @@ controller& chain_plugin::chain() { return *my->chain; }
 const controller& chain_plugin::chain() const { return *my->chain; }
 
 chain::chain_id_type chain_plugin::get_chain_id()const {
-   FC_ASSERT( my->chain_id.valid(), "chain ID has not been initialized yet" );
+   EOS_ASSERT( my->chain_id.valid(), chain_id_type_exception, "chain ID has not been initialized yet" );
    return *my->chain_id;
 }
 
@@ -840,7 +845,7 @@ uint64_t convert_to_type(const string& str, const string& desc) {
             try {
                value = ( eosio::chain::string_to_symbol( 0, str.c_str() ) >> 8 );
             } catch( ... ) {
-               FC_ASSERT( false, "Could not convert ${desc} string '${str}' to any of the following: "
+               EOS_ASSERT( false, chain_type_exception, "Could not convert ${desc} string '${str}' to any of the following: "
                                  "uint64_t, valid name, or valid symbol (with or without the precision)",
                           ("desc", desc)("str", str));
             }
@@ -1184,7 +1189,7 @@ static void push_recurse(read_write* rw, int index, const std::shared_ptr<read_w
 
 void read_write::push_transactions(const read_write::push_transactions_params& params, next_function<read_write::push_transactions_results> next) {
    try {
-      FC_ASSERT( params.size() <= 1000, "Attempt to push too many transactions at once" );
+      EOS_ASSERT( params.size() <= 1000, too_many_tx_at_once, "Attempt to push too many transactions at once" );
       auto params_copy = std::make_shared<read_write::push_transactions_params>(params.begin(), params.end());
       auto result = std::make_shared<read_write::push_transactions_results>();
       result->reserve(params.size());
@@ -1264,7 +1269,7 @@ read_only::get_account_results read_only::get_account( const get_account_params&
       if( perm->parent._id ) {
          const auto* p = d.find<permission_object,by_id>( perm->parent );
          if( p ) {
-            FC_ASSERT(perm->owner == p->owner, "Invalid parent");
+            EOS_ASSERT(perm->owner == p->owner, invalid_parent_permission, "Invalid parent permission");
             parent = p->name;
          }
       }

--- a/plugins/history_plugin/history_plugin.cpp
+++ b/plugins/history_plugin/history_plugin.cpp
@@ -346,7 +346,7 @@ namespace eosio {
            if( start > pos ) start = 0;
            end   = pos;
         }
-        FC_ASSERT( end >= start );
+        EOS_ASSERT( end >= start, chain::plugin_exception, "end position is earlier than start position" );
 
         idump((start)(end));
 
@@ -393,7 +393,7 @@ namespace eosio {
          bool in_history = (itr != idx.end() && fc::variant(itr->trx_id).as_string().substr(0,8) == short_id );
 
          if( !in_history && !p.block_num_hint ) {
-            FC_THROW("Transaction ${id} not found in history and no block hint was given", ("id",p.id));
+            EOS_THROW(tx_not_found, "Transaction ${id} not found in history and no block hint was given", ("id",p.id));
          }
 
          get_transaction_result result;
@@ -481,7 +481,7 @@ namespace eosio {
             }
 
             if (!found) {
-               FC_THROW("Transaction ${id} not found in history or in block number ${n}", ("id",p.id)("n", *p.block_num_hint));
+               EOS_THROW(tx_not_found, "Transaction ${id} not found in history or in block number ${n}", ("id",p.id)("n", *p.block_num_hint));
             }
          }
 

--- a/plugins/http_client_plugin/CMakeLists.txt
+++ b/plugins/http_client_plugin/CMakeLists.txt
@@ -3,5 +3,5 @@ add_library( http_client_plugin
              http_client_plugin.cpp
              ${HEADERS} )
 
-target_link_libraries( http_client_plugin appbase fc )
+target_link_libraries( http_client_plugin appbase eosio_chain fc )
 target_include_directories( http_client_plugin PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" )

--- a/plugins/http_client_plugin/http_client_plugin.cpp
+++ b/plugins/http_client_plugin/http_client_plugin.cpp
@@ -3,6 +3,7 @@
  *  @copyright defined in eos/LICENSE.txt
  */
 #include <eosio/http_client_plugin/http_client_plugin.hpp>
+#include <eosio/chain/exceptions.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 #include <fstream>
 
@@ -33,7 +34,8 @@ void http_client_plugin::plugin_initialize(const variables_map& options) {
                   std::stringstream sstr;
                   sstr << infile.rdbuf();
                   pem_str = sstr.str();
-                  FC_ASSERT( boost::algorithm::starts_with( pem_str, "-----BEGIN CERTIFICATE-----\n" ),
+                  EOS_ASSERT( boost::algorithm::starts_with( pem_str, "-----BEGIN CERTIFICATE-----\n" ),
+                              chain::invalid_http_client_root_cert,
                              "File does not appear to be a PEM encoded certificate" );
                } catch ( const fc::exception& e ) {
                   elog( "Failed to read PEM ${f} : ${e}", ("f", root_pem)( "e", e.to_detail_string()));

--- a/plugins/http_plugin/http_plugin.cpp
+++ b/plugins/http_plugin/http_plugin.cpp
@@ -117,14 +117,14 @@ namespace eosio {
 
                fc::ec_key ecdh = EC_KEY_new_by_curve_name(NID_secp384r1);
                if (!ecdh)
-                  FC_THROW("Failed to set NID_secp384r1");
+                  EOS_THROW(chain::http_exception, "Failed to set NID_secp384r1");
                if(SSL_CTX_set_tmp_ecdh(ctx->native_handle(), (EC_KEY*)ecdh) != 1)
-                  FC_THROW("Failed to set ECDH PFS");
+                  EOS_THROW(chain::http_exception, "Failed to set ECDH PFS");
 
                if(SSL_CTX_set_cipher_list(ctx->native_handle(), \
                   "EECDH+ECDSA+AESGCM:EECDH+aRSA+AESGCM:EECDH+ECDSA+SHA384:EECDH+ECDSA+SHA256:AES256:" \
                   "!DHE:!RSA:!AES128:!RC4:!DES:!3DES:!DSS:!SRP:!PSK:!EXP:!MD5:!LOW:!aNULL:!eNULL") != 1)
-                  FC_THROW("Failed to set HTTPS cipher list");
+                  EOS_THROW(chain::http_exception, "Failed to set HTTPS cipher list");
             } catch (const fc::exception& e) {
                elog("https server initialization error: ${w}", ("w", e.to_detail_string()));
             } catch(std::exception& e) {

--- a/plugins/mongo_db_plugin/mongo_db_plugin.cpp
+++ b/plugins/mongo_db_plugin/mongo_db_plugin.cpp
@@ -429,7 +429,7 @@ void handle_mongo_exception( const std::string& desc, int line_num ) {
                   try {
                      if( !accounts.update_one( make_document( kvp( "_id", from_account->view()["_id"].get_oid())),
                                                update_from.view())) {
-                        FC_ASSERT( false, "Failed to udpdate account ${n}", ("n", setabi.account));
+                        EOS_ASSERT( false, chain::mongo_db_update_fail, "Failed to udpdate account ${n}", ("n", setabi.account));
                      }
                   } catch( ... ) {
                      handle_mongo_exception( "account update", __LINE__ );
@@ -748,7 +748,7 @@ void mongo_db_plugin_impl::_process_accepted_transaction( const chain::transacti
 
       try {
          if( !trans.insert_one( trans_doc.view())) {
-            FC_ASSERT( false, "Failed to insert trans ${id}", ("id", trx_id));
+            EOS_ASSERT( false, chain::mongo_db_insert_fail, "Failed to insert trans ${id}", ("id", trx_id));
          }
       } catch(...) {
          handle_mongo_exception("trans insert", __LINE__);
@@ -757,7 +757,7 @@ void mongo_db_plugin_impl::_process_accepted_transaction( const chain::transacti
       if (actions_to_write) {
          try {
             if( !bulk_actions.execute() ) {
-               FC_ASSERT( false, "Bulk actions insert failed for transaction: ${id}", ("id", trx_id_str));
+               EOS_ASSERT( false, chain::mongo_db_insert_fail, "Bulk actions insert failed for transaction: ${id}", ("id", trx_id_str));
             }
          } catch(...) {
             handle_mongo_exception("actions insert", __LINE__);
@@ -796,7 +796,7 @@ void mongo_db_plugin_impl::_process_applied_transaction( const chain::transactio
 
    try {
       if( !trans_traces.insert_one( trans_traces_doc.view())) {
-         FC_ASSERT( false, "Failed to insert trans ${id}", ("id", t->id));
+         EOS_ASSERT( false, chain::mongo_db_insert_fail, "Failed to insert trans ${id}", ("id", t->id));
       }
    } catch(...) {
       handle_mongo_exception("trans_traces insert: " + json, __LINE__);
@@ -844,7 +844,7 @@ void mongo_db_plugin_impl::_process_accepted_block( const chain::block_state_ptr
 
    try {
       if( !block_states.insert_one( block_state_doc.view())) {
-         FC_ASSERT( false, "Failed to insert block_state ${bid}", ("bid", block_id));
+         EOS_ASSERT( false, chain::mongo_db_insert_fail, "Failed to insert block_state ${bid}", ("bid", block_id));
       }
    } catch(...) {
       handle_mongo_exception("block_states insert: " + json, __LINE__);
@@ -876,7 +876,7 @@ void mongo_db_plugin_impl::_process_accepted_block( const chain::block_state_ptr
 
    try {
       if( !blocks.insert_one( block_doc.view())) {
-         FC_ASSERT( false, "Failed to insert block ${bid}", ("bid", block_id));
+         EOS_ASSERT( false, chain::mongo_db_insert_fail, "Failed to insert block ${bid}", ("bid", block_id));
       }
    } catch(...) {
       handle_mongo_exception("blocks insert: " + json, __LINE__);
@@ -952,7 +952,7 @@ void mongo_db_plugin_impl::_process_irreversible_block(const chain::block_state_
    if( transactions_in_block ) {
       try {
          if( !bulk.execute()) {
-            FC_ASSERT( false, "Bulk transaction insert failed for block: ${bid}", ("bid", block_id));
+            EOS_ASSERT( false, chain::mongo_db_insert_fail, "Bulk transaction insert failed for block: ${bid}", ("bid", block_id));
          }
       } catch(...) {
          handle_mongo_exception("bulk transaction insert", __LINE__);
@@ -1015,7 +1015,7 @@ void mongo_db_plugin_impl::init() {
 
       try {
          if( !accounts.insert_one( doc.view())) {
-            FC_ASSERT( false, "Failed to insert account ${n}",
+            EOS_ASSERT( false, chain::mongo_db_insert_fail, "Failed to insert account ${n}",
                        ("n", name( chain::config::system_account_name ).to_string()));
          }
       } catch(...) {
@@ -1095,13 +1095,13 @@ void mongo_db_plugin::plugin_initialize(const variables_map& options)
                ilog( "Wiping mongo database on startup" );
                my->wipe_database_on_startup = true;
             } else if( options.count( "mongodb-block-start" ) == 0 ) {
-               FC_ASSERT( false, "--mongodb-wipe required with --replay-blockchain, --hard-replay-blockchain, or --delete-all-blocks"
+               EOS_ASSERT( false, chain::plugin_config_exception, "--mongodb-wipe required with --replay-blockchain, --hard-replay-blockchain, or --delete-all-blocks"
                                  " --mongodb-wipe will remove all EOS collections from mongodb." );
             }
          }
 
          if( options.count( "abi-serializer-max-time-ms") == 0 ) {
-            FC_ASSERT(false, "--abi-serializer-max-time-ms required as default value not appropriate for parsing full blocks");
+            EOS_ASSERT(false, chain::plugin_config_exception, "--abi-serializer-max-time-ms required as default value not appropriate for parsing full blocks");
          }
          my->abi_serializer_max_time = app().get_plugin<chain_plugin>().get_abi_serializer_max_time();
 
@@ -1125,7 +1125,7 @@ void mongo_db_plugin::plugin_initialize(const variables_map& options)
 
          // hook up to signals on controller
          chain_plugin* chain_plug = app().find_plugin<chain_plugin>();
-         FC_ASSERT( chain_plug );
+         EOS_ASSERT( chain_plug, chain::missing_chain_plugin_exception, ""  );
          auto& chain = chain_plug->chain();
          my->chain_id.emplace( chain.get_chain_id());
 

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2144,7 +2144,7 @@ namespace eosio {
                         elog("async_read_some callback: bytes_transfered = ${bt}, buffer.bytes_to_write = ${btw}",
                              ("bt",bytes_transferred)("btw",conn->pending_message_buffer.bytes_to_write()));
                      }
-                     FC_ASSERT(bytes_transferred <= conn->pending_message_buffer.bytes_to_write());
+                     EOS_ASSERT(bytes_transferred <= conn->pending_message_buffer.bytes_to_write(), plugin_exception, "");
                      conn->pending_message_buffer.advance_write_ptr(bytes_transferred);
                      while (conn->pending_message_buffer.bytes_to_read() > 0) {
                         uint32_t bytes_in_buffer = conn->pending_message_buffer.bytes_to_read();
@@ -3018,7 +3018,8 @@ namespace eosio {
          }
 
          if( my->allowed_connections & net_plugin_impl::Specified )
-            FC_ASSERT( options.count( "peer-key" ),
+            EOS_ASSERT( options.count( "peer-key" ),
+                        plugin_config_exception,
                        "At least one peer-key must accompany 'allowed-connection=specified'" );
 
          if( options.count( "peer-key" )) {

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -250,7 +250,7 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
       void on_incoming_block(const signed_block_ptr& block) {
          fc_dlog(_log, "received incoming block ${id}", ("id", block->id()));
 
-         FC_ASSERT( block->timestamp < (fc::time_point::now() + fc::seconds(7)), "received a block from the future, ignoring it" );
+         EOS_ASSERT( block->timestamp < (fc::time_point::now() + fc::seconds(7)), block_from_the_future, "received a block from the future, ignoring it" );
 
 
          chain::controller& chain = app().get_plugin<chain_plugin>().chain();
@@ -455,7 +455,7 @@ chain::signature_type producer_plugin::sign_compact(const chain::public_key_type
 {
   if(key != chain::public_key_type()) {
     auto private_key_itr = my->_signature_providers.find(key);
-    FC_ASSERT(private_key_itr != my->_signature_providers.end(), "Local producer has no private key in config.ini corresponding to public key ${key}", ("key", key));
+    EOS_ASSERT(private_key_itr != my->_signature_providers.end(), producer_priv_key_not_found, "Local producer has no private key in config.ini corresponding to public key ${key}", ("key", key));
 
     return private_key_itr->second(digest);
   }
@@ -526,12 +526,12 @@ void producer_plugin::plugin_initialize(const boost::program_options::variables_
       for (const auto& key_spec_pair : key_spec_pairs) {
          try {
             auto delim = key_spec_pair.find("=");
-            FC_ASSERT(delim != std::string::npos);
+            EOS_ASSERT(delim != std::string::npos, plugin_config_exception, "Missing \"=\" in the key spec pair");
             auto pub_key_str = key_spec_pair.substr(0, delim);
             auto spec_str = key_spec_pair.substr(delim + 1);
 
             auto spec_delim = spec_str.find(":");
-            FC_ASSERT(spec_delim != std::string::npos);
+            EOS_ASSERT(spec_delim != std::string::npos, plugin_config_exception, "Missing \":\" in the key spec pair");
             auto spec_type_str = spec_str.substr(0, spec_delim);
             auto spec_data = spec_str.substr(spec_delim + 1);
 
@@ -590,7 +590,7 @@ void producer_plugin::plugin_startup()
    ilog("producer plugin:  plugin_startup() begin");
 
    chain::controller& chain = app().get_plugin<chain_plugin>().chain();
-   FC_ASSERT( my->_producers.empty() || chain.get_read_mode() == chain::db_read_mode::SPECULATIVE,
+   EOS_ASSERT( my->_producers.empty() || chain.get_read_mode() == chain::db_read_mode::SPECULATIVE, plugin_config_exception,
               "node cannot have any producer-name configured because block production is impossible when read_mode is not \"speculative\"" );
 
    my->_accepted_block_connection.emplace(chain.accepted_block.connect( [this]( const auto& bsp ){ my->on_block( bsp ); } ));
@@ -1066,15 +1066,14 @@ static auto maybe_make_debug_time_logger() -> fc::optional<decltype(make_debug_t
 
 void producer_plugin_impl::produce_block() {
    //ilog("produce_block ${t}", ("t", fc::time_point::now())); // for testing _produce_time_offset_us
-   FC_ASSERT(_pending_block_mode == pending_block_mode::producing, "called produce_block while not actually producing");
-
+   EOS_ASSERT(_pending_block_mode == pending_block_mode::producing, producer_exception, "called produce_block while not actually producing");
    chain::controller& chain = app().get_plugin<chain_plugin>().chain();
    const auto& pbs = chain.pending_block_state();
    const auto& hbs = chain.head_block_state();
-   FC_ASSERT(pbs, "pending_block_state does not exist but it should, another plugin may have corrupted it");
+   EOS_ASSERT(pbs, missing_pending_block_state, "pending_block_state does not exist but it should, another plugin may have corrupted it");
    auto signature_provider_itr = _signature_providers.find( pbs->block_signing_key );
 
-   FC_ASSERT(signature_provider_itr != _signature_providers.end(), "Attempting to produce a block for which we don't have the private key");
+   EOS_ASSERT(signature_provider_itr != _signature_providers.end(), producer_priv_key_not_found, "Attempting to produce a block for which we don't have the private key");
 
    //idump( (fc::time_point::now() - chain.pending_block_time()) );
    chain.finalize_block();

--- a/plugins/sql_db_plugin/sql_db_plugin.cpp
+++ b/plugins/sql_db_plugin/sql_db_plugin.cpp
@@ -65,7 +65,7 @@ void sql_db_plugin::plugin_initialize(const variables_map& options)
         }
 
         chain_plugin* chain_plug = app().find_plugin<chain_plugin>();
-        FC_ASSERT( chain_plug );
+        EOS_ASSERT( chain_plug, missing_chain_plugin_exception, "" );
         auto& chain = chain_plug->chain();
 
         m_irreversible_block_consumer = std::make_unique < consumer <

--- a/plugins/wallet_plugin/se_wallet.cpp
+++ b/plugins/wallet_plugin/se_wallet.cpp
@@ -284,7 +284,7 @@ static void check_signed() {
 
    if(is_valid != errSecSuccess) {
       wlog("Application does not have a valid signature; Secure Enclave support disabled");
-      FC_THROW("");
+      EOS_THROW(secure_enclave_exception, "");
    }
 }
 
@@ -310,7 +310,7 @@ se_wallet::se_wallet() : my(new detail::se_wallet_impl()) {
       }
    }
 
-   FC_THROW("Secure Enclave not supported on this hardware");
+   EOS_THROW(secure_enclave_exception, "Secure Enclave not supported on this hardware");
 }
 
 se_wallet::~se_wallet() {
@@ -324,7 +324,7 @@ bool se_wallet::is_locked() const {
    return my->locked;
 }
 void se_wallet::lock() {
-   FC_ASSERT(!is_locked());
+   EOS_ASSERT(!is_locked(), wallet_locked_exception, "You can not lock an already locked wallet");
    my->locked = true;
 }
 
@@ -361,7 +361,7 @@ string se_wallet::create_key(string key_type) {
 }
 
 bool se_wallet::remove_key(string key) {
-   FC_ASSERT(!is_locked());
+   EOS_ASSERT(!is_locked(), wallet_locked_exception, "You can not remove a key from a locked wallet");
    return my->remove_key(key);
 }
 

--- a/plugins/wallet_plugin/wallet.cpp
+++ b/plugins/wallet_plugin/wallet.cpp
@@ -235,7 +235,7 @@ public:
          ofstream outfile{ wallet_filename };
          if (!outfile) {
             elog("Unable to open file: ${fn}", ("fn", wallet_filename));
-            FC_THROW("Unable to open file: ${fn}", ("fn", wallet_filename));
+            EOS_THROW(wallet_exception, "Unable to open file: ${fn}", ("fn", wallet_filename));
          }
          outfile.write( data.c_str(), data.length() );
          outfile.flush();
@@ -286,7 +286,7 @@ string soft_wallet::get_wallet_filename() const
 
 bool soft_wallet::import_key(string wif_key)
 {
-   FC_ASSERT(!is_locked());
+   EOS_ASSERT(!is_locked(), wallet_locked_exception, "Unable to import key on a locked wallet");
 
    if( my->import_key(wif_key) )
    {
@@ -298,7 +298,7 @@ bool soft_wallet::import_key(string wif_key)
 
 bool soft_wallet::remove_key(string key)
 {
-   FC_ASSERT(!is_locked());
+   EOS_ASSERT(!is_locked(), wallet_locked_exception, "Unable to remove key from a locked wallet");
 
    if( my->remove_key(key) )
    {
@@ -310,7 +310,7 @@ bool soft_wallet::remove_key(string key)
 
 string soft_wallet::create_key(string key_type)
 {
-   FC_ASSERT(!is_locked());
+   EOS_ASSERT(!is_locked(), wallet_locked_exception, "Unable to create key on a locked wallet");
 
    string ret = my->create_key(key_type);
    save_wallet_file();
@@ -344,7 +344,7 @@ void soft_wallet::encrypt_keys()
 
 void soft_wallet::lock()
 { try {
-   FC_ASSERT( !is_locked() );
+   EOS_ASSERT( !is_locked(), wallet_locked_exception, "Unable to lock a locked wallet" );
    encrypt_keys();
    for( auto key : my->_keys )
       key.second = private_key_type();
@@ -378,19 +378,19 @@ void soft_wallet::check_password(string password)
 void soft_wallet::set_password( string password )
 {
    if( !is_new() )
-      FC_ASSERT( !is_locked(), "The wallet must be unlocked before the password can be set" );
+      EOS_ASSERT( !is_locked(), wallet_locked_exception, "The wallet must be unlocked before the password can be set" );
    my->_checksum = fc::sha512::hash( password.c_str(), password.size() );
    lock();
 }
 
 map<public_key_type, private_key_type> soft_wallet::list_keys()
 {
-   FC_ASSERT(!is_locked());
+   EOS_ASSERT(!is_locked(), wallet_locked_exception, "Unable to list public keys of a locked wallet");
    return my->_keys;
 }
 
 flat_set<public_key_type> soft_wallet::list_public_keys() {
-   FC_ASSERT(!is_locked());
+   EOS_ASSERT(!is_locked(), wallet_locked_exception, "Unable to list private keys of a locked wallet");
    flat_set<public_key_type> keys;
    boost::copy(my->_keys | boost::adaptors::map_keys, std::inserter(keys, keys.end()));
    return keys;
@@ -407,7 +407,7 @@ optional<signature_type> soft_wallet::try_sign_digest( const digest_type digest,
 
 pair<public_key_type,private_key_type> soft_wallet::get_private_key_from_password( string account, string role, string password )const {
    auto seed = account + role + password;
-   FC_ASSERT( seed.size() );
+   EOS_ASSERT( seed.size(), wallet_exception, "seed should not be empty" );
    auto secret = fc::sha256::hash( seed.c_str(), seed.size() );
    auto priv = private_key_type::regenerate<fc::ecc::private_key_shim>( secret );
    return std::make_pair(  priv.get_public_key(), priv );

--- a/plugins/wallet_plugin/wallet_manager.cpp
+++ b/plugins/wallet_plugin/wallet_manager.cpp
@@ -37,7 +37,7 @@ void wallet_manager::set_timeout(const std::chrono::seconds& t) {
    timeout = t;
    auto now = std::chrono::system_clock::now();
    timeout_time = now + timeout;
-   FC_ASSERT(timeout_time >= now, "Overflow on timeout_time, specified ${t}, now ${now}, timeout_time ${timeout_time}",
+   EOS_ASSERT(timeout_time >= now, invalid_lock_timeout_exception, "Overflow on timeout_time, specified ${t}, now ${now}, timeout_time ${timeout_time}",
              ("t", t.count())("now", now.time_since_epoch().count())("timeout_time", timeout_time.time_since_epoch().count()));
 }
 

--- a/plugins/wallet_plugin/wallet_plugin.cpp
+++ b/plugins/wallet_plugin/wallet_plugin.cpp
@@ -4,7 +4,7 @@
  */
 #include <eosio/wallet_plugin/wallet_plugin.hpp>
 #include <eosio/wallet_plugin/wallet_manager.hpp>
-
+#include <eosio/chain/exceptions.hpp>
 #include <boost/filesystem/path.hpp>
 #include <chrono>
 
@@ -47,7 +47,7 @@ void wallet_plugin::plugin_initialize(const variables_map& options) {
       }
       if (options.count("unlock-timeout")) {
          auto timeout = options.at("unlock-timeout").as<int64_t>();
-         FC_ASSERT(timeout > 0, "Please specify a positive timeout ${t}", ("t", timeout));
+         EOS_ASSERT(timeout > 0, chain::invalid_lock_timeout_exception, "Please specify a positive timeout ${t}", ("t", timeout));
          std::chrono::seconds t(timeout);
          wallet_manager_ptr->set_timeout(t);
       }

--- a/programs/cleos/httpc.cpp
+++ b/programs/cleos/httpc.cpp
@@ -24,6 +24,7 @@
 #include "httpc.hpp"
 
 using boost::asio::ip::tcp;
+using namespace eosio::chain;
 namespace eosio { namespace client { namespace http {
 
    namespace detail {
@@ -69,7 +70,7 @@ namespace eosio { namespace client { namespace http {
       response_stream >> status_code;
       std::string status_message;
       std::getline(response_stream, status_message);
-      FC_ASSERT( !(!response_stream || http_version.substr(0, 5) != "HTTP/"), "Invalid Response" );
+      EOS_ASSERT( !(!response_stream || http_version.substr(0, 5) != "HTTP/"), invalid_http_response, "Invalid Response" );
 
       // Read the response headers, which are terminated by a blank line.
       boost::asio::read_until(socket, response, "\r\n\r\n");
@@ -83,7 +84,7 @@ namespace eosio { namespace client { namespace http {
          if(std::regex_search(header, match, clregex))
             response_content_length = std::stoi(match[1]);
       }
-      FC_ASSERT(response_content_length >= 0, "Invalid content-length response");
+      EOS_ASSERT(response_content_length >= 0, invalid_http_response, "Invalid content-length response");
 
       std::stringstream re;
       // Write whatever content we already have to output.
@@ -111,9 +112,9 @@ namespace eosio { namespace client { namespace http {
          res.path = match[7];
       }
       if(res.scheme != "http" && res.scheme != "https")
-         FC_THROW("Unrecognized URL scheme (${s}) in URL \"${u}\"", ("s", res.scheme)("u", server_url));
+         EOS_THROW(fail_to_resolve_host, "Unrecognized URL scheme (${s}) in URL \"${u}\"", ("s", res.scheme)("u", server_url));
       if(res.server.empty())
-         FC_THROW("No server parsed from URL \"${u}\"", ("u", server_url));
+         EOS_THROW(fail_to_resolve_host, "No server parsed from URL \"${u}\"", ("u", server_url));
       if(res.port.empty())
          res.port = res.scheme == "http" ? "80" : "443";
       boost::trim_right_if(res.path, boost::is_any_of("/"));
@@ -125,7 +126,7 @@ namespace eosio { namespace client { namespace http {
       boost::system::error_code ec;
       auto result = resolver.resolve(tcp::v4(), url.server, url.port, ec);
       if (ec) {
-         FC_THROW("Error resolving \"${server}:${url}\" : ${m}", ("server", url.server)("port",url.port)("m",ec.message()));
+         EOS_THROW(fail_to_resolve_host, "Error resolving \"${server}:${url}\" : ${m}", ("server", url.server)("port",url.port)("m",ec.message()));
       }
 
       // non error results are guaranteed to return a non-empty range
@@ -142,7 +143,7 @@ namespace eosio { namespace client { namespace http {
          is_loopback = is_loopback && addr.is_loopback();
 
          if (resolved_port) {
-            FC_ASSERT(*resolved_port == port, "Service name \"${port}\" resolved to multiple ports and this is not supported!", ("port",url.port));
+            EOS_ASSERT(*resolved_port == port, resolved_to_multiple_ports, "Service name \"${port}\" resolved to multiple ports and this is not supported!", ("port",url.port));
          } else {
             resolved_port = port;
          }
@@ -200,7 +201,7 @@ namespace eosio { namespace client { namespace http {
       //TODO: this is undocumented/not supported; fix with keychain based approach
       ssl_context.load_verify_file("/private/etc/ssl/cert.pem");
 #elif defined( _WIN32 )
-      FC_THROW("HTTPS on Windows not supported");
+      EOS_THROW(http_exception, "HTTPS on Windows not supported");
 #else
       ssl_context.set_default_verify_paths();
 #endif
@@ -251,7 +252,7 @@ namespace eosio { namespace client { namespace http {
       throw fc::exception(logs, error_info.code, error_info.name, error_info.what);
    }
 
-   FC_ASSERT( status_code == 200, "Error code ${c}\n: ${msg}\n", ("c", status_code)("msg", re) );
+   EOS_ASSERT( status_code == 200, http_request_fail, "Error code ${c}\n: ${msg}\n", ("c", status_code)("msg", re) );
    return response_result;
    }
 }}}

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -586,7 +586,7 @@ asset to_asset( const string& code, const string& s ) {
          auto p = cache.insert(make_pair( sym, result.max_supply.get_symbol() ));
          it = p.first;
       } else {
-         FC_THROW("Symbol ${s} is not supported by token contract ${c}", ("s", sym_str)("c", code));
+         EOS_THROW(symbol_type_exception, "Symbol ${s} is not supported by token contract ${c}", ("s", sym_str)("c", code));
       }
    }
    auto expected_symbol = it->second;
@@ -595,7 +595,7 @@ asset to_asset( const string& code, const string& s ) {
       auto a_old = a;
       a = asset( a.get_amount() * factor, expected_symbol );
    } else if ( a.decimals() > expected_symbol.decimals() ) {
-      FC_THROW("Too many decimal digits in ${a}, only ${d} supported", ("a", a)("d", expected_symbol.decimals()));
+      EOS_THROW(symbol_type_exception, "Too many decimal digits in ${a}, only ${d} supported", ("a", a)("d", expected_symbol.decimals()));
    } // else precision matches
    return a;
 }
@@ -960,7 +960,7 @@ struct approve_producer_subcommand {
                std::cerr << "Voter info not found for account " << voter << std::endl;
                return;
             }
-            FC_ASSERT( 1 == res.rows.size(), "More than one voter_info for account" );
+            EOS_ASSERT( 1 == res.rows.size(), multiple_voter_info, "More than one voter_info for account" );
             auto prod_vars = res.rows[0]["producers"].get_array();
             vector<eosio::name> prods;
             for ( auto& x : prod_vars ) {
@@ -1006,7 +1006,7 @@ struct unapprove_producer_subcommand {
                std::cerr << "Voter info not found for account " << voter << std::endl;
                return;
             }
-            FC_ASSERT( 1 == res.rows.size(), "More than one voter_info for account" );
+            EOS_ASSERT( 1 == res.rows.size(), multiple_voter_info, "More than one voter_info for account" );
             auto prod_vars = res.rows[0]["producers"].get_array();
             vector<eosio::name> prods;
             for ( auto& x : prod_vars ) {
@@ -2081,7 +2081,7 @@ int main( int argc, char** argv ) {
 
       std::cerr << localized(("Reading WAST/WASM from " + wastPath + "...").c_str()) << std::endl;
       fc::read_file_contents(wastPath, wast);
-      FC_ASSERT( !wast.empty(), "no wast file found ${f}", ("f", wastPath) );
+      EOS_ASSERT( !wast.empty(), wast_file_not_found, "no wast file found ${f}", ("f", wastPath) );
       vector<uint8_t> wasm;
       const string binary_wasm_header("\x00\x61\x73\x6d", 4);
       if(wast.compare(0, 4, binary_wasm_header) == 0) {
@@ -2109,7 +2109,7 @@ int main( int argc, char** argv ) {
          abiPath = (cpath / (cpath.filename().generic_string()+".abi")).generic_string();
       }
 
-      FC_ASSERT( fc::exists( abiPath ), "no abi file found ${f}", ("f", abiPath)  );
+      EOS_ASSERT( fc::exists( abiPath ), abi_file_not_found, "no abi file found ${f}", ("f", abiPath)  );
 
       try {
          actions.emplace_back( create_setabi(account, fc::json::from_file(abiPath).as<abi_def>()) );

--- a/unittests/abi_tests.cpp
+++ b/unittests/abi_tests.cpp
@@ -2048,14 +2048,14 @@ BOOST_AUTO_TEST_CASE(abi_cycle)
 
    auto abi = eosio_contract_abi(fc::json::from_string(typedef_cycle_abi).as<abi_def>());
 
-   auto is_assert_exception = [](fc::assert_exception const & e) -> bool {
+   auto is_assert_exception = [](const auto& e) -> bool {
       wlog(e.to_string()); return true;
    };
-   BOOST_CHECK_EXCEPTION( abi_serializer abis(abi, max_serialization_time), fc::assert_exception, is_assert_exception );
+   BOOST_CHECK_EXCEPTION( abi_serializer abis(abi, max_serialization_time), duplicate_abi_type_def_exception, is_assert_exception);
 
    abi = fc::json::from_string(struct_cycle_abi).as<abi_def>();
    abi_serializer abis;
-   BOOST_CHECK_EXCEPTION( abis.set_abi(abi, max_serialization_time), fc::assert_exception, is_assert_exception );
+   BOOST_CHECK_EXCEPTION( abis.set_abi(abi, max_serialization_time), abi_circular_def_exception, is_assert_exception );
 
 } FC_LOG_AND_RETHROW() }
 
@@ -2895,8 +2895,8 @@ BOOST_AUTO_TEST_CASE(abi_type_repeat)
    )=====";
 
    auto abi = eosio_contract_abi(fc::json::from_string(repeat_abi).as<abi_def>());
-   auto is_table_exception = [](fc::assert_exception const & e) -> bool { return e.to_detail_string().find("type already exists") != std::string::npos; };
-   BOOST_CHECK_EXCEPTION( abi_serializer abis(abi, max_serialization_time), fc::assert_exception, is_table_exception );
+   auto is_table_exception = [](fc::exception const & e) -> bool { return e.to_detail_string().find("type already exists") != std::string::npos; };
+   BOOST_CHECK_EXCEPTION( abi_serializer abis(abi, max_serialization_time), duplicate_abi_type_def_exception, is_table_exception );
 } FC_LOG_AND_RETHROW() }
 
 BOOST_AUTO_TEST_CASE(abi_struct_repeat)
@@ -2952,8 +2952,7 @@ BOOST_AUTO_TEST_CASE(abi_struct_repeat)
    )=====";
 
    auto abi = eosio_contract_abi(fc::json::from_string(repeat_abi).as<abi_def>());
-   auto is_table_exception = [](fc::assert_exception const & e) -> bool { return e.to_detail_string().find("structs.size") != std::string::npos; };
-   BOOST_CHECK_EXCEPTION( abi_serializer abis(abi, max_serialization_time), fc::assert_exception, is_table_exception );
+   BOOST_CHECK_THROW( abi_serializer abis(abi, max_serialization_time), duplicate_abi_struct_def_exception );
 } FC_LOG_AND_RETHROW() }
 
 BOOST_AUTO_TEST_CASE(abi_action_repeat)
@@ -3012,8 +3011,7 @@ BOOST_AUTO_TEST_CASE(abi_action_repeat)
    )=====";
 
    auto abi = eosio_contract_abi(fc::json::from_string(repeat_abi).as<abi_def>());
-   auto is_table_exception = [](fc::assert_exception const & e) -> bool { return e.to_detail_string().find("actions.size") != std::string::npos; };
-   BOOST_CHECK_EXCEPTION( abi_serializer abis(abi, max_serialization_time), fc::assert_exception, is_table_exception );
+   BOOST_CHECK_THROW( abi_serializer abis(abi, max_serialization_time), duplicate_abi_action_def_exception );
 } FC_LOG_AND_RETHROW() }
 
 BOOST_AUTO_TEST_CASE(abi_table_repeat)
@@ -3075,8 +3073,7 @@ BOOST_AUTO_TEST_CASE(abi_table_repeat)
    )=====";
 
    auto abi = eosio_contract_abi(fc::json::from_string(repeat_abi).as<abi_def>());
-   auto is_table_exception = [](fc::assert_exception const & e) -> bool { return e.to_detail_string().find("tables.size") != std::string::npos; };
-   BOOST_CHECK_EXCEPTION( abi_serializer abis(abi, max_serialization_time), fc::assert_exception, is_table_exception );
+   BOOST_CHECK_THROW( abi_serializer abis(abi, max_serialization_time), duplicate_abi_table_def_exception );
 } FC_LOG_AND_RETHROW() }
 
 BOOST_AUTO_TEST_CASE(abi_type_def)
@@ -3169,8 +3166,8 @@ BOOST_AUTO_TEST_CASE(abi_type_loop)
    }
    )=====";
 
-   auto is_type_exception = [](fc::assert_exception const & e) -> bool { return e.to_detail_string().find("type already exists") != std::string::npos; };
-   BOOST_CHECK_EXCEPTION( abi_serializer abis(fc::json::from_string(repeat_abi).as<abi_def>(), max_serialization_time), fc::assert_exception, is_type_exception );
+   auto is_type_exception = [](fc::exception const & e) -> bool { return e.to_detail_string().find("type already exists") != std::string::npos; };
+   BOOST_CHECK_EXCEPTION( abi_serializer abis(fc::json::from_string(repeat_abi).as<abi_def>(), max_serialization_time), duplicate_abi_type_def_exception, is_type_exception );
 
 } FC_LOG_AND_RETHROW() }
 
@@ -3209,8 +3206,8 @@ BOOST_AUTO_TEST_CASE(abi_type_redefine)
    }
    )=====";
 
-   auto is_type_exception = [](fc::assert_exception const & e) -> bool { return e.to_detail_string().find("invalid type") != std::string::npos; };
-   BOOST_CHECK_EXCEPTION( abi_serializer abis(fc::json::from_string(repeat_abi).as<abi_def>(), max_serialization_time), fc::assert_exception, is_type_exception );
+   auto is_type_exception = [](fc::exception const & e) -> bool { return e.to_detail_string().find("invalid type") != std::string::npos; };
+   BOOST_CHECK_EXCEPTION( abi_serializer abis(fc::json::from_string(repeat_abi).as<abi_def>(), max_serialization_time), invalid_type_inside_abi, is_type_exception );
 
 } FC_LOG_AND_RETHROW() }
 
@@ -3230,8 +3227,8 @@ BOOST_AUTO_TEST_CASE(abi_type_redefine_to_name)
    }
    )=====";
 
-   auto is_type_exception = [](fc::assert_exception const & e) -> bool { return e.to_detail_string().find("type already exists") != std::string::npos; };
-   BOOST_CHECK_EXCEPTION( abi_serializer abis(fc::json::from_string(repeat_abi).as<abi_def>(), max_serialization_time), fc::assert_exception, is_type_exception );
+   auto is_type_exception = [](fc::exception const & e) -> bool { return e.to_detail_string().find("type already exists") != std::string::npos; };
+   BOOST_CHECK_EXCEPTION( abi_serializer abis(fc::json::from_string(repeat_abi).as<abi_def>(), max_serialization_time), duplicate_abi_type_def_exception, is_type_exception );
 
 } FC_LOG_AND_RETHROW() }
 

--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -426,7 +426,7 @@ BOOST_FIXTURE_TEST_CASE(action_tests, TESTER) { try {
    CALL_TEST_FUNCTION( *this, "test_action", "test_publication_time", fc::raw::pack(pub_time) );
 
    // test test_abort
-   BOOST_CHECK_EXCEPTION(CALL_TEST_FUNCTION( *this, "test_action", "test_abort", {} ), assert_exception,
+   BOOST_CHECK_EXCEPTION(CALL_TEST_FUNCTION( *this, "test_action", "test_abort", {} ), abort_called,
          [](const fc::exception& e) {
             return expect_assert_message(e, "abort() called");
          }
@@ -496,7 +496,7 @@ BOOST_FIXTURE_TEST_CASE(cf_action_tests, TESTER) { try {
       set_transaction_headers(trx);
       // run (dummy_action.b = 200) case looking for invalid use of context_free api
       sigs = trx.sign(get_private_key(N(testapi), "active"), control->get_chain_id());
-      BOOST_CHECK_EXCEPTION(push_transaction(trx), assert_exception,
+      BOOST_CHECK_EXCEPTION(push_transaction(trx), unaccessible_api,
                             [](const fc::exception& e) {
                                return expect_assert_message(e, "this API may only be called from context_free apply");
                             }
@@ -521,7 +521,7 @@ BOOST_FIXTURE_TEST_CASE(cf_action_tests, TESTER) { try {
             trx.signatures.clear();
             set_transaction_headers(trx);
             sigs = trx.sign(get_private_key(N(testapi), "active"), control->get_chain_id());
-            BOOST_CHECK_EXCEPTION(push_transaction(trx), assert_exception,
+            BOOST_CHECK_EXCEPTION(push_transaction(trx), unaccessible_api,
                  [](const fc::exception& e) {
                     return expect_assert_message(e, "only context free api's can be used in this context" );
                  }
@@ -872,7 +872,7 @@ BOOST_FIXTURE_TEST_CASE(compiler_builtins_tests, TESTER) { try {
    CALL_TEST_FUNCTION( *this, "test_compiler_builtins", "test_divti3", {});
 
    // test test_divti3_by_0
-   BOOST_CHECK_EXCEPTION(CALL_TEST_FUNCTION( *this, "test_compiler_builtins", "test_divti3_by_0", {}), assert_exception,
+   BOOST_CHECK_EXCEPTION(CALL_TEST_FUNCTION( *this, "test_compiler_builtins", "test_divti3_by_0", {}), arithmetic_exception,
          [](const fc::exception& e) {
             return expect_assert_message(e, "divide by zero");
          }
@@ -882,7 +882,7 @@ BOOST_FIXTURE_TEST_CASE(compiler_builtins_tests, TESTER) { try {
    CALL_TEST_FUNCTION( *this, "test_compiler_builtins", "test_udivti3", {});
 
    // test test_udivti3_by_0
-   BOOST_CHECK_EXCEPTION(CALL_TEST_FUNCTION( *this, "test_compiler_builtins", "test_udivti3_by_0", {}), assert_exception,
+   BOOST_CHECK_EXCEPTION(CALL_TEST_FUNCTION( *this, "test_compiler_builtins", "test_udivti3_by_0", {}), arithmetic_exception,
          [](const fc::exception& e) {
             return expect_assert_message(e, "divide by zero");
          }
@@ -892,7 +892,7 @@ BOOST_FIXTURE_TEST_CASE(compiler_builtins_tests, TESTER) { try {
    CALL_TEST_FUNCTION( *this, "test_compiler_builtins", "test_modti3", {});
 
    // test test_modti3_by_0
-   BOOST_CHECK_EXCEPTION(CALL_TEST_FUNCTION( *this, "test_compiler_builtins", "test_modti3_by_0", {}), assert_exception,
+   BOOST_CHECK_EXCEPTION(CALL_TEST_FUNCTION( *this, "test_compiler_builtins", "test_modti3_by_0", {}), arithmetic_exception,
          [](const fc::exception& e) {
             return expect_assert_message(e, "divide by zero");
          }
@@ -946,9 +946,9 @@ BOOST_FIXTURE_TEST_CASE(transaction_tests, TESTER) { try {
    CALL_TEST_FUNCTION(*this, "test_transaction", "send_action_empty", {});
 
    // test send_action_large
-   BOOST_CHECK_EXCEPTION(CALL_TEST_FUNCTION(*this, "test_transaction", "send_action_large", {}), assert_exception,
+   BOOST_CHECK_EXCEPTION(CALL_TEST_FUNCTION(*this, "test_transaction", "send_action_large", {}), inline_action_too_big,
          [](const fc::exception& e) {
-            return expect_assert_message(e, "data_len < context.control.get_global_properties().configuration.max_inline_action_size: inline action too big");
+            return expect_assert_message(e, "inline action too big");
          }
       );
 
@@ -1417,7 +1417,7 @@ BOOST_FIXTURE_TEST_CASE(crypto_tests, TESTER) { try {
       CALL_TEST_FUNCTION( *this, "test_crypto", "test_recover_key_assert_true", payload );
       payload[payload.size()-1] = 0;
       BOOST_CHECK_EXCEPTION( CALL_TEST_FUNCTION( *this, "test_crypto", "test_recover_key_assert_false", payload ),
-                             fc::assert_exception, fc_assert_exception_message_is("Error expected key different than recovered key") );
+                             crypto_api_exception, fc_exception_message_is("Error expected key different than recovered key") );
 	}
 
    CALL_TEST_FUNCTION( *this, "test_crypto", "test_sha1", {} );
@@ -1430,22 +1430,22 @@ BOOST_FIXTURE_TEST_CASE(crypto_tests, TESTER) { try {
    CALL_TEST_FUNCTION( *this, "test_crypto", "ripemd160_no_data", {} );
 
    CALL_TEST_FUNCTION_AND_CHECK_EXCEPTION( *this, "test_crypto", "assert_sha256_false", {},
-                                           assert_exception, "hash mismatch" );
+                                           crypto_api_exception, "hash mismatch" );
 
    CALL_TEST_FUNCTION( *this, "test_crypto", "assert_sha256_true", {} );
 
    CALL_TEST_FUNCTION_AND_CHECK_EXCEPTION( *this, "test_crypto", "assert_sha1_false", {},
-                                           assert_exception, "hash mismatch" );
+                                           crypto_api_exception, "hash mismatch" );
 
    CALL_TEST_FUNCTION( *this, "test_crypto", "assert_sha1_true", {} );
 
    CALL_TEST_FUNCTION_AND_CHECK_EXCEPTION( *this, "test_crypto", "assert_sha512_false", {},
-                                           assert_exception, "hash mismatch" );
+                                           crypto_api_exception, "hash mismatch" );
 
    CALL_TEST_FUNCTION( *this, "test_crypto", "assert_sha512_true", {} );
 
    CALL_TEST_FUNCTION_AND_CHECK_EXCEPTION( *this, "test_crypto", "assert_ripemd160_false", {},
-                                           assert_exception, "hash mismatch" );
+                                           crypto_api_exception, "hash mismatch" );
 
    CALL_TEST_FUNCTION( *this, "test_crypto", "assert_ripemd160_true", {} );
 
@@ -1886,15 +1886,15 @@ BOOST_FIXTURE_TEST_CASE(new_api_feature_tests, TESTER) { try {
    produce_blocks(1);
 
    BOOST_CHECK_EXCEPTION( CALL_TEST_FUNCTION( *this, "test_transaction", "new_feature", {} ),
-      assert_exception,
+      unaccessible_api,
       [](const fc::exception& e) {
-         return expect_assert_message(e, "context.privileged: testapi does not have permission to call this API");
+         return expect_assert_message(e, "testapi does not have permission to call this API");
       });
 
    BOOST_CHECK_EXCEPTION( CALL_TEST_FUNCTION( *this, "test_transaction", "active_new_feature", {} ),
-      assert_exception,
+      unaccessible_api,
       [](const fc::exception& e) {
-         return expect_assert_message(e, "context.privileged: testapi does not have permission to call this API");
+         return expect_assert_message(e, "testapi does not have permission to call this API");
       });
 
    // change privilege
@@ -1919,7 +1919,7 @@ BOOST_FIXTURE_TEST_CASE(new_api_feature_tests, TESTER) { try {
    CALL_TEST_FUNCTION( *this, "test_transaction", "new_feature", {} );
 
    BOOST_CHECK_EXCEPTION( CALL_TEST_FUNCTION( *this, "test_transaction", "active_new_feature", {} ),
-      assert_exception,
+      unsupported_feature,
       [](const fc::exception& e) {
          return expect_assert_message(e, "Unsupported Hardfork Detected");
       });

--- a/unittests/auth_tests.cpp
+++ b/unittests/auth_tests.cpp
@@ -499,17 +499,15 @@ BOOST_AUTO_TEST_CASE( linkauth_special ) { try {
    );
 
    auto validate_disallow = [&] (const char *type) {
-   BOOST_REQUIRE_EXCEPTION(
-   chain.push_action(config::system_account_name, linkauth::get_name(), tester_account, fc::mutable_variant_object()
-           ("account", "tester")
-           ("code", "eosio")
-           ("type", type)
-           ("requirement", "first")),
-   action_validate_exception,
-   [] (const action_validate_exception &ex)->bool {
-      BOOST_REQUIRE_EQUAL(std::string("action exception"), ex.what());
-      return true;
-   });
+      BOOST_REQUIRE_EXCEPTION(
+         chain.push_action(config::system_account_name, linkauth::get_name(), tester_account, fc::mutable_variant_object()
+               ("account", "tester")
+               ("code", "eosio")
+               ("type", type)
+               ("requirement", "first")),
+         action_validate_exception,
+         fc_exception_message_is(std::string("Cannot link eosio::") + std::string(type) + std::string(" to a minimum permission"))
+      );
    };
 
    validate_disallow("linkauth");

--- a/unittests/currency_tests.cpp
+++ b/unittests/currency_tests.cpp
@@ -298,13 +298,13 @@ BOOST_FIXTURE_TEST_CASE(test_symbol, TESTER) try {
    // from empty string
    {
       BOOST_CHECK_EXCEPTION(symbol::from_string(""),
-                            fc::assert_exception, fc_assert_exception_message_is("creating symbol from empty string"));
+                            symbol_type_exception, fc_exception_message_is("creating symbol from empty string"));
    }
 
    // precision part missing
    {
       BOOST_CHECK_EXCEPTION(symbol::from_string("RND"),
-                            fc::assert_exception, fc_assert_exception_message_is("missing comma in symbol"));
+                            symbol_type_exception, fc_exception_message_is("missing comma in symbol"));
    }
 
    // 0 decimals part
@@ -317,13 +317,13 @@ BOOST_FIXTURE_TEST_CASE(test_symbol, TESTER) try {
    // invalid - contains lower case characters, no validation
    {
       BOOST_CHECK_EXCEPTION(symbol malformed(SY(6,EoS)),
-                            fc::assert_exception, fc_assert_exception_message_is("invalid symbol: EoS"));
+                            symbol_type_exception, fc_exception_message_is("invalid symbol: EoS"));
    }
 
    // invalid - contains lower case characters, exception thrown
    {
       BOOST_CHECK_EXCEPTION(symbol(5,"EoS"),
-                            fc::assert_exception, fc_assert_exception_message_is("invalid character in symbol name"));
+                            symbol_type_exception, fc_exception_message_is("invalid character in symbol name"));
    }
 
    // Missing decimal point, should create asset with 0 decimals

--- a/unittests/misc_tests.cpp
+++ b/unittests/misc_tests.cpp
@@ -110,16 +110,16 @@ BOOST_AUTO_TEST_CASE(asset_from_string_overflow)
    asset a;
 
    // precision = 19, magnitude < 2^61
-   BOOST_CHECK_EXCEPTION( asset::from_string("0.1000000000000000000 CUR") , assert_exception, [](const assert_exception& e) {
+   BOOST_CHECK_EXCEPTION( asset::from_string("0.1000000000000000000 CUR") , symbol_type_exception, [](const auto& e) {
       return expect_assert_message(e, "precision 19 should be <= 18");
    });
-   BOOST_CHECK_EXCEPTION( asset::from_string("-0.1000000000000000000 CUR") , assert_exception, [](const assert_exception& e) {
+   BOOST_CHECK_EXCEPTION( asset::from_string("-0.1000000000000000000 CUR") , symbol_type_exception, [](const auto& e) {
       return expect_assert_message(e, "precision 19 should be <= 18");
    });
-   BOOST_CHECK_EXCEPTION( asset::from_string("1.0000000000000000000 CUR") , assert_exception, [](const assert_exception& e) {
+   BOOST_CHECK_EXCEPTION( asset::from_string("1.0000000000000000000 CUR") , symbol_type_exception, [](const auto& e) {
       return expect_assert_message(e, "precision 19 should be <= 18");
    });
-   BOOST_CHECK_EXCEPTION( asset::from_string("-1.0000000000000000000 CUR") , assert_exception, [](const assert_exception& e) {
+   BOOST_CHECK_EXCEPTION( asset::from_string("-1.0000000000000000000 CUR") , symbol_type_exception, [](const auto& e) {
       return expect_assert_message(e, "precision 19 should be <= 18");
    });
 
@@ -188,10 +188,10 @@ BOOST_AUTO_TEST_CASE(asset_from_string_overflow)
    });
 
    // precision = 20, magnitude > 2^142
-   BOOST_CHECK_EXCEPTION( asset::from_string("100000000000000000000000.00000000000000000000 CUR") , assert_exception, [](const assert_exception& e) {
+   BOOST_CHECK_EXCEPTION( asset::from_string("100000000000000000000000.00000000000000000000 CUR") , symbol_type_exception, [](const auto& e) {
       return expect_assert_message(e, "precision 20 should be <= 18");
    });
-   BOOST_CHECK_EXCEPTION( asset::from_string("-100000000000000000000000.00000000000000000000 CUR") , assert_exception, [](const assert_exception& e) {
+   BOOST_CHECK_EXCEPTION( asset::from_string("-100000000000000000000000.00000000000000000000 CUR") , symbol_type_exception, [](const auto& e) {
       return expect_assert_message(e, "precision 20 should be <= 18");
    });
 }


### PR DESCRIPTION
- Update FC_ASSERT to EOS_ASSERT for a more descriptive concise error message
- Update FC_THROW to EOS_THROW for a more descriptive concise error message
- Classify exceptions.hpp to be more detailed

#4150 