### PR TITLE
Fix unchecked unapplied transaction growth on relays

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1744,6 +1744,10 @@ void controller::drop_unapplied_transaction(const transaction_metadata_ptr& trx)
    my->unapplied_transactions.erase(trx->signed_id);
 }
 
+void controller::drop_all_unapplied_transactions() {
+   my->unapplied_transactions.clear();
+}
+
 vector<transaction_id_type> controller::get_scheduled_transactions() const {
    const auto& idx = db().get_index<generated_transaction_multi_index,by_delay>();
 

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -107,6 +107,7 @@ namespace eosio { namespace chain {
           */
          vector<transaction_metadata_ptr> get_unapplied_transactions() const;
          void drop_unapplied_transaction(const transaction_metadata_ptr& trx);
+         void drop_all_unapplied_transactions();
 
          /**
           * These transaction IDs represent transactions available in the head chain state as scheduled

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -896,11 +896,8 @@ fc::time_point producer_plugin_impl::calculate_pending_block_time() const {
 producer_plugin_impl::start_block_result producer_plugin_impl::start_block(bool &last_block) {
    chain::controller& chain = app().get_plugin<chain_plugin>().chain();
 
-   if( chain.get_read_mode() == chain::db_read_mode::READ_ONLY ) {
-      // a read only node will never need the unapplied transactions.  so, let controller drop them
-      chain.drop_all_unapplied_transactions();
+   if( chain.get_read_mode() == chain::db_read_mode::READ_ONLY )
       return start_block_result::waiting;
-   }
 
    const auto& hbs = chain.head_block_state();
 

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -80,23 +80,6 @@ using transaction_id_with_expiry_index = multi_index_container<
    >
 >;
 
-struct lazy_unapplied_transactions {
-   lazy_unapplied_transactions (const controller& _controller)
-   : _controller(_controller)
-   {
-   }
-
-   vector<transaction_metadata_ptr>& get() {
-      if (!_data) {
-         _data.emplace(_controller.get_unapplied_transactions());
-      }
-      return *_data;
-   }
-
-   optional<vector<transaction_metadata_ptr>>   _data;
-   const  controller&                           _controller;
-};
-
 enum class pending_block_mode {
    producing,
    speculating
@@ -992,18 +975,18 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block(bool 
 
       try {
          size_t orig_pending_txn_size = _pending_incoming_transactions.size();
-         lazy_unapplied_transactions lazy_unapplied_trxs(chain);
 
-         // step one, if we will never produce, prune unapplied to our persisted trxs
-         if (_producers.empty()) {
+         // Processing unapplied transactions...
+         //
+         if (_producers.empty() && persisted_by_id.empty()) {
+            // if this node can never produce and has no persisted transactions,
+            // there is no need for unapplied transactions they can be dropped
+            chain.drop_all_unapplied_transactions();
+         } else {
+            auto unapplied_trxs = chain.get_unapplied_transactions();
 
-            auto& unapplied_trxs = lazy_unapplied_trxs.get();
-
-            if (persisted_by_id.empty()) {
-               chain.drop_all_unapplied_transactions();
-               unapplied_trxs.clear();
-
-            } else {
+            // step one, if we will never produce, prune unapplied to our persisted trxs
+            if (_producers.empty()) {
                for (auto itr = unapplied_trxs.begin(); itr != unapplied_trxs.end(); ) {
                   const auto& trx = *itr;
                   if (persisted_by_id.find(trx->id) == persisted_by_id.end()) {
@@ -1015,85 +998,80 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block(bool 
                      ++itr;
                   }
                }
-            }
-         } else {
-
-            // step two, if we may one day produce at least prune the expired trxs
-            auto& unapplied_trxs = lazy_unapplied_trxs.get();
-            for (auto itr = unapplied_trxs.begin(); itr != unapplied_trxs.end(); ) {
-               const auto& trx = *itr;
-               if (trx->packed_trx.expiration() < pbs->header.timestamp.to_time_point()) {
-                  // expired, drop it
-                  chain.drop_unapplied_transaction(trx);
-                  std::iter_swap(itr, std::min_element(itr, unapplied_trxs.end()));
-                  unapplied_trxs.pop_back();
-               } else {
-                  ++itr;
+            } else {
+               // step two, if we may one day produce at least prune the expired trxs
+               for (auto itr = unapplied_trxs.begin(); itr != unapplied_trxs.end(); ) {
+                  const auto& trx = *itr;
+                  if (trx->packed_trx.expiration() < pbs->header.timestamp.to_time_point()) {
+                     // expired, drop it
+                     chain.drop_unapplied_transaction(trx);
+                     std::iter_swap(itr, std::min_element(itr, unapplied_trxs.end()));
+                     unapplied_trxs.pop_back();
+                  } else {
+                     ++itr;
+                  }
                }
             }
-         }
 
-         // step three if we have persisted transactions apply them regarless of mode
-         if (!persisted_by_expiry.empty()) {
-            auto& unapplied_trxs = lazy_unapplied_trxs.get();
-            for (auto itr = unapplied_trxs.begin(); itr != unapplied_trxs.end();) {
-               const auto& trx = *itr;
-               if (persisted_by_id.find(trx->id) != persisted_by_id.end()) {
+            // step three if we have persisted transactions apply them regarless of mode
+            if (!persisted_by_expiry.empty()) {
+               for (auto itr = unapplied_trxs.begin(); itr != unapplied_trxs.end();) {
+                  const auto& trx = *itr;
+                  if (persisted_by_id.find(trx->id) != persisted_by_id.end()) {
 
-                  // this is a persisted transaction, push it into the block (even if we are speculating) with
-                  // no deadline as it has already passed the subjective deadlines once and we want to represent
-                  // the state of the chain including this transaction
+                     // this is a persisted transaction, push it into the block (even if we are speculating) with
+                     // no deadline as it has already passed the subjective deadlines once and we want to represent
+                     // the state of the chain including this transaction
+                     try {
+                        chain.push_transaction(trx, fc::time_point::maximum());
+                     } catch ( const guard_exception& e ) {
+                        app().get_plugin<chain_plugin>().handle_guard_exception(e);
+                        return start_block_result::failed;
+                     } FC_LOG_AND_DROP();
+
+                     // remove it from further consideration as it is applied and either
+                     // failed and was removed -or-
+                     // subjectively failed and should be tried _next_ block
+
+                     std::iter_swap(itr, std::min_element(itr, unapplied_trxs.end()));
+                     unapplied_trxs.pop_back();
+                  } else {
+                     ++itr;
+                  }
+               }
+            }
+
+            // FINAL STEP FOUR if we are producing, attempt to apply unapplied transactions
+            // if this becomes the none final step it will need to prune the local cache of unapplied transactions
+            if (_pending_block_mode == pending_block_mode::producing) {
+               for (const auto& trx : unapplied_trxs) {
+                  if (block_time <= fc::time_point::now()) exhausted = true;
+                  if (exhausted) {
+                     break;
+                  }
+
                   try {
-                     chain.push_transaction(trx, fc::time_point::maximum());
+                     auto deadline = fc::time_point::now() + fc::milliseconds(_max_transaction_time_ms);
+                     bool deadline_is_subjective = false;
+                     if (_max_transaction_time_ms < 0 || (_pending_block_mode == pending_block_mode::producing && block_time < deadline)) {
+                        deadline_is_subjective = true;
+                        deadline = block_time;
+                     }
+
+                     auto trace = chain.push_transaction(trx, deadline);
+                     if (trace->except) {
+                        if (failure_is_subjective(*trace->except, deadline_is_subjective)) {
+                           exhausted = true;
+                        } else {
+                           // this failed our configured maximum transaction time, we don't want to replay it
+                           chain.drop_unapplied_transaction(trx);
+                        }
+                     }
                   } catch ( const guard_exception& e ) {
                      app().get_plugin<chain_plugin>().handle_guard_exception(e);
                      return start_block_result::failed;
                   } FC_LOG_AND_DROP();
-
-                  // remove it from further consideration as it is applied and either
-                  // failed and was removed -or-
-                  // subjectively failed and should be tried _next_ block
-
-                  std::iter_swap(itr, std::min_element(itr, unapplied_trxs.end()));
-                  unapplied_trxs.pop_back();
-               } else {
-                  ++itr;
                }
-            }
-         }
-
-         // FINAL STEP FOUR if we are producing, attempt to apply unapplied transactions
-         // if this becomes the none final step it will need to prune the local cache of unapplied transactions
-         if (_pending_block_mode == pending_block_mode::producing) {
-            auto& unapplied_trxs = lazy_unapplied_trxs.get();
-
-            for (const auto& trx : unapplied_trxs) {
-               if (block_time <= fc::time_point::now()) exhausted = true;
-               if (exhausted) {
-                  break;
-               }
-
-               try {
-                  auto deadline = fc::time_point::now() + fc::milliseconds(_max_transaction_time_ms);
-                  bool deadline_is_subjective = false;
-                  if (_max_transaction_time_ms < 0 || (_pending_block_mode == pending_block_mode::producing && block_time < deadline)) {
-                     deadline_is_subjective = true;
-                     deadline = block_time;
-                  }
-
-                  auto trace = chain.push_transaction(trx, deadline);
-                  if (trace->except) {
-                     if (failure_is_subjective(*trace->except, deadline_is_subjective)) {
-                        exhausted = true;
-                     } else {
-                        // this failed our configured maximum transaction time, we don't want to replay it
-                        chain.drop_unapplied_transaction(trx);
-                     }
-                  }
-               } catch ( const guard_exception& e ) {
-                  app().get_plugin<chain_plugin>().handle_guard_exception(e);
-                  return start_block_result::failed;
-               } FC_LOG_AND_DROP();
             }
          }
 


### PR DESCRIPTION
Unapplied transactions were only being pruned in a few instances:
- when an HTTP RPC request was made to the node, the node would persistently attempt to apply that transaction until it was done OR expired, cleaning it up appropriately
- when a Producer attempts to produce a block, it would apply as many unapplied transactions as it could, cleaning them up appropriately

This means that relay nodes which never produce would also never prune the unapplied list.

We now have 4 phases:

1. [If not a producing node] prune all unapplied transactions that are not "persisted" due to being directly received over HTTP RPC
1. [If potentially producing] prune all unapplied transactions that expired
1. [If not "read only"] attempt application of all unapplied transactions that are "persisted" due to being directly received over HTTP RPC
1. [If producing the next block] attempt application of all remaining unapplied transactions

Each of these phases potentially prunes.  Phases 1 & 2 are the new phases that cover P2P relays

Additionally, Read-only nodes were never pruning the unapplied transactions.  As they will never have need of them, nodes configured in this mode will unilaterally drop all unapplied transactions

However, a p2p relay node neither producers no accepts the transactions