### PR TITLE
fix _last_sent_block_id

### DIFF
--- a/plugins/bnet_plugin/bnet_plugin.cpp
+++ b/plugins/bnet_plugin/bnet_plugin.cpp
@@ -788,7 +788,7 @@ namespace eosio {
 
             /// if something changed, the next block doesn't link to the last
             /// block we sent, local chain must have switched forks
-            if( nextblock->previous != _last_sent_block_id ) {
+            if( nextblock->previous != _last_sent_block_id && _last_sent_block_id != block_id_type() ) {
                 if( !is_known_by_peer( nextblock->previous ) ) {
                   _last_sent_block_id  = _local_lib_id;
                   _last_sent_block_num = _local_lib;


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- Give your PR a title that is sufficient to understand what is being changed. -->

**Fix sync block**
bnet_plugin cannot sync block? 
this commit make it work correctly when syncing blocks.
_last_sent_block_id initialized to 0.
I think It's not forked.
https://github.com/EOSIO/eos/blob/f9a3d023c05d6b7984cbd7263a5a39e650c87e90/plugins/bnet_plugin/bnet_plugin.cpp#L791-L799