### PR TITLE
Update txn_test_gen_plugin to print the actual TPS

### DIFF
--- a/plugins/txn_test_gen_plugin/txn_test_gen_plugin.cpp
+++ b/plugins/txn_test_gen_plugin/txn_test_gen_plugin.cpp
@@ -91,6 +91,7 @@ struct txn_test_gen_plugin_impl {
 
    uint64_t _total_us = 0;
    uint64_t _txcount = 0;
+   time_point _start_time;
 
    int _remain = 0;
 
@@ -262,6 +263,7 @@ struct txn_test_gen_plugin_impl {
          throw fc::exception(fc::invalid_operation_exception_code);
 
       running = true;
+      _start_time = fc::time_point::now();
 
       controller& cc = app().get_plugin<chain_plugin>().chain();
       auto abi_serializer_max_time = app().get_plugin<chain_plugin>().get_abi_serializer_max_time();
@@ -368,10 +370,12 @@ struct txn_test_gen_plugin_impl {
          throw fc::exception(fc::invalid_operation_exception_code);
       timer.cancel();
       running = false;
+      auto elapsed_ms = (fc::time_point::now() - _start_time).count()/1000;
       ilog("Stopping transaction generation test");
 
       if (_txcount) {
-         ilog("${d} transactions executed, ${t}us / transaction", ("d", _txcount)("t", _total_us / (double)_txcount));
+         ilog("${d} transactions executed for ${s} ms (${tps} TPS), ${t} us / transaction",
+            ("d", _txcount) ("s", elapsed_ms) ("tps", (uint16_t)(((double)_txcount/elapsed_ms)*1000)) ("t", _total_us / (double)_txcount));
          _txcount = _total_us = 0;
       }
    }


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- Give your PR a title that is sufficient to understand what is being changed. -->

## Change Description

<!-- Describe the change you made, the motivation for it, and the impact it will have. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
When you stop the test, "us / transaction" shows the average value of `cpu_usage_us` (= billed CPU usage) of transactions.
Based on this value, you can not estimate how many transactions per second (TPS) an actual node generates.

We recorded the time at which the test was performed and print the actual TPS.

## Consensus Changes

<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->

N/A


## API Changes

<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->

N/A


## Documentation Additions

<!-- List all the information that needs to be added to the documentation after merge. -->

N/A