### PR TITLE
respect deterministic row conversion in integrity hash

### DIFF
--- a/libraries/chain/authorization_manager.cpp
+++ b/libraries/chain/authorization_manager.cpp
@@ -35,15 +35,6 @@ namespace eosio { namespace chain {
       _db.create<permission_object>([](auto&){}); /// reserve perm 0 (used else where)
    }
 
-   void authorization_manager::calculate_integrity_hash( fc::sha256::encoder& enc ) const {
-      authorization_index_set::walk_indices([this, &enc]( auto utils ){
-         decltype(utils)::walk(_db, [this, &enc]( const auto &row ) {
-            using row_type = std::decay_t<decltype(row)>;
-            fc::raw::pack(enc, detail::snapshot_row_traits<row_type>::to_snapshot_row(row, _db));
-         });
-      });
-   }
-
    namespace detail {
       template<>
       struct snapshot_row_traits<permission_object> {

--- a/libraries/chain/authorization_manager.cpp
+++ b/libraries/chain/authorization_manager.cpp
@@ -37,8 +37,9 @@ namespace eosio { namespace chain {
 
    void authorization_manager::calculate_integrity_hash( fc::sha256::encoder& enc ) const {
       authorization_index_set::walk_indices([this, &enc]( auto utils ){
-         decltype(utils)::walk(_db, [&enc]( const auto &row ) {
-            fc::raw::pack(enc, row);
+         decltype(utils)::walk(_db, [this, &enc]( const auto &row ) {
+            using row_type = std::decay_t<decltype(row)>;
+            fc::raw::pack(enc, detail::snapshot_row_traits<row_type>::to_snapshot_row(row, _db));
          });
       });
    }

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -419,24 +419,6 @@ struct controller_impl {
       });
    }
 
-   void calculate_contract_tables_integrity_hash( sha256::encoder& enc ) const {
-      index_utils<table_id_multi_index>::walk(db, [this, &enc]( const table_id_object& table_row ){
-         fc::raw::pack(enc, table_row);
-
-         contract_database_index_set::walk_indices([this, &enc, &table_row]( auto utils ) {
-            using value_t = typename decltype(utils)::index_t::value_type;
-            using by_table_id = object_to_table_id_tag_t<value_t>;
-
-            auto tid_key = boost::make_tuple(table_row.id);
-            auto next_tid_key = boost::make_tuple(table_id_object::id_type(table_row.id._id + 1));
-            decltype(utils)::template walk_range<by_table_id>(db, tid_key, next_tid_key, [this, &enc](const auto& row){
-               using row_type = std::decay_t<decltype(row)>;
-               fc::raw::pack(enc, detail::snapshot_row_traits<row_type>::to_snapshot_row(row, db));
-            });
-         });
-      });
-   }
-
    void add_contract_tables_to_snapshot( const snapshot_writer_ptr& snapshot ) const {
       snapshot->write_section("contract_tables", [this]( auto& section ) {
          index_utils<table_id_multi_index>::walk(db, [this, &section]( const table_id_object& table_row ){
@@ -490,29 +472,6 @@ struct controller_impl {
             });
          }
       });
-   }
-
-   sha256 calculate_integrity_hash() const {
-      sha256::encoder enc;
-      controller_index_set::walk_indices([this, &enc]( auto utils ){
-         using value_t = typename decltype(utils)::index_t::value_type;
-
-         // skip the table_id_object as its inlined with contract tables section
-         if (std::is_same<value_t, table_id_object>::value) {
-            return;
-         }
-
-         decltype(utils)::walk(db, [this, &enc]( const auto &row ) {
-            using row_type = std::decay_t<decltype(row)>;
-            fc::raw::pack(enc, detail::snapshot_row_traits<row_type>::to_snapshot_row(row, db));
-         });
-      });
-
-      calculate_contract_tables_integrity_hash(enc);
-
-      authorization.calculate_integrity_hash(enc);
-      resource_limits.calculate_integrity_hash(enc);
-      return enc.result();
    }
 
    void add_to_snapshot( const snapshot_writer_ptr& snapshot ) const {
@@ -594,6 +553,16 @@ struct controller_impl {
 
       db.set_revision( head->block_num );
    }
+
+   sha256 calculate_integrity_hash() const {
+      sha256::encoder enc;
+      auto hash_writer = std::make_shared<integrity_hash_snapshot_writer>(enc);
+      add_to_snapshot(hash_writer);
+      hash_writer->finalize();
+
+      return enc.result();
+   }
+
 
    /**
     *  Sets fork database head to the genesis state.

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -429,8 +429,9 @@ struct controller_impl {
 
             auto tid_key = boost::make_tuple(table_row.id);
             auto next_tid_key = boost::make_tuple(table_id_object::id_type(table_row.id._id + 1));
-            decltype(utils)::template walk_range<by_table_id>(db, tid_key, next_tid_key, [&enc](const auto& row){
-               fc::raw::pack(enc, row);
+            decltype(utils)::template walk_range<by_table_id>(db, tid_key, next_tid_key, [this, &enc](const auto& row){
+               using row_type = std::decay_t<decltype(row)>;
+               fc::raw::pack(enc, detail::snapshot_row_traits<row_type>::to_snapshot_row(row, db));
             });
          });
       });
@@ -501,8 +502,9 @@ struct controller_impl {
             return;
          }
 
-         decltype(utils)::walk(db, [&enc]( const auto &row ) {
-            fc::raw::pack(enc, row);
+         decltype(utils)::walk(db, [this, &enc]( const auto &row ) {
+            using row_type = std::decay_t<decltype(row)>;
+            fc::raw::pack(enc, detail::snapshot_row_traits<row_type>::to_snapshot_row(row, db));
          });
       });
 

--- a/libraries/chain/include/eosio/chain/authorization_manager.hpp
+++ b/libraries/chain/include/eosio/chain/authorization_manager.hpp
@@ -28,7 +28,6 @@ namespace eosio { namespace chain {
 
          void add_indices();
          void initialize_database();
-         void calculate_integrity_hash( fc::sha256::encoder& enc ) const;
          void add_to_snapshot( const snapshot_writer_ptr& snapshot ) const;
          void read_from_snapshot( const snapshot_reader_ptr& snapshot );
 

--- a/libraries/chain/include/eosio/chain/resource_limits.hpp
+++ b/libraries/chain/include/eosio/chain/resource_limits.hpp
@@ -44,7 +44,6 @@ namespace eosio { namespace chain { namespace resource_limits {
 
          void add_indices();
          void initialize_database();
-         void calculate_integrity_hash( fc::sha256::encoder& enc ) const;
          void add_to_snapshot( const snapshot_writer_ptr& snapshot ) const;
          void read_from_snapshot( const snapshot_reader_ptr& snapshot );
 

--- a/libraries/chain/include/eosio/chain/snapshot.hpp
+++ b/libraries/chain/include/eosio/chain/snapshot.hpp
@@ -74,6 +74,7 @@ namespace eosio { namespace chain {
 
       struct abstract_snapshot_row_writer {
          virtual void write(ostream_wrapper& out) const = 0;
+         virtual void write(fc::sha256::encoder& out) const = 0;
          virtual variant to_variant() const = 0;
          virtual std::string row_type_name() const = 0;
       };
@@ -83,8 +84,17 @@ namespace eosio { namespace chain {
          explicit snapshot_row_writer( const T& data )
          :data(data) {}
 
-         void write(ostream_wrapper& out) const override {
+         template<typename DataStream>
+         void write_stream(DataStream& out) const {
             fc::raw::pack(out, data);
+         }
+
+         void write(ostream_wrapper& out) const override {
+            write_stream(out);
+         }
+
+         void write(fc::sha256::encoder& out) const override {
+            write_stream(out);
          }
 
          fc::variant to_variant() const override {
@@ -354,6 +364,20 @@ namespace eosio { namespace chain {
          std::streampos header_pos;
          uint64_t       num_rows;
          uint64_t       cur_row;
+   };
+
+   class integrity_hash_snapshot_writer : public snapshot_writer {
+      public:
+         explicit integrity_hash_snapshot_writer(fc::sha256::encoder&  enc);
+
+         void write_start_section( const std::string& section_name ) override;
+         void write_row( const detail::abstract_snapshot_row_writer& row_writer ) override;
+         void write_end_section( ) override;
+         void finalize();
+
+      private:
+         fc::sha256::encoder&  enc;
+
    };
 
 }}

--- a/libraries/chain/resource_limits.cpp
+++ b/libraries/chain/resource_limits.cpp
@@ -67,8 +67,9 @@ void resource_limits_manager::initialize_database() {
 
 void resource_limits_manager::calculate_integrity_hash( fc::sha256::encoder& enc ) const {
    resource_index_set::walk_indices([this, &enc]( auto utils ){
-      decltype(utils)::walk(_db, [&enc]( const auto &row ) {
-         fc::raw::pack(enc, row);
+      decltype(utils)::walk(_db, [this, &enc]( const auto &row ) {
+         using row_type = std::decay_t<decltype(row)>;
+         fc::raw::pack(enc, detail::snapshot_row_traits<row_type>::to_snapshot_row(row, _db));
       });
    });
 }

--- a/libraries/chain/resource_limits.cpp
+++ b/libraries/chain/resource_limits.cpp
@@ -65,15 +65,6 @@ void resource_limits_manager::initialize_database() {
    });
 }
 
-void resource_limits_manager::calculate_integrity_hash( fc::sha256::encoder& enc ) const {
-   resource_index_set::walk_indices([this, &enc]( auto utils ){
-      decltype(utils)::walk(_db, [this, &enc]( const auto &row ) {
-         using row_type = std::decay_t<decltype(row)>;
-         fc::raw::pack(enc, detail::snapshot_row_traits<row_type>::to_snapshot_row(row, _db));
-      });
-   });
-}
-
 void resource_limits_manager::add_to_snapshot( const snapshot_writer_ptr& snapshot ) const {
    resource_index_set::walk_indices([this, &snapshot]( auto utils ){
       snapshot->write_section<typename decltype(utils)::index_t::value_type>([this]( auto& section ){

--- a/libraries/chain/snapshot.cpp
+++ b/libraries/chain/snapshot.cpp
@@ -336,4 +336,26 @@ void istream_snapshot_reader::clear_section() {
    cur_row = 0;
 }
 
+integrity_hash_snapshot_writer::integrity_hash_snapshot_writer(fc::sha256::encoder& enc)
+:enc(enc)
+{
+}
+
+void integrity_hash_snapshot_writer::write_start_section( const std::string& )
+{
+   // no-op for structural details
+}
+
+void integrity_hash_snapshot_writer::write_row( const detail::abstract_snapshot_row_writer& row_writer ) {
+   row_writer.write(enc);
+}
+
+void integrity_hash_snapshot_writer::write_end_section( ) {
+   // no-op for structural details
+}
+
+void integrity_hash_snapshot_writer::finalize() {
+   // no-op for structural details
+}
+
 }}


### PR DESCRIPTION
**Change Description**

To avoid leaking implementation details into snapshots, we create proxy types for some rows.  For instance, if a row contains a foreign key or if a logical table was split to improve runtime performance.  Those proxies were not being respected in the integrity hash calculation resulting in non-deterministic hashes.  This did _not_ affect the integrity or correctness of snapshots

Additionally, to prevent future issues, this is now routing the integrity hash through the snapshot code.  This imposes slightly more runtime overhead but should be more maintainable in the future.

**Consensus Changes**

none

**API Changes**

none

**Documentation Additions**

none