### PR TITLE
More flag in get table wrong when limit equals rows

### DIFF
--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -445,6 +445,7 @@ public:
             }
 
             if (++count == p.limit || fc::time_point::now() > end) {
+               ++itr;
                break;
             }
          }


### PR DESCRIPTION
Advance itr when limit hit so 'more' flag can be calculated correctly.  Resolves #4942.