### PR TITLE
fix replay with --disable-replay-opts

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -275,9 +275,10 @@ struct controller_impl {
             std::cerr<< "\n";
             ilog( "${n} blocks replayed", ("n", head->block_num) );
 
-            // the irreverible log is played without undo sessions enabled, so we need to sync the
+            // if the irreverible log is played without undo sessions enabled, we need to sync the
             // revision ordinal to the appropriate expected value here.
-            db.set_revision(head->block_num);
+            if( self.skip_db_sessions( controller::block_status::irreversible ) )
+               db.set_revision(head->block_num);
 
             int rev = 0;
             while( auto obj = reversible_blocks.find<reversible_block_object,by_num>(head->block_num+1) ) {
@@ -1051,7 +1052,7 @@ struct controller_impl {
          // on replay irreversible is not emitted by fork database, so emit it explicitly here
          if( s == controller::block_status::irreversible )
             emit( self.irreversible_block, new_header_state );
-            
+
       } FC_LOG_AND_RETHROW( )
    }
 


### PR DESCRIPTION
Fixes the bug in which a replay with `--disable-replay-opts` ends with the `cannot set revision while there is an existing undo stack` exception.