### PR TITLE
Fix build script for Amazon Linux 2

### DIFF
--- a/eosio_build.sh
+++ b/eosio_build.sh
@@ -153,7 +153,7 @@
       OS_NAME=$( cat /etc/os-release | grep ^NAME | cut -d'=' -f2 | sed 's/\"//gI' )
 
       case "$OS_NAME" in
-         "Amazon Linux AMI")
+         "Amazon Linux AMI"|"Amazon Linux")
             FILE="${SOURCE_DIR}/scripts/eosio_build_amazon.sh"
             CXX_COMPILER=g++
             C_COMPILER=gcc

--- a/scripts/eosio_build_amazon.sh
+++ b/scripts/eosio_build_amazon.sh
@@ -23,7 +23,7 @@
 		exit 1
 	fi
 
-	if [ "${OS_VER}" -lt 2017 ]; then
+	if [[ "${OS_NAME}" == "Amazon Linux AMI" && "${OS_VER}" -lt 2017 ]]; then
 		printf "\\tYou must be running Amazon Linux 2017.09 or higher to install EOSIO.\\n"
 		printf "\\texiting now.\\n"
 		exit 1
@@ -53,9 +53,15 @@
 	fi
 	printf "\\t%s\\n" "${UPDATE}"
 
-	DEP_ARRAY=( git gcc72.x86_64 gcc72-c++.x86_64 autoconf automake libtool make bzip2 \
-	bzip2-devel.x86_64 openssl-devel.x86_64 gmp-devel.x86_64 libstdc++72.x86_64 \
-	python27.x86_64 python36-devel.x86_64 libedit-devel.x86_64 doxygen.x86_64 graphviz.x86_64)
+	if [[ "${OS_NAME}" == "Amazon Linux AMI" ]]; then
+		DEP_ARRAY=( git gcc72.x86_64 gcc72-c++.x86_64 autoconf automake libtool make bzip2 \
+		bzip2-devel.x86_64 openssl-devel.x86_64 gmp-devel.x86_64 libstdc++72.x86_64 \
+		python27.x86_64 python36-devel.x86_64 libedit-devel.x86_64 doxygen.x86_64 graphviz.x86_64)
+	else
+		DEP_ARRAY=( git gcc gcc-c++ autoconf automake libtool make bzip2 \
+		bzip2-devel.x86_64 openssl-devel.x86_64 gmp-devel.x86_64 \
+		python3-devel libedit-devel.x86_64 doxygen.x86_64 graphviz.x86_64)
+	fi
 	COUNT=1
 	DISPLAY=""
 	DEP=""


### PR DESCRIPTION
A user implicitly reported via #5840 that Amazon Linux 2 does not build out of the box. Fix the build script to handle it.

```
$ cat /etc/os-release 
NAME="Amazon Linux"
VERSION="2"
ID="amzn"
ID_LIKE="centos rhel fedora"
VERSION_ID="2"
PRETTY_NAME="Amazon Linux 2"
ANSI_COLOR="0;33"
CPE_NAME="cpe:2.3:o:amazon:amazon_linux:2"
HOME_URL="https://amazonlinux.com/"
```