### PR TITLE
duplicated error message

### DIFF
--- a/libraries/chain/include/eosio/chain/exceptions.hpp
+++ b/libraries/chain/include/eosio/chain/exceptions.hpp
@@ -230,7 +230,7 @@ namespace eosio { namespace chain {
                                     3060004, "Contract Query Exception" )
 
    FC_DECLARE_DERIVED_EXCEPTION( guard_exception, database_exception,
-                                 3060100, "Database exception" )
+                                 3060100, "Guard Exception" )
 
       FC_DECLARE_DERIVED_EXCEPTION( database_guard_exception, guard_exception,
                                     3060101, "Database usage is at unsafe levels" )


### PR DESCRIPTION
There is a duplicated error message for database_exception and guard_exception. 
![image](https://user-images.githubusercontent.com/5457407/46932749-a27a0900-d083-11e8-9a7f-ce65e7446c5c.png)

Maybe if the error were exposed to users like developer, they may be confused about what really happens without checking the exact error code.