### PR TITLE
cleos: fix broken -r,--header - was passing headers after the double CRLF

### DIFF
--- a/programs/cleos/httpc.cpp
+++ b/programs/cleos/httpc.cpp
@@ -198,12 +198,12 @@ namespace eosio { namespace client { namespace http {
    request_stream << "content-length: " << postjson.size() << "\r\n";
    request_stream << "Accept: */*\r\n";
    request_stream << "Connection: close\r\n";
-   request_stream << "\r\n";
    // append more customized headers
    std::vector<string>::iterator itr;
    for (itr = cp.headers.begin(); itr != cp.headers.end(); itr++) {
       request_stream << *itr << "\r\n";
    }
+   request_stream << "\r\n";
    request_stream << postjson;
 
    if ( print_request ) {


### PR DESCRIPTION
**Change Description**

The `-r` or `--header` feature was broken, as headers were sent *after* the last double CRLF.

Since this feature is broken, perhaps it was never used. I suggest we rename `-r` to `-H` to make it more `curl`-like.
**Consensus Changes**

None

**API Changes**

None (yet, unless we rename `-r` to `-H` please? :)

**Documentation Additions**

None

