### PR TITLE
wrong branch/tag name

### DIFF
--- a/Docker/README.md
+++ b/Docker/README.md
@@ -23,7 +23,7 @@ docker build . -t eosio/eos
 The above will build off the most recent commit to the master branch by default. If you would like to target a specific branch/tag, you may use a build argument. For example, if you wished to generate a docker image based off of the 1.6.2 tag, you could do the following:
 
 ```bash
-docker build -t eosio/eos:v1.6.2 --build-arg branch=1.6.2 .
+docker build -t eosio/eos:v1.6.2 --build-arg branch=v1.6.2 .
 ```
 
 By default, the symbol in eosio.system is set to SYS. You can override this using the symbol argument while building the docker image.


### PR DESCRIPTION
there is no tag or branch named "1.6.2", I think it should be "v1.6.2"?

<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- Give your PR a title that is sufficient to understand what is being changed. -->

## Change Description

<!-- Describe the change you made, the motivation for it, and the impact it will have. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

## Consensus Changes

<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes

<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions

<!-- List all the information that needs to be added to the documentation after merge. -->
