### PR TITLE
fix dereference empty optional bug in api_tests/transaction_tests

### DIFF
--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -1013,15 +1013,16 @@ BOOST_FIXTURE_TEST_CASE(transaction_tests, TESTER) { try {
       );
 
    {
-   produce_blocks(10);
-   transaction_trace_ptr trace;
-   auto c = control->applied_transaction.connect([&]( const transaction_trace_ptr& t) { if (t && t->receipt->status != transaction_receipt::executed) { trace = t; } } );
+      produce_blocks(10);
+      transaction_trace_ptr trace;
+      auto c = control->applied_transaction.connect([&]( const transaction_trace_ptr& t) { if (t && t->receipt && t->receipt->status != transaction_receipt::executed) { trace = t; } } );
 
-   // test error handling on deferred transaction failure
-   CALL_TEST_FUNCTION(*this, "test_transaction", "send_transaction_trigger_error_handler", {});
+      // test error handling on deferred transaction failure
+      CALL_TEST_FUNCTION(*this, "test_transaction", "send_transaction_trigger_error_handler", {});
 
-   BOOST_CHECK(trace);
-   BOOST_CHECK_EQUAL(trace->receipt->status, transaction_receipt::soft_fail);
+      BOOST_REQUIRE(trace);
+      BOOST_CHECK_EQUAL(trace->receipt->status, transaction_receipt::soft_fail);
+      c.disconnect();
    }
 
    // test test_transaction_size


### PR DESCRIPTION
The `applied_transaction` signal can be given a `transaction_trace` for a failed input transaction in which the receipt optional is empty.

Disconnect the connection to the `applied_transaction` signal that was only meant for the `send_transaction_trigger_error_handler` test after that particular unit test is completed. This ensures that the stale signal handling lambda function is not called when applying the later transactions in the test.

Furthermore, the signal handler should still check if the receipt is empty before attempting to dereference it even for the `send_transaction_trigger_error_handler` unit test, since the initial 
transaction to send the deferred transaction could fail, and it is better for the official failure in the Boost tests to be from `BOOST_REQUIRE(trace)` rather than from a `SIGABRT`.