### PR TITLE
reflector_init fix

### DIFF
--- a/libraries/chain/include/eosio/chain/abi_serializer.hpp
+++ b/libraries/chain/include/eosio/chain/abi_serializer.hpp
@@ -633,7 +633,7 @@ namespace impl {
     * @tparam Reslover - callable with the signature (const name& code_account) -> optional<abi_def>
     */
    template<typename T, typename Resolver>
-   class abi_from_variant_visitor : reflector_init_visitor<T>
+   class abi_from_variant_visitor : public reflector_init_visitor<T>
    {
       public:
          abi_from_variant_visitor( const variant_object& _vo, T& v, Resolver _resolver, abi_traverse_context& _ctx )

--- a/libraries/chain/transaction.cpp
+++ b/libraries/chain/transaction.cpp
@@ -327,7 +327,6 @@ packed_transaction::packed_transaction( transaction&& t, vector<signature_type>&
 void packed_transaction::reflector_init()
 {
    // called after construction, but always on the same thread and before packed_transaction passed to any other threads
-   static_assert(&fc::reflector_init_visitor<packed_transaction>::reflector_init, "FC with reflector_init required");
    static_assert(fc::raw::has_feature_reflector_init_on_unpacked_reflected_types,
                  "FC unpack needs to call reflector_init otherwise unpacked_trx will not be initialized");
    EOS_ASSERT( unpacked_trx.expiration == time_point_sec(), tx_decompression_error, "packed_transaction already unpacked" );

--- a/unittests/misc_tests.cpp
+++ b/unittests/misc_tests.cpp
@@ -645,6 +645,10 @@ BOOST_AUTO_TEST_CASE(transaction_test) { try {
    ds2.seekp(0);
    packed_transaction pkt4;
    fc::raw::unpack(ds2, pkt4);
+   // to/from variant
+   fc::variant pkt_v( pkt3 );
+   packed_transaction pkt5;
+   fc::from_variant(pkt_v, pkt5);
 
    bytes raw3 = pkt3.get_raw_transaction();
    bytes raw4 = pkt4.get_raw_transaction();
@@ -654,6 +658,7 @@ BOOST_AUTO_TEST_CASE(transaction_test) { try {
    BOOST_CHECK_EQUAL(true, std::equal(raw.begin(), raw.end(), raw4.begin()));
    BOOST_CHECK_EQUAL(pkt.get_signed_transaction().id(), pkt3.get_signed_transaction().id());
    BOOST_CHECK_EQUAL(pkt.get_signed_transaction().id(), pkt4.get_signed_transaction().id());
+   BOOST_CHECK_EQUAL(pkt.get_signed_transaction().id(), pkt5.get_signed_transaction().id()); // failure indicates reflector_init not working
    BOOST_CHECK_EQUAL(pkt.id(), pkt4.get_signed_transaction().id());
    BOOST_CHECK_EQUAL(true, trx.expiration == pkt4.expiration());
    BOOST_CHECK_EQUAL(true, trx.expiration == pkt4.get_signed_transaction().expiration);


### PR DESCRIPTION
## Change Description

- Update fc to latest.
  -- Includes gcc warning fixes
  -- Includes fix for reflector_init
- Added unittest for to/from variant of packed_transaction which requires the fc https://github.com/EOSIO/fc/pull/57

- See: Fix for reflector_init: https://github.com/EOSIO/fc/pull/57

## Consensus Changes

None

## API Changes

None

## Documentation Additions

None
