### PR TITLE
Read only mode

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1423,6 +1423,7 @@ void controller::push_confirmation( const header_confirmation& c ) {
 
 transaction_trace_ptr controller::push_transaction( const transaction_metadata_ptr& trx, fc::time_point deadline, uint32_t billed_cpu_time_us ) {
    validate_db_available_size();
+   EOS_ASSERT( get_read_mode() != chain::db_read_mode::READ_ONLY, transaction_type_exception, "push transaction not allowed in read-only mode" );
    EOS_ASSERT( trx && !trx->implicit && !trx->scheduled, transaction_type_exception, "Implicit/Scheduled transaction not allowed" );
    return my->push_transaction(trx, deadline, billed_cpu_time_us, billed_cpu_time_us > 0 );
 }

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -36,6 +36,7 @@ namespace eosio { namespace chain {
    enum class db_read_mode {
       SPECULATIVE,
       HEAD,
+      READ_ONLY,
       IRREVERSIBLE
    };
 

--- a/plugins/bnet_plugin/bnet_plugin.cpp
+++ b/plugins/bnet_plugin/bnet_plugin.cpp
@@ -1038,6 +1038,8 @@ namespace eosio {
               peer_elog(this, "bad packed_transaction_ptr : null pointer");
               EOS_THROW(transaction_exception, "bad transaction");
            }
+           if( app().get_plugin<chain_plugin>().chain().get_read_mode() == chain::db_read_mode::READ_ONLY )
+              return;
 
            auto id = p->id();
           // ilog( "recv trx ${n}", ("n", id) );
@@ -1367,6 +1369,11 @@ namespace eosio {
                                        my->on_bad_block(b);
                                 });
 
+
+      if( app().get_plugin<chain_plugin>().chain().get_read_mode() == chain::db_read_mode::READ_ONLY ) {
+         my->_request_trx = false;
+         ilog( "setting bnet-no-trx to true since in read-only mode" );
+      }
 
       const auto address = boost::asio::ip::make_address( my->_bnet_endpoint_address );
       my->_ioc.reset( new boost::asio::io_context{my->_num_threads} );

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -40,6 +40,8 @@ std::ostream& operator<<(std::ostream& osm, eosio::chain::db_read_mode m) {
       osm << "speculative";
    } else if ( m == eosio::chain::db_read_mode::HEAD ) {
       osm << "head";
+   } else if ( m == eosio::chain::db_read_mode::READ_ONLY ) {
+      osm << "read-only";
    } else if ( m == eosio::chain::db_read_mode::IRREVERSIBLE ) {
       osm << "irreversible";
    }
@@ -65,6 +67,8 @@ void validate(boost::any& v,
      v = boost::any(eosio::chain::db_read_mode::SPECULATIVE);
   } else if ( s == "head" ) {
      v = boost::any(eosio::chain::db_read_mode::HEAD);
+  } else if ( s == "read-only" ) {
+     v = boost::any(eosio::chain::db_read_mode::READ_ONLY);
   } else if ( s == "irreversible" ) {
      v = boost::any(eosio::chain::db_read_mode::IRREVERSIBLE);
   } else {
@@ -655,6 +659,13 @@ void chain_plugin::plugin_shutdown() {
    my->applied_transaction_connection.reset();
    my->accepted_confirmation_connection.reset();
    my->chain.reset();
+}
+
+chain_apis::read_write::read_write(controller& db, const fc::microseconds& abi_serializer_max_time)
+: db(db)
+, abi_serializer_max_time(abi_serializer_max_time)
+{
+   EOS_ASSERT( db.get_read_mode() != chain::db_read_mode::READ_ONLY, missing_chain_api_plugin_exception, "Not allowed, node in read-only mode" );
 }
 
 chain_apis::read_write chain_plugin::get_read_write_api() {

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -470,8 +470,7 @@ class read_write {
    controller& db;
    const fc::microseconds abi_serializer_max_time;
 public:
-   read_write(controller& db, const fc::microseconds& abi_serializer_max_time)
-         : db(db), abi_serializer_max_time(abi_serializer_max_time) {}
+   read_write(controller& db, const fc::microseconds& abi_serializer_max_time);
 
    using push_block_params = chain::signed_block;
    using push_block_results = empty;

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -877,6 +877,10 @@ fc::time_point producer_plugin_impl::calculate_pending_block_time() const {
 
 producer_plugin_impl::start_block_result producer_plugin_impl::start_block(bool &last_block) {
    chain::controller& chain = app().get_plugin<chain_plugin>().chain();
+
+   if( chain.get_read_mode() == chain::db_read_mode::READ_ONLY )
+      return start_block_result::waiting;
+
    const auto& hbs = chain.head_block_state();
 
    //Schedule for the next second's tick regardless of chain state

--- a/unittests/forked_tests.cpp
+++ b/unittests/forked_tests.cpp
@@ -453,6 +453,11 @@ BOOST_AUTO_TEST_CASE( read_modes ) try {
    BOOST_REQUIRE_EQUAL(head_block_num, head.control->fork_db_head_block_num());
    BOOST_REQUIRE_EQUAL(head_block_num, head.control->head_block_num());
 
+   tester read_only(true, db_read_mode::READ_ONLY);
+   push_blocks(c, read_only);
+   BOOST_REQUIRE_EQUAL(head_block_num, read_only.control->fork_db_head_block_num());
+   BOOST_REQUIRE_EQUAL(head_block_num, read_only.control->head_block_num());
+
    tester irreversible(true, db_read_mode::IRREVERSIBLE);
    push_blocks(c, irreversible);
    BOOST_REQUIRE_EQUAL(head_block_num, irreversible.control->fork_db_head_block_num());

--- a/unittests/forked_tests.cpp
+++ b/unittests/forked_tests.cpp
@@ -453,7 +453,7 @@ BOOST_AUTO_TEST_CASE( read_modes ) try {
    BOOST_REQUIRE_EQUAL(head_block_num, head.control->fork_db_head_block_num());
    BOOST_REQUIRE_EQUAL(head_block_num, head.control->head_block_num());
 
-   tester read_only(true, db_read_mode::READ_ONLY);
+   tester read_only(false, db_read_mode::READ_ONLY);
    push_blocks(c, read_only);
    BOOST_REQUIRE_EQUAL(head_block_num, read_only.control->fork_db_head_block_num());
    BOOST_REQUIRE_EQUAL(head_block_num, read_only.control->head_block_num());


### PR DESCRIPTION
- Create a new read-only db mode where incoming blocks are processed but with no speculative processing of blocks. This is similar to head mode except for no speculative execution or relaying of transactions are performed.
- In read-only mode no p2p connections are allowed since transactions are not speculatively executed or relayed.
- This mode is useful for plugins such as the mongo_db_plugin where consistent state is the most important characteristic.
- Note that non-irreversible blocks are still processed so forks are recorded when they happen.