### PR TITLE
Improve Integration Test Diagnostics for missing transactions

### DIFF
--- a/tests/Node.py
+++ b/tests/Node.py
@@ -248,10 +248,45 @@ class Node(object):
         """Is blockNum finalized"""
         return self.isBlockPresent(blockNum, blockType=BlockType.lib)
 
+    class BlockWalker:
+        def __init__(self, node, trans, startBlockNum=None, endBlockNum=None):
+            self.trans=trans
+            self.node=node
+            self.startBlockNum=startBlockNum
+            self.endBlockNum=endBlockNum
+
+        def walkBlocks(self):
+            start=None
+            end=None
+            blockNum=self.trans["processed"]["action_traces"][0]["block_num"]
+            # it should be blockNum or later, but just in case the block leading up have any clues...
+            if self.startBlockNum is not None:
+                start=self.startBlockNum
+            else:
+                start=blockNum-5
+            if self.endBlockNum is not None:
+                end=self.endBlockNum
+            else:
+                info=self.node.getInfo()
+                end=info["head_block_num"]
+            msg="Original transaction=\n%s\nExpected block_num=%s\n" % (json.dumps(trans, indent=2, sort_keys=True), blockNum)
+            for blockNum in range(start, end+1):
+                block=self.node.getBlock(blockNum)
+                msg+=json.dumps(block, indent=2, sort_keys=True)+"\n"
+
     # pylint: disable=too-many-branches
-    def getTransaction(self, transId, silentErrors=False, exitOnError=False, delayedRetry=True):
+    def getTransaction(self, transOrTransId, silentErrors=False, exitOnError=False, delayedRetry=True):
+        transId=None
+        trans=None
+        assert(isinstance(transOrTransId, (str,dict)))
+        if isinstance(transOrTransId, str):
+            transId=transOrTransId
+        else:
+            trans=transOrTransId
+            transId=Node.getTransId(trans)
         exitOnErrorForDelayed=not delayedRetry and exitOnError
         timeout=3
+        blockWalker=None
         if not self.enableMongo:
             cmdDesc="get transaction"
             cmd="%s %s" % (cmdDesc, transId)
@@ -260,9 +295,12 @@ class Node(object):
                 trans=self.processCleosCmd(cmd, cmdDesc, silentErrors=silentErrors, exitOnError=exitOnErrorForDelayed, exitMsg=msg)
                 if trans is not None or not delayedRetry:
                     return trans
+                if blockWalker is None:
+                    blockWalker=Node.BlockWalker(node, trans)
                 if Utils.Debug: Utils.Print("Could not find transaction with id %s, delay and retry" % (transId))
                 time.sleep(timeout)
 
+            msg+="\nBlock printout -->>\n%s" % blockWalker.walkBlocks();
             # either it is there or the transaction has timed out
             return self.processCleosCmd(cmd, cmdDesc, silentErrors=silentErrors, exitOnError=exitOnError, exitMsg=msg)
         else:
@@ -329,11 +367,16 @@ class Node(object):
 
         return False
 
-    def getBlockIdByTransId(self, transId, delayedRetry=True):
-        """Given a transaction Id (string), will return block id (int) containing the transaction"""
-        assert(transId)
-        assert(isinstance(transId, str))
-        trans=self.getTransaction(transId, exitOnError=True, delayedRetry=delayedRetry)
+    def getBlockIdByTransId(self, transOrTransId, delayedRetry=True):
+        """Given a transaction (dictionary) or transaction Id (string), will return the actual block id (int) containing the transaction"""
+        assert(transOrTransId)
+        transId=None
+        assert(isinstance(transOrTransId, (str,dict)))
+        if isinstance(transOrTransId, str):
+            transId=transOrTransId
+        else:
+            transId=Node.getTransId(transOrTransId)
+        trans=self.getTransaction(transOrTransId, exitOnError=True, delayedRetry=delayedRetry)
 
         refBlockNum=None
         key=""

--- a/tests/WalletMgr.py
+++ b/tests/WalletMgr.py
@@ -72,10 +72,10 @@ class WalletMgr(object):
                     continue
 
                 msg=ex.output.decode("utf-8")
-                msg="ERROR: Failed to create wallet - %s. %s" % (name, msg)
+                errorMsg="ERROR: Failed to create wallet - %s. %s" % (name, msg)
                 if exitOnError:
-                    Utils.errorExit("%s" % (msg))
-                Utils.Print("%s" % (msg))
+                    Utils.errorExit("%s" % (errorMsg))
+                Utils.Print("%s" % (errorMsg))
                 return None
 
         m=p.search(retStr)

--- a/tests/consensus-validation-malicious-producers.py
+++ b/tests/consensus-validation-malicious-producers.py
@@ -328,7 +328,7 @@ def myTest(transWillEnterBlock):
                 return False
 
             Print("Get details for transaction %s" % (transId))
-            transaction=node2.getTransaction(transId, exitOnError=True)
+            transaction=node2.getTransaction(trans[1], exitOnError=True)
             signature=transaction["transaction"]["signatures"][0]
 
             blockNum=int(transaction["transaction"]["ref_block_num"])

--- a/tests/launcher_test.py
+++ b/tests/launcher_test.py
@@ -191,7 +191,7 @@ try:
 
     node.waitForTransInBlock(transId)
 
-    transaction=node.getTransaction(transId, exitOnError=True, delayedRetry=False)
+    transaction=node.getTransaction(trans, exitOnError=True, delayedRetry=False)
 
     typeVal=None
     amountVal=None

--- a/tests/nodeos_run_test.py
+++ b/tests/nodeos_run_test.py
@@ -282,7 +282,7 @@ try:
 
     node.waitForTransInBlock(transId)
 
-    transaction=node.getTransaction(transId, exitOnError=True, delayedRetry=False)
+    transaction=node.getTransaction(trans, exitOnError=True, delayedRetry=False)
 
     typeVal=None
     amountVal=None
@@ -467,7 +467,7 @@ try:
         raise
 
     Print("Test for block decoded packed transaction (issue 2932)")
-    blockId=node.getBlockIdByTransId(transId)
+    blockId=node.getBlockIdByTransId(trans[1])
     assert(blockId)
     block=node.getBlock(blockId, exitOnError=True)
 


### PR DESCRIPTION
#5674 
Add diagnostics in Node.getTransaction to walk the blocks on the node and print out when transaction cannot be found.