### PR TITLE
Increase timeout for slow test machines

### DIFF
--- a/tests/Cluster.py
+++ b/tests/Cluster.py
@@ -129,7 +129,7 @@ class Cluster(object):
         if self.staging:
             cmdArr.append("--nogen")
 
-        nodeosArgs="--max-transaction-time 50000 --abi-serializer-max-time-ms 65000 --filter-on * --p2p-max-nodes-per-host %d" % (totalNodes)
+        nodeosArgs="--max-transaction-time 50000 --abi-serializer-max-time-ms 990000 --filter-on * --p2p-max-nodes-per-host %d" % (totalNodes)
         if not self.walletd:
             nodeosArgs += " --plugin eosio::wallet_api_plugin"
         if self.enableMongo:


### PR DESCRIPTION
- None of the smoke test depend on normal abi-serializer timeouts, so increase to allow slow servers more time.