### PR TITLE
Include cmake in ubuntu build dependencies

### DIFF
--- a/scripts/eosio_build_ubuntu.sh
+++ b/scripts/eosio_build_ubuntu.sh
@@ -62,7 +62,7 @@
 
 	DEP_ARRAY=(clang-4.0 lldb-4.0 libclang-4.0-dev cmake make automake libbz2-dev libssl-dev \
 	libgmp3-dev autotools-dev build-essential libicu-dev python2.7-dev python3-dev \
-    autoconf libtool curl zlib1g-dev doxygen graphviz)
+    autoconf libtool curl zlib1g-dev doxygen graphviz cmake)
 	COUNT=1
 	DISPLAY=""
 	DEP=""


### PR DESCRIPTION
cmake is required for the ubuntu build but not included in the list of
dependencies which can cause a failed build