### PR TITLE
Replay/Resync Optimizations: Low Hanging Fruit

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1656,7 +1656,7 @@ bool controller::skip_auth_check() const {
    bool consider_skipping = my->replaying;
 
    // OR in light validation mode
-   consider_skipping = consider_skipping || my->conf.validation_mode == validation_mode::LIGHT;
+   consider_skipping = consider_skipping || my->conf.block_validation_mode == validation_mode::LIGHT;
 
    return consider_skipping
       && !my->conf.force_all_checks
@@ -1675,7 +1675,7 @@ bool controller::skip_trx_checks() const {
    bool consider_skipping = my->pending && ( my->pending->_block_status == block_status::irreversible || my->pending->_block_status == block_status::validated );
 
    // OR in light validation mode
-   consider_skipping = consider_skipping || my->conf.validation_mode == validation_mode::LIGHT;
+   consider_skipping = consider_skipping || my->conf.block_validation_mode == validation_mode::LIGHT;
 
    return consider_skipping
       && !my->conf.disable_replay_opts
@@ -1695,7 +1695,7 @@ db_read_mode controller::get_read_mode()const {
 }
 
 validation_mode controller::get_validation_mode()const {
-   return my->conf.validation_mode;
+   return my->conf.block_validation_mode;
 }
 
 const apply_handler* controller::find_apply_handler( account_name receiver, account_name scope, action_name act ) const

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -872,7 +872,7 @@ struct controller_impl {
          pending.reset();
       });
 
-      bool skip_db_sessions = !conf.force_all_checks && (s == controller::block_status::irreversible);
+      bool skip_db_sessions = !conf.disable_replay_opts && (s == controller::block_status::irreversible);
       if (!skip_db_sessions) {
          EOS_ASSERT( db.revision() == head->block_num, database_exception, "db revision is not on par with head block",
                      ("db.revision()", db.revision())("controller_head_block", head->block_num)("fork_db_head_block", fork_db.head()->block_num) );
@@ -1655,11 +1655,11 @@ bool controller::skip_auth_check() const {
 }
 
 bool controller::skip_db_sessions() const {
-   return !my->conf.force_all_checks && my->pending && !my->in_trx_requiring_checks && my->pending->_block_status == block_status::irreversible;
+   return !my->conf.disable_replay_opts && my->pending && !my->in_trx_requiring_checks && my->pending->_block_status == block_status::irreversible;
 }
 
 bool controller::skip_trx_checks() const {
-   return !my->conf.force_all_checks  &&my->pending && !my->in_trx_requiring_checks && (my->pending->_block_status == block_status::irreversible || my->pending->_block_status == block_status::validated);
+   return !my->conf.disable_replay_opts  &&my->pending && !my->in_trx_requiring_checks && (my->pending->_block_status == block_status::irreversible || my->pending->_block_status == block_status::validated);
 }
 
 bool controller::contracts_console()const {

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -63,6 +63,8 @@ class maybe_session {
          } else {
             _session.reset();
          }
+
+         return *this;
       };
 
    private:

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -254,8 +254,8 @@ struct controller_impl {
          initialize_fork_db(); // set head to genesis state
 
          auto end = blog.read_head();
-         auto end_time = end->timestamp.to_time_point();
          if( end && end->block_num() > 1 ) {
+            auto end_time = end->timestamp.to_time_point();
             replaying = true;
             replay_head_time = end_time;
             ilog( "existing block log, attempting to replay ${n} blocks", ("n",end->block_num()) );

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -39,6 +39,11 @@ namespace eosio { namespace chain {
       IRREVERSIBLE
    };
 
+   enum class validation_mode {
+      FULL,
+      LIGHT
+   };
+
    class controller {
       public:
 
@@ -63,7 +68,8 @@ namespace eosio { namespace chain {
             genesis_state            genesis;
             wasm_interface::vm_type  wasm_runtime = chain::config::default_wasm_runtime;
 
-            db_read_mode             read_mode    = db_read_mode::SPECULATIVE;
+            db_read_mode             read_mode              = db_read_mode::SPECULATIVE;
+            validation_mode          validation_mode        = validation_mode::FULL;
 
             flat_set<account_name>   resource_greylist;
          };
@@ -221,6 +227,7 @@ namespace eosio { namespace chain {
          chain_id_type get_chain_id()const;
 
          db_read_mode get_read_mode()const;
+         validation_mode get_validation_mode()const;
 
          void set_subjective_cpu_leeway(fc::microseconds leeway);
 

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -219,7 +219,8 @@ namespace eosio { namespace chain {
          int64_t set_proposed_producers( vector<producer_key> producers );
 
          bool skip_auth_check()const;
-         bool skip_db_sessions()const;
+         bool skip_db_sessions( )const;
+         bool skip_db_sessions( block_status bs )const;
          bool skip_trx_checks()const;
 
          bool contracts_console()const;

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -212,6 +212,8 @@ namespace eosio { namespace chain {
          int64_t set_proposed_producers( vector<producer_key> producers );
 
          bool skip_auth_check()const;
+         bool skip_db_sessions()const;
+         bool skip_trx_checks()const;
 
          bool contracts_console()const;
 

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -57,6 +57,7 @@ namespace eosio { namespace chain {
             uint64_t                 reversible_guard_size  =  chain::config::default_reversible_guard_size;
             bool                     read_only              =  false;
             bool                     force_all_checks       =  false;
+            bool                     disable_replay_opts    =  false;
             bool                     contracts_console      =  false;
 
             genesis_state            genesis;
@@ -286,6 +287,7 @@ FC_REFLECT( eosio::chain::controller::config,
             (reversible_cache_size)
             (read_only)
             (force_all_checks)
+            (disable_replay_opts)
             (contracts_console)
             (genesis)
             (wasm_runtime)

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -69,7 +69,7 @@ namespace eosio { namespace chain {
             wasm_interface::vm_type  wasm_runtime = chain::config::default_wasm_runtime;
 
             db_read_mode             read_mode              = db_read_mode::SPECULATIVE;
-            validation_mode          validation_mode        = validation_mode::FULL;
+            validation_mode          block_validation_mode  = validation_mode::FULL;
 
             flat_set<account_name>   resource_greylist;
          };

--- a/libraries/chain/include/eosio/chain/transaction_context.hpp
+++ b/libraries/chain/include/eosio/chain/transaction_context.hpp
@@ -19,7 +19,8 @@ namespace eosio { namespace chain {
 
          void init_for_input_trx( uint64_t packed_trx_unprunable_size,
                                   uint64_t packed_trx_prunable_size,
-                                  uint32_t num_signatures);
+                                  uint32_t num_signatures,
+                                  bool skip_recording);
 
          void init_for_deferred_trx( fc::time_point published );
 
@@ -63,7 +64,7 @@ namespace eosio { namespace chain {
          controller&                   control;
          const signed_transaction&     trx;
          transaction_id_type           id;
-         chainbase::database::session  undo_session;
+         optional<chainbase::database::session>  undo_session;
          transaction_trace_ptr         trace;
          fc::time_point                start;
 

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -554,7 +554,7 @@ void chain_plugin::plugin_initialize(const variables_map& options) {
       }
 
       if ( options.count("validation-mode") ) {
-         my->chain_config->validation_mode = options.at("validation-mode").as<validation_mode>();
+         my->chain_config->block_validation_mode = options.at("validation-mode").as<validation_mode>();
       }
 
       my->chain.emplace( *my->chain_config );

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -48,7 +48,7 @@ std::ostream& operator<<(std::ostream& osm, eosio::chain::db_read_mode m) {
 }
 
 void validate(boost::any& v,
-              std::vector<std::string> const& values,
+              const std::vector<std::string>& values,
               eosio::chain::db_read_mode* /* target_type */,
               int)
 {
@@ -83,7 +83,7 @@ std::ostream& operator<<(std::ostream& osm, eosio::chain::validation_mode m) {
 }
 
 void validate(boost::any& v,
-              std::vector<std::string> const& values,
+              const std::vector<std::string>& values,
               eosio::chain::validation_mode* /* target_type */,
               int)
 {

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -225,6 +225,8 @@ void chain_plugin::set_program_options(options_description& cli, options_descrip
           "recovers reversible block database if that database is in a bad state")
          ("force-all-checks", bpo::bool_switch()->default_value(false),
           "do not skip any checks that can be skipped while replaying irreversible blocks")
+         ("disable-replay-opts", bpo::bool_switch()->default_value(false),
+          "disable optimizations that specifically target replay")
          ("replay-blockchain", bpo::bool_switch()->default_value(false),
           "clear chain state database and replay all blocks")
          ("hard-replay-blockchain", bpo::bool_switch()->default_value(false),
@@ -359,6 +361,7 @@ void chain_plugin::plugin_initialize(const variables_map& options) {
          my->chain_config->wasm_runtime = *my->wasm_runtime;
 
       my->chain_config->force_all_checks = options.at( "force-all-checks" ).as<bool>();
+      my->chain_config->disable_replay_opts = options.at( "disable-replay-opts" ).as<bool>();
       my->chain_config->contracts_console = options.at( "contracts-console" ).as<bool>();
 
       if( options.count( "extract-genesis-json" ) || options.at( "print-genesis-json" ).as<bool>()) {

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -650,6 +650,10 @@ void producer_plugin::plugin_startup()
    EOS_ASSERT( my->_producers.empty() || chain.get_read_mode() == chain::db_read_mode::SPECULATIVE, plugin_config_exception,
               "node cannot have any producer-name configured because block production is impossible when read_mode is not \"speculative\"" );
 
+   EOS_ASSERT( my->_producers.empty() || chain.get_validation_mode() == chain::validation_mode::FULL, plugin_config_exception,
+              "node cannot have any producer-name configured because block production is not safe when validation_mode is not \"full\"" );
+
+
    my->_accepted_block_connection.emplace(chain.accepted_block.connect( [this]( const auto& bsp ){ my->on_block( bsp ); } ));
    my->_irreversible_block_connection.emplace(chain.irreversible_block.connect( [this]( const auto& bsp ){ my->on_irreversible_block( bsp->block ); } ));
 


### PR DESCRIPTION
Identified and implemented some low hanging fruit for Replays where we assume the block.log is trusted.

# Replay

## The optimizations

- don't create database undo sessions when replaying blocks from the block.log unless they are necessary for concensus (as they are when processing failing scheduled transactions)
- don't add transactions to the deduplication set if they will have expired before the replay ends
- disable transactions level checks (such as resource billing enforcement) that we can infer will always pass in replay

## The caveats

A new config/cli option is provided `disable-replay-opts` which will disable all of the above optimizations and result in the current processing of replay.   There are a few reasons why this option may be neccessary:

- these optimizations are provided as "best-effort" and they may have bugs.  For users that need guarantees on replay, disabling optimizations may be appropriate.
- these optimizations leave the fork-database in a state where it thinks it may "rewind" a block BUT we have not created the proper database states to do so.  This *should not* happen as we have previously established trust in the block.log as irreversible.  The ability to fix this desync depends on a future fork-database audit/refact

## The Results

A very basic test of v1.1.1, v1.1.3 and the new optimizations on my development machine yields:

<img width="495" alt="screen shot 2018-08-09 at 9 08 48 am" src="https://user-images.githubusercontent.com/2494946/43900812-e7e83368-9bb3-11e8-987c-d1d993825c40.png">

# (re)sync

## Light validation mode
    
This mode enables skipping of auth checks, transaction signature recovery and other tests that can be inferred as passed if the node implicitly trusts the active set of producers to maintain correctness.  This is essentially the same trust semantics that a header-validating light client would have.  

## The Caveats

This is not safe for use on any node that does not implicitly trust the elected set of producers.  That should include the other elected producers (this mode is considered invalid if you are running a production node).

This mode is intended to help nodes (re)syncing from trusted peers and any other node that can outsource trust to a set of independent validators.  For example, nodes that maintain MongoDB integration behind a layer of full validation-mode peers, or a new node that is syncing into an established blockchain and has well-known-checkpoints to enforce validity. 