### PR TITLE
get_code_id intrinsic API

### DIFF
--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -184,6 +184,10 @@ void apply_context::require_recipient( account_name recipient ) {
    }
 }
 
+checksum256_type apply_context::get_code_id( const account_name& code )const {
+   const auto& account = db.get<account_object,by_name>(code);
+   return account.code_version;
+}
 
 /**
  *  This will execute an action after checking the authorization. Inline transactions are

--- a/libraries/chain/include/eosio/chain/apply_context.hpp
+++ b/libraries/chain/include/eosio/chain/apply_context.hpp
@@ -513,6 +513,11 @@ class apply_context {
        */
       bool has_recipient(account_name account)const;
 
+      /**
+       * Return code_id of the specified account
+       */
+      checksum256_type get_code_id(const account_name& code)const;
+
    /// Console methods:
    public:
 

--- a/libraries/chain/wasm_interface.cpp
+++ b/libraries/chain/wasm_interface.cpp
@@ -885,6 +885,9 @@ class authorization_api : public context_aware_api {
       return context.is_account( account );
    }
 
+   void get_code_id( const account_name& account, fc::sha256& code_id )const {
+      code_id = context.get_code_id( account );
+   }
 };
 
 class system_api : public context_aware_api {
@@ -1789,6 +1792,7 @@ REGISTER_INTRINSICS(authorization_api,
    (require_authorization, void(int64_t, int64_t), "require_auth2", void(authorization_api::*)(const account_name&, const permission_name& permission) )
    (has_authorization,     int(int64_t), "has_auth", bool(authorization_api::*)(const account_name&)const )
    (is_account,            int(int64_t)           )
+   (get_code_id,           void(int64_t, int)     )
 );
 
 REGISTER_INTRINSICS(console_api,


### PR DESCRIPTION
## Change Description

`hardfork` is required. User can check whether code is changed before sending an inline action.

## Consensus Changes

None.

## API Changes

`void get_code_id(capi_name code, capi_checksum256* hash);` would be added into `eosiolib` in CDT.

## Documentation Additions

Description for new contract API `get_code_id` would be added.