### PR TITLE
Use 64-bit float printing of 128-bit floats on non x86_64

### DIFF
--- a/libraries/chain/wasm_interface.cpp
+++ b/libraries/chain/wasm_interface.cpp
@@ -1063,12 +1063,16 @@ class console_api : public context_aware_api {
             auto& console = context.get_console_stream();
             auto orig_prec = console.precision();
 
+#ifdef __x86_64__
             console.precision( std::numeric_limits<long double>::digits10 );
-
             extFloat80_t val_approx;
             f128M_to_extF80M(&val, &val_approx);
             context.console_append( *(long double*)(&val_approx) );
-
+#else
+            console.precision( std::numeric_limits<double>::digits10 );
+            double val_approx = from_softfloat64( f128M_to_f64(&val) );
+            context.console_append(val_approx);
+#endif
             console.precision( orig_prec );
          }
       }

--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -1723,14 +1723,23 @@ BOOST_FIXTURE_TEST_CASE(print_tests, TESTER) { try {
    BOOST_CHECK_EQUAL( tx9_act_cnsl.substr(start, end-start), "6.666666666666666e-07" );
 
    // test printqf
+#ifdef __x86_64__
+   std::string expect1 = "5.000000000000000000e-01";
+   std::string expect2 = "-3.750000000000000000e+00";
+   std::string expect3 = "6.666666666666666667e-07";
+#else
+   std::string expect1 = "5.000000000000000e-01";
+   std::string expect2 = "-3.750000000000000e+00";
+   std::string expect3 = "6.666666666666667e-07";
+#endif
    auto tx10_trace = CALL_TEST_FUNCTION( *this, "test_print", "test_printqf", {} );
    auto tx10_act_cnsl = tx10_trace->action_traces.front().console;
    start = 0; end = tx10_act_cnsl.find('\n', start);
-   BOOST_CHECK_EQUAL( tx10_act_cnsl.substr(start, end-start), "5.000000000000000000e-01" );
+   BOOST_CHECK_EQUAL( tx10_act_cnsl.substr(start, end-start), expect1 );
    start = end + 1; end = tx10_act_cnsl.find('\n', start);
-   BOOST_CHECK_EQUAL( tx10_act_cnsl.substr(start, end-start), "-3.750000000000000000e+00" );
+   BOOST_CHECK_EQUAL( tx10_act_cnsl.substr(start, end-start), expect2 );
    start = end + 1; end = tx10_act_cnsl.find('\n', start);
-   BOOST_CHECK_EQUAL( tx10_act_cnsl.substr(start, end-start), "6.666666666666666667e-07" );
+   BOOST_CHECK_EQUAL( tx10_act_cnsl.substr(start, end-start), expect3 );
 
    BOOST_REQUIRE_EQUAL( validate(), true );
 } FC_LOG_AND_RETHROW() }


### PR DESCRIPTION


<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- Give your PR a title that is sufficient to understand what is being changed. -->

## Change Description
For platforms other then x86_64, have the 128-bit float console print API (printqf()) convert to a 64-bit float before printing. While this loses precision it’s enough to get the unit tests for printqf() working on ARM8, which actually was the only unit_test unit test that failed on that platform.

Fixes issue #6402
<!-- Describe the change you made, the motivation for it, and the impact it will have. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

## Consensus Changes

<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes

<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions

<!-- List all the information that needs to be added to the documentation after merge. -->
