### PR TITLE
Test Control Startup Error

### DIFF
--- a/plugins/test_control_plugin/test_control_plugin.cpp
+++ b/plugins/test_control_plugin/test_control_plugin.cpp
@@ -108,7 +108,6 @@ void test_control_plugin_impl::kill_on_head(account_name prod, uint32_t where_in
 }
 
 test_control_plugin::test_control_plugin()
-: my(new test_control_plugin_impl(app().get_plugin<chain_plugin>().chain()))
 {
 }
 
@@ -119,6 +118,7 @@ void test_control_plugin::plugin_initialize(const variables_map& options) {
 }
 
 void test_control_plugin::plugin_startup() {
+   my.reset(new test_control_plugin_impl(app().get_plugin<chain_plugin>().chain()));
    my->connect();
 }
 

--- a/tests/nodeos_forked_chain_test.py
+++ b/tests/nodeos_forked_chain_test.py
@@ -344,13 +344,15 @@ try:
 
     firstDivergence=analyzeBPs(blockProducers0, blockProducers1, expectDivergence=True)
     # Nodes should not have diverged till the last block
-    assert(firstDivergence==blockNum)
+    if firstDivergence!=blockNum:
+        Utils.errorExit("Expected to diverge at %s, but diverged at %s." % (firstDivergence, blockNum))
     blockProducers0=[]
     blockProducers1=[]
 
     #verify that the non producing node is not alive (and populate the producer nodes with current getInfo data to report if
     #an error occurs)
-    assert(not nonProdNode.verifyAlive())
+    if nonProdNode.verifyAlive():
+        Utils.errorExit("Expected the non-producing node to have shutdown.")
     for prodNode in prodNodes:
         prodNode.getInfo()
 
@@ -369,7 +371,8 @@ try:
     # ***   Analyze the producers from the divergence to the lastBlockNum and verify they stay diverged   ***
 
     firstDivergence=analyzeBPs(blockProducers0, blockProducers1, expectDivergence=True)
-    assert(firstDivergence==killBlockNum)
+    if firstDivergence!=killBlockNum:
+        Utils.errorExit("Expected to diverge at %s, but diverged at %s." % (firstDivergence, killBlockNum))
     blockProducers0=[]
     blockProducers1=[]
 
@@ -397,8 +400,8 @@ try:
 
     # ***   Analyze the producers from the saved LIB to the current highest head and verify they match now   ***
 
-    firstDivergence=analyzeBPs(blockProducers0, blockProducers1, expectDivergence=False)
-    assert(firstDivergence==None)
+    analyzeBPs(blockProducers0, blockProducers1, expectDivergence=False)
+
     blockProducers0=[]
     blockProducers1=[]
 


### PR DESCRIPTION
#5653 
Moved call on chain_plugin till startup phase.
Changed test to use if checks and errorExit instead of assert to allow diagnostic data to be printed by shutdown function.