### PR TITLE
Fix documentation of current_time

### DIFF
--- a/contracts/eosiolib/system.h
+++ b/contracts/eosiolib/system.h
@@ -72,9 +72,9 @@ extern "C" {
 
 
    /**
-    *  Returns the time in microseconds from 1970 of the current block
+    *  Returns the time in seconds from 1970 of the current block
     *  @brief Get time of the current block (i.e. the block including this action)
-    *  @return time in microseconds from 1970 of the current block
+    *  @return time in seconds from 1970 of the current block
     */
    uint64_t  current_time();
 


### PR DESCRIPTION
#4652 is a wrong fix. current_time() in EOS is returning seconds, not milli seconds