### PR TITLE
CPU greylist fixes

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -574,6 +574,7 @@ struct controller_impl {
              || (code == block_net_usage_exceeded::code_value)
              || (code == greylist_net_usage_exceeded::code_value)
              || (code == block_cpu_usage_exceeded::code_value)
+             || (code == greylist_cpu_usage_exceeded::code_value)
              || (code == deadline_exception::code_value)
              || (code == leeway_deadline_exception::code_value)
              || (code == actor_whitelist_exception::code_value)
@@ -714,7 +715,7 @@ struct controller_impl {
             auto& rl = self.get_mutable_resource_limits_manager();
             rl.update_account_usage( trx_context.bill_to_accounts, block_timestamp_type(self.pending_block_time()).slot );
             int64_t account_cpu_limit = 0;
-            std::tie( std::ignore, account_cpu_limit, std::ignore ) = trx_context.max_bandwidth_billed_accounts_can_pay( true );
+            std::tie( std::ignore, account_cpu_limit, std::ignore, std::ignore ) = trx_context.max_bandwidth_billed_accounts_can_pay( true );
 
             cpu_time_to_bill_us = static_cast<uint32_t>( std::min( std::min( static_cast<int64_t>(cpu_time_to_bill_us),
                                                                              account_cpu_limit                          ),

--- a/libraries/chain/include/eosio/chain/exceptions.hpp
+++ b/libraries/chain/include/eosio/chain/exceptions.hpp
@@ -268,6 +268,8 @@ namespace eosio { namespace chain {
                                     3080006, "Transaction took too long" )
       FC_DECLARE_DERIVED_EXCEPTION( greylist_net_usage_exceeded, resource_exhausted_exception,
                                     3080007, "Transaction exceeded the current greylisted account network usage limit" )
+      FC_DECLARE_DERIVED_EXCEPTION( greylist_cpu_usage_exceeded, resource_exhausted_exception,
+                                    3080008, "Transaction exceeded the current greylisted account CPU usage limit" )
       FC_DECLARE_DERIVED_EXCEPTION( leeway_deadline_exception, deadline_exception,
                                     3081001, "Transaction reached the deadline set due to leeway on account CPU limits" )
 

--- a/libraries/chain/include/eosio/chain/transaction_context.hpp
+++ b/libraries/chain/include/eosio/chain/transaction_context.hpp
@@ -42,7 +42,7 @@ namespace eosio { namespace chain {
 
          uint32_t update_billed_cpu_time( fc::time_point now );
 
-         std::tuple<int64_t, int64_t, bool> max_bandwidth_billed_accounts_can_pay( bool force_elastic_limits = false )const;
+         std::tuple<int64_t, int64_t, bool, bool> max_bandwidth_billed_accounts_can_pay( bool force_elastic_limits = false )const;
 
       private:
 
@@ -97,6 +97,8 @@ namespace eosio { namespace chain {
          bool                          net_limit_due_to_greylist = false;
          uint64_t                      eager_net_limit = 0;
          uint64_t&                     net_usage; /// reference to trace->net_usage
+
+         bool                          cpu_limit_due_to_greylist = false;
 
          fc::microseconds              initial_objective_duration_limit;
          fc::microseconds              objective_duration_limit;

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -277,11 +277,11 @@ namespace eosio { namespace chain {
                           ("net_usage", net_usage)("net_limit", eager_net_limit) );
             }  else if (net_limit_due_to_greylist) {
                EOS_THROW( greylist_net_usage_exceeded,
-                          "net usage of transaction is too high: ${net_usage} > ${net_limit}",
+                          "greylisted transaction net usage is too high: ${net_usage} > ${net_limit}",
                           ("net_usage", net_usage)("net_limit", eager_net_limit) );
             } else {
                EOS_THROW( tx_net_usage_exceeded,
-                          "net usage of transaction is too high: ${net_usage} > ${net_limit}",
+                          "transaction net usage is too high: ${net_usage} > ${net_limit}",
                           ("net_usage", net_usage)("net_limit", eager_net_limit) );
             }
          }
@@ -302,7 +302,7 @@ namespace eosio { namespace chain {
             } else if( deadline_exception_code == tx_cpu_usage_exceeded::code_value ) {
                if (cpu_limit_due_to_greylist) {
                   EOS_THROW( greylist_cpu_usage_exceeded,
-                           "transaction was executing for too long",
+                           "greylisted transaction was executing for too long",
                            ("now", now)("deadline", _deadline)("start", start)("billing_timer", now - pseudo_start) );
                } else {
                   EOS_THROW( tx_cpu_usage_exceeded,

--- a/plugins/http_plugin/http_plugin.cpp
+++ b/plugins/http_plugin/http_plugin.cpp
@@ -468,9 +468,11 @@ namespace eosio {
          } catch (fc::exception& e) {
             error_results results{500, "Internal Service Error", error_results::error_info(e, verbose_http_errors)};
             cb( 500, fc::json::to_string( results ));
-            elog( "FC Exception encountered while processing ${api}.${call}",
-                  ("api", api_name)( "call", call_name ));
-            dlog( "Exception Details: ${e}", ("e", e.to_detail_string()));
+            if (e.code() != chain::greylist_net_usage_exceeded::code_value && e.code() != chain::greylist_cpu_usage_exceeded::code_value) {
+               elog( "FC Exception encountered while processing ${api}.${call}",
+                     ("api", api_name)( "call", call_name ));
+               dlog( "Exception Details: ${e}", ("e", e.to_detail_string()));
+            }
          } catch (std::exception& e) {
             error_results results{500, "Internal Service Error", error_results::error_info(fc::exception( FC_LOG_MESSAGE( error, e.what())), verbose_http_errors)};
             cb( 500, fc::json::to_string( results ));

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2492,7 +2492,9 @@ namespace eosio {
       chain_plug->accept_transaction(msg, [=](const static_variant<fc::exception_ptr, transaction_trace_ptr>& result) {
          if (result.contains<fc::exception_ptr>()) {
             auto e_ptr = result.get<fc::exception_ptr>();
-            if (e_ptr->code() != tx_duplicate::code_value && e_ptr->code() != expired_tx_exception::code_value) {
+            if (e_ptr->code() != tx_duplicate::code_value && e_ptr->code() != expired_tx_exception::code_value 
+                && e_ptr->code() != greylist_net_usage_exceeded::code_value 
+                && e_ptr->code() != greylist_cpu_usage_exceeded::code_value) {
                elog("accept txn threw  ${m}",("m",result.get<fc::exception_ptr>()->to_detail_string()));
                peer_elog(c, "bad packed_transaction : ${m}", ("m",result.get<fc::exception_ptr>()->what()));
             }


### PR DESCRIPTION
Replaces #5439 rebased to release/1.2.x.

When a transaction exhausts CPU resources possibly due to greylisting, it will throw a subjective `greylist_cpu_usage_exceeded` rather than an objective `tx_cpu_usage_exceeded`. Beyond being more accurate in its description, this has important implications when it comes to CPU resource exhaustion in deferred transactions. A producer with greylisting enabled could fail a deferred transaction in a manner that is not reproducible during validation (since greylisting does not apply during validation), which would lead to generating blocks that are rejected by all other nodes.

This PR also suppresses logging greylist related exceptions within the http plugin.

Note that the current greylisting code (both before and after the changes in this PR) modifies the values of `net_limit` and `objective_duration_limit` in `transaction_context::finalize` based on subjective data (the non-elastic limits used only for those accounts in the local greylist) thus making those variables no longer objective generally. This doesn't break the greylisting feature, but I think it isn't appropriate use of those variables and could potentially lead to future problems if those variables are later used in ways that assume they must be objective. In short, this part of the code is in need of a refactor to clean up a lot of the complicated and hard-to-follow logic, but this patch release is not the time for it.