### PR TITLE
extended_symbol operator <

### DIFF
--- a/contracts/eosiolib/symbol.hpp
+++ b/contracts/eosiolib/symbol.hpp
@@ -215,6 +215,10 @@ namespace eosio {
         return std::tie( a.value, a.contract ) != std::tie( b.value, b.contract );
       }
 
+      friend bool operator < ( const extended_symbol& a, const extended_symbol& b ) {
+        return std::tie( a.value, a.contract ) < std::tie( b.value, b.contract );
+      }
+
       EOSLIB_SERIALIZE( extended_symbol, (value)(contract) )
    };
 


### PR DESCRIPTION
Related to #4525 since it was pulling in the wrong comparison. Doesn't fix #4525 since that's an API change.