### PR TITLE
Fix awk to correctly match mojave version when building bottle

### DIFF
--- a/scripts/generate_bottle.sh
+++ b/scripts/generate_bottle.sh
@@ -3,7 +3,7 @@
 VERS=`sw_vers -productVersion | awk '/10\.13\..*/{print $0}'`
 if [[ -z "$VERS" ]];
 then
-   VERS=`sw_vers -productVersion | awk '/10\.14\..*/{print $0}'`
+   VERS=`sw_vers -productVersion | awk '/10\.14.*/{print $0}'`
    if [[ -z "$VERS" ]];
    then
       echo "Error, unsupported OS X version"


### PR DESCRIPTION
**Change Description**

Fixes the awk in the build script to correctly match mojave version string

**Consensus Changes**

None

**API Changes**

None

**Documentation Additions**

None
