### PR TITLE
cleos set account permission default parent error

### DIFF
--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -681,8 +681,8 @@ struct set_account_permission_subcommand {
                const auto& existing_permissions = account_result.get_object()["permissions"].get_array();
                auto permissionPredicate = [this](const auto& perm) {
                   return perm.is_object() &&
-                        perm.get_object().contains("permission") &&
-                        boost::equals(perm.get_object()["permission"].get_string(), permissionStr);
+                        perm.get_object().contains("perm_name") &&
+                        boost::equals(perm.get_object()["perm_name"].get_string(), permissionStr);
                };
 
                auto itr = boost::find_if(existing_permissions, permissionPredicate);


### PR DESCRIPTION
RPC /get_account use struct get_account_results {
  ..
 vector<permission>         permissions;
 ..
}
struct permission {
  name              perm_name;
  name              parent;
  authority         required_auth;
};

i thank this mistake  maybe  because of struct permission_level{account_name actor, permission_name permission;} use name 'permission'

try it:
./cleos set account permission ACCOUNT active  PUBKEY
shoud equ
./cleos set account permission ACCOUNT active  owner PUBKEY