### PR TITLE
Stop the unix_server from listening in shutdown stage as well.

### DIFF
--- a/plugins/http_plugin/http_plugin.cpp
+++ b/plugins/http_plugin/http_plugin.cpp
@@ -548,6 +548,8 @@ namespace eosio {
          my->server.stop_listening();
       if(my->https_server.is_listening())
          my->https_server.stop_listening();
+      if(my->unix_server.is_listening())
+         my->unix_server.stop_listening();
    }
 
    void http_plugin::add_handler(const string& url, const url_handler& handler) {


### PR DESCRIPTION
**Change Description**
We should also unlink the socket file in shutdown stage.
#6393 

**API Changes**
none
**Documentation Additions**
none
