### PR TITLE
Remove unused eosio::sort_names()

### DIFF
--- a/libraries/chain/include/eosio/chain/name.hpp
+++ b/libraries/chain/include/eosio/chain/name.hpp
@@ -91,12 +91,6 @@ namespace eosio { namespace chain {
       operator unsigned __int128()const       { return value; }
    };
 
-
-   inline std::vector<name> sort_names( std::vector<name>&& names ) {
-      fc::deduplicate(names);
-      return names;
-   }
-
 } } // eosio::chain
 
 namespace std {


### PR DESCRIPTION
This function is causing clang7 to fire a warning on dozens of files.
```
/home/spoon/eos/src/libraries/chain/include/eosio/chain/name.hpp:97:14: warning: local variable 'names' will be copied despite being returned by name [-Wreturn-std-move]
      return names;
             ^~~~~
/home/spoon/eos/src/libraries/chain/include/eosio/chain/name.hpp:97:14: note: call 'std::move' explicitly to avoid copying
      return names;
             ^~~~~
             std::move(names)
```
Turns out this is never used anyways so just remove it.