### PR TITLE
Http response thread pool

### DIFF
--- a/plugins/http_plugin/http_plugin.cpp
+++ b/plugins/http_plugin/http_plugin.cpp
@@ -322,7 +322,8 @@ namespace eosio {
                ws.init_asio(&(*server_ioc));
                ws.set_reuse_addr(true);
                ws.set_max_http_body_size(max_body_size);
-               ws.set_http_handler([&](connection_hdl hdl) {
+               auto ioc = server_ioc; // capture server_ioc shared_ptr in http handler to keep it alive while in use
+               ws.set_http_handler([&, ioc](connection_hdl hdl) {
                   handle_http_request<detail::asio_with_stub_log<T>>(ws.get_con_from_hdl(hdl));
                });
             } catch ( const fc::exception& e ){

--- a/plugins/http_plugin/http_plugin.cpp
+++ b/plugins/http_plugin/http_plugin.cpp
@@ -300,7 +300,7 @@ namespace eosio {
                if( handler_itr != url_handlers.end()) {
                   con->defer_http_response();
                   bytes_in_flight += body.size();
-                  app().post( appbase::priority::low-1,
+                  app().post( appbase::priority::low,
                               [&tp = *this->thread_pool, &bytes_in_flight = this->bytes_in_flight, handler_itr,
                                resource{std::move( resource )}, body{std::move( body )}, con]() {
                      try {
@@ -545,10 +545,10 @@ namespace eosio {
       if(my->unix_endpoint) {
          try {
             my->unix_server.clear_access_channels(websocketpp::log::alevel::all);
-            my->unix_server.init_asio(&app().get_io_service());
+            my->unix_server.init_asio(&(*my->server_ioc));
             my->unix_server.set_max_http_body_size(my->max_body_size);
             my->unix_server.listen(*my->unix_endpoint);
-            my->unix_server.set_http_handler([&](connection_hdl hdl) {
+            my->unix_server.set_http_handler([&, ioc = my->server_ioc](connection_hdl hdl) {
                my->handle_http_request<detail::asio_local_with_stub_log>( my->unix_server.get_con_from_hdl(hdl));
             });
             my->unix_server.start_accept();

--- a/plugins/http_plugin/http_plugin.cpp
+++ b/plugins/http_plugin/http_plugin.cpp
@@ -144,6 +144,7 @@ namespace eosio {
          std::shared_ptr<boost::asio::io_context>    server_ioc;
          optional<io_work_t>                         server_ioc_work;
          std::atomic<int64_t>                        bytes_in_flight{0};
+         size_t                                      max_bytes_in_flight = 0;
 
          optional<tcp::endpoint>  https_listen_endpoint;
          string                   https_cert_chain;
@@ -418,6 +419,8 @@ namespace eosio {
              "Specify if Access-Control-Allow-Credentials: true should be returned on each request.")
             ("max-body-size", bpo::value<uint32_t>()->default_value(1024*1024),
              "The maximum body size in bytes allowed for incoming RPC requests")
+            ("http-max-bytes-in-flight-mb", bpo::value<uint32_t>()->default_value(500),
+             "Maximum size in megabytes http_plugin should use for processing http requests. 503 error response when exceeded." )
             ("verbose-http-errors", bpo::bool_switch()->default_value(false),
              "Append the error log to HTTP responses")
             ("http-validate-host", boost::program_options::value<bool>()->default_value(true),
@@ -503,6 +506,8 @@ namespace eosio {
          my->thread_pool_size = options.at( "http-threads" ).as<uint16_t>();
          EOS_ASSERT( my->thread_pool_size > 1, chain::plugin_config_exception,
                      "http-threads ${num} must be greater than 1", ("num", my->thread_pool_size));
+
+         my->max_bytes_in_flight = options.at( "http-max-bytes-in-flight-mb" ).as<uint32_t>() * 1024 * 1024;
 
          //watch out for the returns above when adding new code here
       } FC_LOG_AND_RETHROW()

--- a/plugins/http_plugin/http_plugin.cpp
+++ b/plugins/http_plugin/http_plugin.cpp
@@ -286,7 +286,7 @@ namespace eosio {
 
                con->append_header( "Content-type", "application/json" );
 
-               if( bytes_in_flight > 500*1024*1024 ) {
+               if( bytes_in_flight > max_bytes_in_flight ) {
                   dlog( "503 - too many bytes in flight: ${bytes}", ("bytes", bytes_in_flight.load()) );
                   error_results results{websocketpp::http::status_code::too_many_requests, "Busy", error_results::error_info()};
                   con->set_body( fc::json::to_string( results ));

--- a/plugins/http_plugin/http_plugin.cpp
+++ b/plugins/http_plugin/http_plugin.cpp
@@ -139,7 +139,7 @@ namespace eosio {
 
          websocket_server_type    server;
 
-         uint16_t                                    thread_pool_size;
+         uint16_t                                    thread_pool_size = 2;
          optional<boost::asio::thread_pool>          thread_pool;
          std::shared_ptr<boost::asio::io_context>    server_ioc;
          optional<io_work_t>                         server_ioc_work;
@@ -406,7 +406,7 @@ namespace eosio {
              "If set to false, then any incoming \"Host\" header is considered valid")
             ("http-alias", bpo::value<std::vector<string>>()->composing(),
              "Additionaly acceptable values for the \"Host\" header of incoming HTTP requests, can be specified multiple times.  Includes http/s_server_address by default.")
-            ("http-threads", bpo::value<uint16_t>()->default_value(2),
+            ("http-threads", bpo::value<uint16_t>()->default_value( my->thread_pool_size ),
              "Number of worker threads in http thread pool")
             ;
    }
@@ -483,8 +483,8 @@ namespace eosio {
          verbose_http_errors = options.at( "verbose-http-errors" ).as<bool>();
 
          my->thread_pool_size = options.at( "http-threads" ).as<uint16_t>();
-         EOS_ASSERT( my->thread_pool_size > 0, chain::plugin_config_exception,
-                     "http-threads ${num} must be greater than 0", ("num", my->thread_pool_size));
+         EOS_ASSERT( my->thread_pool_size > 1, chain::plugin_config_exception,
+                     "http-threads ${num} must be greater than 1", ("num", my->thread_pool_size));
 
          //watch out for the returns above when adding new code here
       } FC_LOG_AND_RETHROW()

--- a/programs/nodeos/main.cpp
+++ b/programs/nodeos/main.cpp
@@ -100,7 +100,7 @@ int main(int argc, char** argv)
          .default_unix_socket_path = "",
          .default_http_port = 8888
       });
-      if(!app().initialize<chain_plugin, http_plugin, net_plugin, producer_plugin>(argc, argv))
+      if(!app().initialize<chain_plugin, net_plugin, producer_plugin>(argc, argv))
          return INITIALIZE_FAIL;
       initialize_logging();
       ilog("nodeos version ${ver}", ("ver", app().version_string()));


### PR DESCRIPTION
## Change Description

- Thanks go to @bspark8 #6678 for testing and verifying the improvement of processing/sending http request on a different thread.
- This PR adds a thread pool to the http_plugin used for processing/sending http requests.
- Remove auto load of http_plugin in nodeos main.cpp since not all nodeos need the http_plugin and the extra threads it spawns.
- Application logic is still processed on the application thread.
- See #6678 for additional info

## Consensus Changes

None

## API Changes

None

## Documentation Additions

- http_plugin has new option:
  --http-threads arg (=2)               Number of worker threads in http thread pool

