### PR TITLE
do not apply transaction optimizations on light-nodes when speculating

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1651,16 +1651,25 @@ optional<producer_schedule_type> controller::proposed_producers()const {
    return gpo.proposed_schedule;
 }
 
+bool controller::light_validation_allowed(bool replay_opts_disabled_by_policy) const {
+   if (!my->pending || my->in_trx_requiring_checks) {
+      return false;
+   }
+
+   auto pb_status = my->pending->_block_status;
+
+   // in a pending irreversible or previously validated block and we have forcing all checks
+   bool consider_skipping_on_replay = (pb_status == block_status::irreversible || pb_status == block_status::validated) && !replay_opts_disabled_by_policy;
+
+   // OR in a signed block and in light validation mode
+   bool consider_skipping_on_validate = (pb_status == block_status::complete && my->conf.block_validation_mode == validation_mode::LIGHT);
+
+   return consider_skipping_on_replay || consider_skipping_on_validate;
+}
+
+
 bool controller::skip_auth_check() const {
-   // replaying
-   bool consider_skipping = my->replaying;
-
-   // OR in light validation mode
-   consider_skipping = consider_skipping || my->conf.block_validation_mode == validation_mode::LIGHT;
-
-   return consider_skipping
-      && !my->conf.force_all_checks
-      && !my->in_trx_requiring_checks;
+   return light_validation_allowed(my->conf.force_all_checks);
 }
 
 bool controller::skip_db_sessions( block_status bs ) const {
@@ -1679,15 +1688,7 @@ bool controller::skip_db_sessions( ) const {
 }
 
 bool controller::skip_trx_checks() const {
-   // in a pending irreversible or previously validated block
-   bool consider_skipping = my->pending && ( my->pending->_block_status == block_status::irreversible || my->pending->_block_status == block_status::validated );
-
-   // OR in light validation mode
-   consider_skipping = consider_skipping || my->conf.block_validation_mode == validation_mode::LIGHT;
-
-   return consider_skipping
-      && !my->conf.disable_replay_opts
-      && !my->in_trx_requiring_checks;
+   light_validation_allowed(my->conf.disable_replay_opts);
 }
 
 bool controller::contracts_console()const {

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1688,7 +1688,7 @@ bool controller::skip_db_sessions( ) const {
 }
 
 bool controller::skip_trx_checks() const {
-   light_validation_allowed(my->conf.disable_replay_opts);
+   return light_validation_allowed(my->conf.disable_replay_opts);
 }
 
 bool controller::contracts_console()const {

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -219,6 +219,7 @@ namespace eosio { namespace chain {
 
          int64_t set_proposed_producers( vector<producer_key> producers );
 
+         bool light_validation_allowed(bool replay_opts_disabled_by_policy) const;
          bool skip_auth_check()const;
          bool skip_db_sessions( )const;
          bool skip_db_sessions( block_status bs )const;


### PR DESCRIPTION
fixed an issue where block status was not taken into account when determining whether or not to skip some expensive checks.  As a result light validation nodes would not apply those checks even when speculatively executing new transactions (which are not signed by producers).

Also refactored common logic while maintaining the 2 config/parameters that control different sets of optimizations

resolves EOSIO/eos#5408