### PR TITLE
4904 add hint if launcher fails, more reliable port available check

### DIFF
--- a/programs/eosio-launcher/main.cpp
+++ b/programs/eosio-launcher/main.cpp
@@ -596,7 +596,7 @@ launcher_def::initialize (const variables_map &vmap) {
 
   stage = bfs::path(erd);
   if (!bfs::exists(stage)) {
-    cerr << erd << " is not a valid path" << endl;
+    cerr << "\"" << erd << "\" is not a valid path. Please ensure environment variable EOSIO_HOME is set to the build path." << endl;
     exit (-1);
   }
   stage /= bfs::path("staging");

--- a/tests/Cluster.py
+++ b/tests/Cluster.py
@@ -118,9 +118,13 @@ class Cluster(object):
             assert(isinstance(totalProducers, (str,int)))
             producerFlag="--producers %s" % (totalProducers)
 
-        if not Cluster.arePortsAvailable(set(range(self.port, self.port+totalNodes+1))):
-            Utils.Print("ERROR: Another process is listening on nodeos default port.")
-            return False
+        tries = 30
+        while not Cluster.arePortsAvailable(set(range(self.port, self.port+totalNodes+1))):
+            Utils.Print("ERROR: Another process is listening on nodeos default port. wait...")
+            if tries == 0:
+                return False
+            tries = tries - 1
+            time.sleep(2)
 
         cmd="%s -p %s -n %s -s %s -d %s -i %s -f --p2p-plugin %s %s" % (
             Utils.EosLauncherPath, pnodes, totalNodes, topo, delay, datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3],
@@ -147,7 +151,7 @@ class Cluster(object):
         s=" ".join(cmdArr)
         if Utils.Debug: Utils.Print("cmd: %s" % (s))
         if 0 != subprocess.call(cmdArr):
-            Utils.Print("ERROR: Launcher failed to launch.")
+            Utils.Print("ERROR: Launcher failed to launch. failed cmd: %s" % (s))
             return False
 
         self.nodes=list(range(totalNodes)) # placeholder for cleanup purposes only


### PR DESCRIPTION
provide hint (env EOSIO_HOME) to issue #4904 #4765  or similar test failed issues.