### PR TITLE
Prevent blocking of name auctions

### DIFF
--- a/contracts/eosio.system/producer_pay.cpp
+++ b/contracts/eosio.system/producer_pay.cpp
@@ -49,7 +49,7 @@ namespace eosiosystem {
          if( (timestamp.slot - _gstate.last_name_close.slot) > blocks_per_day ) {
             name_bid_table bids(_self,_self);
             auto idx = bids.get_index<N(highbid)>();
-            auto highest = idx.begin();
+            auto highest = idx.lower_bound(INT64_MAX); // ignore negative range of int64_t (closed auctions)
             if( highest != idx.end() &&
                 highest->high_bid > 0 &&
                 highest->last_bid_time < (current_time() - useconds_per_day) &&


### PR DESCRIPTION
The premium name auctions have been blocked for several days because the user who won the auction for the `cn` name hasn't claimed it by creating an account with that name. The system looks for the first entry in the index that sorts by `static_cast<uint64_t>(-high_bid)` but since that field is an `int64_t` and it gets converted to a `uint64_t`, the negative values end up before the positive ones in that index. This causes the closed auctions that haven't been claimed to show up as the highest bid in the list of what is assumed are active auctions, when in fact they have finished already and that's why they have this value set to a negative number. This, combined with the check for `highest->high_bid > 0` in the `if` clause makes it impossible for the auctions that are actually still active to be marked as finished (when they should) until the previous ones have been claimed.

Basically this gives the winner of an auction the power to stop auctions for everybody else. This fix prevents that.