### PR TITLE
Nodeos permissive of redundant genesis state command line arguments

### DIFF
--- a/libraries/chain/include/eosio/chain/chain_config.hpp
+++ b/libraries/chain/include/eosio/chain/chain_config.hpp
@@ -60,10 +60,50 @@ struct chain_config {
                  << "Max Inline Action Depth: " << c.max_inline_action_depth << ", "
                  << "Max Authority Depth: " << c.max_authority_depth << "\n";
    }
-};
 
-       bool operator==(const chain_config& a, const chain_config& b);
-inline bool operator!=(const chain_config& a, const chain_config& b) { return !(a == b); }
+   friend inline bool operator ==( const chain_config& lhs, const chain_config& rhs ) {
+      return   std::tie(   lhs.max_block_net_usage,
+                           lhs.target_block_net_usage_pct,
+                           lhs.max_transaction_net_usage,
+                           lhs.base_per_transaction_net_usage,
+                           lhs.net_usage_leeway,
+                           lhs.context_free_discount_net_usage_num,
+                           lhs.context_free_discount_net_usage_den,
+                           lhs.max_block_cpu_usage,
+                           lhs.target_block_cpu_usage_pct,
+                           lhs.max_transaction_cpu_usage,
+                           lhs.max_transaction_cpu_usage,
+                           lhs.max_transaction_lifetime,
+                           lhs.deferred_trx_expiration_window,
+                           lhs.max_transaction_delay,
+                           lhs.max_inline_action_size,
+                           lhs.max_inline_action_depth,
+                           lhs.max_authority_depth
+                        )
+               ==
+               std::tie(   rhs.max_block_net_usage,
+                           rhs.target_block_net_usage_pct,
+                           rhs.max_transaction_net_usage,
+                           rhs.base_per_transaction_net_usage,
+                           rhs.net_usage_leeway,
+                           rhs.context_free_discount_net_usage_num,
+                           rhs.context_free_discount_net_usage_den,
+                           rhs.max_block_cpu_usage,
+                           rhs.target_block_cpu_usage_pct,
+                           rhs.max_transaction_cpu_usage,
+                           rhs.max_transaction_cpu_usage,
+                           rhs.max_transaction_lifetime,
+                           rhs.deferred_trx_expiration_window,
+                           rhs.max_transaction_delay,
+                           rhs.max_inline_action_size,
+                           rhs.max_inline_action_depth,
+                           rhs.max_authority_depth
+                        );
+   };
+
+   friend inline bool operator !=( const chain_config& lhs, const chain_config& rhs ) { return !(lhs == rhs); }
+
+};
 
 } } // namespace eosio::chain
 

--- a/libraries/chain/include/eosio/chain/genesis_state.hpp
+++ b/libraries/chain/include/eosio/chain/genesis_state.hpp
@@ -51,6 +51,14 @@ struct genesis_state {
     * This is the SHA256 serialization of the genesis_state.
     */
    chain_id_type compute_chain_id() const;
+
+   friend inline bool operator==( const genesis_state& lhs, const genesis_state& rhs ) {
+      return std::tie( lhs.initial_configuration, lhs.initial_timestamp, lhs.initial_key )
+               == std::tie( rhs.initial_configuration, rhs.initial_timestamp, rhs.initial_key );
+   };
+
+   friend inline bool operator!=( const genesis_state& lhs, const genesis_state& rhs ) { return !(lhs == rhs); }
+
 };
 
 } } // namespace eosio::chain

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -571,12 +571,17 @@ void chain_plugin::plugin_initialize(const variables_map& options) {
          }
 
       } else {
-         if( options.count( "genesis-json" )) {
-            EOS_ASSERT( !fc::exists( my->blocks_dir / "blocks.log" ),
-                        plugin_config_exception,
-                       "Genesis state can only be set on a fresh blockchain." );
+         bfs::path genesis_file;
+         bool genesis_timestamp_specified = false;
+         fc::optional<genesis_state> existing_genesis;
+         genesis_state genesis;
 
-            auto genesis_file = options.at( "genesis-json" ).as<bfs::path>();
+         if( fc::exists( my->blocks_dir / "blocks.log" ) ) {
+            existing_genesis = block_log::extract_genesis_state( my->blocks_dir );
+         }
+
+         if( options.count( "genesis-json" )) {
+            genesis_file = options.at( "genesis-json" ).as<bfs::path>();
             if( genesis_file.is_relative()) {
                genesis_file = bfs::current_path() / genesis_file;
             }
@@ -586,29 +591,33 @@ void chain_plugin::plugin_initialize(const variables_map& options) {
                        "Specified genesis file '${genesis}' does not exist.",
                        ("genesis", genesis_file.generic_string()));
 
-            my->chain_config->genesis = fc::json::from_file( genesis_file ).as<genesis_state>();
+            genesis = fc::json::from_file( genesis_file ).as<genesis_state>();
+         }
 
-            ilog( "Using genesis state provided in '${genesis}'", ("genesis", genesis_file.generic_string()));
+         if( options.count( "genesis-timestamp" ) ) {
+            genesis.initial_timestamp = calculate_genesis_timestamp( options.at( "genesis-timestamp" ).as<string>() );
+            genesis_timestamp_specified = true;
+         }
 
-            if( options.count( "genesis-timestamp" )) {
-               my->chain_config->genesis.initial_timestamp = calculate_genesis_timestamp(
-                     options.at( "genesis-timestamp" ).as<string>());
+         if( !existing_genesis ) {
+            my->chain_config->genesis = genesis;
+            if( !genesis_file.empty() ) {
+               if( genesis_timestamp_specified ) {
+                  ilog( "Using genesis state provided in '${genesis}' but with adjusted genesis timestamp",
+                        ("genesis", genesis_file.generic_string()) );
+               } else {
+                  ilog( "Using genesis state provided in '${genesis}'", ("genesis", genesis_file.generic_string()));
+               }
+               wlog( "Starting up fresh blockchain with provided genesis state." );
+            } else if( genesis_timestamp_specified ) {
+               wlog( "Starting up fresh blockchain with default genesis state but with adjusted genesis timestamp." );
+            } else {
+               wlog( "Starting up fresh blockchain with default genesis state." );
             }
-
-            wlog( "Starting up fresh blockchain with provided genesis state." );
-         } else if( options.count( "genesis-timestamp" )) {
-            EOS_ASSERT( !fc::exists( my->blocks_dir / "blocks.log" ),
-                        plugin_config_exception,
-                       "Genesis state can only be set on a fresh blockchain." );
-
-            my->chain_config->genesis.initial_timestamp = calculate_genesis_timestamp(
-                  options.at( "genesis-timestamp" ).as<string>());
-
-            wlog( "Starting up fresh blockchain with default genesis state but with adjusted genesis timestamp." );
-         } else if( fc::is_regular_file( my->blocks_dir / "blocks.log" )) {
-            my->chain_config->genesis = block_log::extract_genesis_state( my->blocks_dir );
          } else {
-            wlog( "Starting up fresh blockchain with default genesis state." );
+            my->chain_config->genesis = *existing_genesis;
+            EOS_ASSERT( *existing_genesis == genesis, plugin_config_exception,
+                        "Genesis state provided via command line arguments does not match the existing genesis state in blocks.log" );
          }
       }
 
@@ -1707,7 +1716,7 @@ read_only::get_account_results read_only::get_account( const get_account_params&
 
       auto core_symbol = extract_core_symbol();
 
-      if (params.expected_core_symbol.valid()) 
+      if (params.expected_core_symbol.valid())
          core_symbol = *(params.expected_core_symbol);
 
       const auto* t_id = d.find<chain::table_id_object, chain::by_code_scope_table>(boost::make_tuple( token_code, params.account_name, N(accounts) ));


### PR DESCRIPTION
**Change Description**

Now nodeos will permit specifying genesis state on command line even with an existing blocks.log but only if it exactly matches the genesis state already stored in the blocks.log file.

This makes it easier for the same startup script to both setup a fresh blockchain if necessary and restart nodeos, which is convenient for testing and automation purposes.

Resolves #6209.

**Consensus Changes**

None

**API Changes**

None

**Documentation Additions**

None
