### PR TITLE
Fix startup logging for snapshots.

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1742,8 +1742,13 @@ void controller::startup( std::function<bool()> shutdown, const snapshot_reader_
       elog( "No head block in fork db, perhaps we need to replay" );
    }
 
-   my->init(shutdown, snapshot);
-
+   try {
+      my->init(shutdown, snapshot);
+   } catch (boost::interprocess::bad_alloc& e) {
+      if ( snapshot )
+         elog( "db storage not configured to have enough storage for the provided snapshot, please increase and retry snapshot" );
+      throw e;
+   }
    if( snapshot ) {
       ilog( "Finished initialization from snapshot" );
    }

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1735,10 +1735,18 @@ void controller::add_indices() {
 
 void controller::startup( std::function<bool()> shutdown, const snapshot_reader_ptr& snapshot ) {
    my->head = my->fork_db.head();
-   if( !my->head ) {
+   if( snapshot ) {
+      ilog( "Starting initialization from snapshot, this may take a significant amount of time" );
+   }
+   else if( !my->head ) {
       elog( "No head block in fork db, perhaps we need to replay" );
    }
+
    my->init(shutdown, snapshot);
+
+   if( snapshot ) {
+      ilog( "Finished initialization from snapshot" );
+   }
 }
 
 const chainbase::database& controller::db()const { return my->db; }


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- Give your PR a title that is sufficient to understand what is being changed. -->

## Change Description

#6697 
Fixing logging to not report erroneous error for snapshots and to also indicate when snapshot initialization starts and stops.

## Consensus Changes

N/A


## API Changes

N/A


## Documentation Additions

N/A
