### PR TITLE
Add get_supported_apis RPC API

### DIFF
--- a/plugins/http_plugin/http_plugin.cpp
+++ b/plugins/http_plugin/http_plugin.cpp
@@ -632,7 +632,8 @@ namespace eosio {
       get_supported_apis_result result;
 
       for (const auto& handler : my->url_handlers) {
-         result.apis.emplace_back(handler.first);
+         if (handler.first != "/v1/node/get_supported_apis")
+            result.apis.emplace_back(handler.first);
       }
 
       return result;

--- a/plugins/http_plugin/http_plugin.cpp
+++ b/plugins/http_plugin/http_plugin.cpp
@@ -542,21 +542,18 @@ namespace eosio {
          }
       }
 
-#define CALL(api_name, call_name, http_response_code) \
-{std::string("/v1/" #api_name "/" #call_name), \
-   [&](string, string body, url_response_callback cb) mutable { \
-          try { \
-             if (body.empty()) body = "{}"; \
-             auto result = (*this).call_name(); \
-             cb(http_response_code, fc::json::to_string(result)); \
-          } catch (...) { \
-             http_plugin::handle_exception(#api_name, #call_name, body, cb); \
-          } \
-       }}
-
-      add_api({
-         CALL(node, get_supported_apis, 200)
-      });
+      add_api({{
+         std::string("/v1/node/get_supported_apis"),
+         [&](string, string body, url_response_callback cb) mutable {
+            try {
+               if (body.empty()) body = "{}";
+               auto result = (*this).get_supported_apis();
+               cb(200, fc::json::to_string(result));
+            } catch (...) {
+               handle_exception("node", "get_supported_apis", body, cb);
+            }
+         }
+      }});
    }
 
    void http_plugin::plugin_shutdown() {

--- a/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
@@ -97,6 +97,12 @@ namespace eosio {
 
         bool verbose_errors()const;
 
+        struct get_supported_apis_result {
+           vector<string> apis;
+        };
+
+        get_supported_apis_result get_supported_apis()const;
+
       private:
         std::unique_ptr<class http_plugin_impl> my;
    };
@@ -152,3 +158,4 @@ namespace eosio {
 FC_REFLECT(eosio::error_results::error_info::error_detail, (message)(file)(line_number)(method))
 FC_REFLECT(eosio::error_results::error_info, (code)(name)(what)(details))
 FC_REFLECT(eosio::error_results, (code)(message)(error))
+FC_REFLECT(eosio::http_plugin::get_supported_apis_result, (apis))


### PR DESCRIPTION
## Change Description

Each API endpoint doesn't support every APIs because of different sets of activated plugins. Generally, wallet applications can change API endpoint, but they are not sure what features can be provided with that endpoint. (Eg. without history_api_plugin, wallets cannot provide transaction list) By calling this API, they can deactivate UI related the features which cannot be provided with given endpoint.

## Consensus Changes

None

## API Changes

`/v1/node/get_supported_apis` RPC API is added.

## Documentation Additions

Need to add RPC API docmentation