### PR TITLE
remove producer-subjectivness from leeway

### DIFF
--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -60,8 +60,7 @@ namespace {
       auto code = e.code();
       return (code == block_cpu_usage_exceeded::code_value) ||
              (code == block_net_usage_exceeded::code_value) ||
-             (code == deadline_exception::code_value && deadline_is_subjective) ||
-             (code == leeway_deadline_exception::code_value && deadline_is_subjective);
+             (code == deadline_exception::code_value && deadline_is_subjective);
    }
 }
 


### PR DESCRIPTION
producer plugin was treating leeway cpu exceptions as subjective which in turn implies to the rest of the producer code that the block is exhausted.  However, this exception rarely clears in a fresh block (only on wall-clock wobble) so it is in-appropriate for the producer plugin to consider this "subjective"