### PR TITLE
Update buildkite agent and set instance type

### DIFF
--- a/.buildkite/sanitizers.yml
+++ b/.buildkite/sanitizers.yml
@@ -21,7 +21,8 @@ steps:
         echo "--- :beers: Done"
     label: ":_: Undefined Sanitizer"
     agents:
-      - "role=automation-builder-large"
+      role: 'automation-builder-fleet'
+      aws:instance-type: 'm5d.2xlarge'
     artifact_paths:
       - "build.tar.gz"
       - "ninja.log"
@@ -64,7 +65,8 @@ steps:
         echo "--- :beers: Done"
     label: ":_: Address Sanitizer"
     agents:
-      - "role=automation-builder-large"
+      role: 'automation-builder-fleet'
+      aws:instance-type: 'm5d.2xlarge'
     artifact_paths:
       - "build.tar.gz"
       - "ninja.log"
@@ -96,7 +98,8 @@ steps:
         ctest -j8 -LE _tests -V -O sanitizer.log || true
     label: ":_: Undefined Sanitizer Tests"
     agents:
-      - "role=automation-builder-large"
+      role: 'automation-builder-fleet'
+      aws:instance-type: 'm5d.2xlarge'
     artifact_paths:
       - "mongod.log"
       - "sanitizer.log"
@@ -118,7 +121,8 @@ steps:
         ctest -j8 -LE _tests -V -O sanitizer.log || true
     label: ":_: Address Sanitizer Tests"
     agents:
-      - "role=automation-builder-large"
+      role: 'automation-builder-fleet'
+      aws:instance-type: 'm5d.2xlarge'
     artifact_paths:
       - "mongod.log"
       - "sanitizer.log"


### PR DESCRIPTION
Change Description

Stop using 'automation-builder-large' as a Buildkite agent role in sanitizer pipeline. Use 'automation-builder-fleet' instead.  Additionally, specify aws instance-type to be 'm5d.2xlarge'.

Consensus Changes

None.

API Changes

None.

Documentation Additions

None.