### PR TITLE
Don't unlink what we install via brew - 1.6.x

### DIFF
--- a/scripts/eosio_build_darwin.sh
+++ b/scripts/eosio_build_darwin.sh
@@ -161,13 +161,12 @@
 						printf "\\tExiting now.\\n\\n"
 						exit 1;
 					fi
-                                        if [[ "$DEP" == "llvm@4" ]]; then
-                                                "${BREW}" unlink ${DEP}
-					elif ! "${BREW}" unlink ${DEP} && "${BREW}" link --force ${DEP}
-					then
-						printf "\\tHomebrew exited with the above errors.\\n"
-						printf "\\tExiting now.\\n\\n"
-						exit 1;
+					if [ $PERMISSION_GETTEXT -eq 1 ]; then
+						if ! "${BREW}" link --force gettext; then
+							printf "\\tHomebrew exited with the above errors.\\n"
+							printf "\\tExiting now.\\n\\n"
+							exit 1;
+						fi
 					fi
 				break;;
 				[Nn]* ) echo "User aborting installation of required dependencies, Exiting now."; exit;;


### PR DESCRIPTION


<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- Give your PR a title that is sufficient to understand what is being changed. -->

## Change Description
unlinking everything we install makes no sense -- it means things like cmake aren't in the path any longer like the script expects. So don't do that any more. Unfortuately this old script requires that gettext be force linked. So implement that behavior explictly for now
<!-- Describe the change you made, the motivation for it, and the impact it will have. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

## Consensus Changes

<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes

<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions

<!-- List all the information that needs to be added to the documentation after merge. -->
