### PR TITLE
net_plugin::plugin_startup gives more information when it attempts to…

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -3008,7 +3008,13 @@ namespace eosio {
       if( my->acceptor ) {
          my->acceptor->open(my->listen_endpoint.protocol());
          my->acceptor->set_option(tcp::acceptor::reuse_address(true));
-         my->acceptor->bind(my->listen_endpoint);
+         try {
+           my->acceptor->bind(my->listen_endpoint);
+         } catch (const std::exception& e) {
+           ilog("net_plugin::plugin_startup failed to bind to port ${port}",
+             ("port", my->listen_endpoint.port()));
+           throw e;
+         }
          my->acceptor->listen();
          ilog("starting listener, max clients is ${mc}",("mc",my->max_client_count));
          my->start_listen_loop();


### PR DESCRIPTION
If net_plugin::plugin_startup fails to bind, the error message in the log is mysterious; all you know is that something, somewhere failed to bind to a port.

After the patch, you get:

```
2018-08-12T16:09:51.860 thread-0   net_plugin.cpp:3015           plugin_startup       ] net_plugin::plugin_startup failed to bind to port 9876
2018-08-12T16:09:51.878 thread-0   main.cpp:145                  main                 ] std::exception
```

Before the patch, you get no indication of what code might be causing the problem:

```
2018-08-12T16:19:45.887 thread-0   http_plugin.cpp:401           plugin_startup       ] start listening for http requests
2018-08-12T16:19:45.909 thread-0   main.cpp:131                  main                 ] Throw location unknown (consider using BOOST_THROW_EXCEPTION)
Dynamic exception type: boost::exception_detail::clone_impl<boost::exception_detail::error_info_injector<boost::system::system_error> >
std::exception::what: bind: Address already in use
```
Helps people diagnose problems with issues like #3999.