### PR TITLE
remove unused variables from authorization_manager

### DIFF
--- a/libraries/chain/authorization_manager.cpp
+++ b/libraries/chain/authorization_manager.cpp
@@ -448,7 +448,6 @@ namespace eosio { namespace chain {
                   ("provided_delay", provided_delay.count()/1000)
                   ("provided_permissions", provided_permissions)
                   ("provided_keys", provided_keys)
-                  ("delay_max_limit_ms", delay_max_limit.count()/1000)
                 );
 
       if( !allow_unused_keys ) {


### PR DESCRIPTION
Remove unused variables from authorization_manager.
It is not necessary I think.