### PR TITLE
memoryleak and memory access after free

### DIFF
--- a/contracts/eosio.bios/eosio.bios.hpp
+++ b/contracts/eosio.bios/eosio.bios.hpp
@@ -30,9 +30,11 @@ namespace eosio {
             constexpr size_t max_stack_buffer_size = 512;
             size_t size = action_data_size();
             char* buffer = (char*)( max_stack_buffer_size < size ? malloc(size) : alloca(size) );
+            struct { 
+               struct S { ~S()  { if (buf) free(buf); } char *buf; } s; 
+            } __freemem{max_stack_buffer_size<size?buffer:0};             
             read_action_data( buffer, size );
             set_proposed_producers(buffer, size);
-            if (max_stack_buffer_size < size) free(buffer);
          }
 
          void reqauth( action_name from ) {

--- a/contracts/eosio.bios/eosio.bios.hpp
+++ b/contracts/eosio.bios/eosio.bios.hpp
@@ -32,6 +32,7 @@ namespace eosio {
             char* buffer = (char*)( max_stack_buffer_size < size ? malloc(size) : alloca(size) );
             read_action_data( buffer, size );
             set_proposed_producers(buffer, size);
+            if (max_stack_buffer_size < size) free(buffer);
          }
 
          void reqauth( action_name from ) {

--- a/contracts/eosio.msig/eosio.msig.cpp
+++ b/contracts/eosio.msig/eosio.msig.cpp
@@ -20,6 +20,9 @@ void multisig::propose() {
    constexpr size_t max_stack_buffer_size = 512;
    size_t size = action_data_size();
    char* buffer = (char*)( max_stack_buffer_size < size ? malloc(size) : alloca(size) );
+   struct { 
+      struct S { ~S()  { if (buf) free(buf); } char *buf; } s; 
+   } __freemem{max_stack_buffer_size<size?buffer:0};
    read_action_data( buffer, size );
 
    account_name proposer;

--- a/contracts/eosio.sudo/eosio.sudo.cpp
+++ b/contracts/eosio.sudo/eosio.sudo.cpp
@@ -19,6 +19,9 @@ void sudo::exec() {
    constexpr size_t max_stack_buffer_size = 512;
    size_t size = action_data_size();
    char* buffer = (char*)( max_stack_buffer_size < size ? malloc(size) : alloca(size) );
+   struct { 
+      struct S { ~S()  { if (buf) free(buf); } char *buf; } s; 
+   } __freemem{max_stack_buffer_size<size?buffer:0};  
    read_action_data( buffer, size );
 
    account_name executer;
@@ -30,6 +33,7 @@ void sudo::exec() {
 
    size_t trx_pos = ds.tellp();
    send_deferred( (uint128_t(executer) << 64) | current_time(), executer, buffer+trx_pos, size-trx_pos );
+  
 }
 
 } /// namespace eosio

--- a/contracts/eosiolib/multi_index.hpp
+++ b/contracts/eosiolib/multi_index.hpp
@@ -562,6 +562,9 @@ class multi_index
 
          //using malloc/free here potentially is not exception-safe, although WASM doesn't support exceptions
          void* buffer = max_stack_buffer_size < size_t(size) ? malloc(size_t(size)) : alloca(size_t(size));
+         struct { 
+            struct S { ~S()  { if (buf) free(buf); } void *buf; } s; 
+         } __freemem{max_stack_buffer_size<size_t(size)?buffer:0};          
 
          db_get_i64( itr, buffer, uint32_t(size) );
 
@@ -585,9 +588,6 @@ class multi_index
 
          _items_vector.emplace_back( std::move(itm), pk, pitr );
          
-         if (max_stack_buffer_size < size_t(size) ) {
-            free(buffer);
-         }
 
          return *ptr;
       } /// load_object_by_primary_iterator

--- a/contracts/eosiolib/multi_index.hpp
+++ b/contracts/eosiolib/multi_index.hpp
@@ -567,10 +567,6 @@ class multi_index
 
          datastream<const char*> ds( (char*)buffer, uint32_t(size) );
 
-         if ( max_stack_buffer_size < size_t(size) ) {
-            free(buffer);
-         }
-
          auto itm = std::make_unique<item>( this, [&]( auto& i ) {
             T& val = static_cast<T&>(i);
             ds >> val;
@@ -588,6 +584,10 @@ class multi_index
          auto pitr = itm->__primary_itr;
 
          _items_vector.emplace_back( std::move(itm), pk, pitr );
+         
+         if (max_stack_buffer_size < size_t(size) ) {
+            free(buffer);
+         }
 
          return *ptr;
       } /// load_object_by_primary_iterator

--- a/contracts/eosiolib/transaction.hpp
+++ b/contracts/eosiolib/transaction.hpp
@@ -87,6 +87,9 @@ namespace eosio {
       eosio_assert( s > 0, "get_action size failed" );
       size_t size = static_cast<size_t>(s);
       char* buffer = (char*)( max_stack_buffer_size < size ? malloc(size) : alloca(size) );
+      struct { 
+         struct S { ~S()  { if (buf) free(buf); } char *buf; } s; 
+      } __freemem{max_stack_buffer_size<size?buffer:0};
       auto size2 = ::get_action( type, index, buffer, size );
       eosio_assert( size == static_cast<size_t>(size2), "get_action failed" );
       return eosio::unpack<eosio::action>( buffer, size );


### PR DESCRIPTION
multi_index db access contract interface will access the free's date when load more then 512 key_value_object. fix memory leak in another system contract