### PR TITLE
Fix for transaction_traces store in mongo_db_plugin

### DIFF
--- a/plugins/mongo_db_plugin/mongo_db_plugin.cpp
+++ b/plugins/mongo_db_plugin/mongo_db_plugin.cpp
@@ -811,7 +811,7 @@ mongo_db_plugin_impl::add_action_trace( mongocxx::bulk_write& bulk_action_traces
    }
 
    bool added = false;
-   bool in_filter = (store_action_traces || store_transaction_traces) && start_block_reached &&
+   const bool in_filter = (store_action_traces || store_transaction_traces) && start_block_reached &&
                     filter_include( atrace.receipt.receiver, atrace.act.name, atrace.act.authorization );
    write_ttrace |= in_filter;
    if( start_block_reached && store_action_traces && in_filter ) {

--- a/plugins/mongo_db_plugin/mongo_db_plugin.cpp
+++ b/plugins/mongo_db_plugin/mongo_db_plugin.cpp
@@ -98,7 +98,8 @@ public:
 
    bool add_action_trace( mongocxx::bulk_write& bulk_action_traces, const chain::action_trace& atrace,
                           const chain::transaction_trace_ptr& t,
-                          bool executed, const std::chrono::milliseconds& now );
+                          bool executed, const std::chrono::milliseconds& now,
+                          bool& write_ttrace );
 
    void update_account(const chain::action& act);
 
@@ -799,7 +800,8 @@ void mongo_db_plugin_impl::_process_accepted_transaction( const chain::transacti
 bool
 mongo_db_plugin_impl::add_action_trace( mongocxx::bulk_write& bulk_action_traces, const chain::action_trace& atrace,
                                         const chain::transaction_trace_ptr& t,
-                                        bool executed, const std::chrono::milliseconds& now )
+                                        bool executed, const std::chrono::milliseconds& now,
+                                        bool& write_ttrace )
 {
    using namespace bsoncxx::types;
    using bsoncxx::builder::basic::kvp;
@@ -809,8 +811,10 @@ mongo_db_plugin_impl::add_action_trace( mongocxx::bulk_write& bulk_action_traces
    }
 
    bool added = false;
-   if( start_block_reached && store_action_traces &&
-       filter_include( atrace.receipt.receiver, atrace.act.name, atrace.act.authorization ) ) {
+   bool in_filter = (store_action_traces || store_transaction_traces) && start_block_reached &&
+                    filter_include( atrace.receipt.receiver, atrace.act.name, atrace.act.authorization );
+   write_ttrace |= in_filter;
+   if( start_block_reached && store_action_traces && in_filter ) {
       auto action_traces_doc = bsoncxx::builder::basic::document{};
       const chain::base_action_trace& base = atrace; // without inline action traces
 
@@ -841,7 +845,7 @@ mongo_db_plugin_impl::add_action_trace( mongocxx::bulk_write& bulk_action_traces
    }
 
    for( const auto& iline_atrace : atrace.inline_traces ) {
-      added |= add_action_trace( bulk_action_traces, iline_atrace, t, executed, now );
+      added |= add_action_trace( bulk_action_traces, iline_atrace, t, executed, now, write_ttrace );
    }
 
    return added;
@@ -861,22 +865,22 @@ void mongo_db_plugin_impl::_process_applied_transaction( const chain::transactio
    bulk_opts.ordered(false);
    mongocxx::bulk_write bulk_action_traces = _action_traces.create_bulk_write(bulk_opts);
    bool write_atraces = false;
+   bool write_ttrace = false; // filters apply to transaction_traces as well
    bool executed = t->receipt.valid() && t->receipt->status == chain::transaction_receipt_header::executed;
 
    for( const auto& atrace : t->action_traces ) {
       try {
-         write_atraces |= add_action_trace( bulk_action_traces, atrace, t, executed, now );
+         write_atraces |= add_action_trace( bulk_action_traces, atrace, t, executed, now, write_ttrace );
       } catch(...) {
          handle_mongo_exception("add action traces", __LINE__);
       }
    }
 
    if( !start_block_reached ) return; //< add_action_trace calls update_account which must be called always
-   if( !write_atraces ) return; //< do not insert transaction_trace if all action_traces filtered out
 
    // transaction trace insert
 
-   if( store_transaction_traces ) {
+   if( store_transaction_traces && write_ttrace ) {
       try {
          auto v = to_variant_with_abi( *t );
          string json = fc::json::to_string( v );
@@ -909,13 +913,15 @@ void mongo_db_plugin_impl::_process_applied_transaction( const chain::transactio
    }
 
    // insert action_traces
-   try {
-      if( !bulk_action_traces.execute() ) {
-         EOS_ASSERT( false, chain::mongo_db_insert_fail,
-                     "Bulk action traces insert failed for transaction trace: ${id}", ("id", t->id) );
+   if( write_atraces ) {
+      try {
+         if( !bulk_action_traces.execute() ) {
+            EOS_ASSERT( false, chain::mongo_db_insert_fail,
+                        "Bulk action traces insert failed for transaction trace: ${id}", ("id", t->id) );
+         }
+      } catch( ... ) {
+         handle_mongo_exception( "action traces insert", __LINE__ );
       }
-   } catch( ... ) {
-      handle_mongo_exception( "action traces insert", __LINE__ );
    }
 
 }


### PR DESCRIPTION
**Change Description**

- transaction_traces were not stored if action_traces were not stored
- Now transaction_traces are stored if enabled even if action_trace storage is disabled
- Filtering is applied to transaction_traces even if action_trace storage is disabled

Resolves #6088 