### PR TITLE
Fix plugin test

### DIFF
--- a/libraries/chain/include/eosio/chain/abi_serializer.hpp
+++ b/libraries/chain/include/eosio/chain/abi_serializer.hpp
@@ -124,8 +124,16 @@ namespace impl {
 
    struct abi_traverse_context {
       abi_traverse_context( fc::microseconds max_serialization_time )
-      : max_serialization_time( max_serialization_time ), deadline( fc::time_point::now() + max_serialization_time ), recursion_depth(0)
-      {}
+      : max_serialization_time( max_serialization_time ),
+        deadline( fc::time_point::now() ), // init to now, updated below
+        recursion_depth(0)
+      {
+         if( max_serialization_time > fc::microseconds::maximum() - deadline.time_since_epoch() ) {
+            deadline = fc::time_point::maximum();
+         } else {
+            deadline += max_serialization_time;
+         }
+      }
 
       abi_traverse_context( fc::microseconds max_serialization_time, fc::time_point deadline )
       : max_serialization_time( max_serialization_time ), deadline( deadline ), recursion_depth(0)

--- a/tests/chain_plugin_tests.cpp
+++ b/tests/chain_plugin_tests.cpp
@@ -93,7 +93,7 @@ BOOST_FIXTURE_TEST_CASE( get_block_with_invalid_abi, TESTER ) try {
    char headnumstr[20];
    sprintf(headnumstr, "%d", headnum);
    chain_apis::read_only::get_block_params param{headnumstr};
-   chain_apis::read_only plugin(*(this->control), fc::microseconds(INT_MAX));
+   chain_apis::read_only plugin(*(this->control), fc::microseconds::maximum());
 
    // block should be decoded successfully
    std::string block_str = json::to_pretty_string(plugin.get_block(param));

--- a/tests/get_table_tests.cpp
+++ b/tests/get_table_tests.cpp
@@ -69,7 +69,7 @@ BOOST_FIXTURE_TEST_CASE( get_scope_test, TESTER ) try {
    produce_blocks(1);
 
    // iterate over scope
-   eosio::chain_apis::read_only plugin(*(this->control), fc::microseconds(INT_MAX));
+   eosio::chain_apis::read_only plugin(*(this->control), fc::microseconds::maximum());
    eosio::chain_apis::read_only::get_table_by_scope_params param{N(eosio.token), N(accounts), "inita", "", 10};
    eosio::chain_apis::read_only::get_table_by_scope_result result = plugin.read_only::get_table_by_scope(param);
 
@@ -190,7 +190,7 @@ BOOST_FIXTURE_TEST_CASE( get_table_test, TESTER ) try {
    produce_blocks(1);
 
    // get table: normal case
-   eosio::chain_apis::read_only plugin(*(this->control), fc::microseconds(INT_MAX));
+   eosio::chain_apis::read_only plugin(*(this->control), fc::microseconds::maximum());
    eosio::chain_apis::read_only::get_table_rows_params p;
    p.code = N(eosio.token);
    p.scope = "inita";
@@ -363,7 +363,7 @@ BOOST_FIXTURE_TEST_CASE( get_table_by_seckey_test, TESTER ) try {
    produce_blocks(1);
 
    // get table: normal case
-   eosio::chain_apis::read_only plugin(*(this->control), fc::microseconds(INT_MAX));
+   eosio::chain_apis::read_only plugin(*(this->control), fc::microseconds::maximum());
    eosio::chain_apis::read_only::get_table_rows_params p;
    p.code = N(eosio);
    p.scope = "eosio";


### PR DESCRIPTION
## Change Description

- plugin_test failed because it was passing `INT_MAX` as max serialization time and we were adding that to `now()`.
- Add check to use maximum time_point if the maximum deadline requested

## Consensus Changes

## API Changes

## Documentation Additions
