### PR TITLE
base speculation staleness on time

### DIFF
--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -876,8 +876,10 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block(bool 
       }
    }
 
-   if (_pending_block_mode == pending_block_mode::speculating && !_production_enabled) {
-      return start_block_result::waiting;
+   if (_pending_block_mode == pending_block_mode::speculating) {
+      auto head_block_age = now - chain.head_block_time();
+      if (head_block_age > fc::seconds(5))
+         return start_block_result::waiting;
    }
 
    try {


### PR DESCRIPTION
Previously, we based the stale speculation check on the `_production_enabled` flag which is set, at most, once per process.  This lead to a situation where a node which fell behind would still speculate.  This changes that check to be based on the age of the head block so, nodes which fall behind will stop speculating.  NOTE, this only affects speculative modes, actual production should attempt to proceed despite the age of the head block.

relates to EOSIO/eos#4649