### PR TITLE
On keosd auto-launch force unix socket path

### DIFF
--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -829,6 +829,8 @@ void ensure_keosd_running(CLI::App* app) {
         pargs.push_back("");
         pargs.push_back("--https-server-address");
         pargs.push_back("");
+        pargs.push_back("--unix-socket-path");
+        pargs.push_back(string(key_store_executable_name) + ".sock");
 
         ::boost::process::child keos(binPath, pargs,
                                      bp::std_in.close(),


### PR DESCRIPTION
cleos will only autolaunch keosd when cleos' wallet url is left at the default of `unix:///home/user/eosio-wallet/keosd.sock`

When it does the autolaunch it was launching keosd as
`keosd --http-server-address  --https-server-address  `
to explicitly disable HTTP & HTTPS. However, there is a possibility that a user's `~/eosio-wallet/config.ini` may have another unix-socket-path set in it that prevents cleos and the auto launched keosd to be able to communicate.

Now force set `unix-socket-path` to the default value.