### PR TITLE
Consolidated Security Fixes for 1.5.1

### DIFF
--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -208,6 +208,15 @@ void apply_context::execute_inline( action&& a ) {
    bool enforce_actor_whitelist_blacklist = trx_context.enforce_whiteblacklist && control.is_producing_block();
    flat_set<account_name> actors;
 
+   bool disallow_send_to_self_bypass = false; // eventually set to whether the appropriate protocol feature has been activated
+   bool send_to_self = (a.account == receiver);
+   bool inherit_parent_authorizations = (!disallow_send_to_self_bypass && send_to_self && (receiver == act.account) && control.is_producing_block());
+
+   flat_set<permission_level> inherited_authorizations;
+   if( inherit_parent_authorizations ) {
+      inherited_authorizations.reserve( a.authorization.size() );
+   }
+
    for( const auto& auth : a.authorization ) {
       auto* actor = control.db().find<account_object, by_name>(auth.actor);
       EOS_ASSERT( actor != nullptr, action_validate_exception,
@@ -217,26 +226,49 @@ void apply_context::execute_inline( action&& a ) {
                   ("permission", auth) );
       if( enforce_actor_whitelist_blacklist )
          actors.insert( auth.actor );
+
+      if( inherit_parent_authorizations && std::find(act.authorization.begin(), act.authorization.end(), auth) != act.authorization.end() ) {
+         inherited_authorizations.insert( auth );
+      }
    }
 
    if( enforce_actor_whitelist_blacklist ) {
       control.check_actor_list( actors );
    }
 
-   // No need to check authorization if: replaying irreversible blocks; contract is privileged; or, contract is calling itself.
-   if( !control.skip_auth_check() && !privileged && a.account != receiver ) {
-      control.get_authorization_manager()
-             .check_authorization( {a},
-                                   {},
-                                   {{receiver, config::eosio_code_name}},
-                                   control.pending_block_time() - trx_context.published,
-                                   std::bind(&transaction_context::checktime, &this->trx_context),
-                                   false
-                                 );
+   // No need to check authorization if replaying irreversible blocks or contract is privileged
+   if( !control.skip_auth_check() && !privileged ) {
+      try {
+         control.get_authorization_manager()
+                .check_authorization( {a},
+                                      {},
+                                      {{receiver, config::eosio_code_name}},
+                                      control.pending_block_time() - trx_context.published,
+                                      std::bind(&transaction_context::checktime, &this->trx_context),
+                                      false,
+                                      inherited_authorizations
+                                    );
 
-      //QUESTION: Is it smart to allow a deferred transaction that has been delayed for some time to get away
-      //          with sending an inline action that requires a delay even though the decision to send that inline
-      //          action was made at the moment the deferred transaction was executed with potentially no forewarning?
+         //QUESTION: Is it smart to allow a deferred transaction that has been delayed for some time to get away
+         //          with sending an inline action that requires a delay even though the decision to send that inline
+         //          action was made at the moment the deferred transaction was executed with potentially no forewarning?
+      } catch( const fc::exception& e ) {
+         if( disallow_send_to_self_bypass || !send_to_self ) {
+            throw;
+         } else if( control.is_producing_block() ) {
+            subjective_block_production_exception new_exception(FC_LOG_MESSAGE( error, "Authorization failure with inline action sent to self"));
+            for (const auto& log: e.get_log()) {
+               new_exception.append_log(log);
+            }
+            throw new_exception;
+         }
+      } catch( ... ) {
+         if( disallow_send_to_self_bypass || !send_to_self ) {
+            throw;
+         } else if( control.is_producing_block() ) {
+            EOS_THROW(subjective_block_production_exception, "Unexpected exception occurred validating inline action sent to self");
+         }
+      }
    }
 
    _inline_actions.emplace_back( move(a) );
@@ -276,16 +308,30 @@ void apply_context::schedule_deferred_transaction( const uint128_t& sender_id, a
          require_authorization(payer); /// uses payer's storage
       }
 
-      // if a contract is deferring only actions to itself then there is no need
-      // to check permissions, it could have done everything anyway.
-      bool check_auth = false;
-      for( const auto& act : trx.actions ) {
-         if( act.account != receiver ) {
-            check_auth = true;
-            break;
+      // Originally this code bypassed authorization checks if a contract was deferring only actions to itself.
+      // The idea was that the code could already do whatever the deferred transaction could do, so there was no point in checking authorizations.
+      // But this is not true. The original implementation didn't validate the authorizations on the actions which allowed for privilege escalation.
+      // It would make it possible to bill RAM to some unrelated account.
+      // Furthermore, even if the authorizations were forced to be a subset of the current action's authorizations, it would still violate the expectations
+      // of the signers of the original transaction, because the deferred transaction would allow billing more CPU and network bandwidth than the maximum limit
+      // specified on the original transaction.
+      // So, the deferred transaction must always go through the authorization checking if it is not sent by a privileged contract.
+      // However, the old logic must still be considered because it cannot objectively change until a consensus protocol upgrade.
+
+      bool disallow_send_to_self_bypass = false; // eventually set to whether the appropriate protocol feature has been activated
+
+      auto is_sending_only_to_self = [&trx]( const account_name& self ) {
+         bool send_to_self = true;
+         for( const auto& act : trx.actions ) {
+            if( act.account != self ) {
+               send_to_self = false;
+               break;
+            }
          }
-      }
-      if( check_auth ) {
+         return send_to_self;
+      };
+
+      try {
          control.get_authorization_manager()
                 .check_authorization( trx.actions,
                                       {},
@@ -294,6 +340,22 @@ void apply_context::schedule_deferred_transaction( const uint128_t& sender_id, a
                                       std::bind(&transaction_context::checktime, &this->trx_context),
                                       false
                                     );
+      } catch( const fc::exception& e ) {
+         if( disallow_send_to_self_bypass || !is_sending_only_to_self(receiver) ) {
+            throw;
+         } else if( control.is_producing_block() ) {
+            subjective_block_production_exception new_exception(FC_LOG_MESSAGE( error, "Authorization failure with sent deferred transaction consisting only of actions to self"));
+            for (const auto& log: e.get_log()) {
+               new_exception.append_log(log);
+            }
+            throw new_exception;
+         }
+      } catch( ... ) {
+         if( disallow_send_to_self_bypass || !is_sending_only_to_self(receiver) ) {
+            throw;
+         } else if( control.is_producing_block() ) {
+            EOS_THROW(subjective_block_production_exception, "Unexpected exception occurred validating sent deferred transaction consisting only of actions to self");
+         }
       }
    }
 

--- a/libraries/chain/authorization_manager.cpp
+++ b/libraries/chain/authorization_manager.cpp
@@ -431,7 +431,8 @@ namespace eosio { namespace chain {
                                                const flat_set<permission_level>&    provided_permissions,
                                                fc::microseconds                     provided_delay,
                                                const std::function<void()>&         _checktime,
-                                               bool                                 allow_unused_keys
+                                               bool                                 allow_unused_keys,
+                                               const flat_set<permission_level>&    satisfied_authorizations
                                              )const
    {
       const auto& checktime = ( static_cast<bool>(_checktime) ? _checktime : _noop_checktime );
@@ -488,9 +489,11 @@ namespace eosio { namespace chain {
                }
             }
 
-            auto res = permissions_to_satisfy.emplace( declared_auth, delay );
-            if( !res.second && res.first->second > delay) { // if the declared_auth was already in the map and with a higher delay
-               res.first->second = delay;
+            if( satisfied_authorizations.find( declared_auth ) == satisfied_authorizations.end() ) {
+               auto res = permissions_to_satisfy.emplace( declared_auth, delay );
+               if( !res.second && res.first->second > delay) { // if the declared_auth was already in the map and with a higher delay
+                  res.first->second = delay;
+               }
             }
          }
       }

--- a/libraries/chain/include/eosio/chain/authorization_manager.hpp
+++ b/libraries/chain/include/eosio/chain/authorization_manager.hpp
@@ -84,7 +84,8 @@ namespace eosio { namespace chain {
                               const flat_set<permission_level>&    provided_permissions = flat_set<permission_level>(),
                               fc::microseconds                     provided_delay = fc::microseconds(0),
                               const std::function<void()>&         checktime = std::function<void()>(),
-                              bool                                 allow_unused_keys = false
+                              bool                                 allow_unused_keys = false,
+                              const flat_set<permission_level>&    satisfied_authorizations = flat_set<permission_level>()
                             )const;
 
 

--- a/unittests/whitelist_blacklist_tests.cpp
+++ b/unittests/whitelist_blacklist_tests.cpp
@@ -463,7 +463,7 @@ BOOST_AUTO_TEST_CASE( actor_blacklist_inline_deferred ) { try {
    );
 
    auth = authority(eosio::testing::base_tester::get_public_key("bob", "active"));
-   auth.accounts.push_back( permission_level_weight{{N(alice), config::active_name}, 1} );
+   auth.accounts.push_back( permission_level_weight{{N(alice), config::eosio_code_name}, 1} );
    auth.accounts.push_back( permission_level_weight{{N(bob), config::eosio_code_name}, 1} );
 
    tester1.chain->push_action( N(eosio), N(updateauth), N(bob), mvo()


### PR DESCRIPTION
- Only allow authorizations that are satisfiable by `eosio.code` for self-addressed deferred transactions
- Only allow authorizations that are satisfiable by `eosio.code` OR on the parent action for self-addressed inline actions sent from direct actions
- Only allow authorizations that are satisfiable by `eosio.code` for self-addressed inline actions sent from recipient handlers

Co-authored-by: arhag <arhag@users.noreply.github.com>
Co-authored-by: Bart Wyatt <bart.wyatt@block.one>

<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- Give your PR a title that is sufficient to understand what is being changed. -->

## Change Description

<!-- Describe the change you made, the motivation for it, and the impact it will have. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

## Consensus Changes

<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes

<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions

<!-- List all the information that needs to be added to the documentation after merge. -->
