### PR TITLE
Remove double quotes when saving wallet password to file

### DIFF
--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -2561,8 +2561,10 @@ int main( int argc, char** argv ) {
          std::cout << fc::json::to_pretty_string(v) << std::endl;
       } else {
          std::cerr << localized("saving password to ${filename}", ("filename", password_file)) << std::endl;
+         auto password_str = fc::json::to_pretty_string(v);
+         boost::replace_all(password_str, "\"", "");
          std::ofstream out( password_file.c_str() );
-         out << fc::json::to_pretty_string(v);
+         out << password_str;
       }
    });
 


### PR DESCRIPTION
**Change Description**

When creating a wallet with writing password to file, password string is wrapped by double quotes. If double quotes are removed, following commands are available.
```
$ cleos wallet create --file FILENAME
$ cleos wallet unlock --password $(cat FILENAME)
```

This is not an essential feature, so if not necessary, feel free to reject PR.