### PR TITLE
Remove config.ini options that are no longer supported by nodeos

### DIFF
--- a/Docker/config.ini
+++ b/Docker/config.ini
@@ -151,12 +151,6 @@ keosd-provider-timeout = 5
 # Lag in number of blocks from the head block when selecting the reference block for transactions (-1 means Last Irreversible Block) (eosio::txn_test_gen_plugin)
 txn-reference-block-lag = 0
 
-# The path of the wallet files (absolute path or relative to application data dir) (eosio::wallet_plugin)
-wallet-dir = "."
-
-# Timeout for unlocked wallet in seconds (default 900 (15 minutes)). Wallets will automatically lock after specified number of seconds of inactivity. Activity is defined as any wallet command e.g. list-wallets. (eosio::wallet_plugin)
-unlock-timeout = 900
-
 # eosio key that will be imported automatically when a wallet is created. (eosio::wallet_plugin)
 # eosio-key =
 


### PR DESCRIPTION
The default eosio/eos-dev docker image will not run nodeos without replacing the config.ini with a working version. It will give an error message about invalid options in the config.ini.

Originally created as a PR to merge into master, https://github.com/EOSIO/eos/pull/5987