### PR TITLE
Add ability to sign arbitrary messages to cleos

### DIFF
--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -2872,7 +2872,7 @@ int main( int argc, char** argv ) {
          std::getline( std::cin, str_private_key, '\n' );
          fc::set_console_echo(true);
       }
-      auto priv_key = fc::crypto::private_key::regenerate(*utilities::wif_to_key(str_private_key));
+      auto priv_key = private_key_type(str_private_key);
       fc::sha256 digest = fc::sha256::hash(trx_json_to_sign.c_str(), trx_json_to_sign.length());
       fc::crypto::signature sig = priv_key.sign( digest );
       std::cout << std::string( sig ) << std::endl;

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -2859,9 +2859,11 @@ int main( int argc, char** argv ) {
       }
    });
 
+   string msg_to_sign;
+   
    auto signMessage = sign->add_subcommand("message", localized("Sign a message"));
    signMessage->fallthrough(false);
-   signMessage->add_option("message", trx_json_to_sign,
+   signMessage->add_option("message", msg_to_sign,
                                  localized("A string to sign"), true)->required();
    signMessage->add_option("-k,--private-key", str_private_key, localized("The private key that will be used to sign the transaction"));
 
@@ -2873,7 +2875,7 @@ int main( int argc, char** argv ) {
          fc::set_console_echo(true);
       }
       auto priv_key = private_key_type(str_private_key);
-      fc::sha256 digest = fc::sha256::hash(trx_json_to_sign.c_str(), trx_json_to_sign.length());
+      fc::sha256 digest = fc::sha256::hash(msg_to_sign.c_str(), msg_to_sign.length());
       fc::crypto::signature sig = priv_key.sign( digest );
       std::cout << std::string( sig ) << std::endl;
    });


### PR DESCRIPTION
Right now cleos can only sign transaction messages with a private key. I've modified cleos so it can sign arbitrary messages as well with the `cleos sign message` command. 

There are 2 changes to the cleos API: 

1. `cleos sign` is now `cleos sign transaction`
2. `cleos sign message` is a new command 

Documentation will have to be changed to reflect these changes. 