### PR TITLE
throw exception when serializing struct with incompatiable type 5629

### DIFF
--- a/libraries/chain/abi_serializer.cpp
+++ b/libraries/chain/abi_serializer.cpp
@@ -362,6 +362,8 @@ namespace eosio { namespace chain {
                   ++i;
                }
             }
+         } else {
+            EOS_THROW( pack_exception, "Failed to serialize struct '${t}' in variant object", ("t", st.name));
          }
       }
    } FC_CAPTURE_AND_RETHROW( (type)(var) ) }


### PR DESCRIPTION
fix #5629 , throw exception if serialising struct with neither object type nor array type