### PR TITLE
Priority queue

### DIFF
--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -253,7 +253,6 @@ namespace eosio { namespace chain {
          signal<void(const block_state_ptr&)>          irreversible_block;
          signal<void(const transaction_metadata_ptr&)> accepted_transaction;
          signal<void(const transaction_trace_ptr&)>    applied_transaction;
-         signal<void(const header_confirmation&)>      accepted_confirmation;
          signal<void(const int&)>                      bad_alloc;
 
          /*

--- a/plugins/bnet_plugin/bnet_plugin.cpp
+++ b/plugins/bnet_plugin/bnet_plugin.cpp
@@ -1251,10 +1251,10 @@ namespace eosio {
             /// add some random delay so that all my peers don't attempt to reconnect to me
             /// at the same time after shutting down..
             _timer->expires_from_now( boost::posix_time::microseconds( 1000000*(10+rand()%5) ) );
-            _timer->async_wait([=](const boost::system::error_code& ec) {
+            _timer->async_wait(app().get_priority_queue().wrap(priority::low, [=](const boost::system::error_code& ec) {
                 if( ec ) { return; }
                 on_reconnect_peers();
-            });
+            }));
          }
    };
 

--- a/plugins/bnet_plugin/bnet_plugin.cpp
+++ b/plugins/bnet_plugin/bnet_plugin.cpp
@@ -917,7 +917,7 @@ namespace eosio {
          */
         void wait_on_app() {
            app().post( priority::low, [self = shared_from_this()]() {
-              boost::asio::bind_executor( self->_strand, [self] { self->do_read(); } );
+              app().get_io_service().post( boost::asio::bind_executor( self->_strand, [self] { self->do_read(); } ) );
            } );
         }
 

--- a/plugins/bnet_plugin/bnet_plugin.cpp
+++ b/plugins/bnet_plugin/bnet_plugin.cpp
@@ -1252,7 +1252,7 @@ namespace eosio {
             _timer->async_wait(app().get_priority_queue().wrap(priority::low, [=](const boost::system::error_code& ec) {
                 if( ec ) { return; }
                 on_reconnect_peers();
-            }, __FILE__, __LINE__, __func__));
+            }));
          }
    };
 

--- a/plugins/bnet_plugin/bnet_plugin.cpp
+++ b/plugins/bnet_plugin/bnet_plugin.cpp
@@ -1254,7 +1254,7 @@ namespace eosio {
             _timer->async_wait(app().get_priority_queue().wrap(priority::low, [=](const boost::system::error_code& ec) {
                 if( ec ) { return; }
                 on_reconnect_peers();
-            }));
+            }, __FILE__, __LINE__, __func__));
          }
    };
 

--- a/plugins/bnet_plugin/bnet_plugin.cpp
+++ b/plugins/bnet_plugin/bnet_plugin.cpp
@@ -1002,7 +1002,7 @@ namespace eosio {
            auto id = b->id();
            mark_block_status( id, true, true );
 
-           app().get_channel<incoming::channels::block>().publish(b);
+           app().get_channel<incoming::channels::block>().publish(priority::high, b);
 
            mark_block_transactions_known_by_peer( b );
         }
@@ -1553,6 +1553,6 @@ namespace eosio {
 
       auto ptr = std::make_shared<transaction_metadata>(p);
 
-      app().get_channel<incoming::channels::transaction>().publish(ptr);
+      app().get_channel<incoming::channels::transaction>().publish(priority::low, ptr);
    }
 } /// namespace eosio

--- a/plugins/bnet_plugin/bnet_plugin.cpp
+++ b/plugins/bnet_plugin/bnet_plugin.cpp
@@ -1159,7 +1159,6 @@ namespace eosio {
          }
 
          void on_session_close( const session* s ) {
-            verify_strand_in_this_thread(app().get_io_service().get_executor(), __func__, __LINE__);
             auto itr = _sessions.find(s);
             if( _sessions.end() != itr )
                _sessions.erase(itr);
@@ -1223,7 +1222,6 @@ namespace eosio {
          };
 
          void on_reconnect_peers() {
-             verify_strand_in_this_thread(app().get_io_service().get_executor(), __func__, __LINE__);
              for( const auto& peer : _connect_to_peers ) {
                 bool found = false;
                 for( const auto& con : _sessions ) {

--- a/plugins/bnet_plugin/bnet_plugin.cpp
+++ b/plugins/bnet_plugin/bnet_plugin.cpp
@@ -290,7 +290,6 @@ namespace eosio {
         boost::asio::io_service&                                       _ios;
         unique_ptr<ws::stream<tcp::socket>>                            _ws;
         boost::asio::strand< boost::asio::io_context::executor_type>   _strand;
-        boost::asio::io_service&                                       _app_ios;
 
         methods::get_block_by_number::method_type& _get_block_by_number;
 
@@ -320,7 +319,6 @@ namespace eosio {
          _ios(socket.get_io_service()),
          _ws( new ws::stream<tcp::socket>(move(socket)) ),
          _strand(_ws->get_executor() ),
-         _app_ios( app().get_io_service() ),
          _get_block_by_number( app().get_method<methods::get_block_by_number>() )
         {
             _session_num = next_session_id();
@@ -339,7 +337,6 @@ namespace eosio {
          _ios(ioc),
          _ws( new ws::stream<tcp::socket>(ioc) ),
          _strand( _ws->get_executor() ),
-         _app_ios( app().get_io_service() ),
          _get_block_by_number( app().get_method<methods::get_block_by_number>() )
         {
            _session_num = next_session_id();
@@ -570,7 +567,7 @@ namespace eosio {
         template<typename L>
         void async_get_pending_block_ids( L&& callback ) {
            /// send peer my head block status which is read from chain plugin
-           _app_ios.post( [self = shared_from_this(),callback]{
+           app().post(priority::low, [self = shared_from_this(),callback]{
               auto& control = app().get_plugin<chain_plugin>().chain();
               auto lib = control.last_irreversible_block_num();
               auto head = control.fork_db_head_block_id();
@@ -595,7 +592,7 @@ namespace eosio {
 
         template<typename L>
         void async_get_block_num( uint32_t blocknum, L&& callback ) {
-           _app_ios.post( [self = shared_from_this(), blocknum, callback]{
+           app().post(priority::low, [self = shared_from_this(), blocknum, callback]{
               auto& control = app().get_plugin<chain_plugin>().chain();
               signed_block_ptr sblockptr;
               try {
@@ -919,9 +916,9 @@ namespace eosio {
          * the connection from being closed.
          */
         void wait_on_app() {
-            app().get_io_service().post( 
-                boost::asio::bind_executor( _strand, [self=shared_from_this()]{ self->do_read(); } )
-            );
+           app().post( priority::low, [self = shared_from_this()]() {
+              boost::asio::bind_executor( self->_strand, [self] { self->do_read(); } );
+           } );
         }
 
         void on_message( const bnet_message& msg, fc::datastream<const char*>& ds ) {
@@ -1154,7 +1151,7 @@ namespace eosio {
          channels::accepted_transaction::channel_type::handle   _on_appled_trx_handle;
 
          void async_add_session( std::weak_ptr<session> wp ) {
-            app().get_io_service().post( [wp,this]{
+            app().post(priority::low, [wp,this]{
                if( auto l = wp.lock() ) {
                   _sessions[l.get()] = wp;
                }
@@ -1170,7 +1167,7 @@ namespace eosio {
 
          template<typename Call>
          void for_each_session( Call callback ) {
-            app().get_io_service().post([this, callback = callback] {
+            app().post(priority::low, [this, callback = callback] {
                for (const auto& item : _sessions) {
                   if (auto ses = item.second.lock()) {
                      ses->_ios.post(boost::asio::bind_executor(
@@ -1449,7 +1446,7 @@ namespace eosio {
    session::~session() {
      wlog( "close session ${n}",("n",_session_num) );
      std::weak_ptr<bnet_plugin_impl> netp = _net_plugin;
-     _app_ios.post( [netp,ses=this]{
+      app().post(priority::low, [netp,ses=this]{
         if( auto net = netp.lock() )
            net->on_session_close(ses);
      });
@@ -1476,7 +1473,7 @@ namespace eosio {
    }
 
    void session::check_for_redundant_connection() {
-     app().get_io_service().post( [self=shared_from_this()]{
+     app().post(priority::low, [self=shared_from_this()]{
        self->_net_plugin->for_each_session( [self]( auto ses ){
          if( ses != self && ses->_remote_peer_id == self->_remote_peer_id ) {
            self->do_goodbye( "redundant connection" );

--- a/plugins/bnet_plugin/bnet_plugin.cpp
+++ b/plugins/bnet_plugin/bnet_plugin.cpp
@@ -916,7 +916,7 @@ namespace eosio {
          * the connection from being closed.
          */
         void wait_on_app() {
-           app().post( priority::low, [self = shared_from_this()]() {
+           app().post( priority::medium, [self = shared_from_this()]() {
               app().get_io_service().post( boost::asio::bind_executor( self->_strand, [self] { self->do_read(); } ) );
            } );
         }

--- a/plugins/chain_interface/include/eosio/chain/plugin_interface.hpp
+++ b/plugins/chain_interface/include/eosio/chain/plugin_interface.hpp
@@ -29,8 +29,6 @@ namespace eosio { namespace chain { namespace plugin_interface {
       using irreversible_block     = channel_decl<struct irreversible_block_tag,    block_state_ptr>;
       using accepted_transaction   = channel_decl<struct accepted_transaction_tag,  transaction_metadata_ptr>;
       using applied_transaction    = channel_decl<struct applied_transaction_tag,   transaction_trace_ptr>;
-      using accepted_confirmation  = channel_decl<struct accepted_confirmation_tag, header_confirmation>;
-
    }
 
    namespace methods {

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -146,7 +146,6 @@ public:
    ,irreversible_block_channel(app().get_channel<channels::irreversible_block>())
    ,accepted_transaction_channel(app().get_channel<channels::accepted_transaction>())
    ,applied_transaction_channel(app().get_channel<channels::applied_transaction>())
-   ,accepted_confirmation_channel(app().get_channel<channels::accepted_confirmation>())
    ,incoming_block_channel(app().get_channel<incoming::channels::block>())
    ,incoming_block_sync_method(app().get_method<incoming::methods::block_sync>())
    ,incoming_transaction_async_method(app().get_method<incoming::methods::transaction_async>())
@@ -174,7 +173,6 @@ public:
    channels::irreversible_block::channel_type&     irreversible_block_channel;
    channels::accepted_transaction::channel_type&   accepted_transaction_channel;
    channels::applied_transaction::channel_type&    applied_transaction_channel;
-   channels::accepted_confirmation::channel_type&  accepted_confirmation_channel;
    incoming::channels::block::channel_type&         incoming_block_channel;
 
    // retained references to methods for easy calling
@@ -194,8 +192,6 @@ public:
    fc::optional<scoped_connection>                                   irreversible_block_connection;
    fc::optional<scoped_connection>                                   accepted_transaction_connection;
    fc::optional<scoped_connection>                                   applied_transaction_connection;
-   fc::optional<scoped_connection>                                   accepted_confirmation_connection;
-
 
 };
 
@@ -672,35 +668,30 @@ void chain_plugin::plugin_initialize(const variables_map& options) {
             );
          }
 
-         my->pre_accepted_block_channel.publish(blk);
+         my->pre_accepted_block_channel.publish(priority::medium, blk);
       });
 
       my->accepted_block_header_connection = my->chain->accepted_block_header.connect(
             [this]( const block_state_ptr& blk ) {
-               my->accepted_block_header_channel.publish( blk );
+               my->accepted_block_header_channel.publish( priority::medium, blk );
             } );
 
       my->accepted_block_connection = my->chain->accepted_block.connect( [this]( const block_state_ptr& blk ) {
-         my->accepted_block_channel.publish( blk );
+         my->accepted_block_channel.publish( priority::high, blk );
       } );
 
       my->irreversible_block_connection = my->chain->irreversible_block.connect( [this]( const block_state_ptr& blk ) {
-         my->irreversible_block_channel.publish( blk );
+         my->irreversible_block_channel.publish( priority::low, blk );
       } );
 
       my->accepted_transaction_connection = my->chain->accepted_transaction.connect(
             [this]( const transaction_metadata_ptr& meta ) {
-               my->accepted_transaction_channel.publish( meta );
+               my->accepted_transaction_channel.publish( priority::low, meta );
             } );
 
       my->applied_transaction_connection = my->chain->applied_transaction.connect(
             [this]( const transaction_trace_ptr& trace ) {
-               my->applied_transaction_channel.publish( trace );
-            } );
-
-      my->accepted_confirmation_connection = my->chain->accepted_confirmation.connect(
-            [this]( const header_confirmation& conf ) {
-               my->accepted_confirmation_channel.publish( conf );
+               my->applied_transaction_channel.publish( priority::low, trace );
             } );
 
       my->chain->add_indices();
@@ -744,7 +735,6 @@ void chain_plugin::plugin_shutdown() {
    my->irreversible_block_connection.reset();
    my->accepted_transaction_connection.reset();
    my->applied_transaction_connection.reset();
-   my->accepted_confirmation_connection.reset();
    my->chain->get_thread_pool().stop();
    my->chain->get_thread_pool().join();
    my->chain.reset();

--- a/plugins/http_plugin/http_plugin.cpp
+++ b/plugins/http_plugin/http_plugin.cpp
@@ -560,7 +560,7 @@ namespace eosio {
 
    void http_plugin::add_handler(const string& url, const url_handler& handler) {
       ilog( "add api url: ${c}", ("c",url) );
-      app().get_io_service().post([=](){
+      app().post(priority::low, [=](){
         my->url_handlers.insert(std::make_pair(url,handler));
       });
    }

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -165,7 +165,7 @@ namespace eosio {
       size_t count_open_sockets() const;
 
       template<typename VerifierFunc>
-      void send_all( const std::shared_ptr<std::vector<char>>& send_buffer, VerifierFunc verify );
+      void send_transaction_to_all( const std::shared_ptr<std::vector<char>>& send_buffer, VerifierFunc verify );
 
       void accepted_block(const block_state_ptr&);
       void transaction_ack(const std::pair<fc::exception_ptr, transaction_metadata_ptr>&);
@@ -1620,7 +1620,7 @@ namespace eosio {
       node_transaction_state nts = {id, trx_expiration, 0, buff};
       my_impl->local_txns.insert(std::move(nts));
 
-      my_impl->send_all( buff, [&id, &skips, trx_expiration](const connection_ptr& c) -> bool {
+      my_impl->send_transaction_to_all( buff, [&id, &skips, trx_expiration](const connection_ptr& c) -> bool {
          if( skips.find(c) != skips.end() || c->syncing ) {
             return false;
           }
@@ -1997,7 +1997,7 @@ namespace eosio {
                            }
                         }
                      }
-                     app().post(priority::medium, [this, conn]() { start_read_message(conn); });
+                     start_read_message(conn);
                   } else {
                      auto pname = conn->peer_name();
                      if (ec.value() != boost::asio::error::eof) {
@@ -2043,7 +2043,7 @@ namespace eosio {
 
 
    template<typename VerifierFunc>
-   void net_plugin_impl::send_all(const std::shared_ptr<std::vector<char>>& send_buffer, VerifierFunc verify) {
+   void net_plugin_impl::send_transaction_to_all(const std::shared_ptr<std::vector<char>>& send_buffer, VerifierFunc verify) {
       for( auto &c : connections) {
          if( c->current() && verify( c )) {
             c->enqueue_buffer( send_buffer, true, priority::low, no_reason );

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2456,7 +2456,8 @@ namespace eosio {
 
    void net_plugin_impl::start_txn_timer() {
       transaction_check->expires_from_now( txn_exp_period);
-      transaction_check->async_wait(app().get_priority_queue().wrap(priority::low-1, [this](boost::system::error_code ec) {
+      int lower_than_low = priority::low - 1;
+      transaction_check->async_wait(app().get_priority_queue().wrap(lower_than_low, [this](boost::system::error_code ec) {
             if( !ec) {
                expire_txns();
             }

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -1037,7 +1037,7 @@ namespace eosio {
    }
 
    void connection::enqueue_block( const signed_block_ptr& sb, bool trigger_send ) {
-      enqueue_buffer( create_send_buffer( sb ), trigger_send, priority::high, no_reason );
+      enqueue_buffer( create_send_buffer( sb ), trigger_send, priority::low, no_reason );
    }
 
    void connection::enqueue_buffer( const std::shared_ptr<std::vector<char>>& send_buffer,

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -954,7 +954,7 @@ namespace eosio {
                string pname = conn ? conn->peer_name() : "no connection name";
                elog("Exception in do_queue_write to ${p}", ("p",pname) );
             }
-         }, __FILE__, __LINE__, __func__));
+         }));
    }
 
    void connection::cancel_sync(go_away_reason reason) {
@@ -1075,7 +1075,7 @@ namespace eosio {
             }
 
             conn->sync_timeout(ec);
-         }, __FILE__, __LINE__, __func__) );
+         } ) );
    }
 
    void connection::fetch_wait() {
@@ -1089,7 +1089,7 @@ namespace eosio {
             }
 
             conn->fetch_timeout(ec);
-         }, __FILE__, __LINE__, __func__) );
+         } ) );
    }
 
    void connection::sync_timeout( boost::system::error_code ec ) {
@@ -1793,7 +1793,7 @@ namespace eosio {
                                      elog( "Unable to resolve ${peer_addr}: ${error}",
                                            (  "peer_addr", c->peer_name() )("error", err.message() ) );
                                   }
-                               }, __FILE__, __LINE__, __func__));
+                               }));
    }
 
    void net_plugin_impl::connect(const connection_ptr& c, tcp::resolver::iterator endpoint_itr) {
@@ -1826,7 +1826,7 @@ namespace eosio {
                   my_impl->close(c);
                }
             }
-         }, __FILE__, __LINE__, __func__ ));
+         }));
    }
 
    bool net_plugin_impl::start_session(const connection_ptr& con) {
@@ -1913,7 +1913,7 @@ namespace eosio {
                }
             }
             start_listen_loop();
-         }, __FILE__, __LINE__, __func__));
+         }));
    }
 
    void net_plugin_impl::start_read_message(const connection_ptr& conn) {
@@ -2023,7 +2023,7 @@ namespace eosio {
                   elog( "Undefined exception hanlding the read data from connection ${p}",( "p",pname));
                   close( conn );
                }
-            }, __FILE__, __LINE__, __func__ ));
+            }));
       } catch (...) {
          string pname = conn ? conn->peer_name() : "no connection name";
          elog( "Undefined exception handling reading ${p}",("p",pname) );
@@ -2451,7 +2451,7 @@ namespace eosio {
                elog( "Error from connection check monitor: ${m}",( "m", ec.message()));
                start_conn_timer( connector_period, std::weak_ptr<connection>());
             }
-         }, __FILE__, __LINE__, __func__));
+         }));
    }
 
    void net_plugin_impl::start_txn_timer() {
@@ -2464,7 +2464,7 @@ namespace eosio {
                elog( "Error from transaction check monitor: ${m}",( "m", ec.message()));
                start_txn_timer();
             }
-         }, __FILE__, __LINE__, __func__));
+         }));
    }
 
    void net_plugin_impl::ticker() {
@@ -2479,7 +2479,7 @@ namespace eosio {
                   c->send_time();
                }
             }
-         }, __FILE__, __LINE__, __func__));
+         }));
    }
 
    void net_plugin_impl::start_monitors() {

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2334,7 +2334,6 @@ namespace eosio {
       auto ptrx = std::make_shared<transaction_metadata>( trx );
       const auto& tid = ptrx->id;
 
-      c->cancel_wait();
       if(local_txns.get<by_id>().find(tid) != local_txns.end()) {
          fc_dlog(logger, "got a duplicate transaction - dropping");
          return;

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -954,7 +954,7 @@ namespace eosio {
                string pname = conn ? conn->peer_name() : "no connection name";
                elog("Exception in do_queue_write to ${p}", ("p",pname) );
             }
-         }));
+         }, __FILE__, __LINE__, __func__));
    }
 
    void connection::cancel_sync(go_away_reason reason) {
@@ -1071,7 +1071,7 @@ namespace eosio {
             }
 
             conn->sync_timeout(ec);
-         }) );
+         }, __FILE__, __LINE__, __func__) );
    }
 
    void connection::fetch_wait() {
@@ -1085,7 +1085,7 @@ namespace eosio {
             }
 
             conn->fetch_timeout(ec);
-         }) );
+         }, __FILE__, __LINE__, __func__) );
    }
 
    void connection::sync_timeout( boost::system::error_code ec ) {
@@ -1785,7 +1785,7 @@ namespace eosio {
                                      elog( "Unable to resolve ${peer_addr}: ${error}",
                                            (  "peer_addr", c->peer_name() )("error", err.message() ) );
                                   }
-                               }));
+                               }, __FILE__, __LINE__, __func__));
    }
 
    void net_plugin_impl::connect(const connection_ptr& c, tcp::resolver::iterator endpoint_itr) {
@@ -1818,7 +1818,7 @@ namespace eosio {
                   my_impl->close(c);
                }
             }
-         } ));
+         }, __FILE__, __LINE__, __func__ ));
    }
 
    bool net_plugin_impl::start_session(const connection_ptr& con) {
@@ -1905,7 +1905,7 @@ namespace eosio {
                }
             }
             start_listen_loop();
-         }));
+         }, __FILE__, __LINE__, __func__));
    }
 
    void net_plugin_impl::start_read_message(const connection_ptr& conn) {
@@ -1989,7 +1989,7 @@ namespace eosio {
                            }
                         }
                      }
-                     start_read_message(conn);
+                     app().post(priority::medium, [this, conn]() { start_read_message(conn); });
                   } else {
                      auto pname = conn->peer_name();
                      if (ec.value() != boost::asio::error::eof) {
@@ -2015,7 +2015,7 @@ namespace eosio {
                   elog( "Undefined exception hanlding the read data from connection ${p}",( "p",pname));
                   close( conn );
                }
-            } ));
+            }, __FILE__, __LINE__, __func__ ));
       } catch (...) {
          string pname = conn ? conn->peer_name() : "no connection name";
          elog( "Undefined exception handling reading ${p}",("p",pname) );
@@ -2443,7 +2443,7 @@ namespace eosio {
                elog( "Error from connection check monitor: ${m}",( "m", ec.message()));
                start_conn_timer( connector_period, std::weak_ptr<connection>());
             }
-         }));
+         }, __FILE__, __LINE__, __func__));
    }
 
    void net_plugin_impl::start_txn_timer() {
@@ -2456,7 +2456,7 @@ namespace eosio {
                elog( "Error from transaction check monitor: ${m}",( "m", ec.message()));
                start_txn_timer();
             }
-         }));
+         }, __FILE__, __LINE__, __func__));
    }
 
    void net_plugin_impl::ticker() {
@@ -2471,7 +2471,7 @@ namespace eosio {
                   c->send_time();
                }
             }
-         }));
+         }, __FILE__, __LINE__, __func__));
    }
 
    void net_plugin_impl::start_monitors() {

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -1836,7 +1836,8 @@ namespace eosio {
 
    void net_plugin_impl::start_listen_loop() {
       auto socket = std::make_shared<tcp::socket>( std::ref( app().get_io_service() ) );
-      acceptor->async_accept( *socket, [socket,this]( boost::system::error_code ec ) {
+      acceptor->async_accept( *socket,
+            app().get_priority_queue().wrap(priority::low, [socket,this]( boost::system::error_code ec ) {
             if( !ec ) {
                uint32_t visitors = 0;
                uint32_t from_addr = 0;
@@ -1895,7 +1896,7 @@ namespace eosio {
                }
             }
             start_listen_loop();
-         });
+         }));
    }
 
    void net_plugin_impl::start_read_message(const connection_ptr& conn) {

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1372,7 +1372,7 @@ void producer_plugin_impl::schedule_production_loop() {
              if( self && ec != boost::asio::error::operation_aborted && cid == self->_timer_corelation_id ) {
                 self->schedule_production_loop();
              }
-          }, __FILE__, __LINE__, __func__ ) );
+          } ) );
    } else if (result == start_block_result::waiting){
       if (!_producers.empty() && !production_disabled_by_policy()) {
          fc_dlog(_log, "Waiting till another block is received and scheduling Speculative/Production Change");
@@ -1418,7 +1418,7 @@ void producer_plugin_impl::schedule_production_loop() {
                   auto res = self->maybe_produce_block();
                   fc_dlog( _log, "Producing Block #${num} returned: ${res}", ("num", block_num)( "res", res ) );
                }
-            }, __FILE__, __LINE__, __func__ ) );
+            } ) );
    } else if (_pending_block_mode == pending_block_mode::speculating && !_producers.empty() && !production_disabled_by_policy()){
       fc_dlog(_log, "Specualtive Block Created; Scheduling Speculative/Production Change");
       EOS_ASSERT( chain.pending_block_state(), missing_pending_block_state, "speculating without pending_block_state" );
@@ -1455,7 +1455,7 @@ void producer_plugin_impl::schedule_delayed_production_loop(const std::weak_ptr<
             if( self && ec != boost::asio::error::operation_aborted && cid == self->_timer_corelation_id ) {
                self->schedule_production_loop();
             }
-         }, __FILE__, __LINE__, __func__ ) );
+         } ) );
    } else {
       fc_dlog(_log, "Not Scheduling Speculative/Production, no local producers had valid wake up times");
    }

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1034,6 +1034,8 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block(bool 
    if( chain.get_read_mode() == chain::db_read_mode::READ_ONLY )
       return start_block_result::waiting;
 
+   fc_dlog(_log, "Starting block at ${time}", ("time", fc::time_point::now()));
+
    const auto& hbs = chain.head_block_state();
 
    //Schedule for the next second's tick regardless of chain state
@@ -1328,7 +1330,7 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block(bool 
             _incoming_trx_weight = 0.0;
 
             if (!_pending_incoming_transactions.empty()) {
-               fc_dlog(_log, "Processing ${n} pending transactions");
+               fc_dlog(_log, "Processing ${n} pending transactions", ("n", _pending_incoming_transactions.size()));
                while (orig_pending_txn_size && _pending_incoming_transactions.size()) {
                   auto e = _pending_incoming_transactions.front();
                   _pending_incoming_transactions.pop_front();
@@ -1387,23 +1389,27 @@ void producer_plugin_impl::schedule_production_loop() {
          EOS_ASSERT( chain.pending_block_state(), missing_pending_block_state, "producing without pending_block_state, start_block succeeded" );
          auto deadline = chain.pending_block_time().time_since_epoch().count() + (last_block ? _last_block_time_offset_us : _produce_time_offset_us);
          _timer.expires_at( epoch + boost::posix_time::microseconds( deadline ));
-         fc_dlog(_log, "Scheduling Block Production on Normal Block #${num} for ${time}", ("num", chain.pending_block_state()->block_num)("time",deadline));
+         fc_dlog(_log, "Scheduling Block Production on Normal Block #${num} for ${time}",
+                       ("num", chain.pending_block_state()->block_num)("time", fc::time_point(fc::microseconds(deadline))));
       } else {
          EOS_ASSERT( chain.pending_block_state(), missing_pending_block_state, "producing without pending_block_state" );
          auto expect_time = chain.pending_block_time() - fc::microseconds(config::block_interval_us);
          // ship this block off up to 1 block time earlier or immediately
          if (fc::time_point::now() >= expect_time) {
             _timer.expires_from_now( boost::posix_time::microseconds( 0 ));
-            fc_dlog(_log, "Scheduling Block Production on Exhausted Block #${num} immediately", ("num", chain.pending_block_state()->block_num));
+            fc_dlog(_log, "Scheduling Block Production on Exhausted Block #${num} immediately",
+                          ("num", chain.pending_block_state()->block_num));
          } else {
             _timer.expires_at(epoch + boost::posix_time::microseconds(expect_time.time_since_epoch().count()));
-            fc_dlog(_log, "Scheduling Block Production on Exhausted Block #${num} at ${time}", ("num", chain.pending_block_state()->block_num)("time",expect_time));
+            fc_dlog(_log, "Scheduling Block Production on Exhausted Block #${num} at ${time}",
+                          ("num", chain.pending_block_state()->block_num)("time",expect_time));
          }
       }
 
       _timer.async_wait([&chain,weak_this,cid=++_timer_corelation_id](const boost::system::error_code& ec) {
          auto self = weak_this.lock();
          if (self && ec != boost::asio::error::operation_aborted && cid == self->_timer_corelation_id) {
+            fc_dlog(_log, "Produce block timer running at ${time}", ("time", fc::time_point::now()));
             // pending_block_state expected, but can't assert inside async_wait
             auto block_num = chain.pending_block_state() ? chain.pending_block_state()->block_num : 0;
             auto res = self->maybe_produce_block();

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -353,7 +353,7 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
          boost::asio::post( *_thread_pool, [self = this, trx, persist_until_expired, next]() {
             if( trx->signing_keys_future.valid() )
                trx->signing_keys_future.wait();
-            app().get_io_service().post( [self, trx, persist_until_expired, next]() {
+            app().post(priority::low, [self, trx, persist_until_expired, next]() {
                self->process_incoming_transaction_async( trx, persist_until_expired, next );
             });
          });

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -327,7 +327,7 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
          }
 
          if( except ) {
-            app().get_channel<channels::rejected_block>().publish( block );
+            app().get_channel<channels::rejected_block>().publish( priority::medium, block );
             return;
          }
 
@@ -371,7 +371,7 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
          auto send_response = [this, &trx, &chain, &next](const fc::static_variant<fc::exception_ptr, transaction_trace_ptr>& response) {
             next(response);
             if (response.contains<fc::exception_ptr>()) {
-               _transaction_ack_channel.publish(std::pair<fc::exception_ptr, transaction_metadata_ptr>(response.get<fc::exception_ptr>(), trx));
+               _transaction_ack_channel.publish(priority::low, std::pair<fc::exception_ptr, transaction_metadata_ptr>(response.get<fc::exception_ptr>(), trx));
                if (_pending_block_mode == pending_block_mode::producing) {
                   fc_dlog(_trx_trace_log, "[TRX_TRACE] Block ${block_num} for producer ${prod} is REJECTING tx: ${txid} : ${why} ",
                         ("block_num", chain.head_block_num() + 1)
@@ -384,7 +384,7 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
                           ("why",response.get<fc::exception_ptr>()->what()));
                }
             } else {
-               _transaction_ack_channel.publish(std::pair<fc::exception_ptr, transaction_metadata_ptr>(nullptr, trx));
+               _transaction_ack_channel.publish(priority::low, std::pair<fc::exception_ptr, transaction_metadata_ptr>(nullptr, trx));
                if (_pending_block_mode == pending_block_mode::producing) {
                   fc_dlog(_trx_trace_log, "[TRX_TRACE] Block ${block_num} for producer ${prod} is ACCEPTING tx: ${txid}",
                           ("block_num", chain.head_block_num() + 1)

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1366,7 +1366,7 @@ void producer_plugin_impl::schedule_production_loop() {
       _timer.expires_from_now( boost::posix_time::microseconds( config::block_interval_us  / 10 ));
 
       // we failed to start a block, so try again later?
-      _timer.async_wait( app().get_priority_queue().wrap( priority::medium,
+      _timer.async_wait( app().get_priority_queue().wrap( priority::high,
           [weak_this, cid = ++_timer_corelation_id]( const boost::system::error_code& ec ) {
              auto self = weak_this.lock();
              if( self && ec != boost::asio::error::operation_aborted && cid == self->_timer_corelation_id ) {


### PR DESCRIPTION
## Change Description

- Add priority queue for main `application` thread
- Use low priority for transaction processing
- Use high priority for block production and block propagation

All posted jobs now require a priority that determines the order of execution. If any jobs are posted to the main application thread without using the provided priority wrapper they are executed as if they have the highest priority. Therefore, the priority wrapper should be used for all jobs posted either via `post`, `async_read`, `async_write`, `async_wait`, etc.

## Consensus Changes

None

## API Changes

Any plugins posting to the main `application` thread should consider using the new priority wrapper.

## Documentation Additions

See API changes.
