### PR TITLE
secp256 dependency ordering error

### DIFF
--- a/CMakeModules/EosioTester.cmake.in
+++ b/CMakeModules/EosioTester.cmake.in
@@ -88,8 +88,8 @@ macro(add_eosio_test test_name)
        ${liblogging}
        ${libchainbase}
        ${libbuiltins}
-       ${GMP_LIBRARIES}
        ${libsecp256k1}
+       ${GMP_LIBRARIES}
 
        LLVMX86Disassembler
        LLVMX86AsmParser


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- Give your PR a title that is sufficient to understand what is being changed. -->

**Change Description**

<!-- Describe the change you made, the motivation for it, and the impact it will have. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
#6266 
secp256 is dependent on gmp, so gmp should be listed first.

**Consensus Changes**

<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->
N/A

**API Changes**

<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->
N/A

**Documentation Additions**

<!-- List all the information that needs to be added to the documentation after merge. -->
N/A