### PR TITLE
Improve error messaging for invalid requests

### DIFF
--- a/libraries/chain/include/eosio/chain/exceptions.hpp
+++ b/libraries/chain/include/eosio/chain/exceptions.hpp
@@ -477,12 +477,14 @@ namespace eosio { namespace chain {
                                     3200001, "invalid http client root certificate" )
       FC_DECLARE_DERIVED_EXCEPTION( invalid_http_response, http_exception,
                                     3200002, "invalid http response" )
-      FC_DECLARE_DERIVED_EXCEPTION( resolved_to_multiple_ports, block_log_exception,
+      FC_DECLARE_DERIVED_EXCEPTION( resolved_to_multiple_ports, http_exception,
                                     3200003, "service resolved to multiple ports" )
-      FC_DECLARE_DERIVED_EXCEPTION( fail_to_resolve_host, block_log_exception,
+      FC_DECLARE_DERIVED_EXCEPTION( fail_to_resolve_host, http_exception,
                                     3200004, "fail to resolve host" )
-      FC_DECLARE_DERIVED_EXCEPTION( http_request_fail, block_log_exception,
+      FC_DECLARE_DERIVED_EXCEPTION( http_request_fail, http_exception,
                                     3200005, "http request fail" )
+      FC_DECLARE_DERIVED_EXCEPTION( invalid_http_request, http_exception,
+                                    3200006, "invalid http request" )
 
    FC_DECLARE_DERIVED_EXCEPTION( resource_limit_exception, chain_exception,
                                  3210000, "Resource limit exception" )


### PR DESCRIPTION
When the server rejects a cleos RPC call as invalid (http 400) we now produce a more friendly error message

relates to EOSIO/eos#4613

it looks something like this:
```
$ cleos --url http://localhost:8888 get info
Error 3200002: invalid http request
Error Details:
The server has rejected the request as invalid!
Please verify this url is valid: http://localhost:8888/v1/chain/get_info
If the condition persists, please contact the RPC server administrator for localhost!
```