### PR TITLE
optimization when writing shared_blob data

### DIFF
--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -521,9 +521,8 @@ int apply_context::db_store_i64( uint64_t code, uint64_t scope, uint64_t table, 
    const auto& obj = db.create<key_value_object>( [&]( auto& o ) {
       o.t_id        = tableid;
       o.primary_key = id;
-      o.value.resize( buffer_size );
+      o.value.assign( buffer, buffer_size );
       o.payer       = payer;
-      memcpy( o.value.data(), buffer, buffer_size );
    });
 
    db.modify( tab, [&]( auto& t ) {
@@ -562,8 +561,7 @@ void apply_context::db_update_i64( int iterator, account_name payer, const char*
    }
 
    db.modify( obj, [&]( auto& o ) {
-     o.value.resize( buffer_size );
-     memcpy( o.value.data(), buffer, buffer_size );
+     o.value.assign( buffer, buffer_size );
      o.payer = payer;
    });
 }

--- a/libraries/chain/eosio_contract.cpp
+++ b/libraries/chain/eosio_contract.cpp
@@ -155,10 +155,11 @@ void apply_eosio_setcode(apply_context& context) {
       // TODO: update setcode message to include the hash, then validate it in validate
       a.last_code_update = context.control.pending_block_time();
       a.code_version = code_id;
-      a.code.resize( code_size );
-      if( code_size > 0 )
-         memcpy( a.code.data(), act.code.data(), code_size );
-
+      if ( code_size > 0 ) {
+         a.code.assign(act.code.data(), code_size);
+      } else {
+         a.code.resize(0);
+      }
    });
 
    const auto& account_sequence = db.get<account_sequence_object, by_name>(act.account);
@@ -185,9 +186,11 @@ void apply_eosio_setabi(apply_context& context) {
    int64_t new_size = abi_size;
 
    db.modify( account, [&]( auto& a ) {
-      a.abi.resize( abi_size );
-      if( abi_size > 0 )
-         memcpy( a.abi.data(), act.abi.data(), abi_size );
+      if (abi_size > 0) {
+         a.abi.assign(act.abi.data(), abi_size);
+      } else {
+         a.abi.resize(0);
+      }
    });
 
    const auto& account_sequence = db.get<account_sequence_object, by_name>(act.account);

--- a/libraries/chain/include/eosio/chain/types.hpp
+++ b/libraries/chain/include/eosio/chain/types.hpp
@@ -112,10 +112,13 @@ namespace eosio { namespace chain {
             assign(s.c_str(), s.size());
          }
 
-         shared_blob &operator=(const shared_blob &s) {
+
+         shared_blob& operator=(const shared_blob& s) {
             assign(s.c_str(), s.size());
             return *this;
          }
+
+         shared_blob& operator=(shared_blob&& ) = default;
 
          template <typename InputIterator>
          shared_blob(InputIterator f, InputIterator l, const allocator_type& a)

--- a/libraries/chain/include/eosio/chain/types.hpp
+++ b/libraries/chain/include/eosio/chain/types.hpp
@@ -103,7 +103,19 @@ namespace eosio { namespace chain {
     */
    class shared_blob : public shared_string {
       public:
-         shared_blob() = default;
+         shared_blob() = delete;
+         shared_blob(shared_blob&&) = default;
+
+         shared_blob(const shared_blob& s)
+         :shared_string(s.get_allocator())
+         {
+            assign(s.c_str(), s.size());
+         }
+
+         shared_blob &operator=(const shared_blob &s) {
+            assign(s.c_str(), s.size());
+            return *this;
+         }
 
          template <typename InputIterator>
          shared_blob(InputIterator f, InputIterator l, const allocator_type& a)


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- Give your PR a title that is sufficient to understand what is being changed. -->

## Change Description

@taokayan analyzed the cost associated with the `resize` + `memcpy` approach to updating these buffers and discovered that `resize` was very slow.  In addition, the default copy constructor for `shared_blob` had the same issues.

using `assign` directly in both cases was a clear win. 

I've ported these changes from another branch @taokayan shared with so that they can be adopted for the 1.6.0-rc1 pre-release.

## Consensus Changes

none

## API Changes

none

## Documentation Additions

<!-- List all the information that needs to be added to the documentation after merge. -->
