### PR TITLE
"cleos get table" support find by string 

### DIFF
--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -227,6 +227,7 @@ public:
       uint32_t    limit = 10;
       string      key_type;  // type of key specified by index_position
       string      index_position; // 1 - primary (first), 2 - secondary index (in order defined by multi_index), 3 - third index, etc
+      string      find_by_str;
     };
 
    struct get_table_rows_result {
@@ -341,8 +342,28 @@ public:
          decltype(index_t_id->id) next_tid(index_t_id->id._id + 1);
          auto lower = secidx.lower_bound(boost::make_tuple(low_tid));
          auto upper = secidx.lower_bound(boost::make_tuple(next_tid));
+	
+	if(p.find_by_str.size())
+	{
+		 uint64_t hash = 0;
+		 char *str = const_cast<char*>(p.find_by_str.c_str());
+		 while (*str)
+		 {
+			hash = (*str++)+(hash<<6)+(hash<<16)-hash;
+		 }
+		
+		 char buf[64] = {0};
+		 sprintf(buf, "%ld", (hash & 0x7FFFFFFF));
+		 SecKeyType lv = convert_to_type<SecKeyType>( buf, "lower_bound name" ); // avoids compiler error
+		 lower = secidx.lower_bound( boost::make_tuple( low_tid, conv( lv )));
 
-         if (p.lower_bound.size()) {
+		 SecKeyType uv = convert_to_type<SecKeyType>( buf, "upper_bound name" );
+		 upper = secidx.upper_bound( boost::make_tuple( low_tid, conv( uv )));
+	}
+	else
+        {
+
+	 if (p.lower_bound.size()) {
             if (p.key_type == "name") {
                name s(p.lower_bound);
                SecKeyType lv = convert_to_type<SecKeyType>( s.to_string(), "lower_bound name" ); // avoids compiler error
@@ -362,6 +383,7 @@ public:
                upper = secidx.lower_bound( boost::make_tuple( low_tid, conv( uv )));
             }
          }
+	}
 
          vector<char> data;
 
@@ -547,7 +569,7 @@ FC_REFLECT(eosio::chain_apis::read_only::get_block_header_state_params, (block_n
 
 FC_REFLECT( eosio::chain_apis::read_write::push_transaction_results, (transaction_id)(processed) )
 
-FC_REFLECT( eosio::chain_apis::read_only::get_table_rows_params, (json)(code)(scope)(table)(table_key)(lower_bound)(upper_bound)(limit)(key_type)(index_position) )
+FC_REFLECT( eosio::chain_apis::read_only::get_table_rows_params, (json)(code)(scope)(table)(table_key)(find_by_str)(lower_bound)(upper_bound)(limit)(key_type)(index_position) )
 FC_REFLECT( eosio::chain_apis::read_only::get_table_rows_result, (rows)(more) );
 
 FC_REFLECT( eosio::chain_apis::read_only::get_currency_balance_params, (code)(account)(symbol));

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -1814,6 +1814,7 @@ int main( int argc, char** argv ) {
    string lower;
    string upper;
    string table_key;
+   string find_by_str;
    string key_type;
    bool binary = false;
    uint32_t limit = 10;
@@ -1825,7 +1826,7 @@ int main( int argc, char** argv ) {
    getTable->add_option( "-b,--binary", binary, localized("Return the value as BINARY rather than using abi to interpret as JSON") );
    getTable->add_option( "-l,--limit", limit, localized("The maximum number of rows to return") );
    getTable->add_option( "-k,--key", table_key, localized("Deprecated") );
-   getTable->add_option( "-L,--lower", lower, localized("JSON representation of lower bound value of key, defaults to first") );
+    getTable->add_option( "-L,--lower", lower, localized("JSON representation of lower bound value of key, defaults to first") );
    getTable->add_option( "-U,--upper", upper, localized("JSON representation of upper bound value value of key, defaults to last") );
    getTable->add_option( "--index", index_position,
                          localized("Index number, 1 - primary (first), 2 - secondary index (in order defined by multi_index), 3 - third index, etc.\n"
@@ -1833,6 +1834,7 @@ int main( int argc, char** argv ) {
    getTable->add_option( "--key-type", key_type,
                          localized("The key type of --index, primary only supports (i64), all others support (i64, i128, i256, float64, float128).\n"
                                    "\t\t\t\tSpecial type 'name' indicates an account name."));
+   getTable->add_option( "--findbystr", find_by_str, localized("find by string") );
 
    getTable->set_callback([&] {
       auto result = call(get_table_func, fc::mutable_variant_object("json", !binary)
@@ -1840,6 +1842,7 @@ int main( int argc, char** argv ) {
                          ("scope",scope)
                          ("table",table)
                          ("table_key",table_key) // not used
+                         ("find_by_str",find_by_str)
                          ("lower_bound",lower)
                          ("upper_bound",upper)
                          ("limit",limit)


### PR DESCRIPTION
We need to support string lookup in accordance with our business needs. I believe there are many applications that required. And how it works？
I will convert the string to uint64_t format in the second key function in our constract，and add --findbystr parameter to “cleos get table” command. when the parameter is add，the follow string info will be convert to uint64_t format by same algorithm.

Example:
I have the following information in my testtable.
cleos get table chan chan testtable
![image](https://user-images.githubusercontent.com/9347690/43436861-d494235a-94b8-11e8-9bc6-29a80f11039d.png)


I can select the phone(string) info of "2linisyiengiis"
cleos get table chan chan testtable --key-type i64 --index 3 --findbystr 2linisyiengiis
![image](https://user-images.githubusercontent.com/9347690/43438556-627282cc-94c1-11e8-98ba-33783b74f875.png)

You must make some change like this when you create contract
![image](https://user-images.githubusercontent.com/9347690/43436785-8c0b0d7e-94b8-11e8-8b09-ebef9fd7efbb.png)
