### PR TITLE
mongo_db_plugin action_trace indexes 

### DIFF
--- a/plugins/mongo_db_plugin/mongo_db_plugin.cpp
+++ b/plugins/mongo_db_plugin/mongo_db_plugin.cpp
@@ -1426,7 +1426,7 @@ void mongo_db_plugin_impl::init() {
 
             // action traces indexes
             auto action_traces = mongo_conn[db_name][action_traces_col];
-            action_traces.create_index( bsoncxx::from_json( R"xxx({ "trx_id" : 1 })xxx" ));
+            action_traces.create_index( bsoncxx::from_json( R"xxx({ "block_num" : 1 })xxx" ));
 
             // pub_keys indexes
             auto pub_keys = mongo_conn[db_name][pub_keys_col];


### PR DESCRIPTION
## Change Description

- Resolves #6484 
- Add action_trace.block_num index
- Remove action_trace.trx_id index

## Consensus Changes

None

## API Changes

None

## Documentation Additions

If we list mongo_db_plugin indexes, then update the list.
