### PR TITLE
Update README for txn_test_gen_plugin 

### DIFF
--- a/plugins/txn_test_gen_plugin/README.md
+++ b/plugins/txn_test_gen_plugin/README.md
@@ -56,12 +56,13 @@ $ ./nodeos -d ~/eos.data/producer_node --config-dir ~/eos.data/producer_node -l 
 
 ### Launch non-producer that will generate transactions
 ```bash
-$ ./nodeos -d ~/eos.data/generator_node --config-dir ~/eos.data/generator_node -l ~/eos.data/logging.json --plugin eosio::txn_test_gen_plugin --plugin eosio::wallet_api_plugin --plugin eosio::chain_api_plugin --p2p-peer-address localhost:9876 --p2p-listen-endpoint localhost:5555
+$ ./nodeos -d ~/eos.data/generator_node --config-dir ~/eos.data/generator_node -l ~/eos.data/logging.json --plugin eosio::txn_test_gen_plugin --plugin eosio::chain_api_plugin --p2p-peer-address localhost:9876 --p2p-listen-endpoint localhost:5555  --http-validate-host=0
 ```
 
 ### Create a wallet on the non-producer and set bios contract
 ```bash
 $ ./cleos wallet create
+$ ./cleos wallet import --private-key 5KQwrPbwdL6PhXujxW37FSSQZ1JiwsST4cqQzDeyXtP79zkvFD3
 $ ./cleos set contract eosio ~/eos/build.release/contracts/eosio.bios/ 
 ```
 
@@ -83,3 +84,6 @@ eosio generated block b243aeaa... #3221 @ 2018-04-25T16:07:48.000 with 500 trxs,
 ```
 
 Note in the console output there are 500 transactions in each of the blocks which are produced every 500 ms yielding 1,000 transactions / second.
+
+### Demonstration
+The following video provides a demo: https://vimeo.com/266585781

--- a/plugins/txn_test_gen_plugin/README.md
+++ b/plugins/txn_test_gen_plugin/README.md
@@ -56,24 +56,24 @@ $ ./nodeos -d ~/eos.data/producer_node --config-dir ~/eos.data/producer_node -l 
 
 ### Launch non-producer that will generate transactions
 ```bash
-$ ./nodeos -d ~/eos.data/generator_node --config-dir ~/eos.data/generator_node -l ~/eos.data/logging.json --plugin eosio::txn_test_gen_plugin --plugin eosio::chain_api_plugin --p2p-peer-address localhost:9876 --p2p-listen-endpoint localhost:5555  --http-validate-host=0
+$ ./nodeos -d ~/eos.data/generator_node --config-dir ~/eos.data/generator_node -l ~/eos.data/logging.json --plugin eosio::txn_test_gen_plugin --plugin eosio::chain_api_plugin --p2p-peer-address localhost:9876 --p2p-listen-endpoint localhost:5555
 ```
 
 ### Create a wallet on the non-producer and set bios contract
 ```bash
-$ ./cleos wallet create
+$ ./cleos wallet create --to-console
 $ ./cleos wallet import --private-key 5KQwrPbwdL6PhXujxW37FSSQZ1JiwsST4cqQzDeyXtP79zkvFD3
 $ ./cleos set contract eosio ~/eos/build.release/contracts/eosio.bios/ 
 ```
 
 ### Initialize the accounts txn_test_gen_plugin uses
 ```bash
-$ curl --data-binary '["eosio", "5KQwrPbwdL6PhXujxW37FSSQZ1JiwsST4cqQzDeyXtP79zkvFD3"]' http://localhost:8888/v1/txn_test_gen/create_test_accounts
+$ curl --data-binary '["eosio", "5KQwrPbwdL6PhXujxW37FSSQZ1JiwsST4cqQzDeyXtP79zkvFD3"]' http://127.0.0.1:8888/v1/txn_test_gen/create_test_accounts
 ```
 
 ### Start transaction generation, this will submit 20 transactions evey 20ms (total of 1000TPS)
 ```bash
-$ curl --data-binary '["", 20, 20]' http://localhost:8888/v1/txn_test_gen/start_generation
+$ curl --data-binary '["", 20, 20]' http://127.0.0.1:8888/v1/txn_test_gen/start_generation
 ```
 
 ### Note the producer console prints


### PR DESCRIPTION
 --http-validate-host=0 is required when launching the non-producer or curl requests will fail. 
keosd no longer adds the default private key to the wallet on creation. Manually add. 
Added link to the demo video. Also removed eosio::wallet_api_plugin as it is no longer used. 