### PR TITLE
Remove the redundant signature recovery and hash

### DIFF
--- a/libraries/chain/block_header_state.cpp
+++ b/libraries/chain/block_header_state.cpp
@@ -177,6 +177,7 @@ namespace eosio { namespace chain {
     result.header.producer_signature = h.producer_signature;
     result.id                        = result.header.id();
 
+    // ASSUMPTION FROM controller_impl::apply_block = all untrusted blocks will have their signatures pre-validated here
     if( !trust ) {
        EOS_ASSERT( result.block_signing_key == result.signee(), wrong_signing_key, "block not signed by expected key",
                   ("result.block_signing_key", result.block_signing_key)("signee", result.signee() ) );
@@ -225,12 +226,10 @@ namespace eosio { namespace chain {
      return digest_type::hash( std::make_pair(header_bmroot, pending_schedule_hash) );
   }
 
-  void block_header_state::sign( const std::function<signature_type(const digest_type&)>& signer, bool trust ) {
+  void block_header_state::sign( const std::function<signature_type(const digest_type&)>& signer ) {
      auto d = sig_digest();
      header.producer_signature = signer( d );
-     if( !trust ) {
-        EOS_ASSERT( block_signing_key == fc::crypto::public_key( header.producer_signature, d ), wrong_signing_key, "block is signed with unexpected key" );
-     }
+     EOS_ASSERT( block_signing_key == fc::crypto::public_key( header.producer_signature, d ), wrong_signing_key, "block is signed with unexpected key" );
   }
 
   public_key_type block_header_state::signee()const {

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -231,7 +231,7 @@ struct controller_impl {
             std::cerr<< "\n";
             ilog( "${n} reversible blocks replayed", ("n",rev) );
             auto end = fc::time_point::now();
-            ilog( "replayed ${n} blocks in seconds, ${mspb} ms/block",
+            ilog( "replayed ${n} blocks in ${duration} seconds, ${mspb} ms/block",
                   ("n", head->block_num)("duration", (end-start).count()/1000000)
                   ("mspb", ((end-start).count()/1000.0)/head->block_num)        );
             std::cerr<< "\n";

--- a/libraries/chain/include/eosio/chain/block_header_state.hpp
+++ b/libraries/chain/include/eosio/chain/block_header_state.hpp
@@ -49,7 +49,7 @@ struct block_header_state {
     producer_key         get_scheduled_producer( block_timestamp_type t )const;
     const block_id_type& prev()const { return header.previous; }
     digest_type          sig_digest()const;
-    void                 sign( const std::function<signature_type(const digest_type&)>& signer, bool trust = false );
+    void                 sign( const std::function<signature_type(const digest_type&)>& signer );
     public_key_type      signee()const;
 };
 


### PR DESCRIPTION
Before applying blocks, we add them to fork-db.  Only if fork-db signals better header-validated fork do we bother to apply the block.  As part of header-validation we validate the signature therefore, the additional check in `::apply_block` is wasteful.