### PR TITLE
Add daemonization to keosd & have cleos auto launch mindful of it

### DIFF
--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -772,17 +772,6 @@ bool local_port_used(const string& lo_address, uint16_t port) {
     return !ec;
 }
 
-void try_local_port( const string& lo_address, uint16_t port, uint32_t duration ) {
-   using namespace std::chrono;
-   auto start_time = duration_cast<std::chrono::milliseconds>( system_clock::now().time_since_epoch() ).count();
-   while ( !local_port_used(lo_address, port)) {
-      if (duration_cast<std::chrono::milliseconds>( system_clock::now().time_since_epoch()).count() - start_time > duration ) {
-         std::cerr << "Unable to connect to keosd, if keosd is running please kill the process and try again.\n";
-         throw connection_exception(fc::log_messages{FC_LOG_MESSAGE(error, "Unable to connect to keosd")});
-      }
-   }
-}
-
 void ensure_keosd_running(CLI::App* app) {
     if (no_auto_keosd)
         return;
@@ -823,19 +812,26 @@ void ensure_keosd_running(CLI::App* app) {
 
         vector<std::string> pargs;
         pargs.push_back("--http-server-address=" + lo_address + ":" + std::to_string(resolved_url.resolved_port));
+#ifndef _WIN32
+        pargs.push_back("--daemon");
+#endif
 
         ::boost::process::child keos(binPath, pargs,
                                      bp::std_in.close(),
                                      bp::std_out > bp::null,
                                      bp::std_err > bp::null);
-        if (keos.running()) {
-            std::cerr << binPath << " launched" << std::endl;
-            keos.detach();
-            try_local_port(lo_address, resolved_url.resolved_port, 2000);
-        } else {
-            std::cerr << "No wallet service listening on " << lo_address << ":"
-                      << std::to_string(resolved_url.resolved_port) << ". Failed to launch " << binPath << std::endl;
+#ifdef _WIN32
+        Sleep(2000); //fixme one day...
+#else
+        keos.wait();
+        if(keos.exit_code()) {
+            std::cerr << "No wallet service listening on " << lo_address << ":" << std::to_string(resolved_url.resolved_port)
+                      << ". keosd failed to initialize. " << std::endl;
+            exit(1); //just returning would allow the normal path to go through and print "is keosd running?"
         }
+        else
+            std::cerr << binPath << " launched" << std::endl;
+#endif
     } else {
         std::cerr << "No wallet service listening on " << lo_address << ":" << std::to_string(resolved_url.resolved_port)
                   << ". Cannot automatically start keosd because keosd was not found." << std::endl;

--- a/programs/keosd/main.cpp
+++ b/programs/keosd/main.cpp
@@ -40,6 +40,7 @@ int main(int argc, char** argv)
       bfs::path home = determine_home_directory();
       app().set_default_data_dir(home / "eosio-wallet");
       app().set_default_config_dir(home / "eosio-wallet");
+      app().allow_daemonization();
       http_plugin::set_defaults({
          .address_config_prefix = "",
          .default_unix_socket_path = keosd::config::key_store_executable_name + ".sock",
@@ -52,6 +53,7 @@ int main(int argc, char** argv)
       http.add_handler("/v1/keosd/stop", [](string, string, url_response_callback cb) { cb(200, "{}"); std::raise(SIGTERM); } );
       app().startup();
       app().exec();
+      return 0;
    } catch (const fc::exception& e) {
       elog("${e}", ("e",e.to_detail_string()));
    } catch (const boost::exception& e) {
@@ -61,5 +63,5 @@ int main(int argc, char** argv)
    } catch (...) {
       elog("unknown exception");
    }
-   return 0;
+   return -1;
 }


### PR DESCRIPTION
When cleos auto-launches keosd it suffers from two inter related problems — It has no way of knowing if keosd started successfully or not, and it attempts to judge this on if it’s connectable or not by just spinning in a loop banging on the TCP port.

Add a new option to keosd, --daemon. This will cause keosd to background it self (returning 0) after it has done the plugin initialize and startup (so, it has validated that it can bind to ports & acquire the wallet lock successfully). Failure to initialize or startup will cause the process to return -1 (255) before daemonizing. cleos auto launch uses this to know for certain if keosd has successfully launched or not.

This functionality may additionally be useful in the unit tests. For example, consider #5650 which suffers from a keosd that isn’t quite ready to take commands as quickly as expected.