### PR TITLE
Allow eosiocpp to run without make install

### DIFF
--- a/tools/eosiocpp.in
+++ b/tools/eosiocpp.in
@@ -5,7 +5,27 @@ if [ "${EOSIO_BIN_INSTALL_DIR}" == "." ]; then
   EOSIO_BIN_INSTALL_DIR=`pwd`
 fi
 EOSIO_INSTALL_DIR=`dirname ${EOSIO_BIN_INSTALL_DIR}`
-ABIGEN=${EOSIO_INSTALL_DIR}/bin/eosio-abigen
+if [ -x "@CMAKE_BINARY_DIR@/programs/eosio-abigen/eosio-abigen" ]; then
+    ABIGEN="@CMAKE_BINARY_DIR@/programs/eosio-abigen/eosio-abigen"
+elif [ -x "${EOSIO_INSTALL_DIR}/bin/eosio-abigen" ]; then
+    ABIGEN=${EOSIO_INSTALL_DIR}/bin/eosio-abigen
+fi
+if [ -x "@CMAKE_BINARY_DIR@/externals/binaryen/bin/eosio-s2wasm" ]; then
+    EOSIO_S2WASM="@CMAKE_BINARY_DIR@/externals/binaryen/bin/eosio-s2wasm"
+elif [ -x "${EOSIO_INSTALL_DIR}/bin/eosio-s2wasm" ]; then
+    EOSIO_S2WASM="${EOSIO_INSTALL_DIR}/bin/eosio-s2wasm"
+else
+    echo "eosio-s2wasm not found either built or installed"
+    exit 12
+fi
+if [ -x "@CMAKE_BINARY_DIR@/libraries/wasm-jit/Source/Programs/eosio-wast2wasm" ]; then
+    EOSIO_WAST2WASM="@CMAKE_BINARY_DIR@/libraries/wasm-jit/Source/Programs/eosio-wast2wasm"
+elif [ -x "${EOSIO_INSTALL_DIR}/bin/eosio-wast2wasm" ]; then
+    EOSIO_WAST2WASM="${EOSIO_INSTALL_DIR}/bin/eosio-wast2wasm"
+else
+    echo "eosio-wast2wasm not found either built or installed"
+    exit 14
+fi
 BOOST_INCLUDE_DIR=@Boost_INCLUDE_DIR@
 function copy_skeleton {
     set -e
@@ -41,8 +61,13 @@ function build_contract {
 
         ($PRINT_CMDS; @WASM_CLANG@ -emit-llvm -O3 --std=c++14 --target=wasm32 -nostdinc \
                                    -DBOOST_DISABLE_ASSERTS -DBOOST_EXCEPTION_DISABLE \
-                                   -nostdlib -nostdlibinc -ffreestanding -nostdlib -fno-threadsafe-statics -fno-rtti \
-                                   -fno-exceptions -I ${EOSIO_INSTALL_DIR}/include \
+                                   -nostdlib -nostdlibinc -ffreestanding -nostdlib \
+                                   -fno-threadsafe-statics -fno-rtti -fno-exceptions \
+                                   -I @CMAKE_SOURCE_DIR@/contracts \
+                                   -I @CMAKE_SOURCE_DIR@/contracts/libc++/upstream/include \
+                                   -I @CMAKE_SOURCE_DIR@/contracts/musl/upstream/include \
+                                   -I @CMAKE_SOURCE_DIR@/externals/magic_get/include \
+                                   -I ${EOSIO_INSTALL_DIR}/include \
                                    -I${EOSIO_INSTALL_DIR}/include/libc++/upstream/include \
                                    -I${EOSIO_INSTALL_DIR}/include/musl/upstream/include \
                                    -I${BOOST_INCLUDE_DIR} \
@@ -53,16 +78,22 @@ function build_contract {
 
     done
 
-    ($PRINT_CMDS; @WASM_LLVM_LINK@ -only-needed -o $workdir/linked.bc $workdir/built/* \
-                                   ${EOSIO_INSTALL_DIR}/usr/share/eosio/contractsdk/lib/eosiolib.bc \
-                                   ${EOSIO_INSTALL_DIR}/usr/share/eosio/contractsdk/lib/libc++.bc \
-                                   ${EOSIO_INSTALL_DIR}/usr/share/eosio/contractsdk/lib/libc.bc
-
-
-    )
+    declare -a possible_libs=("@CMAKE_BINARY_DIR@/contracts/eosiolib/eosiolib.bc"
+                              "@CMAKE_BINARY_DIR@/contracts/libc++/libc++.bc"
+                              "@CMAKE_BINARY_DIR@/contracts/musl/libc.bc"
+                              "${EOSIO_INSTALL_DIR}/usr/share/eosio/contractsdk/lib/eosiolib.bc"
+                              "${EOSIO_INSTALL_DIR}/usr/share/eosio/contractsdk/lib/libc++.bc"
+                              "${EOSIO_INSTALL_DIR}/usr/share/eosio/contractsdk/lib/libc.bc")
+    declare libs=""
+    for lib in "${possible_libs[@]}"; do
+        if [ -f "${lib}" ]; then
+            libs="${libs} ${lib}"
+        fi
+    done
+    ($PRINT_CMDS; @WASM_LLVM_LINK@ -only-needed -o $workdir/linked.bc $workdir/built/* ${libs})
     ($PRINT_CMDS; @WASM_LLC@ -thread-model=single --asm-verbose=false -o $workdir/assembly.s $workdir/linked.bc)
-    ($PRINT_CMDS; ${EOSIO_INSTALL_DIR}/bin/eosio-s2wasm -o $outname -s 16384 $workdir/assembly.s)
-    ($PRINT_CMDS; ${EOSIO_INSTALL_DIR}/bin/eosio-wast2wasm $outname ${outname%.*}.wasm -n)
+    ($PRINT_CMDS; ${EOSIO_S2WASM} -o $outname -s 16384 $workdir/assembly.s)
+    ($PRINT_CMDS; ${EOSIO_WAST2WASM} $outname ${outname%.*}.wasm -n)
 
     ($PRINT_CMDS; rm -rf $workdir)
     set +e
@@ -79,6 +110,10 @@ function generate_abi {
     
     ${ABIGEN} -extra-arg=-c -extra-arg=--std=c++14 -extra-arg=--target=wasm32 \
         -extra-arg=-nostdinc -extra-arg=-nostdinc++ -extra-arg=-DABIGEN \
+        -extra-arg=-I@CMAKE_SOURCE_DIR@/contracts \
+        -extra-arg=-I@CMAKE_SOURCE_DIR@/contracts/libc++/upstream/include \
+        -extra-arg=-I@CMAKE_SOURCE_DIR@/contracts/musl/upstream/include \
+        -extra-arg=-I@CMAKE_SOURCE_DIR@/externals/magic_get/include \
         -extra-arg=-I${EOSIO_INSTALL_DIR}/include/libc++/upstream/include \
         -extra-arg=-I${EOSIO_INSTALL_DIR}/include/musl/upstream/include \
         -extra-arg=-I${BOOST_INCLUDE_DIR} \


### PR DESCRIPTION
Add include paths and library locations to allow eosiocpp to run in-place.  Works on contract paths outside of eos hierarchy.  Still works when installed.