### PR TITLE
Remove the copy of the contracts directory from the Dockerfile

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -14,7 +14,6 @@ FROM ubuntu:18.04
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install openssl ca-certificates && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /usr/local/lib/* /usr/local/lib/
 COPY --from=builder /tmp/build/bin /opt/eosio/bin
-COPY --from=builder /tmp/build/contracts /contracts
 COPY --from=builder /eos/Docker/config.ini /
 COPY --from=builder /etc/eosio-version /etc
 COPY --from=builder /eos/Docker/nodeosd.sh /opt/eosio/bin/nodeosd.sh


### PR DESCRIPTION
## Change Description

The Dockerfile on develop will no longer work, since contracts are now removed from eos.  This causes automated build on the Docker Build pipeline to fail.

## Consensus Changes

None

## API Changes

None

## Documentation Additions

None