### PR TITLE
Warn when trying to set code with something non-wasm

### DIFF
--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -2282,6 +2282,10 @@ int main( int argc, char** argv ) {
       fc::read_file_contents(wasmPath, wasm);
       EOS_ASSERT( !wasm.empty(), wast_file_not_found, "no wasm file found ${f}", ("f", wasmPath) );
 
+      const string binary_wasm_header("\x00\x61\x73\x6d\x01\x00\x00\x00", 8);
+      if(wasm.compare(0, 8, binary_wasm_header))
+         std::cerr << localized("WARNING: ") << wasmPath << localized(" doesn't look like a binary WASM file. Is it something else, like WAST? Trying anyways...") << std::endl;
+
       actions.emplace_back( create_setcode(account, bytes(wasm.begin(), wasm.end()) ) );
       if ( shouldSend ) {
          std::cerr << localized("Setting Code...") << std::endl;


### PR DESCRIPTION
Add a warning when set code/contract detects an apparent non-wasm being used (like wast)