### PR TITLE
Don't change txn if already signed

### DIFF
--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -276,12 +276,11 @@ void sign_transaction(signed_transaction& trx, fc::variant& required_keys, const
 
 fc::variant push_transaction( signed_transaction& trx, int32_t extra_kcpu = 1000, packed_transaction::compression_type compression = packed_transaction::none ) {
    auto info = get_info();
-   if (trx.expiration == time_point_sec()) {
-      trx.expiration = info.head_block_time + tx_expiration;
-   }
 
-   // Set tapos, default to last irreversible block if it's not specified by the user
-   if (trx.ref_block_prefix == 0 && trx.ref_block_num == 0) {
+   if (trx.signatures.size() == 0) { // #5445 can't change txn content if already signed
+      trx.expiration = info.head_block_time + tx_expiration;
+
+      // Set tapos, default to last irreversible block if it's not specified by the user
       block_id_type ref_block_id = info.last_irreversible_block_id;
       try {
          fc::variant ref_block;
@@ -291,14 +290,14 @@ fc::variant push_transaction( signed_transaction& trx, int32_t extra_kcpu = 1000
          }
       } EOS_RETHROW_EXCEPTIONS(invalid_ref_block_exception, "Invalid reference block num or id: ${block_num_or_id}", ("block_num_or_id", tx_ref_block_num_or_id));
       trx.set_reference_block(ref_block_id);
-   }
 
-   if (tx_force_unique) {
-      trx.context_free_actions.emplace_back( generate_nonce_action() );
-   }
+      if (tx_force_unique) {
+         trx.context_free_actions.emplace_back( generate_nonce_action() );
+      }
 
-   trx.max_cpu_usage_ms = tx_max_cpu_usage;
-   trx.max_net_usage_words = (tx_max_net_usage + 7)/8;
+      trx.max_cpu_usage_ms = tx_max_cpu_usage;
+      trx.max_net_usage_words = (tx_max_net_usage + 7)/8;
+   }
 
    if (!tx_skip_sign) {
       auto required_keys = determine_required_keys(trx);


### PR DESCRIPTION
- Replaces #5457 rebased to `release/1.2.x`
- Resolves #5445 

Do not modify transaction if already signed.
