### PR TITLE
modify wastPath and abiPath of cleos set contract to be relative to contract dir

### DIFF
--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -2115,11 +2115,12 @@ int main( int argc, char** argv ) {
 
       if( cpath.filename().generic_string() == "." ) cpath = cpath.parent_path();
 
-      if( wastPath.empty() )
-      {
+      if( wastPath.empty() ) {
          wastPath = (cpath / (cpath.filename().generic_string()+".wasm")).generic_string();
          if (!fc::exists(wastPath))
             wastPath = (cpath / (cpath.filename().generic_string()+".wast")).generic_string();
+      } else {
+         wastPath = (cpath / wastPath).generic_string();
       }
 
       std::cerr << localized(("Reading WAST/WASM from " + wastPath + "...").c_str()) << std::endl;
@@ -2147,9 +2148,10 @@ int main( int argc, char** argv ) {
       fc::path cpath(contractPath);
       if( cpath.filename().generic_string() == "." ) cpath = cpath.parent_path();
 
-      if( abiPath.empty() )
-      {
+      if( abiPath.empty() ) {
          abiPath = (cpath / (cpath.filename().generic_string()+".abi")).generic_string();
+      } else {
+         abiPath = (cpath / abiPath).generic_string();
       }
 
       EOS_ASSERT( fc::exists( abiPath ), abi_file_not_found, "no abi file found ${f}", ("f", abiPath)  );

--- a/testnet.template
+++ b/testnet.template
@@ -75,7 +75,7 @@ wcmd create -n ignition
 # ------ DO NOT ALTER THE NEXT LINE -------
 ###INSERT prodkeys
 
-ecmd set contract eosio contracts/eosio.bios contracts/eosio.bios/eosio.bios.wast contracts/eosio.bios/eosio.bios.abi
+ecmd set contract eosio contracts/eosio.bios eosio.bios.wast eosio.bios.abi
 
 # Create required system accounts
 ecmd create key
@@ -94,9 +94,9 @@ ecmd create account eosio eosio.token $pubsyskey $pubsyskey
 ecmd create account eosio eosio.vpay $pubsyskey $pubsyskey
 ecmd create account eosio eosio.sudo $pubsyskey $pubsyskey
 
-ecmd set contract eosio.token contracts/eosio.token contracts/eosio.token/eosio.token.wast contracts/eosio.token/eosio.token.abi
-ecmd set contract eosio.msig contracts/eosio.msig contracts/eosio.msig/eosio.msig.wast contracts/eosio.msig/eosio.msig.abi
-ecmd set contract eosio.sudo contracts/eosio.sudo contracts/eosio.sudo/eosio.sudo.wast contracts/eosio.sudo/eosio.sudo.abi
+ecmd set contract eosio.token contracts/eosio.token eosio.token.wast eosio.token.abi
+ecmd set contract eosio.msig contracts/eosio.msig eosio.msig.wast eosio.msig.abi
+ecmd set contract eosio.sudo contracts/eosio.sudo eosio.sudo.wast eosio.sudo.abi
 
 echo ===== Start: $step ============ >> $logfile
 echo executing: cleos --wallet-url $wdurl --url http://$bioshost:$biosport push action eosio.token create '[ "eosio", "10000000000.0000 SYS" ]' -p eosio.token | tee -a $logfile
@@ -107,7 +107,7 @@ programs/cleos/cleos --wallet-url $wdurl --url http://$bioshost:$biosport push a
 echo ==== End: $step ============== >> $logfile
 step=$(($step + 1))
 
-ecmd set contract eosio contracts/eosio.system contracts/eosio.system/eosio.system.wast contracts/eosio.system/eosio.system.abi
+ecmd set contract eosio contracts/eosio.system eosio.system.wast eosio.system.abi
 
 # Manual deployers, add a series of lines below this block that looks like:
 #    cacmd $PRODNAME[0] $OWNERKEY[0] $ACTIVEKEY[0]

--- a/tests/Cluster.py
+++ b/tests/Cluster.py
@@ -722,8 +722,8 @@ class Cluster(object):
 
             contract="eosio.bios"
             contractDir="contracts/%s" % (contract)
-            wastFile="contracts/%s/%s.wast" % (contract, contract)
-            abiFile="contracts/%s/%s.abi" % (contract, contract)
+            wastFile="%s.wast" % (contract)
+            abiFile="%s.abi" % (contract)
             Utils.Print("Publish %s contract" % (contract))
             trans=biosNode.publishContract(eosioAccount.name, contractDir, wastFile, abiFile, waitForTransBlock=True)
             if trans is None:
@@ -846,8 +846,8 @@ class Cluster(object):
 
             contract="eosio.token"
             contractDir="contracts/%s" % (contract)
-            wastFile="contracts/%s/%s.wast" % (contract, contract)
-            abiFile="contracts/%s/%s.abi" % (contract, contract)
+            wastFile="%s.wast" % (contract)
+            abiFile="%s.abi" % (contract)
             Utils.Print("Publish %s contract" % (contract))
             trans=biosNode.publishContract(eosioTokenAccount.name, contractDir, wastFile, abiFile, waitForTransBlock=True)
             if trans is None:
@@ -901,8 +901,8 @@ class Cluster(object):
 
             contract="eosio.system"
             contractDir="contracts/%s" % (contract)
-            wastFile="contracts/%s/%s.wast" % (contract, contract)
-            abiFile="contracts/%s/%s.abi" % (contract, contract)
+            wastFile="%s.wast" % (contract)
+            abiFile="%s.abi" % (contract)
             Utils.Print("Publish %s contract" % (contract))
             trans=biosNode.publishContract(eosioAccount.name, contractDir, wastFile, abiFile, waitForTransBlock=True)
             if trans is None:

--- a/tests/consensus-validation-malicious-producers.py
+++ b/tests/consensus-validation-malicious-producers.py
@@ -298,8 +298,8 @@ def myTest(transWillEnterBlock):
             error("Failed to create account %s" % (currencyAccount.name))
             return False
 
-        wastFile="contracts/currency/currency.wast"
-        abiFile="contracts/currency/currency.abi"
+        wastFile="currency.wast"
+        abiFile="currency.abi"
         Print("Publish contract")
         trans=node.publishContract(currencyAccount.name, wastFile, abiFile, waitForTransBlock=True)
         if trans is None:

--- a/tests/nodeos_run_test.py
+++ b/tests/nodeos_run_test.py
@@ -357,8 +357,8 @@ try:
         errorExit("FAILURE - get code currency1111 failed", raw=True)
 
     contractDir="contracts/eosio.token"
-    wastFile="contracts/eosio.token/eosio.token.wast"
-    abiFile="contracts/eosio.token/eosio.token.abi"
+    wastFile="eosio.token.wast"
+    abiFile="eosio.token.abi"
     Print("Publish contract")
     trans=node.publishContract(currencyAccount.name, contractDir, wastFile, abiFile, waitForTransBlock=True)
     if trans is None:
@@ -644,8 +644,8 @@ try:
     Print("upload exchange contract")
 
     contractDir="contracts/exchange"
-    wastFile="contracts/exchange/exchange.wast"
-    abiFile="contracts/exchange/exchange.abi"
+    wastFile="exchange.wast"
+    abiFile="exchange.abi"
     Print("Publish exchange contract")
     trans=node.publishContract(exchangeAccount.name, contractDir, wastFile, abiFile, waitForTransBlock=True)
     if trans is None:
@@ -653,8 +653,8 @@ try:
         errorExit("Failed to publish contract.")
 
     contractDir="contracts/simpledb"
-    wastFile="contracts/simpledb/simpledb.wast"
-    abiFile="contracts/simpledb/simpledb.abi"
+    wastFile="simpledb.wast"
+    abiFile="simpledb.abi"
     Print("Setting simpledb contract without simpledb account was causing core dump in %s." % (ClientName))
     Print("Verify %s generates an error, but does not core dump." % (ClientName))
     retMap=node.publishContract("simpledb", contractDir, wastFile, abiFile, shouldFail=True)

--- a/tests/p2p_network_test.py
+++ b/tests/p2p_network_test.py
@@ -152,8 +152,8 @@ for i in range(len(hosts)):
     Print("host %s: %s" % (hosts[i], trans))
 
 
-wastFile="contracts/eosio.system/eosio.system.wast"
-abiFile="contracts/eosio.system/eosio.system.abi"
+wastFile="eosio.system.wast"
+abiFile="eosio.system.abi"
 Print("\nPush system contract %s %s" % (wastFile, abiFile))
 trans=node0.publishContract(eosio.name, wastFile, abiFile, waitForTransBlock=True)
 if trans is None:


### PR DESCRIPTION
Based on the comment on github issue #2032, the documentation of `cleos set contract` expects wastPath and abiPath to be relative to contract directory. However, this is not the case and cause misunderstanding to developers who read the instruction. This PR makes wastPath and abiPath relative to contract directory.