### PR TITLE
Create action_trace & action_receipt on hard_fail

### DIFF
--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -92,11 +92,11 @@ void apply_context::exec_one( action_trace& trace )
 
    trx_context.executed.emplace_back( move(r) );
 
+   finalize_trace( trace, start );
+
    if ( control.contracts_console() ) {
       print_debug(receiver, trace);
    }
-
-   finalize_trace( trace, start );
 }
 
 void apply_context::finalize_trace( action_trace& trace, const fc::time_point& start )

--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -77,12 +77,12 @@ void apply_context::exec_one( action_trace& trace )
       throw;
    }
 
+   r.global_sequence  = next_global_sequence();
+   r.recv_sequence    = next_recv_sequence( receiver );
+
    const auto& account_sequence = db.get<account_sequence_object, by_name>(act.account);
    r.code_sequence    = account_sequence.code_sequence; // could be modified by action execution above
    r.abi_sequence     = account_sequence.abi_sequence;  // could be modified by action execution above
-
-   r.global_sequence  = next_global_sequence();
-   r.recv_sequence    = next_recv_sequence( receiver );
 
    for( const auto& auth : act.authorization ) {
       r.auth_sequence[auth.actor] = next_auth_sequence( auth.actor );

--- a/libraries/chain/include/eosio/chain/apply_context.hpp
+++ b/libraries/chain/include/eosio/chain/apply_context.hpp
@@ -472,8 +472,8 @@ class apply_context {
    /// Execution methods:
    public:
 
-      action_trace exec_one();
-      void exec();
+      void exec_one( action_trace& trace );
+      void exec( action_trace& trace );
       void execute_inline( action&& a );
       void execute_context_free_inline( action&& a );
       void schedule_deferred_transaction( const uint128_t& sender_id, account_name payer, transaction&& trx, bool replace_existing );
@@ -573,6 +573,7 @@ class apply_context {
       uint64_t next_auth_sequence( account_name actor );
 
       void add_ram_usage( account_name account, int64_t ram_delta );
+      void finalize_trace( action_trace& trace, const fc::time_point& start );
 
    private:
 
@@ -599,8 +600,6 @@ class apply_context {
       generic_index<index256_object, uint128_t*, const uint128_t*>   idx256;
       generic_index<index_double_object>                             idx_double;
       generic_index<index_long_double_object>                        idx_long_double;
-
-      action_trace                                trace;
 
    private:
 

--- a/libraries/chain/include/eosio/chain/trace.hpp
+++ b/libraries/chain/include/eosio/chain/trace.hpp
@@ -28,10 +28,8 @@ namespace eosio { namespace chain {
       action               act;
       bool                 context_free = false;
       fc::microseconds     elapsed;
-      uint64_t             cpu_usage = 0;
       string               console;
 
-      uint64_t             total_cpu_usage = 0; /// total of inline_traces[x].cpu_usage + cpu_usage
       transaction_id_type  trx_id; ///< the transaction that generated this action
       uint32_t             block_num = 0;
       block_timestamp_type block_time;
@@ -71,7 +69,7 @@ FC_REFLECT( eosio::chain::account_delta,
             (account)(delta) )
 
 FC_REFLECT( eosio::chain::base_action_trace,
-                    (receipt)(act)(context_free)(elapsed)(cpu_usage)(console)(total_cpu_usage)(trx_id)
+                    (receipt)(act)(context_free)(elapsed)(console)(trx_id)
                     (block_num)(block_time)(producer_block_id)(account_ram_deltas)(except) )
 
 FC_REFLECT_DERIVED( eosio::chain::action_trace,

--- a/libraries/chain/include/eosio/chain/trace.hpp
+++ b/libraries/chain/include/eosio/chain/trace.hpp
@@ -37,6 +37,7 @@ namespace eosio { namespace chain {
       block_timestamp_type block_time;
       fc::optional<block_id_type>     producer_block_id;
       flat_set<account_delta>         account_ram_deltas;
+      fc::optional<fc::exception>     except;
    };
 
    struct action_trace : public base_action_trace {
@@ -71,7 +72,7 @@ FC_REFLECT( eosio::chain::account_delta,
 
 FC_REFLECT( eosio::chain::base_action_trace,
                     (receipt)(act)(context_free)(elapsed)(cpu_usage)(console)(total_cpu_usage)(trx_id)
-                    (block_num)(block_time)(producer_block_id)(account_ram_deltas) )
+                    (block_num)(block_time)(producer_block_id)(account_ram_deltas)(except) )
 
 FC_REFLECT_DERIVED( eosio::chain::action_trace,
                     (eosio::chain::base_action_trace), (inline_traces) )

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -429,14 +429,7 @@ namespace eosio { namespace chain {
       acontext.context_free = context_free;
       acontext.receiver     = receiver;
 
-      try {
-         acontext.exec();
-      } catch( ... ) {
-         trace = move(acontext.trace);
-         throw;
-      }
-
-      trace = move(acontext.trace);
+      acontext.exec( trace );
    }
 
    void transaction_context::schedule_transaction() {


### PR DESCRIPTION
- `hard_fail` was creating default constructed `action_trace` to be added to `transaction_trace`
- Fill out `action_trace` and `action_receipt` even when exception while processing action
- Add optional `except` to `action_trace` to store exception that is also stored on `transaction_trace`
- **Note:** Includes change to `action_trace` which will likely cause problems with `history_plugin` unless full replay