### PR TITLE
 Remove WAST support from cleos set code/contract

### DIFF
--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -2163,7 +2163,7 @@ int main( int argc, char** argv ) {
       if( wasmPath.empty() )
          wasmPath = (cpath / (cpath.filename().generic_string()+".wasm")).generic_string();
       else
-         wastPath = (cpath / wastPath).generic_string();
+         wasmPath = (cpath / wasmPath).generic_string();
 
       std::cerr << localized(("Reading WASM from " + wasmPath + "...").c_str()) << std::endl;
       fc::read_file_contents(wasmPath, wast);

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -2155,7 +2155,7 @@ int main( int argc, char** argv ) {
 
    std::vector<chain::action> actions;
    auto set_code_callback = [&]() {
-      std::string wast;
+      std::string wasm;
       fc::path cpath(contractPath);
 
       if( cpath.filename().generic_string() == "." ) cpath = cpath.parent_path();
@@ -2166,9 +2166,8 @@ int main( int argc, char** argv ) {
          wasmPath = (cpath / wasmPath).generic_string();
 
       std::cerr << localized(("Reading WASM from " + wasmPath + "...").c_str()) << std::endl;
-      fc::read_file_contents(wasmPath, wast);
-      EOS_ASSERT( !wast.empty(), wast_file_not_found, "no wasm file found ${f}", ("f", wasmPath) );
-      vector<uint8_t> wasm = vector<uint8_t>(wast.begin(), wast.end());
+      fc::read_file_contents(wasmPath, wasm);
+      EOS_ASSERT( !wasm.empty(), wast_file_not_found, "no wasm file found ${f}", ("f", wasmPath) );
 
       actions.emplace_back( create_setcode(account, bytes(wasm.begin(), wasm.end()) ) );
       if ( shouldSend ) {

--- a/testnet.template
+++ b/testnet.template
@@ -75,7 +75,7 @@ wcmd create -n ignition
 # ------ DO NOT ALTER THE NEXT LINE -------
 ###INSERT prodkeys
 
-ecmd set contract eosio contracts/eosio.bios eosio.bios.wast eosio.bios.abi
+ecmd set contract eosio contracts/eosio.bios eosio.bios.wasm eosio.bios.abi
 
 # Create required system accounts
 ecmd create key

--- a/tests/Cluster.py
+++ b/tests/Cluster.py
@@ -726,10 +726,10 @@ class Cluster(object):
 
             contract="eosio.bios"
             contractDir="contracts/%s" % (contract)
-            wastFile="%s.wast" % (contract)
+            wasmFile="%s.wasm" % (contract)
             abiFile="%s.abi" % (contract)
             Utils.Print("Publish %s contract" % (contract))
-            trans=biosNode.publishContract(eosioAccount.name, contractDir, wastFile, abiFile, waitForTransBlock=True)
+            trans=biosNode.publishContract(eosioAccount.name, contractDir, wasmFile, abiFile, waitForTransBlock=True)
             if trans is None:
                 Utils.Print("ERROR: Failed to publish contract %s." % (contract))
                 return None
@@ -850,10 +850,10 @@ class Cluster(object):
 
             contract="eosio.token"
             contractDir="contracts/%s" % (contract)
-            wastFile="%s.wast" % (contract)
+            wasmFile="%s.wasm" % (contract)
             abiFile="%s.abi" % (contract)
             Utils.Print("Publish %s contract" % (contract))
-            trans=biosNode.publishContract(eosioTokenAccount.name, contractDir, wastFile, abiFile, waitForTransBlock=True)
+            trans=biosNode.publishContract(eosioTokenAccount.name, contractDir, wasmFile, abiFile, waitForTransBlock=True)
             if trans is None:
                 Utils.Print("ERROR: Failed to publish contract %s." % (contract))
                 return None
@@ -905,10 +905,10 @@ class Cluster(object):
 
             contract="eosio.system"
             contractDir="contracts/%s" % (contract)
-            wastFile="%s.wast" % (contract)
+            wasmFile="%s.wasm" % (contract)
             abiFile="%s.abi" % (contract)
             Utils.Print("Publish %s contract" % (contract))
-            trans=biosNode.publishContract(eosioAccount.name, contractDir, wastFile, abiFile, waitForTransBlock=True)
+            trans=biosNode.publishContract(eosioAccount.name, contractDir, wasmFile, abiFile, waitForTransBlock=True)
             if trans is None:
                 Utils.Print("ERROR: Failed to publish contract %s." % (contract))
                 return None

--- a/tests/Node.py
+++ b/tests/Node.py
@@ -757,9 +757,9 @@ class Node(object):
             return None
 
     # publish contract and return transaction as json object
-    def publishContract(self, account, contractDir, wastFile, abiFile, waitForTransBlock=False, shouldFail=False):
+    def publishContract(self, account, contractDir, wasmFile, abiFile, waitForTransBlock=False, shouldFail=False):
         cmd="%s %s -v set contract -j %s %s" % (Utils.EosClientPath, self.endpointArgs, account, contractDir)
-        cmd += "" if wastFile is None else (" "+ wastFile)
+        cmd += "" if wasmFile is None else (" "+ wasmFile)
         cmd += "" if abiFile is None else (" " + abiFile)
         if Utils.Debug: Utils.Print("cmd: %s" % (cmd))
         trans=None

--- a/tests/consensus-validation-malicious-producers.py
+++ b/tests/consensus-validation-malicious-producers.py
@@ -288,10 +288,10 @@ def myTest(transWillEnterBlock):
             error("Failed to create account %s" % (currencyAccount.name))
             return False
 
-        wastFile="currency.wast"
+        wasmFile="currency.wasm"
         abiFile="currency.abi"
         Print("Publish contract")
-        trans=node.publishContract(currencyAccount.name, wastFile, abiFile, waitForTransBlock=True)
+        trans=node.publishContract(currencyAccount.name, wasmFile, abiFile, waitForTransBlock=True)
         if trans is None:
             error("Failed to publish contract.")
             return False

--- a/tests/nodeos_run_test.py
+++ b/tests/nodeos_run_test.py
@@ -319,10 +319,10 @@ try:
         errorExit("FAILURE - get code currency1111 failed", raw=True)
 
     contractDir="contracts/eosio.token"
-    wastFile="eosio.token.wast"
+    wasmFile="eosio.token.wasm"
     abiFile="eosio.token.abi"
     Print("Publish contract")
-    trans=node.publishContract(currencyAccount.name, contractDir, wastFile, abiFile, waitForTransBlock=True)
+    trans=node.publishContract(currencyAccount.name, contractDir, wasmFile, abiFile, waitForTransBlock=True)
     if trans is None:
         cmdError("%s set contract currency1111" % (ClientName))
         errorExit("Failed to publish contract.")
@@ -605,20 +605,20 @@ try:
     Print("upload exchange contract")
 
     contractDir="contracts/exchange"
-    wastFile="exchange.wast"
+    wasmFile="exchange.wasm"
     abiFile="exchange.abi"
     Print("Publish exchange contract")
-    trans=node.publishContract(exchangeAccount.name, contractDir, wastFile, abiFile, waitForTransBlock=True)
+    trans=node.publishContract(exchangeAccount.name, contractDir, wasmFile, abiFile, waitForTransBlock=True)
     if trans is None:
         cmdError("%s set contract exchange" % (ClientName))
         errorExit("Failed to publish contract.")
 
     contractDir="contracts/simpledb"
-    wastFile="simpledb.wast"
+    wasmFile="simpledb.wasm"
     abiFile="simpledb.abi"
     Print("Setting simpledb contract without simpledb account was causing core dump in %s." % (ClientName))
     Print("Verify %s generates an error, but does not core dump." % (ClientName))
-    retMap=node.publishContract("simpledb", contractDir, wastFile, abiFile, shouldFail=True)
+    retMap=node.publishContract("simpledb", contractDir, wasmFile, abiFile, shouldFail=True)
     if retMap is None:
         errorExit("Failed to publish, but should have returned a details map")
     if retMap["returncode"] == 0 or retMap["returncode"] == 139: # 139 SIGSEGV

--- a/tests/nodeos_under_min_avail_ram.py
+++ b/tests/nodeos_under_min_avail_ram.py
@@ -138,10 +138,10 @@ try:
     trans=nodes[0].delegatebw(contractAccount, 1000000.0000, 88000000.0000, exitOnError=True)
 
     contractDir="contracts/integration_test"
-    wastFile="contracts/integration_test/integration_test.wast"
+    wasmFile="contracts/integration_test/integration_test.wasm"
     abiFile="contracts/integration_test/integration_test.abi"
     Print("Publish contract")
-    trans=nodes[0].publishContract(contractAccount.name, contractDir, wastFile, abiFile, waitForTransBlock=True)
+    trans=nodes[0].publishContract(contractAccount.name, contractDir, wasmFile, abiFile, waitForTransBlock=True)
     if trans is None:
         cmdError("%s set contract %s" % (ClientName, contractAccount.name))
         errorExit("Failed to publish contract.")

--- a/tests/p2p_network_test.py
+++ b/tests/p2p_network_test.py
@@ -144,10 +144,10 @@ for i in range(len(hosts)):
     Print("host %s: %s" % (hosts[i], trans))
 
 
-wastFile="eosio.system.wast"
+wasmFile="eosio.system.wasm"
 abiFile="eosio.system.abi"
-Print("\nPush system contract %s %s" % (wastFile, abiFile))
-trans=node0.publishContract(eosio.name, wastFile, abiFile, waitForTransBlock=True)
+Print("\nPush system contract %s %s" % (wasmFile, abiFile))
+trans=node0.publishContract(eosio.name, wasmFile, abiFile, waitForTransBlock=True)
 if trans is None:
     Utils.errorExit("Failed to publish eosio.system.")
 else:


### PR DESCRIPTION
The textual format of WebAssembly continues to be somewhat fluid. For example, the renaming of `grow_memory` with `memory.grow`. The binary format has been stable for some time. Only consume the binary format in cleos now -- the eosio tools (like eosiocpp) have produced binary .wasm files since the 1.0 release by default as do most other toolchains. This protects us from further deviations of the textual format