### PR TITLE
make next_session_id thread safe

### DIFF
--- a/plugins/bnet_plugin/bnet_plugin.cpp
+++ b/plugins/bnet_plugin/bnet_plugin.cpp
@@ -306,7 +306,7 @@ namespace eosio {
 
 
         int next_session_id()const {
-           static int session_count = 0;
+           static std::atomic<int> session_count(0);
            return ++session_count;
         }
 


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- Give your PR a title that is sufficient to understand what is being changed. -->

**Make next_session_id thread safe**

next_session_id called from session constructor

Main thread:
https://github.com/EOSIO/eos/blob/f9a3d023c05d6b7984cbd7263a5a39e650c87e90/plugins/bnet_plugin/bnet_plugin.cpp#L1262
https://github.com/EOSIO/eos/blob/f9a3d023c05d6b7984cbd7263a5a39e650c87e90/plugins/bnet_plugin/bnet_plugin.cpp#L1429

Work thread(on_accept):
https://github.com/EOSIO/eos/blob/f9a3d023c05d6b7984cbd7263a5a39e650c87e90/plugins/bnet_plugin/bnet_plugin.cpp#L1293