### PR TITLE
Add UNIX socket HTTP server to keosd

### DIFF
--- a/plugins/http_plugin/http_plugin.cpp
+++ b/plugins/http_plugin/http_plugin.cpp
@@ -350,7 +350,7 @@ namespace eosio {
       my->mangle_option_names();
       if(current_http_plugin_defaults.default_unix_socket_path.length())
          cfg.add_options()
-            (my->unix_socket_path_option_name.c_str(), bpo::value<boost::filesystem::path>()->default_value(current_http_plugin_defaults.default_unix_socket_path),
+            (my->unix_socket_path_option_name.c_str(), bpo::value<string>()->default_value(current_http_plugin_defaults.default_unix_socket_path),
              "The filename (relative to data-dir) to create a unix socket for HTTP RPC; set blank to disable.");
 
       if(current_http_plugin_defaults.default_http_port)
@@ -431,8 +431,8 @@ namespace eosio {
             }
          }
 
-         if( options.count( my->unix_socket_path_option_name ) && !options.at( my->unix_socket_path_option_name ).as<boost::filesystem::path>().empty()) {
-            boost::filesystem::path sock_path = options.at(my->unix_socket_path_option_name).as<boost::filesystem::path>();
+         if( options.count( my->unix_socket_path_option_name ) && !options.at( my->unix_socket_path_option_name ).as<string>().empty()) {
+            boost::filesystem::path sock_path = options.at(my->unix_socket_path_option_name).as<string>();
             if (sock_path.is_relative())
                sock_path = app().data_dir() / sock_path;
             my->unix_endpoint = asio::local::stream_protocol::endpoint(sock_path.string());

--- a/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
@@ -40,6 +40,19 @@ namespace eosio {
     */
    using api_description = std::map<string, url_handler>;
 
+   struct http_plugin_defaults {
+      //If not empty, this string is prepended on to the various configuration
+      // items for setting listen addresses
+      string address_config_prefix;
+      //If empty, unix socket support will be completely disabled. If not empty,
+      // unix socket support is enabled with the given default path (treated relative
+      // to the datadir)
+      string default_unix_socket_path;
+      //If non 0, HTTP will be enabled by default on the given port number. If
+      // 0, HTTP will not be enabled by default
+      uint16_t default_http_port{0};
+   };
+
    /**
     *  This plugin starts an HTTP server and dispatches queries to
     *  registered handles based upon URL. The handler is passed the
@@ -59,6 +72,9 @@ namespace eosio {
       public:
         http_plugin();
         virtual ~http_plugin();
+
+        //must be called before initialize
+        static void set_defaults(const http_plugin_defaults config);
 
         APPBASE_PLUGIN_REQUIRES()
         virtual void set_program_options(options_description&, options_description& cfg) override;

--- a/plugins/http_plugin/include/eosio/http_plugin/local_endpoint.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/local_endpoint.hpp
@@ -386,9 +386,7 @@ public:
             m_acceptor->open(ep.protocol(),bec);
         }
         if (!bec) {
-            mode_t old_mask = umask(S_IXUSR|S_IXGRP|S_IRWXO);
             m_acceptor->bind(ep,bec);
-            umask(old_mask);
         }
         if (!bec) {
             m_acceptor->listen(boost::asio::socket_base::max_listen_connections,bec);

--- a/plugins/http_plugin/include/eosio/http_plugin/local_endpoint.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/local_endpoint.hpp
@@ -58,7 +58,7 @@ public:
     }
 
     std::string get_remote_endpoint(lib::error_code & ec) const {
-        return "fixme";
+        return "UNIX Socket Endpoint";
     }
 
    void pre_init(init_handler callback) {

--- a/plugins/http_plugin/include/eosio/http_plugin/local_endpoint.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/local_endpoint.hpp
@@ -1,0 +1,790 @@
+#pragma once
+
+#include <websocketpp/transport/base/endpoint.hpp>
+#include <websocketpp/transport/asio/connection.hpp>
+#include <websocketpp/transport/asio/security/none.hpp>
+
+#include <websocketpp/uri.hpp>
+#include <websocketpp/logger/levels.hpp>
+
+#include <websocketpp/common/functional.hpp>
+
+#include <sstream>
+#include <string>
+
+namespace websocketpp {
+namespace transport {
+namespace asio {
+
+namespace basic_socket {
+
+class local_connection : public lib::enable_shared_from_this<local_connection> {
+public:
+    /// Type of this connection socket component
+    typedef local_connection type;
+    /// Type of a shared pointer to this connection socket component
+    typedef lib::shared_ptr<type> ptr;
+
+    /// Type of a pointer to the Asio io_service being used
+    typedef lib::asio::io_service* io_service_ptr;
+    /// Type of a pointer to the Asio io_service strand being used
+    typedef lib::shared_ptr<lib::asio::io_service::strand> strand_ptr;
+    /// Type of the ASIO socket being used
+    typedef lib::asio::local::stream_protocol::socket socket_type;
+    /// Type of a shared pointer to the socket being used.
+    typedef lib::shared_ptr<socket_type> socket_ptr;
+
+    explicit local_connection() : m_state(UNINITIALIZED) {
+    }
+
+    ptr get_shared() {
+        return shared_from_this();
+    }
+
+    bool is_secure() const {
+        return false;
+    }
+
+    lib::asio::local::stream_protocol::socket & get_socket() {
+        return *m_socket;
+    }
+
+    lib::asio::local::stream_protocol::socket & get_next_layer() {
+        return *m_socket;
+    }
+
+    lib::asio::local::stream_protocol::socket & get_raw_socket() {
+        return *m_socket;
+    }
+
+    std::string get_remote_endpoint(lib::error_code & ec) const {
+        return "fixme";
+    }
+
+   void pre_init(init_handler callback) {
+      if (m_state != READY) {
+         callback(socket::make_error_code(socket::error::invalid_state));
+         return;
+      }
+
+      m_state = READING;
+
+      callback(lib::error_code());
+   }
+
+   void post_init(init_handler callback) {
+        callback(lib::error_code());
+   }
+protected:
+    lib::error_code init_asio (io_service_ptr service, strand_ptr, bool)
+    {
+        if (m_state != UNINITIALIZED) {
+            return socket::make_error_code(socket::error::invalid_state);
+        }
+
+        m_socket = lib::make_shared<lib::asio::local::stream_protocol::socket>(
+            lib::ref(*service));
+
+        m_state = READY;
+
+        return lib::error_code();
+    }
+
+    void set_handle(connection_hdl hdl) {
+        m_hdl = hdl;
+    }
+
+    lib::asio::error_code cancel_socket() {
+        lib::asio::error_code ec;
+        m_socket->cancel(ec);
+        return ec;
+    }
+
+    void async_shutdown(socket::shutdown_handler h) {
+        lib::asio::error_code ec;
+        m_socket->shutdown(lib::asio::ip::tcp::socket::shutdown_both, ec);
+        h(ec);
+    }
+
+    lib::error_code get_ec() const {
+        return lib::error_code();
+    }
+
+    template <typename ErrorCodeType>
+    lib::error_code translate_ec(ErrorCodeType) {
+        return make_error_code(transport::error::pass_through);
+    }
+    
+    lib::error_code translate_ec(lib::error_code ec) {
+        return ec;
+    }
+private:
+    enum state {
+        UNINITIALIZED = 0,
+        READY = 1,
+        READING = 2
+    };
+
+    socket_ptr          m_socket;
+    state               m_state;
+
+    connection_hdl      m_hdl;
+    socket_init_handler m_socket_init_handler;
+};
+
+class local_endpoint {
+public:
+    /// The type of this endpoint socket component
+    typedef local_endpoint type;
+
+    /// The type of the corresponding connection socket component
+    typedef local_connection socket_con_type;
+    /// The type of a shared pointer to the corresponding connection socket
+    /// component.
+    typedef socket_con_type::ptr socket_con_ptr;
+
+    explicit local_endpoint() {}
+
+    bool is_secure() const {
+        return false;
+    }
+};
+}
+
+/// Asio based endpoint transport component
+/**
+ * transport::asio::endpoint implements an endpoint transport component using
+ * Asio.
+ */
+template <typename config>
+class local_endpoint : public config::socket_type {
+public:
+    /// Type of this endpoint transport component
+    typedef local_endpoint<config> type;
+
+    /// Type of the concurrency policy
+    typedef typename config::concurrency_type concurrency_type;
+    /// Type of the socket policy
+    typedef typename config::socket_type socket_type;
+    /// Type of the error logging policy
+    typedef typename config::elog_type elog_type;
+    /// Type of the access logging policy
+    typedef typename config::alog_type alog_type;
+
+    /// Type of the socket connection component
+    typedef typename socket_type::socket_con_type socket_con_type;
+    /// Type of a shared pointer to the socket connection component
+    typedef typename socket_con_type::ptr socket_con_ptr;
+
+    /// Type of the connection transport component associated with this
+    /// endpoint transport component
+    typedef asio::connection<config> transport_con_type;
+    /// Type of a shared pointer to the connection transport component
+    /// associated with this endpoint transport component
+    typedef typename transport_con_type::ptr transport_con_ptr;
+
+    /// Type of a pointer to the ASIO io_service being used
+    typedef lib::asio::io_service * io_service_ptr;
+    /// Type of a shared pointer to the acceptor being used
+    typedef lib::shared_ptr<lib::asio::local::stream_protocol::acceptor> acceptor_ptr;
+    /// Type of timer handle
+    typedef lib::shared_ptr<lib::asio::steady_timer> timer_ptr;
+    /// Type of a shared pointer to an io_service work object
+    typedef lib::shared_ptr<lib::asio::io_service::work> work_ptr;
+
+    // generate and manage our own io_service
+    explicit local_endpoint()
+      : m_io_service(NULL)
+      , m_state(UNINITIALIZED)
+    {
+        //std::cout << "transport::asio::endpoint constructor" << std::endl;
+    }
+
+    ~local_endpoint() {
+        if (m_acceptor && m_state == LISTENING)
+            ::unlink(m_acceptor->local_endpoint().path().c_str());
+
+        // Explicitly destroy local objects
+        m_acceptor.reset();
+        m_work.reset();
+    }
+
+    /// transport::asio objects are moveable but not copyable or assignable.
+    /// The following code sets this situation up based on whether or not we
+    /// have C++11 support or not
+#ifdef _WEBSOCKETPP_DEFAULT_DELETE_FUNCTIONS_
+    local_endpoint(const local_endpoint & src) = delete;
+    local_endpoint& operator= (const local_endpoint & rhs) = delete;
+#else
+private:
+    local_endpoint(const local_endpoint & src);
+    local_endpoint & operator= (const local_endpoint & rhs);
+public:
+#endif // _WEBSOCKETPP_DEFAULT_DELETE_FUNCTIONS_
+
+#ifdef _WEBSOCKETPP_MOVE_SEMANTICS_
+    local_endpoint (local_endpoint && src)
+      : config::socket_type(std::move(src))
+      , m_tcp_pre_init_handler(src.m_tcp_pre_init_handler)
+      , m_tcp_post_init_handler(src.m_tcp_post_init_handler)
+      , m_io_service(src.m_io_service)
+      , m_acceptor(src.m_acceptor)
+      , m_elog(src.m_elog)
+      , m_alog(src.m_alog)
+      , m_state(src.m_state)
+    {
+        src.m_io_service = NULL;
+        src.m_acceptor = NULL;
+        src.m_state = UNINITIALIZED;
+    }
+
+#endif // _WEBSOCKETPP_MOVE_SEMANTICS_
+
+    /// Return whether or not the endpoint produces secure connections.
+    bool is_secure() const {
+        return socket_type::is_secure();
+    }
+
+    /// initialize asio transport with external io_service (exception free)
+    /**
+     * Initialize the ASIO transport policy for this endpoint using the provided
+     * io_service object. asio_init must be called exactly once on any endpoint
+     * that uses transport::asio before it can be used.
+     *
+     * @param ptr A pointer to the io_service to use for asio events
+     * @param ec Set to indicate what error occurred, if any.
+     */
+    void init_asio(io_service_ptr ptr, lib::error_code & ec) {
+        if (m_state != UNINITIALIZED) {
+            m_elog->write(log::elevel::library,
+                "asio::init_asio called from the wrong state");
+            using websocketpp::error::make_error_code;
+            ec = make_error_code(websocketpp::error::invalid_state);
+            return;
+        }
+
+        m_alog->write(log::alevel::devel,"asio::init_asio");
+
+        m_io_service = ptr;
+        m_acceptor = lib::make_shared<lib::asio::local::stream_protocol::acceptor>(
+            lib::ref(*m_io_service));
+
+        m_state = READY;
+        ec = lib::error_code();
+    }
+
+    /// initialize asio transport with external io_service
+    /**
+     * Initialize the ASIO transport policy for this endpoint using the provided
+     * io_service object. asio_init must be called exactly once on any endpoint
+     * that uses transport::asio before it can be used.
+     *
+     * @param ptr A pointer to the io_service to use for asio events
+     */
+    void init_asio(io_service_ptr ptr) {
+        lib::error_code ec;
+        init_asio(ptr,ec);
+        if (ec) { throw exception(ec); }
+    }
+
+    /// Sets the tcp pre init handler
+    /**
+     * The tcp pre init handler is called after the raw tcp connection has been
+     * established but before any additional wrappers (proxy connects, TLS
+     * handshakes, etc) have been performed.
+     *
+     * @since 0.3.0
+     *
+     * @param h The handler to call on tcp pre init.
+     */
+    void set_tcp_pre_init_handler(tcp_init_handler h) {
+        m_tcp_pre_init_handler = h;
+    }
+
+    /// Sets the tcp pre init handler (deprecated)
+    /**
+     * The tcp pre init handler is called after the raw tcp connection has been
+     * established but before any additional wrappers (proxy connects, TLS
+     * handshakes, etc) have been performed.
+     *
+     * @deprecated Use set_tcp_pre_init_handler instead
+     *
+     * @param h The handler to call on tcp pre init.
+     */
+    void set_tcp_init_handler(tcp_init_handler h) {
+        set_tcp_pre_init_handler(h);
+    }
+
+    /// Sets the tcp post init handler
+    /**
+     * The tcp post init handler is called after the tcp connection has been
+     * established and all additional wrappers (proxy connects, TLS handshakes,
+     * etc have been performed. This is fired before any bytes are read or any
+     * WebSocket specific handshake logic has been performed.
+     *
+     * @since 0.3.0
+     *
+     * @param h The handler to call on tcp post init.
+     */
+    void set_tcp_post_init_handler(tcp_init_handler h) {
+        m_tcp_post_init_handler = h;
+    }
+
+    /// Retrieve a reference to the endpoint's io_service
+    /**
+     * The io_service may be an internal or external one. This may be used to
+     * call methods of the io_service that are not explicitly wrapped by the
+     * endpoint.
+     *
+     * This method is only valid after the endpoint has been initialized with
+     * `init_asio`. No error will be returned if it isn't.
+     *
+     * @return A reference to the endpoint's io_service
+     */
+    lib::asio::io_service & get_io_service() {
+        return *m_io_service;
+    }
+
+    /// Set up endpoint for listening manually (exception free)
+    /**
+     * Bind the internal acceptor using the specified settings. The endpoint
+     * must have been initialized by calling init_asio before listening.
+     *
+     * @param ep An endpoint to read settings from
+     * @param ec Set to indicate what error occurred, if any.
+     */
+    void listen(lib::asio::local::stream_protocol::endpoint const & ep, lib::error_code & ec)
+    {
+        if (m_state != READY) {
+            m_elog->write(log::elevel::library,
+                "asio::listen called from the wrong state");
+            using websocketpp::error::make_error_code;
+            ec = make_error_code(websocketpp::error::invalid_state);
+            return;
+        }
+
+        m_alog->write(log::alevel::devel,"asio::listen");
+
+        lib::asio::error_code bec;
+
+        {
+            boost::system::error_code test_ec;
+            lib::asio::local::stream_protocol::socket test_socket(get_io_service());
+            test_socket.connect(ep, test_ec);
+
+            //looks like a service is already running on that socket, probably another keosd, don't touch it
+            if(test_ec == boost::system::errc::success)
+               bec = boost::system::errc::make_error_code(boost::system::errc::address_in_use);
+            //socket exists but no one home, go ahead and remove it and continue on
+            else if(test_ec == boost::system::errc::connection_refused)
+               ::unlink(ep.path().c_str());
+            else if(test_ec != boost::system::errc::no_such_file_or_directory)
+               bec = test_ec;
+        }
+
+        if (!bec) {
+            m_acceptor->open(ep.protocol(),bec);
+        }
+        if (!bec) {
+            mode_t old_mask = umask(S_IXUSR|S_IXGRP|S_IRWXO);
+            m_acceptor->bind(ep,bec);
+            umask(old_mask);
+        }
+        if (!bec) {
+            m_acceptor->listen(boost::asio::socket_base::max_listen_connections,bec);
+        }
+        if (bec) {
+            if (m_acceptor->is_open()) {
+                m_acceptor->close();
+            }
+            log_err(log::elevel::info,"asio listen",bec);
+            ec = bec;//make_error_code(error::pass_through);
+        } else {
+            m_state = LISTENING;
+            ec = lib::error_code();
+        }
+    }
+
+    /// Set up endpoint for listening manually
+    /**
+     * Bind the internal acceptor using the settings specified by the endpoint e
+     *
+     * @param ep An endpoint to read settings from
+     */
+    void listen(lib::asio::local::stream_protocol::endpoint const & ep) {
+        lib::error_code ec;
+        listen(ep,ec);
+        if (ec) { throw exception(ec); }
+    }
+
+    /// Stop listening (exception free)
+    /**
+     * Stop listening and accepting new connections. This will not end any
+     * existing connections.
+     *
+     * @since 0.3.0-alpha4
+     * @param ec A status code indicating an error, if any.
+     */
+    void stop_listening(lib::error_code & ec) {
+        if (m_state != LISTENING) {
+            m_elog->write(log::elevel::library,
+                "asio::listen called from the wrong state");
+            using websocketpp::error::make_error_code;
+            ec = make_error_code(websocketpp::error::invalid_state);
+            return;
+        }
+
+        ::unlink(m_acceptor->local_endpoint().path().c_str());
+        m_acceptor->close();
+        m_state = READY;
+        ec = lib::error_code();
+    }
+
+    /// Stop listening
+    /**
+     * Stop listening and accepting new connections. This will not end any
+     * existing connections.
+     *
+     * @since 0.3.0-alpha4
+     */
+    void stop_listening() {
+        lib::error_code ec;
+        stop_listening(ec);
+        if (ec) { throw exception(ec); }
+    }
+
+    /// Check if the endpoint is listening
+    /**
+     * @return Whether or not the endpoint is listening.
+     */
+    bool is_listening() const {
+        return (m_state == LISTENING);
+    }
+
+    /// wraps the run method of the internal io_service object
+    std::size_t run() {
+        return m_io_service->run();
+    }
+
+    /// wraps the run_one method of the internal io_service object
+    /**
+     * @since 0.3.0-alpha4
+     */
+    std::size_t run_one() {
+        return m_io_service->run_one();
+    }
+
+    /// wraps the stop method of the internal io_service object
+    void stop() {
+        m_io_service->stop();
+    }
+
+    /// wraps the poll method of the internal io_service object
+    std::size_t poll() {
+        return m_io_service->poll();
+    }
+
+    /// wraps the poll_one method of the internal io_service object
+    std::size_t poll_one() {
+        return m_io_service->poll_one();
+    }
+
+    /// wraps the reset method of the internal io_service object
+    void reset() {
+        m_io_service->reset();
+    }
+
+    /// wraps the stopped method of the internal io_service object
+    bool stopped() const {
+        return m_io_service->stopped();
+    }
+
+    /// Marks the endpoint as perpetual, stopping it from exiting when empty
+    /**
+     * Marks the endpoint as perpetual. Perpetual endpoints will not
+     * automatically exit when they run out of connections to process. To stop
+     * a perpetual endpoint call `end_perpetual`.
+     *
+     * An endpoint may be marked perpetual at any time by any thread. It must be
+     * called either before the endpoint has run out of work or before it was
+     * started
+     *
+     * @since 0.3.0
+     */
+    void start_perpetual() {
+        m_work = lib::make_shared<lib::asio::io_service::work>(
+            lib::ref(*m_io_service)
+        );
+    }
+
+    /// Clears the endpoint's perpetual flag, allowing it to exit when empty
+    /**
+     * Clears the endpoint's perpetual flag. This will cause the endpoint's run
+     * method to exit normally when it runs out of connections. If there are
+     * currently active connections it will not end until they are complete.
+     *
+     * @since 0.3.0
+     */
+    void stop_perpetual() {
+        m_work.reset();
+    }
+
+    /// Call back a function after a period of time.
+    /**
+     * Sets a timer that calls back a function after the specified period of
+     * milliseconds. Returns a handle that can be used to cancel the timer.
+     * A cancelled timer will return the error code error::operation_aborted
+     * A timer that expired will return no error.
+     *
+     * @param duration Length of time to wait in milliseconds
+     * @param callback The function to call back when the timer has expired
+     * @return A handle that can be used to cancel the timer if it is no longer
+     * needed.
+     */
+    timer_ptr set_timer(long duration, timer_handler callback) {
+        timer_ptr new_timer = lib::make_shared<lib::asio::steady_timer>(
+            *m_io_service,
+             lib::asio::milliseconds(duration)
+        );
+
+        new_timer->async_wait(
+            lib::bind(
+                &type::handle_timer,
+                this,
+                new_timer,
+                callback,
+                lib::placeholders::_1
+            )
+        );
+
+        return new_timer;
+    }
+
+    /// Timer handler
+    /**
+     * The timer pointer is included to ensure the timer isn't destroyed until
+     * after it has expired.
+     *
+     * @param t Pointer to the timer in question
+     * @param callback The function to call back
+     * @param ec A status code indicating an error, if any.
+     */
+    void handle_timer(timer_ptr, timer_handler callback,
+        lib::asio::error_code const & ec)
+    {
+        if (ec) {
+            if (ec == lib::asio::error::operation_aborted) {
+                callback(make_error_code(transport::error::operation_aborted));
+            } else {
+                m_elog->write(log::elevel::info,
+                    "asio handle_timer error: "+ec.message());
+                log_err(log::elevel::info,"asio handle_timer",ec);
+                callback(ec);
+            }
+        } else {
+            callback(lib::error_code());
+        }
+    }
+
+    /// Accept the next connection attempt and assign it to con (exception free)
+    /**
+     * @param tcon The connection to accept into.
+     * @param callback The function to call when the operation is complete.
+     * @param ec A status code indicating an error, if any.
+     */
+    void async_accept(transport_con_ptr tcon, accept_handler callback,
+        lib::error_code & ec)
+    {
+        if (m_state != LISTENING) {
+            using websocketpp::error::make_error_code;
+            ec = make_error_code(websocketpp::error::async_accept_not_listening);
+            return;
+        }
+
+        m_alog->write(log::alevel::devel, "asio::async_accept");
+
+        if (config::enable_multithreading) {
+            m_acceptor->async_accept(
+                tcon->get_raw_socket(),
+                tcon->get_strand()->wrap(lib::bind(
+                    &type::handle_accept,
+                    this,
+                    callback,
+                    lib::placeholders::_1
+                ))
+            );
+        } else {
+            m_acceptor->async_accept(
+                tcon->get_raw_socket(),
+                lib::bind(
+                    &type::handle_accept,
+                    this,
+                    callback,
+                    lib::placeholders::_1
+                )
+            );
+        }
+    }
+
+    /// Accept the next connection attempt and assign it to con.
+    /**
+     * @param tcon The connection to accept into.
+     * @param callback The function to call when the operation is complete.
+     */
+    void async_accept(transport_con_ptr tcon, accept_handler callback) {
+        lib::error_code ec;
+        async_accept(tcon,callback,ec);
+        if (ec) { throw exception(ec); }
+    }
+protected:
+    /// Initialize logging
+    /**
+     * The loggers are located in the main endpoint class. As such, the
+     * transport doesn't have direct access to them. This method is called
+     * by the endpoint constructor to allow shared logging from the transport
+     * component. These are raw pointers to member variables of the endpoint.
+     * In particular, they cannot be used in the transport constructor as they
+     * haven't been constructed yet, and cannot be used in the transport
+     * destructor as they will have been destroyed by then.
+     */
+    void init_logging(alog_type* a, elog_type* e) {
+        m_alog = a;
+        m_elog = e;
+    }
+
+    void handle_accept(accept_handler callback, lib::asio::error_code const & 
+        asio_ec)
+    {
+        lib::error_code ret_ec;
+
+        m_alog->write(log::alevel::devel, "asio::handle_accept");
+
+        if (asio_ec) {
+            if (asio_ec == lib::asio::errc::operation_canceled) {
+                ret_ec = make_error_code(websocketpp::error::operation_canceled);
+            } else {
+                log_err(log::elevel::info,"asio handle_accept",asio_ec);
+                ret_ec = asio_ec;
+            }
+        }
+
+        callback(ret_ec);
+    }
+
+    /// Asio connect timeout handler
+    /**
+     * The timer pointer is included to ensure the timer isn't destroyed until
+     * after it has expired.
+     *
+     * @param tcon Pointer to the transport connection that is being connected
+     * @param con_timer Pointer to the timer in question
+     * @param callback The function to call back
+     * @param ec A status code indicating an error, if any.
+     */
+    void handle_connect_timeout(transport_con_ptr tcon, timer_ptr,
+        connect_handler callback, lib::error_code const & ec)
+    {
+        lib::error_code ret_ec;
+
+        if (ec) {
+            if (ec == transport::error::operation_aborted) {
+                m_alog->write(log::alevel::devel,
+                    "asio handle_connect_timeout timer cancelled");
+                return;
+            }
+
+            log_err(log::elevel::devel,"asio handle_connect_timeout",ec);
+            ret_ec = ec;
+        } else {
+            ret_ec = make_error_code(transport::error::timeout);
+        }
+
+        m_alog->write(log::alevel::devel,"TCP connect timed out");
+        tcon->cancel_socket_checked();
+        callback(ret_ec);
+    }
+
+    void handle_connect(transport_con_ptr tcon, timer_ptr con_timer,
+        connect_handler callback, lib::asio::error_code const & ec)
+    {
+        if (ec == lib::asio::error::operation_aborted ||
+            lib::asio::is_neg(con_timer->expires_from_now()))
+        {
+            m_alog->write(log::alevel::devel,"async_connect cancelled");
+            return;
+        }
+
+        con_timer->cancel();
+
+        if (ec) {
+            log_err(log::elevel::info,"asio async_connect",ec);
+            callback(ec);
+            return;
+        }
+
+        if (m_alog->static_test(log::alevel::devel)) {
+            m_alog->write(log::alevel::devel,
+                "Async connect to "+tcon->get_remote_endpoint()+" successful.");
+        }
+
+        callback(lib::error_code());
+    }
+
+    /// Initialize a connection
+    /**
+     * init is called by an endpoint once for each newly created connection.
+     * It's purpose is to give the transport policy the chance to perform any
+     * transport specific initialization that couldn't be done via the default
+     * constructor.
+     *
+     * @param tcon A pointer to the transport portion of the connection.
+     *
+     * @return A status code indicating the success or failure of the operation
+     */
+    lib::error_code init(transport_con_ptr tcon) {
+        m_alog->write(log::alevel::devel, "transport::asio::init");
+
+        lib::error_code ec;
+
+        ec = tcon->init_asio(m_io_service);
+        if (ec) {return ec;}
+
+        tcon->set_tcp_pre_init_handler(m_tcp_pre_init_handler);
+        tcon->set_tcp_post_init_handler(m_tcp_post_init_handler);
+
+        return lib::error_code();
+    }
+private:
+    /// Convenience method for logging the code and message for an error_code
+    template <typename error_type>
+    void log_err(log::level l, char const * msg, error_type const & ec) {
+        std::stringstream s;
+        s << msg << " error: " << ec << " (" << ec.message() << ")";
+        m_elog->write(l,s.str());
+    }
+
+    enum state {
+        UNINITIALIZED = 0,
+        READY = 1,
+        LISTENING = 2
+    };
+
+    // Handlers
+    tcp_init_handler    m_tcp_pre_init_handler;
+    tcp_init_handler    m_tcp_post_init_handler;
+
+    // Network Resources
+    io_service_ptr      m_io_service;
+    acceptor_ptr        m_acceptor;
+    work_ptr            m_work;
+
+    elog_type* m_elog;
+    alog_type* m_alog;
+
+    // Transport state
+    state               m_state;
+};
+
+} // namespace asio
+} // namespace transport
+} // namespace websocketpp

--- a/plugins/http_plugin/include/eosio/http_plugin/local_endpoint.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/local_endpoint.hpp
@@ -396,7 +396,7 @@ public:
                 m_acceptor->close();
             }
             log_err(log::elevel::info,"asio listen",bec);
-            ec = bec;//make_error_code(error::pass_through);
+            ec = bec;
         } else {
             m_state = LISTENING;
             ec = lib::error_code();

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -17,6 +17,7 @@
 
 #include <iostream>
 #include <algorithm>
+#include <boost/algorithm/string.hpp>
 #include <boost/range/adaptor/map.hpp>
 #include <boost/function_output_iterator.hpp>
 #include <boost/multi_index_container.hpp>
@@ -533,7 +534,13 @@ make_key_signature_provider(const private_key_type& key) {
 
 static producer_plugin_impl::signature_provider_type
 make_keosd_signature_provider(const std::shared_ptr<producer_plugin_impl>& impl, const string& url_str, const public_key_type pubkey) {
-   auto keosd_url = fc::url(url_str);
+   fc::url keosd_url;
+   if(boost::algorithm::starts_with(url_str, "unix://"))
+      //send the entire string after unix:// to http_plugin. It'll auto-detect which part
+      // is the unix socket path, and which part is the url to hit on the server
+      keosd_url = fc::url("unix", url_str.substr(7), ostring(), ostring(), ostring(), ostring(), ovariant_object(), fc::optional<uint16_t>());
+   else
+      keosd_url = fc::url(url_str);
    std::weak_ptr<producer_plugin_impl> weak_impl = impl;
 
    return [weak_impl, keosd_url, pubkey]( const chain::digest_type& digest ) {

--- a/programs/cleos/httpc.cpp
+++ b/programs/cleos/httpc.cpp
@@ -104,6 +104,13 @@ namespace eosio { namespace client { namespace http {
    parsed_url parse_url( const string& server_url ) {
       parsed_url res;
 
+      //unix socket doesn't quite follow classical "URL" rules so deal with it manually
+      if(boost::algorithm::starts_with(server_url, "unix://")) {
+         res.scheme = "unix";
+         res.server = server_url.substr(strlen("unix://"));
+         return res;
+      }
+
       //via rfc3986 and modified a bit to suck out the port number
       //Sadly this doesn't work for ipv6 addresses
       std::regex rgx(R"xx(^(([^:/?#]+):)?(//([^:/?#]*)(:(\d+))?)?([^?#]*)(\?([^#]*))?(#(.*))?)xx");
@@ -125,6 +132,9 @@ namespace eosio { namespace client { namespace http {
    }
 
    resolved_url resolve_url( const http_context& context, const parsed_url& url ) {
+      if(url.scheme == "unix")
+         return resolved_url(url);
+
       tcp::resolver resolver(context->ios);
       boost::system::error_code ec;
       auto result = resolver.resolve(tcp::v4(), url.server, url.port, ec);
@@ -207,7 +217,12 @@ namespace eosio { namespace client { namespace http {
    std::string re;
 
    try {
-      if(url.scheme == "http") {
+      if(url.scheme == "unix") {
+         boost::asio::local::stream_protocol::socket unix_socket(cp.context->ios);
+         unix_socket.connect(boost::asio::local::stream_protocol::endpoint(url.server));
+         re = do_txrx(unix_socket, request, status_code);
+      }
+      else if(url.scheme == "http") {
          tcp::socket socket(cp.context->ios);
          do_connect(socket, url);
          re = do_txrx(socket, request, status_code);

--- a/programs/cleos/httpc.hpp
+++ b/programs/cleos/httpc.hpp
@@ -42,9 +42,12 @@ namespace eosio { namespace client { namespace http {
       {
       }
 
+      //used for unix domain, where resolving and ports are nonapplicable
+      resolved_url(const parsed_url& url) : parsed_url(url) {}
+
       vector<string> resolved_addresses;
-      uint16_t resolved_port;
-      bool is_loopback;
+      uint16_t resolved_port = 0;
+      bool is_loopback = false;
    };
 
    resolved_url resolve_url( const http_context& context,

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -72,6 +72,7 @@ Options:
 ```
 */
 
+#include <pwd.h>
 #include <string>
 #include <vector>
 #include <regex>
@@ -148,8 +149,24 @@ FC_DECLARE_EXCEPTION( localized_exception, 10000000, "an error occured" );
     FC_MULTILINE_MACRO_END \
   )
 
+//copy pasta from keosd's main.cpp
+bfs::path determine_home_directory()
+{
+   bfs::path home;
+   struct passwd* pwd = getpwuid(getuid());
+   if(pwd) {
+      home = pwd->pw_dir;
+   }
+   else {
+      home = getenv("HOME");
+   }
+   if(home.empty())
+      home = "./";
+   return home;
+}
+
 string url = "http://127.0.0.1:8888/";
-string wallet_url = "http://127.0.0.1:8900/";
+string wallet_url = "unix://" + (determine_home_directory() / "eosio-wallet" / (string(key_store_executable_name) + ".sock")).string();
 bool no_verify = false;
 vector<string> headers;
 

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -166,7 +166,7 @@ bfs::path determine_home_directory()
 }
 
 string url = "http://127.0.0.1:8888/";
-string wallet_url = "unix://" + (determine_home_directory() / "eosio-wallet" / (string(key_store_executable_name) + ".sock")).string();
+string wallet_url = "http://127.0.0.1:8900/";
 bool no_verify = false;
 vector<string> headers;
 

--- a/programs/keosd/CMakeLists.txt
+++ b/programs/keosd/CMakeLists.txt
@@ -9,11 +9,14 @@ if( GPERFTOOLS_FOUND )
     list( APPEND PLATFORM_SPECIFIC_LIBS tcmalloc )
 endif()
 
+configure_file(config.hpp.in config.hpp ESCAPE_QUOTES)
+
 target_link_libraries( ${KEY_STORE_EXECUTABLE_NAME}
         PRIVATE appbase
         PRIVATE wallet_api_plugin wallet_plugin
         PRIVATE http_plugin
         PRIVATE eosio_chain fc ${CMAKE_DL_LIBS} ${PLATFORM_SPECIFIC_LIBS} )
+target_include_directories(${KEY_STORE_EXECUTABLE_NAME} PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
 
 mas_sign(${KEY_STORE_EXECUTABLE_NAME})
 

--- a/programs/keosd/config.hpp.in
+++ b/programs/keosd/config.hpp.in
@@ -1,0 +1,11 @@
+/**
+ *  @file
+ *  @copyright defined in eos/LICENSE.txt
+ *
+ * \warning This file is machine generated. DO NOT EDIT.  See config.hpp.in for changes.
+ */
+#pragma once
+
+namespace eosio { namespace keosd { namespace config {
+  const string key_store_executable_name = "${KEY_STORE_EXECUTABLE_NAME}";
+}}}

--- a/programs/keosd/main.cpp
+++ b/programs/keosd/main.cpp
@@ -41,9 +41,9 @@ int main(int argc, char** argv)
       app().set_default_data_dir(home / "eosio-wallet");
       app().set_default_config_dir(home / "eosio-wallet");
       http_plugin::set_defaults({
-         .address_config_prefix = keosd::config::key_store_executable_name,
+         .address_config_prefix = "",
          .default_unix_socket_path = keosd::config::key_store_executable_name + ".sock",
-         .default_http_port = 0
+         .default_http_port = 8900
       });
       app().register_plugin<wallet_api_plugin>();
       if(!app().initialize<wallet_plugin, wallet_api_plugin, http_plugin>(argc, argv))

--- a/programs/keosd/main.cpp
+++ b/programs/keosd/main.cpp
@@ -14,6 +14,7 @@
 #include <boost/exception/diagnostic_information.hpp>
 
 #include <pwd.h>
+#include "config.hpp"
 
 using namespace appbase;
 using namespace eosio;
@@ -39,6 +40,11 @@ int main(int argc, char** argv)
       bfs::path home = determine_home_directory();
       app().set_default_data_dir(home / "eosio-wallet");
       app().set_default_config_dir(home / "eosio-wallet");
+      http_plugin::set_defaults({
+         .address_config_prefix = keosd::config::key_store_executable_name,
+         .default_unix_socket_path = keosd::config::key_store_executable_name + ".sock",
+         .default_http_port = 0
+      });
       app().register_plugin<wallet_api_plugin>();
       if(!app().initialize<wallet_plugin, wallet_api_plugin, http_plugin>(argc, argv))
          return -1;

--- a/programs/nodeos/main.cpp
+++ b/programs/nodeos/main.cpp
@@ -99,6 +99,11 @@ int main(int argc, char** argv)
       auto root = fc::app_path();
       app().set_default_data_dir(root / "eosio/nodeos/data" );
       app().set_default_config_dir(root / "eosio/nodeos/config" );
+      http_plugin::set_defaults({
+         .address_config_prefix = "",
+         .default_unix_socket_path = "",
+         .default_http_port = 8888
+      });
       if(!app().initialize<chain_plugin, http_plugin, net_plugin, producer_plugin>(argc, argv))
          return INITIALIZE_FAIL;
       initialize_logging();


### PR DESCRIPTION
The http_plugin now has the capability to serve its HTTP RPC on a UNIX domain socket in addition to the TCP and TLS over TCP sockets already supported. This option is currently only present in keosd even though nodeos also uses the http_plugin.

### User facing changes for keosd
* A new option unix-socket-path configures where to create the unix socket. By default this will be “keosd.sock” and created within keosd's data-dir which by default is ~/eosio.wallet/ . So the socket would reside at ~/eosio.wallet/keosd.sock.
You can also use an absolute path for unix-socket-path if you want to place it more globally accessible. This may be useful for more advanced deployments where, for example, nodeos and keosd run as different users but are members of the same group. The socket has mode 0660 so only the user who executed keosd as well as members of the group of the user who executed keosd can open it.
If you wish to disable the unix socket, you can use either `unix-socket-path =` (in the config file) or `--unix-socket-path ''` (on the command line) to set an empty path which disables it. If you desire to only use the unix socket, you can similarly set the http-server-address to empty which will disable it. 
* The default HTTP port for keosd has changed to 8900. This resolves an inconstancy where when you launched keosd manually with no options it would listen on 8888, but if you had cleos launch keosd for you it would listen on 8900. Be aware that this default port change won’t take affect for current users — your config.ini will still contain the original 8888 default which will be treated as user specified and thus overrule the new default.

### Using the socket with cleos
By default cleos will still try to access the wallet on http://127.0.0.1:8900. To have it access via UNIX socket pass something like `--wallet-url unix://${HOME}/eosio-wallet/keosd.sock`

### Using the socket with nodeos producer_plugin
If you would like to use keosd via UNIX socket as a signature provider the syntax is of the form
`signature-provider = EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV=KEOSD:unix:///home/username/eosio-wallet/keosd.sock/v1/wallet/sign_digest`
Nodeos will discover that /home/username/eosio-wallet/keosd.sock is the path to the socket, and /v1/wallet/sign_digest is the URL path.

### Implementation/PR notes
I had to pretty much copy pasta the asio_endpoint.hpp code from websocketpp in to a new local_endpoint.hpp and change a few items. It seemed like tcp was baked deep in to how the original code worked.
