### PR TITLE
"cleos get table" support find by string 

### DIFF
--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -227,7 +227,6 @@ public:
       uint32_t    limit = 10;
       string      key_type;  // type of key specified by index_position
       string      index_position; // 1 - primary (first), 2 - secondary index (in order defined by multi_index), 3 - third index, etc
-      string      index_by_str;
       string      find_by_str;
     };
 
@@ -343,36 +342,25 @@ public:
          decltype(index_t_id->id) next_tid(index_t_id->id._id + 1);
          auto lower = secidx.lower_bound(boost::make_tuple(low_tid));
          auto upper = secidx.lower_bound(boost::make_tuple(next_tid));
-
-	 bool flag = false;
-	 if(p.index_by_str.size())
-	 {
-		 if(0 == p.index_by_str.compare("true"))
+	
+	if(p.find_by_str.size())
+	{
+		 uint64_t hash = 0;
+		 char *str = const_cast<char*>(p.find_by_str.c_str());
+		 while (*str)
 		 {
-			 flag = true;
-			 if(p.find_by_str.size())
-			 {
-				 uint64_t hash = 0;
-				 char *str = (char*)p.find_by_str.c_str();
-				 while (*str)
-				 {
-					 hash = (*str++) + (hash << 6) + (hash << 16) - hash;
-				 }
-				 uint64_t key = (hash & 0x7FFFFFFF);
-
-				 char buf[64];
-				 memset(buf, 0, 64);
-				 sprintf(buf, "%ld", key);
-				 SecKeyType lv = convert_to_type<SecKeyType>( buf, "lower_bound name" ); // avoids compiler error
-				 lower = secidx.lower_bound( boost::make_tuple( low_tid, conv( lv )));
-
-				 SecKeyType uv = convert_to_type<SecKeyType>( buf, "upper_bound name" );
-				 upper = secidx.upper_bound( boost::make_tuple( low_tid, conv( uv )));
-			 }
+			hash = (*str++)+(hash<<6)+(hash<<16)-hash;
 		 }
-	 }
+		
+		 char buf[64] = {0};
+		 sprintf(buf, "%ld", (hash & 0x7FFFFFFF));
+		 SecKeyType lv = convert_to_type<SecKeyType>( buf, "lower_bound name" ); // avoids compiler error
+		 lower = secidx.lower_bound( boost::make_tuple( low_tid, conv( lv )));
 
- 	if(!flag)
+		 SecKeyType uv = convert_to_type<SecKeyType>( buf, "upper_bound name" );
+		 upper = secidx.upper_bound( boost::make_tuple( low_tid, conv( uv )));
+	}
+	else
         {
 
 	 if (p.lower_bound.size()) {
@@ -581,7 +569,7 @@ FC_REFLECT(eosio::chain_apis::read_only::get_block_header_state_params, (block_n
 
 FC_REFLECT( eosio::chain_apis::read_write::push_transaction_results, (transaction_id)(processed) )
 
-FC_REFLECT( eosio::chain_apis::read_only::get_table_rows_params, (json)(code)(scope)(table)(table_key)(find_by_str)(index_by_str)(lower_bound)(upper_bound)(limit)(key_type)(index_position) )
+FC_REFLECT( eosio::chain_apis::read_only::get_table_rows_params, (json)(code)(scope)(table)(table_key)(find_by_str)(lower_bound)(upper_bound)(limit)(key_type)(index_position) )
 FC_REFLECT( eosio::chain_apis::read_only::get_table_rows_result, (rows)(more) );
 
 FC_REFLECT( eosio::chain_apis::read_only::get_currency_balance_params, (code)(account)(symbol));

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -1814,7 +1814,6 @@ int main( int argc, char** argv ) {
    string lower;
    string upper;
    string table_key;
-   string index_by_str;
    string find_by_str;
    string key_type;
    bool binary = false;
@@ -1836,7 +1835,6 @@ int main( int argc, char** argv ) {
                          localized("The key type of --index, primary only supports (i64), all others support (i64, i128, i256, float64, float128).\n"
                                    "\t\t\t\tSpecial type 'name' indicates an account name."));
    getTable->add_option( "--findbystr", find_by_str, localized("find by string") );
-   getTable->add_option( "--indexbystr", index_by_str, localized("when you want index by string,you must set true") );
 
    getTable->set_callback([&] {
       auto result = call(get_table_func, fc::mutable_variant_object("json", !binary)
@@ -1845,7 +1843,6 @@ int main( int argc, char** argv ) {
                          ("table",table)
                          ("table_key",table_key) // not used
                          ("find_by_str",find_by_str)
-                         ("index_by_str",index_by_str)
                          ("lower_bound",lower)
                          ("upper_bound",upper)
                          ("limit",limit)


### PR DESCRIPTION
i have the following information in my testtable.
cleos get table chan chan testtable --key-type i64 --index 1
![image](https://user-images.githubusercontent.com/9347690/43309391-4470e6c2-91b7-11e8-8e95-4f5b766acdc8.png)

i can Select the phone(string) info of "wls"
cleos get table chan chan testtable --key-type i64 --index 3 --findbystr wls
![image](https://user-images.githubusercontent.com/9347690/43309449-676357dc-91b7-11e8-9dc6-364c85af82da.png)

You must make some change like this when you create contract
![image](https://user-images.githubusercontent.com/9347690/43310232-9fd0be96-91b9-11e8-9b56-c85e73ab45dd.png)
