### PR TITLE
Remove skip_trx_checks() from checktime hot path

### DIFF
--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -268,7 +268,10 @@ namespace bacc = boost::accumulators;
 
       checktime(); // Fail early if deadline has already been exceeded
 
-      _deadline_timer.start(_deadline);
+      if(control.skip_trx_checks())
+         _deadline_timer.expired = 0;
+      else
+         _deadline_timer.start(_deadline);
 
       is_initialized = true;
    }
@@ -430,36 +433,34 @@ namespace bacc = boost::accumulators;
    }
 
    void transaction_context::checktime()const {
-      if (!control.skip_trx_checks()) {
-         if(BOOST_LIKELY(_deadline_timer.expired == false))
-            return;
-         auto now = fc::time_point::now();
-         if( BOOST_UNLIKELY( now > _deadline ) ) {
-            // edump((now-start)(now-pseudo_start));
-            if( explicit_billed_cpu_time || deadline_exception_code == deadline_exception::code_value ) {
-               EOS_THROW( deadline_exception, "deadline exceeded", ("now", now)("deadline", _deadline)("start", start) );
-            } else if( deadline_exception_code == block_cpu_usage_exceeded::code_value ) {
-               EOS_THROW( block_cpu_usage_exceeded,
-                          "not enough time left in block to complete executing transaction",
-                          ("now", now)("deadline", _deadline)("start", start)("billing_timer", now - pseudo_start) );
-            } else if( deadline_exception_code == tx_cpu_usage_exceeded::code_value ) {
-               if (cpu_limit_due_to_greylist) {
-                  EOS_THROW( greylist_cpu_usage_exceeded,
-                           "greylisted transaction was executing for too long",
-                           ("now", now)("deadline", _deadline)("start", start)("billing_timer", now - pseudo_start) );
-               } else {
-                  EOS_THROW( tx_cpu_usage_exceeded,
-                           "transaction was executing for too long",
-                           ("now", now)("deadline", _deadline)("start", start)("billing_timer", now - pseudo_start) );
-               }
-            } else if( deadline_exception_code == leeway_deadline_exception::code_value ) {
-               EOS_THROW( leeway_deadline_exception,
-                          "the transaction was unable to complete by deadline, "
-                          "but it is possible it could have succeeded if it were allowed to run to completion",
-                          ("now", now)("deadline", _deadline)("start", start)("billing_timer", now - pseudo_start) );
+      if(BOOST_LIKELY(_deadline_timer.expired == false))
+         return;
+      auto now = fc::time_point::now();
+      if( BOOST_UNLIKELY( now > _deadline ) ) {
+         // edump((now-start)(now-pseudo_start));
+         if( explicit_billed_cpu_time || deadline_exception_code == deadline_exception::code_value ) {
+            EOS_THROW( deadline_exception, "deadline exceeded", ("now", now)("deadline", _deadline)("start", start) );
+         } else if( deadline_exception_code == block_cpu_usage_exceeded::code_value ) {
+            EOS_THROW( block_cpu_usage_exceeded,
+                        "not enough time left in block to complete executing transaction",
+                        ("now", now)("deadline", _deadline)("start", start)("billing_timer", now - pseudo_start) );
+         } else if( deadline_exception_code == tx_cpu_usage_exceeded::code_value ) {
+            if (cpu_limit_due_to_greylist) {
+               EOS_THROW( greylist_cpu_usage_exceeded,
+                        "greylisted transaction was executing for too long",
+                        ("now", now)("deadline", _deadline)("start", start)("billing_timer", now - pseudo_start) );
+            } else {
+               EOS_THROW( tx_cpu_usage_exceeded,
+                        "transaction was executing for too long",
+                        ("now", now)("deadline", _deadline)("start", start)("billing_timer", now - pseudo_start) );
             }
-            EOS_ASSERT( false,  transaction_exception, "unexpected deadline exception code" );
+         } else if( deadline_exception_code == leeway_deadline_exception::code_value ) {
+            EOS_THROW( leeway_deadline_exception,
+                        "the transaction was unable to complete by deadline, "
+                        "but it is possible it could have succeeded if it were allowed to run to completion",
+                        ("now", now)("deadline", _deadline)("start", start)("billing_timer", now - pseudo_start) );
          }
+         EOS_ASSERT( false,  transaction_exception, "unexpected deadline exception code" );
       }
    }
 


### PR DESCRIPTION
Checktime can easily be called over 100000 times a block. The benign looking skip_trx_checks() done in checktime ends up running quite a bit of code during contract execution.

Refactor the flow a little bit to rely on the new deadline_timer. if skip_trx_checks() is true,  never start the deadline_timer, expired will always be 0, and one branch is removed from checktime()

Billed time of a popular benchmark contract reduced by ~2% in my tests.