### PR TITLE
Gh#4968 inline actions

### DIFF
--- a/libraries/chain/abi_serializer.cpp
+++ b/libraries/chain/abi_serializer.cpp
@@ -55,6 +55,11 @@ namespace eosio { namespace chain {
       set_abi(abi, max_serialization_time);
    }
 
+   void abi_serializer::add_specialized_unpack_pack( const string& name,
+                                                     std::pair<abi_serializer::unpack_function, abi_serializer::pack_function> unpack_pack ) {
+      built_in_types[name] = std::move( unpack_pack );
+   }
+
    void abi_serializer::configure_built_in_types() {
 
       built_in_types.emplace("bool",                      pack_unpack<uint8_t>());

--- a/libraries/chain/include/eosio/chain/abi_serializer.hpp
+++ b/libraries/chain/include/eosio/chain/abi_serializer.hpp
@@ -86,10 +86,12 @@ struct abi_serializer {
       return false;
    }
 
-   static const size_t max_recursion_depth = 32; // arbitrary depth to prevent infinite recursion
-
    typedef std::function<fc::variant(fc::datastream<const char*>&, bool, bool)>  unpack_function;
    typedef std::function<void(const fc::variant&, fc::datastream<char*>&, bool, bool)>  pack_function;
+
+   void add_specialized_unpack_pack( const string& name, std::pair<abi_serializer::unpack_function, abi_serializer::pack_function> unpack_pack );
+
+   static const size_t max_recursion_depth = 32; // arbitrary depth to prevent infinite recursion
 
 private:
 

--- a/libraries/chain/include/eosio/chain/abi_serializer.hpp
+++ b/libraries/chain/include/eosio/chain/abi_serializer.hpp
@@ -134,6 +134,7 @@ namespace impl {
              std::is_same<T, packed_transaction>::value ||
              std::is_same<T, transaction_trace>::value ||
              std::is_same<T, transaction_receipt>::value ||
+             std::is_same<T, base_action_trace>::value ||
              std::is_same<T, action_trace>::value ||
              std::is_same<T, signed_transaction>::value ||
              std::is_same<T, signed_block>::value ||

--- a/plugins/mongo_db_plugin/mongo_db_plugin.cpp
+++ b/plugins/mongo_db_plugin/mongo_db_plugin.cpp
@@ -594,8 +594,7 @@ void mongo_db_plugin_impl::_process_accepted_transaction( const chain::transacti
    };
 
    if( start_block_reached ) {
-      trans_doc.append( kvp( "trx_id", trx_id_str ),
-                        kvp( "irreversible", b_bool{false} ));
+      trans_doc.append( kvp( "trx_id", trx_id_str ) );
 
       string signing_keys_json;
       if( t->signing_keys.valid()) {
@@ -821,9 +820,8 @@ void mongo_db_plugin_impl::_process_accepted_block( const chain::block_state_ptr
 
    auto blocks = mongo_conn[db_name][blocks_col];
    auto block_doc = bsoncxx::builder::basic::document{};
-   block_doc.append(kvp( "block_num", b_int32{static_cast<int32_t>(block_num)} ),
-                    kvp( "block_id", block_id_str ),
-                    kvp( "irreversible", b_bool{false} ));
+   block_doc.append( kvp( "block_num", b_int32{static_cast<int32_t>(block_num)} ),
+                     kvp( "block_id", block_id_str ) );
 
    auto v = to_variant_with_abi( *bs->block );
    json = fc::json::to_string( v );

--- a/plugins/mongo_db_plugin/mongo_db_plugin.cpp
+++ b/plugins/mongo_db_plugin/mongo_db_plugin.cpp
@@ -293,28 +293,28 @@ void mongo_db_plugin_impl::consume_blocks() {
 
          // process transactions
          auto start_time = fc::time_point::now();
-         auto size = transaction_metadata_process_queue.size();
-         while (!transaction_metadata_process_queue.empty()) {
-            const auto& t = transaction_metadata_process_queue.front();
-            process_accepted_transaction(t);
-            transaction_metadata_process_queue.pop_front();
-         }
-         auto time = fc::time_point::now() - start_time;
-         auto per = size > 0 ? time.count()/size : 0;
-         if( time > fc::microseconds(500000) ) // reduce logging, .5 secs
-            ilog( "process_accepted_transaction, time per: ${p}, size: ${s}, time: ${t}", ("s", size)( "t", time )( "p", per ));
-
-         start_time = fc::time_point::now();
-         size = transaction_trace_process_queue.size();
+         auto size = transaction_trace_process_queue.size();
          while (!transaction_trace_process_queue.empty()) {
             const auto& t = transaction_trace_process_queue.front();
             process_applied_transaction(t);
             transaction_trace_process_queue.pop_front();
          }
+         auto time = fc::time_point::now() - start_time;
+         auto per = size > 0 ? time.count()/size : 0;
+         if( time > fc::microseconds(500000) ) // reduce logging, .5 secs
+            ilog( "process_applied_transaction,  time per: ${p}, size: ${s}, time: ${t}", ("s", size)("t", time)("p", per) );
+
+         start_time = fc::time_point::now();
+         size = transaction_metadata_process_queue.size();
+         while (!transaction_metadata_process_queue.empty()) {
+            const auto& t = transaction_metadata_process_queue.front();
+            process_accepted_transaction(t);
+            transaction_metadata_process_queue.pop_front();
+         }
          time = fc::time_point::now() - start_time;
          per = size > 0 ? time.count()/size : 0;
          if( time > fc::microseconds(500000) ) // reduce logging, .5 secs
-            ilog( "process_applied_transaction,  time per: ${p}, size: ${s}, time: ${t}", ("s", size)("t", time)("p", per) );
+            ilog( "process_accepted_transaction, time per: ${p}, size: ${s}, time: ${t}", ("s", size)( "t", time )( "p", per ));
 
          // process blocks
          start_time = fc::time_point::now();

--- a/plugins/mongo_db_plugin/mongo_db_plugin.cpp
+++ b/plugins/mongo_db_plugin/mongo_db_plugin.cpp
@@ -451,8 +451,7 @@ void handle_mongo_exception( const std::string& desc, int line_num ) {
          elog( "mongo exception, ${desc}, line ${line}, code ${code}, ${details}",
                ("desc", desc)( "line", line_num )( "code", e.code().value() )( "details", e.code().message() ));
          if (e.raw_server_error()) {
-            elog( "mongo exception, ${desc}, line ${line}, ${details}",
-                  ("desc", desc)( "line", line_num )( "details", bsoncxx::to_json(e.raw_server_error()->view())));
+            elog( "  raw_server_error: ${e}", ( "e", bsoncxx::to_json(e.raw_server_error()->view())));
          }
       } catch( mongocxx::exception& e) {
          elog( "mongo exception, ${desc}, line ${line}, code ${code}, ${what}",

--- a/plugins/mongo_db_plugin/mongo_db_plugin.cpp
+++ b/plugins/mongo_db_plugin/mongo_db_plugin.cpp
@@ -203,15 +203,14 @@ const std::string mongo_db_plugin_impl::account_controls_col = "account_controls
 
 bool mongo_db_plugin_impl::filter_include( const chain::action& act ) const {
    bool include = false;
-   if( filter_on_star ) {
+   if( filter_on_star || filter_on.find( {act.account, act.name, 0} ) != filter_on.end() ) {
       include = true;
-   }
-   if( filter_on.find( {act.account, act.name, 0} ) != filter_on.end() ) {
-      include = true;
-   }
-   for( const auto& a : act.authorization ) {
-      if( filter_on.find( {act.account, act.name, a.actor} ) != filter_on.end() ) {
-         include = true;
+   } else {
+      for( const auto& a : act.authorization ) {
+         if( filter_on.find( {act.account, act.name, a.actor} ) != filter_on.end() ) {
+            include = true;
+            break;
+         }
       }
    }
 

--- a/plugins/mongo_db_plugin/mongo_db_plugin.cpp
+++ b/plugins/mongo_db_plugin/mongo_db_plugin.cpp
@@ -1343,15 +1343,15 @@ void mongo_db_plugin::set_program_options(options_description& cli, options_desc
          "MongoDB URI connection string, see: https://docs.mongodb.com/master/reference/connection-string/."
                " If not specified then plugin is disabled. Default database 'EOS' is used if not specified in URI."
                " Example: mongodb://127.0.0.1:27017/EOS")
-         ("mongodb-store-blocks", bpo::bool_switch()->default_value(true),
+         ("mongodb-store-blocks", bpo::value<bool>()->default_value(true),
           "Enables storing blocks in mongodb.")
-         ("mongodb-store-block-states", bpo::bool_switch()->default_value(true),
+         ("mongodb-store-block-states", bpo::value<bool>()->default_value(true),
           "Enables storing block state in mongodb.")
-         ("mongodb-store-transactions", bpo::bool_switch()->default_value(true),
+         ("mongodb-store-transactions", bpo::value<bool>()->default_value(true),
           "Enables storing transactions in mongodb.")
-         ("mongodb-store-transaction-traces", bpo::bool_switch()->default_value(true),
+         ("mongodb-store-transaction-traces", bpo::value<bool>()->default_value(true),
           "Enables storing transaction traces in mongodb.")
-         ("mongodb-store-action-traces", bpo::bool_switch()->default_value(true),
+         ("mongodb-store-action-traces", bpo::value<bool>()->default_value(true),
           "Enables storing action traces in mongodb.")
          ("mongodb-filter-on", bpo::value<vector<string>>()->composing(),
           "Mongodb: Track actions which match receiver:action:actor. Actor may be blank to include all. Receiver and Action may not be blank. Default is * include everything.")

--- a/tests/Node.py
+++ b/tests/Node.py
@@ -334,8 +334,8 @@ class Node(object):
                 key="[trx][trx][ref_block_num]"
                 refBlockNum=trans["trx"]["trx"]["ref_block_num"]
             else:
-                key="[transaction_header][ref_block_num]"
-                refBlockNum=trans["transaction_header"]["ref_block_num"]
+                key="[ref_block_num]"
+                refBlockNum=trans["ref_block_num"]
             refBlockNum=int(refBlockNum)+1
         except (TypeError, ValueError, KeyError) as _:
             Utils.Print("transaction%s not found. Transaction: %s" % (key, trans))
@@ -366,10 +366,10 @@ class Node(object):
 
         refBlockNum=None
         try:
-            refBlockNum=trans["transaction_header"]["ref_block_num"]
+            refBlockNum=trans["ref_block_num"]
             refBlockNum=int(refBlockNum)+1
         except (TypeError, ValueError, KeyError) as _:
-            Utils.Print("transaction[transaction_header][ref_block_num] not found. Transaction: %s" % (trans))
+            Utils.Print("transaction[ref_block_num] not found. Transaction: %s" % (trans))
             return None
 
         headBlockNum=self.getHeadBlockNum()
@@ -688,7 +688,7 @@ class Node(object):
         assert(isinstance(offset, int))
 
         cmd="%s %s" % (Utils.MongoPath, self.mongoEndpointArgs)
-        subcommand='db.actions.find({$or: [{"data.from":"%s"},{"data.to":"%s"}]}).sort({"_id":%d}).limit(%d)' % (account.name, account.name, pos, abs(offset))
+        subcommand='db.action_traces.find({$or: [{"act.data.from":"%s"},{"act.data.to":"%s"}]}).sort({"_id":%d}).limit(%d)' % (account.name, account.name, pos, abs(offset))
         if Utils.Debug: Utils.Print("cmd: echo '%s' | %s" % (subcommand, cmd))
         try:
             actions=Node.runMongoCmdReturnJson(cmd.split(), subcommand, exitOnError=exitOnError)

--- a/tests/nodeos_run_test.py
+++ b/tests/nodeos_run_test.py
@@ -275,7 +275,7 @@ try:
         if not enableMongo:
             assert(actions["actions"][0]["action_trace"]["act"]["name"] == "transfer")
         else:
-            assert(actions["name"] == "transfer")
+            assert(actions["act"]["name"] == "transfer")
     except (AssertionError, TypeError, KeyError) as _:
         Print("Action validation failed. Actions: %s" % (actions))
         raise


### PR DESCRIPTION
Resolves #4968 

- Action traces now stored instead of actions
  -- New action_traces collection replaces actions collection
  -- action_traces include all actions including inline, implicit, and scheduled
- irreversible attribute on transactions and blocks is now only added with a value of true when irreversible to prevent a race condition of an update of transaction overwriting the irreversible true with a false. This is now needed since upsert is used for insert and strict ordering is not guaranteed. 
- Simplified transaction serialization and now store all eosio abi as abi_def instead of bytes. 
- Added filter-on and filter-out similar to history_plugin.
  -- Thanks to Scott Sallinen (TeamGreymass) for implementation.
- Added options to not store blocks, block-states, transactions, transaction-traces, and action-traces.