### PR TITLE
Mitigation for 4986

### DIFF
--- a/libraries/chain/include/eosio/chain/transaction_context.hpp
+++ b/libraries/chain/include/eosio/chain/transaction_context.hpp
@@ -81,6 +81,7 @@ namespace eosio { namespace chain {
          fc::time_point                deadline = fc::time_point::maximum();
          fc::microseconds              leeway = fc::microseconds(3000);
          int64_t                       billed_cpu_time_us = 0;
+         bool                          explicit_billed_cpu_time = false;
 
       private:
          bool                          is_initialized = false;

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -70,7 +70,7 @@ namespace eosio { namespace chain {
          }
       }
 
-      if( billed_cpu_time_us > 0 )
+      if( explicit_billed_cpu_time || billed_cpu_time_us > 0 )
          validate_cpu_usage_to_bill( billed_cpu_time_us, false ); // Fail early if the amount to be billed is too high
 
       // Record accounts to be billed for network and CPU usage
@@ -115,7 +115,7 @@ namespace eosio { namespace chain {
       billing_timer_duration_limit = _deadline - start;
 
       // Check if deadline is limited by caller-set deadline (only change deadline if billed_cpu_time_us is not set)
-      if( billed_cpu_time_us > 0 || deadline < _deadline ) {
+      if( explicit_billed_cpu_time || billed_cpu_time_us > 0 || deadline < _deadline ) {
          _deadline = deadline;
          deadline_exception_code = deadline_exception::code_value;
       } else {
@@ -316,7 +316,7 @@ namespace eosio { namespace chain {
    }
 
    void transaction_context::pause_billing_timer() {
-      if( billed_cpu_time_us > 0 || pseudo_start == fc::time_point() ) return; // either irrelevant or already paused
+      if( explicit_billed_cpu_time || billed_cpu_time_us > 0 || pseudo_start == fc::time_point() ) return; // either irrelevant or already paused
 
       auto now = fc::time_point::now();
       billed_time = now - pseudo_start;
@@ -325,7 +325,7 @@ namespace eosio { namespace chain {
    }
 
    void transaction_context::resume_billing_timer() {
-      if( billed_cpu_time_us > 0 || pseudo_start != fc::time_point() ) return; // either irrelevant or already running
+      if( explicit_billed_cpu_time || billed_cpu_time_us > 0 || pseudo_start != fc::time_point() ) return; // either irrelevant or already running
 
       auto now = fc::time_point::now();
       pseudo_start = now - billed_time;


### PR DESCRIPTION
Currently, hard_fail scheduled transactions in blocks can be validly billed 0 cpu usage for the failure.  All releases have had a bug where this 0 value is ambiguously used as a totem that indicates that the execution engine should time the transaction subjectively.  As a result, accounts with low cpu availability could cause validators to subjectively reject a good block when subjectivity should have been disabled ( by the billed cpu time == 0 totem ).  Validators at v1.1.1 or earlier, were awarding those accounts some leeway cpu time (removed in 1.1.2) that made these validators slightly more tolerant when encountering transactions in this state.  However, the success or failure to validate the objectively good block would depend on whether the local validator could process the transaction, to its eventual objective failure, in the accounts available CPU + leeway time.

This has likely been the root cause of several intermittant failures to sync, particularly on slower hardware.

This fix will provide the same semantics for scheduled transactions as normal transactions, which is that the subjectivity is disabled when validating.

resolves EOSIO/eos#4986