### PR TITLE
Fix null pointer dereference while find_plugin

### DIFF
--- a/plugins/account_history_plugin/account_history_plugin.cpp
+++ b/plugins/account_history_plugin/account_history_plugin.cpp
@@ -51,7 +51,7 @@ public:
    void applied_block(const chain::block_trace&);
    fc::variant transaction_to_variant(const packed_transaction& pretty_input) const;
 
-   chain_plugin* chain_plug;
+   chain_plugin* chain_plug = nullptr;
    static const int64_t DEFAULT_TRANSACTION_TIME_LIMIT;
    int64_t transactions_time_limit = DEFAULT_TRANSACTION_TIME_LIMIT;
    std::set<account_name> filter_on;
@@ -479,6 +479,7 @@ void account_history_plugin::plugin_initialize(const variables_map& options)
    }
 
    my->chain_plug = app().find_plugin<chain_plugin>();
+   EOS_ASSERT( my->chain_plug, chain::missing_chain_plugin_exception, ""  );
    my->chain_plug->chain_config().applied_block_callbacks.emplace_back(
             [&impl = my](const chain::block_trace& trace) {
                   impl->check_init_db();

--- a/plugins/history_plugin/history_plugin.cpp
+++ b/plugins/history_plugin/history_plugin.cpp
@@ -286,6 +286,7 @@ namespace eosio {
          }
 
          my->chain_plug = app().find_plugin<chain_plugin>();
+         EOS_ASSERT( my->chain_plug, chain::missing_chain_plugin_exception, ""  );
          auto& chain = my->chain_plug->chain();
 
          chain.db().add_index<account_history_index>();

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -171,7 +171,7 @@ namespace eosio {
       fc::sha256                    node_id;
 
       string                        user_agent_name;
-      chain_plugin*                 chain_plug;
+      chain_plugin*                 chain_plug = nullptr;
       int                           started_sessions = 0;
 
       node_transaction_index        local_txns;
@@ -649,7 +649,7 @@ namespace eosio {
       connection_ptr source;
       stages         state;
 
-      chain_plugin* chain_plug;
+      chain_plugin* chain_plug = nullptr;
 
       constexpr auto stage_str(stages s );
 
@@ -1255,6 +1255,7 @@ namespace eosio {
       ,state(in_sync)
    {
       chain_plug = app( ).find_plugin<chain_plugin>( );
+      EOS_ASSERT( chain_plug, chain::missing_chain_plugin_exception, ""  );
    }
 
    constexpr auto sync_manager::stage_str(stages s ) {
@@ -2995,6 +2996,7 @@ namespace eosio {
          }
 
          my->chain_plug = app().find_plugin<chain_plugin>();
+         EOS_ASSERT( my->chain_plug, chain::missing_chain_plugin_exception, ""  );
          my->chain_id = app().get_plugin<chain_plugin>().get_chain_id();
          fc::rand_pseudo_bytes( my->node_id.data(), my->node_id.data_size());
          ilog( "my node_id is ${id}", ("id", my->node_id));


### PR DESCRIPTION
There are chances that `application::find_plugin`return `nullptr`, So it's safer to `EOS_ASSERT` all before dereference plugin pointer. While `mongo_db_plugin.cpp` and `sql_db_plugin.cpp` does the job.