### PR TITLE
Password and keys to file instead of console

### DIFF
--- a/contracts/CMakeLists.txt
+++ b/contracts/CMakeLists.txt
@@ -34,6 +34,7 @@ add_subdirectory(noop)
 add_subdirectory(dice)
 add_subdirectory(tic_tac_toe)
 add_subdirectory(payloadless)
+add_subdirectory(integration_test)
 
 
 file(GLOB SKELETONS RELATIVE ${CMAKE_SOURCE_DIR}/contracts "skeleton/*")

--- a/contracts/integration_test/CMakeLists.txt
+++ b/contracts/integration_test/CMakeLists.txt
@@ -1,0 +1,8 @@
+file(GLOB ABI_FILES "*.abi")
+configure_file("${ABI_FILES}" "${CMAKE_CURRENT_BINARY_DIR}" COPYONLY)
+
+add_wast_executable(TARGET integration_test
+  INCLUDE_FOLDERS "${STANDARD_INCLUDE_FOLDERS}"
+  LIBRARIES libc libc++ eosiolib
+  DESTINATION_FOLDER ${CMAKE_CURRENT_BINARY_DIR}
+)

--- a/contracts/integration_test/integration_test.abi
+++ b/contracts/integration_test/integration_test.abi
@@ -1,0 +1,41 @@
+{
+   "version": "eosio::abi/1.0",
+   "types": [{
+      "new_type_name": "account_name",
+      "type": "name"
+   }],
+  "structs": [{
+      "name": "store",
+      "base": "",
+      "fields": [
+        {"name":"from", "type":"account_name"},
+        {"name":"to", "type":"account_name"},
+        {"name":"num", "type":"uint64"}
+      ]
+    },{
+     "name": "payload",
+     "base": "",
+     "fields": [
+        {"name":"key", "type":"uint64"},
+        {"name":"data", "type":"uint64[]"}
+     ]
+  }
+  ],
+  "actions": [{
+      "name": "store",
+      "type": "store",
+      "ricardian_contract": ""
+    }
+
+  ],
+  "tables": [{
+      "name": "payloads",
+      "type": "payload",
+      "index_type": "i64",
+      "key_names" : ["key"],
+      "key_types" : ["uint64"]
+    }
+  ],
+  "ricardian_clauses": [],
+  "abi_extensions": []
+}

--- a/contracts/integration_test/integration_test.cpp
+++ b/contracts/integration_test/integration_test.cpp
@@ -1,0 +1,36 @@
+#include <eosiolib/eosio.hpp>
+using namespace eosio;
+
+struct integration_test : public eosio::contract {
+      using contract::contract;
+
+      struct payload {
+         uint64_t            key;
+         vector<uint64_t>    data;
+
+         uint64_t primary_key()const { return key; }
+      };
+      typedef eosio::multi_index<N(payloads), payload> payloads;
+
+      /// @abi action 
+      void store( account_name from,
+                  account_name to,
+                  uint64_t     num ) {
+         require_auth( from );
+         eosio_assert( is_account( to ), "to account does not exist");
+         payloads data ( _self, from );
+         uint64_t key = 0;
+         const uint64_t num_keys = 5;
+         while (data.find( key ) != data.end()) {
+            key += num_keys;
+         }
+         for (uint64_t i = 0; i < num_keys; ++i) {
+            data.emplace(from, [&]( auto& g ) {
+               g.key = key + i;
+               g.data = vector<uint64_t>(num, 5);
+            });
+         }
+      }
+};
+
+EOSIO_ABI( integration_test, (store) )

--- a/libraries/chain/include/eosio/chain/config.hpp
+++ b/libraries/chain/include/eosio/chain/config.hpp
@@ -20,7 +20,7 @@ const static auto default_reversible_guard_size = 2*1024*1024ll;/// 1MB * 340 bl
 const static auto default_state_dir_name     = "state";
 const static auto forkdb_filename            = "forkdb.dat";
 const static auto default_state_size            = 1*1024*1024*1024ll;
-const static auto default_state_guard_size      = 128*1024*1024ll;
+const static auto default_state_guard_size      =    128*1024*1024ll;
 
 
 const static uint64_t system_account_name    = N(eosio);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -36,6 +36,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/sample-cluster-map.json ${CMAKE_CURRE
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/restart-scenarios-test.py ${CMAKE_CURRENT_BINARY_DIR}/restart-scenarios-test.py COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/nodeos_run_test.py ${CMAKE_CURRENT_BINARY_DIR}/nodeos_run_test.py COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/nodeos_run_remote_test.py ${CMAKE_CURRENT_BINARY_DIR}/nodeos_run_remote_test.py COPYONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/nodeos_under_min_avail_ram.py ${CMAKE_CURRENT_BINARY_DIR}/nodeos_under_min_avail_ram.py COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/nodeos_voting_test.py ${CMAKE_CURRENT_BINARY_DIR}/nodeos_voting_test.py COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/consensus-validation-malicious-producers.py ${CMAKE_CURRENT_BINARY_DIR}/consensus-validation-malicious-producers.py COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/validate-dirty-db.py ${CMAKE_CURRENT_BINARY_DIR}/validate-dirty-db.py COPYONLY)
@@ -67,6 +68,9 @@ set_property(TEST nodeos_sanity_lr_test PROPERTY LABELS long_running_tests)
 
 add_test(NAME nodeos_voting_lr_test COMMAND tests/nodeos_voting_test.py -v --clean-run --dump-error-detail WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 set_property(TEST nodeos_voting_lr_test PROPERTY LABELS long_running_tests)
+
+add_test(NAME nodeos_under_min_avail_ram_lr_test COMMAND tests/nodeos_under_min_avail_ram.py -v --clean-run --dump-error-detail WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+set_property(TEST nodeos_under_min_avail_ram_lr_test PROPERTY LABELS long_running_tests)
 
 
 if(ENABLE_COVERAGE_TESTING)

--- a/tests/Cluster.py
+++ b/tests/Cluster.py
@@ -97,7 +97,7 @@ class Cluster(object):
     # pylint: disable=too-many-branches
     # pylint: disable=too-many-statements
     def launch(self, pnodes=1, totalNodes=1, prodCount=1, topo="mesh", p2pPlugin="net", delay=1, onlyBios=False, dontKill=False
-               , dontBootstrap=False, totalProducers=None):
+               , dontBootstrap=False, totalProducers=None, extraNodeosArgs=None):
         """Launch cluster.
         pnodes: producer nodes count
         totalNodes: producer + non-producer nodes count
@@ -129,11 +129,14 @@ class Cluster(object):
         if self.staging:
             cmdArr.append("--nogen")
 
-        nodeosArgs="--max-transaction-time 5000 --abi-serializer-max-time-ms 5000 --filter-on * --p2p-max-nodes-per-host %d" % (totalNodes)
+        nodeosArgs="--max-transaction-time 50000 --abi-serializer-max-time-ms 50000 --filter-on * --p2p-max-nodes-per-host %d" % (totalNodes)
         if not self.walletd:
             nodeosArgs += " --plugin eosio::wallet_api_plugin"
         if self.enableMongo:
             nodeosArgs += " --plugin eosio::mongo_db_plugin --mongodb-wipe --delete-all-blocks --mongodb-uri %s" % self.mongoUri
+        if extraNodeosArgs is not None:
+            assert(isinstance(extraNodeosArgs, str))
+            nodeosArgs += extraNodeosArgs
         if Utils.Debug:
             nodeosArgs += " --contracts-console"
 
@@ -564,11 +567,11 @@ class Cluster(object):
 
         node.validateAccounts(myAccounts)
 
-    def createAccountAndVerify(self, account, creator, stakedDeposit=1000):
+    def createAccountAndVerify(self, account, creator, stakedDeposit=1000, stakeNet=100, stakeCPU=100, buyRAM=100):
         """create account, verify account and return transaction id"""
         assert(len(self.nodes) > 0)
         node=self.nodes[0]
-        trans=node.createInitializeAccount(account, creator, stakedDeposit)
+        trans=node.createInitializeAccount(account, creator, stakedDeposit, stakeNet=stakeNet, stakeCPU=stakeCPU, buyRAM=buyRAM)
         assert(trans)
         assert(node.verifyAccount(account))
         return trans
@@ -586,10 +589,10 @@ class Cluster(object):
     #         return transId
     #     return None
 
-    def createInitializeAccount(self, account, creatorAccount, stakedDeposit=1000, waitForTransBlock=False):
+    def createInitializeAccount(self, account, creatorAccount, stakedDeposit=1000, waitForTransBlock=False, stakeNet=100, stakeCPU=100, buyRAM=100):
         assert(len(self.nodes) > 0)
         node=self.nodes[0]
-        trans=node.createInitializeAccount(account, creatorAccount, stakedDeposit, waitForTransBlock)
+        trans=node.createInitializeAccount(account, creatorAccount, stakedDeposit, waitForTransBlock, stakeNet=stakeNet, stakeCPU=stakeCPU, buyRAM=buyRAM)
         return trans
 
     @staticmethod

--- a/tests/Cluster.py
+++ b/tests/Cluster.py
@@ -354,7 +354,7 @@ class Cluster(object):
         p = re.compile('Private key: (.+)\nPublic key: (.+)\n', re.MULTILINE)
         for _ in range(0, count):
             try:
-                cmd="%s create key" % (Utils.EosClientPath)
+                cmd="%s create key --to-console" % (Utils.EosClientPath)
                 if Utils.Debug: Utils.Print("cmd: %s" % (cmd))
                 keyStr=Utils.checkOutput(cmd.split())
                 m=p.search(keyStr)
@@ -365,7 +365,7 @@ class Cluster(object):
                 ownerPrivate=m.group(1)
                 ownerPublic=m.group(2)
 
-                cmd="%s create key" % (Utils.EosClientPath)
+                cmd="%s create key --to-console" % (Utils.EosClientPath)
                 if Utils.Debug: Utils.Print("cmd: %s" % (cmd))
                 keyStr=Utils.checkOutput(cmd.split())
                 m=p.match(keyStr)

--- a/tests/Node.py
+++ b/tests/Node.py
@@ -991,6 +991,23 @@ class Node(object):
         self.killed=True
         return True
 
+    def verifyAlive(self):
+        if Utils.Debug: Utils.Print("Checking if node(pid=%s) is alive(killed=%s): %s" % (self.pid, self.killed, self.cmd))
+        if self.killed or self.pid is None:
+            return False
+
+        try:
+            os.kill(self.pid, 0)
+        except ProcessLookupError as ex:
+            # mark node as killed
+            self.pid=None
+            self.killed=True
+            return False
+        except PermissionError as ex:
+            return True
+        else:
+            return True
+
     # TBD: make nodeId an internal property
     # pylint: disable=too-many-locals
     def relaunch(self, nodeId, chainArg, newChain=False, timeout=Utils.systemWaitTimeout, addOrSwapFlags=None):

--- a/tests/WalletMgr.py
+++ b/tests/WalletMgr.py
@@ -53,7 +53,7 @@ class WalletMgr(object):
             if Utils.Debug: Utils.Print("Wallet \"%s\" already exists. Returning same." % name)
             return wallet
         p = re.compile(r'\n\"(\w+)\"\n', re.MULTILINE)
-        cmd="%s %s wallet create --name %s" % (Utils.EosClientPath, self.endpointArgs, name)
+        cmd="%s %s wallet create --name %s --to-console" % (Utils.EosClientPath, self.endpointArgs, name)
         if Utils.Debug: Utils.Print("cmd: %s" % (cmd))
         retStr=Utils.checkOutput(cmd.split())
         #Utils.Print("create: %s" % (retStr))

--- a/tests/nodeos_under_min_avail_ram.py
+++ b/tests/nodeos_under_min_avail_ram.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+
+from core_symbol import CORE_SYMBOL
+from Cluster import Cluster
+from WalletMgr import WalletMgr
+from Node import Node
+from TestHelper import TestHelper
+from testUtils import Utils
+import testUtils
+import time
+
+import decimal
+import math
+import re
+
+class NamedAccounts:
+
+    def __init__(self, cluster, numAccounts):
+        Print("NamedAccounts %d" % (numAccounts))
+        self.numAccounts=numAccounts
+        self.accounts=cluster.createAccountKeys(numAccounts)
+        if self.accounts is None:
+            errorExit("FAILURE - create keys")
+        accountNum = 0
+        for account in self.accounts:
+            Print("NamedAccounts Name for %d" % (accountNum))
+            account.name=self.setName(accountNum)
+            accountNum+=1
+
+    def setName(self, num):
+        retStr="test"
+        digits=[]
+        maxDigitVal=5
+        maxDigits=8
+        temp=num
+        while len(digits) < maxDigits:
+            digit=(num % maxDigitVal)+1
+            num=int(num/maxDigitVal)
+            digits.append(digit)
+
+        digits.reverse()
+        for digit in digits:
+            retStr=retStr+str(digit)
+
+        Print("NamedAccounts Name for %d is %s" % (temp, retStr))
+        return retStr
+
+###############################################################
+# nodeos_voting_test
+# --dump-error-details <Upon error print etc/eosio/node_*/config.ini and var/lib/node_*/stderr.log to stdout>
+# --keep-logs <Don't delete var/lib/node_* folders upon test completion>
+###############################################################
+Print=Utils.Print
+errorExit=Utils.errorExit
+
+args = TestHelper.parse_args({"--dump-error-details","--keep-logs","-v","--leave-running","--clean-run"})
+Utils.Debug=args.v
+totalNodes=4
+cluster=Cluster(walletd=True)
+dumpErrorDetails=args.dump_error_details
+keepLogs=args.keep_logs
+dontKill=args.leave_running
+killAll=args.clean_run
+
+walletMgr=WalletMgr(True)
+testSuccessful=False
+killEosInstances=not dontKill
+killWallet=not dontKill
+
+WalletdName="keosd"
+ClientName="cleos"
+
+try:
+    TestHelper.printSystemInfo("BEGIN")
+
+    cluster.killall(allInstances=killAll)
+    cluster.cleanup()
+    Print("Stand up cluster")
+    minRAMFlag="--chain-state-db-guard-size-mb"
+    minRAMValue=1002
+    maxRAMFlag="--chain-state-db-size-mb"
+    maxRAMValue=1010
+    extraNodeosArgs=" %s %d %s %d " % (minRAMFlag, minRAMValue, maxRAMFlag, maxRAMValue)
+    if cluster.launch(onlyBios=False, dontKill=dontKill, pnodes=totalNodes, totalNodes=totalNodes, totalProducers=totalNodes*21, extraNodeosArgs=extraNodeosArgs) is False:
+        Utils.cmdError("launcher")
+        errorExit("Failed to stand up eos cluster.")
+
+    Print("Validating system accounts after bootstrap")
+    cluster.validateAccounts(None)
+
+    Print("creating accounts")
+    namedAccounts=NamedAccounts(cluster,10)
+    accounts=namedAccounts.accounts
+
+    testWalletName="test"
+
+    Print("Creating wallet \"%s\"." % (testWalletName))
+    walletMgr.killall(allInstances=killAll)
+    walletMgr.cleanup()
+    if walletMgr.launch() is False:
+        Utils.cmdError("%s" % (WalletdName))
+        errorExit("Failed to stand up eos walletd.")
+
+    testWallet=walletMgr.create(testWalletName, [cluster.eosioAccount])
+    if testWallet is None:
+        Utils.cmdError("eos wallet create")
+        errorExit("Failed to create wallet %s." % (testWalletName))
+
+    for _, account in cluster.defProducerAccounts.items():
+        walletMgr.importKey(account, testWallet, ignoreDupKeyWarning=True)
+
+    Print("Wallet \"%s\" password=%s." % (testWalletName, testWallet.password.encode("utf-8")))
+
+    nodes=[]
+    nodes.append(cluster.getNode(0))
+    if nodes[0] is None:
+        errorExit("Cluster in bad state, received None node")
+    nodes.append(cluster.getNode(1))
+    if nodes[1] is None:
+        errorExit("Cluster in bad state, received None node")
+    nodes.append(cluster.getNode(2))
+    if nodes[2] is None:
+        errorExit("Cluster in bad state, received None node")
+    nodes.append(cluster.getNode(3))
+    if nodes[3] is None:
+        errorExit("Cluster in bad state, received None node")
+
+
+    for account in accounts:
+        walletMgr.importKey(account, testWallet)
+
+    # create accounts via eosio as otherwise a bid is needed
+    for account in accounts:
+        Print("Create new account %s via %s" % (account.name, cluster.eosioAccount.name))
+        trans=nodes[0].createInitializeAccount(account, cluster.eosioAccount, stakedDeposit=500000, waitForTransBlock=False, stakeNet=50000, stakeCPU=50000, buyRAM=50000)
+        if trans is None:
+            Utils.cmdError("%s create account" % (account.name))
+            errorExit("Failed to create account %s" % (account.name))
+        transferAmount="70000000.0000 {0}".format(CORE_SYMBOL)
+        Print("Transfer funds %s from account %s to %s" % (transferAmount, cluster.eosioAccount.name, account.name))
+        if nodes[0].transferFunds(cluster.eosioAccount, account, transferAmount, "test transfer") is None:
+            errorExit("Failed to transfer funds %d from account %s to %s" % (
+                transferAmount, cluster.eosioAccount.name, account.name))
+        trans=nodes[0].delegatebw(account, 1000000.0000, 68000000.0000) 
+        if trans is None:
+            Utils.cmdError("delegate bandwidth for %s" % (account.name))
+            errorExit("Failed to delegate bandwidth for %s" % (account.name))
+
+    contractAccount=cluster.createAccountKeys(1)[0]
+    contractAccount.name="contracttest"
+    walletMgr.importKey(contractAccount, testWallet)
+    Print("Create new account %s via %s" % (contractAccount.name, cluster.eosioAccount.name))
+    trans=nodes[0].createInitializeAccount(contractAccount, cluster.eosioAccount, stakedDeposit=500000, waitForTransBlock=False, stakeNet=50000, stakeCPU=50000, buyRAM=50000)
+    if trans is None:
+        Utils.cmdError("%s create account" % (contractAccount.name))
+        errorExit("Failed to create account %s" % (contractAccount.name))
+    transferAmount="90000000.0000 {0}".format(CORE_SYMBOL)
+    Print("Transfer funds %s from account %s to %s" % (transferAmount, cluster.eosioAccount.name, contractAccount.name))
+    if nodes[0].transferFunds(cluster.eosioAccount, contractAccount, transferAmount, "test transfer") is None:
+        errorExit("Failed to transfer funds %d from account %s to %s" % (
+            transferAmount, cluster.eosioAccount.name, contractAccount.name))
+    trans=nodes[0].delegatebw(contractAccount, 1000000.0000, 88000000.0000) 
+    if trans is None:
+        Utils.cmdError("delegate bandwidth for %s" % (contractAccount.name))
+        errorExit("Failed to delegate bandwidth for %s" % (contractAccount.name))
+
+    contractDir="contracts/integration_test"
+    wastFile="contracts/integration_test/integration_test.wast"
+    abiFile="contracts/integration_test/integration_test.abi"
+    Print("Publish contract")
+    trans=nodes[0].publishContract(contractAccount.name, contractDir, wastFile, abiFile, waitForTransBlock=True)
+    if trans is None:
+        cmdError("%s set contract %s" % (ClientName, contractAccount.name))
+        errorExit("Failed to publish contract.")
+
+    contract=contractAccount.name
+    Print("push create action to %s contract" % (contract))
+    action="store"
+    numAmount=5000
+    keepProcessing=True
+    count=0
+    while keepProcessing:
+        numAmount+=1
+        for fromIndex in range(namedAccounts.numAccounts):
+            count+=1
+            toIndex=fromIndex+1
+            if toIndex==namedAccounts.numAccounts:
+                toIndex=0
+            fromAccount=accounts[fromIndex]
+            toAccount=accounts[toIndex]
+            data="{\"from\":\"%s\",\"to\":\"%s\",\"num\":%d}" % (fromAccount.name, toAccount.name, numAmount)
+            opts="--permission %s@active --permission %s@active --expiration 90" % (contract, fromAccount.name)
+            try:
+                trans=nodes[0].pushMessage(contract, action, data, opts)
+                if trans is None or not trans[0]:
+                    Print("Failed to push create action to eosio contract. sleep for 60 seconds")
+                    time.sleep(60)
+                time.sleep(1)
+            except TypeError as ex:
+                keepProcessing=False
+                break
+
+    #spread the actions to all accounts, to use each accounts tps bandwidth
+    fromIndexStart=fromIndex+1 if fromIndex+1<namedAccounts.numAccounts else 0
+
+    if count < 5 or count > 15:
+        strMsg="little" if count < 15 else "much"
+        Utils.cmdError("Was able to send %d store actions which was too %s" % (count, strMsg))
+        errorExit("Incorrect number of store actions sent")
+
+    # Make sure all the nodes are shutdown (may take a little while for this to happen, so making multiple passes)
+    allDone=False
+    count=0
+    while not allDone:
+        allDone=True
+        for node in nodes:
+            if node.verifyAlive():
+                allDone=False
+        if not allDone:
+            time.sleep(5)
+        if ++count>5:
+            Utils.cmdError("All Nodes should have died")
+            errorExit("Failure - All Nodes should have died")
+
+    Print("relaunch nodes with new capacity")
+    addOrSwapFlags={}
+    numNodes=len(nodes)
+    maxRAMValue+=2
+    currentMinimumMaxRAM=maxRAMValue
+    for i in range(numNodes):
+        addOrSwapFlags[maxRAMFlag]=str(maxRAMValue)
+        if i==numNodes-1:
+            addOrSwapFlags["--enable-stale-production"]=""   # just enable stale production for the first node
+        nodeIndex=numNodes-i-1
+        if not nodes[nodeIndex].relaunch(nodeIndex, "", newChain=False, addOrSwapFlags=addOrSwapFlags):
+            Utils.cmdError("Failed to restart node0 with new capacity %s" % (maxRAMValue))
+            errorExit("Failure - Node should have restarted")
+        addOrSwapFlags={}
+        maxRAMValue=currentMinimumMaxRAM+30
+
+    time.sleep(10)
+    for i in range(numNodes):
+        if not nodes[i].verifyAlive():
+            Utils.cmdError("Node %d should be alive" % (i))
+            errorExit("Failure - All Nodes should be alive")
+
+    Print("push more actions to %s contract" % (contract))
+    action="store"
+    keepProcessing=True
+    count=0
+    while keepProcessing and count < 40:
+        Print("Send %s" % (action))
+        numAmount+=1
+        for fromIndexOffset in range(namedAccounts.numAccounts):
+            count+=1
+            fromIndex=fromIndexStart+fromIndexOffset
+            if fromIndex>=namedAccounts.numAccounts:
+                fromIndex-=namedAccounts.numAccounts 
+            toIndex=fromIndex+1
+            if toIndex==namedAccounts.numAccounts:
+                toIndex=0
+            fromAccount=accounts[fromIndex]
+            toAccount=accounts[toIndex]
+            data="{\"from\":\"%s\",\"to\":\"%s\",\"num\":%d}" % (fromAccount.name, toAccount.name, numAmount)
+            opts="--permission %s@active --permission %s@active --expiration 90" % (contract, fromAccount.name)
+            try:
+                trans=nodes[0].pushMessage(contract, action, data, opts)
+                if trans is None or not trans[0]:
+                    Print("Failed to push create action to eosio contract. sleep for 60 seconds")
+                    time.sleep(60)
+                time.sleep(1)
+            except TypeError as ex:
+                Print("Failed to send %s" % (action))
+
+            if not nodes[len(nodes)-1].verifyAlive():
+                keepProcessing=False
+                break
+
+    if keepProcessing:
+        Utils.cmdError("node[%d] never shutdown" % (numNodes-1))
+        errorExit("Failure - Node should be shutdown")
+
+    for i in range(numNodes):
+        # only the last node should be dead
+        if not nodes[i].verifyAlive() and i<numNodes-1:
+            Utils.cmdError("Node %d should be alive" % (i))
+            errorExit("Failure - Node should be alive")
+
+    Print("relaunch node with even more capacity")
+    addOrSwapFlags={}
+
+    time.sleep(10)
+    maxRAMValue=currentMinimumMaxRAM+5
+    currentMinimumMaxRAM=maxRAMValue
+    addOrSwapFlags[maxRAMFlag]=str(maxRAMValue)
+    if not nodes[len(nodes)-1].relaunch(nodeIndex, "", newChain=False, addOrSwapFlags=addOrSwapFlags):
+        Utils.cmdError("Failed to restart node i with new capacity %s" % (numNodes-1, maxRAMValue))
+        errorExit("Failure - Node should have restarted")
+    addOrSwapFlags={}
+
+    time.sleep(10)
+    allDone=True
+    for node in nodes:
+        if not node.verifyAlive():
+            Utils.cmdError("All Nodes should be alive")
+            errorExit("Failure - All Nodes should be alive")
+
+    Print("Send 1 more action to every node")
+    numAmount+=1
+    for fromIndexOffset in range(namedAccounts.numAccounts):
+        # just sending one node to each
+        if fromIndexOffset>=len(nodes):
+           break
+        fromIndex=fromIndexStart+fromIndexOffset
+        if fromIndex>=namedAccounts.numAccounts:
+            fromIndex-=namedAccounts.numAccounts 
+        toIndex=fromIndex+1
+        if toIndex==namedAccounts.numAccounts:
+            toIndex=0
+        fromAccount=accounts[fromIndex]
+        toAccount=accounts[toIndex]
+        node=nodes[fromIndexOffset]
+        data="{\"from\":\"%s\",\"to\":\"%s\",\"num\":%d}" % (fromAccount.name, toAccount.name, numAmount)
+        opts="--permission %s@active --permission %s@active --expiration 90" % (contract, fromAccount.name)
+        try:
+            trans=nodes[0].pushMessage(contract, action, data, opts)
+            if trans is None or not trans[0]:
+                Print("Failed to push create action to eosio contract. sleep for 60 seconds")
+                time.sleep(60)
+                continue
+            time.sleep(1)
+        except TypeError as ex:
+            Utils.cmdError("Failed to send %s action to node %d" % (fromAccount, fromIndexOffset, action))
+            errorExit("Failure - send %s action should have succeeded" % (action))
+
+    time.sleep(10)
+    Print("Check nodes are alive")
+    allDone=True
+    for node in nodes:
+        if not node.verifyAlive():
+            Utils.cmdError("All Nodes should be alive")
+            errorExit("Failure - All Nodes should be alive")
+
+    testSuccessful=True
+finally:
+    TestHelper.shutdown(cluster, walletMgr, testSuccessful, killEosInstances, killWallet, keepLogs, killAll, dumpErrorDetails)
+
+exit(0)

--- a/tutorials/bios-boot-tutorial/bios-boot-tutorial.py
+++ b/tutorials/bios-boot-tutorial/bios-boot-tutorial.py
@@ -266,7 +266,7 @@ def msigReplaceSystem():
 def produceNewAccounts():
     with open('newusers', 'w') as f:
         for i in range(120_000, 200_000):
-            x = getOutput(args.cleos + 'create key')
+            x = getOutput(args.cleos + 'create key --to-console')
             r = re.match('Private key: *([^ \n]*)\nPublic key: *([^ \n]*)', x, re.DOTALL | re.MULTILINE)
             name = 'user'
             for j in range(7, -1, -1):


### PR DESCRIPTION
#4554
Changed "wallet create" and "create key" to take a "--file" parameter to pass a filename to write to or else to require "--to-console" to be passed to explicitly indicate sensitive information should be displayed on the console.