### PR TITLE
Remove queued HTTP handler registration

### DIFF
--- a/plugins/http_plugin/http_plugin.cpp
+++ b/plugins/http_plugin/http_plugin.cpp
@@ -560,9 +560,7 @@ namespace eosio {
 
    void http_plugin::add_handler(const string& url, const url_handler& handler) {
       ilog( "add api url: ${c}", ("c",url) );
-      app().post(priority::low, [=](){
-        my->url_handlers.insert(std::make_pair(url,handler));
-      });
+      my->url_handlers.insert(std::make_pair(url,handler));
    }
 
    void http_plugin::handle_exception( const char *api_name, const char *call_name, const string& body, url_response_callback cb ) {


### PR DESCRIPTION


<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- Give your PR a title that is sufficient to understand what is being changed. -->

## Change Description
websocketpp's socket handlers run at ultra-high priority which means they can beat registration of HTTP endpoints because they are queued via low priority. This is what happened in #6683 where the websocketpp code handled an incoming request but the endpoint registration was still queued up low priority

No real reason needed to queue up registration of handlers at this point so just remove this queue
<!-- Describe the change you made, the motivation for it, and the impact it will have. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

## Consensus Changes

<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes

<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions

<!-- List all the information that needs to be added to the documentation after merge. -->
