### PR TITLE
Fix shutdown on error

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -409,8 +409,10 @@ struct controller_impl {
    ~controller_impl() {
       pending.reset();
 
-      thread_pool->join();
-      thread_pool->stop();
+      if( thread_pool ) {
+         thread_pool->join();
+         thread_pool->stop();
+      }
 
       db.flush();
       reversible_blocks.flush();


### PR DESCRIPTION
**Change Description**

When controller destructor called without init() call then `thread_pool` optional is not created. This can happen when plugin command line parsing generates an error. 
