### PR TITLE
Fix bidnameinfo to just return actual matches

### DIFF
--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -1296,7 +1296,8 @@ struct bidname_info_subcommand {
             return;
          }
          auto result = rawResult.as<eosio::chain_apis::read_only::get_table_rows_result>();
-         if ( result.rows.empty() ) {
+         // get_table_func does lower_bound to upper_bound search, so may return erroneous row entry
+         if ( result.rows.empty() || result.rows[0]["newname"].as_string() != newname_str ) {
             std::cout << "No bidname record found" << std::endl;
             return;
          }


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- Give your PR a title that is sufficient to understand what is being changed. -->

**Change Description**

<!-- Describe the change you made, the motivation for it, and the impact it will have. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
#6067 
nodeos's table api returns row entries from lower_bound to upper_bound, so needed to prevent showing bidname rows that were returned with the next available bidname after the requested bidname.

**Consensus Changes**

<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->
N/A (This only effects read only cleos functionality)

**API Changes**

<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->
This affects cloes to only return a matching bidname when "cleos system bidnameinfo" is called.

**Documentation Additions**

<!-- List all the information that needs to be added to the documentation after merge. -->
This would be expected behavior (previous behavior was a bug).
