### PR TITLE
Added has_auth2 Contract API

### DIFF
--- a/contracts/eosiolib/action.h
+++ b/contracts/eosiolib/action.h
@@ -119,6 +119,15 @@ extern "C" {
     */
    void require_auth2( account_name name, permission_name permission );
 
+   /**
+    *  Verifies that @ref name has auth.
+    * 
+    *  @brief Verifies that @ref name has auth.
+    *  @param name - name of the account to be verified
+    *  @param permission - permission level to be verified
+    */
+   bool has_auth2( account_name name, permission_name permission );
+
    bool is_account( account_name name );
 
    /**

--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -151,6 +151,15 @@ void apply_context::require_authorization(const account_name& account,
               ("account",account)("permission",permission) );
 }
 
+bool apply_context::has_authorization(const account_name& account,
+                                      const permission_name& permission) {
+   for( const auto& auth : act.authorization )
+     if( auth.actor == account )
+       if( auth.permission == permission )
+         return true;
+  return false;
+}
+
 bool apply_context::has_recipient( account_name code )const {
    for( auto a : _notified )
       if( a == code )

--- a/libraries/chain/include/eosio/chain/apply_context.hpp
+++ b/libraries/chain/include/eosio/chain/apply_context.hpp
@@ -496,6 +496,7 @@ class apply_context {
       void require_authorization(const account_name& account);
       bool has_authorization(const account_name& account) const;
       void require_authorization(const account_name& account, const permission_name& permission);
+      bool has_authorization(const account_name& account, const permission_name& permission);
 
       /**
        * @return true if account exists, false if it does not

--- a/libraries/chain/wasm_interface.cpp
+++ b/libraries/chain/wasm_interface.cpp
@@ -888,6 +888,11 @@ class authorization_api : public context_aware_api {
       context.require_authorization( account, permission );
    }
 
+   bool has_authorization( const account_name& account,
+                                                 const permission_name& permission )const {
+      return context.has_authorization( account, permission );
+   }
+
    void require_recipient( account_name recipient ) {
       context.require_recipient( recipient );
    }
@@ -1801,6 +1806,7 @@ REGISTER_INTRINSICS(authorization_api,
    (require_authorization, void(int64_t), "require_auth", void(authorization_api::*)(const account_name&) )
    (require_authorization, void(int64_t, int64_t), "require_auth2", void(authorization_api::*)(const account_name&, const permission_name& permission) )
    (has_authorization,     int(int64_t), "has_auth", bool(authorization_api::*)(const account_name&)const )
+   (has_authorization,     int(int64_t, int64_t), "has_auth2", bool(authorization_api::*)(const account_name&, const permission_name&)const )
    (is_account,            int(int64_t)           )
 );
 


### PR DESCRIPTION
Added a new contract interface `has_auth2` which mimics the same pattern of `require_auth` and `require_auth2`. The reason for adding the interface is for contracts to be able to check a specific permission.

I thought it was ok even without the addition of this new interface, as I could first call `require_auth2` and then catch the exception thrown, until I found that **exceptions are not allowed in contracts**. There's **no way** to check a specific permission.

This is a duplicate PR as #5378 as I submitted the previous PR to the `master` branch incorrectly. Please merge this one instead.