### PR TITLE
Fix for mongo empty json keys

### DIFF
--- a/plugins/mongo_db_plugin/mongo_db_plugin.cpp
+++ b/plugins/mongo_db_plugin/mongo_db_plugin.cpp
@@ -652,6 +652,18 @@ optional<abi_serializer> mongo_db_plugin_impl::get_abi_serializer( account_name 
                      }
                   }
                }
+               // mongo does not like empty json keys
+               // make abi_serializer use empty_name instead of "" for the action data
+               for( auto& s : abi.structs ) {
+                  if( s.name.empty() ) {
+                     s.name = "empty_struct_name";
+                  }
+                  for( auto& f : s.fields ) {
+                     if( f.name.empty() ) {
+                        f.name = "empty_field_name";
+                     }
+                  }
+               }
                abis.set_abi( abi, abi_serializer_max_time );
                entry.serializer.emplace( std::move( abis ) );
                abi_cache_index.insert( entry );

--- a/unittests/abi_tests.cpp
+++ b/unittests/abi_tests.cpp
@@ -2460,6 +2460,30 @@ BOOST_AUTO_TEST_CASE(abi_serialize_json_mismatching_type)
    } FC_LOG_AND_RETHROW()
 }
 
+// it is a bit odd to have an empty name for a field, but json seems to allow it
+BOOST_AUTO_TEST_CASE(abi_serialize_json_empty_name)
+{
+   using eosio::testing::fc_exception_message_is;
+
+   auto abi = R"({
+      "version": "eosio::abi/1.0",
+      "structs": [
+         {"name": "s1", "base": "", "fields": [
+            {"name": "", "type": "int8"},
+         ]}
+      ],
+   })";
+
+   try {
+      abi_serializer abis( fc::json::from_string(abi).as<abi_def>(), max_serialization_time );
+
+      auto bin = abis.variant_to_binary("s1", fc::json::from_string(R"({"":1})"), max_serialization_time);
+
+      verify_round_trip_conversion(abis, "s1", R"({"":1})", "01");
+
+   } FC_LOG_AND_RETHROW()
+}
+
 BOOST_AUTO_TEST_CASE(abi_serialize_detailed_error_messages)
 {
    using eosio::testing::fc_exception_message_is;


### PR DESCRIPTION
## Change Description

- Resolves #6542 
- MongoDB throws an exception when inserting JSON with an empty key name.
- Modify the ABI used by `mongo_db_plugin` so that "empty_struct_name" and "empty_field_name" is used in place of "".
- With this change empty key names no longer prevents the transaction_trace, action_trace, etc. from being inserted instead the document will be stored with the field/struct name of `empty_field_name` / `empty_struct_name` .
- Example impacted ABI on mainnet
  -- `zealbounce11` `addbonus` inline action call from `eoszealbank1` `resolvebet`
```
{
      "name": "addbonus",
      "base": "",
      "fields": [{
          "name": "",
          "type": "asset"
        }
      ]
    }
```
Failed before (see #6542)
Now is inserted as:
```
...
			"act" : {
				"account" : "test",
				"name" : "addbonus",
				"authorization" : [
					{
						"actor" : "test",
						"permission" : "active"
					}
				],
				"data" : {
					"empty_field_name" : "8.0000 EOS"
				},
				"hex_data" : "803801000000000004454f5300000000"
			},
...
```

## Consensus Changes

None

## API Changes

- Documents stored in mongo by mongo_db_plugin which contain empty field/struct names will be stored with the field/struct name of `empty_field_name` / `empty_struct_name` .

## Documentation Additions

See API Changes.
