### PR TITLE
increasing vote cap from 30 to 999

### DIFF
--- a/contracts/eosio.system/voting.cpp
+++ b/contracts/eosio.system/voting.cpp
@@ -135,7 +135,7 @@ namespace eosiosystem {
          eosio_assert( voter_name != proxy, "cannot proxy to self" );
          require_recipient( proxy );
       } else {
-         eosio_assert( producers.size() <= 30, "attempt to vote for too many producers" );
+         eosio_assert( producers.size() <= 999, "attempt to vote for too many producers" );
          for( size_t i = 1; i < producers.size(); ++i ) {
             eosio_assert( producers[i-1] < producers[i], "producer votes must be unique and sorted" );
          }


### PR DESCRIPTION
Related https://medium.com/@eoscafeblock/should-block-one-vote-a-case-for-increasing-vote-cap-from-30-to-unlimited-f7583f926ff7