### PR TITLE
update dependencies need for amazon linux 2

### DIFF
--- a/scripts/eosio_build_amazon.sh
+++ b/scripts/eosio_build_amazon.sh
@@ -58,9 +58,9 @@
 		bzip2-devel.x86_64 openssl-devel.x86_64 gmp-devel.x86_64 libstdc++72.x86_64 \
 		python27.x86_64 python36-devel.x86_64 libedit-devel.x86_64 doxygen.x86_64 graphviz.x86_64)
 	else
-		DEP_ARRAY=( git gcc gcc-c++ autoconf automake libtool make bzip2 \
-		bzip2-devel.x86_64 openssl-devel.x86_64 gmp-devel.x86_64 \
-		python3-devel libedit-devel.x86_64 doxygen.x86_64 graphviz.x86_64)
+		DEP_ARRAY=( git gcc.x86_64 gcc-c++.x86_64 autoconf automake libtool make bzip2 \
+		bzip2-devel.x86_64 openssl-devel.x86_64 gmp-devel.x86_64 libstdc++.x86_64 \
+		python3.x86_64 python3-devel.x86_64 libedit-devel.x86_64 doxygen.x86_64 graphviz.x86_64)
 	fi
 	COUNT=1
 	DISPLAY=""


### PR DESCRIPTION
Hi,

Thanks a lot for working on issue #5840 quickly! I have checked the required dependencies name changes from Amazon Linux AMI to Amazon Linux 2, and make the below improvement. Could you kindly review it?

gcc72.x86_64   ->   gcc.x86_64
gcc72-c++.x86_64   ->   gcc-c++.x86_64
libstdc++72.x86_64   ->   libstdc++.x86_64
python27.x86_64   ->   python3.x86_64
python36-devel.x86_64   ->   python3-devel.x86_64

Thanks,