### PR TITLE
Use https url for wabt submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -14,4 +14,4 @@
 	url = https://github.com/EOSIO/fc
 [submodule "libraries/wabt"]
 	path = libraries/wabt
-	url = http://github.com/EOSIO/wabt
+	url = https://github.com/EOSIO/wabt


### PR DESCRIPTION
## Change Description

A user agent that doesn't respect hsts could potentially be coerced into downloading malicious sources for wabt via a mitm attack. Prevent this by using a https upstream like the other submodules already do

## Consensus Changes

n/a

## API Changes

n/a

## Documentation Additions

n/a