### PR TITLE
docker: add needed privilege and give container enough time to shutdown

### DIFF
--- a/Docker/docker-compose-eosio-latest.yaml
+++ b/Docker/docker-compose-eosio-latest.yaml
@@ -12,6 +12,9 @@ services:
       - "8888"
     volumes:
       - nodeos-data-volume:/opt/eosio/bin/data-dir
+    cap_add:
+      - IPC_LOCK
+    stop_grace_period: 10m
 
   keosd:
     image: eosio/eos:latest
@@ -21,6 +24,7 @@ services:
       - nodeosd
     volumes:
       - keosd-data-volume:/opt/eosio/bin/data-dir
+    stop_grace_period: 10m
 
 volumes:
  nodeos-data-volume:

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -19,6 +19,9 @@ services:
       - "8888"
     volumes:
       - nodeos-data-volume:/opt/eosio/bin/data-dir
+    cap_add:
+      - IPC_LOCK
+    stop_grace_period: 10m
 
   keosd:
     image: eosio/eos
@@ -28,6 +31,7 @@ services:
       - nodeosd
     volumes:
       - keosd-data-volume:/opt/eosio/bin/data-dir
+    stop_grace_period: 10m
 
 volumes:
   nodeos-data-volume:


### PR DESCRIPTION
This PR resolves #4462 and #4117 :

* `stop_grace_period` gives nodeos enough time to shutdown gracefully, avoids the situation to run `--hard-replay-blockchain`;
* `IPC_LOCK` gives nodeos needed privilege to pin chainbase shared memory.