### PR TITLE
Fixed Bug Ignoring Action Name in ABI Generation

### DIFF
--- a/libraries/abi_generator/abi_generator.cpp
+++ b/libraries/abi_generator/abi_generator.cpp
@@ -112,14 +112,19 @@ bool abi_generator::inspect_type_methods_for_actions(const Decl* decl) { try {
 
     // Try to get "action" annotation from method comment
     bool raw_comment_is_action = false;
+    string action_name_from_comment;
     const RawComment* raw_comment = ast_context->getRawCommentForDeclNoCache(method);
     if(raw_comment != nullptr) {
       SourceManager& source_manager = ast_context->getSourceManager();
       string raw_text = raw_comment->getRawText(source_manager);
-      regex r(R"(@abi (action)((?: [a-z0-9]+)*))");
+      regex r(R"(@abi (action) ?((?:[a-z0-9]+)*))");
       smatch smatch;
       regex_search(raw_text, smatch, r);
       raw_comment_is_action = smatch.size() == 3;
+
+      if (raw_comment_is_action) {
+        action_name_from_comment = smatch[2];
+      }
     }
 
     // Check if current method is listed the EOSIO_ABI macro
@@ -156,7 +161,8 @@ bool abi_generator::inspect_type_methods_for_actions(const Decl* decl) { try {
 
     full_types[method_name] = method_name;
 
-    output->actions.push_back({method_name, method_name, rc[method_name]});
+    string action_name = action_name_from_comment.empty() ? method_name : action_name_from_comment;
+    output->actions.push_back({action_name, method_name, rc[method_name]});
     at_least_one_action = true;
   };
 


### PR DESCRIPTION
# Problem

There is currently a bug in ABI generation with the program `eosio-abigen`. For a comment like:

    @abi action hi

The action name `hi` is ignored for good. The tool simple takes the method name and put it in the `name` field of the action.

This is **NOT** an intended behavior as shown by the RegEx found in the file `abi_generator.cpp`:

    (@abi (action)((?: [a-z0-9]+)*))

Obviously, there is supposed to be an optional trailing action name.

# The Need to Fix it

Sometimes we may want to use action names that are not allowed to be method names (e.g. C++ keywords like `register`). In this case, we would manually wire the request to a method with a different name as the action.

# Cause

The problem is two-fold:

## Incorrect RegEx

The third match of the following comment under the current RegEx would be `<space>hi`:

    @abi action hi

If the name is used directly, an error would be thrown due to invalid format.

## Name was Set to `method_name` Directly

The following line is found in the file `abi_generator.cpp`:

    output->actions.push_back({method_name, method_name, rc[method_name]});

The program puts `method_name` for both the `name` and `type` fields unconditionally, without respecting the action name specified in the comment.

# Solution

## Fix the RegEx

The original RegEx:

    (@abi (action)((?: [a-z0-9]+)*))

was changed to:

    (@abi (action) ?((?:[a-z0-9]+)*))

so that the action name can be captured properly.

## Capture the Optional Name if Present

A new variable `action_name_from_comment` is defined to capture the action name when `raw_comment_is_action` is true, and use it over `method_name` when it's not empty.

# Result

After the fix, the following action:

    /// @abi action hi
    void hey(account_name user)
    {
      print("Hello ", name{user});
    }

can be correctly transformed to:

    {
      "name": "hi",
      "type": "hey",
      "ricardian_contract": ""
    }