### PR TITLE
Fix for nullptr deref when producers are waiting

### DIFF
--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -831,10 +831,13 @@ optional<fc::time_point> producer_plugin_impl::calculate_next_block_time(const a
    auto current_watermark_itr = _producer_watermarks.find(producer_name);
    if (current_watermark_itr != _producer_watermarks.end()) {
       auto watermark = current_watermark_itr->second;
-      const auto& pbs = chain.pending_block_state();
-      if (watermark > pbs->block_num) {
+      auto block_num = chain.head_block_state()->block_num;
+      if (chain.pending_block_state()) {
+         ++block_num;
+      }
+      if (watermark > block_num) {
          // if I have a watermark then I need to wait until after that watermark
-         minimum_offset = watermark - pbs->block_num + 1;
+         minimum_offset = watermark - block_num + 1;
       }
    }
 


### PR DESCRIPTION
EOSIO/eos#4972 created a different calling path into `producer_plugin_impl::calculate_next_block_time` where there was no pending block state.  As a result when the following conditions were met the code would dereference a null ptr:

* the node was a producer, who _had_ produced during this processes lifetime OR replayed a block where they produced (so they have watermark data)
* still in the active schedule of producers
* experienced a gap in blocks of > 5 seconds (so they moved to our “waiting” mode)

Credit goes to @heifner for the find