### PR TITLE
Revert ability to customize name of http_plugin options

### DIFF
--- a/plugins/http_plugin/http_plugin.cpp
+++ b/plugins/http_plugin/http_plugin.cpp
@@ -150,10 +150,6 @@ namespace eosio {
          bool                     validate_host;
          set<string>              valid_hosts;
 
-         string                   unix_socket_path_option_name     = "unix-socket-path";
-         string                   http_server_address_option_name  = "http-server-address";
-         string                   https_server_address_option_name = "https-server-address";
-
          bool host_port_is_valid( const std::string& header_host_port, const string& endpoint_local_host_port ) {
             return !validate_host || header_host_port == endpoint_local_host_port || valid_hosts.find(header_host_port) != valid_hosts.end();
          }
@@ -328,14 +324,6 @@ namespace eosio {
             valid_hosts.emplace(host + ":" + port);
             valid_hosts.emplace(host + ":" + resolved_port_str);
          }
-
-         void mangle_option_names() {
-            if(current_http_plugin_defaults.address_config_prefix.empty())
-               return;
-            unix_socket_path_option_name.insert(0, current_http_plugin_defaults.address_config_prefix+"-");
-            http_server_address_option_name.insert(0, current_http_plugin_defaults.address_config_prefix+"-");
-            https_server_address_option_name.insert(0, current_http_plugin_defaults.address_config_prefix+"-");
-         }
    };
 
    template<>
@@ -347,23 +335,22 @@ namespace eosio {
    http_plugin::~http_plugin(){}
 
    void http_plugin::set_program_options(options_description&, options_description& cfg) {
-      my->mangle_option_names();
       if(current_http_plugin_defaults.default_unix_socket_path.length())
          cfg.add_options()
-            (my->unix_socket_path_option_name.c_str(), bpo::value<string>()->default_value(current_http_plugin_defaults.default_unix_socket_path),
+            ("unix-socket-path", bpo::value<string>()->default_value(current_http_plugin_defaults.default_unix_socket_path),
              "The filename (relative to data-dir) to create a unix socket for HTTP RPC; set blank to disable.");
 
       if(current_http_plugin_defaults.default_http_port)
          cfg.add_options()
-            (my->http_server_address_option_name.c_str(), bpo::value<string>()->default_value("127.0.0.1:" + std::to_string(current_http_plugin_defaults.default_http_port)),
+            ("http-server-address", bpo::value<string>()->default_value("127.0.0.1:" + std::to_string(current_http_plugin_defaults.default_http_port)),
              "The local IP and port to listen for incoming http connections; set blank to disable.");
       else
          cfg.add_options()
-            (my->http_server_address_option_name.c_str(), bpo::value<string>(),
+            ("http-server-address", bpo::value<string>(),
              "The local IP and port to listen for incoming http connections; leave blank to disable.");
 
       cfg.add_options()
-            (my->https_server_address_option_name.c_str(), bpo::value<string>(),
+            ("https-server-address", bpo::value<string>(),
              "The local IP and port to listen for incoming https connections; leave blank to disable.")
 
             ("https-certificate-chain-file", bpo::value<string>(),
@@ -412,8 +399,8 @@ namespace eosio {
          }
 
          tcp::resolver resolver( app().get_io_service());
-         if( options.count( my->http_server_address_option_name ) && options.at( my->http_server_address_option_name ).as<string>().length()) {
-            string lipstr = options.at( my->http_server_address_option_name ).as<string>();
+         if( options.count( "http-server-address" ) && options.at( "http-server-address" ).as<string>().length()) {
+            string lipstr = options.at( "http-server-address" ).as<string>();
             string host = lipstr.substr( 0, lipstr.find( ':' ));
             string port = lipstr.substr( host.size() + 1, lipstr.size());
             tcp::resolver::query query( tcp::v4(), host.c_str(), port.c_str());
@@ -431,14 +418,14 @@ namespace eosio {
             }
          }
 
-         if( options.count( my->unix_socket_path_option_name ) && !options.at( my->unix_socket_path_option_name ).as<string>().empty()) {
-            boost::filesystem::path sock_path = options.at(my->unix_socket_path_option_name).as<string>();
+         if( options.count( "unix-socket-path" ) && !options.at( "unix-socket-path" ).as<string>().empty()) {
+            boost::filesystem::path sock_path = options.at("unix-socket-path").as<string>();
             if (sock_path.is_relative())
                sock_path = app().data_dir() / sock_path;
             my->unix_endpoint = asio::local::stream_protocol::endpoint(sock_path.string());
          }
 
-         if( options.count( my->https_server_address_option_name ) && options.at( my->https_server_address_option_name ).as<string>().length()) {
+         if( options.count( "https-server-address" ) && options.at( "https-server-address" ).as<string>().length()) {
             if( !options.count( "https-certificate-chain-file" ) ||
                 options.at( "https-certificate-chain-file" ).as<string>().empty()) {
                elog( "https-certificate-chain-file is required for HTTPS" );
@@ -450,7 +437,7 @@ namespace eosio {
                return;
             }
 
-            string lipstr = options.at( my->https_server_address_option_name ).as<string>();
+            string lipstr = options.at( "https-server-address" ).as<string>();
             string host = lipstr.substr( 0, lipstr.find( ':' ));
             string port = lipstr.substr( host.size() + 1, lipstr.size());
             tcp::resolver::query query( tcp::v4(), host.c_str(), port.c_str());

--- a/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
@@ -41,9 +41,6 @@ namespace eosio {
    using api_description = std::map<string, url_handler>;
 
    struct http_plugin_defaults {
-      //If not empty, this string is prepended on to the various configuration
-      // items for setting listen addresses
-      string address_config_prefix;
       //If empty, unix socket support will be completely disabled. If not empty,
       // unix socket support is enabled with the given default path (treated relative
       // to the datadir)

--- a/programs/keosd/main.cpp
+++ b/programs/keosd/main.cpp
@@ -41,7 +41,6 @@ int main(int argc, char** argv)
       app().set_default_data_dir(home / "eosio-wallet");
       app().set_default_config_dir(home / "eosio-wallet");
       http_plugin::set_defaults({
-         .address_config_prefix = "",
          .default_unix_socket_path = keosd::config::key_store_executable_name + ".sock",
          .default_http_port = 0
       });

--- a/programs/nodeos/main.cpp
+++ b/programs/nodeos/main.cpp
@@ -97,7 +97,6 @@ int main(int argc, char** argv)
       app().set_default_data_dir(root / "eosio/nodeos/data" );
       app().set_default_config_dir(root / "eosio/nodeos/config" );
       http_plugin::set_defaults({
-         .address_config_prefix = "",
          .default_unix_socket_path = "",
          .default_http_port = 8888
       });


### PR DESCRIPTION


<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- Give your PR a title that is sufficient to understand what is being changed. -->

## Change Description
Once upon a time it was thought we may change the http_plugin option names per application. For example, nodeos would be http-server-address but keosd would be keosd-http-server-address. Ultimately this was not done, so remove this code to make the http option code simple again
<!-- Describe the change you made, the motivation for it, and the impact it will have. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

## Consensus Changes

<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes

<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions

<!-- List all the information that needs to be added to the documentation after merge. -->
