### PR TITLE
txn_test_gen_plugin thread pool

### DIFF
--- a/plugins/txn_test_gen_plugin/txn_test_gen_plugin.cpp
+++ b/plugins/txn_test_gen_plugin/txn_test_gen_plugin.cpp
@@ -93,21 +93,16 @@ struct txn_test_gen_plugin_impl {
    uint64_t _total_us = 0;
    uint64_t _txcount = 0;
 
-   int _remain = 0;
-
    std::shared_ptr<boost::asio::io_context>             gen_ioc;
    optional<io_work_t>                                  gen_ioc_work;
    uint16_t                                             thread_pool_size;
    optional<boost::asio::thread_pool>                   thread_pool;
    std::shared_ptr<boost::asio::high_resolution_timer>  timer;
 
-   void push_next_transaction(const std::shared_ptr<std::vector<signed_transaction>>& trxs, size_t index, const std::function<void(const fc::exception_ptr&)>& next ) {
+   void push_next_transaction(const std::shared_ptr<std::vector<signed_transaction>>& trxs, const std::function<void(const fc::exception_ptr&)>& next ) {
       chain_plugin& cp = app().get_plugin<chain_plugin>();
 
-      const int overlap = 20;
-      size_t end = std::min(index + overlap, trxs->size());
-      _remain = end - index;
-      for (int i = index; i < end; ++i) {
+      for (int i = 0; i < trxs->size(); ++i) {
          cp.accept_transaction( packed_transaction(trxs->at(i)), [=](const fc::static_variant<fc::exception_ptr, transaction_trace_ptr>& result){
             if (result.contains<fc::exception_ptr>()) {
                next(result.get<fc::exception_ptr>());
@@ -115,14 +110,6 @@ struct txn_test_gen_plugin_impl {
                if (result.contains<transaction_trace_ptr>() && result.get<transaction_trace_ptr>()->receipt) {
                   _total_us += result.get<transaction_trace_ptr>()->receipt->cpu_usage_us;
                   ++_txcount;
-               }
-               --_remain;
-               if (_remain == 0 ) {
-                  if (end < trxs->size()) {
-                     push_next_transaction(trxs, index + overlap, next);
-                  } else {
-                     next(nullptr);
-                  }
                }
             }
          });
@@ -132,7 +119,7 @@ struct txn_test_gen_plugin_impl {
    void push_transactions( std::vector<signed_transaction>&& trxs, const std::function<void(fc::exception_ptr)>& next ) {
       auto trxs_copy = std::make_shared<std::decay_t<decltype(trxs)>>(std::move(trxs));
       app().post(priority::low, [this, trxs_copy, next]() {
-         push_next_transaction(trxs_copy, 0, next);
+         push_next_transaction(trxs_copy, next);
       });
    }
 

--- a/plugins/txn_test_gen_plugin/txn_test_gen_plugin.cpp
+++ b/plugins/txn_test_gen_plugin/txn_test_gen_plugin.cpp
@@ -226,7 +226,7 @@ struct txn_test_gen_plugin_impl {
                act.account = N(txn.test.t);
                act.name = N(issue);
                act.authorization = vector<permission_level>{{newaccountC,config::active_name}};
-               act.data = eosio_token_serializer.variant_to_binary("issue", fc::json::from_string("{\"to\":\"txn.test.t\",\"quantity\":\"600.0000 CUR\",\"memo\":\"\"}"), abi_serializer_max_time);
+               act.data = eosio_token_serializer.variant_to_binary("issue", fc::json::from_string("{\"to\":\"txn.test.t\",\"quantity\":\"60000.0000 CUR\",\"memo\":\"\"}"), abi_serializer_max_time);
                trx.actions.push_back(act);
             }
             {
@@ -234,7 +234,7 @@ struct txn_test_gen_plugin_impl {
                act.account = N(txn.test.t);
                act.name = N(transfer);
                act.authorization = vector<permission_level>{{newaccountC,config::active_name}};
-               act.data = eosio_token_serializer.variant_to_binary("transfer", fc::json::from_string("{\"from\":\"txn.test.t\",\"to\":\"txn.test.a\",\"quantity\":\"200.0000 CUR\",\"memo\":\"\"}"), abi_serializer_max_time);
+               act.data = eosio_token_serializer.variant_to_binary("transfer", fc::json::from_string("{\"from\":\"txn.test.t\",\"to\":\"txn.test.a\",\"quantity\":\"20000.0000 CUR\",\"memo\":\"\"}"), abi_serializer_max_time);
                trx.actions.push_back(act);
             }
             {
@@ -242,7 +242,7 @@ struct txn_test_gen_plugin_impl {
                act.account = N(txn.test.t);
                act.name = N(transfer);
                act.authorization = vector<permission_level>{{newaccountC,config::active_name}};
-               act.data = eosio_token_serializer.variant_to_binary("transfer", fc::json::from_string("{\"from\":\"txn.test.t\",\"to\":\"txn.test.b\",\"quantity\":\"200.0000 CUR\",\"memo\":\"\"}"), abi_serializer_max_time);
+               act.data = eosio_token_serializer.variant_to_binary("transfer", fc::json::from_string("{\"from\":\"txn.test.t\",\"to\":\"txn.test.b\",\"quantity\":\"20000.0000 CUR\",\"memo\":\"\"}"), abi_serializer_max_time);
                trx.actions.push_back(act);
             }
 


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- Give your PR a title that is sufficient to understand what is being changed. -->

## Change Description

- When using txn_test_gen_plugin, the node's main thread will create (sign) and process (accept) transactions.
- However, transaction creation is a client operation, not a node.
- Furthermore, the transaction creation overhead is high, affecting performance results.
- This PR adds a thread pool, which creates transactions and posts them to the main thread.
- The following experiment shows the results of applying txn_test_gen thread pool.

#### Environments
- Node: 1 producing node (start_generation here)
- HW: Intel(R) Xeon(R) CPU E5-2699 v4 @ 2.20GHz (44 cores), 128GB
- Options: 8 producer threads, 8 chain threads, 2 txn_test_gen threads, wavm
- Benchmark: generate 20 transactions every 2 ms (intended 10,000 TPS) for 30 seconds
> Note that this configuration is intended to focus on the performance of processing transactions except network overhead.

#### Before
- 4,547 TPS, 97% CPU usage (main thread)

#### After
- 9,992 TPS, 98% CPU usage (main thread), 74% CPU usage (per txn_test_gen thread)

> Note that the number of txn_test_gen threads does not affect the intended input parameter.
> That is, if a value that generates 20 transactions every 2 ms is input, it tries to generate transactions at this cycle even if the number of threads increases.
> However, depending on the CPU performance, it is necessary to use multiple threads to match the input transaction generation cycle.
> In above case (20 transactions every 2 ms), two threads were needed in our environment.


<!-- Describe the change you made, the motivation for it, and the impact it will have. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

## Consensus Changes

<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes

<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions

- txn_test_gen_plugin has new option:
  --txn-test-gen-threads arg (=2)      Number of worker threads in txn_test_gen thread pool

<!-- List all the information that needs to be added to the documentation after merge. -->
