### PR TITLE
Replay complete, delete the unuseful backup dir.

### DIFF
--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -495,6 +495,7 @@ void chain_plugin::plugin_initialize(const variables_map& options) {
                fc::copy( backup_dir / config::reversible_blocks_dir_name / "shared_memory.meta",
                          my->chain_config->blocks_dir / config::reversible_blocks_dir_name / "shared_memory.meta" );
             }
+          fc::remove_all( backup_dir ); // Replay complete, delete the unuseful backup_dir.
          }
       } else if( options.at( "replay-blockchain" ).as<bool>()) {
          ilog( "Replay requested: deleting state database" );


### PR DESCRIPTION
## delete backup dir after replay

**change**
Add oneline code after replay complete.
```
fc::remove_all(backup_dir)
```

**two reasons for change:**
- The old 'backup_dir' data is wasting of space. 
- The operator just want recover the 'blocks.log' as the same with the old one.  It's puzzled about the complex directory structure. 

Related the space issue, maybe lead to [GH-6190](https://github.com/EOSIO/eos/issues/6190)

**potential impact**
If this PR was merged, I think there's no impact to the current blockchain.  Because the  old 'backup_dir' data is recovered into the real 'blocks.log'.

