### PR TITLE
Add a new WASM backend: wabt

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -27,3 +27,6 @@
 [submodule "libraries/fc"]
 	path = libraries/fc
 	url = https://github.com/EOSIO/fc
+[submodule "libraries/wabt"]
+	path = libraries/wabt
+	url = http://github.com/EOSIO/wabt

--- a/libraries/CMakeLists.txt
+++ b/libraries/CMakeLists.txt
@@ -8,3 +8,8 @@ add_subdirectory( appbase )
 add_subdirectory( chain )
 add_subdirectory( testing )
 add_subdirectory( abi_generator )
+
+#turn these off for now
+set(BUILD_TESTS OFF CACHE BOOL "Build GTest-based tests")
+set(RUN_RE2C OFF CACHE BOOL "Run re2c")
+add_subdirectory( wabt )

--- a/libraries/chain/CMakeLists.txt
+++ b/libraries/chain/CMakeLists.txt
@@ -38,6 +38,7 @@ add_library( eosio_chain
 
              webassembly/wavm.cpp
              webassembly/binaryen.cpp
+             webassembly/wabt.cpp
 
 #             get_config.cpp
 #             global_property_object.cpp
@@ -50,12 +51,14 @@ add_library( eosio_chain
              )
 
 target_link_libraries( eosio_chain eos_utilities fc chainbase Logging IR WAST WASM Runtime
-      wasm asmjs passes cfg ast emscripten-optimizer support softfloat builtins
+      wasm asmjs passes cfg ast emscripten-optimizer support softfloat builtins libwabt
                      )
 target_include_directories( eosio_chain
                             PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" "${CMAKE_CURRENT_BINARY_DIR}/include"
                                    "${CMAKE_CURRENT_SOURCE_DIR}/../wasm-jit/Include"
                                    "${CMAKE_CURRENT_SOURCE_DIR}/../../externals/binaryen/src"
+                                   "${CMAKE_SOURCE_DIR}/libraries/wabt"
+                                   "${CMAKE_BINARY_DIR}/libraries/wabt"
                             )
 
 install( TARGETS eosio_chain

--- a/libraries/chain/include/eosio/chain/wasm_interface.hpp
+++ b/libraries/chain/include/eosio/chain/wasm_interface.hpp
@@ -54,6 +54,7 @@ namespace eosio { namespace chain {
          enum class vm_type {
             wavm,
             binaryen,
+            wabt
          };
 
          wasm_interface(vm_type vm);
@@ -76,4 +77,4 @@ namespace eosio{ namespace chain {
    std::istream& operator>>(std::istream& in, wasm_interface::vm_type& runtime);
 }}
 
-FC_REFLECT_ENUM( eosio::chain::wasm_interface::vm_type, (wavm)(binaryen) )
+FC_REFLECT_ENUM( eosio::chain::wasm_interface::vm_type, (wavm)(binaryen)(wabt) )

--- a/libraries/chain/include/eosio/chain/wasm_interface_private.hpp
+++ b/libraries/chain/include/eosio/chain/wasm_interface_private.hpp
@@ -3,6 +3,7 @@
 #include <eosio/chain/wasm_interface.hpp>
 #include <eosio/chain/webassembly/wavm.hpp>
 #include <eosio/chain/webassembly/binaryen.hpp>
+#include <eosio/chain/webassembly/wabt.hpp>
 #include <eosio/chain/webassembly/runtime_interface.hpp>
 #include <eosio/chain/wasm_eosio_injection.hpp>
 #include <eosio/chain/transaction_context.hpp>
@@ -28,6 +29,8 @@ namespace eosio { namespace chain {
             runtime_interface = std::make_unique<webassembly::wavm::wavm_runtime>();
          else if(vm == wasm_interface::vm_type::binaryen)
             runtime_interface = std::make_unique<webassembly::binaryen::binaryen_runtime>();
+         else if(vm == wasm_interface::vm_type::wabt)
+            runtime_interface = std::make_unique<webassembly::wabt_runtime::wabt_runtime>();
          else
             EOS_THROW(wasm_exception, "wasm_interface_impl fall through");
       }
@@ -95,7 +98,8 @@ namespace eosio { namespace chain {
 
 #define _REGISTER_INTRINSIC_EXPLICIT(CLS, MOD, METHOD, WASM_SIG, NAME, SIG)\
    _REGISTER_WAVM_INTRINSIC(CLS, MOD, METHOD, WASM_SIG, NAME, SIG)\
-   _REGISTER_BINARYEN_INTRINSIC(CLS, MOD, METHOD, WASM_SIG, NAME, SIG)
+   _REGISTER_BINARYEN_INTRINSIC(CLS, MOD, METHOD, WASM_SIG, NAME, SIG)\
+   _REGISTER_WABT_INTRINSIC(CLS, MOD, METHOD, WASM_SIG, NAME, SIG)
 
 #define _REGISTER_INTRINSIC4(CLS, MOD, METHOD, WASM_SIG, NAME, SIG)\
    _REGISTER_INTRINSIC_EXPLICIT(CLS, MOD, METHOD, WASM_SIG, NAME, SIG )

--- a/libraries/chain/include/eosio/chain/webassembly/wabt.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/wabt.hpp
@@ -1,0 +1,713 @@
+#pragma once
+
+#include <eosio/chain/webassembly/common.hpp>
+#include <eosio/chain/webassembly/runtime_interface.hpp>
+#include <eosio/chain/exceptions.hpp>
+#include <eosio/chain/apply_context.hpp>
+#include <softfloat_types.h>
+
+//wabt includes
+#include <src/error-handler.h>
+#include <src/binary-reader.h>
+#include <src/common.h>
+#include <src/interp.h>
+
+namespace eosio { namespace chain { namespace webassembly { namespace wabt_runtime {
+
+using namespace fc;
+using namespace wabt;
+using namespace wabt::interp;
+using namespace eosio::chain::webassembly::common;
+
+struct wabt_apply_instance_vars {
+   Memory* memory;
+   apply_context& ctx;
+
+   char* get_validated_pointer(uint32_t offset, uint32_t size) {
+      EOS_ASSERT(memory, wasm_execution_error, "access violation");
+      EOS_ASSERT(offset + size <= memory->data.size() && offset + size >= offset, wasm_execution_error, "access violation");
+      return memory->data.data() + offset;
+   }
+};
+
+struct intrinsic_registrator {
+   using intrinsic_fn = TypedValue(*)(wabt_apply_instance_vars&, const TypedValues&);
+
+   struct intrinsic_func_info {
+      FuncSignature sig;
+      intrinsic_fn func;
+   }; 
+
+   static auto& get_map(){
+      static map<string, map<string, intrinsic_func_info>> _map;
+      return _map;
+   };
+
+   intrinsic_registrator(const char* mod, const char* name, const FuncSignature& sig, intrinsic_fn fn) {
+      get_map()[string(mod)][string(name)] = intrinsic_func_info{sig, fn};
+   }
+};
+
+class wabt_runtime : public eosio::chain::wasm_runtime_interface {
+   public:
+      wabt_runtime();
+      std::unique_ptr<wasm_instantiated_module_interface> instantiate_module(const char* code_bytes, size_t code_size, std::vector<uint8_t> initial_memory) override;
+
+   private:
+      wabt::ReadBinaryOptions read_binary_options;  //note default ctor will look at each option in feature.def and default to DISABLED for the feature
+};
+
+/**
+ * class to represent an in-wasm-memory array
+ * it is a hint to the transcriber that the next parameter will
+ * be a size (data bytes length) and that the pair are validated together
+ * This triggers the template specialization of intrinsic_invoker_impl
+ * @tparam T
+ */
+template<typename T>
+inline array_ptr<T> array_ptr_impl (wabt_apply_instance_vars& vars, uint32_t ptr, uint32_t length)
+{
+   EOS_ASSERT( length < INT_MAX/(uint32_t)sizeof(T), binaryen_exception, "length will overflow" );
+   return array_ptr<T>((T*)(vars.get_validated_pointer(ptr, length * (uint32_t)sizeof(T))));
+}
+
+/**
+ * class to represent an in-wasm-memory char array that must be null terminated
+ */
+inline null_terminated_ptr null_terminated_ptr_impl(wabt_apply_instance_vars& vars, uint32_t ptr)
+{
+   char *value = vars.get_validated_pointer(ptr, 1);
+   const char* p = value;
+   const char* const top_of_memory = vars.memory->data.data() + vars.memory->data.size();
+   while(p < top_of_memory)
+      if(*p++ == '\0')
+         return null_terminated_ptr(value);
+
+   FC_THROW_EXCEPTION(wasm_execution_error, "unterminated string");
+}
+
+
+template<typename T>
+struct is_reference_from_value {
+   static constexpr bool value = false;
+};
+
+template<>
+struct is_reference_from_value<name> {
+   static constexpr bool value = true;
+};
+
+template<>
+struct is_reference_from_value<fc::time_point_sec> {
+   static constexpr bool value = true;
+};
+
+template<typename T>
+constexpr bool is_reference_from_value_v = is_reference_from_value<T>::value;
+
+template<typename T>
+T convert_literal_to_native(const TypedValue& v);
+
+template<>
+inline double convert_literal_to_native<double>(const TypedValue& v) {
+   return v.get_f64();
+}
+
+template<>
+inline float convert_literal_to_native<float>(const TypedValue& v) {
+   return v.get_f32();
+}
+
+template<>
+inline int64_t convert_literal_to_native<int64_t>(const TypedValue& v) {
+   return v.get_i64();
+}
+
+template<>
+inline uint64_t convert_literal_to_native<uint64_t>(const TypedValue& v) {
+   return v.get_i64();
+}
+
+template<>
+inline int32_t convert_literal_to_native<int32_t>(const TypedValue& v) {
+   return v.get_i32();
+}
+
+template<>
+inline uint32_t convert_literal_to_native<uint32_t>(const TypedValue& v) {
+   return v.get_i32();
+}
+
+template<>
+inline bool convert_literal_to_native<bool>(const TypedValue& v) {
+   return v.get_i32();
+}
+
+template<>
+inline name convert_literal_to_native<name>(const TypedValue& v) {
+   int64_t val = v.get_i64();
+   return name(val);
+}
+
+inline auto convert_native_to_literal(const wabt_apply_instance_vars&, const uint32_t &val) {
+   TypedValue tv(Type::I32);
+   tv.set_i32(val);
+   return tv;
+}
+
+inline auto convert_native_to_literal(const wabt_apply_instance_vars&, const int32_t &val) {
+   TypedValue tv(Type::I32);
+   tv.set_i32(val);
+   return tv;
+}
+
+inline auto convert_native_to_literal(const wabt_apply_instance_vars&, const uint64_t &val) {
+   TypedValue tv(Type::I64);
+   tv.set_i64(val);
+   return tv;
+}
+
+inline auto convert_native_to_literal(const wabt_apply_instance_vars&, const int64_t &val) {
+   TypedValue tv(Type::I64);
+   tv.set_i64(val);
+   return tv;
+}
+
+inline auto convert_native_to_literal(const wabt_apply_instance_vars&, const float &val) {
+   TypedValue tv(Type::F32);
+   tv.set_f32(val);
+   return tv;
+}
+
+inline auto convert_native_to_literal(const wabt_apply_instance_vars&, const double &val) {
+   TypedValue tv(Type::F64);
+   tv.set_f64(val);
+   return tv;
+}
+
+inline auto convert_native_to_literal(const wabt_apply_instance_vars&, const name &val) {
+   TypedValue tv(Type::I64);
+   tv.set_i64(val.value);
+   return tv;
+}
+
+inline auto convert_native_to_literal(const wabt_apply_instance_vars& vars, char* ptr) {
+   const char* base = vars.memory->data.data();
+   const char* top_of_memory = base + vars.memory->data.size();
+   EOS_ASSERT(ptr >= base && ptr < top_of_memory, wasm_execution_error, "returning pointer not in linear memory");
+   Value v;
+   v.i32 = (int)(ptr - base);
+   return TypedValue(Type::I32, v);
+}
+
+struct void_type {
+};
+
+template<typename T>
+struct wabt_to_value_type;
+
+template<>
+struct wabt_to_value_type<F32> {
+   static constexpr auto value = Type::F32;
+};
+
+template<>
+struct wabt_to_value_type<F64> {
+   static constexpr auto value = Type::F64;
+};
+template<>
+struct wabt_to_value_type<I32> {
+   static constexpr auto value = Type::I32;
+};
+template<>
+struct wabt_to_value_type<I64> {
+   static constexpr auto value = Type::I64;
+};
+
+template<typename T>
+constexpr auto wabt_to_value_type_v = wabt_to_value_type<T>::value;
+
+template<typename T>
+struct wabt_to_rvalue_type;
+template<>
+struct wabt_to_rvalue_type<F32> {
+   static constexpr auto value = Type::F32;
+};
+template<>
+struct wabt_to_rvalue_type<F64> {
+   static constexpr auto value = Type::F64;
+};
+template<>
+struct wabt_to_rvalue_type<I32> {
+   static constexpr auto value = Type::I32;
+};
+template<>
+struct wabt_to_rvalue_type<I64> {
+   static constexpr auto value = Type::I64;
+};
+template<>
+struct wabt_to_rvalue_type<const name&> {
+   static constexpr auto value = Type::I64;
+};
+template<>
+struct wabt_to_rvalue_type<name> {
+   static constexpr auto value = Type::I64;
+};
+
+template<>
+struct wabt_to_rvalue_type<char*> {
+   static constexpr auto value = Type::I32;
+};
+
+template<typename T>
+constexpr auto wabt_to_rvalue_type_v = wabt_to_rvalue_type<T>::value;
+
+template<typename>
+struct wabt_function_type_provider;
+
+template<typename Ret, typename ...Args>
+struct wabt_function_type_provider<Ret(Args...)> {
+   static FuncSignature type() {
+      return FuncSignature({wabt_to_value_type_v<Args> ...}, {wabt_to_rvalue_type_v<Ret>});
+   }
+};
+template<typename ...Args>
+struct wabt_function_type_provider<void(Args...)> {
+   static FuncSignature type() {
+      return FuncSignature({wabt_to_value_type_v<Args> ...}, {});
+   }
+};
+
+/**
+ * Forward declaration of the invoker type which transcribes arguments to/from a native method
+ * and injects the appropriate checks
+ *
+ * @tparam Ret - the return type of the native function
+ * @tparam NativeParameters - a std::tuple of the remaining native parameters to transcribe
+ * @tparam WasmParameters - a std::tuple of the transribed parameters
+ */
+template<typename Ret, typename NativeParameters>
+struct intrinsic_invoker_impl;
+
+/**
+ * Specialization for the fully transcribed signature
+ * @tparam Ret - the return type of the native function
+ */
+template<typename Ret>
+struct intrinsic_invoker_impl<Ret, std::tuple<>> {
+   using next_method_type        = Ret (*)(wabt_apply_instance_vars&, const TypedValues&, int);
+
+   template<next_method_type Method>
+   static TypedValue invoke(wabt_apply_instance_vars& vars, const TypedValues& args) {
+      return convert_native_to_literal(vars, Method(vars, args, args.size() - 1));
+   }
+
+   template<next_method_type Method>
+   static const auto fn() {
+      return invoke<Method>;
+   }
+};
+
+/**
+ * specialization of the fully transcribed signature for void return values
+ * @tparam Translated - the arguments to the wasm function
+ */
+template<>
+struct intrinsic_invoker_impl<void_type, std::tuple<>> {
+   using next_method_type        = void_type (*)(wabt_apply_instance_vars&, const TypedValues&, int);
+
+   template<next_method_type Method>
+   static TypedValue invoke(wabt_apply_instance_vars& vars, const TypedValues& args) {
+      Method(vars, args, args.size() - 1);
+      return TypedValue(Type::Void);
+   }
+
+   template<next_method_type Method>
+   static const auto fn() {
+      return invoke<Method>;
+   }
+};
+
+/**
+ * Sepcialization for transcribing  a simple type in the native method signature
+ * @tparam Ret - the return type of the native method
+ * @tparam Input - the type of the native parameter to transcribe
+ * @tparam Inputs - the remaining native parameters to transcribe
+ */
+template<typename Ret, typename Input, typename... Inputs>
+struct intrinsic_invoker_impl<Ret, std::tuple<Input, Inputs...>> {
+   using next_step = intrinsic_invoker_impl<Ret, std::tuple<Inputs...>>;
+   using then_type = Ret (*)(wabt_apply_instance_vars&, Input, Inputs..., const TypedValues&, int);
+
+   template<then_type Then>
+   static Ret translate_one(wabt_apply_instance_vars& vars, Inputs... rest, const TypedValues& args, int offset) {
+      auto& last = args.at(offset);
+      auto native = convert_literal_to_native<Input>(last);
+      return Then(vars, native, rest..., args, (uint32_t)offset - 1);
+   };
+
+   template<then_type Then>
+   static const auto fn() {
+      return next_step::template fn<translate_one<Then>>();
+   }
+};
+
+/**
+ * Specialization for transcribing  a array_ptr type in the native method signature
+ * This type transcribes into 2 wasm parameters: a pointer and byte length and checks the validity of that memory
+ * range before dispatching to the native method
+ *
+ * @tparam Ret - the return type of the native method
+ * @tparam Inputs - the remaining native parameters to transcribe
+ */
+template<typename T, typename Ret, typename... Inputs>
+struct intrinsic_invoker_impl<Ret, std::tuple<array_ptr<T>, size_t, Inputs...>> {
+   using next_step = intrinsic_invoker_impl<Ret, std::tuple<Inputs...>>;
+   using then_type = Ret(*)(wabt_apply_instance_vars&, array_ptr<T>, size_t, Inputs..., const TypedValues&, int);
+
+   template<then_type Then, typename U=T>
+   static auto translate_one(wabt_apply_instance_vars& vars, Inputs... rest, const TypedValues& args, int offset) -> std::enable_if_t<std::is_const<U>::value, Ret> {
+      static_assert(!std::is_pointer<U>::value, "Currently don't support array of pointers");
+      uint32_t ptr = args.at((uint32_t)offset - 1).get_i32();
+      size_t length = args.at((uint32_t)offset).get_i32();
+      T* base = array_ptr_impl<T>(vars, ptr, length);
+      if ( reinterpret_cast<uintptr_t>(base) % alignof(T) != 0 ) {
+         wlog( "misaligned array of const values" );
+         std::vector<std::remove_const_t<T> > copy(length > 0 ? length : 1);
+         T* copy_ptr = &copy[0];
+         memcpy( (void*)copy_ptr, (void*)base, length * sizeof(T) );
+         return Then(vars, static_cast<array_ptr<T>>(copy_ptr), length, rest..., args, (uint32_t)offset - 2);
+      }
+      return Then(vars, static_cast<array_ptr<T>>(base), length, rest..., args, (uint32_t)offset - 2);
+   };
+
+   template<then_type Then, typename U=T>
+   static auto translate_one(wabt_apply_instance_vars& vars, Inputs... rest, const TypedValues& args, int offset) -> std::enable_if_t<!std::is_const<U>::value, Ret> {
+      static_assert(!std::is_pointer<U>::value, "Currently don't support array of pointers");
+      uint32_t ptr = args.at((uint32_t)offset - 1).get_i32();
+      size_t length = args.at((uint32_t)offset).get_i32();
+      T* base = array_ptr_impl<T>(vars, ptr, length);
+      if ( reinterpret_cast<uintptr_t>(base) % alignof(T) != 0 ) {
+         wlog( "misaligned array of values" );
+         std::vector<std::remove_const_t<T> > copy(length > 0 ? length : 1);
+         T* copy_ptr = &copy[0];
+         memcpy( (void*)copy_ptr, (void*)base, length * sizeof(T) );
+         Ret ret = Then(vars, static_cast<array_ptr<T>>(copy_ptr), length, rest..., args, (uint32_t)offset - 2);  
+         memcpy( (void*)base, (void*)copy_ptr, length * sizeof(T) );
+         return ret;
+      }
+      return Then(vars, static_cast<array_ptr<T>>(base), length, rest..., args, (uint32_t)offset - 2);
+   };
+   
+   template<then_type Then>
+   static const auto fn() {
+      return next_step::template fn<translate_one<Then>>();
+   }
+};
+
+/**
+ * Specialization for transcribing  a null_terminated_ptr type in the native method signature
+ * This type transcribes 1 wasm parameters: a char pointer which is validated to contain
+ * a null value before the end of the allocated memory.
+ *
+ * @tparam Ret - the return type of the native method
+ * @tparam Inputs - the remaining native parameters to transcribe
+ */
+template<typename Ret, typename... Inputs>
+struct intrinsic_invoker_impl<Ret, std::tuple<null_terminated_ptr, Inputs...>> {
+   using next_step = intrinsic_invoker_impl<Ret, std::tuple<Inputs...>>;
+   using then_type = Ret(*)(wabt_apply_instance_vars&, null_terminated_ptr, Inputs..., const TypedValues&, int);
+
+   template<then_type Then>
+   static Ret translate_one(wabt_apply_instance_vars& vars, Inputs... rest, const TypedValues& args, int offset) {
+      uint32_t ptr = args.at((uint32_t)offset).get_i32();
+      return Then(vars, null_terminated_ptr_impl(vars, ptr), rest..., args, (uint32_t)offset - 1);
+   };
+
+   template<then_type Then>
+   static const auto fn() {
+      return next_step::template fn<translate_one<Then>>();
+   }
+};
+
+/**
+ * Specialization for transcribing  a pair of array_ptr types in the native method signature that share size
+ * This type transcribes into 3 wasm parameters: 2 pointers and byte length and checks the validity of those memory
+ * ranges before dispatching to the native method
+ *
+ * @tparam Ret - the return type of the native method
+ * @tparam Inputs - the remaining native parameters to transcribe
+ */
+template<typename T, typename U, typename Ret, typename... Inputs>
+struct intrinsic_invoker_impl<Ret, std::tuple<array_ptr<T>, array_ptr<U>, size_t, Inputs...>> {
+   using next_step = intrinsic_invoker_impl<Ret, std::tuple<Inputs...>>;
+   using then_type = Ret(*)(wabt_apply_instance_vars&, array_ptr<T>, array_ptr<U>, size_t, Inputs..., const TypedValues&, int);
+
+   template<then_type Then>
+   static Ret translate_one(wabt_apply_instance_vars& vars, Inputs... rest, const TypedValues& args, int offset) {
+      uint32_t ptr_t = args.at((uint32_t)offset - 2).get_i32();
+      uint32_t ptr_u = args.at((uint32_t)offset - 1).get_i32();
+      size_t length = args.at((uint32_t)offset).get_i32();
+      static_assert(std::is_same<std::remove_const_t<T>, char>::value && std::is_same<std::remove_const_t<U>, char>::value, "Currently only support array of (const)chars");
+      return Then(vars, array_ptr_impl<T>(vars, ptr_t, length), array_ptr_impl<U>(vars, ptr_u, length), length, args, (uint32_t)offset - 3);
+   };
+
+   template<then_type Then>
+   static const auto fn() {
+      return next_step::template fn<translate_one<Then>>();
+   }
+};
+
+/**
+ * Specialization for transcribing memset parameters
+ *
+ * @tparam Ret - the return type of the native method
+ * @tparam Inputs - the remaining native parameters to transcribe
+ */
+template<typename Ret>
+struct intrinsic_invoker_impl<Ret, std::tuple<array_ptr<char>, int, size_t>> {
+   using next_step = intrinsic_invoker_impl<Ret, std::tuple<>>;
+   using then_type = Ret(*)(wabt_apply_instance_vars&, array_ptr<char>, int, size_t, const TypedValues&, int);
+
+   template<then_type Then>
+   static Ret translate_one(wabt_apply_instance_vars& vars, const TypedValues& args, int offset) {
+      uint32_t ptr = args.at((uint32_t)offset - 2).get_i32();
+      uint32_t value = args.at((uint32_t)offset - 1).get_i32();
+      size_t length = args.at((uint32_t)offset).get_i32();
+      return Then(vars, array_ptr_impl<char>(vars, ptr, length), value, length, args, (uint32_t)offset - 3);
+   };
+
+   template<then_type Then>
+   static const auto fn() {
+      return next_step::template fn<translate_one<Then>>();
+   }
+};
+
+/**
+ * Specialization for transcribing  a pointer type in the native method signature
+ * This type transcribes into an int32  pointer checks the validity of that memory
+ * range before dispatching to the native method
+ *
+ * @tparam Ret - the return type of the native method
+ * @tparam Inputs - the remaining native parameters to transcribe
+ */
+template<typename T, typename Ret, typename... Inputs>
+struct intrinsic_invoker_impl<Ret, std::tuple<T *, Inputs...>> {
+   using next_step = intrinsic_invoker_impl<Ret, std::tuple<Inputs...>>;
+   using then_type = Ret (*)(wabt_apply_instance_vars&, T *, Inputs..., const TypedValues&, int);
+
+   template<then_type Then, typename U=T>
+   static auto translate_one(wabt_apply_instance_vars& vars, Inputs... rest, const TypedValues& args, int offset) -> std::enable_if_t<std::is_const<U>::value, Ret> {
+      uint32_t ptr = args.at((uint32_t)offset).get_i32();
+      T* base = array_ptr_impl<T>(vars, ptr, 1);
+      if ( reinterpret_cast<uintptr_t>(base) % alignof(T) != 0 ) {
+         wlog( "misaligned const pointer" );
+         std::remove_const_t<T> copy;
+         T* copy_ptr = &copy;
+         memcpy( (void*)copy_ptr, (void*)base, sizeof(T) );
+         return Then(vars, copy_ptr, rest..., args, (uint32_t)offset - 1);
+      }
+      return Then(vars, base, rest..., args, (uint32_t)offset - 1);
+   };
+
+   template<then_type Then, typename U=T>
+   static auto translate_one(wabt_apply_instance_vars& vars, Inputs... rest, const TypedValues& args, int offset) -> std::enable_if_t<!std::is_const<U>::value, Ret> {
+      uint32_t ptr = args.at((uint32_t)offset).get_i32();
+      T* base = array_ptr_impl<T>(vars, ptr, 1);
+      if ( reinterpret_cast<uintptr_t>(base) % alignof(T) != 0 ) {
+         wlog( "misaligned pointer" );
+         T copy;
+         memcpy( (void*)&copy, (void*)base, sizeof(T) );
+         Ret ret = Then(vars, &copy, rest..., args, (uint32_t)offset - 1);
+         memcpy( (void*)base, (void*)&copy, sizeof(T) );
+         return ret; 
+      }
+      return Then(vars, base, rest..., args, (uint32_t)offset - 1);
+   };
+
+   template<then_type Then>
+   static const auto fn() {
+      return next_step::template fn<translate_one<Then>>();
+   }
+};
+
+/**
+ * Specialization for transcribing a reference to a name which can be passed as a native value
+ *    This type transcribes into a native type which is loaded by value into a
+ *    variable on the stack and then passed by reference to the intrinsic.
+ *
+ * @tparam Ret - the return type of the native method
+ * @tparam Inputs - the remaining native parameters to transcribe
+ */
+template<typename Ret, typename... Inputs>
+struct intrinsic_invoker_impl<Ret, std::tuple<const name&, Inputs...>> {
+   using next_step = intrinsic_invoker_impl<Ret, std::tuple<Inputs...>>;
+   using then_type = Ret (*)(wabt_apply_instance_vars&, const name&, Inputs..., const TypedValues&, int);
+
+   template<then_type Then>
+   static Ret translate_one(wabt_apply_instance_vars& vars, Inputs... rest, const TypedValues& args, int offset) {
+      uint64_t wasm_value = args.at((uint32_t)offset).get_i64();
+      auto value = name(wasm_value);
+      return Then(vars, value, rest..., args, (uint32_t)offset - 1);
+   }
+
+   template<then_type Then>
+   static const auto fn() {
+      return next_step::template fn<translate_one<Then>>();
+   }
+};
+
+/**
+ * Specialization for transcribing a reference to a fc::time_point_sec which can be passed as a native value
+ *    This type transcribes into a native type which is loaded by value into a
+ *    variable on the stack and then passed by reference to the intrinsic.
+ *
+ * @tparam Ret - the return type of the native method
+ * @tparam Inputs - the remaining native parameters to transcribe
+ */
+template<typename Ret, typename... Inputs>
+struct intrinsic_invoker_impl<Ret, std::tuple<const fc::time_point_sec&, Inputs...>> {
+   using next_step = intrinsic_invoker_impl<Ret, std::tuple<Inputs...>>;
+   using then_type = Ret (*)(wabt_apply_instance_vars&, const fc::time_point_sec&, Inputs..., const TypedValues&, int);
+
+   template<then_type Then>
+   static Ret translate_one(wabt_apply_instance_vars& vars, Inputs... rest, const TypedValues& args, int offset) {
+      uint32_t wasm_value = args.at((uint32_t)offset).get_i32();
+      auto value = fc::time_point_sec(wasm_value);
+      return Then(vars, value, rest..., args, (uint32_t)offset - 1);
+   }
+
+   template<then_type Then>
+   static const auto fn() {
+      return next_step::template fn<translate_one<Then>>();
+   }
+};
+
+
+/**
+ * Specialization for transcribing  a reference type in the native method signature
+ *    This type transcribes into an int32  pointer checks the validity of that memory
+ *    range before dispatching to the native method
+ *
+ * @tparam Ret - the return type of the native method
+ * @tparam Inputs - the remaining native parameters to transcribe
+ */
+template<typename T, typename Ret, typename... Inputs>
+struct intrinsic_invoker_impl<Ret, std::tuple<T &, Inputs...>> {
+   using next_step = intrinsic_invoker_impl<Ret, std::tuple<Inputs...>>;
+   using then_type = Ret (*)(wabt_apply_instance_vars&, T &, Inputs..., const TypedValues&, int);
+
+   template<then_type Then, typename U=T>
+   static auto translate_one(wabt_apply_instance_vars& vars, Inputs... rest, const TypedValues& args, int offset) -> std::enable_if_t<std::is_const<U>::value, Ret> {
+      // references cannot be created for null pointers
+      uint32_t ptr = args.at((uint32_t)offset).get_i32();
+      EOS_ASSERT(ptr != 0, binaryen_exception, "references cannot be created for null pointers");
+      T* base = array_ptr_impl<T>(vars, ptr, 1);
+      if ( reinterpret_cast<uintptr_t>(base) % alignof(T) != 0 ) {
+         wlog( "misaligned const reference" );
+         std::remove_const_t<T> copy;
+         T* copy_ptr = &copy;
+         memcpy( (void*)copy_ptr, (void*)base, sizeof(T) );
+         return Then(vars, *copy_ptr, rest..., args, (uint32_t)offset - 1);
+      }
+      return Then(vars, *base, rest..., args, (uint32_t)offset - 1);
+   }
+
+   template<then_type Then, typename U=T>
+   static auto translate_one(wabt_apply_instance_vars& vars, Inputs... rest, const TypedValues& args, int offset) -> std::enable_if_t<!std::is_const<U>::value, Ret> {
+      // references cannot be created for null pointers
+      uint32_t ptr = args.at((uint32_t)offset).get_i32();
+      EOS_ASSERT(ptr != 0, binaryen_exception, "references cannot be created for null pointers");
+      T* base = array_ptr_impl<T>(vars, ptr, 1);
+      if ( reinterpret_cast<uintptr_t>(base) % alignof(T) != 0 ) {
+         wlog( "misaligned reference" );
+         T copy;
+         memcpy( (void*)&copy, (void*)base, sizeof(T) );
+         Ret ret = Then(vars, copy, rest..., args, (uint32_t)offset - 1);
+         memcpy( (void*)base, (void*)&copy, sizeof(T) );
+         return ret; 
+      }
+      return Then(vars, *base, rest..., args, (uint32_t)offset - 1);
+   }
+
+
+   template<then_type Then>
+   static const auto fn() {
+      return next_step::template fn<translate_one<Then>>();
+   }
+};
+
+extern apply_context* fixme_context;
+
+/**
+ * forward declaration of a wrapper class to call methods of the class
+ */
+template<typename Ret, typename MethodSig, typename Cls, typename... Params>
+struct intrinsic_function_invoker {
+   using impl = intrinsic_invoker_impl<Ret, std::tuple<Params...>>;
+
+   template<MethodSig Method>
+   static Ret wrapper(wabt_apply_instance_vars& vars, Params... params, const TypedValues&, int) {
+      class_from_wasm<Cls>::value(vars.ctx).checktime();
+      return (class_from_wasm<Cls>::value(vars.ctx).*Method)(params...);
+   }
+
+   template<MethodSig Method>
+   static const intrinsic_registrator::intrinsic_fn fn() {
+      return impl::template fn<wrapper<Method>>();
+   }
+};
+
+template<typename MethodSig, typename Cls, typename... Params>
+struct intrinsic_function_invoker<void, MethodSig, Cls, Params...> {
+   using impl = intrinsic_invoker_impl<void_type, std::tuple<Params...>>;
+
+   template<MethodSig Method>
+   static void_type wrapper(wabt_apply_instance_vars& vars, Params... params, const TypedValues& args, int offset) {
+      class_from_wasm<Cls>::value(vars.ctx).checktime();
+      (class_from_wasm<Cls>::value(vars.ctx).*Method)(params...);
+      return void_type();
+   }
+
+   template<MethodSig Method>
+   static const intrinsic_registrator::intrinsic_fn fn() {
+      return impl::template fn<wrapper<Method>>();
+   }
+
+};
+
+template<typename>
+struct intrinsic_function_invoker_wrapper;
+
+template<typename Cls, typename Ret, typename... Params>
+struct intrinsic_function_invoker_wrapper<Ret (Cls::*)(Params...)> {
+   using type = intrinsic_function_invoker<Ret, Ret (Cls::*)(Params...), Cls, Params...>;
+};
+
+template<typename Cls, typename Ret, typename... Params>
+struct intrinsic_function_invoker_wrapper<Ret (Cls::*)(Params...) const> {
+   using type = intrinsic_function_invoker<Ret, Ret (Cls::*)(Params...) const, Cls, Params...>;
+};
+
+template<typename Cls, typename Ret, typename... Params>
+struct intrinsic_function_invoker_wrapper<Ret (Cls::*)(Params...) volatile> {
+   using type = intrinsic_function_invoker<Ret, Ret (Cls::*)(Params...) volatile, Cls, Params...>;
+};
+
+template<typename Cls, typename Ret, typename... Params>
+struct intrinsic_function_invoker_wrapper<Ret (Cls::*)(Params...) const volatile> {
+   using type = intrinsic_function_invoker<Ret, Ret (Cls::*)(Params...) const volatile, Cls, Params...>;
+};
+
+#define __INTRINSIC_NAME(LABEL, SUFFIX) LABEL##SUFFIX
+#define _INTRINSIC_NAME(LABEL, SUFFIX) __INTRINSIC_NAME(LABEL,SUFFIX)
+
+#define _REGISTER_WABT_INTRINSIC(CLS, MOD, METHOD, WASM_SIG, NAME, SIG)\
+   static eosio::chain::webassembly::wabt_runtime::intrinsic_registrator _INTRINSIC_NAME(__wabt_intrinsic_fn, __COUNTER__) (\
+      MOD,\
+      NAME,\
+      eosio::chain::webassembly::wabt_runtime::wabt_function_type_provider<WASM_SIG>::type(),\
+      eosio::chain::webassembly::wabt_runtime::intrinsic_function_invoker_wrapper<SIG>::type::fn<&CLS::METHOD>()\
+   );\
+
+} } } }// eosio::chain::webassembly::wabt_runtime

--- a/libraries/chain/wasm_interface.cpp
+++ b/libraries/chain/wasm_interface.cpp
@@ -1913,6 +1913,8 @@ std::istream& operator>>(std::istream& in, wasm_interface::vm_type& runtime) {
       runtime = eosio::chain::wasm_interface::vm_type::wavm;
    else if (s == "binaryen")
       runtime = eosio::chain::wasm_interface::vm_type::binaryen;
+   else if (s == "wabt")
+      runtime = eosio::chain::wasm_interface::vm_type::wabt;
    else
       in.setstate(std::ios_base::failbit);
    return in;

--- a/libraries/chain/webassembly/wabt.cpp
+++ b/libraries/chain/webassembly/wabt.cpp
@@ -1,0 +1,98 @@
+#include <eosio/chain/webassembly/wabt.hpp>
+#include <eosio/chain/apply_context.hpp>
+#include <eosio/chain/wasm_eosio_constraints.hpp>
+
+//wabt includes
+#include <src/interp.h>
+#include <src/binary-reader-interp.h>
+
+namespace eosio { namespace chain { namespace webassembly { namespace wabt_runtime {
+
+//yep 🤮
+static wabt_apply_instance_vars* static_wabt_vars;
+
+using namespace wabt;
+using namespace wabt::interp;
+namespace wasm_constraints = eosio::chain::wasm_constraints;
+
+class wabt_instantiated_module : public wasm_instantiated_module_interface {
+   public:
+      wabt_instantiated_module(std::unique_ptr<interp::Environment> e, std::vector<uint8_t> initial_mem, interp::DefinedModule* mod) :
+         _env(move(e)), _instatiated_module(mod), _initial_memory(initial_mem),
+         _executor(_env.get(), nullptr, Thread::Options(64*1024,
+                                                        wasm_constraints::maximum_call_depth+2))
+      {
+         for(Index i = 0; i < _env->GetGlobalCount(); ++i) {
+            if(_env->GetGlobal(i)->mutable_ == false)
+               continue;
+            _initial_globals.emplace_back(_env->GetGlobal(i), _env->GetGlobal(i)->typed_value);
+         }
+         
+         if(_env->GetMemoryCount())
+            _initial_memory_configuration = _env->GetMemory(0)->page_limits;
+      }
+
+      void apply(apply_context& context) override {
+         //reset mutable globals
+         for(const auto& mg : _initial_globals)
+            mg.first->typed_value = mg.second;
+
+         wabt_apply_instance_vars this_run_vars{nullptr, context};
+         static_wabt_vars = &this_run_vars;
+
+         //reset memory to inital size & copy back in initial data
+         if(_env->GetMemoryCount()) {
+            Memory* memory = this_run_vars.memory = _env->GetMemory(0);
+            memory->page_limits = _initial_memory_configuration;
+            memory->data.resize(_initial_memory_configuration.initial * WABT_PAGE_SIZE);
+            memset(memory->data.data(), 0, memory->data.size());
+            memcpy(memory->data.data(), _initial_memory.data(), _initial_memory.size());
+         }
+
+         _params[0].set_i64(uint64_t(context.receiver));
+         _params[1].set_i64(uint64_t(context.act.account));
+         _params[2].set_i64(uint64_t(context.act.name));
+
+         ExecResult res = _executor.RunStartFunction(_instatiated_module);
+         EOS_ASSERT( res.result == interp::Result::Ok, wasm_execution_error, "wabt start function failure (${s})", ("s", ResultToString(res.result)) );
+
+         res = _executor.RunExportByName(_instatiated_module, "apply", _params);
+         EOS_ASSERT( res.result == interp::Result::Ok, wasm_execution_error, "wabt execution failure (${s})", ("s", ResultToString(res.result)) );
+      }
+
+   private:
+      std::unique_ptr<interp::Environment>              _env;
+      DefinedModule*                                    _instatiated_module;  //this is owned by the Environment
+      std::vector<uint8_t>                              _initial_memory;
+      TypedValues                                       _params{3, TypedValue(Type::I64)};
+      std::vector<std::pair<Global*, TypedValue>>       _initial_globals;
+      Limits                                            _initial_memory_configuration;
+      Executor                                          _executor;
+};
+
+wabt_runtime::wabt_runtime() {}
+
+std::unique_ptr<wasm_instantiated_module_interface> wabt_runtime::instantiate_module(const char* code_bytes, size_t code_size, std::vector<uint8_t> initial_memory) {
+   std::unique_ptr<interp::Environment> env = std::make_unique<interp::Environment>();
+   for(auto it = intrinsic_registrator::get_map().begin() ; it != intrinsic_registrator::get_map().end(); ++it) {
+      interp::HostModule* host_module = env->AppendHostModule(it->first);
+      for(auto itf = it->second.begin(); itf != it->second.end(); ++itf) {
+         host_module->AppendFuncExport(itf->first, itf->second.sig, [fn=itf->second.func](const auto* f, const auto* fs, const auto& args, auto& res) {
+            TypedValue ret = fn(*static_wabt_vars, args);
+            if(ret.type != Type::Void)
+               res[0] = ret;
+            return interp::Result::Ok;
+         });
+      }
+   }
+
+   interp::DefinedModule* instantiated_module = nullptr;
+   ErrorHandlerBuffer error_handler(Location::Type::Binary);
+
+   wabt::Result res = ReadBinaryInterp(env.get(), code_bytes, code_size, read_binary_options, &error_handler, &instantiated_module);
+   EOS_ASSERT( Succeeded(res), wasm_execution_error, "Error building wabt interp: ${e}", ("e", error_handler.buffer()) );
+   
+   return std::make_unique<wabt_instantiated_module>(std::move(env), initial_memory, instantiated_module);
+}
+
+}}}}

--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -332,6 +332,8 @@ namespace eosio { namespace testing {
                vcfg.wasm_runtime = chain::wasm_interface::vm_type::binaryen;
             else if(boost::unit_test::framework::master_test_suite().argv[i] == std::string("--wavm"))
                vcfg.wasm_runtime = chain::wasm_interface::vm_type::wavm;
+            else if(boost::unit_test::framework::master_test_suite().argv[i] == std::string("--wabt"))
+               vcfg.wasm_runtime = chain::wasm_interface::vm_type::wabt;
          }
 
 

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -100,6 +100,8 @@ namespace eosio { namespace testing {
             cfg.wasm_runtime = chain::wasm_interface::vm_type::binaryen;
          else if(boost::unit_test::framework::master_test_suite().argv[i] == std::string("--wavm"))
             cfg.wasm_runtime = chain::wasm_interface::vm_type::wavm;
+         else if(boost::unit_test::framework::master_test_suite().argv[i] == std::string("--wabt"))
+            cfg.wasm_runtime = chain::wasm_interface::vm_type::wabt;
          else
             cfg.wasm_runtime = chain::wasm_interface::vm_type::binaryen;
       }

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -212,7 +212,7 @@ void chain_plugin::set_program_options(options_description& cli, options_descrip
          ("blocks-dir", bpo::value<bfs::path>()->default_value("blocks"),
           "the location of the blocks directory (absolute path or relative to application data dir)")
          ("checkpoint", bpo::value<vector<string>>()->composing(), "Pairs of [BLOCK_NUM,BLOCK_ID] that should be enforced as checkpoints.")
-         ("wasm-runtime", bpo::value<eosio::chain::wasm_interface::vm_type>()->value_name("wavm/binaryen"), "Override default WASM runtime")
+         ("wasm-runtime", bpo::value<eosio::chain::wasm_interface::vm_type>()->value_name("wavm/binaryen/wabt"), "Override default WASM runtime")
          ("abi-serializer-max-time-ms", bpo::value<uint32_t>()->default_value(config::default_abi_serializer_max_time_ms),
           "Override default maximum ABI serialization time allowed in ms")
          ("chain-state-db-size-mb", bpo::value<uint64_t>()->default_value(config::default_state_size / (1024  * 1024)), "Maximum size (in MiB) of the chain state database")

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -38,6 +38,9 @@ add_test(NAME unit_test_binaryen COMMAND unit_test
 add_test(NAME unit_test_wavm COMMAND unit_test
  -t \!wasm_tests/weighted_cpu_limit_tests
  --report_level=detailed --color_output --catch_system_errors=no -- --wavm)
+ add_test(NAME unit_test_wabt COMMAND unit_test
+ -t \!wasm_tests/weighted_cpu_limit_tests
+ --report_level=detailed --color_output -- --wabt)
 
 if(ENABLE_COVERAGE_TESTING)
 

--- a/unittests/whitelist_blacklist_tests.cpp
+++ b/unittests/whitelist_blacklist_tests.cpp
@@ -45,6 +45,8 @@ class whitelist_blacklist_tester {
                cfg.wasm_runtime = chain::wasm_interface::vm_type::binaryen;
             else if(boost::unit_test::framework::master_test_suite().argv[i] == std::string("--wavm"))
                cfg.wasm_runtime = chain::wasm_interface::vm_type::wavm;
+            else if(boost::unit_test::framework::master_test_suite().argv[i] == std::string("--wabt"))
+               cfg.wasm_runtime = chain::wasm_interface::vm_type::wabt;
             else
                cfg.wasm_runtime = chain::wasm_interface::vm_type::binaryen;
          }


### PR DESCRIPTION
Add a new WASM backend using wabt’s interpreter. This interpreter is considerably faster than the current default of binaryen — a replay on the mainnet typically completes in less than half the time compared to binaryen.

For now this will be considered experimental.