### PR TITLE
Reduce error log output in net_plugin

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2491,7 +2491,6 @@ namespace eosio {
       dispatcher->recv_transaction(c, tid);
       chain_plug->accept_transaction(msg, [=](const static_variant<fc::exception_ptr, transaction_trace_ptr>& result) {
          if (result.contains<fc::exception_ptr>()) {
-            dlog("accept txn threw  ${m}",("m",result.get<fc::exception_ptr>()->to_detail_string()));
             peer_dlog(c, "bad packed_transaction : ${m}", ("m",result.get<fc::exception_ptr>()->what()));
          } else {
             auto trace = result.get<transaction_trace_ptr>();

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2491,11 +2491,8 @@ namespace eosio {
       dispatcher->recv_transaction(c, tid);
       chain_plug->accept_transaction(msg, [=](const static_variant<fc::exception_ptr, transaction_trace_ptr>& result) {
          if (result.contains<fc::exception_ptr>()) {
-            auto e_ptr = result.get<fc::exception_ptr>();
-            if (e_ptr->code() != tx_duplicate::code_value && e_ptr->code() != expired_tx_exception::code_value) {
-               elog("accept txn threw  ${m}",("m",result.get<fc::exception_ptr>()->to_detail_string()));
-               peer_elog(c, "bad packed_transaction : ${m}", ("m",result.get<fc::exception_ptr>()->what()));
-            }
+            dlog("accept txn threw  ${m}",("m",result.get<fc::exception_ptr>()->to_detail_string()));
+            peer_dlog(c, "bad packed_transaction : ${m}", ("m",result.get<fc::exception_ptr>()->what()));
          } else {
             auto trace = result.get<transaction_trace_ptr>();
             if (!trace->except) {


### PR DESCRIPTION
greylist exception causing huge number of log messages. Changed logging from error level to debug since exceptions are expected as transactions are processed.

```
2018-08-14T09:38:53.704 thread-0   net_plugin.cpp:2512           operator()           ] accept txn threw  3080007 greylist_net_usage_exceeded: Transaction exceeded the current greylisted account network usage limit
```