### PR TITLE
Support Secure Enclave wallet on 2018 Macmini & MacBookAir

### DIFF
--- a/plugins/wallet_plugin/se_wallet.cpp
+++ b/plugins/wallet_plugin/se_wallet.cpp
@@ -305,6 +305,14 @@ se_wallet::se_wallet() : my(new detail::se_wallet_impl()) {
             return;
          }
       }
+      if(sscanf(model, "Macmini%u", &major) == 1 && major >= 8) {
+         my->populate_existing_keys();
+         return;
+      }
+      if(sscanf(model, "MacBookAir%u", &major) == 1 && major >= 8) {
+         my->populate_existing_keys();
+         return;
+      }
    }
 
    EOS_THROW(secure_enclave_exception, "Secure Enclave not supported on this hardware");


### PR DESCRIPTION
**Change Description**
Add secure enclave support for the 2018 Mac Mini & MacBook Air models. These new models include the T2 chip.

**Consensus Changes**
None

**API Changes**
None

**Documentation Additions**
None
