### PR TITLE
added memo to base_tester::issue

### DIFF
--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -177,7 +177,7 @@ namespace eosio { namespace testing {
          transaction_trace_ptr push_dummy(account_name from, const string& v = "blah", uint32_t billed_cpu_time_us = DEFAULT_BILLED_CPU_TIME_US );
          transaction_trace_ptr transfer( account_name from, account_name to, asset amount, string memo, account_name currency );
          transaction_trace_ptr transfer( account_name from, account_name to, string amount, string memo, account_name currency );
-         transaction_trace_ptr issue( account_name to, string amount, account_name currency );
+         transaction_trace_ptr issue( account_name to, string amount, account_name currency , string memo);
 
          template<typename ObjectType>
          const auto& get(const chainbase::oid< ObjectType >& key) {

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -564,7 +564,7 @@ namespace eosio { namespace testing {
    }
 
 
-   transaction_trace_ptr base_tester::issue( account_name to, string amount, account_name currency ) {
+   transaction_trace_ptr base_tester::issue( account_name to, string amount, account_name currency, string memo ) {
       variant pretty_trx = fc::mutable_variant_object()
          ("actions", fc::variants({
             fc::mutable_variant_object()
@@ -578,6 +578,7 @@ namespace eosio { namespace testing {
                ("data", fc::mutable_variant_object()
                   ("to", to)
                   ("quantity", amount)
+                  ("memo", memo)
                )
             })
          );


### PR DESCRIPTION
## Change Description

- Fixes #6741
- This PR rebases #6742 to `develop`. Thanks @kesar 
- Verified change does not break `eosio.contracts` build

## Consensus Changes

None

## API Changes

None

## Documentation Additions

None
