### PR TITLE
Fix IS #5418

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,9 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules")
 
 if (UNIX)
    if (APPLE)
+      execute_process(COMMAND xcrun --show-sdk-path
+                      OUTPUT_VARIABLE CMAKE_OSX_SYSROOT
+                      OUTPUT_STRIP_TRAILING_WHITESPACE)
       if (LLVM_DIR STREQUAL "" OR NOT LLVM_DIR)
          set(LLVM_DIR "/usr/local/Cellar/llvm@4/4.0.1/lib/cmake/llvm")
       endif()


### PR DESCRIPTION

## Change Description
Fix the framework tdd file out of sync warning without user having to delete files on MacOS

## Consensus Changes

N/A

## API Changes

N/A

## Documentation Additions

N/A