### PR TITLE
Modified the github pull request template to allow developers to use level-3 markdown headers in their descriptions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,20 +1,20 @@
 <!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
 <!-- Give your PR a title that is sufficient to understand what is being changed. -->
 
-**Change Description**
+##Change Description
 
 <!-- Describe the change you made, the motivation for it, and the impact it will have. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
 
-**Consensus Changes**
+##Consensus Changes
 
 <!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->
 
 
-**API Changes**
+##API Changes
 
 <!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->
 
 
-**Documentation Additions**
+##Documentation Additions
 
 <!-- List all the information that needs to be added to the documentation after merge. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,20 +1,20 @@
 <!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
 <!-- Give your PR a title that is sufficient to understand what is being changed. -->
 
-##Change Description
+## Change Description
 
 <!-- Describe the change you made, the motivation for it, and the impact it will have. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
 
-##Consensus Changes
+## Consensus Changes
 
 <!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->
 
 
-##API Changes
+## API Changes
 
 <!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->
 
 
-##Documentation Additions
+## Documentation Additions
 
 <!-- List all the information that needs to be added to the documentation after merge. -->


### PR DESCRIPTION
**Change Description**

Based on a request from the dev team, we modified the github pull request template to allow us to use level-3 markdown headers in their descriptions.  Now, in the release drafts, PR titles will be level-1 markdown, the main subheadings will be level-2, and developers can add level-3 headers within those.

**Consensus Changes**

None

**API Changes**

None

**Documentation Additions**

None