### PR TITLE
Refactor block_header_state

### DIFF
--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -38,7 +38,7 @@ void apply_context::exec_one( action_trace& trace )
    r.act_digest       = digest_type::hash(act);
 
    trace.trx_id = trx_context.id;
-   trace.block_num = control.pending_block_state()->block_num;
+   trace.block_num = control.head_block_num() + 1;
    trace.block_time = control.pending_block_time();
    trace.producer_block_id = control.pending_producer_block_id();
    trace.act = act;

--- a/libraries/chain/block_header_state.cpp
+++ b/libraries/chain/block_header_state.cpp
@@ -15,113 +15,245 @@ namespace eosio { namespace chain {
       return active_schedule.producers[index];
    }
 
-   uint32_t block_header_state::calc_dpos_last_irreversible()const {
+   uint32_t block_header_state::calc_dpos_last_irreversible( account_name producer_of_next_block )const {
       vector<uint32_t> blocknums; blocknums.reserve( producer_to_last_implied_irb.size() );
       for( auto& i : producer_to_last_implied_irb ) {
-         blocknums.push_back(i.second);
+         blocknums.push_back( (i.first == producer_of_next_block) ? dpos_proposed_irreversible_blocknum : i.second);
       }
       /// 2/3 must be greater, so if I go 1/3 into the list sorted from low to high, then 2/3 are greater
 
       if( blocknums.size() == 0 ) return 0;
-      /// TODO: update to nth_element 
+      /// TODO: update to nth_element
       std::sort( blocknums.begin(), blocknums.end() );
       return blocknums[ (blocknums.size()-1) / 3 ];
    }
 
-  /**
-   *  Generate a template block header state for a given block time, it will not
-   *  contain a transaction mroot, action mroot, or new_producers as those components
-   *  are derived from chain state.
-   */
-  block_header_state block_header_state::generate_next( block_timestamp_type when )const {
-    block_header_state result;
+   pending_block_header_state  block_header_state::next( block_timestamp_type when,
+                                                         uint16_t num_prev_blocks_to_confirm )const
+   {
+      pending_block_header_state result;
 
-    if( when != block_timestamp_type() ) {
-       EOS_ASSERT( when > header.timestamp, block_validate_exception, "next block must be in the future" );
-    } else {
-       (when = header.timestamp).slot++;
-    }
-    result.header.timestamp                                = when;
-    result.header.previous                                 = id;
-    result.header.schedule_version                         = active_schedule.version;
-                                                           
-    auto prokey                                            = get_scheduled_producer(when);
-    result.block_signing_key                               = prokey.block_signing_key;
-    result.header.producer                                 = prokey.producer_name;
-                                                           
-    result.pending_schedule_lib_num                        = pending_schedule_lib_num;
-    result.pending_schedule_hash                           = pending_schedule_hash;
-    result.block_num                                       = block_num + 1;
-    result.producer_to_last_produced                       = producer_to_last_produced;
-    result.producer_to_last_implied_irb                    = producer_to_last_implied_irb;
-    result.producer_to_last_produced[prokey.producer_name] = result.block_num;
-    result.blockroot_merkle = blockroot_merkle;
-    result.blockroot_merkle.append( id );
+      if( when != block_timestamp_type() ) {
+        EOS_ASSERT( when > header.timestamp, block_validate_exception, "next block must be in the future" );
+      } else {
+        (when = header.timestamp).slot++;
+      }
 
-    result.active_schedule                       = active_schedule;
-    result.pending_schedule                      = pending_schedule;
-    result.dpos_proposed_irreversible_blocknum   = dpos_proposed_irreversible_blocknum;
-    result.bft_irreversible_blocknum             = bft_irreversible_blocknum;
+      auto prokey = get_scheduled_producer(when);
 
-    result.producer_to_last_implied_irb[prokey.producer_name] = result.dpos_proposed_irreversible_blocknum;
-    result.dpos_irreversible_blocknum                         = result.calc_dpos_last_irreversible(); 
+      auto itr = producer_to_last_produced.find( prokey.producer_name );
+      if( itr != producer_to_last_produced.end() ) {
+        EOS_ASSERT( itr->second < (block_num+1) - num_prev_blocks_to_confirm, producer_double_confirm,
+                    "producer ${prod} double-confirming known range",
+                    ("prod", prokey.producer_name)("num", block_num+1)
+                    ("confirmed", num_prev_blocks_to_confirm)("last_produced", itr->second) );
+      }
 
-    /// grow the confirmed count
-    static_assert(std::numeric_limits<uint8_t>::max() >= (config::max_producers * 2 / 3) + 1, "8bit confirmations may not be able to hold all of the needed confirmations");
+      result.block_num                                       = block_num + 1;
+      result.previous                                        = id;
+      result.timestamp                                       = when;
+      result.confirmed                                       = num_prev_blocks_to_confirm;
+      result.active_schedule_version                         = active_schedule.version;
 
-    // This uses the previous block active_schedule because thats the "schedule" that signs and therefore confirms _this_ block
-    auto num_active_producers = active_schedule.producers.size();
-    uint32_t required_confs = (uint32_t)(num_active_producers * 2 / 3) + 1;
+      result.block_signing_key                               = prokey.block_signing_key;
+      result.producer                                        = prokey.producer_name;
 
-    if( confirm_count.size() < config::maximum_tracked_dpos_confirmations ) {
-       result.confirm_count.reserve( confirm_count.size() + 1 );
-       result.confirm_count  = confirm_count;
-       result.confirm_count.resize( confirm_count.size() + 1 );
-       result.confirm_count.back() = (uint8_t)required_confs;
-    } else {
-       result.confirm_count.resize( confirm_count.size() );
-       memcpy( &result.confirm_count[0], &confirm_count[1], confirm_count.size() - 1 );
-       result.confirm_count.back() = (uint8_t)required_confs;
-    }
+      result.blockroot_merkle = blockroot_merkle;
+      result.blockroot_merkle.append( id );
 
-    return result;
-  } /// generate_next
+      /// grow the confirmed count
+      static_assert(std::numeric_limits<uint8_t>::max() >= (config::max_producers * 2 / 3) + 1, "8bit confirmations may not be able to hold all of the needed confirmations");
 
-   bool block_header_state::maybe_promote_pending() {
+      // This uses the previous block active_schedule because thats the "schedule" that signs and therefore confirms _this_ block
+      auto num_active_producers = active_schedule.producers.size();
+      uint32_t required_confs = (uint32_t)(num_active_producers * 2 / 3) + 1;
+
+      if( confirm_count.size() < config::maximum_tracked_dpos_confirmations ) {
+         result.confirm_count.reserve( confirm_count.size() + 1 );
+         result.confirm_count  = confirm_count;
+         result.confirm_count.resize( confirm_count.size() + 1 );
+         result.confirm_count.back() = (uint8_t)required_confs;
+      } else {
+         result.confirm_count.resize( confirm_count.size() );
+         memcpy( &result.confirm_count[0], &confirm_count[1], confirm_count.size() - 1 );
+         result.confirm_count.back() = (uint8_t)required_confs;
+      }
+
+      auto new_dpos_proposed_irreversible_blocknum = dpos_proposed_irreversible_blocknum;
+
+      int32_t i = (int32_t)(result.confirm_count.size() - 1);
+      uint32_t blocks_to_confirm = num_prev_blocks_to_confirm + 1; /// confirm the head block too
+      while( i >= 0 && blocks_to_confirm ) {
+        --result.confirm_count[i];
+        //idump((confirm_count[i]));
+        if( result.confirm_count[i] == 0 )
+        {
+            uint32_t block_num_for_i = result.block_num - (uint32_t)(result.confirm_count.size() - 1 - i);
+            new_dpos_proposed_irreversible_blocknum = block_num_for_i;
+            //idump((dpos2_lib)(block_num)(dpos_irreversible_blocknum));
+
+            if (i == result.confirm_count.size() - 1) {
+               result.confirm_count.resize(0);
+            } else {
+               memmove( &result.confirm_count[0], &result.confirm_count[i + 1], result.confirm_count.size() - i  - 1);
+               result.confirm_count.resize( result.confirm_count.size() - i - 1 );
+            }
+
+            break;
+        }
+        --i;
+        --blocks_to_confirm;
+      }
+
+      result.dpos_proposed_irreversible_blocknum   = new_dpos_proposed_irreversible_blocknum;
+      result.dpos_irreversible_blocknum            = calc_dpos_last_irreversible( prokey.producer_name );
+
+      result.prev_pending_schedule                 = pending_schedule;
+      result.prev_pending_schedule_lib_num         = pending_schedule_lib_num;
+      result.prev_pending_schedule_hash            = pending_schedule_hash;
+
       if( pending_schedule.producers.size() &&
-          dpos_irreversible_blocknum >= pending_schedule_lib_num )
+          result.dpos_irreversible_blocknum >= pending_schedule_lib_num )
       {
-         active_schedule = move( pending_schedule );
+         result.active_schedule = pending_schedule;
 
          flat_map<account_name,uint32_t> new_producer_to_last_produced;
-         for( const auto& pro : active_schedule.producers ) {
-            auto existing = producer_to_last_produced.find( pro.producer_name );
-            if( existing != producer_to_last_produced.end() ) {
-               new_producer_to_last_produced[pro.producer_name] = existing->second;
+
+         for( const auto& pro : result.active_schedule.producers ) {
+            if( pro.producer_name == prokey.producer_name ) {
+               new_producer_to_last_produced[pro.producer_name] = result.block_num;
             } else {
-               new_producer_to_last_produced[pro.producer_name] = dpos_irreversible_blocknum;
+               auto existing = producer_to_last_produced.find( pro.producer_name );
+               if( existing != producer_to_last_produced.end() ) {
+                  new_producer_to_last_produced[pro.producer_name] = existing->second;
+               } else {
+                  new_producer_to_last_produced[pro.producer_name] = result.dpos_irreversible_blocknum;
+               }
             }
          }
+
+         result.producer_to_last_produced = std::move( new_producer_to_last_produced );
 
          flat_map<account_name,uint32_t> new_producer_to_last_implied_irb;
-         for( const auto& pro : active_schedule.producers ) {
-            auto existing = producer_to_last_implied_irb.find( pro.producer_name );
-            if( existing != producer_to_last_implied_irb.end() ) {
-               new_producer_to_last_implied_irb[pro.producer_name] = existing->second;
+
+         for( const auto& pro : result.active_schedule.producers ) {
+            if( pro.producer_name == prokey.producer_name ) {
+               new_producer_to_last_implied_irb[pro.producer_name] = dpos_proposed_irreversible_blocknum;
             } else {
-               new_producer_to_last_implied_irb[pro.producer_name] = dpos_irreversible_blocknum;
+               auto existing = producer_to_last_implied_irb.find( pro.producer_name );
+               if( existing != producer_to_last_implied_irb.end() ) {
+                  new_producer_to_last_implied_irb[pro.producer_name] = existing->second;
+               } else {
+                  new_producer_to_last_implied_irb[pro.producer_name] = result.dpos_irreversible_blocknum;
+               }
             }
          }
 
-         producer_to_last_produced = move( new_producer_to_last_produced );
-         producer_to_last_implied_irb = move( new_producer_to_last_implied_irb);
-         producer_to_last_produced[header.producer] = block_num;
+         result.producer_to_last_implied_irb = std::move( new_producer_to_last_implied_irb );
 
-         return true;
+         result.was_pending_promoted = true;
+      } else {
+         result.active_schedule                  = active_schedule;
+         result.producer_to_last_produced        = producer_to_last_produced;
+         result.producer_to_last_produced[prokey.producer_name] = block_num;
+         result.producer_to_last_implied_irb     = producer_to_last_implied_irb;
+         result.producer_to_last_implied_irb[prokey.producer_name] = dpos_proposed_irreversible_blocknum;
       }
-      return false;
+
+      return result;
    }
 
+   signed_block_header pending_block_header_state::make_block_header( const checksum256_type& transaction_mroot,
+                                                                      const checksum256_type& action_mroot,
+                                                                      optional<producer_schedule_type>&& new_producers )const
+   {
+      signed_block_header h;
+
+      h.timestamp         = timestamp;
+      h.producer          = producer;
+      h.confirmed         = confirmed;
+      h.previous          = previous;
+      h.transaction_mroot = transaction_mroot;
+      h.action_mroot      = action_mroot;
+      h.schedule_version  = active_schedule_version;
+      h.new_producers     = std::move(new_producers);
+
+      return h;
+   }
+
+   block_header_state pending_block_header_state::_finish_next( const signed_block_header& h )&&
+   {
+      EOS_ASSERT( h.timestamp == timestamp, block_validate_exception, "timestamp mismatch" );
+      EOS_ASSERT( h.previous == previous, unlinkable_block_exception, "previous mismatch" );
+      EOS_ASSERT( h.confirmed == confirmed, block_validate_exception, "confirmed mismatch" );
+      EOS_ASSERT( h.producer == producer, wrong_producer, "wrong producer specified" );
+      EOS_ASSERT( h.schedule_version == active_schedule_version, producer_schedule_exception, "schedule_version in signed block is corrupted" );
+
+      EOS_ASSERT( h.header_extensions.size() == 0, block_validate_exception, "no supported extensions" );
+
+      if( h.new_producers ) {
+         EOS_ASSERT( !was_pending_promoted, producer_schedule_exception, "cannot set pending producer schedule in the same block in which pending was promoted to active" );
+         EOS_ASSERT( h.new_producers->version == active_schedule.version + 1, producer_schedule_exception, "wrong producer schedule version specified" );
+         EOS_ASSERT( prev_pending_schedule.producers.size() == 0, producer_schedule_exception,
+                    "cannot set new pending producers until last pending is confirmed" );
+      }
+
+      block_header_state result;
+
+      result.id        = h.id();
+      result.block_num = block_num;
+      result.header    = h;
+
+      result.dpos_proposed_irreversible_blocknum = dpos_proposed_irreversible_blocknum;
+      result.dpos_irreversible_blocknum          = dpos_irreversible_blocknum;
+
+      if( h.new_producers ) {
+         result.pending_schedule         = *h.new_producers;
+         result.pending_schedule_hash    = digest_type::hash( result.pending_schedule );
+         result.pending_schedule_lib_num = block_num;
+      } else {
+         if( was_pending_promoted ) {
+            result.pending_schedule.version = prev_pending_schedule.version;
+         } else {
+            result.pending_schedule         = prev_pending_schedule;
+         }
+         result.pending_schedule_hash    = std::move(prev_pending_schedule_hash);
+         result.pending_schedule_lib_num = prev_pending_schedule_lib_num;
+      }
+
+      result.active_schedule                     = std::move(active_schedule);
+      result.blockroot_merkle                    = std::move(blockroot_merkle);
+      result.producer_to_last_produced           = std::move(producer_to_last_produced);
+      result.producer_to_last_implied_irb        = std::move(producer_to_last_implied_irb);
+      result.block_signing_key                   = std::move(block_signing_key);
+      result.confirm_count                       = std::move(confirm_count);
+
+      return result;
+   }
+
+   block_header_state pending_block_header_state::finish_next( const signed_block_header& h,
+                                                               bool skip_validate_signee )&&
+   {
+      auto result = std::move(*this)._finish_next( h );
+
+      // ASSUMPTION FROM controller_impl::apply_block = all untrusted blocks will have their signatures pre-validated here
+      if( !skip_validate_signee ) {
+        result.verify_signee( result.signee() );
+      }
+
+      return result;
+   }
+
+   block_header_state pending_block_header_state::finish_next( signed_block_header& h,
+                                                               const std::function<signature_type(const digest_type&)>& signer )&&
+   {
+      auto result = std::move(*this)._finish_next( h );
+      result.sign( signer );
+      h.producer_signature = result.header.producer_signature;
+      return result;
+   }
+
+   /*
   void block_header_state::set_new_producers( producer_schedule_type pending ) {
       EOS_ASSERT( pending.version == active_schedule.version + 1, producer_schedule_exception, "wrong producer schedule version specified" );
       EOS_ASSERT( pending_schedule.producers.size() == 0, producer_schedule_exception,
@@ -131,92 +263,19 @@ namespace eosio { namespace chain {
       pending_schedule         = *header.new_producers;
       pending_schedule_lib_num = block_num;
   }
-
-
-  /**
-   *  Transitions the current header state into the next header state given the supplied signed block header.
-   *
-   *  Given a signed block header, generate the expected template based upon the header time,
-   *  then validate that the provided header matches the template.
-   *
-   *  If the header specifies new_producers then apply them accordingly.
    */
-  block_header_state block_header_state::next( const signed_block_header& h, bool skip_validate_signee )const {
-    EOS_ASSERT( h.timestamp != block_timestamp_type(), block_validate_exception, "", ("h",h) );
-    EOS_ASSERT( h.header_extensions.size() == 0, block_validate_exception, "no supported extensions" );
 
-    EOS_ASSERT( h.timestamp > header.timestamp, block_validate_exception, "block must be later in time" );
-    EOS_ASSERT( h.previous == id, unlinkable_block_exception, "block must link to current state" );
-    auto result = generate_next( h.timestamp );
-    EOS_ASSERT( result.header.producer == h.producer, wrong_producer, "wrong producer specified" );
-    EOS_ASSERT( result.header.schedule_version == h.schedule_version, producer_schedule_exception, "schedule_version in signed block is corrupted" );
-
-    auto itr = producer_to_last_produced.find(h.producer);
-    if( itr != producer_to_last_produced.end() ) {
-       EOS_ASSERT( itr->second < result.block_num - h.confirmed, producer_double_confirm, "producer ${prod} double-confirming known range", ("prod", h.producer) );
-    }
-
-    // FC_ASSERT( result.header.block_mroot == h.block_mroot, "mismatch block merkle root" );
-
-     /// below this point is state changes that cannot be validated with headers alone, but never-the-less,
-     /// must result in header state changes
-
-    result.set_confirmed( h.confirmed );
-
-    auto was_pending_promoted = result.maybe_promote_pending();
-
-    if( h.new_producers ) {
-      EOS_ASSERT( !was_pending_promoted, producer_schedule_exception, "cannot set pending producer schedule in the same block in which pending was promoted to active" );
-      result.set_new_producers( *h.new_producers );
-    }
-
-    result.header.action_mroot       = h.action_mroot;
-    result.header.transaction_mroot  = h.transaction_mroot;
-    result.header.producer_signature = h.producer_signature;
-    result.id                        = result.header.id();
-
-    // ASSUMPTION FROM controller_impl::apply_block = all untrusted blocks will have their signatures pre-validated here
-    if( !skip_validate_signee ) {
-       result.verify_signee( result.signee() );
-    }
-
-    return result;
-  } /// next
-
-  void block_header_state::set_confirmed( uint16_t num_prev_blocks ) {
-     /*
-     idump((num_prev_blocks)(confirm_count.size()));
-
-     for( uint32_t i = 0; i < confirm_count.size(); ++i ) {
-        std::cerr << "confirm_count["<<i<<"] = " << int(confirm_count[i]) << "\n";
-     }
-     */
-     header.confirmed = num_prev_blocks;
-
-     int32_t i = (int32_t)(confirm_count.size() - 1);
-     uint32_t blocks_to_confirm = num_prev_blocks + 1; /// confirm the head block too
-     while( i >= 0 && blocks_to_confirm ) {
-        --confirm_count[i];
-        //idump((confirm_count[i]));
-        if( confirm_count[i] == 0 )
-        {
-           uint32_t block_num_for_i = block_num - (uint32_t)(confirm_count.size() - 1 - i);
-           dpos_proposed_irreversible_blocknum = block_num_for_i;
-           //idump((dpos2_lib)(block_num)(dpos_irreversible_blocknum));
-
-           if (i == confirm_count.size() - 1) {
-              confirm_count.resize(0);
-           } else {
-              memmove( &confirm_count[0], &confirm_count[i + 1], confirm_count.size() - i  - 1);
-              confirm_count.resize( confirm_count.size() - i - 1 );
-           }
-
-           return;
-        }
-        --i;
-        --blocks_to_confirm;
-     }
-  }
+   /**
+    *  Transitions the current header state into the next header state given the supplied signed block header.
+    *
+    *  Given a signed block header, generate the expected template based upon the header time,
+    *  then validate that the provided header matches the template.
+    *
+    *  If the header specifies new_producers then apply them accordingly.
+    */
+   block_header_state block_header_state::next( const signed_block_header& h, bool skip_validate_signee )const {
+      return next( h.timestamp, h.confirmed ).finish_next( h, skip_validate_signee );
+   }
 
   digest_type   block_header_state::sig_digest()const {
      auto header_bmroot = digest_type::hash( std::make_pair( header.digest(), blockroot_merkle.get_root() ) );
@@ -238,6 +297,7 @@ namespace eosio { namespace chain {
                  ("block_signing_key", block_signing_key)( "signee", signee ) );
   }
 
+  /*
   void block_header_state::add_confirmation( const header_confirmation& conf ) {
      for( const auto& c : confirmations )
         EOS_ASSERT( c.producer != conf.producer, producer_double_confirm, "block already confirmed by this producer" );
@@ -249,6 +309,6 @@ namespace eosio { namespace chain {
 
      confirmations.emplace_back( conf );
   }
-
+  */
 
 } } /// namespace eosio::chain

--- a/libraries/chain/block_state.cpp
+++ b/libraries/chain/block_state.cpp
@@ -3,17 +3,33 @@
 
 namespace eosio { namespace chain {
 
-   block_state::block_state( const block_header_state& prev, block_timestamp_type when )
-   :block_header_state( prev.generate_next( when ) ), 
-    block( std::make_shared<signed_block>()  )
-   {
-      static_cast<block_header&>(*block) = header;
-   }
+   block_state::block_state( const block_header_state& prev,
+                             signed_block_ptr b,
+                             bool skip_validate_signee
+                           )
+   :block_header_state( prev.next( *b, skip_validate_signee ) )
+   ,block( std::move(b) )
+   {}
 
-   block_state::block_state( const block_header_state& prev, signed_block_ptr b, bool skip_validate_signee )
-   :block_header_state( prev.next( *b, skip_validate_signee )), block( move(b) )
-   { }
+   block_state::block_state( pending_block_header_state&& cur,
+                             signed_block_ptr&& b,
+                             vector<transaction_metadata_ptr>&& trx_metas,
+                             const std::function<signature_type(const digest_type&)>& signer
+                           )
+   :block_header_state( std::move(cur).finish_next( *b, signer ) )
+   ,block( std::move(b) )
+   ,trxs( std::move(trx_metas) )
+   {}
 
 
+   block_state::block_state( pending_block_header_state&& cur,
+                             const signed_block_ptr& b,
+                             vector<transaction_metadata_ptr>&& trx_metas,
+                             bool skip_validate_signee
+                           )
+   :block_header_state( std::move(cur).finish_next( *b, skip_validate_signee ) )
+   ,block( b )
+   ,trxs( std::move(trx_metas) )
+   {}
 
 } } /// eosio::chain

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -94,19 +94,69 @@ class maybe_session {
       optional<database::session>     _session;
 };
 
+struct building_block {
+   building_block( const block_header_state& prev, block_timestamp_type when, uint16_t num_prev_blocks_to_confirm )
+   :_pending_block_header_state( prev.next( when, num_prev_blocks_to_confirm ) )
+   {}
+
+   pending_block_header_state         _pending_block_header_state;
+   optional<producer_schedule_type>   _new_pending_producer_schedule;
+   vector<transaction_metadata_ptr>   _pending_trx_metas;
+   vector<transaction_receipt>        _pending_trx_receipts;
+   vector<action_receipt>             _actions;
+};
+
+struct assembled_block {
+   pending_block_header_state        _pending_block_header_state;
+   vector<transaction_metadata_ptr>  _trx_metas;
+   signed_block_ptr                  _unsigned_block;
+};
+
+struct completed_block {
+   block_state_ptr                   _block_state;
+};
+
+using block_stage_type = fc::static_variant<building_block, assembled_block, completed_block>;
+
 struct pending_state {
-   pending_state( maybe_session&& s )
-   :_db_session( move(s) ){}
+   pending_state( maybe_session&& s, const block_header_state& prev,
+                  block_timestamp_type when, uint16_t num_prev_blocks_to_confirm )
+   :_db_session( move(s) )
+   ,_block_stage( building_block( prev, when, num_prev_blocks_to_confirm ) )
+   {}
 
    maybe_session                      _db_session;
-
-   block_state_ptr                    _pending_block_state;
-
-   vector<action_receipt>             _actions;
-
+   block_stage_type                   _block_stage;
    controller::block_status           _block_status = controller::block_status::incomplete;
-
    optional<block_id_type>            _producer_block_id;
+
+   /** @pre _block_stage cannot hold completed_block alternative */
+   const pending_block_header_state& get_pending_block_header_state()const {
+      if( _block_stage.contains<building_block>() )
+         return _block_stage.get<building_block>()._pending_block_header_state;
+
+      return _block_stage.get<assembled_block>()._pending_block_header_state;
+   }
+
+   const vector<transaction_receipt>& get_trx_receipts()const {
+      if( _block_stage.contains<building_block>() )
+         return _block_stage.get<building_block>()._pending_trx_receipts;
+
+      if( _block_stage.contains<assembled_block>() )
+         return _block_stage.get<assembled_block>()._unsigned_block->transactions;
+
+      return _block_stage.get<completed_block>()._block_state->block->transactions;
+   }
+
+   const vector<transaction_metadata_ptr>& get_trx_metas()const {
+      if( _block_stage.contains<building_block>() )
+         return _block_stage.get<building_block>()._pending_trx_metas;
+
+      if( _block_stage.contains<assembled_block>() )
+         return _block_stage.get<assembled_block>()._trx_metas;
+
+      return _block_stage.get<completed_block>()._block_state->trxs;
+   }
 
    void push() {
       _db_session.push();
@@ -534,7 +584,8 @@ struct controller_impl {
          block_header_state head_header_state;
          section.read_row(head_header_state, db);
 
-         auto head_state = std::make_shared<block_state>(head_header_state);
+         auto head_state = std::make_shared<block_state>();
+         static_cast<block_header_state&>(*head_state) = head_header_state;
          fork_db.set(head_state);
          fork_db.set_validity(head_state, true);
          fork_db.mark_in_current_chain(head_state, true);
@@ -594,7 +645,8 @@ struct controller_impl {
       genheader.id                    = genheader.header.id();
       genheader.block_num             = genheader.header.block_num();
 
-      head = std::make_shared<block_state>( genheader );
+      head = std::make_shared<block_state>();
+      static_cast<block_header_state&>(*head) = genheader;
       head->block = std::make_shared<signed_block>(genheader.header);
       fork_db.set( head );
       db.set_revision( head->block_num );
@@ -673,58 +725,22 @@ struct controller_impl {
                                                                              conf.genesis.initial_timestamp );
    }
 
-
-
-   /**
-    * @post regardless of the success of commit block there is no active pending block
-    */
-   void commit_block( bool add_to_fork_db ) {
-      auto reset_pending_on_exit = fc::make_scoped_exit([this]{
-         pending.reset();
-      });
-
-      try {
-         if (add_to_fork_db) {
-            pending->_pending_block_state->validated = true;
-            auto new_bsp = fork_db.add(pending->_pending_block_state, true);
-            emit(self.accepted_block_header, pending->_pending_block_state);
-            head = fork_db.head();
-            EOS_ASSERT(new_bsp == head, fork_database_exception, "committed block did not become the new head in fork database");
-         }
-
-         if( !replaying ) {
-            reversible_blocks.create<reversible_block_object>( [&]( auto& ubo ) {
-               ubo.blocknum = pending->_pending_block_state->block_num;
-               ubo.set_block( pending->_pending_block_state->block );
-            });
-         }
-
-         emit( self.accepted_block, pending->_pending_block_state );
-      } catch (...) {
-         // dont bother resetting pending, instead abort the block
-         reset_pending_on_exit.cancel();
-         abort_block();
-         throw;
-      }
-
-      // push the state for pending.
-      pending->push();
-   }
-
    // The returned scoped_exit should not exceed the lifetime of the pending which existed when make_block_restore_point was called.
    fc::scoped_exit<std::function<void()>> make_block_restore_point() {
-      auto orig_block_transactions_size = pending->_pending_block_state->block->transactions.size();
-      auto orig_state_transactions_size = pending->_pending_block_state->trxs.size();
-      auto orig_state_actions_size      = pending->_actions.size();
+      auto& bb = pending->_block_stage.get<building_block>();
+      auto orig_block_transactions_size = bb._pending_trx_receipts.size();
+      auto orig_state_transactions_size = bb._pending_trx_metas.size();
+      auto orig_state_actions_size      = bb._actions.size();
 
       std::function<void()> callback = [this,
                                         orig_block_transactions_size,
                                         orig_state_transactions_size,
                                         orig_state_actions_size]()
       {
-         pending->_pending_block_state->block->transactions.resize(orig_block_transactions_size);
-         pending->_pending_block_state->trxs.resize(orig_state_transactions_size);
-         pending->_actions.resize(orig_state_actions_size);
+         auto& bb = pending->_block_stage.get<building_block>();
+         bb._pending_trx_receipts.resize(orig_block_transactions_size);
+         bb._pending_trx_metas.resize(orig_state_transactions_size);
+         bb._actions.resize(orig_state_actions_size);
       };
 
       return fc::make_scoped_exit( std::move(callback) );
@@ -762,7 +778,7 @@ struct controller_impl {
          auto restore = make_block_restore_point();
          trace->receipt = push_receipt( gtrx.trx_id, transaction_receipt::soft_fail,
                                         trx_context.billed_cpu_time_us, trace->net_usage );
-         fc::move_append( pending->_actions, move(trx_context.executed) );
+         fc::move_append( pending->_block_stage.get<building_block>()._actions, move(trx_context.executed) );
 
          trx_context.squash();
          restore.cancel();
@@ -846,7 +862,7 @@ struct controller_impl {
       if( gtrx.expiration < self.pending_block_time() ) {
          trace = std::make_shared<transaction_trace>();
          trace->id = gtrx.trx_id;
-         trace->block_num = self.pending_block_state()->block_num;
+         trace->block_num = self.head_block_num() + 1;
          trace->block_time = self.pending_block_time();
          trace->producer_block_id = self.pending_producer_block_id();
          trace->scheduled = true;
@@ -888,7 +904,7 @@ struct controller_impl {
                                         trx_context.billed_cpu_time_us,
                                         trace->net_usage );
 
-         fc::move_append( pending->_actions, move(trx_context.executed) );
+         fc::move_append( pending->_block_stage.get<building_block>()._actions, move(trx_context.executed) );
 
          emit( self.accepted_transaction, trx );
          emit( self.applied_transaction, trace );
@@ -976,8 +992,9 @@ struct controller_impl {
                                             uint64_t cpu_usage_us, uint64_t net_usage ) {
       uint64_t net_usage_words = net_usage / 8;
       EOS_ASSERT( net_usage_words*8 == net_usage, transaction_exception, "net_usage is not divisible by 8" );
-      pending->_pending_block_state->block->transactions.emplace_back( trx );
-      transaction_receipt& r = pending->_pending_block_state->block->transactions.back();
+      auto& receipts = pending->_block_stage.get<building_block>()._pending_trx_receipts;
+      receipts.emplace_back( trx );
+      transaction_receipt& r = receipts.back();
       r.cpu_usage_us         = cpu_usage_us;
       r.net_usage_words      = net_usage_words;
       r.status               = status;
@@ -1053,7 +1070,7 @@ struct controller_impl {
                                                     ? transaction_receipt::executed
                                                     : transaction_receipt::delayed;
                trace->receipt = push_receipt(*trx->packed_trx, s, trx_context.billed_cpu_time_us, trace->net_usage);
-               pending->_pending_block_state->trxs.emplace_back(trx);
+               pending->_block_stage.get<building_block>()._pending_trx_metas.emplace_back(trx);
             } else {
                transaction_receipt_header r;
                r.status = transaction_receipt::executed;
@@ -1062,7 +1079,7 @@ struct controller_impl {
                trace->receipt = r;
             }
 
-            fc::move_append(pending->_actions, move(trx_context.executed));
+            fc::move_append(pending->_block_stage.get<building_block>()._actions, move(trx_context.executed));
 
             // call the accept signal but only once for this transaction
             if (!trx->accepted) {
@@ -1115,43 +1132,42 @@ struct controller_impl {
          EOS_ASSERT( db.revision() == head->block_num, database_exception, "db revision is not on par with head block",
                      ("db.revision()", db.revision())("controller_head_block", head->block_num)("fork_db_head_block", fork_db.head()->block_num) );
 
-         pending.emplace(maybe_session(db));
+         pending.emplace( maybe_session(db), *head, when, confirm_block_count );
       } else {
-         pending.emplace(maybe_session());
+         pending.emplace( maybe_session(), *head, when, confirm_block_count );
       }
 
       pending->_block_status = s;
       pending->_producer_block_id = producer_block_id;
-      pending->_pending_block_state = std::make_shared<block_state>( *head, when ); // promotes pending schedule (if any) to active
-      pending->_pending_block_state->in_current_chain = true;
 
-      pending->_pending_block_state->set_confirmed(confirm_block_count);
-
-      auto was_pending_promoted = pending->_pending_block_state->maybe_promote_pending();
+      const auto& pbhs = pending->get_pending_block_header_state();
 
       //modify state in speculative block only if we are speculative reads mode (other wise we need clean state for head or irreversible reads)
-      if ( read_mode == db_read_mode::SPECULATIVE || pending->_block_status != controller::block_status::incomplete ) {
-
+      if ( read_mode == db_read_mode::SPECULATIVE || pending->_block_status != controller::block_status::incomplete )
+      {
          const auto& gpo = db.get<global_property_object>();
          if( gpo.proposed_schedule_block_num.valid() && // if there is a proposed schedule that was proposed in a block ...
-             ( *gpo.proposed_schedule_block_num <= pending->_pending_block_state->dpos_irreversible_blocknum ) && // ... that has now become irreversible ...
-             pending->_pending_block_state->pending_schedule.producers.size() == 0 && // ... and there is room for a new pending schedule ...
-             !was_pending_promoted // ... and not just because it was promoted to active at the start of this block, then:
+             ( *gpo.proposed_schedule_block_num <= pbhs.dpos_irreversible_blocknum ) && // ... that has now become irreversible ...
+             pbhs.prev_pending_schedule.producers.size() == 0 // ... and there was room for a new pending schedule prior to any possible promotion
          )
-            {
-               // Promote proposed schedule to pending schedule.
-               if( !replaying ) {
-                  ilog( "promoting proposed schedule (set in block ${proposed_num}) to pending; current block: ${n} lib: ${lib} schedule: ${schedule} ",
-                        ("proposed_num", *gpo.proposed_schedule_block_num)("n", pending->_pending_block_state->block_num)
-                        ("lib", pending->_pending_block_state->dpos_irreversible_blocknum)
-                        ("schedule", static_cast<producer_schedule_type>(gpo.proposed_schedule) ) );
-               }
-               pending->_pending_block_state->set_new_producers( gpo.proposed_schedule );
-               db.modify( gpo, [&]( auto& gp ) {
-                     gp.proposed_schedule_block_num = optional<block_num_type>();
-                     gp.proposed_schedule.clear();
-                  });
+         {
+            // Promote proposed schedule to pending schedule.
+            if( !replaying ) {
+               ilog( "promoting proposed schedule (set in block ${proposed_num}) to pending; current block: ${n} lib: ${lib} schedule: ${schedule} ",
+                     ("proposed_num", *gpo.proposed_schedule_block_num)("n", pbhs.block_num)
+                     ("lib", pbhs.dpos_irreversible_blocknum)
+                     ("schedule", static_cast<producer_schedule_type>(gpo.proposed_schedule) ) );
             }
+
+            EOS_ASSERT( gpo.proposed_schedule.version == pbhs.active_schedule_version + 1,
+                        producer_schedule_exception, "wrong producer schedule version specified" );
+
+            pending->_block_stage.get<building_block>()._new_pending_producer_schedule = gpo.proposed_schedule;
+            db.modify( gpo, [&]( auto& gp ) {
+                  gp.proposed_schedule_block_num = optional<block_num_type>();
+                  gp.proposed_schedule.clear();
+            });
+         }
 
          try {
             auto onbtrx = std::make_shared<transaction_metadata>( get_on_block_transaction() );
@@ -1175,17 +1191,106 @@ struct controller_impl {
       }
 
       guard_pending.cancel();
-   } // start_block
+   } /// start_block
 
+   signed_block_ptr finalize_block()
+   {
+      EOS_ASSERT( pending, block_validate_exception, "it is not valid to finalize when there is no pending block");
+      EOS_ASSERT( pending->_block_stage.contains<building_block>(), block_validate_exception, "already called finalize_block");
 
+      try {
 
-   void sign_block( const std::function<signature_type( const digest_type& )>& signer_callback  ) {
-      auto p = pending->_pending_block_state;
+      auto& pbhs = pending->get_pending_block_header_state();
 
-      p->sign( signer_callback );
+      // Update resource limits:
+      resource_limits.process_account_limit_updates();
+      const auto& chain_config = self.get_global_properties().configuration;
+      uint32_t max_virtual_mult = 1000;
+      uint64_t CPU_TARGET = EOS_PERCENT(chain_config.max_block_cpu_usage, chain_config.target_block_cpu_usage_pct);
+      resource_limits.set_block_parameters(
+         { CPU_TARGET, chain_config.max_block_cpu_usage, config::block_cpu_usage_average_window_ms / config::block_interval_ms, max_virtual_mult, {99, 100}, {1000, 999}},
+         {EOS_PERCENT(chain_config.max_block_net_usage, chain_config.target_block_net_usage_pct), chain_config.max_block_net_usage, config::block_size_average_window_ms / config::block_interval_ms, max_virtual_mult, {99, 100}, {1000, 999}}
+      );
+      resource_limits.process_block_usage(pbhs.block_num);
 
-      static_cast<signed_block_header&>(*p->block) = p->header;
-   } /// sign_block
+      auto& bb = pending->_block_stage.get<building_block>();
+
+      // Create (unsigned) block:
+      auto block_ptr = std::make_shared<signed_block>( pbhs.make_block_header(
+         calculate_trx_merkle(),
+         calculate_action_merkle(),
+         std::move( bb._new_pending_producer_schedule )
+      ) );
+
+      block_ptr->transactions = std::move( bb._pending_trx_receipts );
+
+      // Update TaPoS table:
+      create_block_summary( block_ptr->id() );
+
+      /*
+      ilog( "finalized block ${n} (${id}) at ${t} by ${p} (${signing_key}); schedule_version: ${v} lib: ${lib} #dtrxs: ${ndtrxs} ${np}",
+            ("n",pbhs.block_num)
+            ("id",block_ptr->id())
+            ("t",pbhs.timestamp)
+            ("p",pbhs.producer)
+            ("signing_key", pbhs.block_signing_key)
+            ("v",pbhs.active_schedule_version)
+            ("lib",pbhs.dpos_irreversible_blocknum)
+            ("ndtrxs",db.get_index<generated_transaction_multi_index,by_trx_id>().size())
+            ("np",block_ptr->new_producers)
+      );
+      */
+
+      pending->_block_stage = assembled_block{
+                                 std::move( bb._pending_block_header_state ),
+                                 std::move( bb._pending_trx_metas ),
+                                 block_ptr
+                              };
+
+      return block_ptr;
+   } FC_CAPTURE_AND_RETHROW() } /// finalize_block
+
+   /**
+    * @post regardless of the success of commit block there is no active pending block
+    */
+   void commit_block( bool add_to_fork_db ) {
+      auto reset_pending_on_exit = fc::make_scoped_exit([this]{
+         pending.reset();
+      });
+
+      try {
+         EOS_ASSERT( pending->_block_stage.contains<completed_block>(), block_validate_exception,
+                     "cannot call commit_block until pending block is completed" );
+
+         auto bsp = pending->_block_stage.get<completed_block>()._block_state;
+
+         if (add_to_fork_db) {
+            bsp->in_current_chain = true;
+            bsp->validated = true;
+            auto new_bsp = fork_db.add(bsp, true);
+            emit(self.accepted_block_header, bsp);
+            head = fork_db.head();
+            EOS_ASSERT(new_bsp == head, fork_database_exception, "committed block did not become the new head in fork database");
+         }
+
+         if( !replaying ) {
+            reversible_blocks.create<reversible_block_object>( [&]( auto& ubo ) {
+               ubo.blocknum = bsp->block_num;
+               ubo.set_block( bsp->block );
+            });
+         }
+
+         emit( self.accepted_block, bsp );
+      } catch (...) {
+         // dont bother resetting pending, instead abort the block
+         reset_pending_on_exit.cancel();
+         abort_block();
+         throw;
+      }
+
+      // push the state for pending.
+      pending->push();
+   }
 
    void apply_block( const signed_block_ptr& b, controller::block_status s ) { try {
       try {
@@ -1210,7 +1315,8 @@ struct controller_impl {
 
          size_t packed_idx = 0;
          for( const auto& receipt : b->transactions ) {
-            auto num_pending_receipts = pending->_pending_block_state->block->transactions.size();
+            const auto& trx_receipts = pending->_block_stage.get<building_block>()._pending_trx_receipts;
+            auto num_pending_receipts = trx_receipts.size();
             if( receipt.trx.contains<packed_transaction>() ) {
                trace = push_transaction( packed_transactions.at(packed_idx++), fc::time_point::maximum(), receipt.cpu_usage_us, true );
             } else if( receipt.trx.contains<transaction_id_type>() ) {
@@ -1226,36 +1332,37 @@ struct controller_impl {
                throw *trace->except;
             }
 
-            EOS_ASSERT( pending->_pending_block_state->block->transactions.size() > 0,
+            EOS_ASSERT( trx_receipts.size() > 0,
                         block_validate_exception, "expected a receipt",
                         ("block", *b)("expected_receipt", receipt)
                       );
-            EOS_ASSERT( pending->_pending_block_state->block->transactions.size() == num_pending_receipts + 1,
+            EOS_ASSERT( trx_receipts.size() == num_pending_receipts + 1,
                         block_validate_exception, "expected receipt was not added",
                         ("block", *b)("expected_receipt", receipt)
                       );
-            const transaction_receipt_header& r = pending->_pending_block_state->block->transactions.back();
+            const transaction_receipt_header& r = trx_receipts.back();
             EOS_ASSERT( r == static_cast<const transaction_receipt_header&>(receipt),
                         block_validate_exception, "receipt does not match",
-                        ("producer_receipt", receipt)("validator_receipt", pending->_pending_block_state->block->transactions.back()) );
+                        ("producer_receipt", receipt)("validator_receipt", trx_receipts.back()) );
          }
 
-         finalize_block();
+         auto block_ptr = finalize_block();
 
          // this implicitly asserts that all header fields (less the signature) are identical
-         EOS_ASSERT(producer_block_id == pending->_pending_block_state->header.id(),
-                   block_validate_exception, "Block ID does not match",
-                   ("producer_block_id",producer_block_id)("validator_block_id",pending->_pending_block_state->header.id()));
+         auto id = block_ptr->id();
+         EOS_ASSERT( producer_block_id == id, block_validate_exception, "Block ID does not match",
+                     ("producer_block_id",producer_block_id)("validator_block_id",id) );
 
-         // We need to fill out the pending block state's block because that gets serialized in the reversible block log
-         // in the future we can optimize this by serializing the original and not the copy
+         auto&& ab = pending->_block_stage.get<assembled_block>();
 
-         // we can always trust this signature because,
-         //   - prior to apply_block, we call fork_db.add which does a signature check IFF the block is untrusted
-         //   - OTHERWISE the block is trusted and therefore we trust that the signature is valid
-         // Also, as ::sign_block does not lazily calculate the digest of the block, we can just short-circuit to save cycles
-         pending->_pending_block_state->header.producer_signature = b->producer_signature;
-         static_cast<signed_block_header&>(*pending->_pending_block_state->block) =  pending->_pending_block_state->header;
+         auto bsp = std::make_shared<block_state>(
+                        std::move( ab._pending_block_header_state ),
+                        b,
+                        std::move( ab._trx_metas ),
+                        true // signature should have already been verified (assuming untrusted) prior to apply_block
+                    );
+
+         pending->_block_stage = completed_block{ bsp };
 
          commit_block(false);
          return;
@@ -1404,7 +1511,7 @@ struct controller_impl {
    void abort_block() {
       if( pending ) {
          if ( read_mode == db_read_mode::SPECULATIVE ) {
-            for( const auto& t : pending->_pending_block_state->trxs )
+            for( const auto& t : pending->get_trx_metas() )
                unapplied_transactions[t->signed_id] = t;
          }
          pending.reset();
@@ -1416,69 +1523,28 @@ struct controller_impl {
       return false;
    }
 
-   void set_action_merkle() {
+   checksum256_type calculate_action_merkle() {
       vector<digest_type> action_digests;
-      action_digests.reserve( pending->_actions.size() );
-      for( const auto& a : pending->_actions )
+      const auto& actions = pending->_block_stage.get<building_block>()._actions;
+      action_digests.reserve( actions.size() );
+      for( const auto& a : actions )
          action_digests.emplace_back( a.digest() );
 
-      pending->_pending_block_state->header.action_mroot = merkle( move(action_digests) );
+      return merkle( move(action_digests) );
    }
 
-   void set_trx_merkle() {
+   checksum256_type calculate_trx_merkle() {
       vector<digest_type> trx_digests;
-      const auto& trxs = pending->_pending_block_state->block->transactions;
+      const auto& trxs = pending->_block_stage.get<building_block>()._pending_trx_receipts;
       trx_digests.reserve( trxs.size() );
       for( const auto& a : trxs )
          trx_digests.emplace_back( a.digest() );
 
-      pending->_pending_block_state->header.transaction_mroot = merkle( move(trx_digests) );
+      return merkle( move(trx_digests) );
    }
 
-
-   void finalize_block()
-   {
-      EOS_ASSERT(pending, block_validate_exception, "it is not valid to finalize when there is no pending block");
-      try {
-
-
-      /*
-      ilog( "finalize block ${n} (${id}) at ${t} by ${p} (${signing_key}); schedule_version: ${v} lib: ${lib} #dtrxs: ${ndtrxs} ${np}",
-            ("n",pending->_pending_block_state->block_num)
-            ("id",pending->_pending_block_state->header.id())
-            ("t",pending->_pending_block_state->header.timestamp)
-            ("p",pending->_pending_block_state->header.producer)
-            ("signing_key", pending->_pending_block_state->block_signing_key)
-            ("v",pending->_pending_block_state->header.schedule_version)
-            ("lib",pending->_pending_block_state->dpos_irreversible_blocknum)
-            ("ndtrxs",db.get_index<generated_transaction_multi_index,by_trx_id>().size())
-            ("np",pending->_pending_block_state->header.new_producers)
-            );
-      */
-
-      // Update resource limits:
-      resource_limits.process_account_limit_updates();
-      const auto& chain_config = self.get_global_properties().configuration;
-      uint32_t max_virtual_mult = 1000;
-      uint64_t CPU_TARGET = EOS_PERCENT(chain_config.max_block_cpu_usage, chain_config.target_block_cpu_usage_pct);
-      resource_limits.set_block_parameters(
-         { CPU_TARGET, chain_config.max_block_cpu_usage, config::block_cpu_usage_average_window_ms / config::block_interval_ms, max_virtual_mult, {99, 100}, {1000, 999}},
-         {EOS_PERCENT(chain_config.max_block_net_usage, chain_config.target_block_net_usage_pct), chain_config.max_block_net_usage, config::block_size_average_window_ms / config::block_interval_ms, max_virtual_mult, {99, 100}, {1000, 999}}
-      );
-      resource_limits.process_block_usage(pending->_pending_block_state->block_num);
-
-      set_action_merkle();
-      set_trx_merkle();
-
-      auto p = pending->_pending_block_state;
-      p->id = p->header.id();
-
-      create_block_summary(p->id);
-
-   } FC_CAPTURE_AND_RETHROW() }
-
    void update_producers_authority() {
-      const auto& producers = pending->_pending_block_state->active_schedule.producers;
+      const auto& producers = pending->get_pending_block_header_state().active_schedule.producers;
 
       auto update_permission = [&]( auto& permission, auto threshold ) {
          auto auth = authority( threshold, {}, {});
@@ -1753,13 +1819,23 @@ void controller::start_block( block_timestamp_type when, uint16_t confirm_block_
    my->start_block(when, confirm_block_count, block_status::incomplete, optional<block_id_type>() );
 }
 
-void controller::finalize_block() {
+block_state_ptr controller::finalize_block( const std::function<signature_type( const digest_type& )>& signer_callback ) {
    validate_db_available_size();
-   my->finalize_block();
-}
 
-void controller::sign_block( const std::function<signature_type( const digest_type& )>& signer_callback ) {
-   my->sign_block( signer_callback );
+   auto block_ptr = my->finalize_block();
+
+   auto& ab = my->pending->_block_stage.get<assembled_block>();
+
+   auto bsp = std::make_shared<block_state>(
+                  std::move( ab._pending_block_header_state ),
+                  std::move( block_ptr ),
+                  std::move( ab._trx_metas ),
+                  signer_callback
+              );
+
+   my->pending->_block_stage = completed_block{ bsp };
+
+   return bsp;
 }
 
 void controller::commit_block() {
@@ -1876,18 +1952,41 @@ account_name  controller::fork_db_head_block_producer()const {
    return my->fork_db.head()->header.producer;
 }
 
-block_state_ptr controller::pending_block_state()const {
-   if( my->pending ) return my->pending->_pending_block_state;
-   return block_state_ptr();
-}
 time_point controller::pending_block_time()const {
    EOS_ASSERT( my->pending, block_validate_exception, "no pending block" );
-   return my->pending->_pending_block_state->header.timestamp;
+
+   if( my->pending->_block_stage.contains<completed_block>() )
+      return my->pending->_block_stage.get<completed_block>()._block_state->header.timestamp;
+
+   return my->pending->get_pending_block_header_state().timestamp;
+}
+
+account_name controller::pending_block_producer()const {
+   EOS_ASSERT( my->pending, block_validate_exception, "no pending block" );
+
+   if( my->pending->_block_stage.contains<completed_block>() )
+      return my->pending->_block_stage.get<completed_block>()._block_state->header.producer;
+
+   return my->pending->get_pending_block_header_state().producer;
+}
+
+public_key_type controller::pending_block_signing_key()const {
+   EOS_ASSERT( my->pending, block_validate_exception, "no pending block" );
+
+   if( my->pending->_block_stage.contains<completed_block>() )
+      return my->pending->_block_stage.get<completed_block>()._block_state->block_signing_key;
+
+   return my->pending->get_pending_block_header_state().block_signing_key;
 }
 
 optional<block_id_type> controller::pending_producer_block_id()const {
    EOS_ASSERT( my->pending, block_validate_exception, "no pending block" );
    return my->pending->_producer_block_id;
+}
+
+const vector<transaction_receipt>& controller::get_pending_trx_receipts()const {
+   EOS_ASSERT( my->pending, block_validate_exception, "no pending block" );
+   return my->pending->get_trx_receipts();
 }
 
 uint32_t controller::last_irreversible_block_num() const {
@@ -1984,13 +2083,14 @@ int64_t controller::set_proposed_producers( vector<producer_key> producers ) {
    decltype(sch.producers.cend()) end;
    decltype(end)                  begin;
 
-   if( my->pending->_pending_block_state->pending_schedule.producers.size() == 0 ) {
-      const auto& active_sch = my->pending->_pending_block_state->active_schedule;
+   const auto& pending_sch = pending_producers();
+
+   if( pending_sch.producers.size() == 0 ) {
+      const auto& active_sch = active_producers();
       begin = active_sch.producers.begin();
       end   = active_sch.producers.end();
       sch.version = active_sch.version + 1;
    } else {
-      const auto& pending_sch = my->pending->_pending_block_state->pending_schedule;
       begin = pending_sch.producers.begin();
       end   = pending_sch.producers.end();
       sch.version = pending_sch.version + 1;
@@ -2003,6 +2103,8 @@ int64_t controller::set_proposed_producers( vector<producer_key> producers ) {
 
    int64_t version = sch.version;
 
+   wlog( "proposed producer schedule with version ${v}", ("v", version) );
+
    my->db.modify( gpo, [&]( auto& gp ) {
       gp.proposed_schedule_block_num = cur_block_num;
       gp.proposed_schedule = std::move(sch);
@@ -2011,15 +2113,34 @@ int64_t controller::set_proposed_producers( vector<producer_key> producers ) {
 }
 
 const producer_schedule_type&    controller::active_producers()const {
-   if ( !(my->pending) )
+   if( !(my->pending) )
       return  my->head->active_schedule;
-   return my->pending->_pending_block_state->active_schedule;
+
+   if( my->pending->_block_stage.contains<completed_block>() )
+      return my->pending->_block_stage.get<completed_block>()._block_state->active_schedule;
+
+   return my->pending->get_pending_block_header_state().active_schedule;
 }
 
 const producer_schedule_type&    controller::pending_producers()const {
-   if ( !(my->pending) )
+   if( !(my->pending) )
       return  my->head->pending_schedule;
-   return my->pending->_pending_block_state->pending_schedule;
+
+   if( my->pending->_block_stage.contains<completed_block>() )
+      return my->pending->_block_stage.get<completed_block>()._block_state->pending_schedule;
+
+   if( my->pending->_block_stage.contains<assembled_block>() ) {
+      const auto& np = my->pending->_block_stage.get<assembled_block>()._unsigned_block->new_producers;
+      if( np )
+         return *np;
+   }
+
+   const auto& bb = my->pending->_block_stage.get<building_block>();
+
+   if( bb._new_pending_producer_schedule )
+      return *bb._new_pending_producer_schedule;
+
+   return bb._pending_block_header_state.prev_pending_schedule;
 }
 
 optional<producer_schedule_type> controller::proposed_producers()const {
@@ -2161,6 +2282,10 @@ void controller::check_action_list( account_name code, action_name action )const
 
 void controller::check_key_list( const public_key_type& key )const {
    my->check_key_list( key );
+}
+
+bool controller::is_building_block()const {
+   return my->pending.valid();
 }
 
 bool controller::is_producing_block()const {

--- a/libraries/chain/fork_database.cpp
+++ b/libraries/chain/fork_database.cpp
@@ -110,7 +110,7 @@ namespace eosio { namespace chain {
 
    void fork_database::set( block_state_ptr s ) {
       auto result = my->index.insert( s );
-      EOS_ASSERT( s->id == s->header.id(), fork_database_exception, 
+      EOS_ASSERT( s->id == s->header.id(), fork_database_exception,
                   "block state id (${id}) is different from block state header id (${hid})", ("id", string(s->id))("hid", string(s->header.id())) );
 
          //FC_ASSERT( s->block_num == s->header.block_num() );
@@ -196,8 +196,8 @@ namespace eosio { namespace chain {
          result.second.push_back(second_branch);
          first_branch = get_block( first_branch->header.previous );
          second_branch = get_block( second_branch->header.previous );
-         EOS_ASSERT( first_branch && second_branch, fork_db_block_not_found, 
-                     "either block ${fid} or ${sid} does not exist", 
+         EOS_ASSERT( first_branch && second_branch, fork_db_block_not_found,
+                     "either block ${fid} or ${sid} does not exist",
                      ("fid", string(first_branch->header.previous))("sid", string(second_branch->header.previous)) );
       }
 
@@ -297,6 +297,7 @@ namespace eosio { namespace chain {
       return *nitr;
    }
 
+   /*
    void fork_database::add( const header_confirmation& c ) {
       auto b = get_block( c.block_id );
       EOS_ASSERT( b, fork_db_block_not_found, "unable to find block id ${id}", ("id",c.block_id));
@@ -307,7 +308,8 @@ namespace eosio { namespace chain {
          set_bft_irreversible( c.block_id );
       }
    }
-
+   */
+   
    /**
     *  This method will set this block as being BFT irreversible and will update
     *  all blocks which build off of it to have the same bft_irb if their existing
@@ -315,6 +317,7 @@ namespace eosio { namespace chain {
     *
     *  This will require a search over all forks
     */
+#if 0
    void fork_database::set_bft_irreversible( block_id_type id ) {
       auto& idx = my->index.get<by_block_id>();
       auto itr = idx.find(id);
@@ -354,5 +357,6 @@ namespace eosio { namespace chain {
          queue = update( queue );
       }
    }
+#endif
 
 } } /// eosio::chain

--- a/libraries/chain/include/eosio/chain/block_header.hpp
+++ b/libraries/chain/include/eosio/chain/block_header.hpp
@@ -10,15 +10,15 @@ namespace eosio { namespace chain {
       account_name                     producer;
 
       /**
-       *  By signing this block this producer is confirming blocks [block_num() - confirmed, blocknum()) 
+       *  By signing this block this producer is confirming blocks [block_num() - confirmed, blocknum())
        *  as being the best blocks for that range and that he has not signed any other
-       *  statements that would contradict.  
+       *  statements that would contradict.
        *
        *  No producer should sign a block with overlapping ranges or it is proof of byzantine
        *  behavior. When producing a block a producer is always confirming at least the block he
        *  is building off of.  A producer cannot confirm "this" block, only prior blocks.
        */
-      uint16_t                         confirmed = 1;  
+      uint16_t                         confirmed = 1;
 
       block_id_type                    previous;
 
@@ -34,6 +34,8 @@ namespace eosio { namespace chain {
       optional<producer_schedule_type>  new_producers;
       extensions_type                   header_extensions;
 
+
+      block_header() = default;
 
       digest_type       digest()const;
       block_id_type     id() const;
@@ -55,7 +57,7 @@ namespace eosio { namespace chain {
 
 } } /// namespace eosio::chain
 
-FC_REFLECT(eosio::chain::block_header, 
+FC_REFLECT(eosio::chain::block_header,
            (timestamp)(producer)(confirmed)(previous)
            (transaction_mroot)(action_mroot)
            (schedule_version)(new_producers)(header_extensions))

--- a/libraries/chain/include/eosio/chain/block_state.hpp
+++ b/libraries/chain/include/eosio/chain/block_state.hpp
@@ -12,9 +12,23 @@
 namespace eosio { namespace chain {
 
    struct block_state : public block_header_state {
-      explicit block_state( const block_header_state& cur ):block_header_state(cur){}
-      block_state( const block_header_state& prev, signed_block_ptr b, bool skip_validate_signee );
-      block_state( const block_header_state& prev, block_timestamp_type when );
+      block_state( const block_header_state& prev,
+                   signed_block_ptr b,
+                   bool skip_validate_signee
+                 );
+
+      block_state( pending_block_header_state&& cur,
+                  signed_block_ptr&& b, // unsigned block
+                  vector<transaction_metadata_ptr>&& trx_metas,
+                  const std::function<signature_type(const digest_type&)>& signer
+                );
+
+      block_state( pending_block_header_state&& cur,
+                   const signed_block_ptr& b, // signed block
+                   vector<transaction_metadata_ptr>&& trx_metas,
+                   bool skip_validate_signee
+                 );
+
       block_state() = default;
 
       /// weak_ptr prev_block_state....

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -139,7 +139,7 @@ namespace eosio { namespace chain {
           */
          transaction_trace_ptr push_scheduled_transaction( const transaction_id_type& scheduled, fc::time_point deadline, uint32_t billed_cpu_time_us = 0 );
 
-         void finalize_block();
+         block_state_ptr finalize_block( const std::function<signature_type( const digest_type& )>& signer_callback );
          void sign_block( const std::function<signature_type( const digest_type& )>& signer_callback );
          void commit_block();
          void pop_block();
@@ -188,8 +188,11 @@ namespace eosio { namespace chain {
          account_name         fork_db_head_block_producer()const;
 
          time_point              pending_block_time()const;
-         block_state_ptr         pending_block_state()const;
+         account_name            pending_block_producer()const;
+         public_key_type         pending_block_signing_key()const;
          optional<block_id_type> pending_producer_block_id()const;
+
+         const vector<transaction_receipt>& get_pending_trx_receipts()const;
 
          const producer_schedule_type&    active_producers()const;
          const producer_schedule_type&    pending_producers()const;
@@ -214,6 +217,7 @@ namespace eosio { namespace chain {
          void check_contract_list( account_name code )const;
          void check_action_list( account_name code, action_name action )const;
          void check_key_list( const public_key_type& key )const;
+         bool is_building_block()const;
          bool is_producing_block()const;
 
          bool is_ram_billing_in_notify_allowed()const;

--- a/libraries/chain/include/eosio/chain/fork_database.hpp
+++ b/libraries/chain/include/eosio/chain/fork_database.hpp
@@ -44,7 +44,7 @@ namespace eosio { namespace chain {
          block_state_ptr add( const block_state_ptr& next_block, bool skip_validate_previous );
          void            remove( const block_id_type& id );
 
-         void            add( const header_confirmation& c );
+         //void            add( const header_confirmation& c );
 
          const block_state_ptr& head()const;
 
@@ -71,7 +71,7 @@ namespace eosio { namespace chain {
          signal<void(block_state_ptr)> irreversible;
 
       private:
-         void set_bft_irreversible( block_id_type id );
+         //void set_bft_irreversible( block_id_type id );
          unique_ptr<fork_database_impl> my;
    };
 

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -162,7 +162,7 @@ namespace bacc = boost::accumulators;
          undo_session = c.mutable_db().start_undo_session(true);
       }
       trace->id = id;
-      trace->block_num = c.pending_block_state()->block_num;
+      trace->block_num = c.head_block_num() + 1;
       trace->block_time = c.pending_block_time();
       trace->producer_block_id = c.pending_producer_block_id();
       executed.reserve( trx.total_actions() );

--- a/plugins/history_plugin/history_plugin.cpp
+++ b/plugins/history_plugin/history_plugin.cpp
@@ -264,7 +264,7 @@ namespace eosio {
                   datastream<char*> ds( aho.packed_action_trace.data(), ps );
                   fc::raw::pack( ds, at );
                   aho.action_sequence_num = at.receipt.global_sequence;
-                  aho.block_num = chain.pending_block_state()->block_num;
+                  aho.block_num = chain.head_block_num() + 1;
                   aho.block_time = chain.pending_block_time();
                   aho.trx_id     = at.trx_id;
                });
@@ -348,7 +348,7 @@ namespace eosio {
          auto& chain = my->chain_plug->chain();
 
          chainbase::database& db = const_cast<chainbase::database&>( chain.db() ); // Override read-only access to state DB (highly unrecommended practice!)
-         // TODO: Use separate chainbase database for managing the state of the history_plugin (or remove deprecated history_plugin entirely) 
+         // TODO: Use separate chainbase database for managing the state of the history_plugin (or remove deprecated history_plugin entirely)
          db.add_index<account_history_index>();
          db.add_index<action_history_index>();
          db.add_index<account_control_history_multi_index>();
@@ -493,15 +493,16 @@ namespace eosio {
               ++itr;
             }
 
+
+            const vector<transaction_receipt>* receipts = nullptr;
             auto blk = chain.fetch_block_by_number( result.block_num );
-            if( blk == nullptr ) { // still in pending
-                auto blk_state = chain.pending_block_state();
-                if( blk_state != nullptr ) {
-                    blk = blk_state->block;
-                }
+            if( blk ) {
+               receipts = &blk->transactions;
+            } else if( chain.is_building_block() ) { // still in pending
+               receipts = &chain.get_pending_trx_receipts();
             }
-            if( blk != nullptr ) {
-                for (const auto &receipt: blk->transactions) {
+            if( receipts ) {
+                for (const auto &receipt: *receipts) {
                     if (receipt.trx.contains<packed_transaction>()) {
                         auto &pt = receipt.trx.get<packed_transaction>();
                         if (pt.id() == result.id) {

--- a/plugins/test_control_plugin/test_control_plugin.cpp
+++ b/plugins/test_control_plugin/test_control_plugin.cpp
@@ -23,8 +23,7 @@ public:
 private:
    void accepted_block(const chain::block_state_ptr& bsp);
    void applied_irreversible_block(const chain::block_state_ptr& bsp);
-   void retrieve_next_block_state(const chain::block_state_ptr& bsp);
-   void process_next_block_state(const chain::block_header_state& bhs);
+   void process_next_block_state(const chain::block_state_ptr& bsp);
 
    fc::optional<boost::signals2::scoped_connection> _accepted_block_connection;
    fc::optional<boost::signals2::scoped_connection> _irreversible_block_connection;
@@ -55,26 +54,17 @@ void test_control_plugin_impl::disconnect() {
 
 void test_control_plugin_impl::applied_irreversible_block(const chain::block_state_ptr& bsp) {
    if (_track_lib)
-      retrieve_next_block_state(bsp);
+      process_next_block_state(bsp);
 }
 
 void test_control_plugin_impl::accepted_block(const chain::block_state_ptr& bsp) {
    if (_track_head)
-      retrieve_next_block_state(bsp);
+      process_next_block_state(bsp);
 }
 
-void test_control_plugin_impl::retrieve_next_block_state(const chain::block_state_ptr& bsp) {
-   const auto hbn = bsp->block_num;
-   auto new_block_header = bsp->header;
-   new_block_header.timestamp = new_block_header.timestamp.next();
-   new_block_header.previous = bsp->id;
-   auto new_bs = bsp->generate_next(new_block_header.timestamp);
-   process_next_block_state(new_bs);
-}
-
-void test_control_plugin_impl::process_next_block_state(const chain::block_header_state& bhs) {
+void test_control_plugin_impl::process_next_block_state(const chain::block_state_ptr& bsp) {
    const auto block_time = _chain.head_block_time() + fc::microseconds(chain::config::block_interval_us);
-   const auto& producer_name = bhs.get_scheduled_producer(block_time).producer_name;
+   auto producer_name = bsp->get_scheduled_producer(block_time).producer_name;
    // start counting sequences for this producer (once we
    if (producer_name == _producer && _clean_producer_sequence) {
       _producer_sequence += 1;

--- a/unittests/forked_tests.cpp
+++ b/unittests/forked_tests.cpp
@@ -43,7 +43,7 @@ BOOST_AUTO_TEST_CASE( irrblock ) try {
    wlog("set producer schedule to [dan,sam,pam]");
    c.produce_blocks(50);
 
-} FC_LOG_AND_RETHROW() 
+} FC_LOG_AND_RETHROW()
 
 struct fork_tracker {
    vector<signed_block_ptr> blocks;
@@ -60,7 +60,7 @@ BOOST_AUTO_TEST_CASE( fork_with_bad_block ) try {
    auto res = bios.set_producers( {N(a),N(b),N(c),N(d),N(e)} );
 
    // run until the producers are installed and its the start of "a's" round
-   while( bios.control->pending_block_state()->header.producer.to_string() != "a" || bios.control->head_block_state()->header.producer.to_string() != "e") {
+   while( bios.control->pending_block_producer().to_string() != "a" || bios.control->head_block_state()->header.producer.to_string() != "e") {
       bios.produce_block();
    }
 
@@ -313,7 +313,7 @@ BOOST_AUTO_TEST_CASE( prune_remove_branch ) try {
    auto nextproducer = [](tester &c, int skip_interval) ->account_name {
       auto head_time = c.control->head_block_time();
       auto next_time = head_time + fc::milliseconds(config::block_interval_ms * skip_interval);
-      return c.control->head_block_state()->get_scheduled_producer(next_time).producer_name;   
+      return c.control->head_block_state()->get_scheduled_producer(next_time).producer_name;
    };
 
    // fork c: 2 producers: dan, sam
@@ -323,18 +323,18 @@ BOOST_AUTO_TEST_CASE( prune_remove_branch ) try {
       account_name next1 = nextproducer(c, skip1);
       if (next1 == N(dan) || next1 == N(sam)) {
          c.produce_block(fc::milliseconds(config::block_interval_ms * skip1)); skip1 = 1;
-      } 
+      }
       else ++skip1;
       account_name next2 = nextproducer(c2, skip2);
       if (next2 == N(scott)) {
          c2.produce_block(fc::milliseconds(config::block_interval_ms * skip2)); skip2 = 1;
-      } 
+      }
       else ++skip2;
    }
 
    BOOST_REQUIRE_EQUAL(87, c.control->head_block_num());
    BOOST_REQUIRE_EQUAL(73, c2.control->head_block_num());
-   
+
    // push fork from c2 => c
    int p = fork_num;
    while ( p < c2.control->head_block_num()) {
@@ -344,7 +344,7 @@ BOOST_AUTO_TEST_CASE( prune_remove_branch ) try {
 
    BOOST_REQUIRE_EQUAL(73, c.control->head_block_num());
 
-} FC_LOG_AND_RETHROW() 
+} FC_LOG_AND_RETHROW()
 
 
 BOOST_AUTO_TEST_CASE( read_modes ) try {

--- a/unittests/producer_schedule_tests.cpp
+++ b/unittests/producer_schedule_tests.cpp
@@ -239,7 +239,7 @@ BOOST_FIXTURE_TEST_CASE( producer_schedule_promotion_test, TESTER ) try {
    produce_blocks(23); // Alice produces the last block of her first round.
                     // Bob's first block (which advances LIB to Alice's last block) is started but not finalized.
    BOOST_REQUIRE_EQUAL( control->head_block_producer(), N(alice) );
-   BOOST_REQUIRE_EQUAL( control->pending_block_state()->header.producer, N(bob) );
+   BOOST_REQUIRE_EQUAL( control->pending_block_producer(), N(bob) );
    BOOST_CHECK_EQUAL( control->pending_producers().version, 2 );
 
    produce_blocks(12); // Bob produces his first 11 blocks
@@ -247,7 +247,7 @@ BOOST_FIXTURE_TEST_CASE( producer_schedule_promotion_test, TESTER ) try {
    produce_blocks(12); // Bob produces his 12th block.
                     // Alice's first block of the second round is started but not finalized (which advances LIB to Bob's last block).
    BOOST_REQUIRE_EQUAL( control->head_block_producer(), N(alice) );
-   BOOST_REQUIRE_EQUAL( control->pending_block_state()->header.producer, N(bob) );
+   BOOST_REQUIRE_EQUAL( control->pending_block_producer(), N(bob) );
    BOOST_CHECK_EQUAL( control->active_producers().version, 2 );
    BOOST_CHECK_EQUAL( true, compare_schedules( sch2, control->active_producers() ) );
 
@@ -299,7 +299,7 @@ BOOST_FIXTURE_TEST_CASE( producer_schedule_reduction, tester ) try {
 
    produce_blocks(48);
    BOOST_REQUIRE_EQUAL( control->head_block_producer(), N(bob) );
-   BOOST_REQUIRE_EQUAL( control->pending_block_state()->header.producer, N(carol) );
+   BOOST_REQUIRE_EQUAL( control->pending_block_producer(), N(carol) );
    BOOST_CHECK_EQUAL( control->pending_producers().version, 2 );
 
    produce_blocks(47);
@@ -307,7 +307,7 @@ BOOST_FIXTURE_TEST_CASE( producer_schedule_reduction, tester ) try {
    produce_blocks(1);
 
    BOOST_REQUIRE_EQUAL( control->head_block_producer(), N(carol) );
-   BOOST_REQUIRE_EQUAL( control->pending_block_state()->header.producer, N(alice) );
+   BOOST_REQUIRE_EQUAL( control->pending_block_producer(), N(alice) );
    BOOST_CHECK_EQUAL( control->active_producers().version, 2 );
    BOOST_CHECK_EQUAL( true, compare_schedules( sch2, control->active_producers() ) );
 


### PR DESCRIPTION
This is a refactor of how `block_header_state`s are updated as new blocks come in. It conceptually simplifies the process by introducing a `pending_block_header_state` for the new block which is then finalized to the `block_header_state` when the necessary information to do so becomes available. This two stage process allows the class instances to remain immutable after instantiation and thereby get type safety benefits and lower developer cognitive overhead with the previous approach of mutating the `block_header_state` as it moves along through this process.

This refactor helps prepare for the later changes that will be made to `block_header_state` to introduce the field tracking the currently activated protocol features (which is not yet included in this change).

I am aware that this change will break both snapshots and the serialization format of `forkdb.dat`. This is the first part of a larger sequence of other refactors and further changes towards building the foundations that enable consensus protocol upgrade features. With those later changes, the `forkdb.dat` format will officially change and the new format will be stored with proper versioning in a file `fork_db.dat`. Furthermore, the later changes would introduce a second version of the chain snapshot and nodeos will not support reading from the first version of chain snapshots. These eventual changes will force a replay from genesis, which is desired behavior to support one of the protocol features planned.
