### PR TITLE
Add filter-on filter-out to transactions collection

### DIFF
--- a/plugins/mongo_db_plugin/mongo_db_plugin.cpp
+++ b/plugins/mongo_db_plugin/mongo_db_plugin.cpp
@@ -111,7 +111,8 @@ public:
    void remove_account_control( const account_name& name, const permission_name& permission );
 
    /// @return true if act should be added to mongodb, false to skip it
-   bool filter_include( const chain::action_trace& action_trace ) const;
+   bool filter_include( const account_name& receiver, const action_name& act_name,
+                        const vector<chain::permission_level>& authorization ) const;
 
    void init();
    void wipe_database();
@@ -217,20 +218,22 @@ const std::string mongo_db_plugin_impl::accounts_col = "accounts";
 const std::string mongo_db_plugin_impl::pub_keys_col = "pub_keys";
 const std::string mongo_db_plugin_impl::account_controls_col = "account_controls";
 
-bool mongo_db_plugin_impl::filter_include( const chain::action_trace& action_trace ) const {
+bool mongo_db_plugin_impl::filter_include( const account_name& receiver, const action_name& act_name,
+                                           const vector<chain::permission_level>& authorization ) const
+{
    bool include = false;
    if( filter_on_star ) {
       include = true;
    } else {
-      auto itr = std::find_if( filter_on.cbegin(), filter_on.cend(), [&action_trace]( const auto& filter ) {
-         return filter.match( action_trace.receipt.receiver, action_trace.act.name, 0 );
+      auto itr = std::find_if( filter_on.cbegin(), filter_on.cend(), [&receiver, &act_name]( const auto& filter ) {
+         return filter.match( receiver, act_name, 0 );
       } );
       if( itr != filter_on.cend() ) {
          include = true;
       } else {
-         for( const auto& a : action_trace.act.authorization ) {
-            auto itr = std::find_if( filter_on.cbegin(), filter_on.cend(), [&action_trace, &a]( const auto& filter ) {
-               return filter.match( action_trace.receipt.receiver, action_trace.act.name, a.actor );
+         for( const auto& a : authorization ) {
+            auto itr = std::find_if( filter_on.cbegin(), filter_on.cend(), [&receiver, &act_name, &a]( const auto& filter ) {
+               return filter.match( receiver, act_name, a.actor );
             } );
             if( itr != filter_on.cend() ) {
                include = true;
@@ -241,15 +244,16 @@ bool mongo_db_plugin_impl::filter_include( const chain::action_trace& action_tra
    }
 
    if( !include ) { return false; }
+   if( filter_out.empty() ) { return true; }
 
-   auto itr = std::find_if( filter_out.cbegin(), filter_out.cend(), [&action_trace]( const auto& filter ) {
-      return filter.match( action_trace.receipt.receiver, action_trace.act.name, 0 );
+   auto itr = std::find_if( filter_out.cbegin(), filter_out.cend(), [&receiver, &act_name]( const auto& filter ) {
+      return filter.match( receiver, act_name, 0 );
    } );
    if( itr != filter_out.cend() ) { return false; }
 
-   for( const auto& a : action_trace.act.authorization ) {
-      auto itr = std::find_if( filter_out.cbegin(), filter_out.cend(), [&action_trace, &a]( const auto& filter ) {
-         return filter.match( action_trace.receipt.receiver, action_trace.act.name, a.actor );
+   for( const auto& a : authorization ) {
+      auto itr = std::find_if( filter_out.cbegin(), filter_out.cend(), [&receiver, &act_name, &a]( const auto& filter ) {
+         return filter.match( receiver, act_name, a.actor );
       } );
       if( itr != filter_out.cend() ) { return false; }
    }
@@ -694,6 +698,27 @@ void mongo_db_plugin_impl::_process_accepted_transaction( const chain::transacti
    using bsoncxx::builder::basic::make_array;
    namespace bbb = bsoncxx::builder::basic;
 
+   const auto& trx = t->trx;
+
+   if( !filter_on_star || !filter_out.empty() ) {
+      bool include = false;
+      for( const auto& a : trx.actions ) {
+         if( filter_include( a.account, a.name, a.authorization ) ) {
+            include = true;
+            break;
+         }
+      }
+      if( !include ) {
+         for( const auto& a : trx.context_free_actions ) {
+            if( filter_include( a.account, a.name, a.authorization ) ) {
+               include = true;
+               break;
+            }
+         }
+      }
+      if( !include ) return;
+   }
+
    auto trans_doc = bsoncxx::builder::basic::document{};
 
    auto now = std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -701,7 +726,6 @@ void mongo_db_plugin_impl::_process_accepted_transaction( const chain::transacti
 
    const auto& trx_id = t->id;
    const auto trx_id_str = trx_id.str();
-   const auto& trx = t->trx;
 
    trans_doc.append( kvp( "trx_id", trx_id_str ) );
 
@@ -776,7 +800,8 @@ mongo_db_plugin_impl::add_action_trace( mongocxx::bulk_write& bulk_action_traces
    }
 
    bool added = false;
-   if( start_block_reached && store_action_traces && filter_include( atrace ) ) {
+   if( start_block_reached && store_action_traces &&
+       filter_include( atrace.receipt.receiver, atrace.act.name, atrace.act.authorization ) ) {
       auto action_traces_doc = bsoncxx::builder::basic::document{};
       const chain::base_action_trace& base = atrace; // without inline action traces
 


### PR DESCRIPTION
- Updated mongo_db_plugin to filter `transactions` collection via `mongodb-filter-on` and `mongodb-filter-out` options.
- If all actions of a transaction is filtered out then the transaction is not included in the `transactions` collection. If any action of the transaction is not filtered out then the entire transaction is included in the `transactions` collection.
- With this change `mongodb-filter-on` and `mongodb-filter-out` applies to `transactions`, `transaction_traces`, and `action_traces`