### PR TITLE
fix for stale read-write api reference.

### DIFF
--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -38,6 +38,7 @@ struct async_result_visitor : public fc::visitor<std::string> {
 #define CALL(api_name, api_handle, api_namespace, call_name, http_response_code) \
 {std::string("/v1/" #api_name "/" #call_name), \
    [this, api_handle](string, string body, url_response_callback cb) mutable { \
+          api_handle.validate(); \
           try { \
              if (body.empty()) body = "{}"; \
              auto result = api_handle.call_name(fc::json::from_string(body).as<api_namespace::call_name ## _params>()); \
@@ -49,8 +50,9 @@ struct async_result_visitor : public fc::visitor<std::string> {
 
 #define CALL_ASYNC(api_name, api_handle, api_namespace, call_name, call_result, http_response_code) \
 {std::string("/v1/" #api_name "/" #call_name), \
-   [this](string, string body, url_response_callback cb) mutable { \
+   [this, api_handle](string, string body, url_response_callback cb) mutable { \
       if (body.empty()) body = "{}"; \
+      api_handle.validate(); \
       api_handle.call_name(fc::json::from_string(body).as<api_namespace::call_name ## _params>(),\
          [cb, body](const fc::static_variant<fc::exception_ptr, call_result>& result){\
             if (result.contains<fc::exception_ptr>()) {\
@@ -66,16 +68,16 @@ struct async_result_visitor : public fc::visitor<std::string> {
    }\
 }
 
-#define CHAIN_RW_API app().get_plugin<chain_plugin>().get_read_write_api()
 #define CHAIN_RO_CALL(call_name, http_response_code) CALL(chain, ro_api, chain_apis::read_only, call_name, http_response_code)
 #define CHAIN_RW_CALL(call_name, http_response_code) CALL(chain, rw_api, chain_apis::read_write, call_name, http_response_code)
 #define CHAIN_RO_CALL_ASYNC(call_name, call_result, http_response_code) CALL_ASYNC(chain, ro_api, chain_apis::read_only, call_name, call_result, http_response_code)
-#define CHAIN_RW_CALL_ASYNC(call_name, call_result, http_response_code) CALL_ASYNC(chain, (CHAIN_RW_API), chain_apis::read_write, call_name, call_result, http_response_code)
+#define CHAIN_RW_CALL_ASYNC(call_name, call_result, http_response_code) CALL_ASYNC(chain, rw_api, chain_apis::read_write, call_name, call_result, http_response_code)
 
 void chain_api_plugin::plugin_startup() {
    ilog( "starting chain_api_plugin" );
    my.reset(new chain_api_plugin_impl(app().get_plugin<chain_plugin>().chain()));
    auto ro_api = app().get_plugin<chain_plugin>().get_read_only_api();
+   auto rw_api = app().get_plugin<chain_plugin>().get_read_write_api();
 
    app().get_plugin<http_plugin>().add_api({
       CHAIN_RO_CALL(get_info, 200l),

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -666,6 +666,9 @@ chain_apis::read_write::read_write(controller& db, const fc::microseconds& abi_s
 : db(db)
 , abi_serializer_max_time(abi_serializer_max_time)
 {
+}
+
+void chain_apis::read_write::validate() const {
    EOS_ASSERT( db.get_read_mode() != chain::db_read_mode::READ_ONLY, missing_chain_api_plugin_exception, "Not allowed, node in read-only mode" );
 }
 

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -75,6 +75,8 @@ public:
    read_only(const controller& db, const fc::microseconds& abi_serializer_max_time)
       : db(db), abi_serializer_max_time(abi_serializer_max_time) {}
 
+   void validate() const {}
+
    using get_info_params = empty;
 
    struct get_info_results {
@@ -474,6 +476,7 @@ class read_write {
    const fc::microseconds abi_serializer_max_time;
 public:
    read_write(controller& db, const fc::microseconds& abi_serializer_max_time);
+   void validate() const;
 
    using push_block_params = chain::signed_block;
    using push_block_results = empty;


### PR DESCRIPTION
changes to the read-write api meant for async calls we were holding a stale reference.  Reverted to the captured and therfore live object and moved the assert to a validate call which is called just-in-time