### PR TITLE
Define N(eosio) as system_account_name at the eosiolib level

### DIFF
--- a/contracts/eosio.system/eosio.system.cpp
+++ b/contracts/eosio.system/eosio.system.cpp
@@ -74,7 +74,7 @@ namespace eosiosystem {
    }
 
    void system_contract::setparams( const eosio::blockchain_parameters& params ) {
-      require_auth( N(eosio) );
+      require_auth( cfg::system_account_name );
       (eosio::blockchain_parameters&)(_gstate) = params;
       eosio_assert( 3 <= _gstate.max_authority_depth, "max_authority_depth should be at least 3" );
       set_blockchain_parameters( params );

--- a/contracts/eosio.system/producer_pay.cpp
+++ b/contracts/eosio.system/producer_pay.cpp
@@ -20,7 +20,7 @@ namespace eosiosystem {
    void system_contract::onblock( block_timestamp timestamp, account_name producer ) {
       using namespace eosio;
 
-      require_auth(N(eosio));
+      require_auth(cfg::system_account_name);
 
       /** until activated stake crosses this threshold no new rewards are paid */
       if( _gstate.total_activated_stake < min_activated_stake )
@@ -89,17 +89,17 @@ namespace eosiosystem {
          auto to_per_block_pay   = to_producers / 4;
          auto to_per_vote_pay    = to_producers - to_per_block_pay;
 
-         INLINE_ACTION_SENDER(eosio::token, issue)( N(eosio.token), {{N(eosio),N(active)}},
-                                                    {N(eosio), asset(new_tokens), std::string("issue tokens for producer pay and savings")} );
+         INLINE_ACTION_SENDER(eosio::token, issue)( N(eosio.token), {{cfg::system_account_name,N(active)}},
+                                                    {cfg::system_account_name, asset(new_tokens), std::string("issue tokens for producer pay and savings")} );
 
-         INLINE_ACTION_SENDER(eosio::token, transfer)( N(eosio.token), {N(eosio),N(active)},
-                                                       { N(eosio), N(eosio.saving), asset(to_savings), "unallocated inflation" } );
+         INLINE_ACTION_SENDER(eosio::token, transfer)( N(eosio.token), {cfg::system_account_name,N(active)},
+                                                       { cfg::system_account_name, N(eosio.saving), asset(to_savings), "unallocated inflation" } );
 
-         INLINE_ACTION_SENDER(eosio::token, transfer)( N(eosio.token), {N(eosio),N(active)},
-                                                       { N(eosio), N(eosio.bpay), asset(to_per_block_pay), "fund per-block bucket" } );
+         INLINE_ACTION_SENDER(eosio::token, transfer)( N(eosio.token), {cfg::system_account_name,N(active)},
+                                                       { cfg::system_account_name, N(eosio.bpay), asset(to_per_block_pay), "fund per-block bucket" } );
 
-         INLINE_ACTION_SENDER(eosio::token, transfer)( N(eosio.token), {N(eosio),N(active)},
-                                                       { N(eosio), N(eosio.vpay), asset(to_per_vote_pay), "fund per-vote bucket" } );
+         INLINE_ACTION_SENDER(eosio::token, transfer)( N(eosio.token), {cfg::system_account_name,N(active)},
+                                                       { cfg::system_account_name, N(eosio.vpay), asset(to_per_vote_pay), "fund per-vote bucket" } );
 
          _gstate.pervote_bucket  += to_per_vote_pay;
          _gstate.perblock_bucket += to_per_block_pay;

--- a/contracts/eosiolib/config.hpp
+++ b/contracts/eosiolib/config.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <eosiolib/types.hpp>
+
+namespace eosio { namespace cfg {
+
+/**
+ * @defgroup configtype Config Type
+ * @ingroup types
+ * @brief Defines chain configuration constants
+ * 
+ * @{
+ * 
+ */
+
+   /**
+    * The account name of the system
+    * @brief The account name of the system
+    */
+   const static uint64_t system_account_name = N(eosio);
+
+/// @} configtype
+} /// namespace cfg
+} /// namespace eosio

--- a/contracts/eosiolib/dispatcher.hpp
+++ b/contracts/eosiolib/dispatcher.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <eosiolib/config.hpp>
 #include <eosiolib/print.hpp>
 #include <eosiolib/action.hpp>
 
@@ -123,7 +124,7 @@ extern "C" { \
       auto self = receiver; \
       if( action == N(onerror)) { \
          /* onerror is only valid if it is for the "eosio" code account and authorized by "eosio"'s "active permission */ \
-         eosio_assert(code == N(eosio), "onerror action's are only valid from the \"eosio\" system account"); \
+         eosio_assert(code == eosio::cfg::system_account_name, "onerror action's are only valid from the \"eosio\" system account"); \
       } \
       if( code == self || action == N(onerror) ) { \
          TYPE thiscontract( self ); \

--- a/contracts/eosiolib/eosio.hpp
+++ b/contracts/eosiolib/eosio.hpp
@@ -9,3 +9,4 @@
 #include <eosiolib/multi_index.hpp>
 #include <eosiolib/dispatcher.hpp>
 #include <eosiolib/contract.hpp>
+#include <eosiolib/config.hpp>

--- a/contracts/proxy/proxy.cpp
+++ b/contracts/proxy/proxy.cpp
@@ -91,7 +91,7 @@ extern "C" {
 
     /// The apply method implements the dispatch of events to this contract
     void apply( uint64_t receiver, uint64_t code, uint64_t action ) {
-      if( code == N(eosio) && action == N(onerror) ) {
+      if( code == cfg::system_account_name && action == N(onerror) ) {
          apply_onerror( receiver, onerror::from_current_action() );
       } else if( code == N(eosio.token) ) {
          if( action == N(transfer) ) {

--- a/contracts/test_api/test_api.cpp
+++ b/contracts/test_api/test_api.cpp
@@ -22,7 +22,7 @@ account_name global_receiver;
 
 extern "C" {
    void apply( uint64_t receiver, uint64_t code, uint64_t action ) {
-      if( code == N(eosio) && action == N(onerror) ) {
+      if( code == cfg::system_account_name && action == N(onerror) ) {
          auto error = eosio::onerror::from_current_action();
          eosio::print("onerror called\n");
          auto error_trx = error.unpack_sent_trx();

--- a/unittests/contracts/deferred_test/deferred_test.cpp
+++ b/unittests/contracts/deferred_test/deferred_test.cpp
@@ -45,7 +45,7 @@ void apply_onerror(uint64_t receiver, const onerror& error ) {
 extern "C" {
     /// The apply method implements the dispatch of events to this contract
     void apply( uint64_t receiver, uint64_t code, uint64_t action ) {
-      if( code == N(eosio) && action == N(onerror) ) {
+      if( code == cfg::system_account_name && action == N(onerror) ) {
          apply_onerror( receiver, onerror::from_current_action() );
       } else if( code == receiver ) {
          deferred_test thiscontract(receiver);


### PR DESCRIPTION
I wanted to use eosio::config namespace but it showed the symbol collision with proxy::config class. So I decided to use eosio::cfg namespace.