### PR TITLE
Use transaction delay_sec in get_required_keys determination

### DIFF
--- a/contracts/eosiolib/types.h
+++ b/contracts/eosiolib/types.h
@@ -27,13 +27,13 @@ typedef uint64_t account_name;
 
 /**
  * @brief Name of a permission
- * @details Name of an account
+ * @details Name of a permission
  */
 typedef uint64_t permission_name;
 
 /**
  * @brief Name of a table
- * @details Name of atable
+ * @details Name of a table
  */
 typedef uint64_t table_name;
 

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1666,7 +1666,7 @@ read_only::get_required_keys_result read_only::get_required_keys( const get_requ
       abi_serializer::from_variant(params.transaction, pretty_input, resolver, abi_serializer_max_time);
    } EOS_RETHROW_EXCEPTIONS(chain::transaction_type_exception, "Invalid transaction")
 
-   auto required_keys_set = db.get_authorization_manager().get_required_keys(pretty_input, params.available_keys, pretty_input.delay_sec);
+   auto required_keys_set = db.get_authorization_manager().get_required_keys( pretty_input, params.available_keys, fc::seconds( pretty_input.delay_sec ));
    get_required_keys_result result;
    result.required_keys = required_keys_set;
    return result;

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1666,7 +1666,7 @@ read_only::get_required_keys_result read_only::get_required_keys( const get_requ
       abi_serializer::from_variant(params.transaction, pretty_input, resolver, abi_serializer_max_time);
    } EOS_RETHROW_EXCEPTIONS(chain::transaction_type_exception, "Invalid transaction")
 
-   auto required_keys_set = db.get_authorization_manager().get_required_keys(pretty_input, params.available_keys);
+   auto required_keys_set = db.get_authorization_manager().get_required_keys(pretty_input, params.available_keys, pretty_input.delay_sec);
    get_required_keys_result result;
    result.required_keys = required_keys_set;
    return result;

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -2354,7 +2354,6 @@ int main( int argc, char** argv ) {
 
    add_standard_transaction_options(transfer, "sender@active");
    transfer->set_callback([&] {
-      signed_transaction trx;
       if (tx_force_unique && memo.size() == 0) {
          // use the memo to add a nonce
          memo = generate_nonce_string();


### PR DESCRIPTION
Resolves #5281 

- Use the transaction delay_sec in the determination of required keys.-