### PR TITLE
Add pub_keys and account_controls collections.

### DIFF
--- a/plugins/mongo_db_plugin/include/eosio/mongo_db_plugin/mongo_db_plugin.hpp
+++ b/plugins/mongo_db_plugin/include/eosio/mongo_db_plugin/mongo_db_plugin.hpp
@@ -20,6 +20,8 @@ using mongo_db_plugin_impl_ptr = std::shared_ptr<class mongo_db_plugin_impl>;
  * blocks
  * transaction_traces
  * transactions
+ * pub_keys
+ * account_controls
  *
  *   See data dictionary (DB Schema Definition - EOS API) for description of MongoDB schema.
  *


### PR DESCRIPTION
Resolves #4681 

The equivalent of `/v1/history/get_key_accounts` with mongo:
`db.pub_keys.find({"public_key":"EOS7EarnUhcyYqmdnPon8rm7mBCTnBoot6o7fE2WzjvEX2TdggbL3"}).pretty()`

The equivalent of `/v1/history/get_controlled_acounts` with mongo: `db.account_controls.find({"controlling_account":"hellozhangyi"}).pretty()`

This PR also includes a number of performance improvements.