### PR TITLE
Fix wording for Inline Action Depth Reached

### DIFF
--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -102,7 +102,7 @@ void apply_context::exec()
 
    if( _cfa_inline_actions.size() > 0 || _inline_actions.size() > 0 ) {
       EOS_ASSERT( recurse_depth < control.get_global_properties().configuration.max_inline_action_depth,
-                  transaction_exception, "inline action recursion depth reached" );
+                  transaction_exception, "max inline action depth per transaction reached" );
    }
 
    for( const auto& inline_action : _cfa_inline_actions ) {

--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -1041,7 +1041,7 @@ BOOST_FIXTURE_TEST_CASE(transaction_tests, TESTER) { try {
    // test send_action_recurse
    BOOST_CHECK_EXCEPTION(CALL_TEST_FUNCTION(*this, "test_transaction", "send_action_recurse", {}), eosio::chain::transaction_exception,
          [](const eosio::chain::transaction_exception& e) {
-            return expect_assert_message(e, "inline action recursion depth reached");
+            return expect_assert_message(e, "max inline action depth per transaction reached");
          }
       );
 


### PR DESCRIPTION
#5633 
Fixed wording to not erroneously indicate recursive and make it clear it is for the whole transaction