### PR TITLE
Optimize transaction signature recovery

### DIFF
--- a/libraries/chain/CMakeLists.txt
+++ b/libraries/chain/CMakeLists.txt
@@ -46,7 +46,7 @@ add_library( eosio_chain
 #             contracts/chain_initializer.cpp
 
 
-#             transaction_metadata.cpp
+             transaction_metadata.cpp
              ${HEADERS}
              )
 

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1189,7 +1189,7 @@ struct controller_impl {
                auto& pt = receipt.trx.get<packed_transaction>();
                auto mtrx = std::make_shared<transaction_metadata>( std::make_shared<packed_transaction>( pt ) );
                if( !self.skip_auth_check() ) {
-                  transaction_metadata::create_signing_keys_future( mtrx, thread_pool, chain_id, fc::time_point::maximum() );
+                  transaction_metadata::create_signing_keys_future( mtrx, thread_pool, chain_id, microseconds::maximum() );
                }
                packed_transactions.emplace_back( std::move( mtrx ) );
             }

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1192,7 +1192,7 @@ struct controller_impl {
                auto& pt = receipt.trx.get<packed_transaction>();
                auto mtrx = std::make_shared<transaction_metadata>( std::make_shared<packed_transaction>( pt ) );
                if( !self.skip_auth_check() ) {
-                  transaction_metadata::create_signing_keys_future( mtrx, thread_pool, chain_id );
+                  transaction_metadata::create_signing_keys_future( mtrx, thread_pool, chain_id, fc::time_point::maximum() );
                }
                packed_transactions.emplace_back( std::move( mtrx ) );
             }

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -407,9 +407,6 @@ struct controller_impl {
    ~controller_impl() {
       pending.reset();
 
-      thread_pool.join();
-      thread_pool.stop();
-
       db.flush();
       reversible_blocks.flush();
    }

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1000,9 +1000,7 @@ struct controller_impl {
       try {
          auto start = fc::time_point::now();
          if( !explicit_billed_cpu_time ) {
-            int64_t cpu_per_signature_us = 10; // TODO: plumb in producer configuration for this value.
-            auto already_consumed_time = fc::microseconds( cpu_per_signature_us * trx->trx.signatures.size() );
-            // Alternatively store actual time to recover keys in transaction_metadata and use that as already_consumed_time (makes more sense if recovery cache was removed).
+            fc::microseconds already_consumed_time( EOS_PERCENT(trx->sig_cpu_usage.count(), conf.sig_cpu_bill_pct) );
 
             if( start.time_since_epoch() <  already_consumed_time ) {
                start = fc::time_point();

--- a/libraries/chain/include/eosio/chain/abi_serializer.hpp
+++ b/libraries/chain/include/eosio/chain/abi_serializer.hpp
@@ -418,11 +418,11 @@ namespace impl {
          mutable_variant_object mvo;
          auto trx = ptrx.get_transaction();
          mvo("id", trx.id());
-         mvo("signatures", ptrx.signatures);
-         mvo("compression", ptrx.compression);
-         mvo("packed_context_free_data", ptrx.packed_context_free_data);
+         mvo("signatures", ptrx.get_signatures());
+         mvo("compression", ptrx.get_compression());
+         mvo("packed_context_free_data", ptrx.get_packed_context_free_data());
          mvo("context_free_data", ptrx.get_context_free_data());
-         mvo("packed_trx", ptrx.packed_trx);
+         mvo("packed_trx", ptrx.get_packed_transaction());
          add(mvo, "transaction", trx, resolver, ctx);
 
          out(name, std::move(mvo));
@@ -577,32 +577,33 @@ namespace impl {
          const variant_object& vo = v.get_object();
          EOS_ASSERT(vo.contains("signatures"), packed_transaction_type_exception, "Missing signatures");
          EOS_ASSERT(vo.contains("compression"), packed_transaction_type_exception, "Missing compression");
-         from_variant(vo["signatures"], ptrx.signatures);
-         from_variant(vo["compression"], ptrx.compression);
+         std::vector<signature_type> signatures;
+         packed_transaction::compression_type compression;
+         from_variant(vo["signatures"], signatures);
+         from_variant(vo["compression"], compression);
 
-         // TODO: Make this nicer eventually. But for now, if it works... good enough.
+         bytes packed_cfd;
          if( vo.contains("packed_trx") && vo["packed_trx"].is_string() && !vo["packed_trx"].as_string().empty() ) {
-            from_variant(vo["packed_trx"], ptrx.packed_trx);
-            auto trx = ptrx.get_transaction(); // Validates transaction data provided.
+            bytes packed_trx;
+            std::vector<bytes> cfd;
+            from_variant(vo["packed_trx"], packed_trx);
             if( vo.contains("packed_context_free_data") && vo["packed_context_free_data"].is_string() && !vo["packed_context_free_data"].as_string().empty() ) {
-               from_variant(vo["packed_context_free_data"], ptrx.packed_context_free_data );
+               from_variant(vo["packed_context_free_data"], packed_cfd );
             } else if( vo.contains("context_free_data") ) {
-               vector<bytes> context_free_data;
-               from_variant(vo["context_free_data"], context_free_data);
-               ptrx.set_transaction(trx, context_free_data, ptrx.compression);
+               from_variant(vo["context_free_data"], cfd);
             }
+            ptrx = packed_transaction( std::move(packed_trx), std::move(signatures), std::move(packed_cfd), std::move(cfd), compression );
          } else {
             EOS_ASSERT(vo.contains("transaction"), packed_transaction_type_exception, "Missing transaction");
-            transaction trx;
-            vector<bytes> context_free_data;
+            signed_transaction trx;
+            trx.signatures = std::move(signatures);
             extract(vo["transaction"], trx, resolver, ctx);
             if( vo.contains("packed_context_free_data") && vo["packed_context_free_data"].is_string() && !vo["packed_context_free_data"].as_string().empty() ) {
-               from_variant(vo["packed_context_free_data"], ptrx.packed_context_free_data );
-               context_free_data = ptrx.get_context_free_data();
+               from_variant(vo["packed_context_free_data"], packed_cfd );
             } else if( vo.contains("context_free_data") ) {
-               from_variant(vo["context_free_data"], context_free_data);
+               from_variant(vo["context_free_data"], trx.context_free_data );
             }
-            ptrx.set_transaction(trx, context_free_data, ptrx.compression);
+            ptrx = packed_transaction( std::move(trx), std::move(packed_cfd), compression );
          }
       }
    };

--- a/libraries/chain/include/eosio/chain/config.hpp
+++ b/libraries/chain/include/eosio/chain/config.hpp
@@ -79,6 +79,7 @@ const static uint32_t   default_max_trx_delay                  = 45*24*3600; // 
 const static uint32_t   default_max_inline_action_size         = 4 * 1024;   // 4 KB
 const static uint16_t   default_max_inline_action_depth        = 4;
 const static uint16_t   default_max_auth_depth                 = 6;
+const static uint32_t   default_sig_cpu_bill_pct               = 50 * percent_1; // billable percentage of signature recovery
 const static uint16_t   default_controller_thread_pool_size    = 2;
 
 const static uint32_t   min_net_usage_delta_between_base_and_max_for_trx  = 10*1024;

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -11,7 +11,9 @@
 namespace chainbase {
    class database;
 }
-
+namespace boost { namespace asio {
+   class thread_pool;
+}}
 
 namespace eosio { namespace chain {
 
@@ -87,7 +89,7 @@ namespace eosio { namespace chain {
             incomplete  = 3, ///< this is an incomplete block (either being produced by a producer or speculatively produced by a node)
          };
 
-         controller( const config& cfg );
+         explicit controller( const config& cfg );
          ~controller();
 
          void add_indices();
@@ -143,6 +145,8 @@ namespace eosio { namespace chain {
 
          std::future<block_state_ptr> create_block_state_future( const signed_block_ptr& b );
          void push_block( std::future<block_state_ptr>& block_state_future );
+
+         boost::asio::thread_pool& get_thread_pool();
 
          const chainbase::database& db()const;
 

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -65,6 +65,7 @@ namespace eosio { namespace chain {
             uint64_t                 state_guard_size       =  chain::config::default_state_guard_size;
             uint64_t                 reversible_cache_size  =  chain::config::default_reversible_cache_size;
             uint64_t                 reversible_guard_size  =  chain::config::default_reversible_guard_size;
+            uint32_t                 sig_cpu_bill_pct       =  chain::config::default_sig_cpu_bill_pct;
             uint16_t                 thread_pool_size       =  chain::config::default_controller_thread_pool_size;
             bool                     read_only              =  false;
             bool                     force_all_checks       =  false;

--- a/libraries/chain/include/eosio/chain/thread_utils.hpp
+++ b/libraries/chain/include/eosio/chain/thread_utils.hpp
@@ -1,0 +1,24 @@
+/**
+ *  @file
+ *  @copyright defined in eos/LICENSE.txt
+ */
+#pragma once
+
+#include <boost/asio/thread_pool.hpp>
+#include <boost/asio/post.hpp>
+#include <future>
+#include <memory>
+
+namespace eosio { namespace chain {
+
+   // async on thread_pool and return future
+   template<typename F>
+   auto async_thread_pool( boost::asio::thread_pool& thread_pool, F&& f ) {
+      auto task = std::make_shared<std::packaged_task<decltype( f() )()>>( std::forward<F>( f ) );
+      boost::asio::post( thread_pool, [task]() { (*task)(); } );
+      return task->get_future();
+   }
+
+} } // eosio::chain
+
+

--- a/libraries/chain/include/eosio/chain/transaction.hpp
+++ b/libraries/chain/include/eosio/chain/transaction.hpp
@@ -60,9 +60,9 @@ namespace eosio { namespace chain {
       digest_type                sig_digest( const chain_id_type& chain_id, const vector<bytes>& cfd = vector<bytes>() )const;
       flat_set<public_key_type>  get_signature_keys( const vector<signature_type>& signatures,
                                                      const chain_id_type& chain_id,
+                                                     fc::time_point deadline,
                                                      const vector<bytes>& cfd = vector<bytes>(),
-                                                     bool allow_duplicate_keys = false,
-                                                     bool use_cache = true )const;
+                                                     bool allow_duplicate_keys = false)const;
 
       uint32_t total_actions()const { return context_free_actions.size() + actions.size(); }
       account_name first_authorizor()const {
@@ -92,7 +92,8 @@ namespace eosio { namespace chain {
 
       const signature_type&     sign(const private_key_type& key, const chain_id_type& chain_id);
       signature_type            sign(const private_key_type& key, const chain_id_type& chain_id)const;
-      flat_set<public_key_type> get_signature_keys( const chain_id_type& chain_id, bool allow_duplicate_keys = false, bool use_cache = true )const;
+      flat_set<public_key_type> get_signature_keys( const chain_id_type& chain_id, fc::time_point deadline,
+                                                    bool allow_duplicate_keys = false )const;
    };
 
    struct packed_transaction {

--- a/libraries/chain/include/eosio/chain/transaction.hpp
+++ b/libraries/chain/include/eosio/chain/transaction.hpp
@@ -58,11 +58,12 @@ namespace eosio { namespace chain {
 
       transaction_id_type        id()const;
       digest_type                sig_digest( const chain_id_type& chain_id, const vector<bytes>& cfd = vector<bytes>() )const;
-      flat_set<public_key_type>  get_signature_keys( const vector<signature_type>& signatures,
+      fc::microseconds           get_signature_keys( const vector<signature_type>& signatures,
                                                      const chain_id_type& chain_id,
                                                      fc::time_point deadline,
-                                                     const vector<bytes>& cfd = vector<bytes>(),
-                                                     bool allow_duplicate_keys = false)const;
+                                                     const vector<bytes>& cfd,
+                                                     flat_set<public_key_type>& recovered_pub_keys,
+                                                     bool allow_duplicate_keys = false) const;
 
       uint32_t total_actions()const { return context_free_actions.size() + actions.size(); }
       account_name first_authorizor()const {
@@ -92,7 +93,8 @@ namespace eosio { namespace chain {
 
       const signature_type&     sign(const private_key_type& key, const chain_id_type& chain_id);
       signature_type            sign(const private_key_type& key, const chain_id_type& chain_id)const;
-      flat_set<public_key_type> get_signature_keys( const chain_id_type& chain_id, fc::time_point deadline,
+      fc::microseconds          get_signature_keys( const chain_id_type& chain_id, fc::time_point deadline,
+                                                    flat_set<public_key_type>& recovered_pub_keys,
                                                     bool allow_duplicate_keys = false )const;
    };
 

--- a/libraries/chain/include/eosio/chain/transaction_context.hpp
+++ b/libraries/chain/include/eosio/chain/transaction_context.hpp
@@ -33,7 +33,6 @@ namespace eosio { namespace chain {
 
          void init_for_input_trx( uint64_t packed_trx_unprunable_size,
                                   uint64_t packed_trx_prunable_size,
-                                  uint32_t num_signatures,
                                   bool skip_recording);
 
          void init_for_deferred_trx( fc::time_point published );

--- a/libraries/chain/include/eosio/chain/transaction_metadata.hpp
+++ b/libraries/chain/include/eosio/chain/transaction_metadata.hpp
@@ -51,7 +51,7 @@ class transaction_metadata {
 
       const flat_set<public_key_type>& recover_keys( const chain_id_type& chain_id );
 
-      static void create_signing_keys_future( transaction_metadata_ptr& mtrx,
+      static void create_signing_keys_future( const transaction_metadata_ptr& mtrx,
                                               boost::asio::thread_pool& thread_pool, const chain_id_type& chain_id );
 
       uint32_t total_actions()const { return trx.context_free_actions.size() + trx.actions.size(); }

--- a/libraries/chain/include/eosio/chain/transaction_metadata.hpp
+++ b/libraries/chain/include/eosio/chain/transaction_metadata.hpp
@@ -25,8 +25,10 @@ class transaction_metadata {
       transaction_id_type                                        signed_id;
       signed_transaction                                         trx;
       packed_transaction_ptr                                     packed_trx;
+      fc::microseconds                                           sig_cpu_usage;
       optional<pair<chain_id_type, flat_set<public_key_type>>>   signing_keys;
-      std::future<pair<chain_id_type,flat_set<public_key_type>>> signing_keys_future;
+      std::future<std::tuple<chain_id_type, fc::microseconds, flat_set<public_key_type>>>
+                                                                 signing_keys_future;
       bool                                                       accepted = false;
       bool                                                       implicit = false;
       bool                                                       scheduled = false;

--- a/libraries/chain/include/eosio/chain/transaction_metadata.hpp
+++ b/libraries/chain/include/eosio/chain/transaction_metadata.hpp
@@ -52,7 +52,7 @@ class transaction_metadata {
       const flat_set<public_key_type>& recover_keys( const chain_id_type& chain_id );
 
       static void create_signing_keys_future( const transaction_metadata_ptr& mtrx, boost::asio::thread_pool& thread_pool,
-                                              const chain_id_type& chain_id, fc::time_point deadline);
+                                              const chain_id_type& chain_id, fc::microseconds timelimit );
 
       uint32_t total_actions()const { return trx.context_free_actions.size() + trx.actions.size(); }
 };

--- a/libraries/chain/include/eosio/chain/transaction_metadata.hpp
+++ b/libraries/chain/include/eosio/chain/transaction_metadata.hpp
@@ -51,8 +51,8 @@ class transaction_metadata {
 
       const flat_set<public_key_type>& recover_keys( const chain_id_type& chain_id );
 
-      static void create_signing_keys_future( const transaction_metadata_ptr& mtrx,
-                                              boost::asio::thread_pool& thread_pool, const chain_id_type& chain_id );
+      static void create_signing_keys_future( const transaction_metadata_ptr& mtrx, boost::asio::thread_pool& thread_pool,
+                                              const chain_id_type& chain_id, fc::time_point deadline);
 
       uint32_t total_actions()const { return trx.context_free_actions.size() + trx.actions.size(); }
 };

--- a/libraries/chain/include/eosio/chain/transaction_metadata.hpp
+++ b/libraries/chain/include/eosio/chain/transaction_metadata.hpp
@@ -51,7 +51,7 @@ class transaction_metadata {
 
       const flat_set<public_key_type>& recover_keys( const chain_id_type& chain_id );
 
-      static void create_signing_keys_future( const transaction_metadata_ptr& mtrx,
+      static void create_signing_keys_future( transaction_metadata_ptr& mtrx,
                                               boost::asio::thread_pool& thread_pool, const chain_id_type& chain_id );
 
       uint32_t total_actions()const { return trx.context_free_actions.size() + trx.actions.size(); }

--- a/libraries/chain/transaction.cpp
+++ b/libraries/chain/transaction.cpp
@@ -95,9 +95,10 @@ flat_set<public_key_type> transaction::get_signature_keys( const vector<signatur
       public_key_type recov;
       if( use_cache ) {
          recovery_cache_type::index<by_sig>::type::iterator it = recovery_cache.get<by_sig>().find( sig );
-         if( it == recovery_cache.get<by_sig>().end() || it->trx_id != id()) {
+         const auto& tid = id();
+         if( it == recovery_cache.get<by_sig>().end() || it->trx_id != tid) {
             recov = public_key_type( sig, digest );
-            recovery_cache.emplace_back(cached_pub_key{id(), recov, sig} ); //could fail on dup signatures; not a problem
+            recovery_cache.emplace_back(cached_pub_key{tid, recov, sig} ); //could fail on dup signatures; not a problem
          } else {
             recov = it->pub_key;
          }

--- a/libraries/chain/transaction.cpp
+++ b/libraries/chain/transaction.cpp
@@ -88,14 +88,12 @@ flat_set<public_key_type> transaction::get_signature_keys( const vector<signatur
 
    constexpr size_t recovery_cache_size = 1000;
    static thread_local recovery_cache_type recovery_cache;
-   fc::time_point start = fc::time_point::now();
    const digest_type digest = sig_digest(chain_id, cfd);
 
    flat_set<public_key_type> recovered_pub_keys;
    for(const signature_type& sig : signatures) {
-      auto now = fc::time_point::now();
-      EOS_ASSERT( start + now <= deadline, tx_cpu_usage_exceeded, "transaction signature verification executed for too long",
-                  ("now", now)("deadline", deadline)("start", start) );
+      EOS_ASSERT( fc::time_point::now() < deadline, tx_cpu_usage_exceeded, "transaction signature verification executed for too long",
+                  ("now", fc::time_point::now())("deadline", deadline) );
       public_key_type recov;
       recovery_cache_type::index<by_sig>::type::iterator it = recovery_cache.get<by_sig>().find( sig );
       const auto& tid = id();

--- a/libraries/chain/transaction.cpp
+++ b/libraries/chain/transaction.cpp
@@ -6,6 +6,7 @@
 #include <fc/bitutil.hpp>
 #include <fc/smart_ref_impl.hpp>
 #include <algorithm>
+#include <mutex>
 
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/multi_index_container.hpp>
@@ -49,8 +50,6 @@ typedef multi_index_container<
    >
 > recovery_cache_type;
 
-static std::mutex cache_mtx;
-
 void transaction_header::set_reference_block( const block_id_type& reference_block ) {
    ref_block_num    = fc::endian_reverse_u32(reference_block._hash[0]);
    ref_block_prefix = reference_block._hash[1];
@@ -92,6 +91,8 @@ fc::microseconds transaction::get_signature_keys( const vector<signature_type>& 
 
    constexpr size_t recovery_cache_size = 10000;
    static recovery_cache_type recovery_cache;
+   static std::mutex cache_mtx;
+
    auto start = fc::time_point::now();
    const digest_type digest = sig_digest(chain_id, cfd);
 

--- a/libraries/chain/transaction.cpp
+++ b/libraries/chain/transaction.cpp
@@ -94,6 +94,7 @@ fc::microseconds transaction::get_signature_keys( const vector<signature_type>& 
    static std::mutex cache_mtx;
 
    auto start = fc::time_point::now();
+   recovered_pub_keys.clear();
    const digest_type digest = sig_digest(chain_id, cfd);
 
    std::unique_lock<std::mutex> lock(cache_mtx, std::defer_lock);

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -284,7 +284,6 @@ namespace bacc = boost::accumulators;
 
    void transaction_context::init_for_input_trx( uint64_t packed_trx_unprunable_size,
                                                  uint64_t packed_trx_prunable_size,
-                                                 uint32_t num_signatures,
                                                  bool skip_recording )
    {
       const auto& cfg = control.get_global_properties().configuration;

--- a/libraries/chain/transaction_metadata.cpp
+++ b/libraries/chain/transaction_metadata.cpp
@@ -1,0 +1,34 @@
+#include <eosio/chain/transaction_metadata.hpp>
+#include <eosio/chain/thread_utils.hpp>
+#include <boost/asio/thread_pool.hpp>
+
+namespace eosio { namespace chain {
+
+
+const flat_set<public_key_type>& transaction_metadata::recover_keys( const chain_id_type& chain_id ) {
+   // Unlikely for more than one chain_id to be used in one nodeos instance
+   if( !signing_keys || signing_keys->first != chain_id ) {
+      if( signing_keys_future.valid() ) {
+         signing_keys = signing_keys_future.get();
+         if( signing_keys->first == chain_id ) {
+            return signing_keys->second;
+         }
+      }
+      signing_keys = std::make_pair( chain_id, trx.get_signature_keys( chain_id ));
+   }
+   return signing_keys->second;
+}
+
+void transaction_metadata::create_signing_keys_future( transaction_metadata_ptr& mtrx,
+                                                       boost::asio::thread_pool& thread_pool, const chain_id_type& chain_id ) {
+   std::weak_ptr<transaction_metadata> mtrx_wp = mtrx;
+   mtrx->signing_keys_future = async_thread_pool( thread_pool, [chain_id, mtrx_wp]() {
+      auto mtrx = mtrx_wp.lock();
+      return mtrx ?
+             std::make_pair( chain_id, mtrx->trx.get_signature_keys( chain_id ) ) :
+             std::make_pair( chain_id, decltype( mtrx->trx.get_signature_keys( chain_id ) ){} );
+   } );
+}
+
+
+} } // eosio::chain

--- a/libraries/chain/transaction_metadata.cpp
+++ b/libraries/chain/transaction_metadata.cpp
@@ -19,8 +19,14 @@ const flat_set<public_key_type>& transaction_metadata::recover_keys( const chain
    return signing_keys->second;
 }
 
-void transaction_metadata::create_signing_keys_future( transaction_metadata_ptr& mtrx,
+void transaction_metadata::create_signing_keys_future( const transaction_metadata_ptr& mtrx,
                                                        boost::asio::thread_pool& thread_pool, const chain_id_type& chain_id ) {
+   if( mtrx->signing_keys && mtrx->signing_keys->first == chain_id )
+      return;
+
+   if( mtrx->signing_keys.valid() ) // already created
+      return;
+
    std::weak_ptr<transaction_metadata> mtrx_wp = mtrx;
    mtrx->signing_keys_future = async_thread_pool( thread_pool, [chain_id, mtrx_wp]() {
       auto mtrx = mtrx_wp.lock();

--- a/libraries/chain/transaction_metadata.cpp
+++ b/libraries/chain/transaction_metadata.cpp
@@ -38,7 +38,7 @@ void transaction_metadata::create_signing_keys_future( const transaction_metadat
       if( mtrx ) {
          cpu_usage = mtrx->trx.get_signature_keys( chain_id, deadline, recovered_pub_keys );
       }
-      return std::make_tuple( chain_id, cpu_usage, recovered_pub_keys);
+      return std::make_tuple( chain_id, cpu_usage, std::move( recovered_pub_keys ));
    } );
 }
 

--- a/libraries/chain/transaction_metadata.cpp
+++ b/libraries/chain/transaction_metadata.cpp
@@ -21,9 +21,6 @@ const flat_set<public_key_type>& transaction_metadata::recover_keys( const chain
 
 void transaction_metadata::create_signing_keys_future( const transaction_metadata_ptr& mtrx,
                                                        boost::asio::thread_pool& thread_pool, const chain_id_type& chain_id ) {
-   if( mtrx->signing_keys && mtrx->signing_keys->first == chain_id )
-      return;
-
    if( mtrx->signing_keys.valid() ) // already created
       return;
 

--- a/libraries/chain/transaction_metadata.cpp
+++ b/libraries/chain/transaction_metadata.cpp
@@ -14,22 +14,22 @@ const flat_set<public_key_type>& transaction_metadata::recover_keys( const chain
             return signing_keys->second;
          }
       }
-      signing_keys = std::make_pair( chain_id, trx.get_signature_keys( chain_id ));
+      signing_keys = std::make_pair( chain_id, trx.get_signature_keys( chain_id, fc::time_point::maximum() ));
    }
    return signing_keys->second;
 }
 
 void transaction_metadata::create_signing_keys_future( const transaction_metadata_ptr& mtrx,
-                                                       boost::asio::thread_pool& thread_pool, const chain_id_type& chain_id ) {
+      boost::asio::thread_pool& thread_pool, const chain_id_type& chain_id, fc::time_point deadline ) {
    if( mtrx->signing_keys.valid() ) // already created
       return;
 
    std::weak_ptr<transaction_metadata> mtrx_wp = mtrx;
-   mtrx->signing_keys_future = async_thread_pool( thread_pool, [chain_id, mtrx_wp]() {
+   mtrx->signing_keys_future = async_thread_pool( thread_pool, [deadline, chain_id, mtrx_wp]() {
       auto mtrx = mtrx_wp.lock();
       return mtrx ?
-             std::make_pair( chain_id, mtrx->trx.get_signature_keys( chain_id ) ) :
-             std::make_pair( chain_id, decltype( mtrx->trx.get_signature_keys( chain_id ) ){} );
+             std::make_pair( chain_id, mtrx->trx.get_signature_keys( chain_id, deadline ) ) :
+             std::make_pair( chain_id, decltype( mtrx->trx.get_signature_keys( chain_id, deadline ) ){} );
    } );
 }
 

--- a/libraries/chain/transaction_metadata.cpp
+++ b/libraries/chain/transaction_metadata.cpp
@@ -12,7 +12,7 @@ const flat_set<public_key_type>& transaction_metadata::recover_keys( const chain
          std::tuple<chain_id_type, fc::microseconds, flat_set<public_key_type>> sig_keys = signing_keys_future.get();
          if( std::get<0>( sig_keys ) == chain_id ) {
             sig_cpu_usage = std::get<1>( sig_keys );
-            signing_keys.emplace( std::make_pair( std::get<0>( sig_keys ), std::get<2>( sig_keys )));
+            signing_keys.emplace( std::get<0>( sig_keys ), std::move( std::get<2>( sig_keys )));
             return signing_keys->second;
          }
       }
@@ -36,7 +36,7 @@ void transaction_metadata::create_signing_keys_future( const transaction_metadat
       fc::microseconds cpu_usage;
       flat_set<public_key_type> recovered_pub_keys;
       if( mtrx ) {
-         mtrx->trx.get_signature_keys( chain_id, deadline, recovered_pub_keys );
+         cpu_usage = mtrx->trx.get_signature_keys( chain_id, deadline, recovered_pub_keys );
       }
       return std::make_tuple( chain_id, cpu_usage, recovered_pub_keys);
    } );

--- a/libraries/chain/transaction_metadata.cpp
+++ b/libraries/chain/transaction_metadata.cpp
@@ -19,7 +19,7 @@ const flat_set<public_key_type>& transaction_metadata::recover_keys( const chain
    return signing_keys->second;
 }
 
-void transaction_metadata::create_signing_keys_future( const transaction_metadata_ptr& mtrx,
+void transaction_metadata::create_signing_keys_future( transaction_metadata_ptr& mtrx,
                                                        boost::asio::thread_pool& thread_pool, const chain_id_type& chain_id ) {
    if( mtrx->signing_keys && mtrx->signing_keys->first == chain_id )
       return;

--- a/libraries/chain/transaction_metadata.cpp
+++ b/libraries/chain/transaction_metadata.cpp
@@ -20,12 +20,13 @@ const flat_set<public_key_type>& transaction_metadata::recover_keys( const chain
 }
 
 void transaction_metadata::create_signing_keys_future( const transaction_metadata_ptr& mtrx,
-      boost::asio::thread_pool& thread_pool, const chain_id_type& chain_id, fc::time_point deadline ) {
+      boost::asio::thread_pool& thread_pool, const chain_id_type& chain_id, fc::microseconds timelimit ) {
    if( mtrx->signing_keys.valid() ) // already created
       return;
 
    std::weak_ptr<transaction_metadata> mtrx_wp = mtrx;
-   mtrx->signing_keys_future = async_thread_pool( thread_pool, [deadline, chain_id, mtrx_wp]() {
+   mtrx->signing_keys_future = async_thread_pool( thread_pool, [timelimit, chain_id, mtrx_wp]() {
+      fc::time_point deadline = fc::time_point::now() + timelimit;
       auto mtrx = mtrx_wp.lock();
       return mtrx ?
              std::make_pair( chain_id, mtrx->trx.get_signature_keys( chain_id, deadline ) ) :

--- a/libraries/chain/transaction_metadata.cpp
+++ b/libraries/chain/transaction_metadata.cpp
@@ -9,29 +9,36 @@ const flat_set<public_key_type>& transaction_metadata::recover_keys( const chain
    // Unlikely for more than one chain_id to be used in one nodeos instance
    if( !signing_keys || signing_keys->first != chain_id ) {
       if( signing_keys_future.valid() ) {
-         signing_keys = signing_keys_future.get();
-         if( signing_keys->first == chain_id ) {
+         std::tuple<chain_id_type, fc::microseconds, flat_set<public_key_type>> sig_keys = signing_keys_future.get();
+         if( std::get<0>( sig_keys ) == chain_id ) {
+            sig_cpu_usage = std::get<1>( sig_keys );
+            signing_keys.emplace( std::make_pair( std::get<0>( sig_keys ), std::get<2>( sig_keys )));
             return signing_keys->second;
          }
       }
-      signing_keys = std::make_pair( chain_id, trx.get_signature_keys( chain_id, fc::time_point::maximum() ));
+      flat_set<public_key_type> recovered_pub_keys;
+      sig_cpu_usage = trx.get_signature_keys( chain_id, fc::time_point::maximum(), recovered_pub_keys );
+      signing_keys.emplace( chain_id, std::move( recovered_pub_keys ));
    }
    return signing_keys->second;
 }
 
 void transaction_metadata::create_signing_keys_future( const transaction_metadata_ptr& mtrx,
-      boost::asio::thread_pool& thread_pool, const chain_id_type& chain_id, fc::microseconds timelimit ) {
+      boost::asio::thread_pool& thread_pool, const chain_id_type& chain_id, fc::microseconds time_limit ) {
    if( mtrx->signing_keys.valid() ) // already created
       return;
 
    std::weak_ptr<transaction_metadata> mtrx_wp = mtrx;
-   mtrx->signing_keys_future = async_thread_pool( thread_pool, [timelimit, chain_id, mtrx_wp]() {
-      fc::time_point deadline = timelimit == fc::microseconds::maximum() ?
-            fc::time_point::maximum() : fc::time_point::now() + timelimit;
+   mtrx->signing_keys_future = async_thread_pool( thread_pool, [time_limit, chain_id, mtrx_wp]() {
+      fc::time_point deadline = time_limit == fc::microseconds::maximum() ?
+            fc::time_point::maximum() : fc::time_point::now() + time_limit;
       auto mtrx = mtrx_wp.lock();
-      return mtrx ?
-             std::make_pair( chain_id, mtrx->trx.get_signature_keys( chain_id, deadline ) ) :
-             std::make_pair( chain_id, decltype( mtrx->trx.get_signature_keys( chain_id, deadline ) ){} );
+      fc::microseconds cpu_usage;
+      flat_set<public_key_type> recovered_pub_keys;
+      if( mtrx ) {
+         mtrx->trx.get_signature_keys( chain_id, deadline, recovered_pub_keys );
+      }
+      return std::make_tuple( chain_id, cpu_usage, recovered_pub_keys);
    } );
 }
 

--- a/libraries/chain/transaction_metadata.cpp
+++ b/libraries/chain/transaction_metadata.cpp
@@ -19,7 +19,7 @@ const flat_set<public_key_type>& transaction_metadata::recover_keys( const chain
    return signing_keys->second;
 }
 
-void transaction_metadata::create_signing_keys_future( transaction_metadata_ptr& mtrx,
+void transaction_metadata::create_signing_keys_future( const transaction_metadata_ptr& mtrx,
                                                        boost::asio::thread_pool& thread_pool, const chain_id_type& chain_id ) {
    if( mtrx->signing_keys && mtrx->signing_keys->first == chain_id )
       return;

--- a/libraries/chain/transaction_metadata.cpp
+++ b/libraries/chain/transaction_metadata.cpp
@@ -26,7 +26,8 @@ void transaction_metadata::create_signing_keys_future( const transaction_metadat
 
    std::weak_ptr<transaction_metadata> mtrx_wp = mtrx;
    mtrx->signing_keys_future = async_thread_pool( thread_pool, [timelimit, chain_id, mtrx_wp]() {
-      fc::time_point deadline = fc::time_point::now() + timelimit;
+      fc::time_point deadline = timelimit == fc::microseconds::maximum() ?
+            fc::time_point::maximum() : fc::time_point::now() + timelimit;
       auto mtrx = mtrx_wp.lock();
       return mtrx ?
              std::make_pair( chain_id, mtrx->trx.get_signature_keys( chain_id, deadline ) ) :

--- a/plugins/bnet_plugin/bnet_plugin.cpp
+++ b/plugins/bnet_plugin/bnet_plugin.cpp
@@ -1558,6 +1558,8 @@ namespace eosio {
       if( mark_transaction_known_by_peer( id ) )
         return;
 
-      app().get_channel<incoming::channels::transaction>().publish(p);
+      auto ptr = std::make_shared<transaction_metadata>(p);
+
+      app().get_channel<incoming::channels::transaction>().publish(ptr);
    }
 } /// namespace eosio

--- a/plugins/chain_interface/include/eosio/chain/plugin_interface.hpp
+++ b/plugins/chain_interface/include/eosio/chain/plugin_interface.hpp
@@ -45,19 +45,19 @@ namespace eosio { namespace chain { namespace plugin_interface {
    namespace incoming {
       namespace channels {
          using block                 = channel_decl<struct block_tag, signed_block_ptr>;
-         using transaction           = channel_decl<struct transaction_tag, packed_transaction_ptr>;
+         using transaction           = channel_decl<struct transaction_tag, transaction_metadata_ptr>;
       }
 
       namespace methods {
          // synchronously push a block/trx to a single provider
          using block_sync            = method_decl<chain_plugin_interface, void(const signed_block_ptr&), first_provider_policy>;
-         using transaction_async     = method_decl<chain_plugin_interface, void(const packed_transaction_ptr&, bool, next_function<transaction_trace_ptr>), first_provider_policy>;
+         using transaction_async     = method_decl<chain_plugin_interface, void(const transaction_metadata_ptr&, bool, next_function<transaction_trace_ptr>), first_provider_policy>;
       }
    }
 
    namespace compat {
       namespace channels {
-         using transaction_ack       = channel_decl<struct accepted_transaction_tag, std::pair<fc::exception_ptr, packed_transaction_ptr>>;
+         using transaction_ack       = channel_decl<struct accepted_transaction_tag, std::pair<fc::exception_ptr, transaction_metadata_ptr>>;
       }
    }
 

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -428,7 +428,10 @@ void chain_plugin::plugin_initialize(const variables_map& options) {
                      "chain-threads ${num} must be greater than 0", ("num", my->chain_config->thread_pool_size) );
       }
 
-      my->chain_config->sig_cpu_bill_pct = options.at("signature-cpu-billable-pct").as<uint32_t>() * config::percent_1;
+      my->chain_config->sig_cpu_bill_pct = options.at("signature-cpu-billable-pct").as<uint32_t>();
+      EOS_ASSERT( my->chain_config->sig_cpu_bill_pct >= 0 && my->chain_config->sig_cpu_bill_pct <= 100, plugin_config_exception,
+                  "signature-cpu-billable-pct must be 0 - 100, ${pct}", ("pct", my->chain_config->sig_cpu_bill_pct) );
+      my->chain_config->sig_cpu_bill_pct *= config::percent_1;
 
       if( my->wasm_runtime )
          my->chain_config->wasm_runtime = *my->wasm_runtime;

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -218,6 +218,8 @@ void chain_plugin::set_program_options(options_description& cli, options_descrip
          ("chain-state-db-guard-size-mb", bpo::value<uint64_t>()->default_value(config::default_state_guard_size / (1024  * 1024)), "Safely shut down node when free space remaining in the chain state database drops below this size (in MiB).")
          ("reversible-blocks-db-size-mb", bpo::value<uint64_t>()->default_value(config::default_reversible_cache_size / (1024  * 1024)), "Maximum size (in MiB) of the reversible blocks database")
          ("reversible-blocks-db-guard-size-mb", bpo::value<uint64_t>()->default_value(config::default_reversible_guard_size / (1024  * 1024)), "Safely shut down node when free space remaining in the reverseible blocks database drops below this size (in MiB).")
+         ("signature-cpu-billable-pct", bpo::value<uint32_t>()->default_value(config::default_sig_cpu_bill_pct / config::percent_1),
+          "Percentage of actual signature recovery cpu to bill. Whole number percentages, e.g. 50 for 50%")
          ("chain-threads", bpo::value<uint16_t>()->default_value(config::default_controller_thread_pool_size),
           "Number of worker threads in controller thread pool")
          ("contracts-console", bpo::bool_switch()->default_value(false),
@@ -425,6 +427,8 @@ void chain_plugin::plugin_initialize(const variables_map& options) {
          EOS_ASSERT( my->chain_config->thread_pool_size > 0, plugin_config_exception,
                      "chain-threads ${num} must be greater than 0", ("num", my->chain_config->thread_pool_size) );
       }
+
+      my->chain_config->sig_cpu_bill_pct = options.at("signature-cpu-billable-pct").as<uint32_t>() * config::percent_1;
 
       if( my->wasm_runtime )
          my->chain_config->wasm_runtime = *my->wasm_runtime;

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -738,6 +738,8 @@ void chain_plugin::plugin_shutdown() {
    my->accepted_transaction_connection.reset();
    my->applied_transaction_connection.reset();
    my->accepted_confirmation_connection.reset();
+   my->chain->get_thread_pool().stop();
+   my->chain->get_thread_pool().join();
    my->chain.reset();
 }
 

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -664,7 +664,7 @@ public:
 
    void accept_block( const chain::signed_block_ptr& block );
    void accept_transaction(const chain::packed_transaction& trx, chain::plugin_interface::next_function<chain::transaction_trace_ptr> next);
-   void accept_transaction(const chain::packed_transaction_ptr& trx, chain::plugin_interface::next_function<chain::transaction_trace_ptr> next);
+   void accept_transaction(const chain::transaction_metadata_ptr& trx, chain::plugin_interface::next_function<chain::transaction_trace_ptr> next);
 
    bool block_is_on_preferred_chain(const chain::block_id_type& block_id);
 

--- a/plugins/mongo_db_plugin/mongo_db_plugin.cpp
+++ b/plugins/mongo_db_plugin/mongo_db_plugin.cpp
@@ -761,7 +761,7 @@ void mongo_db_plugin_impl::_process_accepted_transaction( const chain::transacti
    if( t->signing_keys.valid() ) {
       signing_keys_json = fc::json::to_string( t->signing_keys->second );
    } else {
-      auto signing_keys = trx.get_signature_keys( *chain_id, false, false );
+      auto signing_keys = trx.get_signature_keys( *chain_id, fc::time_point::maximum(), false );
       if( !signing_keys.empty() ) {
          signing_keys_json = fc::json::to_string( signing_keys );
       }

--- a/plugins/mongo_db_plugin/mongo_db_plugin.cpp
+++ b/plugins/mongo_db_plugin/mongo_db_plugin.cpp
@@ -761,9 +761,10 @@ void mongo_db_plugin_impl::_process_accepted_transaction( const chain::transacti
    if( t->signing_keys.valid() ) {
       signing_keys_json = fc::json::to_string( t->signing_keys->second );
    } else {
-      auto signing_keys = trx.get_signature_keys( *chain_id, fc::time_point::maximum(), false );
-      if( !signing_keys.empty() ) {
-         signing_keys_json = fc::json::to_string( signing_keys );
+      flat_set<public_key_type> keys;
+      trx.get_signature_keys( *chain_id, fc::time_point::maximum(), keys, false );
+      if( !keys.empty() ) {
+         signing_keys_json = fc::json::to_string( keys );
       }
    }
 

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -343,9 +343,9 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
          }
       }
 
-      std::deque<std::tuple<packed_transaction_ptr, bool, next_function<transaction_trace_ptr>>> _pending_incoming_transactions;
+      std::deque<std::tuple<transaction_metadata_ptr, bool, next_function<transaction_trace_ptr>>> _pending_incoming_transactions;
 
-      void on_incoming_transaction_async(const packed_transaction_ptr& trx, bool persist_until_expired, next_function<transaction_trace_ptr> next) {
+      void on_incoming_transaction_async(const transaction_metadata_ptr& trx, bool persist_until_expired, next_function<transaction_trace_ptr> next) {
          chain::controller& chain = chain_plug->chain();
          if (!chain.pending_block_state()) {
             _pending_incoming_transactions.emplace_back(trx, persist_until_expired, next);
@@ -357,34 +357,34 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
          auto send_response = [this, &trx, &chain, &next](const fc::static_variant<fc::exception_ptr, transaction_trace_ptr>& response) {
             next(response);
             if (response.contains<fc::exception_ptr>()) {
-               _transaction_ack_channel.publish(std::pair<fc::exception_ptr, packed_transaction_ptr>(response.get<fc::exception_ptr>(), trx));
+               _transaction_ack_channel.publish(std::pair<fc::exception_ptr, transaction_metadata_ptr>(response.get<fc::exception_ptr>(), trx));
                if (_pending_block_mode == pending_block_mode::producing) {
                   fc_dlog(_trx_trace_log, "[TRX_TRACE] Block ${block_num} for producer ${prod} is REJECTING tx: ${txid} : ${why} ",
                         ("block_num", chain.head_block_num() + 1)
                         ("prod", chain.pending_block_state()->header.producer)
-                        ("txid", trx->id())
+                        ("txid", trx->id)
                         ("why",response.get<fc::exception_ptr>()->what()));
                } else {
                   fc_dlog(_trx_trace_log, "[TRX_TRACE] Speculative execution is REJECTING tx: ${txid} : ${why} ",
-                          ("txid", trx->id())
+                          ("txid", trx->id)
                           ("why",response.get<fc::exception_ptr>()->what()));
                }
             } else {
-               _transaction_ack_channel.publish(std::pair<fc::exception_ptr, packed_transaction_ptr>(nullptr, trx));
+               _transaction_ack_channel.publish(std::pair<fc::exception_ptr, transaction_metadata_ptr>(nullptr, trx));
                if (_pending_block_mode == pending_block_mode::producing) {
                   fc_dlog(_trx_trace_log, "[TRX_TRACE] Block ${block_num} for producer ${prod} is ACCEPTING tx: ${txid}",
                           ("block_num", chain.head_block_num() + 1)
                           ("prod", chain.pending_block_state()->header.producer)
-                          ("txid", trx->id()));
+                          ("txid", trx->id));
                } else {
                   fc_dlog(_trx_trace_log, "[TRX_TRACE] Speculative execution is ACCEPTING tx: ${txid}",
-                          ("txid", trx->id()));
+                          ("txid", trx->id));
                }
             }
          };
 
-         auto id = trx->id();
-         if( fc::time_point(trx->expiration()) < block_time ) {
+         const auto& id = trx->id;
+         if( fc::time_point(trx->packed_trx->expiration()) < block_time ) {
             send_response(std::static_pointer_cast<fc::exception>(std::make_shared<expired_tx_exception>(FC_LOG_MESSAGE(error, "expired transaction ${id}", ("id", id)) )));
             return;
          }
@@ -402,7 +402,7 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
          }
 
          try {
-            auto trace = chain.push_transaction(std::make_shared<transaction_metadata>(trx), deadline);
+            auto trace = chain.push_transaction(trx, deadline);
             if (trace->except) {
                if (failure_is_subjective(*trace->except, deadline_is_subjective)) {
                   _pending_incoming_transactions.emplace_back(trx, persist_until_expired, next);
@@ -410,10 +410,10 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
                      fc_dlog(_trx_trace_log, "[TRX_TRACE] Block ${block_num} for producer ${prod} COULD NOT FIT, tx: ${txid} RETRYING ",
                              ("block_num", chain.head_block_num() + 1)
                              ("prod", chain.pending_block_state()->header.producer)
-                             ("txid", trx->id()));
+                             ("txid", trx->id));
                   } else {
                      fc_dlog(_trx_trace_log, "[TRX_TRACE] Speculative execution COULD NOT FIT tx: ${txid} RETRYING",
-                             ("txid", trx->id()));
+                             ("txid", trx->id));
                   }
                } else {
                   auto e_ptr = trace->except->dynamic_copy_exception();
@@ -423,7 +423,7 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
                if (persist_until_expired) {
                   // if this trx didnt fail/soft-fail and the persist flag is set, store its ID so that we can
                   // ensure its applied to all future speculative blocks as well.
-                  _persistent_transactions.insert(transaction_id_with_expiry{trx->id(), trx->expiration()});
+                  _persistent_transactions.insert(transaction_id_with_expiry{trx->id, trx->packed_trx->expiration()});
                }
                send_response(trace);
             }
@@ -682,7 +682,7 @@ void producer_plugin::plugin_initialize(const boost::program_options::variables_
       } FC_LOG_AND_DROP();
    });
 
-   my->_incoming_transaction_subscription = app().get_channel<incoming::channels::transaction>().subscribe([this](const packed_transaction_ptr& trx){
+   my->_incoming_transaction_subscription = app().get_channel<incoming::channels::transaction>().subscribe([this](const transaction_metadata_ptr& trx){
       try {
          my->on_incoming_transaction_async(trx, false, [](const auto&){});
       } FC_LOG_AND_DROP();
@@ -692,7 +692,7 @@ void producer_plugin::plugin_initialize(const boost::program_options::variables_
       my->on_incoming_block(block);
    });
 
-   my->_incoming_transaction_async_provider = app().get_method<incoming::methods::transaction_async>().register_provider([this](const packed_transaction_ptr& trx, bool persist_until_expired, next_function<transaction_trace_ptr> next) -> void {
+   my->_incoming_transaction_async_provider = app().get_method<incoming::methods::transaction_async>().register_provider([this](const transaction_metadata_ptr& trx, bool persist_until_expired, next_function<transaction_trace_ptr> next) -> void {
       return my->on_incoming_transaction_async(trx, persist_until_expired, next );
    });
 

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -349,8 +349,7 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
       void on_incoming_transaction_async(const transaction_metadata_ptr& trx, bool persist_until_expired, next_function<transaction_trace_ptr> next) {
          chain::controller& chain = chain_plug->chain();
          const auto& cfg = chain.get_global_properties().configuration;
-         fc::time_point deadline = fc::time_point::now() + fc::time_point( fc::microseconds( cfg.max_transaction_cpu_usage ));
-         transaction_metadata::create_signing_keys_future( trx, *_thread_pool, chain.get_chain_id(), deadline );
+         transaction_metadata::create_signing_keys_future( trx, *_thread_pool, chain.get_chain_id(), fc::microseconds( cfg.max_transaction_cpu_usage ) );
          boost::asio::post( *_thread_pool, [self = this, trx, persist_until_expired, next]() {
             if( trx->signing_keys_future.valid() )
                trx->signing_keys_future.wait();

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -347,7 +347,9 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
 
       void on_incoming_transaction_async(const transaction_metadata_ptr& trx, bool persist_until_expired, next_function<transaction_trace_ptr> next) {
          chain::controller& chain = chain_plug->chain();
-         transaction_metadata::create_signing_keys_future( trx, chain.get_thread_pool(), chain.get_chain_id() );
+         const auto& cfg = chain.get_global_properties().configuration;
+         fc::time_point deadline = fc::time_point::now() + fc::time_point( fc::microseconds( cfg.max_transaction_cpu_usage ));
+         transaction_metadata::create_signing_keys_future( trx, chain.get_thread_pool(), chain.get_chain_id(), deadline );
          boost::asio::post( chain.get_thread_pool(), [self = this, trx, persist_until_expired, next]() {
             if( trx->signing_keys_future.valid() )
                trx->signing_keys_future.wait();

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -114,13 +114,6 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
       {
       }
 
-      ~producer_plugin_impl() {
-         if( _thread_pool ) {
-            _thread_pool->join();
-            _thread_pool->stop();
-         }
-      }
-
       optional<fc::time_point> calculate_next_block_time(const account_name& producer_name, const block_timestamp_type& current_block_time) const;
       void schedule_production_loop();
       void produce_block();
@@ -791,6 +784,10 @@ void producer_plugin::plugin_shutdown() {
       edump((e.to_detail_string()));
    }
 
+   if( my->_thread_pool ) {
+      my->_thread_pool->join();
+      my->_thread_pool->stop();
+   }
    my->_accepted_block_connection.reset();
    my->_irreversible_block_connection.reset();
 }

--- a/plugins/txn_test_gen_plugin/txn_test_gen_plugin.cpp
+++ b/plugins/txn_test_gen_plugin/txn_test_gen_plugin.cpp
@@ -87,19 +87,38 @@ using namespace eosio::chain;
    api_handle->call_name(vs.at(0).as<in_param0>(), vs.at(1).as<in_param1>(), result_handler);
 
 struct txn_test_gen_plugin_impl {
-   static void push_next_transaction(const std::shared_ptr<std::vector<signed_transaction>>& trxs, size_t index, const std::function<void(const fc::exception_ptr&)>& next ) {
+
+   uint64_t _total_us = 0;
+   uint64_t _txcount = 0;
+
+   int _remain = 0;
+
+   void push_next_transaction(const std::shared_ptr<std::vector<signed_transaction>>& trxs, size_t index, const std::function<void(const fc::exception_ptr&)>& next ) {
       chain_plugin& cp = app().get_plugin<chain_plugin>();
-      cp.accept_transaction( packed_transaction(trxs->at(index)), [=](const fc::static_variant<fc::exception_ptr, transaction_trace_ptr>& result){
-         if (result.contains<fc::exception_ptr>()) {
-            next(result.get<fc::exception_ptr>());
-         } else {
-            if (index + 1 < trxs->size()) {
-               push_next_transaction(trxs, index + 1, next);
+
+      const int overlap = 20;
+      int end = std::min(index + overlap, trxs->size());
+      _remain = end - index;
+      for (int i = index; i < end; ++i) {
+         cp.accept_transaction( packed_transaction(trxs->at(i)), [=](const fc::static_variant<fc::exception_ptr, transaction_trace_ptr>& result){
+            if (result.contains<fc::exception_ptr>()) {
+               next(result.get<fc::exception_ptr>());
             } else {
-               next(nullptr);
+               if (result.contains<transaction_trace_ptr>() && result.get<transaction_trace_ptr>()->receipt) {
+                  _total_us += result.get<transaction_trace_ptr>()->receipt->cpu_usage_us;
+                  ++_txcount;
+               }
+               --_remain;
+               if (_remain == 0 ) {
+                  if (end < trxs->size()) {
+                     push_next_transaction(trxs, index + overlap, next);
+                  } else {
+                     next(nullptr);
+                  }
+               }
             }
-         }
-      });
+         });
+      }
    }
 
    void push_transactions( std::vector<signed_transaction>&& trxs, const std::function<void(fc::exception_ptr)>& next ) {
@@ -295,13 +314,11 @@ struct txn_test_gen_plugin_impl {
       try {
          controller& cc = app().get_plugin<chain_plugin>().chain();
          auto chainid = app().get_plugin<chain_plugin>().get_chain_id();
-         auto abi_serializer_max_time = app().get_plugin<chain_plugin>().get_abi_serializer_max_time();
 
-         fc::crypto::private_key a_priv_key = fc::crypto::private_key::regenerate(fc::sha256(std::string(64, 'a')));
-         fc::crypto::private_key b_priv_key = fc::crypto::private_key::regenerate(fc::sha256(std::string(64, 'b')));
+         static fc::crypto::private_key a_priv_key = fc::crypto::private_key::regenerate(fc::sha256(std::string(64, 'a')));
+         static fc::crypto::private_key b_priv_key = fc::crypto::private_key::regenerate(fc::sha256(std::string(64, 'b')));
 
          static uint64_t nonce = static_cast<uint64_t>(fc::time_point::now().sec_since_epoch()) << 32;
-         abi_serializer eosio_serializer(cc.db().find<account_object, by_name>(config::system_account_name)->get_abi(), abi_serializer_max_time);
 
          uint32_t reference_block_num = cc.last_irreversible_block_num();
          if (txn_reference_block_lag >= 0) {
@@ -351,6 +368,11 @@ struct txn_test_gen_plugin_impl {
       timer.cancel();
       running = false;
       ilog("Stopping transaction generation test");
+
+      if (_txcount) {
+         ilog("${d} transactions executed, ${t}us / transaction", ("d", _txcount)("t", _total_us / (double)_txcount));
+         _txcount = _total_us = 0;
+      }
    }
 
    boost::asio::high_resolution_timer timer{app().get_io_service()};

--- a/tests/wallet_tests.cpp
+++ b/tests/wallet_tests.cpp
@@ -173,7 +173,7 @@ BOOST_AUTO_TEST_CASE(wallet_manager_test)
    pubkeys.emplace(pkey1.get_public_key());
    pubkeys.emplace(pkey2.get_public_key());
    trx = wm.sign_transaction(trx, pubkeys, chain_id );
-   const auto& pks = trx.get_signature_keys(chain_id);
+   const auto& pks = trx.get_signature_keys(chain_id, fc::time_point::maximum());
    BOOST_CHECK_EQUAL(2, pks.size());
    BOOST_CHECK(find(pks.cbegin(), pks.cend(), pkey1.get_public_key()) != pks.cend());
    BOOST_CHECK(find(pks.cbegin(), pks.cend(), pkey2.get_public_key()) != pks.cend());

--- a/tests/wallet_tests.cpp
+++ b/tests/wallet_tests.cpp
@@ -173,7 +173,8 @@ BOOST_AUTO_TEST_CASE(wallet_manager_test)
    pubkeys.emplace(pkey1.get_public_key());
    pubkeys.emplace(pkey2.get_public_key());
    trx = wm.sign_transaction(trx, pubkeys, chain_id );
-   const auto& pks = trx.get_signature_keys(chain_id, fc::time_point::maximum());
+   flat_set<public_key_type> pks;
+   trx.get_signature_keys(chain_id, fc::time_point::maximum(), pks);
    BOOST_CHECK_EQUAL(2, pks.size());
    BOOST_CHECK(find(pks.cbegin(), pks.cend(), pkey1.get_public_key()) != pks.cend());
    BOOST_CHECK(find(pks.cbegin(), pks.cend(), pkey2.get_public_key()) != pks.cend());

--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -149,7 +149,8 @@ transaction_trace_ptr CallAction(TESTER& test, T ac, const vector<account_name>&
 
    test.set_transaction_headers(trx);
    auto sigs = trx.sign(test.get_private_key(scope[0], "active"), test.control->get_chain_id());
-   trx.get_signature_keys(test.control->get_chain_id(), fc::time_point::maximum());
+   flat_set<public_key_type> keys;
+   trx.get_signature_keys(test.control->get_chain_id(), fc::time_point::maximum(), keys);
    auto res = test.push_transaction(trx);
    BOOST_CHECK_EQUAL(res->receipt->status, transaction_receipt::executed);
    test.produce_block();
@@ -173,7 +174,8 @@ transaction_trace_ptr CallFunction(TESTER& test, T ac, const vector<char>& data,
 
       test.set_transaction_headers(trx, test.DEFAULT_EXPIRATION_DELTA);
       auto sigs = trx.sign(test.get_private_key(scope[0], "active"), test.control->get_chain_id());
-      trx.get_signature_keys(test.control->get_chain_id(), fc::time_point::maximum());
+      flat_set<public_key_type> keys;
+      trx.get_signature_keys(test.control->get_chain_id(), fc::time_point::maximum(), keys);
       auto res = test.push_transaction(trx);
       BOOST_CHECK_EQUAL(res->receipt->status, transaction_receipt::executed);
       test.produce_block();
@@ -266,7 +268,8 @@ BOOST_FIXTURE_TEST_CASE(action_receipt_tests, TESTER) { try {
       trx.actions.push_back(act);
       this->set_transaction_headers(trx, this->DEFAULT_EXPIRATION_DELTA);
       trx.sign(this->get_private_key(config::system_account_name, "active"), control->get_chain_id());
-      trx.get_signature_keys(control->get_chain_id(), fc::time_point::maximum());
+      flat_set<public_key_type> keys;
+      trx.get_signature_keys(control->get_chain_id(), fc::time_point::maximum(), keys);
       auto res = this->push_transaction(trx);
       BOOST_CHECK_EQUAL(res->receipt->status, transaction_receipt::executed);
       this->produce_block();
@@ -745,7 +748,8 @@ void call_test(TESTER& test, T ac, uint32_t billed_cpu_time_us , uint32_t max_cp
    test.set_transaction_headers(trx);
    //trx.max_cpu_usage_ms = max_cpu_usage_ms;
    auto sigs = trx.sign(test.get_private_key(N(testapi), "active"), test.control->get_chain_id());
-   trx.get_signature_keys(test.control->get_chain_id(), fc::time_point::maximum());
+   flat_set<public_key_type> keys;
+   trx.get_signature_keys(test.control->get_chain_id(), fc::time_point::maximum(), keys);
    auto res = test.push_transaction( trx, fc::time_point::now() + fc::milliseconds(max_cpu_usage_ms), billed_cpu_time_us );
    BOOST_CHECK_EQUAL(res->receipt->status, transaction_receipt::executed);
    test.produce_block();

--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -149,7 +149,7 @@ transaction_trace_ptr CallAction(TESTER& test, T ac, const vector<account_name>&
 
    test.set_transaction_headers(trx);
    auto sigs = trx.sign(test.get_private_key(scope[0], "active"), test.control->get_chain_id());
-   trx.get_signature_keys(test.control->get_chain_id());
+   trx.get_signature_keys(test.control->get_chain_id(), fc::time_point::maximum());
    auto res = test.push_transaction(trx);
    BOOST_CHECK_EQUAL(res->receipt->status, transaction_receipt::executed);
    test.produce_block();
@@ -173,7 +173,7 @@ transaction_trace_ptr CallFunction(TESTER& test, T ac, const vector<char>& data,
 
       test.set_transaction_headers(trx, test.DEFAULT_EXPIRATION_DELTA);
       auto sigs = trx.sign(test.get_private_key(scope[0], "active"), test.control->get_chain_id());
-      trx.get_signature_keys(test.control->get_chain_id() );
+      trx.get_signature_keys(test.control->get_chain_id(), fc::time_point::maximum());
       auto res = test.push_transaction(trx);
       BOOST_CHECK_EQUAL(res->receipt->status, transaction_receipt::executed);
       test.produce_block();
@@ -266,7 +266,7 @@ BOOST_FIXTURE_TEST_CASE(action_receipt_tests, TESTER) { try {
       trx.actions.push_back(act);
       this->set_transaction_headers(trx, this->DEFAULT_EXPIRATION_DELTA);
       trx.sign(this->get_private_key(config::system_account_name, "active"), control->get_chain_id());
-      trx.get_signature_keys(control->get_chain_id() );
+      trx.get_signature_keys(control->get_chain_id(), fc::time_point::maximum());
       auto res = this->push_transaction(trx);
       BOOST_CHECK_EQUAL(res->receipt->status, transaction_receipt::executed);
       this->produce_block();
@@ -745,7 +745,7 @@ void call_test(TESTER& test, T ac, uint32_t billed_cpu_time_us , uint32_t max_cp
    test.set_transaction_headers(trx);
    //trx.max_cpu_usage_ms = max_cpu_usage_ms;
    auto sigs = trx.sign(test.get_private_key(N(testapi), "active"), test.control->get_chain_id());
-   trx.get_signature_keys(test.control->get_chain_id() );
+   trx.get_signature_keys(test.control->get_chain_id(), fc::time_point::maximum());
    auto res = test.push_transaction( trx, fc::time_point::now() + fc::milliseconds(max_cpu_usage_ms), billed_cpu_time_us );
    BOOST_CHECK_EQUAL(res->receipt->status, transaction_receipt::executed);
    test.produce_block();

--- a/unittests/misc_tests.cpp
+++ b/unittests/misc_tests.cpp
@@ -590,11 +590,9 @@ BOOST_AUTO_TEST_CASE(transaction_test) { try {
    BOOST_CHECK_EQUAL(1, trx.signatures.size());
    trx.validate();
 
-   packed_transaction pkt;
-   pkt.set_transaction(trx, packed_transaction::none);
+   packed_transaction pkt(trx, packed_transaction::none);
 
-   packed_transaction pkt2;
-   pkt2.set_transaction(trx, packed_transaction::zlib);
+   packed_transaction pkt2(trx, packed_transaction::zlib);
 
    BOOST_CHECK_EQUAL(true, trx.expiration ==  pkt.expiration());
    BOOST_CHECK_EQUAL(true, trx.expiration == pkt2.expiration());


### PR DESCRIPTION
## Change Description

- Multi-thread transaction signature recovery for incoming transactions

## Consensus Changes

None

## API Changes

- New `producer_plugin` option:
  --   `--producer-threads arg (=2)           Number of worker threads in producer thread pool`

- New `chain_plugin` option:
  --   `--signature-cpu-billable-pct arg (=50)
                                        Percentage of actual signature recovery
                                        cpu to bill. Whole number percentages, 
                                        e.g. 50 for 50%`

## Documentation Additions

See API Changes above
