### PR TITLE
Print the canonical path of wasm/abi when not found

### DIFF
--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -2468,7 +2468,7 @@ int main( int argc, char** argv ) {
       bytes code_bytes;
       if(!contract_clear){
         std::string wasm;
-        fc::path cpath(contractPath);
+        fc::path cpath = fc::canonical(fc::path(contractPath));
 
         if( cpath.filename().generic_string() == "." ) cpath = cpath.parent_path();
 
@@ -2523,7 +2523,7 @@ int main( int argc, char** argv ) {
 
       bytes abi_bytes;
       if(!contract_clear){
-        fc::path cpath(contractPath);
+        fc::path cpath = fc::canonical(fc::path(contractPath));
         if( cpath.filename().generic_string() == "." ) cpath = cpath.parent_path();
 
         if( abiPath.empty() ) {

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -2470,8 +2470,6 @@ int main( int argc, char** argv ) {
         std::string wasm;
         fc::path cpath = fc::canonical(fc::path(contractPath));
 
-        if( cpath.filename().generic_string() == "." ) cpath = cpath.parent_path();
-
         if( wasmPath.empty() )
            wasmPath = (cpath / (cpath.filename().generic_string()+".wasm")).generic_string();
         else
@@ -2524,7 +2522,6 @@ int main( int argc, char** argv ) {
       bytes abi_bytes;
       if(!contract_clear){
         fc::path cpath = fc::canonical(fc::path(contractPath));
-        if( cpath.filename().generic_string() == "." ) cpath = cpath.parent_path();
 
         if( abiPath.empty() ) {
            abiPath = (cpath / (cpath.filename().generic_string()+".abi")).generic_string();


### PR DESCRIPTION
**Change Description**

Fixes #6343.
This patch makes cleos print the canonical path of wasm or abi when they are not found. Showing the canonical path for contract-dir can help users find out wrong configuration or option set by themselves. 

**Consensus Changes**

None

**API Changes**

None

**Documentation Additions**

None
