### PR TITLE
Remove *.cmake from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 *.s
 *.dot
 *.abi.hpp
+*.cmake
+!CMakeModules/*.cmake
 *.ninja
 \#*
 \.#*

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@
 *.s
 *.dot
 *.abi.hpp
-*.cmake
 *.ninja
 \#*
 \.#*


### PR DESCRIPTION
I'm not sure how this crept in.  This could've caused issues with lost changes to .cmake files under the CMakeModules folder if the developer wasn't careful.

<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- Give your PR a title that is sufficient to understand what is being changed. -->

## Change Description
Remove *.cmake from .gitignore.
<!-- Describe the change you made, the motivation for it, and the impact it will have. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

## Consensus Changes

<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes

<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions

<!-- List all the information that needs to be added to the documentation after merge. -->
