### PR TITLE
Fix --mongodb-filter-on option

### DIFF
--- a/plugins/mongo_db_plugin/mongo_db_plugin.cpp
+++ b/plugins/mongo_db_plugin/mongo_db_plugin.cpp
@@ -1409,6 +1409,7 @@ void mongo_db_plugin::plugin_initialize(const variables_map& options)
          }
          if( options.count( "mongodb-filter-on" )) {
             auto fo = options.at( "mongodb-filter-on" ).as<vector<string>>();
+            my->filter_on_star = false;
             for( auto& s : fo ) {
                if( s == "*" ) {
                   my->filter_on_star = true;


### PR DESCRIPTION
See #5066 report of issue of filter on by @DenisCarriere 

- Fixes `--mongodb-filter-on` option to not include everything when used.