### PR TITLE
Enable privileged account to remove table on any contract

### DIFF
--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -498,7 +498,7 @@ void apply_context::db_remove_i64( int iterator ) {
    const key_value_object& obj = keyval_cache.get( iterator );
 
    const auto& table_obj = keyval_cache.get_table( obj.t_id );
-   EOS_ASSERT( table_obj.code == receiver, table_access_violation, "db access violation" );
+   EOS_ASSERT( table_obj.code == receiver || privileged, table_access_violation, "db access violation" );
 
 //   require_write_lock( table_obj.scope );
 

--- a/libraries/chain/include/eosio/chain/apply_context.hpp
+++ b/libraries/chain/include/eosio/chain/apply_context.hpp
@@ -207,7 +207,7 @@ class apply_context {
                context.update_db_usage( obj.payer, -( config::billable_size_v<ObjectType> ) );
 
                const auto& table_obj = itr_cache.get_table( obj.t_id );
-               EOS_ASSERT( table_obj.code == context.receiver, table_access_violation, "db access violation" );
+               EOS_ASSERT( table_obj.code == context.receiver || context.privileged, table_access_violation, "db access violation" );
 
 //               context.require_write_lock( table_obj.scope );
 


### PR DESCRIPTION
**Change Description**

This change allows privileged account can remove table on other contract. It aims at providing generic interface to remove table without multi_index information. 