### PR TITLE
add state DB consensus indices during chain_plugin initialize rather than startup; use updated chainbase that ensures undo stacks are in sync among indices

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1387,12 +1387,11 @@ controller::~controller() {
    my->fork_db.close();
 }
 
+void controller::add_indices() {
+   my->add_indices();
+}
 
 void controller::startup() {
-
-   // ilog( "${c}", ("c",fc::json::to_pretty_string(cfg)) );
-   my->add_indices();
-
    my->head = my->fork_db.head();
    if( !my->head ) {
       elog( "No head block in fork db, perhaps we need to replay" );

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -87,6 +87,7 @@ namespace eosio { namespace chain {
          controller( const config& cfg );
          ~controller();
 
+         void add_indices();
          void startup();
 
          /**

--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -348,6 +348,7 @@ namespace eosio { namespace testing {
          vcfg.trusted_producers = trusted_producers;
 
          validating_node = std::make_unique<controller>(vcfg);
+         validating_node->add_indices();
          validating_node->startup();
 
          init(true);
@@ -362,6 +363,7 @@ namespace eosio { namespace testing {
          vcfg.state_dir  = vcfg.state_dir.parent_path() / std::string("v_").append( vcfg.state_dir.filename().generic_string() );
 
          validating_node = std::make_unique<controller>(vcfg);
+         validating_node->add_indices();
          validating_node->startup();
 
          init(config);
@@ -406,6 +408,7 @@ namespace eosio { namespace testing {
 
         validating_node.reset();
         validating_node = std::make_unique<controller>(vcfg);
+        validating_node->add_indices();
         validating_node->startup();
 
         return ok;

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -17,7 +17,7 @@ namespace eosio { namespace testing {
       std::ifstream wast_file(fn);
       FC_ASSERT( wast_file.is_open(), "wast file cannot be found" );
       wast_file.seekg(0, std::ios::end);
-      std::vector<char> wast; 
+      std::vector<char> wast;
       int len = wast_file.tellg();
       FC_ASSERT( len >= 0, "wast file length is -1" );
       wast.resize(len+1);
@@ -32,7 +32,7 @@ namespace eosio { namespace testing {
       std::ifstream wasm_file(fn, std::ios::binary);
       FC_ASSERT( wasm_file.is_open(), "wasm file cannot be found" );
       wasm_file.seekg(0, std::ios::end);
-      std::vector<uint8_t> wasm; 
+      std::vector<uint8_t> wasm;
       int len = wasm_file.tellg();
       FC_ASSERT( len >= 0, "wasm file length is -1" );
       wasm.resize(len);
@@ -46,7 +46,7 @@ namespace eosio { namespace testing {
       std::ifstream abi_file(fn);
       FC_ASSERT( abi_file.is_open(), "abi file cannot be found" );
       abi_file.seekg(0, std::ios::end);
-      std::vector<char> abi; 
+      std::vector<char> abi;
       int len = abi_file.tellg();
       FC_ASSERT( len >= 0, "abi file length is -1" );
       abi.resize(len+1);
@@ -127,6 +127,7 @@ namespace eosio { namespace testing {
 
    void base_tester::open() {
       control.reset( new controller(cfg) );
+      control->add_indices();
       control->startup();
       chain_transactions.clear();
       control->accepted_block.connect([this]( const block_state_ptr& block_state ){

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -643,6 +643,8 @@ void chain_plugin::plugin_initialize(const variables_map& options) {
             [this]( const header_confirmation& conf ) {
                my->accepted_confirmation_channel.publish( conf );
             } );
+
+      my->chain->add_indices();
    } FC_LOG_AND_RETHROW()
 
 }
@@ -904,11 +906,6 @@ bool chain_plugin::export_reversible_blocks( const fc::path& reversible_dir,
             ("num", num)("start", start)("end", end) );
 
    return (end >= start) && ((end - start + 1) == num);
-}
-
-controller::config& chain_plugin::chain_config() {
-   // will trigger optional assert if called before/after plugin_initialize()
-   return *my->chain_config;
 }
 
 controller& chain_plugin::chain() { return *my->chain; }

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -639,11 +639,9 @@ public:
                                         const fc::path& reversible_blocks_file
                                        );
 
-   // Only call this in plugin_initialize() to modify controller constructor configuration
-   controller::config& chain_config();
-   // Only call this after plugin_startup()!
+   // Only call this after plugin_initialize()!
    controller& chain();
-   // Only call this after plugin_startup()!
+   // Only call this after plugin_initialize()!
    const controller& chain() const;
 
    chain::chain_id_type get_chain_id() const;


### PR DESCRIPTION
This change of when the indices are added means that any other plugins which depend on chain_plugin and try to add indices into the state chainbase DB (a highly unrecommended practice by the way!), for example the deprecated history_plugin, will add their indices after the main consensus indices are already added during the chain_plugin initialize stage.

This PR also syncs to a chainbase change (see PR EOSIO/chainbase#23) which ensures the revision and undo stack of an added index to the database is consistent with existing indices in the database (even going so far to modify the revision and undo stack of the added index to ensure the consistency, but only for indices that are brand new to the database).

These two changes combined make it possible for a plugin like history_plugin to be added to nodeos even if its existing state db was formed from a replay or sync while the history_plugin was disabled. However, it can only be added under these conditions once. If the history_plugin was enabled at some point in the history of processing a blockchain, which would have injected its indices into the state DB the first time it was enabled, and then disabled later, then it no longer becomes possible to re-enable the history_plugin on that state DB (a replay would be required to re-enable the history_plugin in that case). The error thrown when attempting to do that would be something like the following:
```
existing index for eosio::account_history_object has an undo stack (revision range [5271, 5272]) that is inconsistent with other indices in the database (revision range [5274, 5275]); corrupted database?
```

A more flexible approach which allows the plugin to be enabled and disabled on demand without requiring replays may or may not make sense for some plugins. It may be a nice feature to have for a plugin tracking the history of actions (at the risk of having gaps in the history of course), but for history_plugin to support behavior like this, it would need to stop using the very bad practice of injecting its indices in the state chainbase DB and instead maintain its own separate database (possibly a chainbase database still) which handles fork resolution properly using signals that currently are not exposed to plugins. Work to enable such functionality will be left to a future PR, but it is unlikely  that history_plugin itself will be updated to use the new appropriate patterns since it is already deprecated.