### PR TITLE
Fix upper_bound bug in chain_plugin

### DIFF
--- a/libraries/chain/include/eosio/chain/contract_table_objects.hpp
+++ b/libraries/chain/include/eosio/chain/contract_table_objects.hpp
@@ -130,33 +130,21 @@ namespace eosio { namespace chain {
    typedef secondary_index<key256_t,index256_object_type>::index_object index256_object;
    typedef secondary_index<key256_t,index256_object_type>::index_index  index256_index;
 
-   struct soft_double_less {
-      bool operator()( const float64_t& lhs, const float64_t& rhs )const {
-         return f64_lt(lhs, rhs);
-      }
-   };
-
-   struct soft_long_double_less {
-      bool operator()( const float128_t lhs, const float128_t& rhs )const {
-         return f128_lt(lhs, rhs);
-      }
-   };
-
    /**
     *  This index supports a deterministic software implementation of double as the secondary key.
     *
     *  The software double implementation is using the Berkeley softfloat library (release 3).
     */
-   typedef secondary_index<float64_t,index_double_object_type,soft_double_less>::index_object  index_double_object;
-   typedef secondary_index<float64_t,index_double_object_type,soft_double_less>::index_index   index_double_index;
+   typedef secondary_index<float64_t,index_double_object_type>::index_object  index_double_object;
+   typedef secondary_index<float64_t,index_double_object_type>::index_index   index_double_index;
 
    /**
     *  This index supports a deterministic software implementation of long double as the secondary key.
     *
     *  The software long double implementation is using the Berkeley softfloat library (release 3).
     */
-   typedef secondary_index<float128_t,index_long_double_object_type,soft_long_double_less>::index_object  index_long_double_object;
-   typedef secondary_index<float128_t,index_long_double_object_type,soft_long_double_less>::index_index   index_long_double_index;
+   typedef secondary_index<float128_t,index_long_double_object_type>::index_object  index_long_double_object;
+   typedef secondary_index<float128_t,index_long_double_object_type>::index_index   index_long_double_index;
 
    /**
     * helper template to map from an index type to the best tag

--- a/libraries/chain/include/eosio/chain/contract_table_objects.hpp
+++ b/libraries/chain/include/eosio/chain/contract_table_objects.hpp
@@ -150,7 +150,7 @@ namespace eosio { namespace chain {
    struct secondary_key_traits {
       using value_type = std::enable_if_t<std::is_integral<T>::value, T>;
 
-      static_assert( std::numeric_limits<uint128_t>::is_specialized, "value_type does not have specialized numeric_limits" );
+      static_assert( std::numeric_limits<value_type>::is_specialized, "value_type does not have specialized numeric_limits" );
 
       static constexpr value_type true_lowest() { return std::numeric_limits<value_type>::lowest(); }
       static constexpr value_type true_highest() { return std::numeric_limits<value_type>::max(); }
@@ -159,7 +159,7 @@ namespace eosio { namespace chain {
    template<size_t N>
    struct secondary_key_traits<std::array<uint128_t, N>> {
    private:
-      static constexpr uint128_t max_uint128 = uint128_t(std::numeric_limits<uint64_t>::max()) << 64 | std::numeric_limits<uint64_t>::max();
+      static constexpr uint128_t max_uint128 = (static_cast<uint128_t>(std::numeric_limits<uint64_t>::max()) << 64) | std::numeric_limits<uint64_t>::max();
       static_assert( std::numeric_limits<uint128_t>::max() == max_uint128, "numeric_limits for uint128_t is not properly defined" );
 
    public:

--- a/libraries/chain/include/eosio/chain/database_utils.hpp
+++ b/libraries/chain/include/eosio/chain/database_utils.hpp
@@ -8,6 +8,14 @@
 #include <fc/io/raw.hpp>
 #include <softfloat.hpp>
 
+inline bool operator< (const float64_t& lhs, const float64_t& rhs) {
+   return f64_lt(lhs, rhs);
+}
+
+inline bool operator< (const float128_t& lhs, const float128_t& rhs) {
+   return f128_lt(lhs, rhs);
+}
+
 namespace eosio { namespace chain {
 
    template<typename ...Indices>
@@ -216,4 +224,3 @@ DataStream& operator >> ( DataStream& ds, float128_t& v ) {
    fc::raw::unpack(ds, *reinterpret_cast<eosio::chain::uint128_t*>(&v));
    return ds;
 }
-

--- a/libraries/chain/include/eosio/chain/database_utils.hpp
+++ b/libraries/chain/include/eosio/chain/database_utils.hpp
@@ -8,14 +8,6 @@
 #include <fc/io/raw.hpp>
 #include <softfloat.hpp>
 
-inline bool operator< (const float64_t& lhs, const float64_t& rhs) {
-   return f64_lt(lhs, rhs);
-}
-
-inline bool operator< (const float128_t& lhs, const float128_t& rhs) {
-   return f128_lt(lhs, rhs);
-}
-
 namespace eosio { namespace chain {
 
    template<typename ...Indices>

--- a/libraries/chain/wasm_interface.cpp
+++ b/libraries/chain/wasm_interface.cpp
@@ -237,8 +237,8 @@ class softfloat_api : public context_aware_api {
          if (is_nan(b)) {
             return bf;
          }
-         if ( sign_bit(a) != sign_bit(b) ) {
-            return sign_bit(a) ? af : bf;
+         if ( f32_sign_bit(a) != f32_sign_bit(b) ) {
+            return f32_sign_bit(a) ? af : bf;
          }
          return f32_lt(a,b) ? af : bf;
       }
@@ -251,8 +251,8 @@ class softfloat_api : public context_aware_api {
          if (is_nan(b)) {
             return bf;
          }
-         if ( sign_bit(a) != sign_bit(b) ) {
-            return sign_bit(a) ? bf : af;
+         if ( f32_sign_bit(a) != f32_sign_bit(b) ) {
+            return f32_sign_bit(a) ? bf : af;
          }
          return f32_lt( a, b ) ? bf : af;
       }
@@ -404,8 +404,8 @@ class softfloat_api : public context_aware_api {
             return af;
          if (is_nan(b))
             return bf;
-         if (sign_bit(a) != sign_bit(b))
-            return sign_bit(a) ? af : bf;
+         if (f64_sign_bit(a) != f64_sign_bit(b))
+            return f64_sign_bit(a) ? af : bf;
          return f64_lt( a, b ) ? af : bf;
       }
       double _eosio_f64_max( double af, double bf ) {
@@ -415,8 +415,8 @@ class softfloat_api : public context_aware_api {
             return af;
          if (is_nan(b))
             return bf;
-         if (sign_bit(a) != sign_bit(b))
-            return sign_bit(a) ? bf : af;
+         if (f64_sign_bit(a) != f64_sign_bit(b))
+            return f64_sign_bit(a) ? bf : af;
          return f64_lt( a, b ) ? bf : af;
       }
       double _eosio_f64_copysign( double af, double bf ) {
@@ -650,32 +650,17 @@ class softfloat_api : public context_aware_api {
       }
 
       static bool is_nan( const float32_t f ) {
-         return ((f.v & 0x7FFFFFFF) > 0x7F800000);
+         return f32_is_nan( f );
       }
       static bool is_nan( const float64_t f ) {
-         return ((f.v & 0x7FFFFFFFFFFFFFFF) > 0x7FF0000000000000);
+         return f64_is_nan( f );
       }
       static bool is_nan( const float128_t& f ) {
-         return (((~(f.v[1]) & uint64_t( 0x7FFF000000000000 )) == 0) && (f.v[0] || ((f.v[1]) & uint64_t( 0x0000FFFFFFFFFFFF ))));
+         return f128_is_nan( f );
       }
-      static float32_t to_softfloat32( float f ) {
-         return *reinterpret_cast<float32_t*>(&f);
-      }
-      static float64_t to_softfloat64( double d ) {
-         return *reinterpret_cast<float64_t*>(&d);
-      }
-      static float from_softfloat32( float32_t f ) {
-         return *reinterpret_cast<float*>(&f);
-      }
-      static double from_softfloat64( float64_t d ) {
-         return *reinterpret_cast<double*>(&d);
-      }
+
       static constexpr uint32_t inv_float_eps = 0x4B000000;
       static constexpr uint64_t inv_double_eps = 0x4330000000000000;
-
-      static bool sign_bit( float32_t f ) { return f.v >> 31; }
-      static bool sign_bit( float64_t f ) { return f.v >> 63; }
-
 };
 
 class producer_api : public context_aware_api {
@@ -1515,18 +1500,18 @@ class compiler_builtins : public context_aware_api {
 
       // conversion long double
       void __extendsftf2( float128_t& ret, float f ) {
-         ret = f32_to_f128( softfloat_api::to_softfloat32(f) );
+         ret = f32_to_f128( to_softfloat32(f) );
       }
       void __extenddftf2( float128_t& ret, double d ) {
-         ret = f64_to_f128( softfloat_api::to_softfloat64(d) );
+         ret = f64_to_f128( to_softfloat64(d) );
       }
       double __trunctfdf2( uint64_t l, uint64_t h ) {
          float128_t f = {{ l, h }};
-         return softfloat_api::from_softfloat64(f128_to_f64( f ));
+         return from_softfloat64(f128_to_f64( f ));
       }
       float __trunctfsf2( uint64_t l, uint64_t h ) {
          float128_t f = {{ l, h }};
-         return softfloat_api::from_softfloat32(f128_to_f32( f ));
+         return from_softfloat32(f128_to_f32( f ));
       }
       int32_t __fixtfsi( uint64_t l, uint64_t h ) {
          float128_t f = {{ l, h }};
@@ -1553,19 +1538,19 @@ class compiler_builtins : public context_aware_api {
          ret = ___fixunstfti( f );
       }
       void __fixsfti( __int128& ret, float a ) {
-         ret = ___fixsfti( softfloat_api::to_softfloat32(a).v );
+         ret = ___fixsfti( to_softfloat32(a).v );
       }
       void __fixdfti( __int128& ret, double a ) {
-         ret = ___fixdfti( softfloat_api::to_softfloat64(a).v );
+         ret = ___fixdfti( to_softfloat64(a).v );
       }
       void __fixunssfti( unsigned __int128& ret, float a ) {
-         ret = ___fixunssfti( softfloat_api::to_softfloat32(a).v );
+         ret = ___fixunssfti( to_softfloat32(a).v );
       }
       void __fixunsdfti( unsigned __int128& ret, double a ) {
-         ret = ___fixunsdfti( softfloat_api::to_softfloat64(a).v );
+         ret = ___fixunsdfti( to_softfloat64(a).v );
       }
       double __floatsidf( int32_t i ) {
-         return softfloat_api::from_softfloat64(i32_to_f64(i));
+         return from_softfloat64(i32_to_f64(i));
       }
       void __floatsitf( float128_t& ret, int32_t i ) {
          ret = i32_to_f128(i);

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1111,6 +1111,19 @@ uint64_t convert_to_type(const string& str, const string& desc) {
    return value;
 }
 
+template<>
+double convert_to_type(const string& str, const string& desc) {
+   double val{};
+   try {
+      val = fc::variant(str).as<double>();
+   } FC_RETHROW_EXCEPTIONS(warn, "Could not convert ${desc} string '${str}' to key type.", ("desc", desc)("str",str) )
+
+   EOS_ASSERT( !std::isnan(val), chain::contract_table_query_exception,
+               "Converted ${desc} string '${str}' to NaN which is not a permitted value for the key type", ("desc", desc)("str",str) );
+
+   return val;
+}
+
 abi_def get_abi( const controller& db, const name& account ) {
    const auto &d = db.db();
    const account_object *code_accnt = d.find<account_object, by_name>(account);

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -55,7 +55,7 @@ struct permission {
 template<typename>
 struct resolver_factory;
 
-// see specialization for uint64_t in source file
+// see specializations for uint64_t and double in source file
 template<typename Type>
 Type convert_to_type(const string& str, const string& desc) {
    try {
@@ -65,6 +65,9 @@ Type convert_to_type(const string& str, const string& desc) {
 
 template<>
 uint64_t convert_to_type(const string& str, const string& desc);
+
+template<>
+double convert_to_type(const string& str, const string& desc);
 
 class read_only {
    const controller& db;
@@ -407,7 +410,7 @@ public:
                                                           eosio::chain::secondary_key_traits<secondary_key_type>::true_lowest(),
                                                           std::numeric_limits<uint64_t>::lowest() );
          auto upper_bound_lookup_tuple = std::make_tuple( index_t_id->id._id,
-                                                          eosio::chain::secondary_key_traits<secondary_key_type>::true_highest(), 
+                                                          eosio::chain::secondary_key_traits<secondary_key_type>::true_highest(),
                                                           std::numeric_limits<uint64_t>::max() );
 
          if( p.lower_bound.size() ) {

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -403,7 +403,7 @@ public:
       const auto* index_t_id = d.find<chain::table_id_object, chain::by_code_scope_table>(boost::make_tuple(p.code, scope, table_with_index));
       if( t_id != nullptr && index_t_id != nullptr ) {
          using secondary_key_type = std::result_of_t<decltype(conv)(SecKeyType)>;
-         static_assert( std::is_same<decltype(IndexType::value_type::secondary_key), secondary_key_type>::value, "Return type of conv does not match type of secondary key for IndexType" );
+         static_assert( std::is_same<typename IndexType::value_type::secondary_key_type, secondary_key_type>::value, "Return type of conv does not match type of secondary key for IndexType" );
 
          const auto& secidx = d.get_index<IndexType, chain::by_secondary>();
          auto lower_bound_lookup_tuple = std::make_tuple( index_t_id->id._id,

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -83,13 +83,13 @@ namespace eosio {
       static value_type true_lowest() {
          float64_t f;
          f.v = 0xff00000000000000ull;
-         return f; // -infinity?
+         return f; // -infinity
       }
 
       static value_type true_highest() {
          float64_t f;
          f.v = 0x7f00000000000000ull;
-         return f; // +infinity?
+         return f; // +infinity
       }
    };
 
@@ -101,14 +101,14 @@ namespace eosio {
          float128_t f;
          f.v[0] = 0x0ull;
          f.v[1] = 0xffff000000000000ull;
-         return f; // -infinity?
+         return f; // -infinity
       }
 
       static value_type true_highest() {
          float128_t f;
          f.v[0] = 0x0ull;
          f.v[1] = 0x7fff000000000000ull;
-         return f; // +infinity?
+         return f; // +infinity
       }
    };
 

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -1119,10 +1119,15 @@ struct approve_producer_subcommand {
                                ("table_key", "owner")
                                ("lower_bound", voter.value)
                                ("upper_bound", voter.value + 1)
+                               // Less than ideal upper_bound usage preserved so cleos can still work with old buggy nodeos versions
+                               // Change to voter.value when cleos no longer needs to support nodeos versions older than 1.5.0
                                ("limit", 1)
             );
             auto res = result.as<eosio::chain_apis::read_only::get_table_rows_result>();
-            if ( res.rows.empty() ) {
+            // Condition in if statement below can simply be res.rows.empty() when cleos no longer needs to support nodeos versions older than 1.5.0
+            // Although since this subcommand will actually change the voter's vote, it is probably better to just keep this check to protect 
+            //  against future potential chain_plugin bugs.
+            if( res.rows.empty() || res.rows[0].get_object()["owner"].as_string() != name(voter).to_string() ) {
                std::cerr << "Voter info not found for account " << voter << std::endl;
                return;
             }
@@ -1167,10 +1172,15 @@ struct unapprove_producer_subcommand {
                                ("table_key", "owner")
                                ("lower_bound", voter.value)
                                ("upper_bound", voter.value + 1)
+                               // Less than ideal upper_bound usage preserved so cleos can still work with old buggy nodeos versions
+                               // Change to voter.value when cleos no longer needs to support nodeos versions older than 1.5.0
                                ("limit", 1)
             );
             auto res = result.as<eosio::chain_apis::read_only::get_table_rows_result>();
-            if ( res.rows.empty() ) {
+            // Condition in if statement below can simply be res.rows.empty() when cleos no longer needs to support nodeos versions older than 1.5.0
+            // Although since this subcommand will actually change the voter's vote, it is probably better to just keep this check to protect
+            //  against future potential chain_plugin bugs.
+            if( res.rows.empty() || res.rows[0].get_object()["owner"].as_string() != name(voter).to_string() ) {
                std::cerr << "Voter info not found for account " << voter << std::endl;
                return;
             }
@@ -1383,29 +1393,32 @@ struct bidname_info_subcommand {
          auto rawResult = call(get_table_func, fc::mutable_variant_object("json", true)
                                ("code", "eosio")("scope", "eosio")("table", "namebids")
                                ("lower_bound", newname.value)
-                               ("upper_bound", newname.value + 1)("limit", 1));
+                               ("upper_bound", newname.value + 1)
+                               // Less than ideal upper_bound usage preserved so cleos can still work with old buggy nodeos versions
+                               // Change to newname.value when cleos no longer needs to support nodeos versions older than 1.5.0
+                               ("limit", 1));
          if ( print_json ) {
             std::cout << fc::json::to_pretty_string(rawResult) << std::endl;
             return;
          }
          auto result = rawResult.as<eosio::chain_apis::read_only::get_table_rows_result>();
-         if ( result.rows.empty() ) {
+         // Condition in if statement below can simply be res.rows.empty() when cleos no longer needs to support nodeos versions older than 1.5.0
+         if( result.rows.empty() || result.rows[0].get_object()["newname"].as_string() != newname.to_string() ) {
             std::cout << "No bidname record found" << std::endl;
             return;
          }
-         for ( auto& row : result.rows ) {
-            string time = row["last_bid_time"].as_string();
-            try {
-                time = (string)fc::time_point(fc::microseconds(to_uint64(time)));
-            } catch (fc::parse_error_exception&) {
-            }
-            int64_t bid = row["high_bid"].as_int64();
-            std::cout << std::left << std::setw(18) << "bidname:" << std::right << std::setw(24) << row["newname"].as_string() << "\n"
-                      << std::left << std::setw(18) << "highest bidder:" << std::right << std::setw(24) << row["high_bidder"].as_string() << "\n"
-                      << std::left << std::setw(18) << "highest bid:" << std::right << std::setw(24) << (bid > 0 ? bid : -bid) << "\n"
-                      << std::left << std::setw(18) << "last bid time:" << std::right << std::setw(24) << time << std::endl;
-            if (bid < 0) std::cout << "This auction has already closed" << std::endl;
+         const auto& row = result.rows[0];
+         string time = row["last_bid_time"].as_string();
+         try {
+             time = (string)fc::time_point(fc::microseconds(to_uint64(time)));
+         } catch (fc::parse_error_exception&) {
          }
+         int64_t bid = row["high_bid"].as_int64();
+         std::cout << std::left << std::setw(18) << "bidname:" << std::right << std::setw(24) << row["newname"].as_string() << "\n"
+                   << std::left << std::setw(18) << "highest bidder:" << std::right << std::setw(24) << row["high_bidder"].as_string() << "\n"
+                   << std::left << std::setw(18) << "highest bid:" << std::right << std::setw(24) << (bid > 0 ? bid : -bid) << "\n"
+                   << std::left << std::setw(18) << "last bid time:" << std::right << std::setw(24) << time << std::endl;
+         if (bid < 0) std::cout << "This auction has already closed" << std::endl;
       });
    }
 };
@@ -3054,12 +3067,15 @@ int main( int argc, char** argv ) {
                          ("table_key", "")
                          ("lower_bound", name(proposal_name).value)
                          ("upper_bound", name(proposal_name).value + 1)
+                         // Less than ideal upper_bound usage preserved so cleos can still work with old buggy nodeos versions
+                         // Change to name(proposal_name).value when cleos no longer needs to support nodeos versions older than 1.5.0
                          ("limit", 1)
                          );
       //std::cout << fc::json::to_pretty_string(result) << std::endl;
 
       fc::variants rows = result.get_object()["rows"].get_array();
-      if (rows.empty()) {
+      // Condition in if statement below can simply be rows.empty() when cleos no longer needs to support nodeos versions older than 1.5.0
+      if( rows.empty() || rows[0].get_object()["proposal_name"] != proposal_name ) {
          std::cerr << "Proposal not found" << std::endl;
          return;
       }

--- a/tests/get_table_tests.cpp
+++ b/tests/get_table_tests.cpp
@@ -52,7 +52,7 @@ BOOST_FIXTURE_TEST_CASE( get_scope_test, TESTER ) try {
    set_abi( N(eosio.token), eosio_token_abi );
    produce_blocks(1);
 
-   // create currency 
+   // create currency
    auto act = mutable_variant_object()
          ("issuer",       "eosio")
          ("maximum_supply", eosio::chain::asset::from_string("1000000000.0000 SYS"));
@@ -88,13 +88,13 @@ BOOST_FIXTURE_TEST_CASE( get_scope_test, TESTER ) try {
    }
 
    param.lower_bound = "initb";
-   param.upper_bound = "initd";
+   param.upper_bound = "initc";
    result = plugin.read_only::get_table_by_scope(param);
    BOOST_REQUIRE_EQUAL(2, result.rows.size());
    BOOST_REQUIRE_EQUAL("", result.more);
    if (result.rows.size() >= 2) {
       BOOST_REQUIRE_EQUAL(name(N(initb)), result.rows[0].scope);
-      BOOST_REQUIRE_EQUAL(name(N(initc)), result.rows[1].scope);      
+      BOOST_REQUIRE_EQUAL(name(N(initc)), result.rows[1].scope);
    }
 
    param.limit = 1;
@@ -110,9 +110,8 @@ BOOST_FIXTURE_TEST_CASE( get_scope_test, TESTER ) try {
    param.table = N(invalid);
    result = plugin.read_only::get_table_by_scope(param);
    BOOST_REQUIRE_EQUAL(0, result.rows.size());
-   BOOST_REQUIRE_EQUAL("", result.more); 
+   BOOST_REQUIRE_EQUAL("", result.more);
 
 } FC_LOG_AND_RETHROW() /// get_scope_test
 
 BOOST_AUTO_TEST_SUITE_END()
-


### PR DESCRIPTION
**Change Description**

Resolves #6273.

PR #6070 revealed an existing bug in the implementation of `chain_plugin` with regards to how it handles the `upper_bound` field in the `get_table_rows` and `get_table_by_scope` RPC calls.

The intended definition for this `upper_bound` field is similar to how it is defined in the [`std::upper_bound` function in the C++ standard library](https://en.cppreference.com/w/cpp/algorithm/upper_bound): the first element within the specified ordered range with a value _greater than_ the given comparison value.

Instead, the implementation in `chain_plugin` handled `upper_bound` as if the definition was the same as that of `lower_bound`: the first element within the specified ordered range with a value _greater than or equal to_ the given comparison value.

The intended definition has the advantage of being consistent with the standard definition of `upper_bound` well known to C++ programmers and it also enables callers to request an [`equal_range`](https://en.cppreference.com/w/cpp/algorithm/equal_range) by simply passing in the same comparison value for both the `lower_bound` and `upper_bound` fields. Attempting to do this with the old definition required knowing and calculating the value immediately succeeding the `lower_bound` value and passing that in as the `upper_bound` field (as PR #6070 did within cleos). Passing in the same comparison value for both the `lower_bound` and `upper_bound` using the old definition would result in no ranges ever returned.

The existing implementation of `chain_plugin` has a further bug (which this PR also fixes) in the case where `upper_bound` is less than `lower_bound`. The correct behavior in such a situation is to never return any results.

This PR fixes the bug in the case where `upper_bound` is less than `lower_bound` and it also changes the implementation of `chain_plugin` to handle the `upper_bound` field according to the intended definition rather than the existing definition. The implications of these changes to users of the chain API are described in detail under the "API Changes" section.

Furthermore, this PR adds back the additional checks in cleos for the `system voteproducer approve`, `system voteproducer unapprove`, `multisig review` sub-commands that were removed in #6070 and ensure the results returned from the chain API RPC are exactly what was requested. It also adds a similar check for the `system bidnameinfo` sub-command (similar to what was in #6068) to fix the bug described in #6067. These additional checks are necessary (even though they were not necessary in PR #6070) because this PR keeps the changes to the `upper_bound` value specified by cleos made in PR #6070 in which the `upper_bound` value is the value immediately succeeding the `lower_bound` value; that `upper_bound` workaround was kept just so that the version of cleos incorporating the changes in this PR can still behave correctly when talking to an old version of nodeos that has not incorporated the changes in this PR. (Also note that an old cleos at version v1.4.x or older would still behave correctly with the `system voteproducer approve`, `system voteproducer unapprove`, and `multisig review` sub-commands even when talking to a new version of nodeos that incorporates the changes in this PR. However, in such a situation, the bug described in #6067 would still of course apply when using `system bidnameinfo`.)

**Consensus Changes**

None

**API Changes**

Users of the `get_table_rows` and `get_table_by_scope` RPCs of the chain API are unaffected by these changes if they are not already using the `upper_bound` field. Existing users of the `upper_bound` field of those two RPCs should read on to understand the changes introduced by this PR.

**`get_table_rows`**

*First some background on `get_table_rows`:*

A particular index type (either the primary key type or one of the five secondary index types) is selected (whether implicitly or explicitly using the `key_type` field) in the `get_table_rows` call. The index type defines the type of the index key within table records to use to sort the table rows in the table for the purposes of this RPC.

A particular index ordinal is selected (whether implicitly or explicitly using the `index_position` field). This index ordinal must correspond to the selected index type (based on how the tables are structured in the persistent state on the blockchain), and the selected index ordinal along with the selected index type (together can be referred to as the selected index) determine how the tables rows in the table are ordered. For selected indices that are secondary indices, the sort order is based first on the index key (in ascending order) and then ties are broken by the primary key (in ascending order).

A particular table is specified by: the index type, index ordinal, and the tuple `(code, scope, table)`. The rows in the table have an index key (of index type) which is the value used to sort the order of the table rows within the selected index.

If `lower_bound` is specified, let `candidate_rows` be the set of table rows in the specified table which have an index key greater than or equal to the value specified in `lower_bound`. Otherwise, let `candidate_rows` be the set of all table rows in the specified table.

*Behavior prior to this PR:*

If `upper_bound` is specified, let `excluded_rows` be the set of table rows in the specified table which have an index key greater than or equal to the value specified in `upper_bound`. Otherwise, let `excluded_rows` be the empty set.

If the value specified in `upper_bound` is less than the value specified in `lower_bound`, the behavior of `get_tables_rows` is undefined. Otherwise, `get_table_rows` returns the set of tables rows (in sorted order) that are in `candidate_rows` but not in `excluded_rows`.

*Behavior as of this PR:*

If `upper_bound` is specified, let `excluded_rows` be the set of table rows in the specified table which have an index key greater than the value specified in `upper_bound`. Otherwise, let `excluded_rows` be the empty set.

If the value specified in `upper_bound` is less than the value specified in `lower_bound`, `get_table_rows` returns no rows. Otherwise, `get_table_rows` returns the set of tables rows (in sorted order) that are in `candidate_rows` but not in `excluded_rows`.

*Implications to existing users of `upper_bound`:*

- Users should not be calling `get_table_rows` with an `upper_bound` less than `lower_bound`. If they currently are doing so and using the returned results, they are relying on undefined behavior. This PR fixes that undefined behavior so that a logically consistent result is returned should users continue to make this inappropriate call.
- Users of `get_table_rows` that call it with an `upper_bound` value greater than or equal to the `lower_bound` value may get back less rows with the new behavior than they received with the old behavior. If users adjust their call by setting `upper_bound` to the value immediately succeeding the value they provided originally, they will receive no less rows with the new behavior than they did before with the old behavior (they can then further filter on the client side).

**`get_table_by_scope`**

*First some background on `get_table_by_scope`:*

The tables within a given `code` account are sorted (for the purposes of `get_table_by_scope`) first by `scope` (in ascending order) and then ties are broken by `table` name (in ascending order).

If `lower_bound` is specified, let `candidate_tables` be the set of tables in the specified `code` account which have `scope` greater than or equal to the value specified in `lower_bound`. Otherwise, let `candidate_tables` be the set of all tables in the specified `code` account.

If the `table` is not specified in the RPC (or its value is 0), then let `excluded_tables1` be the empty set. Otherwise, let `excluded_tables1` be the set of tables in the specified `code` account which have a `table` name equal to the specified `table` value in the RPC.

*Behavior prior to this PR:*

If `upper_bound` is specified, let `excluded_tables2` be the set of tables in the specified `code` account which have a `scope` greater than or equal to the value specified in `upper_bound`. Otherwise, let `excluded_tables2` be the empty set.

If the value specified in `upper_bound` is less than the value specified in `lower_bound`, the behavior of `get_table_by_scope` is undefined. Otherwise, `get_table_by_scope` returns the set of tables (in sorted order) that are in `candidate_tables` but not in the union of `excluded_tables1` and `excluded_tables2`.

*Behavior as of this PR:*

If `upper_bound` is specified, let `excluded_tables2` be the set of tables in the specified `code` account which have a `scope` greater than the value specified in `upper_bound`. Otherwise, let `excluded_tables2` be the empty set.

If the value specified in `upper_bound` is less than the value specified in `lower_bound`, `get_table_by_scope` returns no tables. Otherwise, `get_table_by_scope` returns the set of tables (in sorted order) that are in `candidate_tables` but not in the union of `excluded_tables1` and `excluded_tables2`.

*Implications to existing users of `upper_bound`:*

- Users should not be calling `get_table_by_scope` with an `upper_bound` less than `lower_bound`. If they currently are doing so and using the returned results, they are relying on undefined behavior. This PR fixes that undefined behavior so that a logically consistent result is returned should users continue to make this inappropriate call.
- Users of `get_table_by_scope` that call it with an `upper_bound` value greater than or equal to the `lower_bound` value may get back less tables with the new behavior than they received with the old behavior. If users adjust their call by setting `upper_bound` to the value immediately succeeding the value they provided originally, they will receive no less tables with the new behavior than they did before with the old behavior (they can then further filter on the client side).

**Documentation Additions**

Documentation about the `get_table_rows` and `get_table_by_scope` RPCs of the chain API may need to be updated to reflect the new definition of `upper_bound` and the implications of that as discussed in the "API Changes" section above.
