### PR TITLE
Consolidated Security Fixes for 1.1.1

### DIFF
--- a/libraries/chain/include/eosio/chain/generated_transaction_object.hpp
+++ b/libraries/chain/include/eosio/chain/generated_transaction_object.hpp
@@ -77,6 +77,34 @@ namespace eosio { namespace chain {
       >
    >;
 
+   class generated_transaction
+   {
+      public:
+         generated_transaction(const generated_transaction_object& gto)
+         :trx_id(gto.trx_id)
+         ,sender(gto.sender)
+         ,sender_id(gto.sender_id)
+         ,payer(gto.payer)
+         ,delay_until(gto.delay_until)
+         ,expiration(gto.expiration)
+         ,published(gto.published)
+         ,packed_trx(gto.packed_trx.begin(), gto.packed_trx.end())
+         {}
+
+         generated_transaction(const generated_transaction& gt) = default;
+         generated_transaction(generated_transaction&& gt) = default;
+
+         transaction_id_type           trx_id;
+         account_name                  sender;
+         uint128_t                     sender_id;
+         account_name                  payer;
+         time_point                    delay_until; /// this generated transaction will not be applied until the specified time
+         time_point                    expiration; /// this generated transaction will not be applied after this time
+         time_point                    published;
+         vector<char>                  packed_trx;
+
+   };
+
    namespace config {
       template<>
       struct billable_size<generated_transaction_object> {

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -84,22 +84,6 @@ namespace eosio {
       uint16_t        requests = 0; /// the number of "in flight" requests for this txn
    };
 
-   struct update_entry {
-      const packed_transaction &txn;
-      update_entry(const packed_transaction &msg) : txn(msg) {}
-
-      void operator() (node_transaction_state& nts) {
-         nts.packed_txn = txn;
-         net_message msg(txn);
-         uint32_t packsiz = fc::raw::pack_size(msg);
-         uint32_t bufsiz = packsiz + sizeof(packsiz);
-         nts.serialized_txn.resize(bufsiz);
-         fc::datastream<char*> ds( nts.serialized_txn.data(), bufsiz );
-         ds.write( reinterpret_cast<char*>(&packsiz), sizeof(packsiz) );
-         fc::raw::pack( ds, msg );
-      }
-   };
-
    struct update_in_flight {
       int32_t incr;
       update_in_flight (int32_t delta) : incr (delta) {}
@@ -582,7 +566,6 @@ namespace eosio {
       void blk_send(const vector<block_id_type> &txn_lis);
       void stop_send();
 
-      void enqueue( transaction_id_type id );
       void enqueue( const net_message &msg, bool trigger_send = true );
       void cancel_sync(go_away_reason);
       void flush_queues();
@@ -666,13 +649,12 @@ namespace eosio {
       connection_ptr source;
       stages         state;
 
-      deque<block_id_type> _blocks;
-      chain_plugin * chain_plug;
+      chain_plugin* chain_plug;
 
       constexpr auto stage_str(stages s );
 
    public:
-      sync_manager(uint32_t span);
+      explicit sync_manager(uint32_t span);
       void set_state(stages s);
       bool sync_required();
       void send_handshakes();
@@ -690,13 +672,8 @@ namespace eosio {
 
    class dispatch_manager {
    public:
-      uint32_t just_send_it_max;
+      uint32_t just_send_it_max = 0;
 
-      struct block_request {
-         block_id_type id;
-         bool local_retry;
-      };
-      vector<block_request> req_blks;
       vector<transaction_id_type> req_trx;
 
       struct block_origin {
@@ -1688,6 +1665,7 @@ namespace eosio {
       if (c &&
           c->last_req &&
           c->last_req->req_blocks.mode != none &&
+          !c->last_req->req_blocks.ids.empty() &&
           c->last_req->req_blocks.ids.back() == id) {
          c->last_req.reset();
       }
@@ -1797,6 +1775,7 @@ namespace eosio {
       if (c &&
           c->last_req &&
           c->last_req->req_trx.mode != none &&
+          !c->last_req->req_trx.ids.empty() &&
           c->last_req->req_trx.ids.back() == id) {
          c->last_req.reset();
       }
@@ -1868,7 +1847,6 @@ namespace eosio {
             if (!b) {
                send_req = true;
                req.req_blocks.ids.push_back( blkid );
-               req_blks.push_back( {blkid, generated} );
                entry.requested_time = fc::time_point::now();
             }
             c->add_peer_block(entry);
@@ -1894,11 +1872,11 @@ namespace eosio {
       transaction_id_type tid;
       block_id_type bid;
       bool is_txn = false;
-      if( c->last_req->req_trx.mode == normal ) {
+      if( c->last_req->req_trx.mode == normal && !c->last_req->req_trx.ids.empty() ) {
          is_txn = true;
          tid = c->last_req->req_trx.ids.back();
       }
-      else if( c->last_req->req_blocks.mode == normal ) {
+      else if( c->last_req->req_blocks.mode == normal && !c->last_req->req_blocks.ids.empty() ) {
          bid = c->last_req->req_blocks.ids.back();
       }
       else {


### PR DESCRIPTION
- Fix Bug when deferred transaction cancels itself
- Limit range of tracked block_status notices
- Guard against a malformed notice message accessing the back of an empty vector.

Co-authored-by: Bart Wyatt <bart.wyatt@block.one>
Co-authored-by: Kevin Heifner <heifner_k@ociweb.com>