### PR TITLE
Transaction catch up in net_plugin

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2379,7 +2379,7 @@ namespace eosio {
       request_message req;
       bool send_req = false;
       if (msg.known_trx.mode != none) {
-         fc_dlog(logger,"this is a ${m} notice with ${n} blocks", ("m",modes_str(msg.known_trx.mode))("n",msg.known_trx.pending));
+         fc_dlog(logger,"this is a ${m} notice with ${n} transactions", ("m",modes_str(msg.known_trx.mode))("n",msg.known_trx.pending));
       }
       switch (msg.known_trx.mode) {
       case none:

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2413,9 +2413,6 @@ namespace eosio {
       }
       switch (msg.known_blocks.mode) {
       case none : {
-         if (msg.known_trx.mode != normal) {
-            return;
-         }
          break;
       }
       case last_irr_catch_up:


### PR DESCRIPTION
**Change Description**

- net_plugin was not processing catch_up of transactions when caught up with blocks correctly
- Thanks to @fingera for PR #6033 which described the problem and provided a partial solution
