### PR TITLE
Mongo db plugin transaction_trace filter

### DIFF
--- a/plugins/mongo_db_plugin/mongo_db_plugin.cpp
+++ b/plugins/mongo_db_plugin/mongo_db_plugin.cpp
@@ -785,6 +785,7 @@ void mongo_db_plugin_impl::_process_applied_transaction( const chain::transactio
    }
 
    if( !start_block_reached || !store_transaction_traces ) return;
+   if( !write_atraces ) return; //< do not insert transaction_trace if all action_traces filtered out
 
    // transaction trace insert
 


### PR DESCRIPTION
- transaction_trace is now filtered out if all action_traces of transaction_trace is filtered out.