### PR TITLE
Unit test for self-cancelling deferred transaction bug

### DIFF
--- a/contracts/test_api/test_api.cpp
+++ b/contracts/test_api/test_api.cpp
@@ -148,6 +148,7 @@ extern "C" {
       WASM_TEST_HANDLER(test_transaction, context_free_api);
       WASM_TEST_HANDLER(test_transaction, new_feature);
       WASM_TEST_HANDLER(test_transaction, active_new_feature);
+      WASM_TEST_HANDLER_EX(test_transaction, repeat_deferred_transaction);
 
       //test chain
       WASM_TEST_HANDLER(test_chain, test_activeprods);

--- a/contracts/test_api/test_api.hpp
+++ b/contracts/test_api/test_api.hpp
@@ -181,6 +181,7 @@ struct test_transaction {
   static void context_free_api();
   static void new_feature();
   static void active_new_feature();
+  static void repeat_deferred_transaction(uint64_t receiver, uint64_t code, uint64_t action);
 };
 
 struct test_chain {

--- a/contracts/test_api/test_transaction.cpp
+++ b/contracts/test_api/test_transaction.cpp
@@ -317,3 +317,23 @@ void test_transaction::new_feature() {
 void test_transaction::active_new_feature() {
    activate_feature((int64_t)N(newfeature));
 }
+
+void test_transaction::repeat_deferred_transaction(uint64_t receiver, uint64_t code, uint64_t action) {
+   using namespace eosio;
+
+   uint128_t sender_id = 0;
+
+   uint32_t payload = unpack_action_data<uint32_t>();
+   print( "repeat_deferred_transaction called: payload = ", payload );
+
+   bool res = cancel_deferred( sender_id );
+
+   print( "\nrepeat_deferred_transaction cancelled trx with sender_id = ", sender_id, ", result is ", res );
+
+   if( payload == 0 ) return;
+
+   --payload;
+   transaction trx;
+   trx.actions.emplace_back( permission_level{receiver, N(active)}, code, action, payload );
+   trx.send( sender_id, receiver );
+}


### PR DESCRIPTION
Adds the unit test for the self-cancelling deferred transactions bug that was fixed a month ago in v1.1.1.
