### PR TITLE
print config.ini & data-dir nodeos is using at launch

### DIFF
--- a/programs/nodeos/main.cpp
+++ b/programs/nodeos/main.cpp
@@ -108,7 +108,8 @@ int main(int argc, char** argv)
          return INITIALIZE_FAIL;
       initialize_logging();
       ilog("nodeos version ${ver}", ("ver", app().version_string()));
-      ilog("eosio root is ${root}", ("root", root.string()));
+      ilog("nodeos using configuration file ${c}", ("c", app().full_config_file_path().string()));
+      ilog("nodeos data directory is ${d}", ("d", app().data_dir().string()));
       app().startup();
       app().exec();
    } catch( const extract_genesis_state_exception& e ) {


### PR DESCRIPTION
**Change Description**
Instead of printing the "eosio root" when nodeos starts, print the config.ini used and the data directory used. The "eosio root" is the same no matter the `--config-dir` and `--data-dir` options which can make it deceptive on the actual config.ini used. This will make it a little easier to help users know what file is being used for configuration

**Consensus Changes**
none

**API Changes**
none

**Documentation Additions**
none