### PR TITLE
Revert to previous explicit soft float less operator

### DIFF
--- a/libraries/chain/include/eosio/chain/contract_table_objects.hpp
+++ b/libraries/chain/include/eosio/chain/contract_table_objects.hpp
@@ -130,21 +130,34 @@ namespace eosio { namespace chain {
    typedef secondary_index<key256_t,index256_object_type>::index_object index256_object;
    typedef secondary_index<key256_t,index256_object_type>::index_index  index256_index;
 
+   struct soft_double_less {
+      bool operator()( const float64_t& lhs, const float64_t& rhs ) const {
+         return f64_lt( lhs, rhs );
+      }
+   };
+
+   struct soft_long_double_less {
+      bool operator()( const float128_t& lhs, const float128_t& rhs ) const {
+         return f128_lt( lhs, rhs );
+      }
+   };
+
    /**
     *  This index supports a deterministic software implementation of double as the secondary key.
     *
     *  The software double implementation is using the Berkeley softfloat library (release 3).
     */
-   typedef secondary_index<float64_t,index_double_object_type>::index_object  index_double_object;
-   typedef secondary_index<float64_t,index_double_object_type>::index_index   index_double_index;
+
+   typedef secondary_index<float64_t,index_double_object_type,soft_double_less>::index_object  index_double_object;
+   typedef secondary_index<float64_t,index_double_object_type,soft_double_less>::index_index   index_double_index;
 
    /**
     *  This index supports a deterministic software implementation of long double as the secondary key.
     *
     *  The software long double implementation is using the Berkeley softfloat library (release 3).
     */
-   typedef secondary_index<float128_t,index_long_double_object_type>::index_object  index_long_double_object;
-   typedef secondary_index<float128_t,index_long_double_object_type>::index_index   index_long_double_index;
+   typedef secondary_index<float128_t,index_long_double_object_type,soft_long_double_less>::index_object  index_long_double_object;
+   typedef secondary_index<float128_t,index_long_double_object_type,soft_long_double_less>::index_index   index_long_double_index;
 
    template<typename T>
    struct secondary_key_traits {


### PR DESCRIPTION
**Change Description**

- Reverts part of #6285 which broke consensus.
- Apparently `std::less<float64_t>` and/or `std::less<float128_t>` does not reduce to `f64_lt()` and `f128_lt()`
- On going investigation into why this causes problems. For now, revert back to state that maintains consensus.

**Consensus Changes**

- Reverts an accidental consensus change of #6285. After this change develop branch will again have no consensus changes.
