### PR TITLE
Change http status code for transaction_exception and eof_exception 

### DIFF
--- a/plugins/http_plugin/http_plugin.cpp
+++ b/plugins/http_plugin/http_plugin.cpp
@@ -460,12 +460,9 @@ namespace eosio {
          } catch (chain::tx_duplicate& e) {
             error_results results{409, "Conflict", error_results::error_info(e, verbose_http_errors)};
             cb( 409, fc::json::to_string( results ));
-         } catch (chain::transaction_exception& e) {
-            error_results results{400, "Bad Request", error_results::error_info(e, verbose_http_errors)};
-            cb( 400, fc::json::to_string( results ));
          } catch (fc::eof_exception& e) {
-            error_results results{400, "Bad Request", error_results::error_info(e, verbose_http_errors)};
-            cb( 400, fc::json::to_string( results ));
+            error_results results{422, "Unprocessable Entity", error_results::error_info(e, verbose_http_errors)};
+            cb( 422, fc::json::to_string( results ));
             elog( "Unable to parse arguments to ${api}.${call}", ("api", api_name)( "call", call_name ));
             dlog("Bad arguments: ${args}", ("args", body));
          } catch (fc::exception& e) {


### PR DESCRIPTION
Change http status code for transaction_exception and eof_exception so its error message is not swallowed by cleos. Currently they are treated as 400, which by cleos will be displayed as:
```
Error 3200006: invalid http request
Error Details:
The server has rejected the request as invalid!
Please verify this url is valid: http://127.0.0.1:8888/v1/chain/push_transaction
If the condition persists, please contact the RPC server administrator for 127.0.0.1!
```
and is confusing for the developer when they are trying to investigate the problem.