### PR TITLE
modify the sync numbers of 'start_sync' function

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -1537,7 +1537,7 @@ namespace eosio {
       else {
          c->last_handshake_recv.last_irreversible_block_num = msg.known_trx.pending;
          reset_lib_num (c);
-         start_sync(c, msg.known_blocks.pending);
+         start_sync(c, msg.known_trx.pending);
       }
    }
 


### PR DESCRIPTION
if the 'known_trx.mode' of the 'notice_message' is 'last_irr_catch_up', should use  'known_trx.pending'  instead of 'known_blocks_pending'. because the blocks of 'known_blocks_pending' needs to be verified.