### PR TITLE
Issues/4573 : Use of $JOBS instead of $CPU_CORE for make -j

### DIFF
--- a/eosio_build.sh
+++ b/eosio_build.sh
@@ -276,7 +276,7 @@
       printf "\\n\\t>>>>>>>>>>>>>>>>>>>> EOSIO has been successfully configured but not yet built.\\n\\n"
       exit 0
    fi
-   if [ $CPU_CORE -gt 6 ]; then CPU_CORE=$((CPU_CORE / 3)); fi
+   if [ $CPU_CORE -gt 4 ]; then CPU_CORE=$((CPU_CORE / 2)); fi
    if ! make -j"${CPU_CORE}"
    then
       printf "\\n\\t>>>>>>>>>>>>>>>>>>>> MAKE building EOSIO has exited with the above error.\\n\\n"

--- a/eosio_build.sh
+++ b/eosio_build.sh
@@ -49,6 +49,14 @@
    DOXYGEN=false
    ENABLE_COVERAGE_TESTING=false
    CORE_SYMBOL_NAME="SYS"
+   # Use current directory's tmp directory if noexec is enabled for /tmp
+   if (mount | grep "/tmp " | grep --quiet noexec); then
+        mkdir -p $SOURCE_DIR/tmp
+        TEMP_DIR="${SOURCE_DIR}/tmp"
+        rm -rf $SOURCE_DIR/tmp/*
+   else # noexec wasn't found
+        TEMP_DIR="/tmp"
+   fi
    START_MAKE=true
    TEMP_DIR="/tmp"
    TIME_BEGIN=$( date -u +%s )

--- a/eosio_build.sh
+++ b/eosio_build.sh
@@ -48,14 +48,6 @@
    DISK_MIN=20
    DOXYGEN=false
    ENABLE_COVERAGE_TESTING=false
-   # Use current directory's tmp directory if noexec is enabled for /tmp
-   if (mount | grep "/tmp " | grep --quiet noexec); then
-        mkdir -p $SOURCE_DIR/tmp
-        TEMP_DIR="${SOURCE_DIR}/tmp"
-        rm -rf $SOURCE_DIR/tmp/*
-   else # noexec wasn't found
-        TEMP_DIR="/tmp"
-   fi
    CORE_SYMBOL_NAME="SYS"
    START_MAKE=true
    TEMP_DIR="/tmp"
@@ -276,7 +268,7 @@
       printf "\\n\\t>>>>>>>>>>>>>>>>>>>> EOSIO has been successfully configured but not yet built.\\n\\n"
       exit 0
    fi
-   if [ $CPU_CORE -gt 4 ]; then CPU_CORE=$((CPU_CORE / 2)); fi
+
    if ! make -j"${CPU_CORE}"
    then
       printf "\\n\\t>>>>>>>>>>>>>>>>>>>> MAKE building EOSIO has exited with the above error.\\n\\n"

--- a/eosio_build.sh
+++ b/eosio_build.sh
@@ -48,6 +48,14 @@
    DISK_MIN=20
    DOXYGEN=false
    ENABLE_COVERAGE_TESTING=false
+   # Use current directory's tmp directory if noexec is enabled for /tmp
+   if (mount | grep "/tmp " | grep --quiet noexec); then
+        mkdir -p $SOURCE_DIR/tmp
+        TEMP_DIR="${SOURCE_DIR}/tmp"
+        rm -rf $SOURCE_DIR/tmp/*
+   else # noexec wasn't found
+        TEMP_DIR="/tmp"
+   fi
    CORE_SYMBOL_NAME="SYS"
    START_MAKE=true
    TEMP_DIR="/tmp"
@@ -268,7 +276,7 @@
       printf "\\n\\t>>>>>>>>>>>>>>>>>>>> EOSIO has been successfully configured but not yet built.\\n\\n"
       exit 0
    fi
-
+   if [ $CPU_CORE -gt 4 ]; then CPU_CORE=$((CPU_CORE / 2)); fi
    if ! make -j"${CPU_CORE}"
    then
       printf "\\n\\t>>>>>>>>>>>>>>>>>>>> MAKE building EOSIO has exited with the above error.\\n\\n"

--- a/eosio_build.sh
+++ b/eosio_build.sh
@@ -276,7 +276,7 @@
       printf "\\n\\t>>>>>>>>>>>>>>>>>>>> EOSIO has been successfully configured but not yet built.\\n\\n"
       exit 0
    fi
-   if [ $CPU_CORE -gt 4 ]; then CPU_CORE=$((CPU_CORE / 2)); fi
+   if [ $CPU_CORE -gt 6 ]; then CPU_CORE=$((CPU_CORE / 3)); fi
    if ! make -j"${CPU_CORE}"
    then
       printf "\\n\\t>>>>>>>>>>>>>>>>>>>> MAKE building EOSIO has exited with the above error.\\n\\n"

--- a/eosio_build.sh
+++ b/eosio_build.sh
@@ -276,8 +276,9 @@
       printf "\\n\\t>>>>>>>>>>>>>>>>>>>> EOSIO has been successfully configured but not yet built.\\n\\n"
       exit 0
    fi
-
-   if ! make -j"${CPU_CORE}"
+   
+   if [ -z ${JOBS} ]; then JOBS=$CPU_CORE; fi # Future proofing: Ensure $JOBS is set (usually set in scripts/eosio_build_*.sh scripts)
+   if ! make -j"${JOBS}"
    then
       printf "\\n\\t>>>>>>>>>>>>>>>>>>>> MAKE building EOSIO has exited with the above error.\\n\\n"
       exit -1


### PR DESCRIPTION
I noticed that CPU_CORE is being used in eosio_build.sh, causing my 24 core server to run out of memory (it only has 16GB). Looks like others have been having this issue and my proposed solution should solve it for everyone.