### PR TITLE
Start block state creation early

### DIFF
--- a/libraries/chain/block_header_state.cpp
+++ b/libraries/chain/block_header_state.cpp
@@ -178,9 +178,9 @@ namespace eosio { namespace chain {
     result.id                        = result.header.id();
 
     // ASSUMPTION FROM controller_impl::apply_block = all untrusted blocks will have their signatures pre-validated here
+    // unless light validation in which case it is verified after applying transactions
     if( !trust ) {
-       EOS_ASSERT( result.block_signing_key == result.signee(), wrong_signing_key, "block not signed by expected key",
-                  ("result.block_signing_key", result.block_signing_key)("signee", result.signee() ) );
+       result.verify_signee();
     }
 
     return result;
@@ -234,6 +234,19 @@ namespace eosio { namespace chain {
 
   public_key_type block_header_state::signee()const {
     return fc::crypto::public_key( header.producer_signature, sig_digest(), true );
+  }
+
+  void block_header_state::verify_signee() {
+     if( block_signing_key_future.valid() ) {
+        // if block signing verification delayed for light validation then verify it here
+        auto signee = block_signing_key_future.get();
+        EOS_ASSERT( block_signing_key == signee, wrong_signing_key, "block signed by wrong key",
+                    ("block_signing_key", block_signing_key)("signee", signee ) );
+        block_signing_key_future = decltype( block_signing_key_future ){};
+     } else {
+        EOS_ASSERT( block_signing_key == signee(), wrong_signing_key, "block not signed by expected key",
+                    ("result.block_signing_key", block_signing_key)("signee", signee() ) );
+     }
   }
 
   void block_header_state::add_confirmation( const header_confirmation& conf ) {

--- a/libraries/chain/block_header_state.cpp
+++ b/libraries/chain/block_header_state.cpp
@@ -143,7 +143,7 @@ namespace eosio { namespace chain {
    *
    *  If the header specifies new_producers then apply them accordingly.
    */
-  block_header_state block_header_state::next( const signed_block_header& h, bool trust )const {
+  block_header_state block_header_state::next( const signed_block_header& h, bool skip_validate_signee )const {
     EOS_ASSERT( h.timestamp != block_timestamp_type(), block_validate_exception, "", ("h",h) );
     EOS_ASSERT( h.header_extensions.size() == 0, block_validate_exception, "no supported extensions" );
 
@@ -179,7 +179,7 @@ namespace eosio { namespace chain {
 
     // ASSUMPTION FROM controller_impl::apply_block = all untrusted blocks will have their signatures pre-validated here
     // unless light validation in which case it is verified after applying transactions
-    if( !trust ) {
+    if( !skip_validate_signee ) {
        result.verify_signee();
     }
 

--- a/libraries/chain/block_header_state.cpp
+++ b/libraries/chain/block_header_state.cpp
@@ -58,8 +58,6 @@ namespace eosio { namespace chain {
     result.blockroot_merkle = blockroot_merkle;
     result.blockroot_merkle.append( id );
 
-    auto block_mroot = result.blockroot_merkle.get_root();
-
     result.active_schedule                       = active_schedule;
     result.pending_schedule                      = pending_schedule;
     result.dpos_proposed_irreversible_blocknum   = dpos_proposed_irreversible_blocknum;
@@ -239,13 +237,6 @@ namespace eosio { namespace chain {
   void block_header_state::verify_signee( const public_key_type& signee )const {
      EOS_ASSERT( block_signing_key == signee, wrong_signing_key, "block not signed by expected key",
                  ("block_signing_key", block_signing_key)( "signee", signee ) );
-  }
-
-  void block_header_state::verify_signee_future() {
-     EOS_ASSERT( block_signing_key_future.valid(), wrong_signing_key, "No future setup for signee" );
-     auto signee = block_signing_key_future.get();
-     verify_signee( signee );
-     block_signing_key_future = decltype( block_signing_key_future ){};
   }
 
   void block_header_state::add_confirmation( const header_confirmation& conf ) {

--- a/libraries/chain/block_header_state.cpp
+++ b/libraries/chain/block_header_state.cpp
@@ -176,7 +176,6 @@ namespace eosio { namespace chain {
     result.id                        = result.header.id();
 
     // ASSUMPTION FROM controller_impl::apply_block = all untrusted blocks will have their signatures pre-validated here
-    // unless light validation in which case it is verified after applying transactions
     if( !skip_validate_signee ) {
        result.verify_signee( result.signee() );
     }

--- a/libraries/chain/block_state.cpp
+++ b/libraries/chain/block_state.cpp
@@ -10,9 +10,9 @@ namespace eosio { namespace chain {
       static_cast<block_header&>(*block) = header;
    }
 
-   block_state::block_state( const block_header_state& prev, signed_block_ptr b, bool trust )
-   :block_header_state( prev.next( *b, trust )), block( move(b) )
-   { } 
+   block_state::block_state( const block_header_state& prev, signed_block_ptr b, bool skip_validate_signee )
+   :block_header_state( prev.next( *b, skip_validate_signee )), block( move(b) )
+   { }
 
 
 

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1273,8 +1273,10 @@ struct controller_impl {
          EOS_ASSERT( b, block_validate_exception, "trying to push empty block" );
          EOS_ASSERT( s != controller::block_status::incomplete, block_validate_exception, "invalid block status for a completed block" );
          emit( self.pre_accepted_block, b );
-         bool trust = !conf.force_all_checks && (s == controller::block_status::irreversible || s == controller::block_status::validated);
-         auto new_header_state = fork_db.add( b, trust || conf.block_validation_mode == validation_mode::LIGHT );
+         const bool trust = !conf.force_all_checks &&
+               (s == controller::block_status::irreversible || s == controller::block_status::validated);
+         const bool skip_validate_signee = trust || conf.block_validation_mode == validation_mode::LIGHT;
+         auto new_header_state = fork_db.add( b, skip_validate_signee );
          if( !trust && conf.block_validation_mode == validation_mode::LIGHT ) {
             std::weak_ptr<block_state> new_header_state_wp = new_header_state;
             new_header_state->block_signing_key_future = async_thread_pool(

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -688,7 +688,7 @@ struct controller_impl {
       try {
          if (add_to_fork_db) {
             pending->_pending_block_state->validated = true;
-            auto new_bsp = fork_db.add(pending->_pending_block_state);
+            auto new_bsp = fork_db.add(pending->_pending_block_state, true);
             emit(self.accepted_block_header, pending->_pending_block_state);
             head = fork_db.head();
             EOS_ASSERT(new_bsp == head, fork_database_exception, "committed block did not become the new head in fork database");
@@ -1286,7 +1286,7 @@ struct controller_impl {
          auto& b = new_header_state->block;
          emit( self.pre_accepted_block, b );
 
-         fork_db.add( new_header_state );
+         fork_db.add( new_header_state, false );
 
          if (conf.trusted_producers.count(b->producer)) {
             trusted_producer_light_validation = true;
@@ -1387,7 +1387,7 @@ struct controller_impl {
                throw *except;
             } // end if exception
          } /// end for each block in branch
-         ilog("successfully switched fork to new head ${new_head_id}", ("new_head_id", new_head->id));
+         ilog("successfully switched fork to new head ${new_head_id}", ("new_head_id", new_head->id) );
       }
    } /// push_block
 

--- a/libraries/chain/fork_database.cpp
+++ b/libraries/chain/fork_database.cpp
@@ -139,7 +139,7 @@ namespace eosio { namespace chain {
       return n;
    }
 
-   block_state_ptr fork_database::add( signed_block_ptr b, bool trust ) {
+   block_state_ptr fork_database::add( signed_block_ptr b, bool skip_validate_signee ) {
       EOS_ASSERT( b, fork_database_exception, "attempt to add null block" );
       EOS_ASSERT( my->head, fork_db_block_not_found, "no head block set" );
 
@@ -150,7 +150,7 @@ namespace eosio { namespace chain {
       auto prior = by_id_idx.find( b->previous );
       EOS_ASSERT( prior != by_id_idx.end(), unlinkable_block_exception, "unlinkable block", ("id", string(b->id()))("previous", string(b->previous)) );
 
-      auto result = std::make_shared<block_state>( **prior, move(b), trust );
+      auto result = std::make_shared<block_state>( **prior, move(b), skip_validate_signee );
       EOS_ASSERT( result, fork_database_exception , "fail to add new block state" );
       return add(result);
    }

--- a/libraries/chain/fork_database.cpp
+++ b/libraries/chain/fork_database.cpp
@@ -124,6 +124,9 @@ namespace eosio { namespace chain {
    }
 
    block_state_ptr fork_database::add( block_state_ptr n ) {
+      EOS_ASSERT( n, fork_database_exception, "attempt to add null block state" );
+      EOS_ASSERT( my->head, fork_db_block_not_found, "no head block set" );
+
       auto inserted = my->index.insert(n);
       EOS_ASSERT( inserted.second, fork_database_exception, "duplicate block added?" );
 

--- a/libraries/chain/include/eosio/chain/block_header_state.hpp
+++ b/libraries/chain/include/eosio/chain/block_header_state.hpp
@@ -53,6 +53,7 @@ struct block_header_state {
     digest_type          sig_digest()const;
     void                 sign( const std::function<signature_type(const digest_type&)>& signer );
     public_key_type      signee()const;
+    void                 verify_signee();
 };
 
 

--- a/libraries/chain/include/eosio/chain/block_header_state.hpp
+++ b/libraries/chain/include/eosio/chain/block_header_state.hpp
@@ -53,7 +53,8 @@ struct block_header_state {
     digest_type          sig_digest()const;
     void                 sign( const std::function<signature_type(const digest_type&)>& signer );
     public_key_type      signee()const;
-    void                 verify_signee();
+    void                 verify_signee(const public_key_type& signee)const;
+    void                 verify_signee_future();
 };
 
 

--- a/libraries/chain/include/eosio/chain/block_header_state.hpp
+++ b/libraries/chain/include/eosio/chain/block_header_state.hpp
@@ -26,7 +26,6 @@ struct block_header_state {
     public_key_type                   block_signing_key;
     vector<uint8_t>                   confirm_count;
     vector<header_confirmation>       confirmations;
-    std::shared_future<public_key_type> block_signing_key_future;
 
     block_header_state   next( const signed_block_header& h, bool trust = false )const;
     block_header_state   generate_next( block_timestamp_type when )const;
@@ -54,7 +53,6 @@ struct block_header_state {
     void                 sign( const std::function<signature_type(const digest_type&)>& signer );
     public_key_type      signee()const;
     void                 verify_signee(const public_key_type& signee)const;
-    void                 verify_signee_future();
 };
 
 

--- a/libraries/chain/include/eosio/chain/block_state.hpp
+++ b/libraries/chain/include/eosio/chain/block_state.hpp
@@ -12,8 +12,8 @@
 namespace eosio { namespace chain {
 
    struct block_state : public block_header_state {
-      block_state( const block_header_state& cur ):block_header_state(cur){}
-      block_state( const block_header_state& prev, signed_block_ptr b, bool trust = false );
+      explicit block_state( const block_header_state& cur ):block_header_state(cur){}
+      block_state( const block_header_state& prev, signed_block_ptr b, bool skip_validate_signee );
       block_state( const block_header_state& prev, block_timestamp_type when );
       block_state() = default;
 

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -140,7 +140,8 @@ namespace eosio { namespace chain {
          void commit_block();
          void pop_block();
 
-         void push_block( const signed_block_ptr& b, block_status s = block_status::complete );
+         std::future<block_state_ptr> create_block_state_future( const signed_block_ptr& b );
+         void push_block( std::future<block_state_ptr>& block_state_future );
 
          const chainbase::database& db()const;
 

--- a/libraries/chain/include/eosio/chain/fork_database.hpp
+++ b/libraries/chain/include/eosio/chain/fork_database.hpp
@@ -36,11 +36,11 @@ namespace eosio { namespace chain {
           */
          void            set( block_state_ptr s );
 
-         /** this method will attempt to append the block to an exsting
+         /** this method will attempt to append the block to an existing
           * block_state and will return a pointer to the new block state or
           * throw on error.
           */
-         block_state_ptr add( signed_block_ptr b, bool trust = false );
+         block_state_ptr add( signed_block_ptr b, bool skip_validate_signee );
          block_state_ptr add( block_state_ptr next_block );
          void            remove( const block_id_type& id );
 

--- a/libraries/chain/include/eosio/chain/fork_database.hpp
+++ b/libraries/chain/include/eosio/chain/fork_database.hpp
@@ -41,7 +41,7 @@ namespace eosio { namespace chain {
           * throw on error.
           */
          block_state_ptr add( signed_block_ptr b, bool skip_validate_signee );
-         block_state_ptr add( block_state_ptr next_block );
+         block_state_ptr add( const block_state_ptr& next_block, bool skip_validate_previous );
          void            remove( const block_id_type& id );
 
          void            add( const header_confirmation& c );

--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -373,7 +373,8 @@ namespace eosio { namespace testing {
 
       signed_block_ptr produce_block( fc::microseconds skip_time = fc::milliseconds(config::block_interval_ms), uint32_t skip_flag = 0 /*skip_missed_block_penalty*/ )override {
          auto sb = _produce_block(skip_time, false, skip_flag | 2);
-         validating_node->push_block( sb );
+         auto bs = validating_node->create_block_state_future( sb );
+         validating_node->push_block( bs );
 
          return sb;
       }
@@ -383,15 +384,15 @@ namespace eosio { namespace testing {
       }
 
       void validate_push_block(const signed_block_ptr& sb) {
-         validating_node->push_block( sb );
+         auto bs = validating_node->create_block_state_future( sb );
+         validating_node->push_block( bs );
       }
 
       signed_block_ptr produce_empty_block( fc::microseconds skip_time = fc::milliseconds(config::block_interval_ms), uint32_t skip_flag = 0 /*skip_missed_block_penalty*/ )override {
          control->abort_block();
          auto sb = _produce_block(skip_time, true, skip_flag | 2);
-         validating_node->push_block( sb );
-
-
+         auto bs = validating_node->create_block_state_future( sb );
+         validating_node->push_block( bs );
 
          return sb;
       }

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -141,8 +141,9 @@ namespace eosio { namespace testing {
    }
 
    signed_block_ptr base_tester::push_block(signed_block_ptr b) {
+      auto bs = control->create_block_state_future(b);
       control->abort_block();
-      control->push_block(b);
+      control->push_block(bs);
 
       auto itr = last_produced_block.find(b->producer);
       if (itr == last_produced_block.end() || block_header::num_from_id(b->id()) > block_header::num_from_id(itr->second)) {
@@ -795,8 +796,9 @@ namespace eosio { namespace testing {
          for( int i = 1; i <= a.control->head_block_num(); ++i ) {
             auto block = a.control->fetch_block_by_number(i);
             if( block ) { //&& !b.control->is_known_block(block->id()) ) {
+               auto bs = b.control->create_block_state_future( block );
                b.control->abort_block();
-               b.control->push_block(block); //, eosio::chain::validation_steps::created_block);
+               b.control->push_block(bs); //, eosio::chain::validation_steps::created_block);
             }
          }
       };

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -298,7 +298,8 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
          auto existing = chain.fetch_block_by_id( id );
          if( existing ) { return; }
 
-         ilog("received incoming block ${id}", ("id", id));
+         // start processing of block
+         auto bsf = chain.create_block_state_future( block );
 
          // abort the pending block
          chain.abort_block();
@@ -311,7 +312,7 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
          // push the new block
          bool except = false;
          try {
-            chain.push_block(block);
+            chain.push_block( bsf );
          } catch ( const guard_exception& e ) {
             app().get_plugin<chain_plugin>().handle_guard_exception(e);
             return;

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -285,17 +285,20 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
       };
 
       void on_incoming_block(const signed_block_ptr& block) {
-         fc_dlog(_log, "received incoming block ${id}", ("id", block->id()));
+         auto id = block->id();
 
-         EOS_ASSERT( block->timestamp < (fc::time_point::now() + fc::seconds(7)), block_from_the_future, "received a block from the future, ignoring it" );
+         fc_dlog(_log, "received incoming block ${id}", ("id", id));
 
+         EOS_ASSERT( block->timestamp < (fc::time_point::now() + fc::seconds( 7 )), block_from_the_future,
+                     "received a block from the future, ignoring it: ${id}", ("id", id) );
 
          chain::controller& chain = app().get_plugin<chain_plugin>().chain();
 
          /* de-dupe here... no point in aborting block if we already know the block */
-         auto id = block->id();
          auto existing = chain.fetch_block_by_id( id );
          if( existing ) { return; }
+
+         ilog("received incoming block ${id}", ("id", id));
 
          // abort the pending block
          chain.abort_block();

--- a/unittests/block_tests.cpp
+++ b/unittests/block_tests.cpp
@@ -42,8 +42,9 @@ BOOST_AUTO_TEST_CASE(block_with_invalid_tx_test)
 
    // Push block with invalid transaction to other chain
    tester validator;
+   auto bs = validator.control->create_block_state_future( copy_b );
    validator.control->abort_block();
-   BOOST_REQUIRE_EXCEPTION(validator.control->push_block( copy_b ), fc::exception ,
+   BOOST_REQUIRE_EXCEPTION(validator.control->push_block( bs ), fc::exception ,
    [] (const fc::exception &e)->bool {
       return e.code() == account_name_exists_exception::code_value ;
    }) ;

--- a/unittests/forked_tests.cpp
+++ b/unittests/forked_tests.cpp
@@ -279,8 +279,9 @@ BOOST_AUTO_TEST_CASE( forking ) try {
    wlog( "now push dan's block to c1 but first corrupt it so it is a bad block" );
    auto bad_block = *b;
    bad_block.transaction_mroot = bad_block.previous;
+   auto bad_block_bs = c.control->create_block_state_future( std::make_shared<signed_block>(bad_block) );
    c.control->abort_block();
-   BOOST_REQUIRE_EXCEPTION(c.control->push_block( std::make_shared<signed_block>(bad_block) ), fc::exception,
+   BOOST_REQUIRE_EXCEPTION(c.control->push_block( bad_block_bs ), fc::exception,
       [] (const fc::exception &ex)->bool {
          return ex.to_detail_string().find("block not signed by expected key") != std::string::npos;
       });


### PR DESCRIPTION
**Change Description**

- `controller::push_block()` now takes a future to a block state that can be created by `controller::create_state_block_future()`. This allows the creation of the block state to begin earlier (before abort block) including the verfication of block signee.
- Added a `controller::replay_push_block` for use during replay since futures would only slow that process down (block signee is not verified during normal replay).
- Capture weak_ptr for futures so they do not keep shared_ptr alive