### PR TITLE
 Fix Block Walker For Transactions

### DIFF
--- a/tests/Cluster.py
+++ b/tests/Cluster.py
@@ -840,7 +840,7 @@ class Cluster(object):
         with open(Cluster.__bootlog) as bootFile:
             for line in bootFile:
                 if p.search(line):
-                    Utils.Print("ERROR: bios_boot.sh script resulted in errors. See %s" % (bootlog))
+                    Utils.Print("ERROR: bios_boot.sh script resulted in errors. See %s" % (Cluster.__bootlog))
                     Utils.Print(line)
                     return None
 

--- a/tests/Node.py
+++ b/tests/Node.py
@@ -49,6 +49,7 @@ class Node(object):
         self.infoValid=None
         self.lastRetrievedHeadBlockNum=None
         self.lastRetrievedLIB=None
+        self.transCache={}
         if self.enableMongo:
             self.mongoEndpointArgs += "--host %s --port %d %s" % (mongoHost, mongoPort, mongoDb)
 
@@ -565,7 +566,7 @@ class Node(object):
             account.activePublicKey, stakeNet, CORE_SYMBOL, stakeCPU, CORE_SYMBOL, buyRAM, CORE_SYMBOL)
         msg="(creator account=%s, account=%s)" % (creatorAccount.name, account.name);
         trans=self.processCleosCmd(cmd, cmdDesc, silentErrors=False, exitOnError=exitOnError, exitMsg=msg)
-        Node.logCmdTransaction(trans)
+        self.trackCmdTransaction(trans)
         transId=Node.getTransId(trans)
 
         if stakedDeposit > 0:
@@ -583,13 +584,13 @@ class Node(object):
             cmdDesc, creatorAccount.name, account.name, account.ownerPublicKey, account.activePublicKey)
         msg="(creator account=%s, account=%s)" % (creatorAccount.name, account.name);
         trans=self.processCleosCmd(cmd, cmdDesc, silentErrors=False, exitOnError=exitOnError, exitMsg=msg)
-        Node.logCmdTransaction(trans)
+        self.trackCmdTransaction(trans)
         transId=Node.getTransId(trans)
 
         if stakedDeposit > 0:
             self.waitForTransInBlock(transId) # seems like account creation needs to be finlized before transfer can happen
             trans = self.transferFunds(creatorAccount, account, "%0.04f %s" % (stakedDeposit/10000, CORE_SYMBOL), "init")
-            Node.logCmdTransaction(trans)
+            self.trackCmdTransaction(trans)
             transId=Node.getTransId(trans)
 
         return self.waitForTransBlockIfNeeded(trans, waitForTransBlock, exitOnError=exitOnError)
@@ -740,7 +741,7 @@ class Node(object):
         trans=None
         try:
             trans=Utils.runCmdArrReturnJson(cmdArr)
-            Node.logCmdTransaction(trans)
+            self.trackCmdTransaction(trans)
         except subprocess.CalledProcessError as ex:
             msg=ex.output.decode("utf-8")
             Utils.Print("ERROR: Exception during funds transfer. %s" % (msg))
@@ -922,7 +923,7 @@ class Node(object):
         trans=None
         try:
             trans=Utils.runCmdReturnJson(cmd, trace=False)
-            Node.logCmdTransaction(trans)
+            self.trackCmdTransaction(trans)
         except subprocess.CalledProcessError as ex:
             if not shouldFail:
                 msg=ex.output.decode("utf-8")
@@ -980,7 +981,7 @@ class Node(object):
         if Utils.Debug: Utils.Print("cmd: %s" % (cmdArr))
         try:
             trans=Utils.runCmdArrReturnJson(cmdArr)
-            Node.logCmdTransaction(trans, ignoreNonTrans=True)
+            self.trackCmdTransaction(trans, ignoreNonTrans=True)
             return (True, trans)
         except subprocess.CalledProcessError as ex:
             msg=ex.output.decode("utf-8")
@@ -992,7 +993,7 @@ class Node(object):
         cmdDesc="set action permission"
         cmd="%s -j %s %s %s %s" % (cmdDesc, account, code, pType, requirement)
         trans=self.processCleosCmd(cmd, cmdDesc, silentErrors=False, exitOnError=exitOnError)
-        Node.logCmdTransaction(trans)
+        self.trackCmdTransaction(trans)
 
         return self.waitForTransBlockIfNeeded(trans, waitForTransBlock, exitOnError=exitOnError)
 
@@ -1006,7 +1007,7 @@ class Node(object):
             cmdDesc, fromAccount.name, toAccount.name, netQuantity, CORE_SYMBOL, cpuQuantity, CORE_SYMBOL, transferStr)
         msg="fromAccount=%s, toAccount=%s" % (fromAccount.name, toAccount.name);
         trans=self.processCleosCmd(cmd, cmdDesc, exitOnError=exitOnError, exitMsg=msg)
-        Node.logCmdTransaction(trans)
+        self.trackCmdTransaction(trans)
 
         return self.waitForTransBlockIfNeeded(trans, waitForTransBlock, exitOnError=exitOnError)
 
@@ -1016,7 +1017,7 @@ class Node(object):
             cmdDesc, producer.name, producer.activePublicKey, url, location)
         msg="producer=%s" % (producer.name);
         trans=self.processCleosCmd(cmd, cmdDesc, exitOnError=exitOnError, exitMsg=msg)
-        Node.logCmdTransaction(trans)
+        self.trackCmdTransaction(trans)
 
         return self.waitForTransBlockIfNeeded(trans, waitForTransBlock, exitOnError=exitOnError)
 
@@ -1026,7 +1027,7 @@ class Node(object):
             cmdDesc, account.name, " ".join(producers))
         msg="account=%s, producers=[ %s ]" % (account.name, ", ".join(producers));
         trans=self.processCleosCmd(cmd, cmdDesc, exitOnError=exitOnError, exitMsg=msg)
-        Node.logCmdTransaction(trans)
+        self.trackCmdTransaction(trans)
 
         return self.waitForTransBlockIfNeeded(trans, waitForTransBlock, exitOnError=exitOnError)
 
@@ -1336,23 +1337,25 @@ class Node(object):
         self.killed=False
         return True
 
-    @staticmethod
-    def logCmdTransaction(trans, ignoreNonTrans=False):
-        if not Utils.Debug:
-            return
-
+    def trackCmdTransaction(self, trans, ignoreNonTrans=False):
         if trans is None:
-            Utils.Print("  cmd returned transaction: %s" % (trans))
+            if Utils.Debug: Utils.Print("  cmd returned transaction: %s" % (trans))
             return
 
         if ignoreNonTrans and not Node.isTrans(trans):
-            Utils.Print("  cmd returned a non-transaction")
+            if Utils.Debug: Utils.Print("  cmd returned a non-transaction")
             return
 
         transId=Node.getTransId(trans)
         status=Node.getTransStatus(trans)
         blockNum=Node.getTransBlockNum(trans)
-        Utils.Print("  cmd returned transaction id: %s, status: %s, (possible) block num: %s" % (transId, status, blockNum))
+        if Utils.Debug:
+            if transId in self.transCache.keys():
+                replaceMsg="replacing previous trans=\n%s" % json.dumps(self.transCache[transId], indent=2, sort_keys=True)
+            else:
+                replaceMsg=""
+            Utils.Print("  cmd returned transaction id: %s, status: %s, (possible) block num: %s" % (transId, status, blockNum))
+        self.transCache[transId]=trans
 
     def reportStatus(self):
         Utils.Print("Node State:")

--- a/tests/Node.py
+++ b/tests/Node.py
@@ -338,7 +338,7 @@ class Node(object):
         def walkBlocks(self):
             start=None
             end=None
-            if self.trans is None and self.transId in self.transCache:
+            if self.trans is None and self.transId in self.transCache.keys():
                 self.trans=self.transCache[self.transId]
             if self.trans is not None:
                 cntxt=Node.Context(self.trans, "trans")

--- a/tests/consensus-validation-malicious-producers.py
+++ b/tests/consensus-validation-malicious-producers.py
@@ -328,7 +328,7 @@ def myTest(transWillEnterBlock):
                 return False
 
             Print("Get details for transaction %s" % (transId))
-            transaction=node2.getTransaction(trans[1], exitOnError=True)
+            transaction=node2.getTransaction(transId, exitOnError=True)
             signature=transaction["transaction"]["signatures"][0]
 
             blockNum=int(transaction["transaction"]["ref_block_num"])

--- a/tests/launcher_test.py
+++ b/tests/launcher_test.py
@@ -191,7 +191,7 @@ try:
 
     node.waitForTransInBlock(transId)
 
-    transaction=node.getTransaction(trans, exitOnError=True, delayedRetry=False)
+    transaction=node.getTransaction(transId, exitOnError=True, delayedRetry=False)
 
     typeVal=None
     amountVal=None

--- a/tests/nodeos_run_test.py
+++ b/tests/nodeos_run_test.py
@@ -282,7 +282,7 @@ try:
 
     node.waitForTransInBlock(transId)
 
-    transaction=node.getTransaction(trans, exitOnError=True, delayedRetry=False)
+    transaction=node.getTransaction(transId, exitOnError=True, delayedRetry=False)
 
     typeVal=None
     amountVal=None
@@ -467,7 +467,7 @@ try:
         raise
 
     Print("Test for block decoded packed transaction (issue 2932)")
-    blockId=node.getBlockIdByTransId(trans[1])
+    blockId=node.getBlockIdByTransId(transId)
     assert(blockId)
     block=node.getBlock(blockId, exitOnError=True)
 


### PR DESCRIPTION
#5674 
Fixed paths where original transaction was not passed through by instead caching the original transaction and looking it up by transaction id.