### PR TITLE
Net plugin use local logger

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -745,7 +745,7 @@ namespace eosio {
         fork_head_num(0),
         last_req()
    {
-      wlog( "created connection to ${n}", ("n", endpoint) );
+      fc_wlog( logger, "created connection to ${n}", ("n", endpoint) );
       initialize();
    }
 
@@ -770,7 +770,7 @@ namespace eosio {
         fork_head_num(0),
         last_req()
    {
-      wlog( "accepted network connection" );
+      fc_wlog( logger, "accepted network connection" );
       initialize();
    }
 
@@ -806,7 +806,7 @@ namespace eosio {
          socket->close();
       }
       else {
-         wlog("no socket to close!");
+         fc_wlog( logger, "no socket to close!" );
       }
       flush_queues();
       connecting = false;
@@ -871,7 +871,7 @@ namespace eosio {
          head_id = cc.fork_db_head_block_id();
       }
       catch (const assert_exception& ex) {
-         elog( "unable to retrieve block info: ${n} for ${p}",("n",ex.to_string())("p",peer_name()));
+         fc_elog( logger, "unable to retrieve block info: ${n} for ${p}",("n",ex.to_string())("p",peer_name()) );
          enqueue(note);
          return;
       }
@@ -904,17 +904,17 @@ namespace eosio {
             add_peer_block({blkid, block_header::num_from_id(blkid)});
             enqueue_block( b );
          } else {
-            ilog("fetch block by id returned null, id ${id} for ${p}",
-                  ("id",blkid)("p",peer_name()));
+            fc_ilog( logger, "fetch block by id returned null, id ${id} for ${p}",
+                     ("id",blkid)("p",peer_name()) );
          }
       }
       catch (const assert_exception &ex) {
-         elog( "caught assert on fetch_block_by_id, ${ex}, id ${id} for ${p}",
-               ("ex",ex.to_string())("id",blkid)("p",peer_name()));
+         fc_elog( logger, "caught assert on fetch_block_by_id, ${ex}, id ${id} for ${p}",
+                  ("ex",ex.to_string())("id",blkid)("p",peer_name()) );
       }
       catch (...) {
-         elog( "caught other exception fetching block id ${id} for ${p}",
-               ("id",blkid)("p",peer_name()));
+         fc_elog( logger, "caught other exception fetching block id ${id} for ${p}",
+                  ("id",blkid)("p",peer_name()) );
       }
    }
 
@@ -987,10 +987,10 @@ namespace eosio {
                if(ec) {
                   string pname = conn ? conn->peer_name() : "no connection name";
                   if( ec.value() != boost::asio::error::eof) {
-                     elog("Error sending to peer ${p}: ${i}", ("p",pname)("i", ec.message()));
+                     fc_elog( logger,"Error sending to peer ${p}: ${i}", ("p",pname)("i", ec.message()) );
                   }
                   else {
-                     ilog("connection closure detected on write to ${p}",("p",pname));
+                     fc_ilog( logger, "connection closure detected on write to ${p}",("p",pname) );
                   }
                   my_impl->close(conn);
                   return;
@@ -1002,17 +1002,17 @@ namespace eosio {
             catch(const std::exception &ex) {
                auto conn = c.lock();
                string pname = conn ? conn->peer_name() : "no connection name";
-               elog("Exception in do_queue_write to ${p} ${s}", ("p",pname)("s",ex.what()));
+               fc_elog( logger,"Exception in do_queue_write to ${p} ${s}", ("p",pname)("s",ex.what()) );
             }
             catch(const fc::exception &ex) {
                auto conn = c.lock();
                string pname = conn ? conn->peer_name() : "no connection name";
-               elog("Exception in do_queue_write to ${p} ${s}", ("p",pname)("s",ex.to_string()));
+               fc_elog( logger,"Exception in do_queue_write to ${p} ${s}", ("p",pname)("s",ex.to_string()) );
             }
             catch(...) {
                auto conn = c.lock();
                string pname = conn ? conn->peer_name() : "no connection name";
-               elog("Exception in do_queue_write to ${p}", ("p",pname) );
+               fc_elog( logger,"Exception in do_queue_write to ${p}", ("p",pname) );
             }
          });
       });
@@ -1052,7 +1052,7 @@ namespace eosio {
             return true;
          }
       } catch ( ... ) {
-         wlog( "write loop exception" );
+         fc_wlog( logger, "write loop exception" );
       }
       return false;
    }
@@ -1179,7 +1179,7 @@ namespace eosio {
       else if( ec == boost::asio::error::operation_aborted) {
       }
       else {
-         elog("setting timer for sync request got error ${ec}",("ec", ec.message()));
+         fc_elog( logger,"setting timer for sync request got error ${ec}",("ec", ec.message()) );
       }
    }
 
@@ -1203,7 +1203,7 @@ namespace eosio {
          }
       }
       else {
-         elog( "setting timer for fetch request got error ${ec}", ("ec", ec.message() ) );
+         fc_elog( logger, "setting timer for fetch request got error ${ec}", ("ec", ec.message() ) );
       }
    }
 
@@ -1352,7 +1352,7 @@ namespace eosio {
 
       // verify there is an available source
       if (!source || !source->current() ) {
-         elog("Unable to continue syncing at this time");
+         fc_elog( logger, "Unable to continue syncing at this time");
          sync_known_lib_num = chain_plug->chain().last_irreversible_block_num();
          sync_last_requested_num = 0;
          set_state(in_sync); // probably not, but we can't do anything else
@@ -1488,7 +1488,7 @@ namespace eosio {
          c->syncing = true;
          return;
       }
-      elog("sync check failed to resolve status");
+      fc_elog( logger, "sync check failed to resolve status" );
    }
 
    void sync_manager::verify_catchup(const connection_ptr& c, uint32_t num, const block_id_type& id) {
@@ -1504,8 +1504,8 @@ namespace eosio {
       if( req.req_blocks.mode == catch_up ) {
          c->fork_head = id;
          c->fork_head_num = num;
-         ilog("got a catch_up notice while in ${s}, fork head num = ${fhn} target LIB = ${lib} next_expected = ${ne}",
-               ("s",stage_str(state))("fhn",num)("lib",sync_known_lib_num)("ne", sync_next_expected_num));
+         fc_ilog( logger, "got a catch_up notice while in ${s}, fork head num = ${fhn} target LIB = ${lib} next_expected = ${ne}",
+                  ("s",stage_str(state))("fhn",num)("lib",sync_known_lib_num)("ne", sync_next_expected_num) );
          if (state == lib_catchup)
             return;
          set_state(head_catchup);
@@ -1521,13 +1521,13 @@ namespace eosio {
    void sync_manager::recv_notice(const connection_ptr& c, const notice_message& msg) {
       fc_ilog(logger, "sync_manager got ${m} block notice",("m",modes_str(msg.known_blocks.mode)));
       if( msg.known_blocks.ids.size() > 1 ) {
-         elog( "Invalid notice_message, known_blocks.ids.size ${s}", ("s", msg.known_blocks.ids.size()) );
+         fc_elog( logger, "Invalid notice_message, known_blocks.ids.size ${s}", ("s", msg.known_blocks.ids.size()) );
          my_impl->close(c);
          return;
       }
       if (msg.known_blocks.mode == catch_up) {
          if (msg.known_blocks.ids.size() == 0) {
-            elog("got a catch up with ids size = 0");
+            fc_elog( logger,"got a catch up with ids size = 0" );
          } else {
             verify_catchup(c, msg.known_blocks.pending, msg.known_blocks.ids.back());
          }
@@ -1720,7 +1720,7 @@ namespace eosio {
          send_req = false;
       }
       else if (msg.known_trx.mode != none) {
-         elog("passed a notice_message with something other than a normal on none known_trx");
+         fc_elog( logger,"passed a notice_message with something other than a normal on none known_trx" );
          return;
       }
       if (msg.known_blocks.mode == normal) {
@@ -1736,10 +1736,10 @@ namespace eosio {
                   c->add_peer_block({blkid, block_header::num_from_id(blkid)});
                }
             } catch (const assert_exception &ex) {
-               ilog( "caught assert on fetch_block_by_id, ${ex}",("ex",ex.what()));
+               fc_ilog( logger, "caught assert on fetch_block_by_id, ${ex}",("ex",ex.what()) );
                // keep going, client can ask another peer
             } catch (...) {
-               elog( "failed to retrieve block for id");
+               fc_elog( logger, "failed to retrieve block for id");
             }
             if (!b) {
                send_req = true;
@@ -1748,7 +1748,7 @@ namespace eosio {
          }
       }
       else if (msg.known_blocks.mode != none) {
-         elog("passed a notice_message with something other than a normal on none known_blocks");
+         fc_elog( logger, "passed a notice_message with something other than a normal on none known_blocks" );
          return;
       }
       fc_dlog( logger, "send req = ${sr}", ("sr",send_req));
@@ -1817,7 +1817,7 @@ namespace eosio {
       auto colon = c->peer_addr.find(':');
 
       if (colon == std::string::npos || colon == 0) {
-         elog("Invalid peer address. must be \"host:port\": ${p}", ("p",c->peer_addr));
+         fc_elog( logger, "Invalid peer address. must be \"host:port\": ${p}", ("p",c->peer_addr) );
          for ( auto itr : connections ) {
             if((*itr).peer_addr == c->peer_addr) {
                (*itr).reset();
@@ -1844,7 +1844,8 @@ namespace eosio {
                       if( !err ) {
                          connect( c, endpoint_itr );
                       } else {
-                         elog( "Unable to resolve ${peer_addr}: ${error}", ("peer_addr", c->peer_name())( "error", err.message()));
+                         fc_elog( logger, "Unable to resolve ${peer_addr}: ${error}",
+                                  ("peer_addr", c->peer_name())( "error", err.message()) );
                       }
                    } );
                 } );
@@ -1872,7 +1873,7 @@ namespace eosio {
                   close( c );
                   connect( c, endpoint_itr );
                } else {
-                  elog( "connection failed to ${peer}: ${error}", ("peer", c->peer_name())( "error", err.message()));
+                  fc_elog( logger, "connection failed to ${peer}: ${error}", ("peer", c->peer_name())( "error", err.message()));
                   c->connecting = false;
                   my_impl->close( c );
                }
@@ -1886,8 +1887,7 @@ namespace eosio {
       boost::system::error_code ec;
       con->socket->set_option( nodelay, ec );
       if (ec) {
-         elog( "connection failed to ${peer}: ${error}",
-               ( "peer", con->peer_name())("error",ec.message()));
+         fc_elog( logger, "connection failed to ${peer}: ${error}", ( "peer", con->peer_name())("error",ec.message()) );
          con->connecting = false;
          close(con);
          return false;
@@ -1928,7 +1928,7 @@ namespace eosio {
                      }
                   }
                   if (num_clients != visitors) {
-                     ilog("checking max client, visitors = ${v} num clients ${n}",("v",visitors)("n",num_clients));
+                     fc_ilog( logger,"checking max client, visitors = ${v} num clients ${n}",("v",visitors)("n",num_clients) );
                      num_clients = visitors;
                   }
                   if( from_addr < max_nodes_per_host && (max_client_count == 0 || num_clients < max_client_count )) {
@@ -1951,7 +1951,7 @@ namespace eosio {
                   }
                }
             } else {
-               elog( "Error accepting connection: ${m}",( "m", ec.message() ) );
+               fc_elog( logger, "Error accepting connection: ${m}",( "m", ec.message() ) );
                // For the listed error codes below, recall start_listen_loop()
                switch (ec.value()) {
                   case ECONNABORTED:
@@ -2042,8 +2042,8 @@ namespace eosio {
                try {
                   if( !ec ) {
                      if (bytes_transferred > conn->pending_message_buffer.bytes_to_write()) {
-                        elog("async_read_some callback: bytes_transfered = ${bt}, buffer.bytes_to_write = ${btw}",
-                             ("bt",bytes_transferred)("btw",conn->pending_message_buffer.bytes_to_write()));
+                        fc_elog( logger,"async_read_some callback: bytes_transfered = ${bt}, buffer.bytes_to_write = ${btw}",
+                                 ("bt",bytes_transferred)("btw",conn->pending_message_buffer.bytes_to_write()) );
                      }
                      EOS_ASSERT(bytes_transferred <= conn->pending_message_buffer.bytes_to_write(), plugin_exception, "");
                      conn->pending_message_buffer.advance_write_ptr(bytes_transferred);
@@ -2059,8 +2059,8 @@ namespace eosio {
                            conn->pending_message_buffer.peek(&message_length, sizeof(message_length), index);
                            if(message_length > def_send_buffer_size*2 || message_length == 0) {
                               boost::system::error_code ec;
-                              elog("incoming message length unexpected (${i}), from ${p}",
-                                    ("i", message_length)("p",boost::lexical_cast<std::string>(conn->socket->remote_endpoint(ec))));
+                              fc_elog( logger,"incoming message length unexpected (${i}), from ${p}",
+                                       ("i", message_length)("p",boost::lexical_cast<std::string>(conn->socket->remote_endpoint(ec))) );
                               close(conn);
                               return;
                            }
@@ -2088,33 +2088,33 @@ namespace eosio {
                   } else {
                      auto pname = conn->peer_name();
                      if (ec.value() != boost::asio::error::eof) {
-                        elog( "Error reading message from ${p}: ${m}",("p",pname)( "m", ec.message() ) );
+                        fc_elog( logger, "Error reading message from ${p}: ${m}",("p",pname)( "m", ec.message() ) );
                      } else {
-                        ilog( "Peer ${p} closed connection",("p",pname) );
+                        fc_ilog( logger, "Peer ${p} closed connection",("p",pname) );
                      }
                      close( conn );
                   }
                }
                catch(const std::exception &ex) {
                   string pname = conn ? conn->peer_name() : "no connection name";
-                  elog("Exception in handling read data from ${p} ${s}",("p",pname)("s",ex.what()));
+                  fc_elog( logger, "Exception in handling read data from ${p} ${s}",("p",pname)("s",ex.what()) );
                   close( conn );
                }
                catch(const fc::exception &ex) {
                   string pname = conn ? conn->peer_name() : "no connection name";
-                  elog("Exception in handling read data ${s}", ("p",pname)("s",ex.to_string()));
+                  fc_elog( logger, "Exception in handling read data ${s}", ("p",pname)("s",ex.to_string()) );
                   close( conn );
                }
                catch (...) {
                   string pname = conn ? conn->peer_name() : "no connection name";
-                  elog( "Undefined exception hanlding the read data from connection ${p}",( "p",pname));
+                  fc_elog( logger, "Undefined exception hanlding the read data from connection ${p}",( "p",pname) );
                   close( conn );
                }
             });
          });
       } catch (...) {
          string pname = conn ? conn->peer_name() : "no connection name";
-         elog( "Undefined exception handling reading ${p}",("p",pname) );
+         fc_elog( logger, "Undefined exception handling reading ${p}",("p",pname) );
          close( conn );
       }
    }
@@ -2184,20 +2184,20 @@ namespace eosio {
       // affecting state.
       bool valid = true;
       if (msg.last_irreversible_block_num > msg.head_num) {
-         wlog("Handshake message validation: last irreversible block (${i}) is greater than head block (${h})",
-              ("i", msg.last_irreversible_block_num)("h", msg.head_num));
+         fc_wlog( logger, "Handshake message validation: last irreversible block (${i}) is greater than head block (${h})",
+                  ("i", msg.last_irreversible_block_num)("h", msg.head_num) );
          valid = false;
       }
       if (msg.p2p_address.empty()) {
-         wlog("Handshake message validation: p2p_address is null string");
+         fc_wlog( logger, "Handshake message validation: p2p_address is null string" );
          valid = false;
       }
       if (msg.os.empty()) {
-         wlog("Handshake message validation: os field is null string");
+         fc_wlog( logger, "Handshake message validation: os field is null string" );
          valid = false;
       }
       if ((msg.sig != chain::signature_type() || msg.token != sha256()) && (msg.token != fc::sha256::hash(msg.time))) {
-         wlog("Handshake message validation: token field invalid");
+         fc_wlog( logger, "Handshake message validation: token field invalid" );
          valid = false;
       }
       return valid;
@@ -2222,7 +2222,7 @@ namespace eosio {
       }
       if (msg.generation == 1) {
          if( msg.node_id == node_id) {
-            elog( "Self connection detected. Closing connection");
+            fc_elog( logger, "Self connection detected. Closing connection" );
             c->enqueue( go_away_message( self ) );
             return;
          }
@@ -2254,20 +2254,20 @@ namespace eosio {
          }
 
          if( msg.chain_id != chain_id) {
-            elog( "Peer on a different chain. Closing connection");
+            fc_elog( logger, "Peer on a different chain. Closing connection" );
             c->enqueue( go_away_message(go_away_reason::wrong_chain) );
             return;
          }
          c->protocol_version = to_protocol_version(msg.network_version);
          if(c->protocol_version != net_version) {
             if (network_version_match) {
-               elog("Peer network version does not match expected ${nv} but got ${mnv}",
-                    ("nv", net_version)("mnv", c->protocol_version));
+               fc_elog( logger, "Peer network version does not match expected ${nv} but got ${mnv}",
+                        ("nv", net_version)("mnv", c->protocol_version) );
                c->enqueue(go_away_message(wrong_version));
                return;
             } else {
-               ilog("Local network version: ${nv} Remote version: ${mnv}",
-                    ("nv", net_version)("mnv", c->protocol_version));
+               fc_ilog( logger, "Local network version: ${nv} Remote version: ${mnv}",
+                        ("nv", net_version)("mnv", c->protocol_version));
             }
          }
 
@@ -2276,7 +2276,7 @@ namespace eosio {
          }
 
          if(!authenticate_peer(msg)) {
-            elog("Peer not authenticated.  Closing connection.");
+            fc_elog( logger, "Peer not authenticated.  Closing connection." );
             c->enqueue(go_away_message(authentication));
             return;
          }
@@ -2290,15 +2290,15 @@ namespace eosio {
                on_fork =( msg.last_irreversible_block_id != peer_lib_id);
             }
             catch( const unknown_block_exception &ex) {
-               wlog( "peer last irreversible block ${pl} is unknown", ("pl", peer_lib));
+               fc_wlog( logger, "peer last irreversible block ${pl} is unknown", ("pl", peer_lib) );
                on_fork = true;
             }
             catch( ...) {
-               wlog( "caught an exception getting block id for ${pl}",("pl",peer_lib));
+               fc_wlog( logger, "caught an exception getting block id for ${pl}",("pl",peer_lib) );
                on_fork = true;
             }
             if( on_fork) {
-               elog( "Peer chain is forked");
+               fc_elog( logger, "Peer chain is forked" );
                c->enqueue( go_away_message( forked ));
                return;
             }
@@ -2317,8 +2317,8 @@ namespace eosio {
    void net_plugin_impl::handle_message(const connection_ptr& c, const go_away_message& msg) {
       string rsn = reason_str( msg.reason );
       peer_ilog(c, "received go_away_message");
-      ilog( "received a go away message from ${p}, reason = ${r}",
-            ("p", c->peer_name())("r",rsn));
+      fc_ilog( logger, "received a go away message from ${p}, reason = ${r}",
+               ("p", c->peer_name())("r",rsn) );
       c->no_retry = msg.reason;
       if(msg.reason == duplicate ) {
          c->node_id = msg.node_id;
@@ -2426,7 +2426,7 @@ namespace eosio {
 
    void net_plugin_impl::handle_message(const connection_ptr& c, const request_message& msg) {
       if( msg.req_blocks.ids.size() > 1 ) {
-         elog( "Invalid request_message, req_blocks.ids.size ${s}", ("s", msg.req_blocks.ids.size()) );
+         fc_elog( logger, "Invalid request_message, req_blocks.ids.size ${s}", ("s", msg.req_blocks.ids.size()) );
          close(c);
          return;
       }
@@ -2534,7 +2534,7 @@ namespace eosio {
          }
       } catch( ...) {
          // should this even be caught?
-         elog("Caught an unknown exception trying to recall blockID");
+         fc_elog( logger,"Caught an unknown exception trying to recall blockID" );
       }
 
       dispatcher->recv_block(c, blk_id, blk_num);
@@ -2551,18 +2551,18 @@ namespace eosio {
          reason = unlinkable;
       } catch( const block_validate_exception &ex) {
          peer_elog(c, "bad signed_block : ${m}", ("m",ex.what()));
-         elog( "block_validate_exception accept block #${n} syncing from ${p}",("n",blk_num)("p",c->peer_name()));
+         fc_elog( logger, "block_validate_exception accept block #${n} syncing from ${p}",("n",blk_num)("p",c->peer_name()) );
          reason = validation;
       } catch( const assert_exception &ex) {
          peer_elog(c, "bad signed_block : ${m}", ("m",ex.what()));
-         elog( "unable to accept block on assert exception ${n} from ${p}",("n",ex.to_string())("p",c->peer_name()));
+         fc_elog( logger, "unable to accept block on assert exception ${n} from ${p}",("n",ex.to_string())("p",c->peer_name()));
       } catch( const fc::exception &ex) {
          peer_elog(c, "bad signed_block : ${m}", ("m",ex.what()));
-         elog( "accept_block threw a non-assert exception ${x} from ${p}",( "x",ex.to_string())("p",c->peer_name()));
+         fc_elog( logger, "accept_block threw a non-assert exception ${x} from ${p}",( "x",ex.to_string())("p",c->peer_name()));
          reason = no_reason;
       } catch( ...) {
          peer_elog(c, "bad signed_block : unknown exception");
-         elog( "handle sync block caught something else from ${p}",("num",blk_num)("p",c->peer_name()));
+         fc_elog( logger, "handle sync block caught something else from ${p}",("num",blk_num)("p",c->peer_name()));
       }
 
       update_block_num ubn(blk_num);
@@ -2593,7 +2593,7 @@ namespace eosio {
                connection_monitor(from_connection);
             }
             else {
-               elog( "Error from connection check monitor: ${m}",( "m", ec.message()));
+               fc_elog( logger, "Error from connection check monitor: ${m}",( "m", ec.message()));
                start_conn_timer( connector_period, std::weak_ptr<connection>());
             }
          });
@@ -2608,7 +2608,7 @@ namespace eosio {
             if( !ec ) {
                expire_txns();
             } else {
-               elog( "Error from transaction check monitor: ${m}", ("m", ec.message()));
+               fc_elog( logger, "Error from transaction check monitor: ${m}", ("m", ec.message()));
                start_txn_timer();
             }
          } );
@@ -2621,7 +2621,7 @@ namespace eosio {
          app().post( priority::low, [this, ec]() {
             ticker();
             if( ec ) {
-               wlog( "Peer keepalive ticked sooner than expected: ${m}", ("m", ec.message()));
+               fc_wlog( logger, "Peer keepalive ticked sooner than expected: ${m}", ("m", ec.message()) );
             }
             for( auto& c : connections ) {
                if( c->socket->is_open()) {
@@ -2740,8 +2740,8 @@ namespace eosio {
          if(producer_plug != nullptr)
             found_producer_key = producer_plug->is_producer_key(msg.key);
          if( allowed_it == allowed_peers.end() && private_it == private_keys.end() && !found_producer_key) {
-            elog( "Peer ${peer} sent a handshake with an unauthorized key: ${key}.",
-                  ("peer", msg.p2p_address)("key", msg.key));
+            fc_elog( logger, "Peer ${peer} sent a handshake with an unauthorized key: ${key}.",
+                     ("peer", msg.p2p_address)("key", msg.key) );
             return false;
          }
       }
@@ -2750,16 +2750,15 @@ namespace eosio {
       sc::system_clock::duration msg_time(msg.time);
       auto time = sc::system_clock::now().time_since_epoch();
       if(time - msg_time > peer_authentication_interval) {
-         elog( "Peer ${peer} sent a handshake with a timestamp skewed by more than ${time}.",
-               ("peer", msg.p2p_address)("time", "1 second")); // TODO Add to_variant for std::chrono::system_clock::duration
+         fc_elog( logger, "Peer ${peer} sent a handshake with a timestamp skewed by more than ${time}.",
+                  ("peer", msg.p2p_address)("time", "1 second")); // TODO Add to_variant for std::chrono::system_clock::duration
          return false;
       }
 
       if(msg.sig != chain::signature_type() && msg.token != sha256()) {
          sha256 hash = fc::sha256::hash(msg.time);
          if(hash != msg.token) {
-            elog( "Peer ${peer} sent a handshake with an invalid token.",
-                  ("peer", msg.p2p_address));
+            fc_elog( logger, "Peer ${peer} sent a handshake with an invalid token.", ("peer", msg.p2p_address) );
             return false;
          }
          chain::public_key_type peer_key;
@@ -2767,18 +2766,16 @@ namespace eosio {
             peer_key = crypto::public_key(msg.sig, msg.token, true);
          }
          catch (fc::exception& /*e*/) {
-            elog( "Peer ${peer} sent a handshake with an unrecoverable key.",
-                  ("peer", msg.p2p_address));
+            fc_elog( logger, "Peer ${peer} sent a handshake with an unrecoverable key.", ("peer", msg.p2p_address) );
             return false;
          }
          if((allowed_connections & (Producers | Specified)) && peer_key != msg.key) {
-            elog( "Peer ${peer} sent a handshake with an unauthenticated key.",
-                  ("peer", msg.p2p_address));
+            fc_elog( logger, "Peer ${peer} sent a handshake with an unauthenticated key.", ("peer", msg.p2p_address) );
             return false;
          }
       }
       else if(allowed_connections & (Producers | Specified)) {
-         dlog( "Peer sent a handshake with blank signature and token, but this node accepts only authenticated connections.");
+         fc_dlog( logger, "Peer sent a handshake with blank signature and token, but this node accepts only authenticated connections." );
          return false;
       }
       return true;
@@ -2838,7 +2835,7 @@ namespace eosio {
             hello.last_irreversible_block_id = cc.get_block_id_for_num(hello.last_irreversible_block_num);
          }
          catch( const unknown_block_exception &ex) {
-            ilog("caught unkown_block");
+            fc_ilog( logger, "caught unkown_block" );
             hello.last_irreversible_block_num = 0;
          }
       }
@@ -2900,7 +2897,7 @@ namespace eosio {
    }
 
    void net_plugin::plugin_initialize( const variables_map& options ) {
-      ilog("Initialize net plugin");
+      fc_ilog( logger, "Initialize net plugin" );
       try {
          peer_log_format = options.at( "peer-log-format" ).as<string>();
 
@@ -2977,7 +2974,7 @@ namespace eosio {
          EOS_ASSERT( my->chain_plug, chain::missing_chain_plugin_exception, ""  );
          my->chain_id = my->chain_plug->get_chain_id();
          fc::rand_pseudo_bytes( my->node_id.data(), my->node_id.data_size());
-         ilog( "my node_id is ${id}", ("id", my->node_id));
+         fc_ilog( logger, "my node_id is ${id}", ("id", my->node_id ));
 
       } FC_LOG_AND_RETHROW()
    }
@@ -3031,12 +3028,12 @@ namespace eosio {
          try {
            my->acceptor->bind(my->listen_endpoint);
          } catch (const std::exception& e) {
-           ilog("net_plugin::plugin_startup failed to bind to port ${port}",
-             ("port", my->listen_endpoint.port()));
+           fc_ilog( logger, "net_plugin::plugin_startup failed to bind to port ${port}",
+                    ("port", my->listen_endpoint.port()));
            throw e;
          }
          my->acceptor->listen();
-         ilog("starting listener, max clients is ${mc}",("mc",my->max_client_count));
+         fc_ilog( logger, "starting listener, max clients is ${mc}",("mc",my->max_client_count) );
          my->start_listen_loop();
       }
       chain::controller&cc = my->chain_plug->chain();
@@ -3048,7 +3045,7 @@ namespace eosio {
 
       if( cc.get_read_mode() == chain::db_read_mode::READ_ONLY ) {
          my->max_nodes_per_host = 0;
-         ilog( "node in read-only mode setting max_nodes_per_host to 0 to prevent connections" );
+         fc_ilog( logger, "node in read-only mode setting max_nodes_per_host to 0 to prevent connections" );
       }
 
       my->start_monitors();
@@ -3066,7 +3063,7 @@ namespace eosio {
 
    void net_plugin::plugin_shutdown() {
       try {
-         ilog( "shutdown.." );
+         fc_ilog( logger, "shutdown.." );
          if( my->server_ioc_work )
             my->server_ioc_work->reset();
 
@@ -3079,11 +3076,11 @@ namespace eosio {
 
          my->done = true;
          if( my->acceptor ) {
-            ilog( "close acceptor" );
+            fc_ilog( logger, "close acceptor" );
             my->acceptor->cancel();
             my->acceptor->close();
 
-            ilog( "close ${s} connections",( "s",my->connections.size()) );
+            fc_ilog( logger, "close ${s} connections",( "s",my->connections.size()) );
             for( auto& con : my->connections ) {
                my->close( con );
             }
@@ -3096,7 +3093,7 @@ namespace eosio {
             my->thread_pool->join();
             my->thread_pool->stop();
          }
-         ilog( "exit shutdown" );
+         fc_ilog( logger, "exit shutdown" );
       }
       FC_CAPTURE_AND_RETHROW()
    }

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -1550,7 +1550,7 @@ namespace eosio {
       }
    }
    void sync_manager::recv_block(const connection_ptr& c, const block_id_type& blk_id, uint32_t blk_num) {
-      fc_dlog(logger," got block ${bn} from ${p}",("bn",blk_num)("p",c->peer_name()));
+      fc_dlog(logger, "got block ${bn} from ${p}",("bn",blk_num)("p",c->peer_name()));
       if (state == lib_catchup) {
          if (blk_num != sync_next_expected_num) {
             fc_ilog(logger, "expected block ${ne} but got ${bn}",("ne",sync_next_expected_num)("bn",blk_num));

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -745,7 +745,7 @@ namespace eosio {
         fork_head_num(0),
         last_req()
    {
-      fc_wlog( logger, "created connection to ${n}", ("n", endpoint) );
+      fc_ilog( logger, "created connection to ${n}", ("n", endpoint) );
       initialize();
    }
 
@@ -770,7 +770,7 @@ namespace eosio {
         fork_head_num(0),
         last_req()
    {
-      fc_wlog( logger, "accepted network connection" );
+      fc_ilog( logger, "accepted network connection" );
       initialize();
    }
 
@@ -987,10 +987,10 @@ namespace eosio {
                if(ec) {
                   string pname = conn ? conn->peer_name() : "no connection name";
                   if( ec.value() != boost::asio::error::eof) {
-                     fc_elog( logger,"Error sending to peer ${p}: ${i}", ("p",pname)("i", ec.message()) );
+                     fc_elog( logger, "Error sending to peer ${p}: ${i}", ("p",pname)("i", ec.message()) );
                   }
                   else {
-                     fc_ilog( logger, "connection closure detected on write to ${p}",("p",pname) );
+                     fc_wlog( logger, "connection closure detected on write to ${p}",("p",pname) );
                   }
                   my_impl->close(conn);
                   return;
@@ -2316,8 +2316,8 @@ namespace eosio {
 
    void net_plugin_impl::handle_message(const connection_ptr& c, const go_away_message& msg) {
       string rsn = reason_str( msg.reason );
-      peer_ilog(c, "received go_away_message");
-      fc_ilog( logger, "received a go away message from ${p}, reason = ${r}",
+      peer_wlog(c, "received go_away_message");
+      fc_wlog( logger, "received a go away message from ${p}, reason = ${r}",
                ("p", c->peer_name())("r",rsn) );
       c->no_retry = msg.reason;
       if(msg.reason == duplicate ) {
@@ -2835,7 +2835,7 @@ namespace eosio {
             hello.last_irreversible_block_id = cc.get_block_id_for_num(hello.last_irreversible_block_num);
          }
          catch( const unknown_block_exception &ex) {
-            fc_ilog( logger, "caught unkown_block" );
+            fc_wlog( logger, "caught unkown_block" );
             hello.last_irreversible_block_num = 0;
          }
       }
@@ -3028,7 +3028,7 @@ namespace eosio {
          try {
            my->acceptor->bind(my->listen_endpoint);
          } catch (const std::exception& e) {
-           fc_ilog( logger, "net_plugin::plugin_startup failed to bind to port ${port}",
+           fc_elog( logger, "net_plugin::plugin_startup failed to bind to port ${port}",
                     ("port", my->listen_endpoint.port()));
            throw e;
          }


### PR DESCRIPTION
## Change Description

- Change net_plugin to use plugin-local logger instead of default logger for all logging
- This is PR #6365 with merge conflicts resolved.

Co-Authored-By: Vincent Gu <v@vgu.io>

## Consensus Changes

None

## API Changes

None

## Documentation Additions

Indicate that all net_plugin logging is controlled by "net_plugin_impl" in logging.json.

For example:
```
{
  "includes": [],
  "appenders": [{
      "name": "stderr",
      "type": "console",
      "args": {
        "format": "hello",
        "stream": "std_error",
        "level_colors": [{
            "level": "debug",
            "color": "green"
          },{
            "level": "warn",
            "color": "brown"
          },{
            "level": "error",
            "color": "red"
          }
        ]
      },
      "enabled": true
    },{
      "name": "stdout",
      "type": "console",
      "args": {
        "format": "hello",
        "stream": "std_out",
        "level_colors": [{
            "level": "debug",
            "color": "green"
          },{
            "level": "warn",
            "color": "brown"
          },{
            "level": "error",
            "color": "red"
          }
        ]
      },
      "enabled": true
    },{
      "name": "net",
      "type": "gelf",
      "args": {
        "endpoint": "10.0.0.1:12201",
        "host": "testnet_00"
      },
      "enabled": true
    }
  ],
  "loggers": [{
      "name": "default",
      "level": "debug",
      "enabled": true,
      "additivity": false,
      "appenders": [
        "stderr",
        "net"
      ]
    },{
      "name": "net_plugin_impl",
      "level": "debug",
      "enabled": true,
      "additivity": false,
      "appenders": [
        "stderr",
        "net"
      ]
    }
  ]
}
```
