### PR TITLE
Remove unused variable

### DIFF
--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -568,11 +568,6 @@ chain::action create_transfer(const string& contract, const name& sender, const 
       ("quantity", amount)
       ("memo", memo);
 
-   auto args = fc::mutable_variant_object
-      ("code", contract)
-      ("action", "transfer")
-      ("args", transfer);
-
    return action {
       tx_permission.empty() ? vector<chain::permission_level>{{sender,config::active_name}} : get_account_permissions(tx_permission),
       contract, "transfer", variant_to_bin( contract, N(transfer), transfer )


### PR DESCRIPTION
`args` is declared in `create_transfer()` function, but never used.