### PR TITLE
Consolidated Security Fixes for 1.1.2

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -573,6 +573,7 @@ struct controller_impl {
       in_trx_requiring_checks = true;
 
       transaction_context trx_context( self, dtrx, gtrx.trx_id );
+      trx_context.leeway = fc::microseconds(0); // avoid stealing cpu resource
       trx_context.deadline = deadline;
       trx_context.billed_cpu_time_us = billed_cpu_time_us;
       transaction_trace_ptr trace = trx_context.trace;
@@ -761,7 +762,7 @@ struct controller_impl {
    void start_block( block_timestamp_type when, uint16_t confirm_block_count, controller::block_status s ) {
       EOS_ASSERT( !pending, block_validate_exception, "pending block is not available" );
 
-      EOS_ASSERT( db.revision() == head->block_num, database_exception, "db revision is not on par with head block", 
+      EOS_ASSERT( db.revision() == head->block_num, database_exception, "db revision is not on par with head block",
                 ("db.revision()", db.revision())("controller_head_block", head->block_num)("fork_db_head_block", fork_db.head()->block_num) );
 
       auto guard_pending = fc::make_scoped_exit([this](){

--- a/libraries/chain/include/eosio/chain/webassembly/binaryen.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/binaryen.hpp
@@ -358,7 +358,7 @@ struct intrinsic_invoker_impl<Ret, std::tuple<array_ptr<T>, size_t, Inputs...>> 
       T* base = array_ptr_impl<T>(interface, ptr, length);
       if ( reinterpret_cast<uintptr_t>(base) % alignof(T) != 0 ) {
          wlog( "misaligned array of const values" );
-         std::remove_const_t<T> copy[length];
+         std::vector<std::remove_const_t<T> > copy(length > 0 ? length : 1);
          T* copy_ptr = &copy[0];
          memcpy( (void*)copy_ptr, (void*)base, length * sizeof(T) );
          return Then(interface, static_cast<array_ptr<T>>(copy_ptr), length, rest..., args, (uint32_t)offset - 2);
@@ -374,7 +374,7 @@ struct intrinsic_invoker_impl<Ret, std::tuple<array_ptr<T>, size_t, Inputs...>> 
       T* base = array_ptr_impl<T>(interface, ptr, length);
       if ( reinterpret_cast<uintptr_t>(base) % alignof(T) != 0 ) {
          wlog( "misaligned array of values" );
-         std::remove_const_t<T> copy[length];
+         std::vector<std::remove_const_t<T> > copy(length > 0 ? length : 1);
          T* copy_ptr = &copy[0];
          memcpy( (void*)copy_ptr, (void*)base, length * sizeof(T) );
          Ret ret = Then(interface, static_cast<array_ptr<T>>(copy_ptr), length, rest..., args, (uint32_t)offset - 2);  

--- a/libraries/chain/include/eosio/chain/webassembly/wavm.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/wavm.hpp
@@ -383,7 +383,7 @@ struct intrinsic_invoker_impl<Ret, std::tuple<array_ptr<T>, size_t, Inputs...>, 
       T* base = array_ptr_impl<T>(ctx, (U32)ptr, length);
       if ( reinterpret_cast<uintptr_t>(base) % alignof(T) != 0 ) {
          wlog( "misaligned array of const values" );
-         std::remove_const_t<T> copy[length];
+         std::vector<std::remove_const_t<T> > copy(length > 0 ? length : 1);
          T* copy_ptr = &copy[0];
          memcpy( (void*)copy_ptr, (void*)base, length * sizeof(T) );
          return Then(ctx, static_cast<array_ptr<T>>(copy_ptr), length, rest..., translated...);
@@ -398,7 +398,7 @@ struct intrinsic_invoker_impl<Ret, std::tuple<array_ptr<T>, size_t, Inputs...>, 
       T* base = array_ptr_impl<T>(ctx, (U32)ptr, length);
       if ( reinterpret_cast<uintptr_t>(base) % alignof(T) != 0 ) {
          wlog( "misaligned array of values" );
-         std::remove_const_t<T> copy[length];
+         std::vector<std::remove_const_t<T> > copy(length > 0 ? length : 1);
          T* copy_ptr = &copy[0];
          memcpy( (void*)copy_ptr, (void*)base, length * sizeof(T) );
          Ret ret = Then(ctx, static_cast<array_ptr<T>>(copy_ptr), length, rest..., translated...);  

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -751,12 +751,7 @@ namespace eosio {
       initialize();
    }
 
-   connection::~connection() {
-      if(peer_addr.empty())
-         wlog( "released connection from client" );
-      else
-         wlog( "released connection to server at ${addr}", ("addr", peer_addr) );
-   }
+   connection::~connection() {}
 
    void connection::initialize() {
       auto *rnd = node_id.data();
@@ -2669,27 +2664,18 @@ namespace eosio {
 
    void net_plugin_impl::connection_monitor( ) {
       start_conn_timer();
-      vector <connection_ptr> discards;
-      num_clients = 0;
-      for( auto &c : connections ) {
-         if( !c->socket->is_open() && !c->connecting) {
-            if( c->peer_addr.length() > 0) {
-               connect(c);
+      auto it = connections.begin();
+      while(it != connections.end()) {
+         if( !(*it)->socket->is_open() && !(*it)->connecting) {
+            if( (*it)->peer_addr.length() > 0) {
+               connect(*it);
             }
             else {
-               discards.push_back( c);
-            }
-         } else {
-            if( c->socket->is_open() && c->peer_addr.empty()) {
-               num_clients++;
+               it = connections.erase(it);
+               continue;
             }
          }
-      }
-      if( discards.size( ) ) {
-         for( auto &c : discards) {
-            connections.erase( c );
-            c.reset();
-         }
+         ++it;
       }
    }
 

--- a/plugins/producer_plugin/include/eosio/producer_plugin/producer_plugin.hpp
+++ b/plugins/producer_plugin/include/eosio/producer_plugin/producer_plugin.hpp
@@ -24,6 +24,7 @@ public:
       fc::optional<int32_t> produce_time_offset_us;
       fc::optional<int32_t> last_block_time_offset_us;
       fc::optional<int32_t> subjective_cpu_leeway_us;
+      fc::optional<double>  incoming_defer_ratio;
    };
 
    struct greylist_params {
@@ -62,6 +63,6 @@ private:
 
 } //eosio
 
-FC_REFLECT(eosio::producer_plugin::runtime_options, (max_transaction_time)(max_irreversible_block_age)(produce_time_offset_us)(last_block_time_offset_us)(subjective_cpu_leeway_us));
+FC_REFLECT(eosio::producer_plugin::runtime_options, (max_transaction_time)(max_irreversible_block_age)(produce_time_offset_us)(last_block_time_offset_us)(subjective_cpu_leeway_us)(incoming_defer_ratio));
 FC_REFLECT(eosio::producer_plugin::greylist_params, (accounts));
 

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -340,6 +340,47 @@ void print_action( const fc::variant& at ) {
    }
 }
 
+bytes variant_to_bin( const account_name& account, const action_name& action, const fc::variant& action_args_var ) {
+   static unordered_map<account_name, std::vector<char> > abi_cache;
+   auto it = abi_cache.find( account );
+   if ( it == abi_cache.end() ) {
+      const auto result = call(get_raw_code_and_abi_func, fc::mutable_variant_object("account_name", account));
+      std::tie( it, std::ignore ) = abi_cache.emplace( account, result["abi"].as_blob().data );
+      //we also received result["wasm"], but we don't use it
+   }
+   const std::vector<char>& abi_v = it->second;
+
+   abi_def abi;
+   if( abi_serializer::to_abi(abi_v, abi) ) {
+      abi_serializer abis( abi, fc::seconds(10) );
+      auto action_type = abis.get_action_type(action);
+      FC_ASSERT(!action_type.empty(), "Unknown action ${action} in contract ${contract}", ("action", action)("contract", account));
+      return abis.variant_to_binary(action_type, action_args_var, fc::seconds(10));
+   } else {
+      FC_ASSERT(false, "No ABI found for ${contract}", ("contract", account));
+   }
+}
+
+fc::variant json_from_file_or_string(const string& file_or_str, fc::json::parse_type ptype = fc::json::legacy_parser)
+{
+   regex r("^[ \t]*[\{\[]");
+   if ( !regex_search(file_or_str, r) && fc::is_regular_file(file_or_str) ) {
+      return fc::json::from_file(file_or_str, ptype);
+   } else {
+      return fc::json::from_string(file_or_str, ptype);
+   }
+}
+
+bytes json_or_file_to_bin( const account_name& account, const action_name& action, const string& data_or_filename ) {
+   fc::variant action_args_var;
+   if( !data_or_filename.empty() ) {
+      try {
+         action_args_var = json_from_file_or_string(data_or_filename, fc::json::relaxed_parser);
+      } EOS_RETHROW_EXCEPTIONS(action_type_exception, "Fail to parse action JSON data='${data}'", ("data", data_or_filename));
+   }
+   return variant_to_bin( account, action, action_args_var );
+}
+
 void print_action_tree( const fc::variant& action ) {
    print_action( action );
    const auto& inline_traces = action["inline_traces"].get_array();
@@ -429,14 +470,7 @@ chain::action create_newaccount(const name& creator, const name& newaccount, pub
 }
 
 chain::action create_action(const vector<permission_level>& authorization, const account_name& code, const action_name& act, const fc::variant& args) {
-   auto arg = fc::mutable_variant_object()
-      ("code", code)
-      ("action", act)
-      ("args", args);
-
-   auto result = call(json_to_bin_func, arg);
-   wdump((result)(arg));
-   return chain::action{authorization, code, act, result.get_object()["binargs"].as<bytes>()};
+   return chain::action{authorization, code, act, variant_to_bin(code, act, args)};
 }
 
 chain::action create_buyram(const name& creator, const name& newaccount, const asset& quantity) {
@@ -490,11 +524,9 @@ chain::action create_transfer(const string& contract, const name& sender, const 
       ("action", "transfer")
       ("args", transfer);
 
-   auto result = call(json_to_bin_func, args);
-
    return action {
       tx_permission.empty() ? vector<chain::permission_level>{{sender,config::active_name}} : get_account_permissions(tx_permission),
-      contract, "transfer", result.get_object()["binargs"].as<bytes>()
+      contract, "transfer", variant_to_bin( contract, N(transfer), transfer )
    };
 }
 
@@ -538,16 +570,6 @@ chain::action create_linkauth(const name& account, const name& code, const name&
 chain::action create_unlinkauth(const name& account, const name& code, const name& type) {
    return action { tx_permission.empty() ? vector<chain::permission_level>{{account,config::active_name}} : get_account_permissions(tx_permission),
                    unlinkauth{account, code, type}};
-}
-
-fc::variant json_from_file_or_string(const string& file_or_str, fc::json::parse_type ptype = fc::json::legacy_parser)
-{
-   regex r("^[ \t]*[\{\[]");
-   if ( !regex_search(file_or_str, r) && fc::is_regular_file(file_or_str) ) {
-      return fc::json::from_file(file_or_str, ptype);
-   } else {
-      return fc::json::from_string(file_or_str, ptype);
-   }
 }
 
 authority parse_json_authority(const std::string& authorityJsonOrFile) {
@@ -2459,16 +2481,9 @@ int main( int argc, char** argv ) {
             action_args_var = json_from_file_or_string(data, fc::json::relaxed_parser);
          } EOS_RETHROW_EXCEPTIONS(action_type_exception, "Fail to parse action JSON data='${data}'", ("data", data))
       }
-
-      auto arg= fc::mutable_variant_object
-                ("code", contract_account)
-                ("action", action)
-                ("args", action_args_var);
-      auto result = call(json_to_bin_func, arg);
-
       auto accountPermissions = get_account_permissions(tx_permission);
 
-      send_actions({chain::action{accountPermissions, contract_account, action, result.get_object()["binargs"].as<bytes>()}});
+      send_actions({chain::action{accountPermissions, contract_account, action, variant_to_bin( contract_account, action, action_args_var ) }});
    });
 
    // push transaction
@@ -2548,15 +2563,7 @@ int main( int argc, char** argv ) {
          trx_var = json_from_file_or_string(proposed_transaction);
       } EOS_RETHROW_EXCEPTIONS(transaction_type_exception, "Fail to parse transaction JSON '${data}'", ("data",proposed_transaction))
       transaction proposed_trx = trx_var.as<transaction>();
-
-      auto arg = fc::mutable_variant_object()
-         ("code", proposed_contract)
-         ("action", proposed_action)
-         ("args", trx_var);
-
-      auto result = call(json_to_bin_func, arg);
-
-      bytes proposed_trx_serialized = result.get_object()["binargs"].as<bytes>();
+      bytes proposed_trx_serialized = variant_to_bin( proposed_contract, proposed_action, trx_var );
 
       vector<permission_level> reqperm;
       try {
@@ -2592,17 +2599,13 @@ int main( int argc, char** argv ) {
 
       fc::to_variant(trx, trx_var);
 
-      arg = fc::mutable_variant_object()
-         ("code", "eosio.msig")
-         ("action", "propose")
-         ("args", fc::mutable_variant_object()
-          ("proposer", proposer )
-          ("proposal_name", proposal_name)
-          ("requested", requested_perm_var)
-          ("trx", trx_var)
-         );
-      result = call(json_to_bin_func, arg);
-      send_actions({chain::action{accountPermissions, "eosio.msig", "propose", result.get_object()["binargs"].as<bytes>()}});
+      auto args = fc::mutable_variant_object()
+         ("proposer", proposer )
+         ("proposal_name", proposal_name)
+         ("requested", requested_perm_var)
+         ("trx", trx_var);
+
+      send_actions({chain::action{accountPermissions, "eosio.msig", "propose", variant_to_bin( N(eosio.msig), N(propose), args ) }});
    });
 
    //resolver for ABI serializer to decode actions in proposed transaction in multisig contract
@@ -2648,17 +2651,13 @@ int main( int argc, char** argv ) {
          proposer = name(accountPermissions.at(0).actor).to_string();
       }
 
-      auto arg = fc::mutable_variant_object()
-         ("code", "eosio.msig")
-         ("action", "propose")
-         ("args", fc::mutable_variant_object()
-          ("proposer", proposer )
-          ("proposal_name", proposal_name)
-          ("requested", requested_perm_var)
-          ("trx", trx_var)
-         );
-      auto result = call(json_to_bin_func, arg);
-      send_actions({chain::action{accountPermissions, "eosio.msig", "propose", result.get_object()["binargs"].as<bytes>()}});
+      auto args = fc::mutable_variant_object()
+         ("proposer", proposer )
+         ("proposal_name", proposal_name)
+         ("requested", requested_perm_var)
+         ("trx", trx_var);
+
+      send_actions({chain::action{accountPermissions, "eosio.msig", "propose", variant_to_bin( N(eosio.msig), N(propose), args ) }});
    });
 
 
@@ -2708,17 +2707,13 @@ int main( int argc, char** argv ) {
       try {
          perm_var = json_from_file_or_string(perm);
       } EOS_RETHROW_EXCEPTIONS(transaction_type_exception, "Fail to parse permissions JSON '${data}'", ("data",perm))
-      auto arg = fc::mutable_variant_object()
-         ("code", "eosio.msig")
-         ("action", action)
-         ("args", fc::mutable_variant_object()
-          ("proposer", proposer)
-          ("proposal_name", proposal_name)
-          ("level", perm_var)
-         );
-      auto result = call(json_to_bin_func, arg);
+      auto args = fc::mutable_variant_object()
+         ("proposer", proposer)
+         ("proposal_name", proposal_name)
+         ("level", perm_var);
+
       auto accountPermissions = tx_permission.empty() ? vector<chain::permission_level>{{sender,config::active_name}} : get_account_permissions(tx_permission);
-      send_actions({chain::action{accountPermissions, "eosio.msig", action, result.get_object()["binargs"].as<bytes>()}});
+      send_actions({chain::action{accountPermissions, "eosio.msig", action, variant_to_bin( N(eosio.msig), action, args ) }});
    };
 
    // multisig approve
@@ -2756,16 +2751,12 @@ int main( int argc, char** argv ) {
       if (canceler.empty()) {
          canceler = name(accountPermissions.at(0).actor).to_string();
       }
-      auto arg = fc::mutable_variant_object()
-         ("code", "eosio.msig")
-         ("action", "cancel")
-         ("args", fc::mutable_variant_object()
-          ("proposer", proposer)
-          ("proposal_name", proposal_name)
-          ("canceler", canceler)
-         );
-      auto result = call(json_to_bin_func, arg);
-      send_actions({chain::action{accountPermissions, "eosio.msig", "cancel", result.get_object()["binargs"].as<bytes>()}});
+      auto args = fc::mutable_variant_object()
+         ("proposer", proposer)
+         ("proposal_name", proposal_name)
+         ("canceler", canceler);
+
+      send_actions({chain::action{accountPermissions, "eosio.msig", "cancel", variant_to_bin( N(eosio.msig), N(cancel), args ) }});
       }
    );
 
@@ -2789,17 +2780,12 @@ int main( int argc, char** argv ) {
          executer = name(accountPermissions.at(0).actor).to_string();
       }
 
-      auto arg = fc::mutable_variant_object()
-         ("code", "eosio.msig")
-         ("action", "exec")
-         ("args", fc::mutable_variant_object()
-          ("proposer", proposer )
-          ("proposal_name", proposal_name)
-          ("executer", executer)
-         );
-      auto result = call(json_to_bin_func, arg);
-      //std::cout << "Result: " << result << std::endl;
-      send_actions({chain::action{accountPermissions, "eosio.msig", "exec", result.get_object()["binargs"].as<bytes>()}});
+      auto args = fc::mutable_variant_object()
+         ("proposer", proposer )
+         ("proposal_name", proposal_name)
+         ("executer", executer);
+
+      send_actions({chain::action{accountPermissions, "eosio.msig", "exec", variant_to_bin( N(eosio.msig), N(exec), args ) }});
       }
    );
 
@@ -2826,15 +2812,11 @@ int main( int argc, char** argv ) {
          accountPermissions = vector<permission_level>{{executer, config::active_name}, {"eosio.sudo", config::active_name}};
       }
 
-      auto arg = fc::mutable_variant_object()
-         ("code", "eosio.sudo")
-         ("action", "exec")
-         ("args", fc::mutable_variant_object()
-            ("executer", executer )
-            ("trx", trx_var)
-         );
-      auto result = call(json_to_bin_func, arg);
-      send_actions({chain::action{accountPermissions, "eosio.sudo", "exec", result.get_object()["binargs"].as<bytes>()}});
+      auto args = fc::mutable_variant_object()
+         ("executer", executer )
+         ("trx", trx_var);
+
+      send_actions({chain::action{accountPermissions, "eosio.sudo", "exec", variant_to_bin( N(eosio.sudo), N(exec), args ) }});
    });
 
    // system subcommand


### PR DESCRIPTION
- Optimize block_status tracking in bnet_plugin
- Optimize connection releasing in net_plugin
- Move misaligned array copy to heap
- Dissallow scheduled transactions from using subjective leeway cpu time
- Respect wall-clock deadline for blocks in the producer_plugin::start_block
- Serialize transactions in cleos instead of using an RPC

Co-authored-by: Kevin Heifner <heifner_k@ociweb.com>
Co-authored-by: Matt Witherspoon <32485495+spoonincode@users.noreply.github.com>
Co-authored-by: Kayan <taokayan13@gmail.com>
Co-authored-by: Anton Perkov <anton.perkov@block.one>