### PR TITLE
Display assert to user when --verbose-http-errors not specified

### DIFF
--- a/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
@@ -129,21 +129,22 @@ namespace eosio {
 
          error_info() {};
 
-         error_info(const fc::exception& exc, bool include_log) {
+         error_info(const fc::exception& exc, bool include_full_log) {
             code = exc.code();
             name = exc.name();
             what = exc.what();
-            if (include_log) {
-               for (auto itr = exc.get_log().begin(); itr != exc.get_log().end(); ++itr) {
-                  // Prevent sending trace that are too big
-                  if (details.size() >= details_limit) break;
-                  // Append error
-                  error_detail detail = {
-                          itr->get_message(), itr->get_context().get_file(),
-                          itr->get_context().get_line_number(), itr->get_context().get_method()
-                  };
-                  details.emplace_back(detail);
-               }
+            uint8_t limit = include_full_log ? details_limit : 1;
+            for( auto itr = exc.get_log().begin(); itr != exc.get_log().end(); ++itr ) {
+               // Prevent sending trace that are too big
+               if( details.size() >= limit ) break;
+               // Append error
+               error_detail detail = {
+                     include_full_log ? itr->get_message() : itr->get_limited_message(),
+                     itr->get_context().get_file(),
+                     itr->get_context().get_line_number(),
+                     itr->get_context().get_method()
+               };
+               details.emplace_back( detail );
             }
          }
       };

--- a/unittests/misc_tests.cpp
+++ b/unittests/misc_tests.cpp
@@ -156,6 +156,33 @@ BOOST_AUTO_TEST_CASE(json_from_string_test)
   BOOST_CHECK_EQUAL(exc_found, true);
 }
 
+BOOST_AUTO_TEST_CASE(variant_format_string_limited)
+{
+   const string format = "${a} ${b} ${c}";
+   {
+      fc::mutable_variant_object mu;
+      mu( "a", string( 1024, 'a' ) );
+      mu( "b", string( 1024, 'b' ) );
+      mu( "c", string( 1024, 'c' ) );
+      string result = fc::format_string( format, mu, true );
+      BOOST_CHECK_EQUAL( result, string( 256, 'a' ) + "... " + string( 256, 'b' ) + "... " + string( 256, 'c' ) + "..." );
+   }
+   {
+      fc::mutable_variant_object mu;
+      signed_block a;
+      blob b;
+      for( int i = 0; i < 1024; ++i)
+         b.data.push_back('b');
+      variants c;
+      c.push_back(variant(a));
+      mu( "a", a );
+      mu( "b", b );
+      mu( "c", c );
+      string result = fc::format_string( format, mu, true );
+      BOOST_CHECK_EQUAL( result, "${a} ${b} ${c}");
+   }
+}
+
 // Test overflow handling in asset::from_string
 BOOST_AUTO_TEST_CASE(asset_from_string_overflow)
 {


### PR DESCRIPTION
## Change Description

- Currently the contract's `eosio_assert` message is not reported to the user unless `--verbose-http-errors` is specified to `nodeos`. For example:
```
./cleos push action asserter procassert '[0, "hello"]' -p asserter
Error 3050003: eosio_assert_message assertion failure
```

- This PR adds minimum log_message output so that `eosio_assert` messages are reported to the user even when `--verbose-http-errors` is not enabled. For example:
```
./cleos push action asserter procassert '[0, "hello"]' -p asserter
Error 3050003: eosio_assert_message assertion failure
Error Details:
assertion failure with message: hello
```

## Consensus Changes

None

## API Changes

None

## Documentation Additions

- Some examples may need to be updated to reflect that assert_message now contains the user assert message.
