### PR TITLE
Fix for reflector_init on derived

### DIFF
--- a/libraries/chain/include/eosio/chain/asset.hpp
+++ b/libraries/chain/include/eosio/chain/asset.hpp
@@ -18,7 +18,7 @@ with amount = 10 and symbol(4,"CUR")
 
 */
 
-struct asset
+struct asset : fc::reflect_init
 {
    static constexpr int64_t max_amount = (1LL << 62) - 1;
 

--- a/libraries/chain/include/eosio/chain/symbol.hpp
+++ b/libraries/chain/include/eosio/chain/symbol.hpp
@@ -58,7 +58,7 @@ namespace eosio {
          operator uint64_t()const { return value; }
       };
 
-      class symbol {
+      class symbol : fc::reflect_init {
          public:
 
             static constexpr uint8_t max_precision = 18;

--- a/libraries/chain/include/eosio/chain/transaction.hpp
+++ b/libraries/chain/include/eosio/chain/transaction.hpp
@@ -102,7 +102,7 @@ namespace eosio { namespace chain {
                                                     bool allow_duplicate_keys = false )const;
    };
 
-   struct packed_transaction {
+   struct packed_transaction : fc::reflect_init {
       enum compression_type {
          none = 0,
          zlib = 1,
@@ -158,6 +158,7 @@ namespace eosio { namespace chain {
 
       friend struct fc::reflector<packed_transaction>;
       friend struct fc::reflector_init_visitor<packed_transaction>;
+      friend struct fc::has_reflector_init<packed_transaction>;
       void reflector_init();
    private:
       vector<signature_type>                  signatures;

--- a/unittests/misc_tests.cpp
+++ b/unittests/misc_tests.cpp
@@ -26,13 +26,14 @@ using namespace eosio::testing;
 #include <boost/random/mersenne_twister.hpp>
 #include <boost/random/uniform_int_distribution.hpp>
 
-struct base_reflect {
+struct base_reflect : fc::reflect_init {
    int bv = 0;
    bool base_reflect_initialized = false;
    int base_reflect_called = 0;
 protected:
    friend struct fc::reflector<base_reflect>;
    friend struct fc::reflector_init_visitor<base_reflect>;
+   friend struct fc::has_reflector_init<base_reflect>;
    void reflector_init() {
       BOOST_CHECK_EQUAL( bv, 42 ); // should be deserialized before called, set by test
       ++base_reflect_called;
@@ -47,6 +48,7 @@ struct derived_reflect : public base_reflect {
 protected:
    friend struct fc::reflector<derived_reflect>;
    friend struct fc::reflector_init_visitor<derived_reflect>;
+   friend struct fc::has_reflector_init<derived_reflect>;
    void reflector_init() {
       BOOST_CHECK_EQUAL( bv, 42 ); // should be deserialized before called, set by test
       BOOST_CHECK_EQUAL( dv, 52 ); // should be deserialized before called, set by test
@@ -63,6 +65,7 @@ struct final_reflect : public derived_reflect {
 private:
    friend struct fc::reflector<final_reflect>;
    friend struct fc::reflector_init_visitor<final_reflect>;
+   friend struct fc::has_reflector_init<derived_reflect>;
    void reflector_init() {
       BOOST_CHECK_EQUAL( bv, 42 ); // should be deserialized before called, set by test
       BOOST_CHECK_EQUAL( dv, 52 ); // should be deserialized before called, set by test

--- a/unittests/misc_tests.cpp
+++ b/unittests/misc_tests.cpp
@@ -65,7 +65,7 @@ struct final_reflect : public derived_reflect {
 private:
    friend struct fc::reflector<final_reflect>;
    friend struct fc::reflector_init_visitor<final_reflect>;
-   friend struct fc::has_reflector_init<derived_reflect>;
+   friend struct fc::has_reflector_init<final_reflect>;
    void reflector_init() {
       BOOST_CHECK_EQUAL( bv, 42 ); // should be deserialized before called, set by test
       BOOST_CHECK_EQUAL( dv, 52 ); // should be deserialized before called, set by test

--- a/unittests/misc_tests.cpp
+++ b/unittests/misc_tests.cpp
@@ -44,7 +44,7 @@ struct derived_reflect : public base_reflect {
    int dv = 0;
    bool derived_reflect_initialized = false;
    int derived_reflect_called = 0;
-private:
+protected:
    friend struct fc::reflector<derived_reflect>;
    friend struct fc::reflector_init_visitor<derived_reflect>;
    void reflector_init() {
@@ -56,8 +56,26 @@ private:
    }
 };
 
+struct final_reflect : public derived_reflect {
+   int fv = 0;
+   bool final_reflect_initialized = false;
+   int final_reflect_called = 0;
+private:
+   friend struct fc::reflector<final_reflect>;
+   friend struct fc::reflector_init_visitor<final_reflect>;
+   void reflector_init() {
+      BOOST_CHECK_EQUAL( bv, 42 ); // should be deserialized before called, set by test
+      BOOST_CHECK_EQUAL( dv, 52 ); // should be deserialized before called, set by test
+      BOOST_CHECK_EQUAL( fv, 62 ); // should be deserialized before called, set by test
+      ++final_reflect_called;
+      derived_reflect::reflector_init();
+      final_reflect_initialized = true;
+   }
+};
+
 FC_REFLECT( base_reflect, (bv) )
 FC_REFLECT_DERIVED( derived_reflect, (base_reflect), (dv) )
+FC_REFLECT_DERIVED( final_reflect, (derived_reflect), (fv) )
 
 namespace eosio
 {
@@ -819,6 +837,10 @@ BOOST_AUTO_TEST_CASE(reflector_init_test) {
       derived_reflect dr;
       dr.bv = 42;
       dr.dv = 52;
+      final_reflect fr;
+      fr.bv = 42;
+      fr.dv = 52;
+      fr.fv = 62;
       BOOST_CHECK_EQUAL( br.base_reflect_initialized, false );
       BOOST_CHECK_EQUAL( dr.derived_reflect_initialized, false );
 
@@ -842,9 +864,9 @@ BOOST_AUTO_TEST_CASE(reflector_init_test) {
          base_reflect br3;
          fc::raw::unpack( ds2, br3 );
          // to/from variant
-         fc::variant pkt_v( br3 );
+         fc::variant v( br3 );
          base_reflect br4;
-         fc::from_variant( pkt_v, br4 );
+         fc::from_variant( v, br4 );
 
          BOOST_CHECK_EQUAL( br2.bv, 42 );
          BOOST_CHECK_EQUAL( br2.base_reflect_initialized, true );
@@ -876,9 +898,9 @@ BOOST_AUTO_TEST_CASE(reflector_init_test) {
          derived_reflect dr3;
          fc::raw::unpack( ds2, dr3 );
          // to/from variant
-         fc::variant pkt_v( dr3 );
+         fc::variant v( dr3 );
          derived_reflect dr4;
-         fc::from_variant( pkt_v, dr4 );
+         fc::from_variant( v, dr4 );
 
          BOOST_CHECK_EQUAL( dr2.bv, 42 );
          BOOST_CHECK_EQUAL( dr2.base_reflect_initialized, true );
@@ -899,6 +921,106 @@ BOOST_AUTO_TEST_CASE(reflector_init_test) {
          BOOST_CHECK_EQUAL( dr4.dv, 52 );
          BOOST_CHECK_EQUAL( dr4.derived_reflect_initialized, true );
          BOOST_CHECK_EQUAL( dr4.derived_reflect_called, 1 );
+
+         base_reflect br5;
+         ds2.seekp( 0 );
+         fc::raw::unpack( ds2, br5 );
+         base_reflect br6;
+         fc::from_variant( v, br6 );
+
+         BOOST_CHECK_EQUAL( br5.bv, 42 );
+         BOOST_CHECK_EQUAL( br5.base_reflect_initialized, true );
+         BOOST_CHECK_EQUAL( br5.base_reflect_called, 1 );
+         BOOST_CHECK_EQUAL( br6.bv, 42 );
+         BOOST_CHECK_EQUAL( br6.base_reflect_initialized, true );
+         BOOST_CHECK_EQUAL( br6.base_reflect_called, 1 );
+      }
+      { // final
+         // pack
+         uint32_t pack_size = fc::raw::pack_size( fr );
+         vector<char> buf( pack_size );
+         fc::datastream<char*> ds( buf.data(), pack_size );
+
+         fc::raw::pack( ds, fr );
+         // unpack
+         ds.seekp( 0 );
+         final_reflect fr2;
+         fc::raw::unpack( ds, fr2 );
+         // pack again
+         pack_size = fc::raw::pack_size( fr2 );
+         fc::datastream<char*> ds2( buf.data(), pack_size );
+         fc::raw::pack( ds2, fr2 );
+         // unpack
+         ds2.seekp( 0 );
+         final_reflect fr3;
+         fc::raw::unpack( ds2, fr3 );
+         // to/from variant
+         fc::variant v( fr3 );
+         final_reflect fr4;
+         fc::from_variant( v, fr4 );
+
+         BOOST_CHECK_EQUAL( fr2.bv, 42 );
+         BOOST_CHECK_EQUAL( fr2.base_reflect_initialized, true );
+         BOOST_CHECK_EQUAL( fr2.base_reflect_called, 1 );
+         BOOST_CHECK_EQUAL( fr3.bv, 42 );
+         BOOST_CHECK_EQUAL( fr3.base_reflect_initialized, true );
+         BOOST_CHECK_EQUAL( fr3.base_reflect_called, 1 );
+         BOOST_CHECK_EQUAL( fr4.bv, 42 );
+         BOOST_CHECK_EQUAL( fr4.base_reflect_initialized, true );
+         BOOST_CHECK_EQUAL( fr4.base_reflect_called, 1 );
+
+         BOOST_CHECK_EQUAL( fr2.dv, 52 );
+         BOOST_CHECK_EQUAL( fr2.derived_reflect_initialized, true );
+         BOOST_CHECK_EQUAL( fr2.derived_reflect_called, 1 );
+         BOOST_CHECK_EQUAL( fr3.dv, 52 );
+         BOOST_CHECK_EQUAL( fr3.derived_reflect_initialized, true );
+         BOOST_CHECK_EQUAL( fr3.derived_reflect_called, 1 );
+         BOOST_CHECK_EQUAL( fr4.dv, 52 );
+         BOOST_CHECK_EQUAL( fr4.derived_reflect_initialized, true );
+         BOOST_CHECK_EQUAL( fr4.derived_reflect_called, 1 );
+
+         BOOST_CHECK_EQUAL( fr2.fv, 62 );
+         BOOST_CHECK_EQUAL( fr2.final_reflect_initialized, true );
+         BOOST_CHECK_EQUAL( fr2.final_reflect_called, 1 );
+         BOOST_CHECK_EQUAL( fr3.fv, 62 );
+         BOOST_CHECK_EQUAL( fr3.final_reflect_initialized, true );
+         BOOST_CHECK_EQUAL( fr3.final_reflect_called, 1 );
+         BOOST_CHECK_EQUAL( fr4.fv, 62 );
+         BOOST_CHECK_EQUAL( fr4.final_reflect_initialized, true );
+         BOOST_CHECK_EQUAL( fr4.final_reflect_called, 1 );
+
+         base_reflect br5;
+         ds2.seekp( 0 );
+         fc::raw::unpack( ds2, br5 );
+         base_reflect br6;
+         fc::from_variant( v, br6 );
+
+         BOOST_CHECK_EQUAL( br5.bv, 42 );
+         BOOST_CHECK_EQUAL( br5.base_reflect_initialized, true );
+         BOOST_CHECK_EQUAL( br5.base_reflect_called, 1 );
+         BOOST_CHECK_EQUAL( br6.bv, 42 );
+         BOOST_CHECK_EQUAL( br6.base_reflect_initialized, true );
+         BOOST_CHECK_EQUAL( br6.base_reflect_called, 1 );
+
+         derived_reflect dr7;
+         ds2.seekp( 0 );
+         fc::raw::unpack( ds2, dr7 );
+         derived_reflect dr8;
+         fc::from_variant( v, dr8 );
+
+         BOOST_CHECK_EQUAL( dr7.bv, 42 );
+         BOOST_CHECK_EQUAL( dr7.base_reflect_initialized, true );
+         BOOST_CHECK_EQUAL( dr7.base_reflect_called, 1 );
+         BOOST_CHECK_EQUAL( dr8.bv, 42 );
+         BOOST_CHECK_EQUAL( dr8.base_reflect_initialized, true );
+         BOOST_CHECK_EQUAL( dr8.base_reflect_called, 1 );
+
+         BOOST_CHECK_EQUAL( dr7.dv, 52 );
+         BOOST_CHECK_EQUAL( dr7.derived_reflect_initialized, true );
+         BOOST_CHECK_EQUAL( dr7.derived_reflect_called, 1 );
+         BOOST_CHECK_EQUAL( dr8.dv, 52 );
+         BOOST_CHECK_EQUAL( dr8.derived_reflect_initialized, true );
+         BOOST_CHECK_EQUAL( dr8.derived_reflect_called, 1 );
       }
 
    } FC_LOG_AND_RETHROW()


### PR DESCRIPTION
## Change Description

- Includes update to `fc` (https://github.com/EOSIO/fc/pull/58) that includes a fix for `reflector_init` being called multiple times on derived type.
- See `fc` (https://github.com/EOSIO/fc/pull/58) for more details.
- Add unittest to verify `reflector_init` works for derived types.

## Consensus Changes

None

## API Changes

None

## Documentation Additions

None
