### PR TITLE
sync wabt to upstream as of 2018 Sep 18; considerable performance boost

### DIFF
--- a/libraries/chain/CMakeLists.txt
+++ b/libraries/chain/CMakeLists.txt
@@ -51,7 +51,7 @@ add_library( eosio_chain
              )
 
 target_link_libraries( eosio_chain eos_utilities fc chainbase Logging IR WAST WASM Runtime
-      wasm asmjs passes cfg ast emscripten-optimizer support softfloat builtins libwabt
+      wasm asmjs passes cfg ast emscripten-optimizer support softfloat builtins wabt
                      )
 target_include_directories( eosio_chain
                             PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" "${CMAKE_CURRENT_BINARY_DIR}/include"

--- a/libraries/chain/include/eosio/chain/webassembly/wabt.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/wabt.hpp
@@ -7,7 +7,6 @@
 #include <softfloat_types.h>
 
 //wabt includes
-#include <src/error-handler.h>
 #include <src/binary-reader.h>
 #include <src/common.h>
 #include <src/interp.h>

--- a/libraries/chain/webassembly/wabt.cpp
+++ b/libraries/chain/webassembly/wabt.cpp
@@ -5,6 +5,7 @@
 //wabt includes
 #include <src/interp.h>
 #include <src/binary-reader-interp.h>
+#include <src/error-formatter.h>
 
 namespace eosio { namespace chain { namespace webassembly { namespace wabt_runtime {
 
@@ -87,10 +88,10 @@ std::unique_ptr<wasm_instantiated_module_interface> wabt_runtime::instantiate_mo
    }
 
    interp::DefinedModule* instantiated_module = nullptr;
-   ErrorHandlerBuffer error_handler(Location::Type::Binary);
+   wabt::Errors errors;
 
-   wabt::Result res = ReadBinaryInterp(env.get(), code_bytes, code_size, read_binary_options, &error_handler, &instantiated_module);
-   EOS_ASSERT( Succeeded(res), wasm_execution_error, "Error building wabt interp: ${e}", ("e", error_handler.buffer()) );
+   wabt::Result res = ReadBinaryInterp(env.get(), code_bytes, code_size, read_binary_options, &errors, &instantiated_module);
+   EOS_ASSERT( Succeeded(res), wasm_execution_error, "Error building wabt interp: ${e}", ("e", wabt::FormatErrorsToString(errors, Location::Type::Binary)) );
    
    return std::make_unique<wabt_instantiated_module>(std::move(env), initial_memory, instantiated_module);
 }


### PR DESCRIPTION
This update provides a considerable performance boost -- doing a replay on a network completed 10MM blocks while the older revision was at 7.4 still.

This PR goes with EOSIO/wabt#2 PR; wait for EOSIO/wabt's eosio branch to be updated before merging