### PR TITLE
Net plugin optimizations

### DIFF
--- a/libraries/chain/include/eosio/chain/block.hpp
+++ b/libraries/chain/include/eosio/chain/block.hpp
@@ -19,22 +19,22 @@ namespace eosio { namespace chain {
       };
 
       transaction_receipt_header():status(hard_fail){}
-      transaction_receipt_header( status_enum s ):status(s){}
+      explicit transaction_receipt_header( status_enum s ):status(s){}
 
       friend inline bool operator ==( const transaction_receipt_header& lhs, const transaction_receipt_header& rhs ) {
          return std::tie(lhs.status, lhs.cpu_usage_us, lhs.net_usage_words) == std::tie(rhs.status, rhs.cpu_usage_us, rhs.net_usage_words);
       }
 
       fc::enum_type<uint8_t,status_enum>   status;
-      uint32_t                             cpu_usage_us; ///< total billed CPU usage (microseconds)
+      uint32_t                             cpu_usage_us = 0; ///< total billed CPU usage (microseconds)
       fc::unsigned_int                     net_usage_words; ///<  total billed NET usage, so we can reconstruct resource state when skipping context free data... hard failures...
    };
 
    struct transaction_receipt : public transaction_receipt_header {
 
       transaction_receipt():transaction_receipt_header(){}
-      transaction_receipt( transaction_id_type tid ):transaction_receipt_header(executed),trx(tid){}
-      transaction_receipt( packed_transaction ptrx ):transaction_receipt_header(executed),trx(ptrx){}
+      explicit transaction_receipt( transaction_id_type tid ):transaction_receipt_header(executed),trx(tid){}
+      explicit transaction_receipt( packed_transaction ptrx ):transaction_receipt_header(executed),trx(ptrx){}
 
       fc::static_variant<transaction_id_type, packed_transaction> trx;
 
@@ -59,8 +59,9 @@ namespace eosio { namespace chain {
       signed_block( const signed_block& ) = default;
     public:
       signed_block() = default;
-      signed_block( const signed_block_header& h ):signed_block_header(h){}
+      explicit signed_block( const signed_block_header& h ):signed_block_header(h){}
       signed_block( signed_block&& ) = default;
+      signed_block& operator=(const signed_block&) = delete;
       signed_block clone() const { return *this; }
 
       vector<transaction_receipt>   transactions; /// new or generated transactions

--- a/libraries/chain/include/eosio/chain/block.hpp
+++ b/libraries/chain/include/eosio/chain/block.hpp
@@ -33,8 +33,8 @@ namespace eosio { namespace chain {
    struct transaction_receipt : public transaction_receipt_header {
 
       transaction_receipt():transaction_receipt_header(){}
-      explicit transaction_receipt( transaction_id_type tid ):transaction_receipt_header(executed),trx(tid){}
-      explicit transaction_receipt( packed_transaction ptrx ):transaction_receipt_header(executed),trx(ptrx){}
+      explicit transaction_receipt( const transaction_id_type& tid ):transaction_receipt_header(executed),trx(tid){}
+      explicit transaction_receipt( const packed_transaction& ptrx ):transaction_receipt_header(executed),trx(ptrx){}
 
       fc::static_variant<transaction_id_type, packed_transaction> trx;
 

--- a/libraries/chain/include/eosio/chain/transaction.hpp
+++ b/libraries/chain/include/eosio/chain/transaction.hpp
@@ -107,11 +107,6 @@ namespace eosio { namespace chain {
       packed_transaction& operator=(const packed_transaction&) = delete;
       packed_transaction& operator=(packed_transaction&&) = default;
 
-      explicit packed_transaction(const transaction& t, compression_type _compression = none)
-      {
-         set_transaction(t, _compression);
-      }
-
       explicit packed_transaction(const signed_transaction& t, compression_type _compression = none)
       :signatures(t.signatures)
       {

--- a/libraries/chain/include/eosio/chain/transaction.hpp
+++ b/libraries/chain/include/eosio/chain/transaction.hpp
@@ -102,6 +102,10 @@ namespace eosio { namespace chain {
       };
 
       packed_transaction() = default;
+      packed_transaction(packed_transaction&&) = default;
+      explicit packed_transaction(const packed_transaction&) = default;
+      packed_transaction& operator=(const packed_transaction&) = delete;
+      packed_transaction& operator=(packed_transaction&&) = default;
 
       explicit packed_transaction(const transaction& t, compression_type _compression = none)
       {
@@ -117,7 +121,7 @@ namespace eosio { namespace chain {
       explicit packed_transaction(signed_transaction&& t, compression_type _compression = none)
       :signatures(std::move(t.signatures))
       {
-         set_transaction(t, std::move(t.context_free_data), _compression);
+         set_transaction(t, t.context_free_data, _compression);
       }
 
       uint32_t get_unprunable_size()const;

--- a/libraries/chain/include/eosio/chain/transaction_metadata.hpp
+++ b/libraries/chain/include/eosio/chain/transaction_metadata.hpp
@@ -18,7 +18,7 @@ class transaction_metadata {
       transaction_id_type                                        id;
       transaction_id_type                                        signed_id;
       signed_transaction                                         trx;
-      packed_transaction                                         packed_trx;
+      packed_transaction_ptr                                     packed_trx;
       optional<pair<chain_id_type, flat_set<public_key_type>>>   signing_keys;
       std::future<pair<chain_id_type,flat_set<public_key_type>>> signing_keys_future;
       bool                                                       accepted = false;
@@ -26,17 +26,17 @@ class transaction_metadata {
       bool                                                       scheduled = false;
 
       explicit transaction_metadata( const signed_transaction& t, packed_transaction::compression_type c = packed_transaction::none )
-      :trx(t),packed_trx(t, c) {
+      :trx(t),packed_trx(std::make_shared<packed_transaction>(t, c)) {
          id = trx.id();
          //raw_packed = fc::raw::pack( static_cast<const transaction&>(trx) );
-         signed_id = digest_type::hash(packed_trx);
+         signed_id = digest_type::hash(*packed_trx);
       }
 
-      explicit transaction_metadata( const packed_transaction& ptrx )
-      :trx( ptrx.get_signed_transaction() ), packed_trx(ptrx) {
+      explicit transaction_metadata( const packed_transaction_ptr& ptrx )
+      :trx( ptrx->get_signed_transaction() ), packed_trx(ptrx) {
          id = trx.id();
          //raw_packed = fc::raw::pack( static_cast<const transaction&>(trx) );
-         signed_id = digest_type::hash(packed_trx);
+         signed_id = digest_type::hash(*packed_trx);
       }
 
       const flat_set<public_key_type>& recover_keys( const chain_id_type& chain_id ) {

--- a/libraries/chain/include/eosio/chain/transaction_metadata.hpp
+++ b/libraries/chain/include/eosio/chain/transaction_metadata.hpp
@@ -25,16 +25,20 @@ class transaction_metadata {
       bool                                                       implicit = false;
       bool                                                       scheduled = false;
 
+      transaction_metadata() = delete;
+      transaction_metadata(const transaction_metadata&) = delete;
+      transaction_metadata(transaction_metadata&&) = delete;
+      transaction_metadata operator=(transaction_metadata&) = delete;
+      transaction_metadata operator=(transaction_metadata&&) = delete;
+
       explicit transaction_metadata( const signed_transaction& t, packed_transaction::compression_type c = packed_transaction::none )
-      :trx(t),packed_trx(std::make_shared<packed_transaction>(t, c)) {
-         id = trx.id();
+      :id(t.id()), trx(t), packed_trx(std::make_shared<packed_transaction>(t, c)) {
          //raw_packed = fc::raw::pack( static_cast<const transaction&>(trx) );
          signed_id = digest_type::hash(*packed_trx);
       }
 
       explicit transaction_metadata( const packed_transaction_ptr& ptrx )
-      :trx( ptrx->get_signed_transaction() ), packed_trx(ptrx) {
-         id = trx.id();
+      :id(ptrx->id()), trx( ptrx->get_signed_transaction() ), packed_trx(ptrx) {
          //raw_packed = fc::raw::pack( static_cast<const transaction&>(trx) );
          signed_id = digest_type::hash(*packed_trx);
       }

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -333,7 +333,7 @@ namespace eosio { namespace testing {
    { try {
       if( !control->pending_block_state() )
          _start_block(control->head_block_time() + fc::microseconds(config::block_interval_us));
-      auto r = control->push_transaction( std::make_shared<transaction_metadata>(trx), deadline, billed_cpu_time_us );
+      auto r = control->push_transaction( std::make_shared<transaction_metadata>(std::make_shared<packed_transaction>(trx)), deadline, billed_cpu_time_us );
       if( r->except_ptr ) std::rethrow_exception( r->except_ptr );
       if( r->except ) throw *r->except;
       return r;

--- a/plugins/bnet_plugin/bnet_plugin.cpp
+++ b/plugins/bnet_plugin/bnet_plugin.cpp
@@ -765,7 +765,7 @@ namespace eosio {
               return false;
 
 
-           auto ptrx_ptr = std::make_shared<packed_transaction>( start->trx->packed_trx );
+           auto ptrx_ptr = start->trx->packed_trx;
 
            idx.modify( start, [&]( auto& stat ) {
               stat.mark_known_by_peer();

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -759,6 +759,10 @@ void chain_plugin::accept_transaction(const chain::packed_transaction& trx, next
    my->incoming_transaction_async_method(std::make_shared<packed_transaction>(trx), false, std::forward<decltype(next)>(next));
 }
 
+void chain_plugin::accept_transaction(const chain::packed_transaction_ptr& trx, next_function<chain::transaction_trace_ptr> next) {
+   my->incoming_transaction_async_method(trx, false, std::forward<decltype(next)>(next));
+}
+
 bool chain_plugin::block_is_on_preferred_chain(const block_id_type& block_id) {
    auto b = chain().fetch_block_by_number( block_header::num_from_id(block_id) );
    return b && b->id() == block_id;

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -664,6 +664,7 @@ public:
 
    void accept_block( const chain::signed_block_ptr& block );
    void accept_transaction(const chain::packed_transaction& trx, chain::plugin_interface::next_function<chain::transaction_trace_ptr> next);
+   void accept_transaction(const chain::packed_transaction_ptr& trx, chain::plugin_interface::next_function<chain::transaction_trace_ptr> next);
 
    bool block_is_on_preferred_chain(const chain::block_id_type& block_id);
 

--- a/plugins/history_plugin/history_plugin.cpp
+++ b/plugins/history_plugin/history_plugin.cpp
@@ -504,10 +504,9 @@ namespace eosio {
                 for (const auto &receipt: blk->transactions) {
                     if (receipt.trx.contains<packed_transaction>()) {
                         auto &pt = receipt.trx.get<packed_transaction>();
-                        auto mtrx = transaction_metadata(std::make_shared<packed_transaction>(pt));
-                        if (mtrx.id == result.id) {
+                        if (pt.id() == result.id) {
                             fc::mutable_variant_object r("receipt", receipt);
-                            r("trx", chain.to_variant_with_abi(mtrx.trx, abi_serializer_max_time));
+                            r("trx", chain.to_variant_with_abi(pt.get_signed_transaction(), abi_serializer_max_time));
                             result.trx = move(r);
                             break;
                         }
@@ -528,14 +527,14 @@ namespace eosio {
                for (const auto& receipt: blk->transactions) {
                   if (receipt.trx.contains<packed_transaction>()) {
                      auto& pt = receipt.trx.get<packed_transaction>();
-                     auto mtrx = transaction_metadata(std::make_shared<packed_transaction>(pt));
-                     if( txn_id_matched(mtrx.id) ) {
-                        result.id = mtrx.id;
+                     const auto& id = pt.id();
+                     if( txn_id_matched(id) ) {
+                        result.id = id;
                         result.last_irreversible_block = chain.last_irreversible_block_num();
                         result.block_num = *p.block_num_hint;
                         result.block_time = blk->timestamp;
                         fc::mutable_variant_object r("receipt", receipt);
-                        r("trx", chain.to_variant_with_abi(mtrx.trx, abi_serializer_max_time));
+                        r("trx", chain.to_variant_with_abi(pt.get_signed_transaction(), abi_serializer_max_time));
                         result.trx = move(r);
                         found = true;
                         break;

--- a/plugins/history_plugin/history_plugin.cpp
+++ b/plugins/history_plugin/history_plugin.cpp
@@ -504,7 +504,7 @@ namespace eosio {
                 for (const auto &receipt: blk->transactions) {
                     if (receipt.trx.contains<packed_transaction>()) {
                         auto &pt = receipt.trx.get<packed_transaction>();
-                        auto mtrx = transaction_metadata(pt);
+                        auto mtrx = transaction_metadata(std::make_shared<packed_transaction>(pt));
                         if (mtrx.id == result.id) {
                             fc::mutable_variant_object r("receipt", receipt);
                             r("trx", chain.to_variant_with_abi(mtrx.trx, abi_serializer_max_time));
@@ -528,7 +528,7 @@ namespace eosio {
                for (const auto& receipt: blk->transactions) {
                   if (receipt.trx.contains<packed_transaction>()) {
                      auto& pt = receipt.trx.get<packed_transaction>();
-                     auto mtrx = transaction_metadata(pt);
+                     auto mtrx = transaction_metadata(std::make_shared<packed_transaction>(pt));
                      if( txn_id_matched(mtrx.id) ) {
                         result.id = mtrx.id;
                         result.last_irreversible_block = chain.last_irreversible_block_num();

--- a/plugins/net_plugin/include/eosio/net_plugin/protocol.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/protocol.hpp
@@ -139,8 +139,8 @@ namespace eosio {
                                       notice_message,
                                       request_message,
                                       sync_request_message,
-                                      signed_block, // which = 7
-                                      packed_transaction>;
+                                      signed_block,         // which = 7
+                                      packed_transaction>;  // which = 8
 
 } // namespace eosio
 

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -1388,7 +1388,7 @@ namespace eosio {
       //
       // 0. my head block id == peer head id means we are all caught up block wise
       // 1. my head block num < peer lib - start sync locally
-      // 2. my lib > peer head num - send an last_irr_catch_up notice if not the first generation
+      // 2. my lib > peer lib - send an last_irr_catch_up notice if not the first generation
       //
       // 3  my head block num <= peer head block num - update sync state and send a catchup request
       // 4  my head block num > peer block num send a notice catchup if this is not the first generation
@@ -1415,7 +1415,7 @@ namespace eosio {
          }
          return;
       }
-      if (lib_num > msg.head_num ) {
+      if (lib_num > msg.last_irreversible_block_num ) {
          fc_dlog(logger, "sync check state 2");
          if (msg.generation > 1 || c->protocol_version > proto_base) {
             notice_message note;

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -167,13 +167,7 @@ namespace eosio {
       template<typename VerifierFunc>
       void send_all( const std::shared_ptr<std::vector<char>>& send_buffer, VerifierFunc verify );
 
-      void accepted_block_header(const block_state_ptr&);
       void accepted_block(const block_state_ptr&);
-      void irreversible_block(const block_state_ptr&);
-      void accepted_transaction(const transaction_metadata_ptr&);
-      void applied_transaction(const transaction_trace_ptr&);
-      void accepted_confirmation(const header_confirmation&);
-
       void transaction_ack(const std::pair<fc::exception_ptr, packed_transaction_ptr>&);
 
       bool is_valid( const handshake_message &msg);
@@ -2576,30 +2570,9 @@ namespace eosio {
       c->close();
    }
 
-   void net_plugin_impl::accepted_block_header(const block_state_ptr& block) {
-      fc_dlog(logger,"signaled, id = ${id}",("id", block->id));
-   }
-
    void net_plugin_impl::accepted_block(const block_state_ptr& block) {
       fc_dlog(logger,"signaled, id = ${id}",("id", block->id));
       dispatcher->bcast_block(block);
-   }
-
-   void net_plugin_impl::irreversible_block(const block_state_ptr& block) {
-      fc_dlog(logger,"signaled, id = ${id}",("id", block->id));
-   }
-
-   void net_plugin_impl::accepted_transaction(const transaction_metadata_ptr& md) {
-      fc_dlog(logger,"signaled, id = ${id}",("id", md->id));
-//      dispatcher->bcast_transaction(md->packed_trx);
-   }
-
-   void net_plugin_impl::applied_transaction(const transaction_trace_ptr& txn) {
-      fc_dlog(logger,"signaled, id = ${id}",("id", txn->id));
-   }
-
-   void net_plugin_impl::accepted_confirmation(const header_confirmation& head) {
-      fc_dlog(logger,"signaled, id = ${id}",("id", head.block_id));
    }
 
    void net_plugin_impl::transaction_ack(const std::pair<fc::exception_ptr, packed_transaction_ptr>& results) {
@@ -2908,12 +2881,7 @@ namespace eosio {
       }
       chain::controller&cc = my->chain_plug->chain();
       {
-         cc.accepted_block_header.connect( boost::bind(&net_plugin_impl::accepted_block_header, my.get(), _1));
          cc.accepted_block.connect(  boost::bind(&net_plugin_impl::accepted_block, my.get(), _1));
-         cc.irreversible_block.connect( boost::bind(&net_plugin_impl::irreversible_block, my.get(), _1));
-         cc.accepted_transaction.connect( boost::bind(&net_plugin_impl::accepted_transaction, my.get(), _1));
-         cc.applied_transaction.connect( boost::bind(&net_plugin_impl::applied_transaction, my.get(), _1));
-         cc.accepted_confirmation.connect( boost::bind(&net_plugin_impl::accepted_confirmation, my.get(), _1));
       }
 
       my->incoming_transaction_ack_subscription = app().get_channel<channels::transaction_ack>().subscribe(boost::bind(&net_plugin_impl::transaction_ack, my.get(), _1));

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -145,7 +145,7 @@ namespace eosio {
             };
       possible_connections             allowed_connections{None};
 
-      connection_ptr find_connection( string host )const;
+      connection_ptr find_connection(const string& host)const;
 
       std::set< connection_ptr >       connections;
       bool                             done = false;
@@ -180,13 +180,13 @@ namespace eosio {
 
       channels::transaction_ack::channel_type::handle  incoming_transaction_ack_subscription;
 
-      void connect( connection_ptr c );
-      void connect( connection_ptr c, tcp::resolver::iterator endpoint_itr );
-      bool start_session( connection_ptr c );
+      void connect(const connection_ptr& c);
+      void connect(const connection_ptr& c, tcp::resolver::iterator endpoint_itr);
+      bool start_session(const connection_ptr& c);
       void start_listen_loop( );
-      void start_read_message( connection_ptr c);
+      void start_read_message(const connection_ptr& c);
 
-      void   close( connection_ptr c );
+      void close(const connection_ptr& c);
       size_t count_open_sockets() const;
 
       template<typename VerifierFunc>
@@ -203,9 +203,9 @@ namespace eosio {
 
       bool is_valid( const handshake_message &msg);
 
-      void handle_message( connection_ptr c, const handshake_message &msg);
-      void handle_message( connection_ptr c, const chain_size_message &msg);
-      void handle_message( connection_ptr c, const go_away_message &msg );
+      void handle_message(const connection_ptr& c, const handshake_message& msg);
+      void handle_message(const connection_ptr& c, const chain_size_message& msg);
+      void handle_message(const connection_ptr& c, const go_away_message& msg );
       /** \name Peer Timestamps
        *  Time message handling
        *  @{
@@ -219,14 +219,14 @@ namespace eosio {
        * floating-double arithmetic with rounding done by the hardware.
        * This is necessary in order to avoid overflow and preserve precision.
        */
-      void handle_message( connection_ptr c, const time_message &msg);
+      void handle_message(const connection_ptr& c, const time_message& msg);
       /** @} */
-      void handle_message( connection_ptr c, const notice_message &msg);
-      void handle_message( connection_ptr c, const request_message &msg);
-      void handle_message( connection_ptr c, const sync_request_message &msg);
-      void handle_message( connection_ptr c, const signed_block &msg) = delete; // signed_block_ptr overload used instead
-      void handle_message( connection_ptr c, const signed_block_ptr &msg);
-      void handle_message( connection_ptr c, const packed_transaction &msg);
+      void handle_message(const connection_ptr& c, const notice_message& msg);
+      void handle_message(const connection_ptr& c, const request_message& msg);
+      void handle_message(const connection_ptr& c, const sync_request_message& msg);
+      void handle_message(const connection_ptr& c, const signed_block& msg) = delete; // signed_block_ptr overload used instead
+      void handle_message(const connection_ptr& c, const signed_block_ptr& msg);
+      void handle_message(const connection_ptr& c, const packed_transaction& msg);
 
       void start_conn_timer(boost::asio::steady_timer::duration du, std::weak_ptr<connection> from_connection);
       void start_txn_timer( );
@@ -507,10 +507,6 @@ namespace eosio {
       /** \name Peer Timestamps
        *  Time message handling
        */
-      /** @{ */
-      /** \brief Convert an std::chrono nanosecond rep to a human readable string
-       */
-      char* convert_tstamp(const tstamp& t);
       /**  \brief Populate and queue time_message
        */
       void send_time();
@@ -553,7 +549,7 @@ namespace eosio {
       void sync_timeout(boost::system::error_code ec);
       void fetch_timeout(boost::system::error_code ec);
 
-      void queue_write(std::shared_ptr<vector<char>> buff,
+      void queue_write(const std::shared_ptr<vector<char>>& buff,
                        bool trigger_send,
                        std::function<void(boost::system::error_code, std::size_t)> callback);
       void do_queue_write();
@@ -600,7 +596,7 @@ namespace eosio {
    struct msg_handler : public fc::visitor<void> {
       net_plugin_impl &impl;
       connection_ptr c;
-      msg_handler( net_plugin_impl &imp, connection_ptr conn) : impl(imp), c(conn) {}
+      msg_handler( net_plugin_impl &imp, const connection_ptr& conn) : impl(imp), c(conn) {}
 
       void operator()( const signed_block& msg ) const {
          EOS_ASSERT( false, plugin_config_exception, "visit(signed_block&&) should be called" );
@@ -643,16 +639,16 @@ namespace eosio {
       void set_state(stages s);
       bool sync_required();
       void send_handshakes();
-      bool is_active(connection_ptr conn);
-      void reset_lib_num(connection_ptr conn);
-      void request_next_chunk(connection_ptr conn = connection_ptr() );
-      void start_sync(connection_ptr c, uint32_t target);
-      void reassign_fetch(connection_ptr c, go_away_reason reason);
-      void verify_catchup(connection_ptr c, uint32_t num, block_id_type id);
-      void rejected_block(connection_ptr c, uint32_t blk_num);
-      void recv_block(connection_ptr c, const block_id_type &blk_id, uint32_t blk_num);
-      void recv_handshake(connection_ptr c, const handshake_message& msg);
-      void recv_notice(connection_ptr c, const notice_message& msg);
+      bool is_active(const connection_ptr& conn);
+      void reset_lib_num(const connection_ptr& conn);
+      void request_next_chunk(const connection_ptr& conn = connection_ptr());
+      void start_sync(const connection_ptr& c, uint32_t target);
+      void reassign_fetch(const connection_ptr& c, go_away_reason reason);
+      void verify_catchup(const connection_ptr& c, uint32_t num, const block_id_type& id);
+      void rejected_block(const connection_ptr& c, uint32_t blk_num);
+      void recv_block(const connection_ptr& c, const block_id_type& blk_id, uint32_t blk_num);
+      void recv_handshake(const connection_ptr& c, const handshake_message& msg);
+      void recv_notice(const connection_ptr& c, const notice_message& msg);
    };
 
    class dispatch_manager {
@@ -662,16 +658,16 @@ namespace eosio {
       std::multimap<block_id_type, connection_ptr> received_blocks;
       std::multimap<transaction_id_type, connection_ptr> received_transactions;
 
-      void bcast_transaction (const packed_transaction& msg);
-      void rejected_transaction (const transaction_id_type& msg);
-      void bcast_block (const block_state_ptr& bs);
-      void rejected_block (const block_id_type &id);
+      void bcast_transaction(const packed_transaction& msg);
+      void rejected_transaction(const transaction_id_type& msg);
+      void bcast_block(const block_state_ptr& bs);
+      void rejected_block(const block_id_type &id);
 
-      void recv_block (connection_ptr conn, const block_id_type& msg, uint32_t bnum);
-      void recv_transaction(connection_ptr conn, const transaction_id_type& id);
-      void recv_notice (connection_ptr conn, const notice_message& msg, bool generated);
+      void recv_block(const connection_ptr& conn, const block_id_type& msg, uint32_t bnum);
+      void recv_transaction(const connection_ptr& conn, const transaction_id_type& id);
+      void recv_notice(const connection_ptr& conn, const notice_message& msg, bool generated);
 
-      void retry_fetch (connection_ptr conn);
+      void retry_fetch(const connection_ptr& conn);
    };
 
    //---------------------------------------------------------------------------
@@ -945,15 +941,6 @@ namespace eosio {
       enqueue(last_handshake_sent);
    }
 
-   char* connection::convert_tstamp(const tstamp& t)
-   {
-      const long long NsecPerSec{1000000000};
-      time_t seconds = t / NsecPerSec;
-      strftime(ts, ts_buffer_size, "%F %T", localtime(&seconds));
-      snprintf(ts+19, ts_buffer_size-19, ".%lld", t % NsecPerSec);
-      return ts;
-   }
-
    void connection::send_time() {
       time_message xpkt;
       xpkt.org = rec;
@@ -971,7 +958,7 @@ namespace eosio {
       enqueue(xpkt);
    }
 
-   void connection::queue_write(std::shared_ptr<vector<char>> buff,
+   void connection::queue_write(const std::shared_ptr<vector<char>>& buff,
                                 bool trigger_send,
                                 std::function<void(boost::system::error_code, std::size_t)> callback) {
       write_queue.push_back({buff, callback});
@@ -1155,7 +1142,7 @@ namespace eosio {
          } );
    }
 
-   void connection::fetch_wait( ) {
+   void connection::fetch_wait() {
       response_expected->expires_from_now( my_impl->resp_expected_period);
       connection_wptr c(shared_from_this());
       response_expected->async_wait( [c]( boost::system::error_code ec){
@@ -1280,7 +1267,7 @@ namespace eosio {
       state = newstate;
    }
 
-   bool sync_manager::is_active(connection_ptr c) {
+   bool sync_manager::is_active(const connection_ptr& c) {
       if (state == head_catchup && c) {
          bool fhset = c->fork_head != block_id_type();
          fc_dlog(logger, "fork_head_num = ${fn} fork_head set = ${s}",
@@ -1290,7 +1277,7 @@ namespace eosio {
       return state != in_sync;
    }
 
-   void sync_manager::reset_lib_num(connection_ptr c) {
+   void sync_manager::reset_lib_num(const connection_ptr& c) {
       if(state == in_sync) {
          source.reset();
       }
@@ -1312,7 +1299,7 @@ namespace eosio {
               chain_plug->chain( ).fork_db_head_block_num( ) < sync_last_requested_num );
    }
 
-   void sync_manager::request_next_chunk( connection_ptr conn ) {
+   void sync_manager::request_next_chunk( const connection_ptr& conn ) {
       uint32_t head_block = chain_plug->chain().fork_db_head_block_num();
 
       if (head_block < sync_last_requested_num && source && source->current()) {
@@ -1395,7 +1382,7 @@ namespace eosio {
       }
    }
 
-   void sync_manager::send_handshakes ()
+   void sync_manager::send_handshakes()
    {
       for( auto &ci : my_impl->connections) {
          if( ci->current()) {
@@ -1404,7 +1391,7 @@ namespace eosio {
       }
    }
 
-   void sync_manager::start_sync( connection_ptr c, uint32_t target) {
+   void sync_manager::start_sync(const connection_ptr& c, uint32_t target) {
       if( target > sync_known_lib_num) {
          sync_known_lib_num = target;
       }
@@ -1428,7 +1415,7 @@ namespace eosio {
       request_next_chunk(c);
    }
 
-   void sync_manager::reassign_fetch(connection_ptr c, go_away_reason reason) {
+   void sync_manager::reassign_fetch(const connection_ptr& c, go_away_reason reason) {
       fc_ilog(logger, "reassign_fetch, our last req is ${cc}, next expected is ${ne} peer ${p}",
               ( "cc",sync_last_requested_num)("ne",sync_next_expected_num)("p",c->peer_name()));
 
@@ -1439,7 +1426,7 @@ namespace eosio {
       }
    }
 
-   void sync_manager::recv_handshake (connection_ptr c, const handshake_message &msg) {
+   void sync_manager::recv_handshake(const connection_ptr& c, const handshake_message& msg) {
       controller& cc = chain_plug->chain();
       uint32_t lib_num = cc.last_irreversible_block_num( );
       uint32_t peer_lib = msg.last_irreversible_block_num;
@@ -1494,7 +1481,7 @@ namespace eosio {
 
       if (head <= msg.head_num ) {
          fc_dlog(logger, "sync check state 3");
-         verify_catchup (c, msg.head_num, msg.head_id);
+         verify_catchup(c, msg.head_num, msg.head_id);
          return;
       }
       else {
@@ -1513,7 +1500,7 @@ namespace eosio {
       elog ("sync check failed to resolve status");
    }
 
-   void sync_manager::verify_catchup(connection_ptr c, uint32_t num, block_id_type id) {
+   void sync_manager::verify_catchup(const connection_ptr& c, uint32_t num, const block_id_type& id) {
       request_message req;
       req.req_blocks.mode = catch_up;
       for (const auto& cc : my_impl->connections) {
@@ -1539,14 +1526,14 @@ namespace eosio {
       c->enqueue( req );
    }
 
-   void sync_manager::recv_notice (connection_ptr c, const notice_message &msg) {
+   void sync_manager::recv_notice(const connection_ptr& c, const notice_message& msg) {
       fc_ilog (logger, "sync_manager got ${m} block notice",("m",modes_str(msg.known_blocks.mode)));
       if (msg.known_blocks.mode == catch_up) {
          if (msg.known_blocks.ids.size() == 0) {
             elog ("got a catch up with ids size = 0");
          }
          else {
-            verify_catchup(c,  msg.known_blocks.pending, msg.known_blocks.ids.back());
+            verify_catchup(c, msg.known_blocks.pending, msg.known_blocks.ids.back());
          }
       }
       else {
@@ -1556,7 +1543,7 @@ namespace eosio {
       }
    }
 
-   void sync_manager::rejected_block (connection_ptr c, uint32_t blk_num) {
+   void sync_manager::rejected_block(const connection_ptr& c, uint32_t blk_num) {
       if (state != in_sync ) {
          fc_ilog (logger, "block ${bn} not accepted from ${p}",("bn",blk_num)("p",c->peer_name()));
          sync_last_requested_num = 0;
@@ -1566,7 +1553,7 @@ namespace eosio {
          send_handshakes();
       }
    }
-   void sync_manager::recv_block (connection_ptr c, const block_id_type &blk_id, uint32_t blk_num) {
+   void sync_manager::recv_block(const connection_ptr& c, const block_id_type& blk_id, uint32_t blk_num) {
       fc_dlog(logger," got block ${bn} from ${p}",("bn",blk_num)("p",c->peer_name()));
       if (state == lib_catchup) {
          if (blk_num != sync_next_expected_num) {
@@ -1613,7 +1600,7 @@ namespace eosio {
 
    //------------------------------------------------------------------------
 
-   void dispatch_manager::bcast_block (const block_state_ptr& bs) {
+   void dispatch_manager::bcast_block(const block_state_ptr& bs) {
       std::set<connection_ptr> skips;
       auto range = received_blocks.equal_range(bs->id);
       for (auto org = range.first; org != range.second; ++org) {
@@ -1640,7 +1627,7 @@ namespace eosio {
 
    }
 
-   void dispatch_manager::recv_block (connection_ptr c, const block_id_type& id, uint32_t bnum) {
+   void dispatch_manager::recv_block(const connection_ptr& c, const block_id_type& id, uint32_t bnum) {
       received_blocks.insert(std::make_pair(id, c));
       if (c &&
           c->last_req &&
@@ -1655,13 +1642,13 @@ namespace eosio {
       c->cancel_wait();
    }
 
-   void dispatch_manager::rejected_block (const block_id_type& id) {
+   void dispatch_manager::rejected_block(const block_id_type& id) {
       fc_dlog(logger,"not sending rejected transaction ${tid}",("tid",id));
       auto range = received_blocks.equal_range(id);
       received_blocks.erase(range.first, range.second);
    }
 
-   void dispatch_manager::bcast_transaction (const packed_transaction& trx) {
+   void dispatch_manager::bcast_transaction(const packed_transaction& trx) {
       std::set<connection_ptr> skips;
       transaction_id_type id = trx.id();
 
@@ -1692,7 +1679,7 @@ namespace eosio {
                                     0, 0, 0};
       my_impl->local_txns.insert(std::move(nts));
 
-      my_impl->send_all( buff, [&id, &skips, trx_expiration](connection_ptr c) -> bool {
+      my_impl->send_all( buff, [&id, &skips, trx_expiration](const connection_ptr& c) -> bool {
          if( skips.find(c) != skips.end() || c->syncing ) {
             return false;
           }
@@ -1707,7 +1694,7 @@ namespace eosio {
 
    }
 
-   void dispatch_manager::recv_transaction (connection_ptr c, const transaction_id_type& id) {
+   void dispatch_manager::recv_transaction(const connection_ptr& c, const transaction_id_type& id) {
       received_transactions.insert(std::make_pair(id, c));
       if (c &&
           c->last_req &&
@@ -1721,13 +1708,13 @@ namespace eosio {
       c->cancel_wait();
    }
 
-   void dispatch_manager::rejected_transaction (const transaction_id_type& id) {
+   void dispatch_manager::rejected_transaction(const transaction_id_type& id) {
       fc_dlog(logger,"not sending rejected transaction ${tid}",("tid",id));
       auto range = received_transactions.equal_range(id);
       received_transactions.erase(range.first, range.second);
    }
 
-   void dispatch_manager::recv_notice (connection_ptr c, const notice_message& msg, bool generated) {
+   void dispatch_manager::recv_notice(const connection_ptr& c, const notice_message& msg, bool generated) {
       request_message req;
       req.req_trx.mode = none;
       req.req_blocks.mode = none;
@@ -1777,7 +1764,7 @@ namespace eosio {
       }
    }
 
-   void dispatch_manager::retry_fetch( connection_ptr c ) {
+   void dispatch_manager::retry_fetch(const connection_ptr& c) {
       if (!c->last_req) {
          return;
       }
@@ -1827,7 +1814,7 @@ namespace eosio {
 
    //------------------------------------------------------------------------
 
-   void net_plugin_impl::connect( connection_ptr c ) {
+   void net_plugin_impl::connect(const connection_ptr& c) {
       if( c->no_retry != go_away_reason::no_reason) {
          fc_dlog( logger, "Skipping connect due to go_away reason ${r}",("r", reason_str( c->no_retry )));
          return;
@@ -1869,7 +1856,7 @@ namespace eosio {
                                });
    }
 
-   void net_plugin_impl::connect( connection_ptr c, tcp::resolver::iterator endpoint_itr ) {
+   void net_plugin_impl::connect(const connection_ptr& c, tcp::resolver::iterator endpoint_itr) {
       if( c->no_retry != go_away_reason::no_reason) {
          string rsn = reason_str(c->no_retry);
          return;
@@ -1900,7 +1887,7 @@ namespace eosio {
          } );
    }
 
-   bool net_plugin_impl::start_session( connection_ptr con ) {
+   bool net_plugin_impl::start_session(const connection_ptr& con) {
       boost::asio::ip::tcp::no_delay nodelay( true );
       boost::system::error_code ec;
       con->socket->set_option( nodelay, ec );
@@ -1922,7 +1909,7 @@ namespace eosio {
    }
 
 
-   void net_plugin_impl::start_listen_loop( ) {
+   void net_plugin_impl::start_listen_loop() {
       auto socket = std::make_shared<tcp::socket>( std::ref( app().get_io_service() ) );
       acceptor->async_accept( *socket, [socket,this]( boost::system::error_code ec ) {
             if( !ec ) {
@@ -1986,7 +1973,7 @@ namespace eosio {
          });
    }
 
-   void net_plugin_impl::start_read_message( connection_ptr conn ) {
+   void net_plugin_impl::start_read_message(const connection_ptr& conn) {
 
       try {
          if(!conn->socket) {
@@ -2111,7 +2098,7 @@ namespace eosio {
 
 
    template<typename VerifierFunc>
-   void net_plugin_impl::send_all( const std::shared_ptr<std::vector<char>>& send_buffer, VerifierFunc verify) {
+   void net_plugin_impl::send_all(const std::shared_ptr<std::vector<char>>& send_buffer, VerifierFunc verify) {
       for( auto &c : connections) {
          if( c->current() && verify( c )) {
             c->enqueue_buffer( send_buffer, true, no_reason );
@@ -2119,7 +2106,7 @@ namespace eosio {
       }
    }
 
-   bool net_plugin_impl::is_valid( const handshake_message &msg) {
+   bool net_plugin_impl::is_valid(const handshake_message& msg) {
       // Do some basic validation of an incoming handshake_message, so things
       // that really aren't handshake messages can be quickly discarded without
       // affecting state.
@@ -2144,12 +2131,11 @@ namespace eosio {
       return valid;
    }
 
-   void net_plugin_impl::handle_message( connection_ptr c, const chain_size_message &msg) {
+   void net_plugin_impl::handle_message(const connection_ptr& c, const chain_size_message& msg) {
       peer_ilog(c, "received chain_size_message");
-
    }
 
-   void net_plugin_impl::handle_message( connection_ptr c, const handshake_message &msg) {
+   void net_plugin_impl::handle_message(const connection_ptr& c, const handshake_message& msg) {
       peer_ilog(c, "received handshake_message");
       if (!is_valid(msg)) {
          peer_elog( c, "bad handshake message");
@@ -2256,7 +2242,7 @@ namespace eosio {
       sync_master->recv_handshake(c,msg);
    }
 
-   void net_plugin_impl::handle_message( connection_ptr c, const go_away_message &msg ) {
+   void net_plugin_impl::handle_message(const connection_ptr& c, const go_away_message& msg) {
       string rsn = reason_str( msg.reason );
       peer_ilog(c, "received go_away_message");
       ilog( "received a go away message from ${p}, reason = ${r}",
@@ -2269,7 +2255,7 @@ namespace eosio {
       close (c);
    }
 
-   void net_plugin_impl::handle_message(connection_ptr c, const time_message &msg) {
+   void net_plugin_impl::handle_message(const connection_ptr& c, const time_message& msg) {
       peer_ilog(c, "received time_message");
       /* We've already lost however many microseconds it took to dispatch
        * the message, but it can't be helped.
@@ -2302,7 +2288,7 @@ namespace eosio {
       c->rec = 0;
    }
 
-   void net_plugin_impl::handle_message( connection_ptr c, const notice_message &msg) {
+   void net_plugin_impl::handle_message(const connection_ptr& c, const notice_message& msg) {
       // peer tells us about one or more blocks or txns. When done syncing, forward on
       // notices of previously unknown blocks or txns,
       //
@@ -2366,7 +2352,7 @@ namespace eosio {
       }
    }
 
-   void net_plugin_impl::handle_message( connection_ptr c, const request_message &msg) {
+   void net_plugin_impl::handle_message(const connection_ptr& c, const request_message& msg) {
       switch (msg.req_blocks.mode) {
       case catch_up :
          peer_ilog(c,  "received request_message:catch_up");
@@ -2396,7 +2382,7 @@ namespace eosio {
 
    }
 
-   void net_plugin_impl::handle_message( connection_ptr c, const sync_request_message &msg) {
+   void net_plugin_impl::handle_message(const connection_ptr& c, const sync_request_message& msg) {
       if( msg.end_block == 0) {
          c->peer_requested.reset();
          c->flush_queues();
@@ -2406,7 +2392,7 @@ namespace eosio {
       }
    }
 
-   void net_plugin_impl::handle_message( connection_ptr c, const packed_transaction &msg) {
+   void net_plugin_impl::handle_message(const connection_ptr& c, const packed_transaction& msg) {
       fc_dlog(logger, "got a packed transaction, cancel wait");
       peer_ilog(c, "received packed_transaction");
       controller& cc = my_impl->chain_plug->chain();
@@ -2443,7 +2429,7 @@ namespace eosio {
       });
    }
 
-   void net_plugin_impl::handle_message( connection_ptr c, const signed_block_ptr& msg) {
+   void net_plugin_impl::handle_message(const connection_ptr& c, const signed_block_ptr& msg) {
       controller &cc = chain_plug->chain();
       block_id_type blk_id = msg->id();
       uint32_t blk_num = msg->block_num();
@@ -2602,7 +2588,7 @@ namespace eosio {
       start_conn_timer(connector_period, std::weak_ptr<connection>());
    }
 
-   void net_plugin_impl::close( connection_ptr c ) {
+   void net_plugin_impl::close(const connection_ptr& c ) {
       if( c->peer_addr.empty( ) && c->socket->is_open() ) {
          if (num_clients == 0) {
             fc_wlog( logger, "num_clients already at 0");
@@ -3038,7 +3024,7 @@ namespace eosio {
       }
       return result;
    }
-   connection_ptr net_plugin_impl::find_connection( string host )const {
+   connection_ptr net_plugin_impl::find_connection(const string& host )const {
       for( const auto& c : connections )
          if( c->peer_addr == host ) return c;
       return connection_ptr();

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -92,6 +92,14 @@ namespace eosio {
    struct by_expiry;
    struct by_block_num;
 
+   struct sha256_less {
+      bool operator()( const sha256& lhs, const sha256& rhs ) const {
+       return
+             std::tie(lhs._hash[0], lhs._hash[1], lhs._hash[2], lhs._hash[3]) <
+             std::tie(rhs._hash[0], rhs._hash[1], rhs._hash[2], rhs._hash[3]);
+      }
+   };
+
    typedef multi_index_container<
       node_transaction_state,
       indexed_by<
@@ -99,7 +107,8 @@ namespace eosio {
             tag< by_id >,
             member < node_transaction_state,
                      transaction_id_type,
-                     &node_transaction_state::id > >,
+                     &node_transaction_state::id >,
+            sha256_less >,
          ordered_non_unique<
             tag< by_expiry >,
             member< node_transaction_state,
@@ -364,7 +373,7 @@ namespace eosio {
    typedef multi_index_container<
       transaction_state,
       indexed_by<
-         ordered_unique< tag<by_id>, member<transaction_state, transaction_id_type, &transaction_state::id > >,
+         ordered_unique< tag<by_id>, member<transaction_state, transaction_id_type, &transaction_state::id >, sha256_less >,
          ordered_non_unique< tag< by_expiry >, member< transaction_state,fc::time_point_sec,&transaction_state::expires >>,
          ordered_non_unique<
             tag<by_block_num>,
@@ -398,7 +407,7 @@ namespace eosio {
    typedef multi_index_container<
       eosio::peer_block_state,
       indexed_by<
-         ordered_unique< tag<by_id>, member<eosio::peer_block_state, block_id_type, &eosio::peer_block_state::id > >,
+         ordered_unique< tag<by_id>, member<eosio::peer_block_state, block_id_type, &eosio::peer_block_state::id >, sha256_less >,
          ordered_unique< tag<by_block_num>, member<eosio::peer_block_state, uint32_t, &eosio::peer_block_state::block_num > >
          >
       > peer_block_state_index;

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -774,7 +774,7 @@ namespace eosio {
 
    void connection::txn_send_pending(const vector<transaction_id_type> &ids) {
       for(auto tx = my_impl->local_txns.begin(); tx != my_impl->local_txns.end(); ++tx ){
-         if(tx->serialized_txn->size() && tx->block_num == 0) {
+         if( tx->block_num == 0 ) {
             bool found = false;
             for(auto known : ids) {
                if( known == tx->id) {
@@ -803,7 +803,7 @@ namespace eosio {
    void connection::txn_send(const vector<transaction_id_type> &ids) {
       for(const auto& t : ids) {
          auto tx = my_impl->local_txns.get<by_id>().find(t);
-         if( tx != my_impl->local_txns.end() && tx->serialized_txn->size()) {
+         if( tx != my_impl->local_txns.end() ) {
             my_impl->local_txns.modify( tx,incr_in_flight);
             queue_write(tx->serialized_txn,
                         true,

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -65,7 +65,6 @@ namespace eosio {
       time_point_sec  expires;  /// time after which this may be purged.
                                 /// Expires increased while the txn is
                                 /// "in flight" to anoher peer
-      packed_transaction packed_txn;
       vector<char>    serialized_txn; /// the received raw bundle
       uint32_t        block_num = 0; /// block transaction was included in
       uint32_t        true_block = 0; /// used to reset block_uum when request is 0
@@ -1687,7 +1686,6 @@ namespace eosio {
       fc::raw::pack( ds, msg );
       node_transaction_state nts = {id,
                                     trx_expiration,
-                                    trx,
                                     std::move(buff),
                                     0, 0, 0};
       my_impl->local_txns.insert(std::move(nts));

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -144,6 +144,7 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
       uint32_t   _last_signed_block_num = 0;
 
       producer_plugin* _self = nullptr;
+      chain_plugin* chain_plug = nullptr;
 
       incoming::channels::block::channel_type::handle         _incoming_block_subscription;
       incoming::channels::transaction::channel_type::handle   _incoming_transaction_subscription;
@@ -215,7 +216,7 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
 
          // since the watermark has to be set before a block is created, we are looking into the future to
          // determine the new schedule to identify producers that have become active
-         chain::controller& chain = app().get_plugin<chain_plugin>().chain();
+         chain::controller& chain = chain_plug->chain();
          const auto hbn = bsp->block_num;
          auto new_block_header = bsp->header;
          new_block_header.timestamp = new_block_header.timestamp.next();
@@ -292,7 +293,7 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
          EOS_ASSERT( block->timestamp < (fc::time_point::now() + fc::seconds( 7 )), block_from_the_future,
                      "received a block from the future, ignoring it: ${id}", ("id", id) );
 
-         chain::controller& chain = app().get_plugin<chain_plugin>().chain();
+         chain::controller& chain = chain_plug->chain();
 
          /* de-dupe here... no point in aborting block if we already know the block */
          auto existing = chain.fetch_block_by_id( id );
@@ -314,7 +315,7 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
          try {
             chain.push_block( bsf );
          } catch ( const guard_exception& e ) {
-            app().get_plugin<chain_plugin>().handle_guard_exception(e);
+            chain_plug->handle_guard_exception(e);
             return;
          } catch( const fc::exception& e ) {
             elog((e.to_detail_string()));
@@ -345,8 +346,7 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
       std::deque<std::tuple<packed_transaction_ptr, bool, next_function<transaction_trace_ptr>>> _pending_incoming_transactions;
 
       void on_incoming_transaction_async(const packed_transaction_ptr& trx, bool persist_until_expired, next_function<transaction_trace_ptr> next) {
-         //todo remove chain_plugin lookup
-         chain::controller& chain = app().get_plugin<chain_plugin>().chain();
+         chain::controller& chain = chain_plug->chain();
          if (!chain.pending_block_state()) {
             _pending_incoming_transactions.emplace_back(trx, persist_until_expired, next);
             return;
@@ -429,7 +429,7 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
             }
 
          } catch ( const guard_exception& e ) {
-            app().get_plugin<chain_plugin>().handle_guard_exception(e);
+            chain_plug->handle_guard_exception(e);
          } catch ( boost::interprocess::bad_alloc& ) {
             chain_plugin::handle_db_exhaustion();
          } CATCH_AND_CALL(send_response);
@@ -600,6 +600,8 @@ make_keosd_signature_provider(const std::shared_ptr<producer_plugin_impl>& impl,
 
 void producer_plugin::plugin_initialize(const boost::program_options::variables_map& options)
 { try {
+   my->chain_plug = app().find_plugin<chain_plugin>();
+   EOS_ASSERT( my->chain_plug, plugin_config_exception, "chain_plugin not found" );
    my->_options = &options;
    LOAD_VALUE_SET(options, "producer-name", my->_producers, types::account_name)
 
@@ -718,7 +720,7 @@ void producer_plugin::plugin_startup()
 
    ilog("producer plugin:  plugin_startup() begin");
 
-   chain::controller& chain = app().get_plugin<chain_plugin>().chain();
+   chain::controller& chain = my->chain_plug->chain();
    EOS_ASSERT( my->_producers.empty() || chain.get_read_mode() == chain::db_read_mode::SPECULATIVE, plugin_config_exception,
               "node cannot have any producer-name configured because block production is impossible when read_mode is not \"speculative\"" );
 
@@ -774,7 +776,7 @@ void producer_plugin::resume() {
    // re-evaluate that now
    //
    if (my->_pending_block_mode == pending_block_mode::speculating) {
-      chain::controller& chain = app().get_plugin<chain_plugin>().chain();
+      chain::controller& chain = my->chain_plug->chain();
       chain.abort_block();
       my->schedule_production_loop();
    }
@@ -809,13 +811,13 @@ void producer_plugin::update_runtime_options(const runtime_options& options) {
    }
 
    if (check_speculating && my->_pending_block_mode == pending_block_mode::speculating) {
-      chain::controller& chain = app().get_plugin<chain_plugin>().chain();
+      chain::controller& chain = my->chain_plug->chain();
       chain.abort_block();
       my->schedule_production_loop();
    }
 
    if (options.subjective_cpu_leeway_us) {
-      chain::controller& chain = app().get_plugin<chain_plugin>().chain();
+      chain::controller& chain = my->chain_plug->chain();
       chain.set_subjective_cpu_leeway(fc::microseconds(*options.subjective_cpu_leeway_us));
    }
 }
@@ -830,21 +832,21 @@ producer_plugin::runtime_options producer_plugin::get_runtime_options() const {
 }
 
 void producer_plugin::add_greylist_accounts(const greylist_params& params) {
-   chain::controller& chain = app().get_plugin<chain_plugin>().chain();
+   chain::controller& chain = my->chain_plug->chain();
    for (auto &acc : params.accounts) {
       chain.add_resource_greylist(acc);
    }
 }
 
 void producer_plugin::remove_greylist_accounts(const greylist_params& params) {
-   chain::controller& chain = app().get_plugin<chain_plugin>().chain();
+   chain::controller& chain = my->chain_plug->chain();
    for (auto &acc : params.accounts) {
       chain.remove_resource_greylist(acc);
    }
 }
 
 producer_plugin::greylist_params producer_plugin::get_greylist() const {
-   chain::controller& chain = app().get_plugin<chain_plugin>().chain();
+   chain::controller& chain = my->chain_plug->chain();
    greylist_params result;
    const auto& list = chain.get_resource_greylist();
    result.accounts.reserve(list.size());
@@ -855,7 +857,7 @@ producer_plugin::greylist_params producer_plugin::get_greylist() const {
 }
 
 producer_plugin::whitelist_blacklist producer_plugin::get_whitelist_blacklist() const {
-   chain::controller& chain = app().get_plugin<chain_plugin>().chain();
+   chain::controller& chain = my->chain_plug->chain();
    return {
       chain.get_actor_whitelist(),
       chain.get_actor_blacklist(),
@@ -867,7 +869,7 @@ producer_plugin::whitelist_blacklist producer_plugin::get_whitelist_blacklist() 
 }
 
 void producer_plugin::set_whitelist_blacklist(const producer_plugin::whitelist_blacklist& params) {
-   chain::controller& chain = app().get_plugin<chain_plugin>().chain();
+   chain::controller& chain = my->chain_plug->chain();
    if(params.actor_whitelist.valid()) chain.set_actor_whitelist(*params.actor_whitelist);
    if(params.actor_blacklist.valid()) chain.set_actor_blacklist(*params.actor_blacklist);
    if(params.contract_whitelist.valid()) chain.set_contract_whitelist(*params.contract_whitelist);
@@ -877,7 +879,7 @@ void producer_plugin::set_whitelist_blacklist(const producer_plugin::whitelist_b
 }
 
 producer_plugin::integrity_hash_information producer_plugin::get_integrity_hash() const {
-   chain::controller& chain = app().get_plugin<chain_plugin>().chain();
+   chain::controller& chain = my->chain_plug->chain();
 
    auto reschedule = fc::make_scoped_exit([this](){
       my->schedule_production_loop();
@@ -894,7 +896,7 @@ producer_plugin::integrity_hash_information producer_plugin::get_integrity_hash(
 }
 
 producer_plugin::snapshot_information producer_plugin::create_snapshot() const {
-   chain::controller& chain = app().get_plugin<chain_plugin>().chain();
+   chain::controller& chain = my->chain_plug->chain();
 
    auto reschedule = fc::make_scoped_exit([this](){
       my->schedule_production_loop();
@@ -925,7 +927,7 @@ producer_plugin::snapshot_information producer_plugin::create_snapshot() const {
 }
 
 optional<fc::time_point> producer_plugin_impl::calculate_next_block_time(const account_name& producer_name, const block_timestamp_type& current_block_time) const {
-   chain::controller& chain = app().get_plugin<chain_plugin>().chain();
+   chain::controller& chain = chain_plug->chain();
    const auto& hbs = chain.head_block_state();
    const auto& active_schedule = hbs->active_schedule.producers;
 
@@ -981,7 +983,7 @@ optional<fc::time_point> producer_plugin_impl::calculate_next_block_time(const a
 }
 
 fc::time_point producer_plugin_impl::calculate_pending_block_time() const {
-   const chain::controller& chain = app().get_plugin<chain_plugin>().chain();
+   const chain::controller& chain = chain_plug->chain();
    const fc::time_point now = fc::time_point::now();
    const fc::time_point base = std::max<fc::time_point>(now, chain.head_block_time());
    const int64_t min_time_to_next_block = (config::block_interval_us) - (base.time_since_epoch().count() % (config::block_interval_us) );
@@ -1002,7 +1004,7 @@ enum class tx_category {
 
 
 producer_plugin_impl::start_block_result producer_plugin_impl::start_block(bool &last_block) {
-   chain::controller& chain = app().get_plugin<chain_plugin>().chain();
+   chain::controller& chain = chain_plug->chain();
 
    if( chain.get_read_mode() == chain::db_read_mode::READ_ONLY )
       return start_block_result::waiting;
@@ -1192,7 +1194,7 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block(bool 
                         num_applied++;
                      }
                   } catch ( const guard_exception& e ) {
-                     app().get_plugin<chain_plugin>().handle_guard_exception(e);
+                     chain_plug->handle_guard_exception(e);
                      return start_block_result::failed;
                   } FC_LOG_AND_DROP();
                }
@@ -1277,7 +1279,7 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block(bool 
                         num_applied++;
                      }
                   } catch ( const guard_exception& e ) {
-                     app().get_plugin<chain_plugin>().handle_guard_exception(e);
+                     chain_plug->handle_guard_exception(e);
                      return start_block_result::failed;
                   } FC_LOG_AND_DROP();
 
@@ -1324,7 +1326,7 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block(bool 
 }
 
 void producer_plugin_impl::schedule_production_loop() {
-   chain::controller& chain = app().get_plugin<chain_plugin>().chain();
+   chain::controller& chain = chain_plug->chain();
    _timer.cancel();
    std::weak_ptr<producer_plugin_impl> weak_this = shared_from_this();
 
@@ -1435,7 +1437,7 @@ bool producer_plugin_impl::maybe_produce_block() {
          produce_block();
          return true;
       } catch ( const guard_exception& e ) {
-         app().get_plugin<chain_plugin>().handle_guard_exception(e);
+         chain_plug->handle_guard_exception(e);
          return false;
       } FC_LOG_AND_DROP();
    } catch ( boost::interprocess::bad_alloc&) {
@@ -1444,7 +1446,7 @@ bool producer_plugin_impl::maybe_produce_block() {
    }
 
    fc_dlog(_log, "Aborting block due to produce_block error");
-   chain::controller& chain = app().get_plugin<chain_plugin>().chain();
+   chain::controller& chain = chain_plug->chain();
    chain.abort_block();
    return false;
 }
@@ -1467,7 +1469,7 @@ static auto maybe_make_debug_time_logger() -> fc::optional<decltype(make_debug_t
 void producer_plugin_impl::produce_block() {
    //ilog("produce_block ${t}", ("t", fc::time_point::now())); // for testing _produce_time_offset_us
    EOS_ASSERT(_pending_block_mode == pending_block_mode::producing, producer_exception, "called produce_block while not actually producing");
-   chain::controller& chain = app().get_plugin<chain_plugin>().chain();
+   chain::controller& chain = chain_plug->chain();
    const auto& pbs = chain.pending_block_state();
    const auto& hbs = chain.head_block_state();
    EOS_ASSERT(pbs, missing_pending_block_state, "pending_block_state does not exist but it should, another plugin may have corrupted it");

--- a/unittests/abi_tests.cpp
+++ b/unittests/abi_tests.cpp
@@ -1475,7 +1475,7 @@ public_key_type  get_public_key( name keyname, string role ) {
 BOOST_AUTO_TEST_CASE(packed_transaction)
 { try {
 
-   chain::transaction txn;
+   chain::signed_transaction txn;
    txn.ref_block_num = 1;
    txn.ref_block_prefix = 2;
    txn.expiration.from_iso_string("2021-12-20T15:30");


### PR DESCRIPTION
**Change Description**

Optimizations:
- Minimize `packed_transaction` copies
- Remove calls to `get/find_plugin<chain_plugin>` as lookup is surprisingly expensive
- Provide more efficient `sha256_less` for id lookups

net_plugin:
- Fixed issue during sync where head block num checked instead of lib
- Remove large_msg_notify and associated code as not used

**Consensus Changes**

None

**API Changes**

- No changes to `net_plugin` wire protocol
- signal `accepted_transaction`
  -- `transaction_metadata` `packed_trx` changed from `packed_transaction` to `packed_transaction_ptr`

**Documentation Additions**

None