### PR TITLE
refactor eosio_exit for WAVM; improve long running performance

### DIFF
--- a/libraries/chain/include/eosio/chain/wasm_interface.hpp
+++ b/libraries/chain/include/eosio/chain/wasm_interface.hpp
@@ -65,6 +65,9 @@ namespace eosio { namespace chain {
          //Calls apply or error on a given code
          void apply(const digest_type& code_id, const shared_string& code, apply_context& context);
 
+         //Immediately exits currently running wasm. UB is called when no wasm running
+         void exit();
+
       private:
          unique_ptr<struct wasm_interface_impl> my;
          friend class eosio::chain::webassembly::common::intrinsics_accessor;

--- a/libraries/chain/include/eosio/chain/webassembly/runtime_interface.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/runtime_interface.hpp
@@ -17,6 +17,9 @@ class wasm_runtime_interface {
    public:
       virtual std::unique_ptr<wasm_instantiated_module_interface> instantiate_module(const char* code_bytes, size_t code_size, std::vector<uint8_t> initial_memory) = 0;
 
+      //immediately exit the currently running wasm_instantiated_module_interface. Yep, this assumes only one can possibly run at a time.
+      virtual void immediately_exit_currently_running_module() = 0;
+
       virtual ~wasm_runtime_interface();
 };
 

--- a/libraries/chain/include/eosio/chain/webassembly/wabt.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/wabt.hpp
@@ -52,6 +52,8 @@ class wabt_runtime : public eosio::chain::wasm_runtime_interface {
       wabt_runtime();
       std::unique_ptr<wasm_instantiated_module_interface> instantiate_module(const char* code_bytes, size_t code_size, std::vector<uint8_t> initial_memory) override;
 
+      void immediately_exit_currently_running_module() override;
+
    private:
       wabt::ReadBinaryOptions read_binary_options;  //note default ctor will look at each option in feature.def and default to DISABLED for the feature
 };

--- a/libraries/chain/include/eosio/chain/webassembly/wavm.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/wavm.hpp
@@ -22,6 +22,8 @@ class wavm_runtime : public eosio::chain::wasm_runtime_interface {
       ~wavm_runtime();
       std::unique_ptr<wasm_instantiated_module_interface> instantiate_module(const char* code_bytes, size_t code_size, std::vector<uint8_t> initial_memory) override;
 
+      void immediately_exit_currently_running_module() override;
+
       struct runtime_guard {
          runtime_guard();
          ~runtime_guard();

--- a/libraries/chain/wasm_interface.cpp
+++ b/libraries/chain/wasm_interface.cpp
@@ -57,6 +57,10 @@ namespace eosio { namespace chain {
       my->get_instantiated_module(code_id, code, context.trx_context)->apply(context);
    }
 
+   void wasm_interface::exit() {
+      my->runtime_interface->immediately_exit_currently_running_module();
+   }
+
    wasm_instantiated_module_interface::~wasm_instantiated_module_interface() {}
    wasm_runtime_interface::~wasm_runtime_interface() {}
 
@@ -948,7 +952,7 @@ public:
    }
 
    void eosio_exit(int32_t code) {
-      throw wasm_exit{code};
+      context.control.get_wasm_interface().exit();
    }
 
 };

--- a/libraries/chain/webassembly/wabt.cpp
+++ b/libraries/chain/webassembly/wabt.cpp
@@ -96,4 +96,8 @@ std::unique_ptr<wasm_instantiated_module_interface> wabt_runtime::instantiate_mo
    return std::make_unique<wabt_instantiated_module>(std::move(env), initial_memory, instantiated_module);
 }
 
+void wabt_runtime::immediately_exit_currently_running_module() {
+   throw wasm_exit();
+}
+
 }}}}

--- a/libraries/chain/webassembly/wavm.cpp
+++ b/libraries/chain/webassembly/wavm.cpp
@@ -127,4 +127,12 @@ std::unique_ptr<wasm_instantiated_module_interface> wavm_runtime::instantiate_mo
    return std::make_unique<wavm_instantiated_module>(instance, std::move(module), initial_memory);
 }
 
+void wavm_runtime::immediately_exit_currently_running_module() {
+#ifdef _WIN32
+   throw wasm_exit();
+#else
+   Platform::immediately_exit();
+#endif
+}
+
 }}}}

--- a/libraries/wasm-jit/Include/Platform/Platform.h
+++ b/libraries/wasm-jit/Include/Platform/Platform.h
@@ -134,6 +134,7 @@ namespace Platform
 		Uptr& outTrapOperand,
 		const std::function<void()>& thunk
 		);
+	PLATFORM_API void immediately_exit();
 
 	//
 	// Threading

--- a/libraries/wasm-jit/Source/Platform/POSIX.cpp
+++ b/libraries/wasm-jit/Source/Platform/POSIX.cpp
@@ -276,6 +276,10 @@ namespace Platform
 		return signalType;
 	}
 
+	void immediately_exit() {
+		siglongjmp(signalReturnEnv,1);
+	}
+
 	CallStack captureCallStack(Uptr numOmittedFramesFromTop)
 	{
 		#if 0


### PR DESCRIPTION
WAVM becomes increasingly slow as more and more contracts are activated. The ultimate reason is due to high exception overhead from eosio_exit. I believe this stems from the huge number of memory mappings and interaction with the unwinder. Refactor eosio_exit implementation on WAVM to not use exceptions and instead longjmp out of the running wasm code.

A popular EOSIO based blockchain with approximately 20MM blocks replayed in half the time for me.

I’m aware of the wonkiness with the implementation here — the “get out of a running instance” method is on the global wasm runtime class and not on an instance of a wasm module. This was the easiest way to add the change and touch the least amount of code. Plus, at any point this isn’t sufficient due to having more than one contract running simultaneously, we will need to refactor much of the wasm execution code anyways.