### PR TITLE
Explicitly throw away get_table_type return value for code clarity

### DIFF
--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1248,7 +1248,7 @@ read_only::get_table_by_scope_result read_only::get_table_by_scope( const read_o
 vector<asset> read_only::get_currency_balance( const read_only::get_currency_balance_params& p )const {
 
    const abi_def abi = eosio::chain_apis::get_abi( db, p.code );
-   auto table_type = get_table_type( abi, "accounts" );
+   (void)get_table_type( abi, "accounts" );
 
    vector<asset> results;
    walk_key_value_table(p.code, p.account, N(accounts), [&](const key_value_object& obj){


### PR DESCRIPTION
**Change Description**

Resolves #6276.

get_table_type() is called in order to generate more readable errors in the case the 'accounts' table does not exist when querying currency balances.

**Consensus Changes**

N/A

**API Changes**

N/A

**Documentation Additions**

N/A