### PR TITLE
Free allocated memory in unpack_action_data

### DIFF
--- a/contracts/eosiolib/action.hpp
+++ b/contracts/eosiolib/action.hpp
@@ -50,7 +50,11 @@ namespace eosio {
       size_t size = action_data_size();
       char* buffer = (char*)( max_stack_buffer_size < size ? malloc(size) : alloca(size) );
       read_action_data( buffer, size );
-      return unpack<T>( buffer, size );
+      auto res = unpack<T>( buffer, size );
+      if ( max_stack_buffer_size < size ) {
+         free(buffer);
+      }
+      return res;
    }
 
    using ::require_auth;

--- a/contracts/eosiolib/action.hpp
+++ b/contracts/eosiolib/action.hpp
@@ -48,10 +48,12 @@ namespace eosio {
    T unpack_action_data() {
       constexpr size_t max_stack_buffer_size = 512;
       size_t size = action_data_size();
-      char* buffer = (char*)( max_stack_buffer_size < size ? malloc(size) : alloca(size) );
+      const bool heap_allocation = max_stack_buffer_size < size;
+      char* buffer = (char*)( heap_allocation ? malloc(size) : alloca(size) );
       read_action_data( buffer, size );
       auto res = unpack<T>( buffer, size );
-      if ( max_stack_buffer_size < size ) {
+      // Free allocated memory 
+      if ( heap_allocation ) {
          free(buffer);
       }
       return res;


### PR DESCRIPTION
Looking at issue https://github.com/EOSIO/eos/issues/4930 in these past days, I notice some people are still using `unpack_action_data` instead of `EOSIO_ABI.`

When using `unpack_action_data` and their action structure contains string, it will throw "env.free unresolveable" when uploading the contract. I guess it's not linked with the `free` defined in eosiolib.cpp?