### PR TITLE
Fix late transactions

### DIFF
--- a/tests/Cluster.py
+++ b/tests/Cluster.py
@@ -1116,3 +1116,9 @@ class Cluster(object):
 
         return True
 
+    def reportStatus(self):
+        if hasattr(self, "biosNode") and self.biosNode is not None:
+            self.biosNode.reportStatus()
+        if hasattr(self, "nodes"): 
+            for node in self.nodes:
+                node.reportStatus()

--- a/tests/Cluster.py
+++ b/tests/Cluster.py
@@ -180,7 +180,8 @@ class Cluster(object):
             return True
 
         Utils.Print("Bootstrap cluster.")
-        if not Cluster.bootstrap(totalNodes, prodCount, Cluster.__BiosHost, Cluster.__BiosPort, dontKill, onlyBios):
+        self.biosNode=Cluster.bootstrap(totalNodes, prodCount, Cluster.__BiosHost, Cluster.__BiosPort, dontKill, onlyBios)
+        if self.biosNode is None:
             Utils.Print("ERROR: Bootstrap failed.")
             return False
 
@@ -691,13 +692,13 @@ class Cluster(object):
         biosNode=Node(biosHost, biosPort)
         if not biosNode.checkPulse():
             Utils.Print("ERROR: Bios node doesn't appear to be running...")
-            return False
+            return None
 
         producerKeys=Cluster.parseClusterKeys(totalNodes)
         # should have totalNodes node plus bios node
         if producerKeys is None or len(producerKeys) < (totalNodes+1):
             Utils.Print("ERROR: Failed to parse private keys from cluster config files.")
-            return False
+            return None
 
         walletMgr=WalletMgr(True)
         walletMgr.killall()
@@ -705,7 +706,7 @@ class Cluster(object):
 
         if not walletMgr.launch():
             Utils.Print("ERROR: Failed to launch bootstrap wallet.")
-            return False
+            return None
         biosNode.setWalletEndpointArgs(walletMgr.walletEndpointArgs)
 
         try:
@@ -721,7 +722,7 @@ class Cluster(object):
 
             if not walletMgr.importKey(eosioAccount, ignWallet):
                 Utils.Print("ERROR: Failed to import %s account keys into ignition wallet." % (eosioName))
-                return False
+                return None
 
             contract="eosio.bios"
             contractDir="contracts/%s" % (contract)
@@ -731,7 +732,7 @@ class Cluster(object):
             trans=biosNode.publishContract(eosioAccount.name, contractDir, wastFile, abiFile, waitForTransBlock=True)
             if trans is None:
                 Utils.Print("ERROR: Failed to publish contract %s." % (contract))
-                return False
+                return None
 
             Node.validateTransaction(trans)
 
@@ -748,14 +749,14 @@ class Cluster(object):
                 trans=biosNode.createAccount(initx, eosioAccount, 0)
                 if trans is None:
                     Utils.Print("ERROR: Failed to create account %s" % (name))
-                    return False
+                    return None
                 Node.validateTransaction(trans)
                 accounts.append(initx)
 
             transId=Node.getTransId(trans)
             if not biosNode.waitForTransInBlock(transId):
                 Utils.Print("ERROR: Failed to validate transaction %s got rolled into a block on server port %d." % (transId, biosNode.port))
-                return False
+                return None
 
             Utils.Print("Validating system accounts within bootstrap")
             biosNode.validateAccounts(accounts)
@@ -772,7 +773,7 @@ class Cluster(object):
                         myTrans=biosNode.pushMessage("eosio", "setprods", setProdsStr, opts)
                         if myTrans is None or not myTrans[0]:
                             Utils.Print("ERROR: Failed to set producers.")
-                            return False
+                            return None
                 else:
                     counts=dict.fromkeys(range(totalNodes), 0) #initialize node prods count to 0
                     setProdsStr='{"schedule": ['
@@ -798,54 +799,54 @@ class Cluster(object):
                     trans=biosNode.pushMessage("eosio", "setprods", setProdsStr, opts)
                     if trans is None or not trans[0]:
                         Utils.Print("ERROR: Failed to set producer %s." % (keys["name"]))
-                        return False
+                        return None
 
                 trans=trans[1]
                 transId=Node.getTransId(trans)
                 if not biosNode.waitForTransInBlock(transId):
                     Utils.Print("ERROR: Failed to validate transaction %s got rolled into a block on server port %d." % (transId, biosNode.port))
-                    return False
+                    return None
 
                 # wait for block production handover (essentially a block produced by anyone but eosio).
                 lam = lambda: biosNode.getInfo(exitOnError=True)["head_block_producer"] != "eosio"
                 ret=Utils.waitForBool(lam)
                 if not ret:
                     Utils.Print("ERROR: Block production handover failed.")
-                    return False
+                    return None
 
             eosioTokenAccount=copy.deepcopy(eosioAccount)
             eosioTokenAccount.name="eosio.token"
             trans=biosNode.createAccount(eosioTokenAccount, eosioAccount, 0)
             if trans is None:
                 Utils.Print("ERROR: Failed to create account %s" % (eosioTokenAccount.name))
-                return False
+                return None
 
             eosioRamAccount=copy.deepcopy(eosioAccount)
             eosioRamAccount.name="eosio.ram"
             trans=biosNode.createAccount(eosioRamAccount, eosioAccount, 0)
             if trans is None:
                 Utils.Print("ERROR: Failed to create account %s" % (eosioRamAccount.name))
-                return False
+                return None
 
             eosioRamfeeAccount=copy.deepcopy(eosioAccount)
             eosioRamfeeAccount.name="eosio.ramfee"
             trans=biosNode.createAccount(eosioRamfeeAccount, eosioAccount, 0)
             if trans is None:
                 Utils.Print("ERROR: Failed to create account %s" % (eosioRamfeeAccount.name))
-                return False
+                return None
 
             eosioStakeAccount=copy.deepcopy(eosioAccount)
             eosioStakeAccount.name="eosio.stake"
             trans=biosNode.createAccount(eosioStakeAccount, eosioAccount, 0)
             if trans is None:
                 Utils.Print("ERROR: Failed to create account %s" % (eosioStakeAccount.name))
-                return False
+                return None
 
             Node.validateTransaction(trans)
             transId=Node.getTransId(trans)
             if not biosNode.waitForTransInBlock(transId):
                 Utils.Print("ERROR: Failed to validate transaction %s got rolled into a block on server port %d." % (transId, biosNode.port))
-                return False
+                return None
 
             contract="eosio.token"
             contractDir="contracts/%s" % (contract)
@@ -855,7 +856,7 @@ class Cluster(object):
             trans=biosNode.publishContract(eosioTokenAccount.name, contractDir, wastFile, abiFile, waitForTransBlock=True)
             if trans is None:
                 Utils.Print("ERROR: Failed to publish contract %s." % (contract))
-                return False
+                return None
 
             # Create currency0000, followed by issue currency0000
             contract=eosioTokenAccount.name
@@ -866,13 +867,13 @@ class Cluster(object):
             trans=biosNode.pushMessage(contract, action, data, opts)
             if trans is None or not trans[0]:
                 Utils.Print("ERROR: Failed to push create action to eosio contract.")
-                return False
+                return None
 
             Node.validateTransaction(trans[1])
             transId=Node.getTransId(trans[1])
             if not biosNode.waitForTransInBlock(transId):
                 Utils.Print("ERROR: Failed to validate transaction %s got rolled into a block on server port %d." % (transId, biosNode.port))
-                return False
+                return None
 
             contract=eosioTokenAccount.name
             Utils.Print("push issue action to %s contract" % (contract))
@@ -882,7 +883,7 @@ class Cluster(object):
             trans=biosNode.pushMessage(contract, action, data, opts)
             if trans is None or not trans[0]:
                 Utils.Print("ERROR: Failed to push issue action to eosio contract.")
-                return False
+                return None
 
             Node.validateTransaction(trans[1])
             Utils.Print("Wait for issue action transaction to become finalized.")
@@ -892,7 +893,7 @@ class Cluster(object):
             timeout = .5 * 12 * 2 * len(producerKeys) + 60
             if not biosNode.waitForTransFinalization(transId, timeout=timeout):
                 Utils.Print("ERROR: Failed to validate transaction %s got rolled into a finalized block on server port %d." % (transId, biosNode.port))
-                return False
+                return None
 
             expectedAmount="1000000000.0000 {0}".format(CORE_SYMBOL)
             Utils.Print("Verify eosio issue, Expected: %s" % (expectedAmount))
@@ -900,7 +901,7 @@ class Cluster(object):
             if expectedAmount != actualAmount:
                 Utils.Print("ERROR: Issue verification failed. Excepted %s, actual: %s" %
                             (expectedAmount, actualAmount))
-                return False
+                return None
 
             contract="eosio.system"
             contractDir="contracts/%s" % (contract)
@@ -910,7 +911,7 @@ class Cluster(object):
             trans=biosNode.publishContract(eosioAccount.name, contractDir, wastFile, abiFile, waitForTransBlock=True)
             if trans is None:
                 Utils.Print("ERROR: Failed to publish contract %s." % (contract))
-                return False
+                return None
 
             Node.validateTransaction(trans)
 
@@ -925,7 +926,7 @@ class Cluster(object):
                 trans=biosNode.pushMessage(contract, action, data, opts)
                 if trans is None or not trans[0]:
                     Utils.Print("ERROR: Failed to transfer funds from %s to %s." % (eosioTokenAccount.name, name))
-                    return False
+                    return None
 
                 Node.validateTransaction(trans[1])
 
@@ -933,7 +934,7 @@ class Cluster(object):
             transId=Node.getTransId(trans[1])
             if not biosNode.waitForTransInBlock(transId):
                 Utils.Print("ERROR: Failed to validate transaction %s got rolled into a block on server port %d." % (transId, biosNode.port))
-                return False
+                return None
 
             Utils.Print("Cluster bootstrap done.")
         finally:
@@ -941,7 +942,7 @@ class Cluster(object):
                 walletMgr.killall()
                 walletMgr.cleanup()
 
-        return True
+        return biosNode
 
 
     # Populates list of EosInstanceInfo objects, matched to actual running instances

--- a/tests/TestHelper.py
+++ b/tests/TestHelper.py
@@ -117,6 +117,7 @@ class TestHelper(object):
         else:
             Utils.Print("Test failed.")
         if not testSuccessful and dumpErrorDetails:
+            cluster.reportStatus()
             cluster.dumpErrorDetails()
             if walletMgr:
                 walletMgr.dumpErrorDetails()

--- a/tests/TestHelper.py
+++ b/tests/TestHelper.py
@@ -110,6 +110,8 @@ class TestHelper(object):
         assert(isinstance(cleanRun, bool))
         assert(isinstance(dumpErrorDetails, bool))
 
+        Utils.ShuttingDown=True
+
         if testSuccessful:
             Utils.Print("Test succeeded.")
         else:

--- a/tests/nodeos_run_test.py
+++ b/tests/nodeos_run_test.py
@@ -282,7 +282,7 @@ try:
 
     node.waitForTransInBlock(transId)
 
-    transaction=node.getTransaction(transId, exitOnError=True)
+    transaction=node.getTransaction(transId, exitOnError=True, delayedRetry=False)
 
     typeVal=None
     amountVal=None

--- a/tests/testUtils.py
+++ b/tests/testUtils.py
@@ -23,6 +23,7 @@ class Utils:
 
     EosLauncherPath="programs/eosio-launcher/eosio-launcher"
     MongoPath="mongo"
+    ShuttingDown=False
 
     @staticmethod
     def Print(*args, **kwargs):
@@ -81,6 +82,9 @@ class Utils:
 
     @staticmethod
     def errorExit(msg="", raw=False, errorCode=1):
+        if Utils.ShuttingDown:
+            Utils.Print("ERROR:" if not raw else "", " errorExit called during shutdown, ignoring.  msg=", msg)
+            return
         Utils.Print("ERROR:" if not raw else "", msg)
         traceback.print_stack(limit=-1)
         exit(errorCode)


### PR DESCRIPTION
#4903 
In most cases the transaction has made it into a block and been processed by the history plugin before the python script calls getTransaction on the node, but it can fail sometimes, particularly when transaction is sent to one node and then getTransaction called on another node.
Added a flag to make a second pass if the first attempt to retrieve the transaction fails and some other extras, like reporting cluster status on failed test.