### PR TITLE
check unlock-timeout overflow

### DIFF
--- a/plugins/wallet_plugin/wallet_manager.cpp
+++ b/plugins/wallet_plugin/wallet_manager.cpp
@@ -37,7 +37,7 @@ void wallet_manager::set_timeout(const std::chrono::seconds& t) {
    timeout = t;
    auto now = std::chrono::system_clock::now();
    timeout_time = now + timeout;
-   EOS_ASSERT(timeout_time >= now, invalid_lock_timeout_exception, "Overflow on timeout_time, specified ${t}, now ${now}, timeout_time ${timeout_time}",
+   EOS_ASSERT(timeout_time >= now && timeout_time.time_since_epoch().count() > 0, invalid_lock_timeout_exception, "Overflow on timeout_time, specified ${t}, now ${now}, timeout_time ${timeout_time}",
              ("t", t.count())("now", now.time_since_epoch().count())("timeout_time", timeout_time.time_since_epoch().count()));
 }
 


### PR DESCRIPTION
Should be added if timeout_time.time_since_epoch().count() is negative on Ubuntu 16.04.

$ ./build/programs/keyos/keyos --unlock-timeout 9999999999 --http-server-address 127.0.0.1:8900
2018-09-14T15:00:44.373 thread-0   wallet_plugin.cpp:42          plugin_initialize    ] initializing wallet plugin
2018-09-14T15:00:44.373 thread-0   wallet_plugin.cpp:68          plugin_initialize    ] 3120011 invalid_lock_timeout_exception: Wallet lock timeout is invalid
Overflow on timeout_time, specified 9999999999, now 1536937244373317352, timeout_time -6909806830336234264
    {"t":"9999999999","now":"1536937244373317352","timeout_time":-6909806830336234264}
    thread-0  wallet_manager.cpp:47 set_timeout