### PR TITLE
Kernel timer based checktime

### DIFF
--- a/libraries/chain/include/eosio/chain/transaction_context.hpp
+++ b/libraries/chain/include/eosio/chain/transaction_context.hpp
@@ -6,42 +6,15 @@
 namespace eosio { namespace chain {
 
    struct deadline_timer {
-         deadline_timer() {
-            if(initialized)
-               return;
-            struct sigaction act;
-            act.sa_handler = timer_expired;
-            sigemptyset(&act.sa_mask);
-            act.sa_flags = 0;
-            sigaction(SIGALRM, &act, NULL);
-            initialized = true;
-         }
+         deadline_timer();
+         ~deadline_timer();
 
-         void start(fc::time_point tp) {
-            microseconds x = tp.time_since_epoch() - fc::time_point::now().time_since_epoch();
-            if(x.count() < 18)
-               expired = 1;
-            else if(x.count() < 1000000) {
-               struct itimerval enable = {{0, 0}, {0, (int)x.count()-15}};
-               expired = 0;
-               setitimer(ITIMER_REAL, &enable, NULL);
-            }
-         }
-
-         void stop() {
-            struct itimerval disable = {{0, 0}, {0, 0}};
-            setitimer(ITIMER_REAL, &disable, NULL);
-         }
-
-         ~deadline_timer() {
-            stop();
-         }
+         void start(fc::time_point tp);
+         void stop();
 
          static volatile sig_atomic_t expired;
       private:
-         static void timer_expired(int) {
-            expired = 1;
-         }
+         static void timer_expired(int);
          static bool initialized;
    };
 

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -7,31 +7,130 @@
 #include <eosio/chain/transaction_object.hpp>
 #include <eosio/chain/global_property_object.hpp>
 
+#pragma push_macro("N")
+#undef N
+#include <boost/accumulators/accumulators.hpp>
+#include <boost/accumulators/statistics/stats.hpp>
+#include <boost/accumulators/statistics/min.hpp>
+#include <boost/accumulators/statistics/max.hpp>
+#include <boost/accumulators/statistics/weighted_mean.hpp>
+#include <boost/accumulators/statistics/weighted_variance.hpp>
+#pragma pop_macro("N")
+
+#include <chrono>
+
 namespace eosio { namespace chain {
+
+namespace bacc = boost::accumulators;
+
+   struct deadline_timer_verify {
+      deadline_timer_verify() {
+         //keep longest first in list. You're effectively going to take test_intervals[0]*sizeof(test_intervals[0])
+         //time to do the the "calibration" 
+         int test_intervals[] = {50000, 10000, 5000, 1000, 500, 100, 50, 10};
+
+         struct sigaction act;
+         sigemptyset(&act.sa_mask);
+         act.sa_handler = timer_hit;
+         act.sa_flags = 0;
+         if(sigaction(SIGALRM, &act, NULL))
+            return;
+
+         sigset_t alrm;
+         sigemptyset(&alrm);
+         sigaddset(&alrm, SIGALRM);
+         int dummy;
+
+         for(int& interval : test_intervals) {
+            unsigned int loops = test_intervals[0]/interval;
+
+            for(unsigned int i = 0; i < loops; ++i) {
+               struct itimerval enable = {{0, 0}, {0, interval}};
+               hit = 0;
+               auto start = std::chrono::high_resolution_clock::now();
+               if(setitimer(ITIMER_REAL, &enable, NULL))
+                  return;
+               while(!hit) {}
+               auto end = std::chrono::high_resolution_clock::now();
+               int timer_slop = std::chrono::duration_cast<std::chrono::microseconds>(end-start).count() - interval;
+
+               //since more samples are run for the shorter expirations, weigh the longer expirations accordingly. This
+               //helps to make a few results more fair. Two such examples: AWS c4&i5 xen instances being rather stable
+               //down to 100us but then struggling with 50us and 10us. MacOS having performance that seems to correlate
+               //with expiry length; that is, long expirations have high error, short expirations have low error.
+               //That said, for these platforms, a tighter tolerance may possibly be achieved by taking performance
+               //metrics in mulitple bins and appliying the slop based on which bin a deadline resides in. Not clear
+               //if that's worth the extra complexity at this point.
+               samples(timer_slop, bacc::weight = interval/(float)test_intervals[0]);
+            }
+         }
+         timer_overhead = bacc::mean(samples) + sqrt(bacc::variance(samples))*2; //target 95% of expirations before deadline
+         use_deadline_timer = timer_overhead < 1000;
+
+         act.sa_handler = SIG_DFL;
+         sigaction(SIGALRM, &act, NULL);
+      }
+
+      static void timer_hit(int) {
+         hit = 1;
+      }
+      static volatile sig_atomic_t hit;
+
+      bacc::accumulator_set<int, bacc::stats<bacc::tag::mean, bacc::tag::min, bacc::tag::max, bacc::tag::variance>, float> samples;
+      bool use_deadline_timer = false;
+      int timer_overhead;
+   };
+   volatile sig_atomic_t deadline_timer_verify::hit;
+   static deadline_timer_verify deadline_timer_verification;
 
    deadline_timer::deadline_timer() {
       if(initialized)
          return;
-      struct sigaction act;
-      act.sa_handler = timer_expired;
-      sigemptyset(&act.sa_mask);
-      act.sa_flags = 0;
-      sigaction(SIGALRM, &act, NULL);
       initialized = true;
+
+      #define TIMER_STATS_FORMAT "min:${min}us max:${max}us mean:${mean}us stddev:${stddev}us"
+      #define TIMER_STATS \
+         ("min", bacc::min(deadline_timer_verification.samples))("max", bacc::max(deadline_timer_verification.samples)) \
+         ("mean", (int)bacc::mean(deadline_timer_verification.samples))("stddev", (int)sqrt(bacc::variance(deadline_timer_verification.samples))) \
+         ("t", deadline_timer_verification.timer_overhead)
+
+      if(deadline_timer_verification.use_deadline_timer) {
+         struct sigaction act;
+         act.sa_handler = timer_expired;
+         sigemptyset(&act.sa_mask);
+         act.sa_flags = 0;
+         if(sigaction(SIGALRM, &act, NULL) == 0) {
+            ilog("Using ${t}us deadline timer for checktime: " TIMER_STATS_FORMAT, TIMER_STATS);
+            return;
+         }
+      }
+
+      wlog("Using polled checktime; deadline timer too inaccurate: " TIMER_STATS_FORMAT, TIMER_STATS);
+      deadline_timer_verification.use_deadline_timer = false; //set in case sigaction() fails above
    }
 
    void deadline_timer::start(fc::time_point tp) {
-      microseconds x = tp.time_since_epoch() - fc::time_point::now().time_since_epoch();
-      if(x.count() < 18)
-         expired = 1;
-      else if(x.count() < 1000000) {
-         struct itimerval enable = {{0, 0}, {0, (int)x.count()-15}};
+      if(tp == fc::time_point::maximum()) {
          expired = 0;
-         setitimer(ITIMER_REAL, &enable, NULL);
+         return;
+      }
+      if(!deadline_timer_verification.use_deadline_timer) {
+         expired = 1;
+         return;
+      }
+      microseconds x = tp.time_since_epoch() - fc::time_point::now().time_since_epoch();
+      if(x.count() <= deadline_timer_verification.timer_overhead)
+         expired = 1;
+      else {
+         struct itimerval enable = {{0, 0}, {0, (int)x.count()-deadline_timer_verification.timer_overhead}};
+         expired = 0;
+         expired |= !!setitimer(ITIMER_REAL, &enable, NULL);
       }
    }
 
    void deadline_timer::stop() {
+      if(expired)
+         return;
       struct itimerval disable = {{0, 0}, {0, 0}};
       setitimer(ITIMER_REAL, &disable, NULL);
    }
@@ -41,7 +140,7 @@ namespace eosio { namespace chain {
    }
 
    void deadline_timer::timer_expired(int) {
-         expired = 1;
+      expired = 1;
    }
    volatile sig_atomic_t deadline_timer::expired = 0;
    bool deadline_timer::initialized = false;


### PR DESCRIPTION
Use a kernel timer for much of checktime instead of constantly polling for the current time. checktime is becoming an increasingly hot bottleneck in contract execution. For contracts that make considerable use of CPU I’ve seen a marked improvement in billed CPU usage. A popular benchmarking contract improves by about 15% on my development box: from 3ms to 2.5ms on wabt. For reference, with wavm the delta is even more striking: 750us to 280us

Certainly one of the risks/concerns of using a timer based checktime is the accuracy, resolution, and jitter of said timer. Bare metal, AWS c5 instances (KVMish), Azure F instances (HyperV), and GCE n1 instances (KVM?) all showed excellent performance in empirical testing. Accuracy was typically within  10-15us. The VM instances show some occasional minor jitter but of course that’s to be expected on a shared box. AWS c4 instances (Xen) seem to have reasonable accuracy above 100us timeouts (50us accuracy) but it struggles a bit at lower timeouts. macOS seems to have timer accuracy that follows the timer length: longer timer length means poorer accuracy; short timer length is actually rather accurate.

Code has been added to attempt a "calibration" of the platform's timer accuracy computing the mean and stddev of its accuracy. The checktime timer is then configured to fire the timer μ*2σ microseconds _earlier_ than the transactions deadline. Once the timer is fired checktime continues to operate in its polled mode to get the accuracy closer toward the end. For macOS the deviations are too wild and the calibration routine will decide to stick strictly with the polled approach.