### PR TITLE
Set minimum dependencies for Debian packages.

### DIFF
--- a/scripts/generate_deb.sh
+++ b/scripts/generate_deb.sh
@@ -33,14 +33,14 @@ fi
 
 mkdir -p ${PROJECT}/DEBIAN
 chmod 0755 ${PROJECT}/DEBIAN
-echo "Package: ${PROJECT} 
+echo "Package: ${PROJECT}
 Version: ${VERSION_NO_SUFFIX}-${RELEASE}
 Section: devel
 Priority: optional
 Depends: libc6, libgcc1, ${LIBSSL}, libstdc++6, libtinfo5, zlib1g
 Architecture: amd64
-Homepage: ${URL} 
-Maintainer: ${EMAIL} 
+Homepage: ${URL}
+Maintainer: ${EMAIL}
 Description: ${DESC}" &> ${PROJECT}/DEBIAN/control
 
 export PREFIX
@@ -50,8 +50,8 @@ export SSUBPREFIX
 
 bash generate_tarball.sh ${NAME}.tar.gz
 
-tar -xvzf ${NAME}.tar.gz -C ${PROJECT} 
-dpkg-deb --build ${PROJECT} 
+tar -xvzf ${NAME}.tar.gz -C ${PROJECT}
+dpkg-deb --build ${PROJECT}
 BUILDSTATUS=$?
 mv ${PROJECT}.deb ${NAME}.deb
 rm -r ${PROJECT}

--- a/scripts/generate_deb.sh
+++ b/scripts/generate_deb.sh
@@ -15,14 +15,14 @@ NAME="${PROJECT}_${VERSION_NO_SUFFIX}-${RELEASE}_amd64"
 
 mkdir -p ${PROJECT}/DEBIAN
 chmod 0755 ${PROJECT}/DEBIAN
-echo "Package: ${PROJECT}
+echo "Package: ${PROJECT} 
 Version: ${VERSION_NO_SUFFIX}-${RELEASE}
 Section: devel
 Priority: optional
-Depends: libbz2-dev (>= 1.0), libssl-dev (>= 1.0), libgmp3-dev, build-essential, libicu-dev, zlib1g-dev, libtinfo5
+Depends: libc6, libgcc1, libssl1.0.0, libstdc++6, libtinfo5, zlib1g
 Architecture: amd64
-Homepage: ${URL}
-Maintainer: ${EMAIL}
+Homepage: ${URL} 
+Maintainer: ${EMAIL} 
 Description: ${DESC}" &> ${PROJECT}/DEBIAN/control
 
 export PREFIX
@@ -32,8 +32,8 @@ export SSUBPREFIX
 
 bash generate_tarball.sh ${NAME}.tar.gz
 
-tar -xvzf ${NAME}.tar.gz -C ${PROJECT}
-dpkg-deb --build ${PROJECT}
+tar -xvzf ${NAME}.tar.gz -C ${PROJECT} 
+dpkg-deb --build ${PROJECT} 
 BUILDSTATUS=$?
 mv ${PROJECT}.deb ${NAME}.deb
 rm -r ${PROJECT}

--- a/scripts/generate_deb.sh
+++ b/scripts/generate_deb.sh
@@ -13,13 +13,31 @@ fi
 
 NAME="${PROJECT}_${VERSION_NO_SUFFIX}-${RELEASE}_amd64"
 
+if [[ -f /etc/upstream-release/lsb-release ]]; then
+  source /etc/upstream-release/lsb-release
+elif [[ -f /etc/lsb-release ]]; then
+  source /etc/lsb-release
+else
+  echo "Unrecognized Debian derivative.  Not generating .deb file."
+  exit 1
+fi
+
+if [ ${DISTRIB_RELEASE} = "16.04" ]; then
+  LIBSSL="libssl1.0.0"
+elif [ ${DISTRIB_RELEASE} = "18.04" ]; then
+  LIBSSL="libssl1.1"
+else
+  echo "Unrecognized Ubuntu version.  Update generate_deb.sh.  Not generating .deb file."
+  exit 1
+fi
+
 mkdir -p ${PROJECT}/DEBIAN
 chmod 0755 ${PROJECT}/DEBIAN
 echo "Package: ${PROJECT} 
 Version: ${VERSION_NO_SUFFIX}-${RELEASE}
 Section: devel
 Priority: optional
-Depends: libc6, libgcc1, libssl1.0.0, libstdc++6, libtinfo5, zlib1g
+Depends: libc6, libgcc1, ${LIBSSL}, libstdc++6, libtinfo5, zlib1g
 Architecture: amd64
 Homepage: ${URL} 
 Maintainer: ${EMAIL} 


### PR DESCRIPTION

<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- Give your PR a title that is sufficient to understand what is being changed. -->

## Change Description

Set minimum dependencies for Debian packages. Also ensure Debian subdirectory has correct permissions regardless of umask while packaging.  Resolves #6618.

## Consensus Changes

N/A

## API Changes

N/A

## Documentation Additions

N/A
