### PR TITLE
Ensure Integration Test dependent calls are received sequentially

### DIFF
--- a/tests/Node.py
+++ b/tests/Node.py
@@ -1321,8 +1321,10 @@ class Node(object):
 
         if trans is None:
             Utils.Print("  cmd returned transaction: %s" % (trans))
+            return
 
         if ignoreNonTrans and not Node.isTrans(trans):
+            Utils.Print("  cmd returned a non-transaction")
             return
 
         transId=Node.getTransId(trans)

--- a/tests/nodeos_forked_chain_test.py
+++ b/tests/nodeos_forked_chain_test.py
@@ -212,7 +212,7 @@ try:
         transferAmount="100000000.0000 {0}".format(CORE_SYMBOL)
         Print("Transfer funds %s from account %s to %s" % (transferAmount, cluster.eosioAccount.name, account.name))
         node.transferFunds(cluster.eosioAccount, account, transferAmount, "test transfer")
-        trans=node.delegatebw(account, 20000000.0000, 20000000.0000, exitOnError=True)
+        trans=node.delegatebw(account, 20000000.0000, 20000000.0000, waitForTransBlock=True, exitOnError=True)
 
 
     # ***   vote using accounts   ***
@@ -222,7 +222,7 @@ try:
     index=0
     for account in accounts:
         Print("Vote for producers=%s" % (producers))
-        trans=prodNodes[index % len(prodNodes)].vote(account, producers)
+        trans=prodNodes[index % len(prodNodes)].vote(account, producers, waitForTransBlock=True)
         index+=1
 
 

--- a/tests/nodeos_under_min_avail_ram.py
+++ b/tests/nodeos_under_min_avail_ram.py
@@ -126,7 +126,7 @@ try:
         transferAmount="70000000.0000 {0}".format(CORE_SYMBOL)
         Print("Transfer funds %s from account %s to %s" % (transferAmount, cluster.eosioAccount.name, account.name))
         nodes[0].transferFunds(cluster.eosioAccount, account, transferAmount, "test transfer")
-        trans=nodes[0].delegatebw(account, 1000000.0000, 68000000.0000, exitOnError=True)
+        trans=nodes[0].delegatebw(account, 1000000.0000, 68000000.0000, waitForTransBlock=True, exitOnError=True)
 
     contractAccount=cluster.createAccountKeys(1)[0]
     contractAccount.name="contracttest"
@@ -136,7 +136,7 @@ try:
     transferAmount="90000000.0000 {0}".format(CORE_SYMBOL)
     Print("Transfer funds %s from account %s to %s" % (transferAmount, cluster.eosioAccount.name, contractAccount.name))
     nodes[0].transferFunds(cluster.eosioAccount, contractAccount, transferAmount, "test transfer")
-    trans=nodes[0].delegatebw(contractAccount, 1000000.0000, 88000000.0000, exitOnError=True)
+    trans=nodes[0].delegatebw(contractAccount, 1000000.0000, 88000000.0000, waitForTransBlock=True, exitOnError=True)
 
     contractDir="contracts/integration_test"
     wasmFile="integration_test.wasm"

--- a/tests/nodeos_voting_test.py
+++ b/tests/nodeos_voting_test.py
@@ -216,7 +216,7 @@ try:
         transferAmount="100000000.0000 {0}".format(CORE_SYMBOL)
         Print("Transfer funds %s from account %s to %s" % (transferAmount, cluster.eosioAccount.name, account.name))
         node.transferFunds(cluster.eosioAccount, account, transferAmount, "test transfer")
-        trans=node.delegatebw(account, 20000000.0000, 20000000.0000, exitOnError=True)
+        trans=node.delegatebw(account, 20000000.0000, 20000000.0000, waitForTransBlock=True, exitOnError=True)
 
     # containers for tracking producers
     prodsActive={}
@@ -229,7 +229,7 @@ try:
     #first account will vote for node0 producers, all others will vote for node1 producers
     node=node0
     for account in accounts:
-        trans=node.vote(account, node.producers)
+        trans=node.vote(account, node.producers, waitForTransBlock=True)
         node=node1
 
     setActiveProducers(prodsActive, node1.producers)
@@ -240,7 +240,7 @@ try:
     # first account will vote for node2 producers, all others will vote for node3 producers
     node1
     for account in accounts:
-        trans=node.vote(account, node.producers)
+        trans=node.vote(account, node.producers, waitForTransBlock=True)
         node=node2
 
     setActiveProducers(prodsActive, node2.producers)


### PR DESCRIPTION
#5674 
Added waitForTransBlock flags to calls to ensure the subsequent call doesn't get received out of order