### PR TITLE
Remove unused variable

### DIFF
--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -2350,7 +2350,6 @@ int main( int argc, char** argv ) {
 
    add_standard_transaction_options(transfer, "sender@active");
    transfer->set_callback([&] {
-      signed_transaction trx;
       if (tx_force_unique && memo.size() == 0) {
          // use the memo to add a nonce
          memo = generate_nonce_string();


### PR DESCRIPTION
`signed_transaction trx` in the callback of `cleos transfer` subcommand is not used in that function.