### PR TITLE
Remove nodeos from being MAS signed

### DIFF
--- a/programs/nodeos/CMakeLists.txt
+++ b/programs/nodeos/CMakeLists.txt
@@ -93,5 +93,3 @@ install(DIRECTORY DESTINATION ${CMAKE_INSTALL_FULL_LOCALSTATEDIR}/lib/eosio
                               WORLD_READ
                               WORLD_EXECUTE
 			)
-
-mas_sign(${NODE_EXECUTABLE_NAME})


### PR DESCRIPTION
Now that nodeos cannot be a wallet, remove it from Mac App Store signing -- it has no need to access Secure Enclave