### PR TITLE
cleos support deferred action

### DIFF
--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -167,6 +167,8 @@ bool   print_response = false;
 uint8_t  tx_max_cpu_usage = 0;
 uint32_t tx_max_net_usage = 0;
 
+uint32_t delaysec = 0;
+
 vector<string> tx_permission;
 
 eosio::client::http::http_context context;
@@ -197,6 +199,8 @@ void add_standard_transaction_options(CLI::App* cmd, string default_permission =
 
    cmd->add_option("--max-cpu-usage-ms", tx_max_cpu_usage, localized("set an upper limit on the milliseconds of cpu usage budget, for the execution of the transaction (defaults to 0 which means no limit)"));
    cmd->add_option("--max-net-usage", tx_max_net_usage, localized("set an upper limit on the net usage budget, in bytes, for the transaction (defaults to 0 which means no limit)"));
+  
+   cmd->add_option("-n,--delay", delaysec, localized("set the delay_sec seconds, defaults to 0s"));
 }
 
 vector<chain::permission_level> get_account_permissions(const vector<string>& permissions) {
@@ -295,6 +299,7 @@ fc::variant push_transaction( signed_transaction& trx, int32_t extra_kcpu = 1000
 
    trx.max_cpu_usage_ms = tx_max_cpu_usage;
    trx.max_net_usage_words = (tx_max_net_usage + 7)/8;
+   trx.delay_sec = delaysec;
 
    if (!tx_skip_sign) {
       auto required_keys = determine_required_keys(trx);


### PR DESCRIPTION
for standard transaction options,  add -n delay_sec option to set the transaction deferred.