### PR TITLE
fix ambiguous command line option for filter-on/out

### DIFF
--- a/plugins/history_plugin/history_plugin.cpp
+++ b/plugins/history_plugin/history_plugin.cpp
@@ -303,7 +303,7 @@ namespace eosio {
              "Track actions which match receiver:action:actor. Actor may be blank to include all. Action and Actor both blank allows all from Recieiver. Receiver may not be blank.")
             ;
       cfg.add_options()
-            ("filter-out,f", bpo::value<vector<string>>()->composing(),
+            ("filter-out,F", bpo::value<vector<string>>()->composing(),
              "Do not track actions which match receiver:action:actor. Action and Actor both blank excludes all from Reciever. Actor blank excludes all from reciever:action. Receiver may not be blank.")
             ;
    }


### PR DESCRIPTION
It's impossible to use filter-on/out's short command line option due to them being the same
```
Dynamic exception type: boost::exception_detail::clone_impl<boost::exception_detail::error_info_injector<boost::program_options::ambiguous_option> >
std::exception::what: option '-f' is ambiguous and matches '--filter-on', and '--filter-out'
```
Change filter-out's short option to be -F