### PR TITLE
rewrote dockerfile

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -7,23 +7,23 @@ RUN cmake -DBINARYEN_BIN=/eos/externals/binaryen/bin -DWASM_ROOT=/opt/wasm -DOPE
     make && \
     make install
 
-# FROM ubuntu:18.04
+FROM ubuntu:18.04
 
-# RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install openssl ca-certificates
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install openssl ca-certificates curl
 
-# COPY --from=builder /usr/local/eosio/bin/ /opt/eosio/bin
-# COPY --from=builder /eos/contracts /  
+COPY --from=builder /usr/local/eosio/bin/ /opt/eosio/bin
+COPY --from=builder /eos/contracts /  
 
-# # ###########
-# # # Uncomment the COPY function below to copy a directory that contains your config.ini and genesis.json file 
-# # # if you want to indicate custom parameters. This command assumes that both congig.ini and genesis.json are
-# # # located in a folder called config within your present working directory. 
-# # ###########
+# ###########
+# # Uncomment the COPY function below to copy a directory that contains your config.ini and genesis.json file 
+# # if you want to indicate custom parameters. This command assumes that both congig.ini and genesis.json are
+# # located in a folder called config within your present working directory. 
+# ###########
 
-# # # COPY /config /
+# # COPY /config /
 
-# ENV EOSIO_ROOT=/opt/eosio
-# ENV PATH /opt/eosio/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-# EXPOSE 8889 8899 8999
+ENV EOSIO_ROOT=/opt/eosio
+ENV PATH /opt/eosio/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+EXPOSE 8889 8899 8999
 
-# CMD ["/bin/bash"]
+CMD ["/bin/bash"]

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,25 +1,21 @@
 FROM eosio/builder as builder
-ARG branch=master
-ARG symbol=SYS
 
-RUN git clone -b $branch https://github.com/EOSIO/eos.git --recursive \
-    && cd eos && echo "$branch:$(git rev-parse HEAD)" > /etc/eosio-version \
-    && cmake -H. -B"/tmp/build" -GNinja -DCMAKE_BUILD_TYPE=Release -DWASM_ROOT=/opt/wasm -DCMAKE_CXX_COMPILER=clang++ \
-       -DCMAKE_C_COMPILER=clang -DCMAKE_INSTALL_PREFIX=/tmp/build  -DSecp256k1_ROOT_DIR=/usr/local -DBUILD_MONGO_DB_PLUGIN=true -DCORE_SYMBOL_NAME=$symbol \
-    && cmake --build /tmp/build --target install && rm /tmp/build/bin/eosiocpp
+RUN git clone https://github.com/EOSIO/eos.git --recursive 
+WORKDIR /eos
+RUN cmake -DBINARYEN_BIN=/eos/externals/binaryen/bin -DWASM_ROOT=/opt/wasm -DOPENSSL_ROOT_DIR=/usr/bin/openssl -DOPENSSL_LIBRARIES=/usr/lib/ssl -DBUILD_MONGO_DB_PLUGIN=true .
+RUN make 
+RUN make install
 
+ENV PATH=/usr/local/eosio/bin/:$PATH
 
 FROM ubuntu:18.04
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install openssl ca-certificates && rm -rf /var/lib/apt/lists/*
-COPY --from=builder /usr/local/lib/* /usr/local/lib/
-COPY --from=builder /tmp/build/bin /opt/eosio/bin
-COPY --from=builder /tmp/build/contracts /contracts
-COPY --from=builder /eos/Docker/config.ini /
-COPY --from=builder /etc/eosio-version /etc
-COPY --from=builder /eos/Docker/nodeosd.sh /opt/eosio/bin/nodeosd.sh
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install openssl ca-certificates
+COPY --from=builder /usr/local/eosio/bin/ /opt/eosio/bin
+COPY --from=builder /eos/contracts /  
 ENV EOSIO_ROOT=/opt/eosio
-RUN chmod +x /opt/eosio/bin/nodeosd.sh
-ENV LD_LIBRARY_PATH /usr/local/lib
-VOLUME /opt/eosio/bin/data-dir
 ENV PATH /opt/eosio/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+EXPOSE 8889 8899
+
+CMD ["/bin/bash"]

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,21 +1,29 @@
 FROM eosio/builder as builder
 
 RUN git clone https://github.com/EOSIO/eos.git --recursive 
-WORKDIR /eos
-RUN cmake -DBINARYEN_BIN=/eos/externals/binaryen/bin -DWASM_ROOT=/opt/wasm -DOPENSSL_ROOT_DIR=/usr/bin/openssl -DOPENSSL_LIBRARIES=/usr/lib/ssl -DBUILD_MONGO_DB_PLUGIN=true .
-RUN make 
-RUN make install
 
-ENV PATH=/usr/local/eosio/bin/:$PATH
+WORKDIR /eos
+RUN cmake -DBINARYEN_BIN=/eos/externals/binaryen/bin -DWASM_ROOT=/opt/wasm -DOPENSSL_ROOT_DIR=/usr/bin/openssl -DOPENSSL_LIBRARIES=/usr/lib/ssl -DBUILD_MONGO_DB_PLUGIN=true . && \
+    make && \
+    make install
 
 FROM ubuntu:18.04
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install openssl ca-certificates
+
 COPY --from=builder /usr/local/eosio/bin/ /opt/eosio/bin
 COPY --from=builder /eos/contracts /  
+
+###########
+# Uncomment the COPY function below to copy a directory that contains your config.ini and genesis.json file 
+# if you want to indicate custom parameters. This command assumes that both congig.ini and genesis.json are
+# located in a folder called config within your present working directory. 
+###########
+
+# COPY /config /
+
 ENV EOSIO_ROOT=/opt/eosio
 ENV PATH /opt/eosio/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-
 EXPOSE 8889 8899
 
 CMD ["/bin/bash"]

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -7,23 +7,23 @@ RUN cmake -DBINARYEN_BIN=/eos/externals/binaryen/bin -DWASM_ROOT=/opt/wasm -DOPE
     make && \
     make install
 
-FROM ubuntu:18.04
+# FROM ubuntu:18.04
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install openssl ca-certificates
+# RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install openssl ca-certificates
 
-COPY --from=builder /usr/local/eosio/bin/ /opt/eosio/bin
-COPY --from=builder /eos/contracts /  
+# COPY --from=builder /usr/local/eosio/bin/ /opt/eosio/bin
+# COPY --from=builder /eos/contracts /  
 
-###########
-# Uncomment the COPY function below to copy a directory that contains your config.ini and genesis.json file 
-# if you want to indicate custom parameters. This command assumes that both congig.ini and genesis.json are
-# located in a folder called config within your present working directory. 
-###########
+# # ###########
+# # # Uncomment the COPY function below to copy a directory that contains your config.ini and genesis.json file 
+# # # if you want to indicate custom parameters. This command assumes that both congig.ini and genesis.json are
+# # # located in a folder called config within your present working directory. 
+# # ###########
 
-# COPY /config /
+# # # COPY /config /
 
-ENV EOSIO_ROOT=/opt/eosio
-ENV PATH /opt/eosio/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-EXPOSE 8889 8899
+# ENV EOSIO_ROOT=/opt/eosio
+# ENV PATH /opt/eosio/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+# EXPOSE 8889 8899 8999
 
-CMD ["/bin/bash"]
+# CMD ["/bin/bash"]


### PR DESCRIPTION
Encountered a lot of errors and issues with the provided Dockerfile, so I rewrote it to compile as a static binary so the image requires no external dependencies. I've been using it for my own development purposes for a few days now and it seems to work pretty well so far. 