### PR TITLE
Remove some unused lambda captures

### DIFF
--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -37,7 +37,7 @@ struct async_result_visitor : public fc::visitor<std::string> {
 
 #define CALL(api_name, api_handle, api_namespace, call_name, http_response_code) \
 {std::string("/v1/" #api_name "/" #call_name), \
-   [this, api_handle](string, string body, url_response_callback cb) mutable { \
+   [api_handle](string, string body, url_response_callback cb) mutable { \
           api_handle.validate(); \
           try { \
              if (body.empty()) body = "{}"; \

--- a/plugins/history_api_plugin/history_api_plugin.cpp
+++ b/plugins/history_api_plugin/history_api_plugin.cpp
@@ -21,7 +21,7 @@ void history_api_plugin::plugin_initialize(const variables_map&) {}
 
 #define CALL(api_name, api_handle, api_namespace, call_name) \
 {std::string("/v1/" #api_name "/" #call_name), \
-   [this, api_handle](string, string body, url_response_callback cb) mutable { \
+   [api_handle](string, string body, url_response_callback cb) mutable { \
           try { \
              if (body.empty()) body = "{}"; \
              auto result = api_handle.call_name(fc::json::from_string(body).as<api_namespace::call_name ## _params>()); \

--- a/plugins/test_control_api_plugin/test_control_api_plugin.cpp
+++ b/plugins/test_control_api_plugin/test_control_api_plugin.cpp
@@ -37,7 +37,7 @@ struct async_result_visitor : public fc::visitor<std::string> {
 
 #define CALL(api_name, api_handle, api_namespace, call_name, http_response_code) \
 {std::string("/v1/" #api_name "/" #call_name), \
-   [this, api_handle](string, string body, url_response_callback cb) mutable { \
+   [api_handle](string, string body, url_response_callback cb) mutable { \
           try { \
              if (body.empty()) body = "{}"; \
              auto result = api_handle.call_name(fc::json::from_string(body).as<api_namespace::call_name ## _params>()); \


### PR DESCRIPTION
These fill the output with warnings on newer clang