### PR TITLE
Fix for #4986 and proper CPU billing for soft_fail and hard_fail

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -612,7 +612,7 @@ struct controller_impl {
       }
       trx_context.undo_session.undo();
 
-      // Only soft or hard failure logic below:
+      // Only subjective OR soft OR hard failure logic below:
 
       if( gtrx.sender != account_name() && !failure_is_subjective(*trace->except)) {
          // Attempt error handling for the generated transaction.
@@ -624,13 +624,14 @@ struct controller_impl {
             undo_session.squash();
             return trace;
          }
+         trace->elapsed = fc::time_point::now() - trx_context.start;
       }
 
-      // Only hard failure OR subjective failure logic below:
-
-      trace->elapsed = fc::time_point::now() - trx_context.start;
+      // Only subjective OR hard failure logic below:
 
       if (!failure_is_subjective(*trace->except)) {
+         // hard failure logic
+
          if( !explicit_billed_cpu_time ) {
             auto& rl = self.get_mutable_resource_limits_manager();
             rl.update_account_usage( trx_context.bill_to_accounts, block_timestamp_type(self.pending_block_time()).slot );

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1316,13 +1316,13 @@ void controller::push_confirmation( const header_confirmation& c ) {
 
 transaction_trace_ptr controller::push_transaction( const transaction_metadata_ptr& trx, fc::time_point deadline, uint32_t billed_cpu_time_us ) {
    validate_db_available_size();
-   return my->push_transaction(trx, deadline, false, billed_cpu_time_us);
+   return my->push_transaction(trx, deadline, false, billed_cpu_time_us, billed_cpu_time_us > 0 );
 }
 
 transaction_trace_ptr controller::push_scheduled_transaction( const transaction_id_type& trxid, fc::time_point deadline, uint32_t billed_cpu_time_us )
 {
    validate_db_available_size();
-   return my->push_scheduled_transaction( trxid, deadline, billed_cpu_time_us );
+   return my->push_scheduled_transaction( trxid, deadline, billed_cpu_time_us, billed_cpu_time_us > 0 );
 }
 
 uint32_t controller::head_block_num()const {

--- a/libraries/chain/include/eosio/chain/transaction_context.hpp
+++ b/libraries/chain/include/eosio/chain/transaction_context.hpp
@@ -81,6 +81,7 @@ namespace eosio { namespace chain {
          fc::time_point                deadline = fc::time_point::maximum();
          fc::microseconds              leeway = fc::microseconds(3000);
          int64_t                       billed_cpu_time_us = 0;
+         bool                          explicit_billed_cpu_time = false;
 
       private:
          bool                          is_initialized = false;

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -259,7 +259,7 @@ namespace eosio { namespace chain {
          billed_cpu_time_us = std::max( (now - pseudo_start).count(), static_cast<int64_t>(cfg.min_transaction_cpu_usage) );
       }
 
-      validate_cpu_usage_to_bill( billed_cpu_time_us, billed_cpu_time_us > 0 );
+      validate_cpu_usage_to_bill( billed_cpu_time_us );
 
       rl.add_transaction_usage( bill_to_accounts, static_cast<uint64_t>(billed_cpu_time_us), net_usage,
                                 block_timestamp_type(control.pending_block_time()).slot ); // Should never fail

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -259,7 +259,7 @@ namespace eosio { namespace chain {
          billed_cpu_time_us = std::max( (now - pseudo_start).count(), static_cast<int64_t>(cfg.min_transaction_cpu_usage) );
       }
 
-      validate_cpu_usage_to_bill( billed_cpu_time_us, !explicit_billed_cpu_time );
+      validate_cpu_usage_to_bill( billed_cpu_time_us, billed_cpu_time_us > 0 );
 
       rl.add_transaction_usage( bill_to_accounts, static_cast<uint64_t>(billed_cpu_time_us), net_usage,
                                 block_timestamp_type(control.pending_block_time()).slot ); // Should never fail

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -254,12 +254,12 @@ namespace eosio { namespace chain {
       auto now = fc::time_point::now();
       trace->elapsed = now - start;
 
-      if( billed_cpu_time_us == 0 ) {
+      if( !explicit_billed_cpu_time ) {
          const auto& cfg = control.get_global_properties().configuration;
          billed_cpu_time_us = std::max( (now - pseudo_start).count(), static_cast<int64_t>(cfg.min_transaction_cpu_usage) );
       }
 
-      validate_cpu_usage_to_bill( billed_cpu_time_us );
+      validate_cpu_usage_to_bill( billed_cpu_time_us, !explicit_billed_cpu_time );
 
       rl.add_transaction_usage( bill_to_accounts, static_cast<uint64_t>(billed_cpu_time_us), net_usage,
                                 block_timestamp_type(control.pending_block_time()).slot ); // Should never fail

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -115,7 +115,7 @@ namespace eosio { namespace chain {
       billing_timer_duration_limit = _deadline - start;
 
       // Check if deadline is limited by caller-set deadline (only change deadline if billed_cpu_time_us is not set)
-      if( explicit_billed_cpu_time || billed_cpu_time_us > 0 || deadline < _deadline ) {
+      if( explicit_billed_cpu_time || deadline < _deadline ) {
          _deadline = deadline;
          deadline_exception_code = deadline_exception::code_value;
       } else {
@@ -295,7 +295,7 @@ namespace eosio { namespace chain {
       auto now = fc::time_point::now();
       if( BOOST_UNLIKELY( now > _deadline ) ) {
          // edump((now-start)(now-pseudo_start));
-         if( billed_cpu_time_us > 0 || deadline_exception_code == deadline_exception::code_value ) {
+         if( explicit_billed_cpu_time || deadline_exception_code == deadline_exception::code_value ) {
             EOS_THROW( deadline_exception, "deadline exceeded", ("now", now)("deadline", _deadline)("start", start) );
          } else if( deadline_exception_code == block_cpu_usage_exceeded::code_value ) {
             EOS_THROW( block_cpu_usage_exceeded,
@@ -316,7 +316,7 @@ namespace eosio { namespace chain {
    }
 
    void transaction_context::pause_billing_timer() {
-      if( explicit_billed_cpu_time || billed_cpu_time_us > 0 || pseudo_start == fc::time_point() ) return; // either irrelevant or already paused
+      if( explicit_billed_cpu_time || pseudo_start == fc::time_point() ) return; // either irrelevant or already paused
 
       auto now = fc::time_point::now();
       billed_time = now - pseudo_start;
@@ -325,7 +325,7 @@ namespace eosio { namespace chain {
    }
 
    void transaction_context::resume_billing_timer() {
-      if( explicit_billed_cpu_time || billed_cpu_time_us > 0 || pseudo_start != fc::time_point() ) return; // either irrelevant or already running
+      if( explicit_billed_cpu_time || pseudo_start != fc::time_point() ) return; // either irrelevant or already running
 
       auto now = fc::time_point::now();
       pseudo_start = now - billed_time;

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -70,7 +70,7 @@ namespace eosio { namespace chain {
          }
       }
 
-      if( explicit_billed_cpu_time || billed_cpu_time_us > 0 )
+      if( billed_cpu_time_us > 0 ) // could also call on explicit_billed_cpu_time but it would be redundant
          validate_cpu_usage_to_bill( billed_cpu_time_us, false ); // Fail early if the amount to be billed is too high
 
       // Record accounts to be billed for network and CPU usage

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -70,7 +70,7 @@ namespace eosio { namespace chain {
          }
       }
 
-      if( billed_cpu_time_us > 0 )
+      if( explicit_billed_cpu_time || billed_cpu_time_us > 0 )
          validate_cpu_usage_to_bill( billed_cpu_time_us, false ); // Fail early if the amount to be billed is too high
 
       // Record accounts to be billed for network and CPU usage
@@ -115,7 +115,7 @@ namespace eosio { namespace chain {
       billing_timer_duration_limit = _deadline - start;
 
       // Check if deadline is limited by caller-set deadline (only change deadline if billed_cpu_time_us is not set)
-      if( billed_cpu_time_us > 0 || deadline < _deadline ) {
+      if( explicit_billed_cpu_time || billed_cpu_time_us > 0 || deadline < _deadline ) {
          _deadline = deadline;
          deadline_exception_code = deadline_exception::code_value;
       } else {
@@ -316,7 +316,7 @@ namespace eosio { namespace chain {
    }
 
    void transaction_context::pause_billing_timer() {
-      if( billed_cpu_time_us > 0 || pseudo_start == fc::time_point() ) return; // either irrelevant or already paused
+      if( explicit_billed_cpu_time || billed_cpu_time_us > 0 || pseudo_start == fc::time_point() ) return; // either irrelevant or already paused
 
       auto now = fc::time_point::now();
       billed_time = now - pseudo_start;
@@ -325,7 +325,7 @@ namespace eosio { namespace chain {
    }
 
    void transaction_context::resume_billing_timer() {
-      if( billed_cpu_time_us > 0 || pseudo_start != fc::time_point() ) return; // either irrelevant or already running
+      if( explicit_billed_cpu_time || billed_cpu_time_us > 0 || pseudo_start != fc::time_point() ) return; // either irrelevant or already running
 
       auto now = fc::time_point::now();
       pseudo_start = now - billed_time;

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -384,7 +384,7 @@ namespace eosio { namespace chain {
             account_cpu_limit = std::min( account_cpu_limit, cpu_limit );
       }
 
-      return {account_net_limit, account_cpu_limit, greylisted};
+      return std::make_tuple(account_net_limit, account_cpu_limit, greylisted);
    }
 
    void transaction_context::dispatch_action( action_trace& trace, const action& a, account_name receiver, bool context_free, uint32_t recurse_depth ) {


### PR DESCRIPTION
This PR makes the following changes:
- Fix for #4986
- `transaction_context` contains new boolean field `explicit_billed_cpu_time` which is true iff the `billed_cpu_time_us` was explicitly set (always happens while validating a block). `transaction_context` will never change the value of `billed_cpu_time_us` field if `explicit_billed_cpu_time` is true.
- In the case of soft_fail, the node will now always try to correctly bill for the billable CPU time of the error handler's execution on top of the billable CPU time of the execution of the original deferred transaction which had failed and caused the error handler to run in the first place. 
- In the case of hard_fail, the node will always try to bill the appropriate amount (billable CPU time expended so far) but correctly limited by the maximum of what the protocol rules allow it to charge. This prevents controller from calling `add_transaction_usage` with an inappropriately high amount which would cause it to throw an exception that propagates up until it causes the production of the block to fail. 