### PR TITLE
Transaction trace logging for visibility of transactions on P2P

### DIFF
--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1073,6 +1073,10 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block(bool 
                for (auto& trx: unapplied_trxs) {
                   auto category = calculate_transaction_category(trx);
                   if (category == tx_category::EXPIRED || (category == tx_category::UNEXPIRED_UNPERSISTED && _producers.empty())) {
+                     if (!_producers.empty()) {
+                        fc_dlog(_trx_trace_log, "[TRX_TRACE] Node with producers configured is dropping a PREVIOUSLY ACCEPTED transaction : ${txid}",
+                               ("txid", trx->id));
+                     }
                      chain.drop_unapplied_transaction(trx);
                   } else if (category == tx_category::PERSISTED || (category == tx_category::UNEXPIRED_UNPERSISTED && _pending_block_mode == pending_block_mode::producing)) {
                      apply_trxs.emplace_back(std::move(trx));

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1083,12 +1083,15 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block(bool 
             if (!apply_trxs.empty()) {
                int num_applied = 0;
                int num_failed = 0;
+               int num_processed = 0;
 
                for (const auto& trx: apply_trxs) {
                   if (block_time <= fc::time_point::now()) exhausted = true;
                   if (exhausted) {
                      break;
                   }
+
+                  num_processed++;
 
                   try {
                      auto deadline = fc::time_point::now() + fc::milliseconds(_max_transaction_time_ms);
@@ -1116,7 +1119,8 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block(bool 
                   } FC_LOG_AND_DROP();
                }
 
-               fc_dlog(_log, "Processed ${n} previously applied transactions, Applied ${applied}, Failed/Dropped ${failed}",
+               fc_dlog(_log, "Processed ${m} of ${n} previously applied transactions, Applied ${applied}, Failed/Dropped ${failed}",
+                      ("m", num_processed)
                       ("n", apply_trxs.size())
                       ("applied", num_applied)
                       ("failed", num_failed));
@@ -1145,12 +1149,15 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block(bool 
             if (!scheduled_trxs.empty()) {
                int num_applied = 0;
                int num_failed = 0;
+               int num_processed = 0;
 
                for (const auto& trx : scheduled_trxs) {
                   if (block_time <= fc::time_point::now()) exhausted = true;
                   if (exhausted) {
                      break;
                   }
+
+                  num_processed++;
 
                   // configurable ratio of incoming txns vs deferred txns
                   while (_incoming_trx_weight >= 1.0 && orig_pending_txn_size && _pending_incoming_transactions.size()) {
@@ -1200,8 +1207,11 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block(bool 
                   if (!orig_pending_txn_size) _incoming_trx_weight = 0.0;
                }
 
-               fc_dlog(_log, "Processed ${n} scheduled transactions, Applied ${applied}, Failed/Dropped ${failed}",
-                      ("n", scheduled_trxs.size())("applied", num_applied)("failed", num_failed));
+               fc_dlog(_log, "Processed ${m} of ${n} scheduled transactions, Applied ${applied}, Failed/Dropped ${failed}",
+                      ("m", num_processed)
+                      ("n", scheduled_trxs.size())
+                      ("applied", num_applied)
+                      ("failed", num_failed));
 
             }
          }

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1074,7 +1074,7 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block(bool 
                   auto category = calculate_transaction_category(trx);
                   if (category == tx_category::EXPIRED || (category == tx_category::UNEXPIRED_UNPERSISTED && _producers.empty())) {
                      if (!_producers.empty()) {
-                        fc_dlog(_trx_trace_log, "[TRX_TRACE] Node with producers configured is dropping a PREVIOUSLY ACCEPTED transaction : ${txid}",
+                        fc_dlog(_trx_trace_log, "[TRX_TRACE] Node with producers configured is dropping an EXPIRED transaction that was PREVIOUSLY ACCEPTED : ${txid}",
                                ("txid", trx->id));
                      }
                      chain.drop_unapplied_transaction(trx);

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -349,25 +349,25 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
             if (response.contains<fc::exception_ptr>()) {
                _transaction_ack_channel.publish(std::pair<fc::exception_ptr, packed_transaction_ptr>(response.get<fc::exception_ptr>(), trx));
                if (_pending_block_mode == pending_block_mode::producing) {
-                  fc_ilog(_trx_trace_log, "[TRX_TRACE] Block ${block num} for producer ${prod} is REJECTING tx: ${txid} : ${why} ",
+                  fc_dlog(_trx_trace_log, "[TRX_TRACE] Block ${block num} for producer ${prod} is REJECTING tx: ${txid} : ${why} ",
                         ("block_num", chain.head_block_num() + 1)
                         ("prod", chain.pending_block_state()->header.producer)
                         ("txid", trx->id())
                         ("why",response.get<fc::exception_ptr>()->what()));
                } else {
-                  fc_ilog(_trx_trace_log, "[TRX_TRACE] Speculative execution is REJECTING tx: ${txid} : ${why} ",
+                  fc_dlog(_trx_trace_log, "[TRX_TRACE] Speculative execution is REJECTING tx: ${txid} : ${why} ",
                           ("txid", trx->id())
                           ("why",response.get<fc::exception_ptr>()->what()));
                }
             } else {
                _transaction_ack_channel.publish(std::pair<fc::exception_ptr, packed_transaction_ptr>(nullptr, trx));
                if (_pending_block_mode == pending_block_mode::producing) {
-                  fc_ilog(_trx_trace_log, "[TRX_TRACE] Block ${block num} for producer ${prod} is ACCEPTING tx: ${txid}",
+                  fc_dlog(_trx_trace_log, "[TRX_TRACE] Block ${block num} for producer ${prod} is ACCEPTING tx: ${txid}",
                           ("block_num", chain.head_block_num() + 1)
                           ("prod", chain.pending_block_state()->header.producer)
                           ("txid", trx->id()));
                } else {
-                  fc_ilog(_trx_trace_log, "[TRX_TRACE] Speculative execution is ACCEPTING tx: ${txid}",
+                  fc_dlog(_trx_trace_log, "[TRX_TRACE] Speculative execution is ACCEPTING tx: ${txid}",
                           ("txid", trx->id()));
                }
             }
@@ -397,12 +397,12 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
                if (failure_is_subjective(*trace->except, deadline_is_subjective)) {
                   _pending_incoming_transactions.emplace_back(trx, persist_until_expired, next);
                   if (_pending_block_mode == pending_block_mode::producing) {
-                     fc_ilog(_trx_trace_log, "[TRX_TRACE] Block ${block num} for producer ${prod} COULD NOT FIT, tx: ${txid} RETRYING ",
+                     fc_dlog(_trx_trace_log, "[TRX_TRACE] Block ${block num} for producer ${prod} COULD NOT FIT, tx: ${txid} RETRYING ",
                              ("block_num", chain.head_block_num() + 1)
                              ("prod", chain.pending_block_state()->header.producer)
                              ("txid", trx->id()));
                   } else {
-                     fc_ilog(_trx_trace_log, "[TRX_TRACE] Speculative execution COULD NOT FIT tx: ${txid} RETRYING",
+                     fc_dlog(_trx_trace_log, "[TRX_TRACE] Speculative execution COULD NOT FIT tx: ${txid} RETRYING",
                              ("txid", trx->id()));
                   }
                } else {


### PR DESCRIPTION
In conversations with various block producers, it became apparent that there was no good visibility on how `nodeos` was propagating transactions (or not).  This PR implements some basic transaction tracing intended on a single node in a separate log with the identifier "transaction_tracing" as well as some other basic statistics in the producer plugin specific log.

The goal is that collaborative efforts to aggregate and analyze logs can trace a transaction as it is relayed through the P2P network and eventually finds a place in a block or determine why/when it is unable to achieve that end.  