### PR TITLE
Password and keys to file instead of console

### DIFF
--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -1699,8 +1699,8 @@ int main( int argc, char** argv ) {
       }
    });
    create_key->add_flag( "--r1", r1, "Generate a key using the R1 curve (iPhone), instead of the K1 curve (Bitcoin)"  );
-   create_key->add_option("-f,--file", key_file, localized("Name of file to write wallet password output to. (Must be set, unless \"--to-console\" is passed"));
-   create_key->add_flag( "--to-console", print_console, localized("Print password to console."));
+   create_key->add_option("-f,--file", key_file, localized("Name of file to write private/public key output to. (Must be set, unless \"--to-console\" is passed"));
+   create_key->add_flag( "--to-console", print_console, localized("Print private/public keys to console."));
 
    // create account
    auto createAccount = create_account_subcommand( create, true /*simple*/ );

--- a/tests/Cluster.py
+++ b/tests/Cluster.py
@@ -351,7 +351,7 @@ class Cluster(object):
         p = re.compile('Private key: (.+)\nPublic key: (.+)\n', re.MULTILINE)
         for _ in range(0, count):
             try:
-                cmd="%s create key" % (Utils.EosClientPath)
+                cmd="%s create key --to-console" % (Utils.EosClientPath)
                 if Utils.Debug: Utils.Print("cmd: %s" % (cmd))
                 keyStr=Utils.checkOutput(cmd.split())
                 m=p.search(keyStr)
@@ -362,7 +362,7 @@ class Cluster(object):
                 ownerPrivate=m.group(1)
                 ownerPublic=m.group(2)
 
-                cmd="%s create key" % (Utils.EosClientPath)
+                cmd="%s create key --to-console" % (Utils.EosClientPath)
                 if Utils.Debug: Utils.Print("cmd: %s" % (cmd))
                 keyStr=Utils.checkOutput(cmd.split())
                 m=p.match(keyStr)

--- a/tests/WalletMgr.py
+++ b/tests/WalletMgr.py
@@ -53,7 +53,7 @@ class WalletMgr(object):
             if Utils.Debug: Utils.Print("Wallet \"%s\" already exists. Returning same." % name)
             return wallet
         p = re.compile(r'\n\"(\w+)\"\n', re.MULTILINE)
-        cmd="%s %s wallet create --name %s" % (Utils.EosClientPath, self.endpointArgs, name)
+        cmd="%s %s wallet create --name %s --to-console" % (Utils.EosClientPath, self.endpointArgs, name)
         if Utils.Debug: Utils.Print("cmd: %s" % (cmd))
         retStr=Utils.checkOutput(cmd.split())
         #Utils.Print("create: %s" % (retStr))

--- a/tutorials/bios-boot-tutorial/bios-boot-tutorial.py
+++ b/tutorials/bios-boot-tutorial/bios-boot-tutorial.py
@@ -266,7 +266,7 @@ def msigReplaceSystem():
 def produceNewAccounts():
     with open('newusers', 'w') as f:
         for i in range(120_000, 200_000):
-            x = getOutput(args.cleos + 'create key')
+            x = getOutput(args.cleos + 'create key --to-console')
             r = re.match('Private key: *([^ \n]*)\nPublic key: *([^ \n]*)', x, re.DOTALL | re.MULTILINE)
             name = 'user'
             for j in range(7, -1, -1):


### PR DESCRIPTION
#4554
Changed "wallet create" and "create key" to take a "--file" parameter to pass a filename to write to or else to require "--to-console" to be passed to explicitly indicate sensitive information should be displayed on the console.