### PR TITLE
Gh#6056 long startup

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -387,7 +387,8 @@ struct controller_impl {
       }
 
       if( snapshot ) {
-         ilog( "database initialized with hash: ${hash}", ("hash", calculate_integrity_hash()) );
+         const auto hash = calculate_integrity_hash();
+         ilog( "database initialized with hash: ${hash}", ("hash", hash) );
       }
 
    }

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -386,7 +386,9 @@ struct controller_impl {
          db.undo();
       }
 
-      ilog( "database initialized with hash: ${hash}", ("hash", calculate_integrity_hash()));
+      if( snapshot ) {
+         ilog( "database initialized with hash: ${hash}", ("hash", calculate_integrity_hash()) );
+      }
 
    }
 


### PR DESCRIPTION
**Change Description**

As documented by #6056 some people are seeing slow startup. This is caused by `calculate_integrity_hash()` taking a long time to run. 

Only call the startup `calculate_integrity_hash` when starting from a snapshot to avoid delay.
