### PR TITLE
Enable multi-threading when building boost libraries

### DIFF
--- a/scripts/eosio_build_amazon.sh
+++ b/scripts/eosio_build_amazon.sh
@@ -277,7 +277,7 @@
 			printf "\\n\\tExiting now.\\n"
 			exit 1
 		fi
-		if ! "${TEMP_DIR}"/boost_1_67_0/b2 install
+		if ! "${TEMP_DIR}"/boost_1_67_0/b2 -j"${CPU_CORE}" install
 		then
 			printf "\\n\\tInstallation of boost libraries failed. 1\\n"
 			printf "\\n\\tExiting now.\\n"

--- a/scripts/eosio_build_centos.sh
+++ b/scripts/eosio_build_centos.sh
@@ -363,7 +363,7 @@
 			printf "\\n\\tExiting now.\\n\\n"
 			exit 1;
 		fi
-		if ! "${TEMP_DIR}"/boost_1_67_0/b2 -j2 install
+		if ! "${TEMP_DIR}"/boost_1_67_0/b2 -j"${CPU_CORE}" install
 		then
 			printf "\\n\\tInstallation of boost libraries failed with the above error. 1\\n"
 			printf "\\n\\tExiting now.\\n\\n"

--- a/scripts/eosio_build_fedora.sh
+++ b/scripts/eosio_build_fedora.sh
@@ -220,7 +220,7 @@
 			printf "\\tExiting now.\\n\\n"
 			exit 1;
 		fi
-		if ! "${TEMP_DIR}"/boost_1_67_0/b2 install
+		if ! "${TEMP_DIR}"/boost_1_67_0/b2 -j"${CPU_CORE}" install
 		then
 			printf "\\n\\tInstallation of boost libraries failed. 1\\n"
 			printf "\\tExiting now.\\n\\n"

--- a/scripts/eosio_build_ubuntu.sh
+++ b/scripts/eosio_build_ubuntu.sh
@@ -178,7 +178,7 @@
 			printf "\\n\\tExiting now.\\n\\n"
 			exit 1
 		fi
-		if ! ./b2 install
+		if ! ./b2 -j"${CPU_CORE}" install
 		then
 			printf "\\n\\tInstallation of boost libraries failed. 1\\n"
 			printf "\\n\\tExiting now.\\n\\n"


### PR DESCRIPTION
When I ran eosio_build.sh, it takes too long time.
The cause was that only one thread is used when building the boost libraries.
I modified the script to use multiple threads.
Our time is precious :)