### PR TITLE
Improvements to get account (chain_plugin and cleos) related to core_symbol

### DIFF
--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -512,6 +512,8 @@ public:
       return result;
    }
 
+   chain::symbol extract_core_symbol()const;
+
    friend struct resolver_factory<read_only>;
 };
 

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -217,7 +217,7 @@ void add_standard_transaction_options(CLI::App* cmd, string default_permission =
 
    cmd->add_option("--max-cpu-usage-ms", tx_max_cpu_usage, localized("set an upper limit on the milliseconds of cpu usage budget, for the execution of the transaction (defaults to 0 which means no limit)"));
    cmd->add_option("--max-net-usage", tx_max_net_usage, localized("set an upper limit on the net usage budget, in bytes, for the transaction (defaults to 0 which means no limit)"));
-  
+
    cmd->add_option("--delay-sec", delaysec, localized("set the delay_sec seconds, defaults to 0s"));
 }
 
@@ -1368,7 +1368,7 @@ struct buyram_subcommand {
                   ("payer", from_str)
                   ("receiver", receiver_str)
                   ("bytes", fc::to_uint64(amount) * 1024ull);
-            send_actions({create_action({permission_level{from_str,config::active_name}}, config::system_account_name, N(buyrambytes), act_payload)});            
+            send_actions({create_action({permission_level{from_str,config::active_name}}, config::system_account_name, N(buyrambytes), act_payload)});
          } else {
             fc::variant act_payload = fc::mutable_variant_object()
                ("payer", from_str)
@@ -1479,6 +1479,13 @@ void get_account( const string& accountName, bool json_format ) {
    if (!json_format) {
       asset staked;
       asset unstaking;
+
+      if( res.core_liquid_balance.valid() ) {
+         unstaking = asset( 0, res.core_liquid_balance->get_symbol() ); // Correct core symbol for unstaking asset.
+         staked = asset( 0, res.core_liquid_balance->get_symbol() );    // Correct core symbol for staked asset.
+      }
+
+      std::cout << "created: " << string(res.created) << std::endl;
 
       if(res.privileged) std::cout << "privileged: true" << std::endl;
 
@@ -2235,7 +2242,7 @@ int main( int argc, char** argv ) {
 
    auto getSchedule = get_schedule_subcommand{get};
    auto getTransactionId = get_transaction_id_subcommand{get};
-   
+
    /*
    auto getTransactions = get->add_subcommand("transactions", localized("Retrieve all transactions with specific account name referenced in their scope"), false);
    getTransactions->add_option("account_name", account_name, localized("name of account to query on"))->required();


### PR DESCRIPTION
Changes in this PR:

- `chain_plugin` tries to extract `core_symbol` from the table data (`rammarket`) in the deployed system contract. If it fails, it then resorts to using the default value of the `symbol` class (the one determined by `CORE_SYMBOL_NAME` during build configuration).
- Fix corner cases in `cleos get account` which led to symbol mismatch when calculating total core token balances of an account.
- `cleos get account` sub-command now also prints out the time the account was created.