### PR TITLE
Add filter-out history config option

### DIFF
--- a/plugins/history_plugin/history_plugin.cpp
+++ b/plugins/history_plugin/history_plugin.cpp
@@ -148,10 +148,16 @@ namespace eosio {
             if (bypass_filter) {
               pass_on = true;
             }
+            if (filter_on.find({ act.receipt.receiver, 0, 0 }) != filter_on.end()) {
+              pass_on = true;
+            }
             if (filter_on.find({ act.receipt.receiver, act.act.name, 0 }) != filter_on.end()) {
               pass_on = true;
             }
             for (const auto& a : act.act.authorization) {
+              if (filter_on.find({ act.receipt.receiver, 0, a.actor }) != filter_on.end()) {
+                pass_on = true;
+              }
               if (filter_on.find({ act.receipt.receiver, act.act.name, a.actor }) != filter_on.end()) {
                 pass_on = true;
               }
@@ -166,6 +172,9 @@ namespace eosio {
               return false;
             }
             for (const auto& a : act.act.authorization) {
+              if (filter_out.find({ act.receipt.receiver, 0, a.actor }) != filter_out.end()) {
+                return false;
+              }
               if (filter_out.find({ act.receipt.receiver, act.act.name, a.actor }) != filter_out.end()) {
                 return false;
               }
@@ -180,9 +189,12 @@ namespace eosio {
             result.insert( act.receipt.receiver );
             for( const auto& a : act.act.authorization ) {
                if( bypass_filter ||
+                   filter_on.find({ act.receipt.receiver, 0, 0}) != filter_on.end() ||
+                   filter_on.find({ act.receipt.receiver, 0, a.actor}) != filter_on.end() ||
                    filter_on.find({ act.receipt.receiver, act.act.name, 0}) != filter_on.end() ||
                    filter_on.find({ act.receipt.receiver, act.act.name, a.actor }) != filter_on.end() ) {
                  if ((filter_out.find({ act.receipt.receiver, 0, 0 }) == filter_out.end()) &&
+                     (filter_out.find({ act.receipt.receiver, 0, a.actor }) == filter_out.end()) &&
                      (filter_out.find({ act.receipt.receiver, act.act.name, 0 }) == filter_out.end()) &&
                      (filter_out.find({ act.receipt.receiver, act.act.name, a.actor }) == filter_out.end())) {
                    result.insert( a.actor );
@@ -288,11 +300,11 @@ namespace eosio {
    void history_plugin::set_program_options(options_description& cli, options_description& cfg) {
       cfg.add_options()
             ("filter-on,f", bpo::value<vector<string>>()->composing(),
-             "Track actions which match receiver:action:actor. Actor may be blank to include all. Receiver and Action may not be blank.")
+             "Track actions which match receiver:action:actor. Actor may be blank to include all. Action and Actor both blank allows all from Recieiver. Receiver may not be blank.")
             ;
       cfg.add_options()
             ("filter-out,f", bpo::value<vector<string>>()->composing(),
-             "Do not track actions which match receiver:action:actor. Action and Actor both blank excludes all from reciever. Actor blank excludes all from reciever:action. Receiver may not be blank.")
+             "Do not track actions which match receiver:action:actor. Action and Actor both blank excludes all from Reciever. Actor blank excludes all from reciever:action. Receiver may not be blank.")
             ;
    }
 
@@ -310,7 +322,7 @@ namespace eosio {
                boost::split( v, s, boost::is_any_of( ":" ));
                EOS_ASSERT( v.size() == 3, fc::invalid_arg_exception, "Invalid value ${s} for --filter-on", ("s", s));
                filter_entry fe{v[0], v[1], v[2]};
-               EOS_ASSERT( fe.receiver.value && fe.action.value, fc::invalid_arg_exception,
+               EOS_ASSERT( fe.receiver.value, fc::invalid_arg_exception,
                            "Invalid value ${s} for --filter-on", ("s", s));
                my->filter_on.insert( fe );
             }

--- a/plugins/history_plugin/history_plugin.cpp
+++ b/plugins/history_plugin/history_plugin.cpp
@@ -139,29 +139,56 @@ namespace eosio {
       public:
          bool bypass_filter = false;
          std::set<filter_entry> filter_on;
+         std::set<filter_entry> filter_out;
          chain_plugin*          chain_plug = nullptr;
          fc::optional<scoped_connection> applied_transaction_connection;
 
-         bool filter( const action_trace& act ) {
-            if( bypass_filter )
-               return true;
-            if( filter_on.find({ act.receipt.receiver, act.act.name, 0 }) != filter_on.end() )
-               return true;
-            for( const auto& a : act.act.authorization )
-               if( filter_on.find({ act.receipt.receiver, act.act.name, a.actor }) != filter_on.end() )
-                  return true;
-            return false;
-         }
+          bool filter(const action_trace& act) {
+            bool pass_on = false;
+            if (bypass_filter) {
+              pass_on = true;
+            }
+            if (filter_on.find({ act.receipt.receiver, act.act.name, 0 }) != filter_on.end()) {
+              pass_on = true;
+            }
+            for (const auto& a : act.act.authorization) {
+              if (filter_on.find({ act.receipt.receiver, act.act.name, a.actor }) != filter_on.end()) {
+                pass_on = true;
+              }
+            }
+
+            if (!pass_on) {  return false;  }
+
+            if (filter_out.find({ act.receipt.receiver, 0, 0 }) != filter_out.end()) {
+              return false;
+            }
+            if (filter_out.find({ act.receipt.receiver, act.act.name, 0 }) != filter_out.end()) {
+              return false;
+            }
+            for (const auto& a : act.act.authorization) {
+              if (filter_out.find({ act.receipt.receiver, act.act.name, a.actor }) != filter_out.end()) {
+                return false;
+              }
+            }
+
+            return true;
+          }
 
          set<account_name> account_set( const action_trace& act ) {
             set<account_name> result;
 
             result.insert( act.receipt.receiver );
-            for( const auto& a : act.act.authorization )
+            for( const auto& a : act.act.authorization ) {
                if( bypass_filter ||
                    filter_on.find({ act.receipt.receiver, act.act.name, 0}) != filter_on.end() ||
-                   filter_on.find({ act.receipt.receiver, act.act.name, a.actor }) != filter_on.end() )
-                  result.insert( a.actor );
+                   filter_on.find({ act.receipt.receiver, act.act.name, a.actor }) != filter_on.end() ) {
+                 if ((filter_out.find({ act.receipt.receiver, 0, 0 }) == filter_out.end()) &&
+                     (filter_out.find({ act.receipt.receiver, act.act.name, 0 }) == filter_out.end()) &&
+                     (filter_out.find({ act.receipt.receiver, act.act.name, a.actor }) == filter_out.end())) {
+                   result.insert( a.actor );
+                 }
+               }
+            }
             return result;
          }
 
@@ -263,6 +290,10 @@ namespace eosio {
             ("filter-on,f", bpo::value<vector<string>>()->composing(),
              "Track actions which match receiver:action:actor. Actor may be blank to include all. Receiver and Action may not be blank.")
             ;
+      cfg.add_options()
+            ("filter-out,f", bpo::value<vector<string>>()->composing(),
+             "Do not track actions which match receiver:action:actor. Action and Actor both blank excludes all from reciever. Actor blank excludes all from reciever:action. Receiver may not be blank.")
+            ;
    }
 
    void history_plugin::plugin_initialize(const variables_map& options) {
@@ -282,6 +313,18 @@ namespace eosio {
                EOS_ASSERT( fe.receiver.value && fe.action.value, fc::invalid_arg_exception,
                            "Invalid value ${s} for --filter-on", ("s", s));
                my->filter_on.insert( fe );
+            }
+         }
+         if( options.count( "filter-out" )) {
+            auto fo = options.at( "filter-out" ).as<vector<string>>();
+            for( auto& s : fo ) {
+               std::vector<std::string> v;
+               boost::split( v, s, boost::is_any_of( ":" ));
+               EOS_ASSERT( v.size() == 3, fc::invalid_arg_exception, "Invalid value ${s} for --filter-out", ("s", s));
+               filter_entry fe{v[0], v[1], v[2]};
+               EOS_ASSERT( fe.receiver.value, fc::invalid_arg_exception,
+                           "Invalid value ${s} for --filter-out", ("s", s));
+               my->filter_out.insert( fe );
             }
          }
 


### PR DESCRIPTION
Right now, `filter-on` is opt-in -- that is to say, you choose which contracts to include. This change adds a second filter option, `filter-out`. This removes storing history if it matches the filter-on, but also matches the filter-out.
Filter -on and -out can be combined in multiple ways. For example, we could do the following:
```
filter-on = eosio.token:transfer:
filter-out = eosio.token:transfer:spammer
```
In this case, we can be sure to include all eosio.token history, except for a specific spammer. The only way to do such a system with the current opt-in only filter is to have a filter-on for every single actor that isn't the spammer.

Also allowed is `filter-out = contract:action:`, which could be combined with `filter-on = *` to enable storing history for all except some specific contract's action, or an even more strict `filter-out = contract::` to disable all history for a specific contract.

These changes bring filters more in line with actor blacklist and whitelists, allowing both opt-on or opt-out functionality. 

More work will need to be done to make filters more customizable in the future, but this represents a stepping stone in this direction.
