### PR TITLE
failed deferred transactions were in history (6214)

### DIFF
--- a/plugins/history_plugin/history_plugin.cpp
+++ b/plugins/history_plugin/history_plugin.cpp
@@ -282,6 +282,8 @@ namespace eosio {
          }
 
          void on_applied_transaction( const transaction_trace_ptr& trace ) {
+            if( !trace->receipt || trace->receipt->status != transaction_receipt_header::executed )
+               return;
             for( const auto& atrace : trace->action_traces ) {
                on_action_trace( atrace );
             }

--- a/plugins/history_plugin/history_plugin.cpp
+++ b/plugins/history_plugin/history_plugin.cpp
@@ -282,7 +282,8 @@ namespace eosio {
          }
 
          void on_applied_transaction( const transaction_trace_ptr& trace ) {
-            if( !trace->receipt || trace->receipt->status != transaction_receipt_header::executed )
+            if( !trace->receipt || (trace->receipt->status != transaction_receipt_header::executed &&
+                  trace->receipt->status != transaction_receipt_header::soft_fail) )
                return;
             for( const auto& atrace : trace->action_traces ) {
                on_action_trace( atrace );


### PR DESCRIPTION
**Change Description**

The history plugin sometimes included failed deferred transactions in its history. Since it doesn't store receipt status, there wasn't a reliable way for users of the history API to know which actions were executed. #6214 

As a reminder, the history plugin is deprecated. This fix is included because the bug opens an attack vector against apps which rely on data from the history plugin to make decisions.

**Documentation Additions**

This is a behavior change. Previously `get_transaction` could retrieve failed or expired deferred transactions.