### PR TITLE
allow local CMAKE flags in eosio_build.sh

### DIFF
--- a/eosio_build.sh
+++ b/eosio_build.sh
@@ -258,7 +258,7 @@
       -DCMAKE_C_COMPILER="${C_COMPILER}" -DWASM_ROOT="${WASM_ROOT}" -DCORE_SYMBOL_NAME="${CORE_SYMBOL_NAME}" \
       -DOPENSSL_ROOT_DIR="${OPENSSL_ROOT_DIR}" -DBUILD_MONGO_DB_PLUGIN=true \
       -DENABLE_COVERAGE_TESTING="${ENABLE_COVERAGE_TESTING}" -DBUILD_DOXYGEN="${DOXYGEN}" \
-      -DCMAKE_INSTALL_PREFIX="/usr/local/eosio" "${SOURCE_DIR}"
+      -DCMAKE_INSTALL_PREFIX="/usr/local/eosio" ${LOCAL_CMAKE_FLAGS} "${SOURCE_DIR}"
    then
       printf "\\n\\t>>>>>>>>>>>>>>>>>>>> CMAKE building EOSIO has exited with the above error.\\n\\n"
       exit -1


### PR DESCRIPTION
Fixes https://github.com/EOSIO/eos/issues/5229

```
LOCAL_CMAKE_FLAGS="-DEOSIO_ADDITIONAL_PLUGINS=your_plugin_dir" ./eosio_build.sh
```
Allow to build external plugins

credits to @cc32d9