### PR TITLE
explore real-time multi-thread recover_key capability

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -19,7 +19,6 @@
 #include <eosio/chain/chain_snapshot.hpp>
 
 #include <chainbase/chainbase.hpp>
-#include <appbase/application.hpp>
 #include <fc/io/json.hpp>
 #include <fc/scoped_exit.hpp>
 #include <fc/variant_object.hpp>

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -1,4 +1,7 @@
 #pragma once
+
+#include <boost/asio.hpp>
+
 #include <eosio/chain/block_state.hpp>
 #include <eosio/chain/trace.hpp>
 #include <eosio/chain/genesis_state.hpp>
@@ -87,7 +90,7 @@ namespace eosio { namespace chain {
             incomplete  = 3, ///< this is an incomplete block (either being produced by a producer or speculatively produced by a node)
          };
 
-         controller( const config& cfg );
+         controller( const config& cfg, std::shared_ptr<boost::asio::io_service> io_service = nullptr);
          ~controller();
 
          void add_indices();
@@ -129,6 +132,8 @@ namespace eosio { namespace chain {
           *
           */
          transaction_trace_ptr push_transaction( const transaction_metadata_ptr& trx, fc::time_point deadline, uint32_t billed_cpu_time_us = 0 );
+
+         void warmup_transaction(transaction_metadata_ptr trx, const std::function<void()> next);
 
          /**
           * Attempt to execute a specific transaction in our deferred trx database
@@ -293,6 +298,7 @@ namespace eosio { namespace chain {
          chainbase::database& mutable_db()const;
 
          std::unique_ptr<controller_impl> my;
+         std::shared_ptr<boost::asio::io_service>  io_serv;
 
    };
 

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -631,7 +631,7 @@ void chain_plugin::plugin_initialize(const variables_map& options) {
          my->chain_config->block_validation_mode = options.at("validation-mode").as<validation_mode>();
       }
 
-      my->chain.emplace( *my->chain_config );
+      my->chain.emplace( *my->chain_config, app().get_io_service_ptr());
       my->chain_id.emplace( my->chain->get_chain_id());
 
       // set up method providers

--- a/plugins/txn_test_gen_plugin/txn_test_gen_plugin.cpp
+++ b/plugins/txn_test_gen_plugin/txn_test_gen_plugin.cpp
@@ -87,19 +87,38 @@ using namespace eosio::chain;
    api_handle->call_name(vs.at(0).as<in_param0>(), vs.at(1).as<in_param1>(), result_handler);
 
 struct txn_test_gen_plugin_impl {
-   static void push_next_transaction(const std::shared_ptr<std::vector<signed_transaction>>& trxs, size_t index, const std::function<void(const fc::exception_ptr&)>& next ) {
+
+   uint64_t _total_us = 0;
+   uint64_t _txcount = 0;
+
+   int _remain = 0;
+
+   void push_next_transaction(const std::shared_ptr<std::vector<signed_transaction>>& trxs, size_t index, const std::function<void(const fc::exception_ptr&)>& next ) {
       chain_plugin& cp = app().get_plugin<chain_plugin>();
-      cp.accept_transaction( packed_transaction(trxs->at(index)), [=](const fc::static_variant<fc::exception_ptr, transaction_trace_ptr>& result){
-         if (result.contains<fc::exception_ptr>()) {
-            next(result.get<fc::exception_ptr>());
-         } else {
-            if (index + 1 < trxs->size()) {
-               push_next_transaction(trxs, index + 1, next);
+
+      const int overlap = 20;
+      int end = std::min(index + overlap, trxs->size());
+      _remain = end - index;
+      for (int i = index; i < end; ++i) {
+         cp.accept_transaction( packed_transaction(trxs->at(i)), [=](const fc::static_variant<fc::exception_ptr, transaction_trace_ptr>& result){
+            if (result.contains<fc::exception_ptr>()) {
+               next(result.get<fc::exception_ptr>());
             } else {
-               next(nullptr);
+               if (result.contains<transaction_trace_ptr>() && result.get<transaction_trace_ptr>()->receipt) {
+                  _total_us += result.get<transaction_trace_ptr>()->receipt->cpu_usage_us;
+                  ++_txcount;
+               }
+               --_remain;
+               if (_remain == 0 ) {
+                  if (end < trxs->size()) {
+                     push_next_transaction(trxs, index + overlap, next);
+                  } else {
+                     next(nullptr);
+                  }
+               }
             }
-         }
-      });
+         });
+      }
    }
 
    void push_transactions( std::vector<signed_transaction>&& trxs, const std::function<void(fc::exception_ptr)>& next ) {
@@ -295,13 +314,11 @@ struct txn_test_gen_plugin_impl {
       try {
          controller& cc = app().get_plugin<chain_plugin>().chain();
          auto chainid = app().get_plugin<chain_plugin>().get_chain_id();
-         auto abi_serializer_max_time = app().get_plugin<chain_plugin>().get_abi_serializer_max_time();
 
-         fc::crypto::private_key a_priv_key = fc::crypto::private_key::regenerate(fc::sha256(std::string(64, 'a')));
-         fc::crypto::private_key b_priv_key = fc::crypto::private_key::regenerate(fc::sha256(std::string(64, 'b')));
+         static fc::crypto::private_key a_priv_key = fc::crypto::private_key::regenerate(fc::sha256(std::string(64, 'a')));
+         static fc::crypto::private_key b_priv_key = fc::crypto::private_key::regenerate(fc::sha256(std::string(64, 'b')));
 
          static uint64_t nonce = static_cast<uint64_t>(fc::time_point::now().sec_since_epoch()) << 32;
-         abi_serializer eosio_serializer(cc.db().find<account_object, by_name>(config::system_account_name)->get_abi(), abi_serializer_max_time);
 
          uint32_t reference_block_num = cc.last_irreversible_block_num();
          if (txn_reference_block_lag >= 0) {
@@ -351,6 +368,11 @@ struct txn_test_gen_plugin_impl {
       timer.cancel();
       running = false;
       ilog("Stopping transaction generation test");
+
+      if (_txcount) {
+         ilog("${d} transactions executed, ${t}us / transaction", ("d", _txcount)("t", _total_us / (double)_txcount));
+         _txcount = _total_us = 0;
+      }
    }
 
    boost::asio::high_resolution_timer timer{app().get_io_service()};


### PR DESCRIPTION
## Change Description

Related to #6149, this allows recover_key to be handled for real-time transactions in other threads, freeing up the main thread for over 60% more TPS. Incoming transactions will be handled in a pipe-line illustrated as below:

before (sequential execution), TPS = 2200 in a mac laptop:

| thread ID | time 0  | time 1 | time 2 | time 3 |
| ------------ | ------------- | ------------- | ------------- | ------------- |
| main thread | txn 1 recover_key  | txn 1 execution  | txn 2 recover_key | txn 2 execution |

after (multithreaded pipeline execution), TPS = 3600 in a mac laptop

| thread ID | time 0  | time 1 | time 2 | time 3 | 
| ------------ | ------------- | ------------- | ------------- | ------------- |
| other thread | txn 1 recover_key  | txn 2 recover_key | txn 3 recover_key | idle | 
| main thread | idle | txn 1 execution | txn 2 execution | txn3 execution |

## Test Results:
before:
```
info  2018-12-11T03:40:36.231 thread-0  txn_test_gen_plugin.cp:278    start_generation     ] Started transaction test plugin; performing 20 transactions every 2ms
info  2018-12-11T03:40:36.516 thread-0  producer_plugin.cpp:1490      produce_block        ] Produced block 000000092d7f7de4... #9 @ 2018-12-11T03:40:36.500 signed by eosio [trxs: 829, lib: 8, confirmed: 0]
info  2018-12-11T03:40:37.013 thread-0  producer_plugin.cpp:1490      produce_block        ] Produced block 0000000aacd5df5c... #10 @ 2018-12-11T03:40:37.000 signed by eosio [trxs: 1163, lib: 9, confirmed: 0]
info  2018-12-11T03:40:37.514 thread-0  producer_plugin.cpp:1490      produce_block        ] Produced block 0000000b7064abe8... #11 @ 2018-12-11T03:40:37.500 signed by eosio [trxs: 1154, lib: 10, confirmed: 0]
info  2018-12-11T03:40:38.014 thread-0  producer_plugin.cpp:1490      produce_block        ] Produced block 0000000c97138288... #12 @ 2018-12-11T03:40:38.000 signed by eosio [trxs: 1108, lib: 11, confirmed: 0]
info  2018-12-11T03:40:38.515 thread-0  producer_plugin.cpp:1490      produce_block        ] Produced block 0000000df6dba66b... #13 @ 2018-12-11T03:40:38.500 signed by eosio [trxs: 1147, lib: 12, confirmed: 0]
info  2018-12-11T03:40:39.015 thread-0  producer_plugin.cpp:1490      produce_block        ] Produced block 0000000ee1025698... #14 @ 2018-12-11T03:40:39.000 signed by eosio [trxs: 1153, lib: 13, confirmed: 0]
info  2018-12-11T03:40:39.514 thread-0  producer_plugin.cpp:1490      produce_block        ] Produced block 0000000fcb740168... #15 @ 2018-12-11T03:40:39.500 signed by eosio [trxs: 960, lib: 14, confirmed: 0]
info  2018-12-11T03:40:40.016 thread-0  producer_plugin.cpp:1490      produce_block        ] Produced block 000000108dfbe2ef... #16 @ 2018-12-11T03:40:40.000 signed by eosio [trxs: 1158, lib: 15, confirmed: 0]
info  2018-12-11T03:40:40.513 thread-0  producer_plugin.cpp:1490      produce_block        ] Produced block 00000011c60ce031... #17 @ 2018-12-11T03:40:40.500 signed by eosio [trxs: 1159, lib: 16, confirmed: 0]
info  2018-12-11T03:40:41.012 thread-0  producer_plugin.cpp:1490      produce_block        ] Produced block 00000012770bc2a4... #18 @ 2018-12-11T03:40:41.000 signed by eosio [trxs: 1113, lib: 17, confirmed: 0]
info  2018-12-11T03:40:41.513 thread-0  producer_plugin.cpp:1490      produce_block        ] Produced block 000000138274eef4... #19 @ 2018-12-11T03:40:41.500 signed by eosio [trxs: 1147, lib: 18, confirmed: 0]
info  2018-12-11T03:40:42.018 thread-0  producer_plugin.cpp:1490      produce_block        ] Produced block 0000001443b104ee... #20 @ 2018-12-11T03:40:42.000 signed by eosio [trxs: 1057, lib: 19, confirmed: 0]
```

After:
```
info  2018-12-11T03:39:35.753 thread-0  txn_test_gen_plugin.cp:288    start_generation     ] Started transaction test plugin; performing 20 transactions every 2ms
info  2018-12-11T03:39:36.006 thread-0  producer_plugin.cpp:1503      produce_block        ] Produced block 0000000e2c86bcc9... #14 @ 2018-12-11T03:39:36.000 signed by eosio [trxs: 916, lib: 13, confirmed: 0]
info  2018-12-11T03:39:36.519 thread-0  producer_plugin.cpp:1503      produce_block        ] Produced block 0000000f2d1f59dc... #15 @ 2018-12-11T03:39:36.500 signed by eosio [trxs: 1747, lib: 14, confirmed: 0]
info  2018-12-11T03:39:37.015 thread-0  producer_plugin.cpp:1503      produce_block        ] Produced block 000000106ce9e0fa... #16 @ 2018-12-11T03:39:37.000 signed by eosio [trxs: 1794, lib: 15, confirmed: 0]
info  2018-12-11T03:39:37.520 thread-0  producer_plugin.cpp:1503      produce_block        ] Produced block 00000011bc877142... #17 @ 2018-12-11T03:39:37.500 signed by eosio [trxs: 1841, lib: 16, confirmed: 0]
info  2018-12-11T03:39:38.016 thread-0  producer_plugin.cpp:1503      produce_block        ] Produced block 000000125ec24341... #18 @ 2018-12-11T03:39:38.000 signed by eosio [trxs: 1631, lib: 17, confirmed: 0]
info  2018-12-11T03:39:38.520 thread-0  producer_plugin.cpp:1503      produce_block        ] Produced block 00000013502c3771... #19 @ 2018-12-11T03:39:38.500 signed by eosio [trxs: 1850, lib: 18, confirmed: 0]
info  2018-12-11T03:39:39.013 thread-0  producer_plugin.cpp:1503      produce_block        ] Produced block 000000143f948428... #20 @ 2018-12-11T03:39:39.000 signed by eosio [trxs: 1855, lib: 19, confirmed: 0]
info  2018-12-11T03:39:39.515 thread-0  producer_plugin.cpp:1503      produce_block        ] Produced block 000000150ddb7957... #21 @ 2018-12-11T03:39:39.500 signed by eosio [trxs: 1689, lib: 20, confirmed: 0]
info  2018-12-11T03:39:40.018 thread-0  producer_plugin.cpp:1503      produce_block        ] Produced block 000000166085dbc1... #22 @ 2018-12-11T03:39:40.000 signed by eosio [trxs: 1823, lib: 21, confirmed: 0]
info  2018-12-11T03:39:40.517 thread-0  producer_plugin.cpp:1503      produce_block        ] Produced block 0000001737c4c742... #23 @ 2018-12-11T03:39:40.500 signed by eosio [trxs: 1838, lib: 22, confirmed: 0]
info  2018-12-11T03:39:41.018 thread-0  producer_plugin.cpp:1503      produce_block        ] Produced block 000000187f12fb88... #24 @ 2018-12-11T03:39:41.000 signed by eosio [trxs: 1731, lib: 23, confirmed: 0]
```

## Consensus Changes
N/A

## API Changes
N/A

## Documentation Additions
N/A
