### PR TITLE
Simplify Wallet Tools EOSIO Blockchain Detection for End Users

### DIFF
--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -947,6 +947,8 @@ read_only::get_info_results read_only::get_info(const read_only::get_info_params
       //std::bitset<64>(db.get_dynamic_global_properties().recent_slots_filled).to_string(),
       //__builtin_popcountll(db.get_dynamic_global_properties().recent_slots_filled) / 64.0,
       app().version_string(),
+      symbol().name(),
+      symbol().precision(),
    };
 }
 

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -98,7 +98,7 @@ public:
       //double                  participation_rate = 0;
       optional<string>        server_version_string;
       string                  core_symbol;
-      uint64_t                precision;
+      uint64_t                core_symbol_precision;
    };
    get_info_results get_info(const get_info_params&) const;
 
@@ -617,7 +617,7 @@ private:
 FC_REFLECT( eosio::chain_apis::permission, (perm_name)(parent)(required_auth) )
 FC_REFLECT(eosio::chain_apis::empty, )
 FC_REFLECT(eosio::chain_apis::read_only::get_info_results,
-(server_version)(chain_id)(head_block_num)(last_irreversible_block_num)(last_irreversible_block_id)(head_block_id)(head_block_time)(head_block_producer)(virtual_block_cpu_limit)(virtual_block_net_limit)(block_cpu_limit)(block_net_limit)(server_version_string)(core_symbol)(precision) )
+(server_version)(chain_id)(head_block_num)(last_irreversible_block_num)(last_irreversible_block_id)(head_block_id)(head_block_time)(head_block_producer)(virtual_block_cpu_limit)(virtual_block_net_limit)(block_cpu_limit)(block_net_limit)(server_version_string)(core_symbol)(core_symbol_precision) )
 FC_REFLECT(eosio::chain_apis::read_only::get_block_params, (block_num_or_id))
 FC_REFLECT(eosio::chain_apis::read_only::get_block_header_state_params, (block_num_or_id))
 

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -97,6 +97,8 @@ public:
       //string                  recent_slots;
       //double                  participation_rate = 0;
       optional<string>        server_version_string;
+      string                  core_symbol;
+      uint64_t                precision;
    };
    get_info_results get_info(const get_info_params&) const;
 
@@ -615,7 +617,7 @@ private:
 FC_REFLECT( eosio::chain_apis::permission, (perm_name)(parent)(required_auth) )
 FC_REFLECT(eosio::chain_apis::empty, )
 FC_REFLECT(eosio::chain_apis::read_only::get_info_results,
-(server_version)(chain_id)(head_block_num)(last_irreversible_block_num)(last_irreversible_block_id)(head_block_id)(head_block_time)(head_block_producer)(virtual_block_cpu_limit)(virtual_block_net_limit)(block_cpu_limit)(block_net_limit)(server_version_string) )
+(server_version)(chain_id)(head_block_num)(last_irreversible_block_num)(last_irreversible_block_id)(head_block_id)(head_block_time)(head_block_producer)(virtual_block_cpu_limit)(virtual_block_net_limit)(block_cpu_limit)(block_net_limit)(server_version_string)(core_symbol)(precision) )
 FC_REFLECT(eosio::chain_apis::read_only::get_block_params, (block_num_or_id))
 FC_REFLECT(eosio::chain_apis::read_only::get_block_header_state_params, (block_num_or_id))
 

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -97,8 +97,8 @@ public:
       //string                  recent_slots;
       //double                  participation_rate = 0;
       optional<string>        server_version_string;
-      string                  core_symbol;
-      uint64_t                core_symbol_precision;
+      optional<string>                  core_symbol;
+      optional<uint64_t>                core_symbol_precision;
    };
    get_info_results get_info(const get_info_params&) const;
 


### PR DESCRIPTION
Follow-up to thread: https://github.com/EOSIO/eos/pull/5438

A simple addition of core_symbol to get_info results will go a long way in making it easier for users to interact with all EOSIO chains, by simply entering an endpoint. The get_info results from this endpoint should return not only the chain info as is today, but also the CORE_SYMBOL, making EOSIO extremely easy to interact with/configure for multi-chain use from an end user's perspective. Both eosjs and eosjs-ecc supports different prefixes for public keys (e.g EOSxxx, TLOSxxx, etc), so core support for returning the core symbol can help make multichain support faster and out of the box!

