### PR TITLE
stop creating anonymous volumes during image build

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -21,5 +21,4 @@ COPY --from=builder /eos/Docker/nodeosd.sh /opt/eosio/bin/nodeosd.sh
 ENV EOSIO_ROOT=/opt/eosio
 RUN chmod +x /opt/eosio/bin/nodeosd.sh
 ENV LD_LIBRARY_PATH /usr/local/lib
-VOLUME /opt/eosio/bin/data-dir
 ENV PATH /opt/eosio/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin

--- a/Docker/dev/Dockerfile
+++ b/Docker/dev/Dockerfile
@@ -14,5 +14,4 @@ RUN pip3 install numpy
 ENV EOSIO_ROOT=/opt/eosio
 RUN chmod +x /opt/eosio/bin/nodeosd.sh
 ENV LD_LIBRARY_PATH /usr/local/lib
-VOLUME /opt/eosio/bin/data-dir
 ENV PATH /opt/eosio/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin

--- a/Docker/nodeosd.sh
+++ b/Docker/nodeosd.sh
@@ -1,6 +1,10 @@
 #!/bin/sh
 cd /opt/eosio/bin
 
+if [ ! -d "/opt/eosio/bin/data-dir" ]; then
+    mkdir /opt/eosio/bin/data-dir
+fi
+
 if [ -f '/opt/eosio/bin/data-dir/config.ini' ]; then
     echo
   else


### PR DESCRIPTION
Best practices dictate that you do not define VOLUMEs in the DockerFile.

Instead the volume should be defined in the docker-compose.yml file such that you can name them so they are not 'lost' and can be identified later and managed. 
Creating them during the build means they are only used during the image creation process and then are never utilized again.   This is a wasted effort plus a waste of disk space.
