### PR TITLE
removed eosiocpp reference in dockerfile

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -6,7 +6,7 @@ RUN git clone -b $branch https://github.com/EOSIO/eos.git --recursive \
     && cd eos && echo "$branch:$(git rev-parse HEAD)" > /etc/eosio-version \
     && cmake -H. -B"/tmp/build" -GNinja -DCMAKE_BUILD_TYPE=Release -DWASM_ROOT=/opt/wasm -DCMAKE_CXX_COMPILER=clang++ \
        -DCMAKE_C_COMPILER=clang -DCMAKE_INSTALL_PREFIX=/tmp/build -DBUILD_MONGO_DB_PLUGIN=true -DCORE_SYMBOL_NAME=$symbol \
-    && cmake --build /tmp/build --target install && rm /tmp/build/bin/eosiocpp
+    && cmake --build /tmp/build --target install
 
 
 FROM ubuntu:18.04


### PR DESCRIPTION
**Change Description**

Eliminated the removal of the eosiocpp build artifact, since it has been moved to eosio.cdt
(ref https://github.com/EOSIO/eos/pull/6247); leaving it causes docker builds to fail (https://buildkite.com/EOSIO/eosio-docker-build/builds/78#_).

**Consensus Changes**

None

**API Changes**

None


**Documentation Additions**

None
