### PR TITLE
Enhancements to cleos multisig: approve with proposal_hash, invalidate, and improved review

### DIFF
--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -3298,6 +3298,19 @@ int main( int argc, char** argv ) {
    unapprove->add_option("permissions", perm, localized("The JSON string of filename defining approving permissions"))->required();
    unapprove->set_callback([&] { approve_or_unapprove("unapprove"); });
 
+   // multisig invalidate
+   string invalidator;
+   auto invalidate = msig->add_subcommand("invalidate", localized("Invalidate all multisig approvals of an account"));
+   add_standard_transaction_options(invalidate, "invalidator@active");
+   invalidate->add_option("invalidator", invalidator, localized("invalidator name (string)"))->required();
+   invalidate->set_callback([&] {
+      auto args = fc::mutable_variant_object()
+         ("account", invalidator);
+
+      auto accountPermissions = get_account_permissions(tx_permission, {invalidator,config::active_name});
+      send_actions({chain::action{accountPermissions, "eosio.msig", "invalidate", variant_to_bin( N(eosio.msig), "invalidate", args ) }});
+   });
+
    // multisig cancel
    string canceler;
    auto cancel = msig->add_subcommand("cancel", localized("Cancel proposed transaction"));


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- Give your PR a title that is sufficient to understand what is being changed. -->

**Change Description**

Resolves #6272.

Special shoutout to @conr2d who took the initiative to resolve #6272 with PR #6298. There were undocumented plans to improve the `cleos multisig` sub-commands which this PR addresses in addition to the enhancements described in #6272. So this PR ultimately ended up superseding PR #6298.

Adds optional `proposal_hash` argument to `cleos multisig approve` to support the new safety feature introduce to the `eosio.msig` contract in EOSIO/eosio.contracts#121.

Adds the `cleos multisig invalidate` sub-command to call the `invalidate` action of the `eosio.msig` contract introduced in EOSIO/eosio.contracts#59.

Modifies the `cleos multisig review` sub-command:

- Adds `proposer` and `transaction_id` fields to the returned JSON. The `transaction_id` in particular is useful since that is the hash that would need to be passed in as `proposal_hash` in the `cleos multisig approve` sub-command (assuming the user wants to use that optional feature for added security).

- Adds cleos option `--show-approvals` which if enabled will add an extra array field `approvals` to the returned JSON. This `approvals` field is a list of all the requested approvals for the proposed transaction along with their status: unapproved, approved, invalidated. Approval time, unapproval time, and invalidation time may also be present if appropriate. The `approvals` field will still correctly show up (assuming it is requested with the `--show-approvals` option) even if the `eosio.msig` contract is an old version; however, certain features, such as `invalidation` status and approval/unapproval times, will of course not be available.


**Consensus Changes**

None

**API Changes**

None

**Documentation Additions**

None
