### PR TITLE
Update the bios-boot-tutorial.py script and readme.md

### DIFF
--- a/tutorials/bios-boot-tutorial/README.md
+++ b/tutorials/bios-boot-tutorial/README.md
@@ -2,23 +2,42 @@
 
 The `bios-boot-tutorial.py` script simulates the EOSIO bios boot sequence.
 
-Prerequisites:
+``Prerequisites``:
 
-1. eosio binaries (keosd, nodeos)
-2. system contracts binaries (built eosio.contracts)
-3. python 3.x
+1. Python 3.x
+2. CMake
+3. git
 
+``Steps``:
 
-Assumming you installed the precompiled eosio binaries, and they were installed in /user/local/bin, 
-and assumming you have built the eosio.contracts and they are located in /Users/test/eos/contracts/eosio.contracts/ folder,
-and assuming you have installed python 3.x version,
-this is the simplest command to start the script:
+1. Install eosio binaries by following the steps outlined in below tutorial
+https://github.com/EOSIO/eos#mac-os-x-brew-install
 
+2. Compile eosio.contracts
 
 ```bash
-$ cd tutorials/bios-boot-tutorial
+$ cd ~
+$ git clone https://github.com/EOSIO/eosio.contracts.git
+$ cd ./eosio.contracts/
+$ ./build.sh
+$ pwd
 
-$ python3 bios-boot-tutorial.py --cleos="/usr/local/bin/cleos --wallet-url http://127.0.0.1:6666 " --nodeos=/usr/local/bin/nodeos --keosd="/usr/local/bin/keosd" --contracts-dir="/Users/test/eos/contracts/eosio.contracts/" -a
+```
+
+3. Make note of the directory where the contracts where compiled
+The last command in the previous step printed on the bash console the contracts' directory, make note of it, we'll reference it from now on as `YOU_CONTRACTS_DIRECTORY`
+
+4. Launch the `bios-boot-tutorial.py` script
+Minimal command line to launch the  scrip
+
+```bash
+$ cd ~
+$ git clone https://github.com/EOSIO/eos.git
+$ cd ./eos/tutorials/bios-boot-tutorial/
+$ python3 bios-boot-tutorial.py --cleos="cleos --wallet-url http://127.0.0.1:6666 " --nodeos=nodeos --keosd=keosd --contracts-dir="/YOU_CONTRACTS_DIRECTORY/" -a
+
 ```
 
 See [EOSIO Documentation Wiki: Tutorial - Bios Boot](https://github.com/EOSIO/eos/wiki/Tutorial-Bios-Boot-Sequence) for additional information.
+
+

--- a/tutorials/bios-boot-tutorial/README.md
+++ b/tutorials/bios-boot-tutorial/README.md
@@ -42,5 +42,3 @@ $ python3 bios-boot-tutorial.py --cleos="cleos --wallet-url http://127.0.0.1:666
 ```
 
 See [EOSIO Documentation Wiki: Tutorial - Bios Boot](https://github.com/EOSIO/eos/wiki/Tutorial-Bios-Boot-Sequence) for additional information.
-
-

--- a/tutorials/bios-boot-tutorial/README.md
+++ b/tutorials/bios-boot-tutorial/README.md
@@ -11,9 +11,12 @@ The `bios-boot-tutorial.py` script simulates the EOSIO bios boot sequence.
 ``Steps``:
 
 1. Install eosio binaries by following the steps outlined in below tutorial
-[Install eosio binaries steps](https://github.com/EOSIO/eos#mac-os-x-brew-install)
+[Install eosio binaries](https://github.com/EOSIO/eos#mac-os-x-brew-install)
 
-2. Compile eosio.contracts
+2. Install eosio.cdt binaries by following the steps outlined in below tutorial
+[Install eosio.cdt binaries](https://github.com/EOSIO/eosio.cdt#binary-releases)
+
+3. Compile eosio.contracts
 
 ```bash
 $ cd ~
@@ -24,11 +27,11 @@ $ pwd
 
 ```
 
-3. Make note of the directory where the contracts were compiled
+4. Make note of the directory where the contracts were compiled
 The last command in the previous step printed on the bash console the contracts' directory, make note of it, we'll reference it from now on as `YOU_CONTRACTS_DIRECTORY`
 
-4. Launch the `bios-boot-tutorial.py` script
-Minimal command line to launch the  script
+5. Launch the `bios-boot-tutorial.py` script
+Minimal command line to launch the script below, make sure you replace `YOU_CONTRACTS_DIRECTORY` with actual directory
 
 ```bash
 $ cd ~

--- a/tutorials/bios-boot-tutorial/README.md
+++ b/tutorials/bios-boot-tutorial/README.md
@@ -2,12 +2,23 @@
 
 The `bios-boot-tutorial.py` script simulates the EOSIO bios boot sequence.
 
-The script can be run with no arguments directly from the `tutorials/bios-boot-tutorial` directory.
+Prerequisites:
+
+1. eosio binaries (keosd, nodeos)
+2. system contracts binaries (built eosio.contracts)
+3. python 3.x
+
+
+Assumming you installed the precompiled eosio binaries, and they were installed in /user/local/bin, 
+and assumming you have built the eosio.contracts and they are located in /Users/test/eos/contracts/eosio.contracts/ folder,
+and assuming you have installed python 3.x version,
+this is the simplest command to start the script:
+
 
 ```bash
 $ cd tutorials/bios-boot-tutorial
 
-$ ./bios-boot-tutorial.py
+$ python3 bios-boot-tutorial.py --cleos="/usr/local/bin/cleos --wallet-url http://127.0.0.1:6666 " --nodeos=/usr/local/bin/nodeos --keosd="/usr/local/bin/keosd" --contracts-dir="/Users/test/eos/contracts/eosio.contracts/" -a
 ```
 
 See [EOSIO Documentation Wiki: Tutorial - Bios Boot](https://github.com/EOSIO/eos/wiki/Tutorial-Bios-Boot-Sequence) for additional information.

--- a/tutorials/bios-boot-tutorial/README.md
+++ b/tutorials/bios-boot-tutorial/README.md
@@ -24,11 +24,11 @@ $ pwd
 
 ```
 
-3. Make note of the directory where the contracts where compiled
+3. Make note of the directory where the contracts were compiled
 The last command in the previous step printed on the bash console the contracts' directory, make note of it, we'll reference it from now on as `YOU_CONTRACTS_DIRECTORY`
 
 4. Launch the `bios-boot-tutorial.py` script
-Minimal command line to launch the  scrip
+Minimal command line to launch the  script
 
 ```bash
 $ cd ~

--- a/tutorials/bios-boot-tutorial/README.md
+++ b/tutorials/bios-boot-tutorial/README.md
@@ -11,7 +11,7 @@ The `bios-boot-tutorial.py` script simulates the EOSIO bios boot sequence.
 ``Steps``:
 
 1. Install eosio binaries by following the steps outlined in below tutorial
-https://github.com/EOSIO/eos#mac-os-x-brew-install
+[Install eosio binaries steps](https://github.com/EOSIO/eos#mac-os-x-brew-install)
 
 2. Compile eosio.contracts
 

--- a/tutorials/bios-boot-tutorial/README.md
+++ b/tutorials/bios-boot-tutorial/README.md
@@ -28,16 +28,16 @@ $ pwd
 ```
 
 4. Make note of the directory where the contracts were compiled
-The last command in the previous step printed on the bash console the contracts' directory, make note of it, we'll reference it from now on as `YOU_CONTRACTS_DIRECTORY`
+The last command in the previous step printed on the bash console the contracts' directory, make note of it, we'll reference it from now on as `EOSIO_CONTRACTS_DIRECTORY`
 
 5. Launch the `bios-boot-tutorial.py` script
-Minimal command line to launch the script below, make sure you replace `YOU_CONTRACTS_DIRECTORY` with actual directory
+Minimal command line to launch the script below, make sure you replace `EOSIO_CONTRACTS_DIRECTORY` with actual directory
 
 ```bash
 $ cd ~
 $ git clone https://github.com/EOSIO/eos.git
 $ cd ./eos/tutorials/bios-boot-tutorial/
-$ python3 bios-boot-tutorial.py --cleos="cleos --wallet-url http://127.0.0.1:6666 " --nodeos=nodeos --keosd=keosd --contracts-dir="/YOU_CONTRACTS_DIRECTORY/" -a
+$ python3 bios-boot-tutorial.py --cleos="cleos --wallet-url http://127.0.0.1:6666 " --nodeos=nodeos --keosd=keosd --contracts-dir="/EOSIO_CONTRACTS_DIRECTORY/" -a
 
 ```
 

--- a/tutorials/bios-boot-tutorial/bios-boot-tutorial.py
+++ b/tutorials/bios-boot-tutorial/bios-boot-tutorial.py
@@ -284,17 +284,20 @@ def stepStartBoot():
     startNode(0, {'name': 'eosio', 'pvt': args.private_key, 'pub': args.public_key})
     sleep(1.5)
 def stepInstallSystemContracts():
-    run(args.cleos + 'set contract eosio.token ' + args.contracts_dir + 'eosio.token/')
-    run(args.cleos + 'set contract eosio.msig ' + args.contracts_dir + 'eosio.msig/')
+    run(args.cleos + 'set contract eosio.token ' + args.contracts_dir + '/eosio.token/')
+    run(args.cleos + 'set contract eosio.msig ' + args.contracts_dir + '/eosio.msig/')
 def stepCreateTokens():
     run(args.cleos + 'push action eosio.token create \'["eosio", "10000000000.0000 %s"]\' -p eosio.token' % (args.symbol))
     totalAllocation = allocateFunds(0, len(accounts))
     run(args.cleos + 'push action eosio.token issue \'["eosio", "%s", "memo"]\' -p eosio' % intToCurrency(totalAllocation))
     sleep(1)
 def stepSetSystemContract():
-    retry(args.cleos + 'set contract eosio ' + args.contracts_dir + 'eosio.system/')
+    retry(args.cleos + 'set contract eosio ' + args.contracts_dir + '/eosio.system/')
     sleep(1)
     run(args.cleos + 'push action eosio setpriv' + jsonArg(['eosio.msig', 1]) + '-p eosio@active')
+def stepInitSystemContract():
+    run(args.cleos + 'push action eosio init' + jsonArg(['0', '4,SYS']) + '-p eosio@active')
+    sleep(1)
 def stepCreateStakedAccounts():
     createStakedAccounts(0, len(accounts))
 def stepRegProducers():
@@ -326,23 +329,24 @@ def stepLog():
 parser = argparse.ArgumentParser()
 
 commands = [
-    ('k', 'kill',           stepKillAll,                True,    "Kill all nodeos and keosd processes"),
-    ('w', 'wallet',         stepStartWallet,            True,    "Start keosd, create wallet, fill with keys"),
-    ('b', 'boot',           stepStartBoot,              True,    "Start boot node"),
-    ('s', 'sys',            createSystemAccounts,       True,    "Create system accounts (eosio.*)"),
-    ('c', 'contracts',      stepInstallSystemContracts, True,    "Install system contracts (token, msig)"),
-    ('t', 'tokens',         stepCreateTokens,           True,    "Create tokens"),
-    ('S', 'sys-contract',   stepSetSystemContract,      True,    "Set system contract"),
-    ('T', 'stake',          stepCreateStakedAccounts,   True,    "Create staked accounts"),
-    ('p', 'reg-prod',       stepRegProducers,           True,    "Register producers"),
-    ('P', 'start-prod',     stepStartProducers,         True,    "Start producers"),
-    ('v', 'vote',           stepVote,                   True,    "Vote for producers"),
-    ('R', 'claim',          claimRewards,               True,    "Claim rewards"),
-    ('x', 'proxy',          stepProxyVotes,             True,    "Proxy votes"),
-    ('q', 'resign',         stepResign,                 True,    "Resign eosio"),
-    ('m', 'msg-replace',    msigReplaceSystem,          False,   "Replace system contract using msig"),
-    ('X', 'xfer',           stepTransfer,               False,   "Random transfer tokens (infinite loop)"),
-    ('l', 'log',            stepLog,                    True,    "Show tail of node's log"),
+    ('k', 'kill',               stepKillAll,                True,    "Kill all nodeos and keosd processes"),
+    ('w', 'wallet',             stepStartWallet,            True,    "Start keosd, create wallet, fill with keys"),
+    ('b', 'boot',               stepStartBoot,              True,    "Start boot node"),
+    ('s', 'sys',                createSystemAccounts,       True,    "Create system accounts (eosio.*)"),
+    ('c', 'contracts',          stepInstallSystemContracts, True,    "Install system contracts (token, msig)"),
+    ('t', 'tokens',             stepCreateTokens,           True,    "Create tokens"),
+    ('S', 'sys-contract',       stepSetSystemContract,      True,    "Set system contract"),
+    ('I', 'init-sys-contract',  stepInitSystemContract,     True,    "Initialiaze system contract"),
+    ('T', 'stake',              stepCreateStakedAccounts,   True,    "Create staked accounts"),
+    ('p', 'reg-prod',           stepRegProducers,           True,    "Register producers"),
+    ('P', 'start-prod',         stepStartProducers,         True,    "Start producers"),
+    ('v', 'vote',               stepVote,                   True,    "Vote for producers"),
+    ('R', 'claim',              claimRewards,               True,    "Claim rewards"),
+    ('x', 'proxy',              stepProxyVotes,             True,    "Proxy votes"),
+    ('q', 'resign',             stepResign,                 True,    "Resign eosio"),
+    ('m', 'msg-replace',        msigReplaceSystem,          False,   "Replace system contract using msig"),
+    ('X', 'xfer',               stepTransfer,               False,   "Random transfer tokens (infinite loop)"),
+    ('l', 'log',                stepLog,                    True,    "Show tail of node's log"),
 ]
 
 parser.add_argument('--public-key', metavar='', help="EOSIO Public Key", default='EOS8Znrtgwt8TfpmbVpTKvA2oB8Nqey625CLN8bCN3TEbgx86Dsvr', dest="public_key")


### PR DESCRIPTION
## Change Description

1. System contract has to be initialized before it can be used (e.g. creating staked acconts).
2. Commands list updated to include the new addition stepInitSystemContract.
3. When args.contracts_dir doesn't end in a forward slash, when it is concatenated with a subpath, the subpath has to start with a forward slash; just a safety measure and more forgiving for the end user.
4. README.md updated as well to reflect the current status of the script and requirements.