### PR TITLE
Don't create a wallet when failed to create password file

### DIFF
--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -2548,10 +2548,7 @@ int main( int argc, char** argv ) {
    createWallet->add_option("-f,--file", password_file, localized("Name of file to write wallet password output to. (Must be set, unless \"--to-console\" is passed"));
    createWallet->add_flag( "--to-console", print_console, localized("Print password to console."));
    createWallet->set_callback([&wallet_name, &password_file, &print_console] {
-      if (password_file.empty() && !print_console) {
-         std::cerr << "ERROR: Either indicate a file using \"--file\" or pass \"--to-console\"" << std::endl;
-         return;
-      }
+      EOSC_ASSERT( !password_file.empty() ^ print_console, "ERROR: Either indicate a file using \"--file\" or pass \"--to-console\"" );
 
       const auto& v = call(wallet_url, wallet_create, wallet_name);
       std::cout << localized("Creating wallet: ${wallet_name}", ("wallet_name", wallet_name)) << std::endl;

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -2549,6 +2549,7 @@ int main( int argc, char** argv ) {
    createWallet->add_flag( "--to-console", print_console, localized("Print password to console."));
    createWallet->set_callback([&wallet_name, &password_file, &print_console] {
       EOSC_ASSERT( !password_file.empty() ^ print_console, "ERROR: Either indicate a file using \"--file\" or pass \"--to-console\"" );
+      EOSC_ASSERT( password_file.empty() || !std::ofstream(password_file.c_str()).fail(), "ERROR: Failed to create file in specified path" );
 
       const auto& v = call(wallet_url, wallet_create, wallet_name);
       std::cout << localized("Creating wallet: ${wallet_name}", ("wallet_name", wallet_name)) << std::endl;


### PR DESCRIPTION
**Change Description**

1. Throw an exception when option is not set properly in wallet creation
This patch checks whether either `--file` or `--to-console` option is set. (No option or both options set will raise an exception) `cleos` will return 1 by raising an exception.

2. Don't create a wallet when failed to create password file
When specified path with option `--file` is incorrect, wallet is created and unlocked, even though password file isn't created. There's no way to know the password of created wallet, but user can import a private key (wallet still works until being locked due to timeout) and will lose control eventually. This patch checks whether `std::ofstream` is instantiated properly with specified path.