### PR TITLE
Fix rpm/deb package names

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -477,7 +477,7 @@ steps:
         image: "eosio/ci:fedora"
         workdir: /data/job
     env:
-      OS: "fedora"
+      OS: "fc27"
       PKGTYPE: "rpm"
     timeout: 60
 
@@ -504,6 +504,6 @@ steps:
         image: "eosio/ci:centos"
         workdir: /data/job
     env:
-      OS: "centos"
+      OS: "el7"
       PKGTYPE: "rpm"
     timeout: 60

--- a/scripts/generate_deb.sh
+++ b/scripts/generate_deb.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-NAME="${PROJECT}-${VERSION}-0.x86_64"
+NAME="${PROJECT}_${VERSION}-1_amd64"
 PREFIX="usr"
 SPREFIX=${PREFIX}
 SUBPREFIX="opt/${PROJECT}/${VERSION}"

--- a/scripts/generate_rpm.sh
+++ b/scripts/generate_rpm.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-NAME="${PROJECT}-${VERSION}-0.el7"
+NAME="${PROJECT}-${VERSION}-1"
 PREFIX="usr"
 SPREFIX=${PREFIX}
 SUBPREFIX="opt/${PROJECT}/${VERSION}"
@@ -34,7 +34,7 @@ Requires: openssl-devel.x86_64, gmp-devel.x86_64, libstdc++-devel.x86_64, bzip2.
 URL: ${URL} 
 Packager: ${VENDOR} <${EMAIL}>
 Summary: ${DESC}
-Release: 0.el7
+Release: 1
 %description
 ${DESC}
 %files -f filenames.txt" &> ${PROJECT}.spec


### PR DESCRIPTION
**Change Description**

In response to feedback from the infrastructure team we need to change the format of the package names slightly. This also updates some environment variables in the buildkite pipeline to ensure the packages end up with the appropriate names.

**Consensus Changes**

None


**API Changes**

None


**Documentation Additions**

None