### PR TITLE
Present a clearer message on bad_alloc & return consistent error code

### DIFF
--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -648,6 +648,8 @@ public:
    fc::microseconds get_abi_serializer_max_time() const;
 
    void handle_guard_exception(const chain::guard_exception& e) const;
+
+   static void handle_db_exhaustion();
 private:
    void log_guard_exception(const chain::guard_exception& e) const;
 

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -311,7 +311,7 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
             elog((e.to_detail_string()));
             except = true;
          } catch ( boost::interprocess::bad_alloc& ) {
-            raise(SIGUSR1);
+            chain_plugin::handle_db_exhaustion();
             return;
          }
 
@@ -421,7 +421,7 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
          } catch ( const guard_exception& e ) {
             app().get_plugin<chain_plugin>().handle_guard_exception(e);
          } catch ( boost::interprocess::bad_alloc& ) {
-            raise(SIGUSR1);
+            chain_plugin::handle_db_exhaustion();
          } CATCH_AND_CALL(send_response);
       }
 
@@ -1240,7 +1240,7 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block(bool 
          }
 
       } catch ( boost::interprocess::bad_alloc& ) {
-         raise(SIGUSR1);
+         chain_plugin::handle_db_exhaustion();
          return start_block_result::failed;
       }
 
@@ -1363,7 +1363,7 @@ bool producer_plugin_impl::maybe_produce_block() {
       app().get_plugin<chain_plugin>().handle_guard_exception(e);
       return false;
    } catch ( boost::interprocess::bad_alloc& ) {
-      raise(SIGUSR1);
+      chain_plugin::handle_db_exhaustion();
       return false;
    } FC_LOG_AND_DROP();
 


### PR DESCRIPTION
We normally bet on the DB size guard to cleanly shut down nodeos when the free DB size becomes low. But one user (#5791) encountered a bad_alloc without the guard kicking in. We can't do better then an unclean shutdown but we can do better conveying the error.

Make a bad_alloc exception print a more clear message and make it exit with the same error code as main.cpp lists as BAD_ALLOC by getting rid of the unorthodox SIGUSR1. Also implicitly gets rid of a POSIXism.