### PR TITLE
cleos get transaction_id enhancements

### DIFF
--- a/programs/cleos/help_text.cpp
+++ b/programs/cleos/help_text.cpp
@@ -145,7 +145,7 @@ const char* error_advice_authority_type_exception = R"=====(Ensure that your aut
 )=====";
 const char* error_advice_action_type_exception = R"=====(Ensure that your action JSON follows the contract's abi!)=====";
 const char* error_advice_transaction_type_exception = R"=====(Ensure that your transaction JSON follows the right transaction format!
-You can refer to contracts/eosiolib/transaction.hpp for reference)=====";
+You can refer to eosio.cdt/libraries/eosiolib/transaction.hpp for reference)=====";
 const char* error_advice_abi_type_exception =  R"=====(Ensure that your abi JSON follows the following format!
 {
   "types" : [{ "new_type_name":"type_name", "type":"type_name" }],

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -1309,13 +1309,49 @@ struct get_transaction_id_subcommand {
 
       get_transaction_id->set_callback([&] {
          try {
-            auto trx_var = json_from_file_or_string(trx_to_check);
-            auto trx = trx_var.as<transaction>();
-            transaction_id_type id = trx.id();
-            if( id == transaction().id() ) {
-               std::cerr << "file/string does not represent a transaction" << std::endl;
+            fc::variant trx_var = json_from_file_or_string(trx_to_check);
+            if( trx_var.is_object() ) {
+               fc::variant_object& vo = trx_var.get_object();
+               // if actions.data & actions.hex_data provided, use the hex_data since only currently support unexploded data
+               if( vo.contains("actions") ) {
+                  if( vo["actions"].is_array() ) {
+                     fc::mutable_variant_object mvo = vo;
+                     fc::variants& action_variants = mvo["actions"].get_array();
+                     for( auto& action_v : action_variants ) {
+                        if( !action_v.is_object() ) {
+                           std::cerr << "Empty 'action' in transaction" << endl;
+                           return;
+                        }
+                        fc::variant_object& action_vo = action_v.get_object();
+                        if( action_vo.contains( "data" ) && action_vo.contains( "hex_data" ) ) {
+                           fc::mutable_variant_object maction_vo = action_vo;
+                           maction_vo["data"] = maction_vo["hex_data"];
+                           action_vo = maction_vo;
+                           vo = mvo;
+                        } else if( action_vo.contains( "data" ) ) {
+                           if( !action_vo["data"].is_string() ) {
+                              std::cerr << "get transaction_id only supports un-exploded 'data' (hex form)" << std::endl;
+                              return;
+                           }
+                        }
+                     }
+                  } else {
+                     std::cerr << "transaction json 'actions' is not an array" << std::endl;
+                     return;
+                  }
+               } else {
+                  std::cerr << "transaction json does not include 'actions'" << std::endl;
+                  return;
+               }
+               auto trx = trx_var.as<transaction>();
+               transaction_id_type id = trx.id();
+               if( id == transaction().id() ) {
+                  std::cerr << "file/string does not represent a transaction" << std::endl;
+               } else {
+                  std::cout << string( id ) << std::endl;
+               }
             } else {
-               std::cout << string( id ) << std::endl;
+               std::cerr << "file/string does not represent a transaction" << std::endl;
             }
          } EOS_RETHROW_EXCEPTIONS(transaction_type_exception, "Fail to parse transaction JSON '${data}'", ("data",trx_to_check))
       });

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -1311,7 +1311,12 @@ struct get_transaction_id_subcommand {
          try {
             auto trx_var = json_from_file_or_string(trx_to_check);
             auto trx = trx_var.as<transaction>();
-            std::cout << string(trx.id()) << std::endl;
+            transaction_id_type id = trx.id();
+            if( id == transaction().id() ) {
+               std::cerr << "file/string does not represent a transaction" << std::endl;
+            } else {
+               std::cout << string( id ) << std::endl;
+            }
          } EOS_RETHROW_EXCEPTIONS(transaction_type_exception, "Fail to parse transaction JSON '${data}'", ("data",trx_to_check))
       });
    }


### PR DESCRIPTION
## Change Description

- Currently cleos get transaction_id only works for un-exploded action `data`. See https://github.com/EOSIO/eos/pull/4892#pullrequestreview-145014509 .
- Also variant from file/string will return a default constructed `transaction` if file/string does not actually contain json with `transaction` attributes. Added a check for this case.
- Automatically use `actions.hex_data` for `actions.data` if `action.hex_data` is provided.
- In the future, `cleos get transaction_id` could be improved to support exploded action data if abi is provided.

## Consensus Changes

None

## API Changes

None

## Documentation Additions

- It should be noted that `cleos get transaction_id` currently only works for un-exploded action data.

For example:
```
{
          "expiration": "2019-02-25T13:27:39",
          "ref_block_num": 8695,
          "ref_block_prefix": 3632563554,
          "max_net_usage_words": 0,
          "max_cpu_usage_ms": 0,
          "delay_sec": 0,
          "context_free_actions": [],
          "actions": [
            {
              "account": "eosio.token",
              "name": "transfer",
              "authorization": [
                {
                  "actor": "zjtzjt535353",
                  "permission": "active"
                }
              ],
              "data": {
                "from": "zjtzjt535353",
                "to": "pokereosgame",
                "quantity": "1.2976 EOS",
                "memo": "bet:3244,seed:GWiwC4MTyHKZNCM2YcBC,ref:bitpie4users"
              },
          ],
          "transaction_extensions": []
        }
```
Will NOT work because `data` is exploded. However, this will work:
```
{
          "expiration": "2019-02-25T13:27:39",
          "ref_block_num": 8695,
          "ref_block_prefix": 3632563554,
          "max_net_usage_words": 0,
          "max_cpu_usage_ms": 0,
          "delay_sec": 0,
          "context_free_actions": [],
          "actions": [
            {
              "account": "eosio.token",
              "name": "transfer",
              "authorization": [
                {
                  "actor": "zjtzjt535353",
                  "permission": "active"
                }
              ],
              "data": {
                "from": "zjtzjt535353",
                "to": "pokereosgame",
                "quantity": "1.2976 EOS",
                "memo": "bet:3244,seed:GWiwC4MTyHKZNCM2YcBC,ref:bitpie4users"
              },
              "hex_data": "30ca28a3e4f7f3fba0a46198aaab20adb03200000000000004454f5300000000336265743a333234342c736565643a4757697743344d5479484b5a4e434d32596342432c7265663a626974706965347573657273"
            }
          ],
          "transaction_extensions": []
        }
```
As get transaction_id now will use `actions.hex_data` as `actions.data` if `actions.hex_data` is provided.
