### PR TITLE
Remove LLVM4 wasm & clang from build scripts

### DIFF
--- a/scripts/eosio_build_amazon.sh
+++ b/scripts/eosio_build_amazon.sh
@@ -534,9 +534,9 @@ fi
 		printf "\\tMongo C++ driver found at /usr/local/lib64/libmongocxx-static.a.\\n"
 	fi
 
-	printf "\\n\\tChecking LLVM with WASM support.\\n"
+	printf "\\n\\tChecking LLVM4.\\n"
 	if [ ! -d "${HOME}/opt/wasm/bin" ]; then
-		printf "\\tInstalling LLVM & WASM.\\n"
+		printf "\\tInstalling LLVM4.\\n"
 		if ! cd "${TEMP_DIR}"
 		then
 			printf "\\n\\tUnable to cd into directory %s.\\n" "${TEMP_DIR}"
@@ -567,12 +567,6 @@ fi
 			printf "\\n\\tExiting now.\\n"
 			exit 1;
 		fi
-		if ! git clone --depth 1 --single-branch --branch release_40 https://github.com/llvm-mirror/clang.git
-		then
-			printf "\\tUnable to clone clang repo @ https://github.com/llvm-mirror/clang.git.\\n"
-			printf "\\tExiting now.\\n\\n"
-			exit 1;
-		fi
 		if ! cd "${TEMP_DIR}/llvm-compiler/llvm"
 		then
 			printf "\\n\\tUnable to change directory into %s/llvm-compiler/llvm.\\n" "${TEMP_DIR}"
@@ -592,22 +586,22 @@ fi
 			exit 1;
 		fi
 		if ! "$CMAKE" -G "Unix Makefiles" -DCMAKE_INSTALL_PREFIX="${HOME}/opt/wasm" \
-		-DLLVM_ENABLE_RTTI=1 -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD="WebAssembly" \
+		-DLLVM_ENABLE_RTTI=1 -DLLVM_TARGETS_TO_BUILD="host" -DLLVM_BUILD_TOOLS=false \
 		-DCMAKE_BUILD_TYPE="Release" ..
 		then
-			printf "\\tError compiling LLVM and clang with EXPERIMENTAL WASM support.\\n"
+			printf "\\tError compiling LLVM4.\\n"
 			printf "\\tExiting now.\\n\\n"
 			exit 1;
 		fi
 		if ! make -j"${JOBS}"
 		then
-			printf "\\tError compiling LLVM and clang with EXPERIMENTAL WASM support.\\n"
+			printf "\\tError compiling LLVM4.\\n"
 			printf "\\tExiting now.\\n\\n"
 			exit 1;
 		fi
 		if ! make install
 		then
-			printf "\\tError installing LLVM and clang with EXPERIMENTAL WASM support.\\n"
+			printf "\\tError installing LLVM4.\\n"
 			printf "\\tExiting now.\\n\\n"
 			exit 1;
 		fi
@@ -617,9 +611,9 @@ fi
 			printf "\\tExiting now.\\n\\n"
 			exit 1;
 		fi
-		printf "\\tWASM successfully installed at %s/opt/wasm.\\n" "${HOME}"
+		printf "\\LLVM4 successfully installed at %s/opt/wasm.\\n" "${HOME}"
 	else
-		printf "\\tWASM found at %s/opt/wasm.\\n" "${HOME}"
+		printf "\\LLVM4 found at %s/opt/wasm.\\n" "${HOME}"
 	fi
 
 	function print_instructions()

--- a/scripts/eosio_build_centos.sh
+++ b/scripts/eosio_build_centos.sh
@@ -606,9 +606,9 @@ mongodconf
 
 	printf "\\n"
 
-	printf "\\tChecking LLVM with WASM support installation...\\n"
+	printf "\\tChecking LLVM4 installation...\\n"
 	if [ ! -d "${HOME}/opt/wasm/bin" ]; then
-		printf "\\tInstalling LLVM with WASM...\\n"
+		printf "\\tInstalling LLVM4...\\n"
 		if ! cd "${TEMP_DIR}"; then
 			printf "\\t!! Unable to enter directory %s !!\\n" "${TEMP_DIR}"
 			printf "\\tExiting now.\\n"
@@ -636,12 +636,6 @@ mongodconf
 			printf "\\tExiting now.\\n"
 			exit 1;
 		fi
-		CLANGURL="https://github.com/llvm-mirror/clang.git"
-		if ! git clone --depth 1 --single-branch --branch release_40 "${CLANGURL}"; then
-			printf "\\t!! Unable to clone clang repo from ${CLANGURL} !!\\n"
-			printf "\\tExiting now.\\n"
-			exit 1;
-		fi
 		LLVMMIDLOCATION=$(echo $LLVMLOCATION | sed 's/\/tools//g')
 		if ! cd "${TEMP_DIR}/${LLVMMIDLOCATION}"; then
 			printf "\\t!! Unable to enter directory %s/${LLVMMIDLOCATION} !!\\n" "${TEMP_DIR}"
@@ -659,19 +653,19 @@ mongodconf
 			exit 1;
 		fi
 		if ! "${CMAKE}" -G "Unix Makefiles" -DCMAKE_INSTALL_PREFIX="${HOME}/opt/wasm" \
-		-DLLVM_TARGETS_TO_BUILD="host" -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD="WebAssembly" \
+		-DLLVM_TARGETS_TO_BUILD="host" -DLLVM_BUILD_TOOLS=false \
 		-DLLVM_ENABLE_RTTI=1 -DCMAKE_BUILD_TYPE="Release" ..; then
 			printf "\\t!! CMake has exited with the above error !!\\n"
 			printf "\\tExiting now.\\n"
 			exit 1;
 		fi
 		if ! make -j"${JOBS}"; then
-			printf "\\t!! Compiling LLVM with EXPERIMENTAL WASM support has exited with the above errors !!\\n"
+			printf "\\t!! Compiling LLVM4 has exited with the above errors !!\\n"
 			printf "\\tExiting now.\\n"
 			exit 1;
 		fi
 		if ! make install; then
-			printf "\\t!! Installing LLVM with EXPERIMENTAL WASM support has exited with the above errors !!\\n"
+			printf "\\t!! Installing LLVM4 has exited with the above errors !!\\n"
 			printf "\\tExiting now.\\n"
 			exit 1;
 		fi
@@ -681,9 +675,9 @@ mongodconf
 			printf "\\tExiting now.\\n"
 			exit 1;
 		fi
-		printf "\\tWASM compiler successfully installed at %s/opt/wasm\\n" "${HOME}"
+		printf "\\LLVM4 successfully installed at %s/opt/wasm\\n" "${HOME}"
 	else
-		printf "\\t - WASM found at %s/opt/wasm\\n" "${HOME}"
+		printf "\\t - LLVM4 found at %s/opt/wasm\\n" "${HOME}"
 	fi
 
 	printf "\\n"

--- a/scripts/eosio_build_fedora.sh
+++ b/scripts/eosio_build_fedora.sh
@@ -393,9 +393,9 @@
 		printf "\\tMongo C++ driver found at /usr/local/lib64/libmongocxx-static.a.\\n"
 	fi
 
-	printf "\\n\\tChecking LLVM with WASM support installation.\\n"
+	printf "\\n\\tChecking LLVM4.\\n"
 	if [ ! -d "${HOME}/opt/wasm/bin" ]; then
-		printf "\\tInstalling LLVM & WASM\\n"
+		printf "\\tInstalling LLVM4\\n"
 		if ! cd "${TEMP_DIR}"
 		then
 			printf "\\n\\tUnable to cd into directory %s.\\n" "${TEMP_DIR}"
@@ -438,12 +438,6 @@
 			printf "\\n\\tExiting now.\\n"
 			exit 1;
 		fi
-		if ! git clone --depth 1 --single-branch --branch release_40 https://github.com/llvm-mirror/clang.git
-		then
-			printf "\\tUnable to clone clang repo @ https://github.com/llvm-mirror/clang.git.\\n"
-			printf "\\n\\tExiting now.\\n"
-			exit 1;
-		fi
 		if ! cd "${TEMP_DIR}/llvm-compiler/llvm"
 		then
 			printf "\\n\\tUnable to enter directory %s/llvm-compiler/llvm.\\n" "${TEMP_DIR}"
@@ -463,21 +457,21 @@
 			exit 1;
 		fi
 		if ! cmake -G "Unix Makefiles" -DCMAKE_INSTALL_PREFIX="${HOME}/opt/wasm" -DLLVM_ENABLE_RTTI=1 \
-		-DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=WebAssembly -DCMAKE_BUILD_TYPE=Release ../
+		-DLLVM_TARGETS_TO_BUILD="host" -DLLVM_BUILD_TOOLS=false -DCMAKE_BUILD_TYPE=Release ../
 		then
-			printf "\\tCmake compiling LLVM/Clang with WASM support has exited with the above errors.\\n"
+			printf "\\tCmake compiling LLVM4 has exited with the above errors.\\n"
 			printf "\\n\\tExiting now.\\n"
 			exit 1;
 		fi
 		if ! make -j"${JOBS}"
 		then
-			printf "\\tMake compiling LLVM/Clang with WASM support has exited with the above errors.\\n"
+			printf "\\tMake compiling LLVM4 has exited with the above errors.\\n"
 			printf "\\n\\tExiting now.\\n"
 			exit 1;
 		fi
 		if ! make install
 		then
-			printf "\\tMake installing LLVM/Clang with WASM support has exited with the above errors.\\n"
+			printf "\\tMake installing LLVM4 has exited with the above errors.\\n"
 			printf "\\n\\tExiting now.\\n"
 			exit 1;
 		fi
@@ -487,9 +481,9 @@
 			printf "\\n\\tExiting now.\\n"
 			exit 1;
 		fi
-		printf "\\n\\tWASM successfully installed at %s/opt/wasm\\n\\n" "${HOME}"
+		printf "\\n\\LLVM4 successfully installed at %s/opt/wasm\\n\\n" "${HOME}"
 	else
-		printf "\\n\\tWASM found @ %s/opt/wasm\\n\\n" "${HOME}"
+		printf "\\n\\LLVM4 found @ %s/opt/wasm\\n\\n" "${HOME}"
 	fi
 
 	function print_instructions()


### PR DESCRIPTION


<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- Give your PR a title that is sufficient to understand what is being changed. -->

## Change Description
amazon, centos, and fedora still need a manually built LLVM4 for wavm. However, they no longer need clang & wasm support. Don't compile clang & wasm -- hopefully speeding up this step for users
<!-- Describe the change you made, the motivation for it, and the impact it will have. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

## Consensus Changes

<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes

<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions

<!-- List all the information that needs to be added to the documentation after merge. -->
