### PR TITLE
Fix bug:default producer vote num is bigger than actual producers num.

### DIFF
--- a/tutorials/bios-boot-tutorial/bios-boot-tutorial.py
+++ b/tutorials/bios-boot-tutorial/bios-boot-tutorial.py
@@ -187,7 +187,10 @@ def listProducers():
 def vote(b, e):
     for i in range(b, e):
         voter = accounts[i]['name']
-        prods = random.sample(range(firstProducer, firstProducer + numProducers), args.num_producers_vote)
+        k = args.num_producers_vote
+        if k > numProducers:
+            k = numProducers - 1
+        prods = random.sample(range(firstProducer, firstProducer + numProducers), k)
         prods = ' '.join(map(lambda x: accounts[x]['name'], prods))
         retry(args.cleos + 'system voteproducer prods ' + voter + ' ' + prods)
 


### PR DESCRIPTION
## Bug description
Executing command:
> ./bios-boot-tutorial.py -a --user-limit 30 --producer-limit 3

At the stage of voting, program will call function vote within:
> random.sample(population, k)：

- The first param 'population' is ```range(firstProducer, firstProducer + numProducers)```, equals (30,31,32).
- The second param 'k' is ```args.num_producers_vote```, use the default value which is 20, because we haven't specified in the command.

There is an issue here:
### k is greater than population!

## Changes
I add a variate named k in the function vote.  According the producers number, the k will self-adaption.