### PR TITLE
Notify RAM bought in buyram transaction

### DIFF
--- a/contracts/eosio.system/delegate_bandwidth.cpp
+++ b/contracts/eosio.system/delegate_bandwidth.cpp
@@ -150,8 +150,16 @@ namespace eosiosystem {
             });
       }
       set_resource_limits( res_itr->owner, res_itr->ram_bytes, res_itr->net_weight.amount, res_itr->cpu_weight.amount );
+      SEND_INLINE_ACTION( *this, notifyram, {payer, N(active)}, {payer, receiver, bytes_out, res_itr->ram_bytes} );
    }
 
+   void system_contract::notifyram(account_name payer, account_name receiver, int64_t bytes_out, int64_t ram_balance)
+   {
+       eosio_assert( bytes_out > 0, "must reserve a positive amount" );
+       eosio_assert( ram_balance > 0, "must reserve a positive amount" );
+       require_recipient(payer);
+       require_recipient(receiver);
+   }
 
    /**
     *  The system contract now buys and sells RAM allocations at prevailing market prices.

--- a/contracts/eosio.system/eosio.system.abi
+++ b/contracts/eosio.system/eosio.system.abi
@@ -158,6 +158,15 @@
          {"name":"quant", "type":"asset"}
       ]
     },{
+       "name": "notifyram",
+       "base": "",
+       "fields": [
+          {"name":"payer", "type":"account_name"},
+          {"name":"receiver", "type":"account_name"},
+          {"name":"ram_bought", "type":"int64"},
+          {"name":"ram_balance", "type":"int64"}
+       ]
+    },{
       "name": "delegatebw",
       "base": "",
       "fields": [
@@ -449,6 +458,10 @@
    },{
       "name": "buyram",
       "type": "buyram",
+      "ricardian_contract": ""
+   },{
+      "name": "notifyram",
+      "type": "notifyram",
       "ricardian_contract": ""
    },{
       "name": "sellram",

--- a/contracts/eosio.system/eosio.system.cpp
+++ b/contracts/eosio.system/eosio.system.cpp
@@ -190,7 +190,7 @@ EOSIO_ABI( eosiosystem::system_contract,
      // eosio.system.cpp
      (setram)(setparams)(setpriv)(rmvproducer)(bidname)
      // delegate_bandwidth.cpp
-     (buyrambytes)(buyram)(sellram)(delegatebw)(undelegatebw)(refund)
+     (buyrambytes)(buyram)(notifyram)(sellram)(delegatebw)(undelegatebw)(refund)
      // voting.cpp
      (regproducer)(unregprod)(voteproducer)(regproxy)
      // producer_pay.cpp

--- a/contracts/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/eosio.system.hpp
@@ -180,6 +180,7 @@ namespace eosiosystem {
           */
          void buyram( account_name buyer, account_name receiver, asset tokens );
          void buyrambytes( account_name buyer, account_name receiver, uint32_t bytes );
+         void notifyram(account_name buyer, account_name receiver, int64_t bytes_out, int64_t ram_balance);
 
          /**
           *  Reduces quota my bytes and then performs an inline transfer of tokens


### PR DESCRIPTION
This PR addresses the issue #5350 .

Use inline action to 'notify' payer and receiver in an `buyram` transaction exactly how much RAM the receiver got.

Following is the outcome using cleos tool to buy RAM:

![image](https://user-images.githubusercontent.com/1447307/44460467-c6027380-a63f-11e8-8237-a8ea7ffd0348.png)
