### PR TITLE
Fixed required dependencies display on mac

### DIFF
--- a/scripts/eosio_build_darwin.sh
+++ b/scripts/eosio_build_darwin.sh
@@ -136,7 +136,7 @@
 
 	if [ $COUNT -gt 1 ]; then
 		printf "\\n\\tThe following dependencies are required to install EOSIO.\\n"
-		printf "\\n\\t%s\\n\\n" "${DISPLAY}"
+		printf "\\n\\t${DISPLAY}\\n\\n"
 		echo "Do you wish to install these packages?"
 		select yn in "Yes" "No"; do
 			case $yn in


### PR DESCRIPTION
**Previously:**
The following dependencies are required to install EOSIO.
	1. automake\n\t2. Libtool\n\t3. llvm\n\t4. wget\n\t5. CMake\n\t6. GMP\n\t7. gettext\n\t8. MongoDB\n\t9. Doxygen\n\t10. Graphviz\n\t11. LCOV\n\t

**Now:**
The following dependencies are required to install EOSIO.
	1. automake
	2. Libtool
	3. llvm
	4. wget
	5. CMake
	6. GMP
	7. gettext
	8. MongoDB
	9. Doxygen
	10. Graphviz
	11. LCOV