### PR TITLE
Use https url for wabt submodule - 1.5.x

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -29,4 +29,4 @@
 	url = https://github.com/EOSIO/fc
 [submodule "libraries/wabt"]
 	path = libraries/wabt
-	url = http://github.com/EOSIO/wabt
+	url = https://github.com/EOSIO/wabt


### PR DESCRIPTION
A user agent that doesn't respect hsts could potentially be coerced into downloading malicious sources for wabt via a mitm attack. Prevent this by using a https upstream like the other submodules already do

<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- Give your PR a title that is sufficient to understand what is being changed. -->

## Change Description

<!-- Describe the change you made, the motivation for it, and the impact it will have. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

## Consensus Changes

<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes

<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions

<!-- List all the information that needs to be added to the documentation after merge. -->
