### PR TITLE
Support for amazonlinux2

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,109 +1,88 @@
 steps:
 
-  # - command: |
-  #       echo "+++ :hammer: Building" && \
-  #       ./scripts/eosio_build.sh -y && \
-  #       echo "--- :compression: Compressing build directory" && \
-  #       tar -pczf build.tar.gz build/
-  #   label: ":ubuntu: 16.04 Build"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   artifact_paths: "build.tar.gz"
-  #   plugins:
-  #     ecr#v1.1.4:
-  #       login: true
-  #       account_ids: "436617320021"
-  #       no-include-email: true
-  #       region: "us-west-2"
-  #     docker#v2.1.0:
-  #       debug: true
-  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu16"
-  #       workdir: /data/job
-  #   timeout: 60
+  - command: |
+        echo "+++ :hammer: Building" && \
+        ./scripts/eosio_build.sh -y && \
+        echo "--- :compression: Compressing build directory" && \
+        tar -pczf build.tar.gz build/
+    label: ":ubuntu: 16.04 Build"
+    agents:
+      queue: "automation-large-builder-fleet"
+    artifact_paths: "build.tar.gz"
+    plugins:
+      ecr#v1.1.4:
+        login: true
+        account_ids: "436617320021"
+        no-include-email: true
+        region: "us-west-2"
+      docker#v2.1.0:
+        debug: true
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu16"
+        workdir: /data/job
+    timeout: 60
 
-  # - command: |
-  #       echo "+++ :hammer: Building" && \
-  #       ./scripts/eosio_build.sh -y && \
-  #       echo "--- :compression: Compressing build directory" && \
-  #       tar -pczf build.tar.gz build/
-  #   label: ":ubuntu: 18.04 Build"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   artifact_paths: "build.tar.gz"
-  #   plugins:
-  #     ecr#v1.1.4:
-  #       login: true
-  #       account_ids: "436617320021"
-  #       no-include-email: true
-  #       region: "us-west-2"
-  #     docker#v2.1.0:
-  #       debug: true
-  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu18"
-  #       workdir: /data/job
-  #   timeout: 60
+  - command: |
+        echo "+++ :hammer: Building" && \
+        ./scripts/eosio_build.sh -y && \
+        echo "--- :compression: Compressing build directory" && \
+        tar -pczf build.tar.gz build/
+    label: ":ubuntu: 18.04 Build"
+    agents:
+      queue: "automation-large-builder-fleet"
+    artifact_paths: "build.tar.gz"
+    plugins:
+      ecr#v1.1.4:
+        login: true
+        account_ids: "436617320021"
+        no-include-email: true
+        region: "us-west-2"
+      docker#v2.1.0:
+        debug: true
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu18"
+        workdir: /data/job
+    timeout: 60
 
-  # - command: |
-  #       echo "+++ :hammer: Building" && \
-  #       ./scripts/eosio_build.sh -y && \
-  #       echo "--- :compression: Compressing build directory" && \
-  #       tar -pczf build.tar.gz build/
-  #   label: ":centos: 7 Build"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   artifact_paths: "build.tar.gz"
-  #   plugins:
-  #     ecr#v1.1.4:
-  #       login: true
-  #       account_ids: "436617320021"
-  #       no-include-email: true
-  #       region: "us-west-2"
-  #     docker#v2.1.0:
-  #       debug: true
-  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:centos7"
-  #       workdir: /data/job
-  #   timeout: 60
+  - command: |
+        echo "+++ :hammer: Building" && \
+        ./scripts/eosio_build.sh -y && \
+        echo "--- :compression: Compressing build directory" && \
+        tar -pczf build.tar.gz build/
+    label: ":centos: 7 Build"
+    agents:
+      queue: "automation-large-builder-fleet"
+    artifact_paths: "build.tar.gz"
+    plugins:
+      ecr#v1.1.4:
+        login: true
+        account_ids: "436617320021"
+        no-include-email: true
+        region: "us-west-2"
+      docker#v2.1.0:
+        debug: true
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:centos7"
+        workdir: /data/job
+    timeout: 60
 
-  # - command: |
-  #       echo "+++ :hammer: Building" && \
-  #       ./scripts/eosio_build.sh -y && \
-  #       echo "--- :compression: Compressing build directory" && \
-  #       tar -pczf build.tar.gz build/
-  #   label: ":aws: 1 Build"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   artifact_paths: "build.tar.gz"
-  #   plugins:
-  #     ecr#v1.1.4:
-  #       login: true
-  #       account_ids: "436617320021"
-  #       no-include-email: true
-  #       region: "us-west-2"
-  #     docker#v2.1.0:
-  #       debug: true
-  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:amazonlinux1"
-  #       workdir: /data/job
-  #   timeout: 60
-
-  # - command: |
-  #       echo "+++ :hammer: Building" && \
-  #       ./scripts/eosio_build.sh -y && \
-  #       echo "--- :compression: Compressing build directory" && \
-  #       tar -pczf build.tar.gz build/
-  #   label: ":aws: 2 Build"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   artifact_paths: "build.tar.gz"
-  #   plugins:
-  #     ecr#v1.1.4:
-  #       login: true
-  #       account_ids: "436617320021"
-  #       no-include-email: true
-  #       region: "us-west-2"
-  #     docker#v2.1.0:
-  #       debug: true
-  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:amazonlinux2_2-1"
-  #       workdir: /data/job
-  #   timeout: 60
+  - command: |
+        echo "+++ :hammer: Building" && \
+        ./scripts/eosio_build.sh -y && \
+        echo "--- :compression: Compressing build directory" && \
+        tar -pczf build.tar.gz build/
+    label: ":aws: 1 Build"
+    agents:
+      queue: "automation-large-builder-fleet"
+    artifact_paths: "build.tar.gz"
+    plugins:
+      ecr#v1.1.4:
+        login: true
+        account_ids: "436617320021"
+        no-include-email: true
+        region: "us-west-2"
+      docker#v2.1.0:
+        debug: true
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:amazonlinux1"
+        workdir: /data/job
+    timeout: 60
 
   - command: |
         echo "+++ :hammer: Building" && \
@@ -126,327 +105,294 @@ steps:
         workdir: /data/job
     timeout: 60
 
-  # - command: |
-  #       echo "+++ :hammer: Building" && \
-  #       ./scripts/eosio_build.sh -y && \
-  #       echo "--- :compression: Compressing build directory" && \
-  #       tar -pczf build.tar.gz build/
-  #   label: ":fedora: 27 Build"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   artifact_paths: "build.tar.gz"
-  #   plugins:
-  #     ecr#v1.1.4:
-  #       login: true
-  #       account_ids: "436617320021"
-  #       no-include-email: true
-  #       region: "us-west-2"
-  #     docker#v2.1.0:
-  #       debug: true
-  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:fedora27"
-  #       workdir: /data/job
-  #   timeout: 60
+  - command: |
+        echo "+++ :hammer: Building" && \
+        ./scripts/eosio_build.sh -y && \
+        echo "--- :compression: Compressing build directory" && \
+        tar -pczf build.tar.gz build/
+    label: ":aws: 2 Build"
+    agents:
+      queue: "automation-large-builder-fleet"
+    artifact_paths: "build.tar.gz"
+    plugins:
+      ecr#v1.1.4:
+        login: true
+        account_ids: "436617320021"
+        no-include-email: true
+        region: "us-west-2"
+      docker#v2.1.0:
+        debug: true
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:amazonlinux2_2-1"
+        workdir: /data/job
+    timeout: 60
 
-  # - command: |
-  #     echo "--- Creating symbolic link to job directory :file_folder:" && \
-  #     sleep 5 && ln -s "$(pwd)" /data/job && cd /data/job && \
-  #     echo "+++ Building :hammer:" && \
-  #     ./scripts/eosio_build.sh -y && \
-  #     echo "--- Compressing build directory :compression:" && \
-  #     tar -pczf build.tar.gz build/
-  #   label: ":darwin: Mojave Build"
-  #   agents:
-  #     - "role=builder-v2"
-  #     - "os=mojave"
-  #   artifact_paths: "build.tar.gz"
-  #   timeout: 60
+  - command: |
+        echo "+++ :hammer: Building" && \
+        ./scripts/eosio_build.sh -y && \
+        echo "--- :compression: Compressing build directory" && \
+        tar -pczf build.tar.gz build/
+    label: ":fedora: 27 Build"
+    agents:
+      queue: "automation-large-builder-fleet"
+    artifact_paths: "build.tar.gz"
+    plugins:
+      ecr#v1.1.4:
+        login: true
+        account_ids: "436617320021"
+        no-include-email: true
+        region: "us-west-2"
+      docker#v2.1.0:
+        debug: true
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:fedora27"
+        workdir: /data/job
+    timeout: 60
 
-  # - command: |
-  #     echo "--- Creating symbolic link to job directory :file_folder:" && \
-  #     sleep 5 && ln -s "$(pwd)" /data/job && cd /data/job && \
-  #     echo "+++ Building :hammer:" && \
-  #     ./scripts/eosio_build.sh -y && \
-  #     echo "--- Compressing build directory :compression:" && \
-  #     tar -pczf build.tar.gz build/
-  #   label: ":darwin: High Sierra Build"
-  #   agents:
-  #     - "role=builder-v2"
-  #     - "os=high-sierra"
-  #   artifact_paths: "build.tar.gz"
-  #   timeout: 60
+  - command: |
+      echo "--- Creating symbolic link to job directory :file_folder:" && \
+      sleep 5 && ln -s "$(pwd)" /data/job && cd /data/job && \
+      echo "+++ Building :hammer:" && \
+      ./scripts/eosio_build.sh -y && \
+      echo "--- Compressing build directory :compression:" && \
+      tar -pczf build.tar.gz build/
+    label: ":darwin: Mojave Build"
+    agents:
+      - "role=builder-v2"
+      - "os=mojave"
+    artifact_paths: "build.tar.gz"
+    timeout: 60
+
+  - command: |
+      echo "--- Creating symbolic link to job directory :file_folder:" && \
+      sleep 5 && ln -s "$(pwd)" /data/job && cd /data/job && \
+      echo "+++ Building :hammer:" && \
+      ./scripts/eosio_build.sh -y && \
+      echo "--- Compressing build directory :compression:" && \
+      tar -pczf build.tar.gz build/
+    label: ":darwin: High Sierra Build"
+    agents:
+      - "role=builder-v2"
+      - "os=high-sierra"
+    artifact_paths: "build.tar.gz"
+    timeout: 60
 
   - wait
 
-  # - command: |
-  #       echo "--- :arrow_down: Downloading build directory" && \
-  #       buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 16.04 Build" && \
-  #       tar -zxf build.tar.gz && \
-  #       echo "--- :m: Starting MongoDB" && \
-  #       ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
-  #       echo "+++ :microscope: Running tests" && \
-  #       cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ~/bin/ctest -j8 -LE _tests --output-on-failure
-  #   label: ":ubuntu: 16.04 Tests"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   artifact_paths:
-  #     - "mongod.log"
-  #     - "build/genesis.json"
-  #     - "build/config.ini"
-  #   plugins:
-  #     ecr#v1.1.4:
-  #       login: true
-  #       account_ids: "436617320021"
-  #       no-include-email: true
-  #       region: "us-west-2"
-  #     docker#v2.1.0:
-  #       debug: true
-  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu16"
-  #       workdir: /data/job
-  #   timeout: 60
+  - command: |
+        echo "--- :arrow_down: Downloading build directory" && \
+        buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 16.04 Build" && \
+        tar -zxf build.tar.gz && \
+        echo "--- :m: Starting MongoDB" && \
+        ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
+        echo "+++ :microscope: Running tests" && \
+        cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ~/bin/ctest -j8 -LE _tests --output-on-failure
+    label: ":ubuntu: 16.04 Tests"
+    agents:
+      queue: "automation-large-builder-fleet"
+    artifact_paths:
+      - "mongod.log"
+      - "build/genesis.json"
+      - "build/config.ini"
+    plugins:
+      ecr#v1.1.4:
+        login: true
+        account_ids: "436617320021"
+        no-include-email: true
+        region: "us-west-2"
+      docker#v2.1.0:
+        debug: true
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu16"
+        workdir: /data/job
+    timeout: 60
 
-  # - command: |
-  #       echo "--- :arrow_down: Downloading build directory" && \
-  #       buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 16.04 Build" && \
-  #       tar -zxf build.tar.gz && \
-  #       echo "--- :m: Starting MongoDB" && \
-  #       ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
-  #       echo "+++ :microscope: Running tests" && \
-  #       cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ~/bin/ctest -L nonparallelizable_tests --output-on-failure
-  #   label: ":ubuntu: 16.04 NP Tests"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   artifact_paths:
-  #     - "mongod.log"
-  #     - "build/genesis.json"
-  #     - "build/config.ini"
-  #   plugins:
-  #     ecr#v1.1.4:
-  #       login: true
-  #       account_ids: "436617320021"
-  #       no-include-email: true
-  #       region: "us-west-2"
-  #     docker#v2.1.0:
-  #       debug: true
-  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu16"
-  #       workdir: /data/job
-  #   timeout: 60
+  - command: |
+        echo "--- :arrow_down: Downloading build directory" && \
+        buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 16.04 Build" && \
+        tar -zxf build.tar.gz && \
+        echo "--- :m: Starting MongoDB" && \
+        ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
+        echo "+++ :microscope: Running tests" && \
+        cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ~/bin/ctest -L nonparallelizable_tests --output-on-failure
+    label: ":ubuntu: 16.04 NP Tests"
+    agents:
+      queue: "automation-large-builder-fleet"
+    artifact_paths:
+      - "mongod.log"
+      - "build/genesis.json"
+      - "build/config.ini"
+    plugins:
+      ecr#v1.1.4:
+        login: true
+        account_ids: "436617320021"
+        no-include-email: true
+        region: "us-west-2"
+      docker#v2.1.0:
+        debug: true
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu16"
+        workdir: /data/job
+    timeout: 60
   
-  # - command: |
-  #       echo "--- :arrow_down: Downloading build directory" && \
-  #       buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 18.04 Build" && \
-  #       tar -zxf build.tar.gz && \
-  #       echo "--- :m: Starting MongoDB" && \
-  #       ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
-  #       echo "+++ :microscope: Running tests" && \
-  #       cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ~/bin/ctest -j8 -LE _tests --output-on-failure
-  #   label: ":ubuntu: 18.04 Tests"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   artifact_paths:
-  #     - "mongod.log"
-  #     - "build/genesis.json"
-  #     - "build/config.ini"
-  #   plugins:
-  #     ecr#v1.1.4:
-  #       login: true
-  #       account_ids: "436617320021"
-  #       no-include-email: true
-  #       region: "us-west-2"
-  #     docker#v2.1.0:
-  #       debug: true
-  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu18"
-  #       workdir: /data/job
-  #   timeout: 60
+  - command: |
+        echo "--- :arrow_down: Downloading build directory" && \
+        buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 18.04 Build" && \
+        tar -zxf build.tar.gz && \
+        echo "--- :m: Starting MongoDB" && \
+        ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
+        echo "+++ :microscope: Running tests" && \
+        cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ~/bin/ctest -j8 -LE _tests --output-on-failure
+    label: ":ubuntu: 18.04 Tests"
+    agents:
+      queue: "automation-large-builder-fleet"
+    artifact_paths:
+      - "mongod.log"
+      - "build/genesis.json"
+      - "build/config.ini"
+    plugins:
+      ecr#v1.1.4:
+        login: true
+        account_ids: "436617320021"
+        no-include-email: true
+        region: "us-west-2"
+      docker#v2.1.0:
+        debug: true
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu18"
+        workdir: /data/job
+    timeout: 60
 
-  # - command: |
-  #       echo "--- :arrow_down: Downloading build directory" && \
-  #       buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 18.04 Build" && \
-  #       tar -zxf build.tar.gz && \
-  #       echo "--- :m: Starting MongoDB" && \
-  #       ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
-  #       echo "+++ :microscope: Running tests" && \
-  #       cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ~/bin/ctest -L nonparallelizable_tests --output-on-failure
-  #   label: ":ubuntu: 18.04 NP Tests"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   artifact_paths:
-  #     - "mongod.log"
-  #     - "build/genesis.json"
-  #     - "build/config.ini"
-  #   plugins:
-  #     ecr#v1.1.4:
-  #       login: true
-  #       account_ids: "436617320021"
-  #       no-include-email: true
-  #       region: "us-west-2"
-  #     docker#v2.1.0:
-  #       debug: true
-  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu18"
-  #       workdir: /data/job
-  #   timeout: 60
+  - command: |
+        echo "--- :arrow_down: Downloading build directory" && \
+        buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 18.04 Build" && \
+        tar -zxf build.tar.gz && \
+        echo "--- :m: Starting MongoDB" && \
+        ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
+        echo "+++ :microscope: Running tests" && \
+        cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ~/bin/ctest -L nonparallelizable_tests --output-on-failure
+    label: ":ubuntu: 18.04 NP Tests"
+    agents:
+      queue: "automation-large-builder-fleet"
+    artifact_paths:
+      - "mongod.log"
+      - "build/genesis.json"
+      - "build/config.ini"
+    plugins:
+      ecr#v1.1.4:
+        login: true
+        account_ids: "436617320021"
+        no-include-email: true
+        region: "us-west-2"
+      docker#v2.1.0:
+        debug: true
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu18"
+        workdir: /data/job
+    timeout: 60
 
 
-  # - command: |
-  #       echo "--- :arrow_down: Downloading build directory" && \
-  #       buildkite-agent artifact download "build.tar.gz" . --step ":centos: 7 Build" && \
-  #       tar -zxf build.tar.gz && \
-  #       echo "--- :m: Starting MongoDB" && \
-  #       ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
-  #       echo "+++ :microscope: Running tests" && \
-  #       cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ~/bin/ctest -j8 -LE _tests --output-on-failure
-  #   label: ":centos: 7 Tests"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   artifact_paths:
-  #     - "mongod.log"
-  #     - "build/genesis.json"
-  #     - "build/config.ini"
-  #   plugins:
-  #     ecr#v1.1.4:
-  #       login: true
-  #       account_ids: "436617320021"
-  #       no-include-email: true
-  #       region: "us-west-2"
-  #     docker#v2.1.0:
-  #       debug: true
-  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:centos7"
-  #       workdir: /data/job
-  #   timeout: 60
+  - command: |
+        echo "--- :arrow_down: Downloading build directory" && \
+        buildkite-agent artifact download "build.tar.gz" . --step ":centos: 7 Build" && \
+        tar -zxf build.tar.gz && \
+        echo "--- :m: Starting MongoDB" && \
+        ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
+        echo "+++ :microscope: Running tests" && \
+        cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ~/bin/ctest -j8 -LE _tests --output-on-failure
+    label: ":centos: 7 Tests"
+    agents:
+      queue: "automation-large-builder-fleet"
+    artifact_paths:
+      - "mongod.log"
+      - "build/genesis.json"
+      - "build/config.ini"
+    plugins:
+      ecr#v1.1.4:
+        login: true
+        account_ids: "436617320021"
+        no-include-email: true
+        region: "us-west-2"
+      docker#v2.1.0:
+        debug: true
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:centos7"
+        workdir: /data/job
+    timeout: 60
 
-  # - command: |
-  #       echo "--- :arrow_down: Downloading build directory" && \
-  #       buildkite-agent artifact download "build.tar.gz" . --step ":centos: 7 Build" && \
-  #       tar -zxf build.tar.gz && \
-  #       echo "--- :m: Starting MongoDB" && \
-  #       ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
-  #       echo "+++ :microscope: Running tests" && \
-  #       cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ~/bin/ctest -L nonparallelizable_tests --output-on-failure
-  #   label: ":centos: 7 NP Tests"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   artifact_paths:
-  #     - "mongod.log"
-  #     - "build/genesis.json"
-  #     - "build/config.ini"
-  #   plugins:
-  #     ecr#v1.1.4:
-  #       login: true
-  #       account_ids: "436617320021"
-  #       no-include-email: true
-  #       region: "us-west-2"
-  #     docker#v2.1.0:
-  #       debug: true
-  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:centos7"
-  #       workdir: /data/job
-  #   timeout: 60
+  - command: |
+        echo "--- :arrow_down: Downloading build directory" && \
+        buildkite-agent artifact download "build.tar.gz" . --step ":centos: 7 Build" && \
+        tar -zxf build.tar.gz && \
+        echo "--- :m: Starting MongoDB" && \
+        ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
+        echo "+++ :microscope: Running tests" && \
+        cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ~/bin/ctest -L nonparallelizable_tests --output-on-failure
+    label: ":centos: 7 NP Tests"
+    agents:
+      queue: "automation-large-builder-fleet"
+    artifact_paths:
+      - "mongod.log"
+      - "build/genesis.json"
+      - "build/config.ini"
+    plugins:
+      ecr#v1.1.4:
+        login: true
+        account_ids: "436617320021"
+        no-include-email: true
+        region: "us-west-2"
+      docker#v2.1.0:
+        debug: true
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:centos7"
+        workdir: /data/job
+    timeout: 60
 
-  # - command: |
-  #       echo "--- :arrow_down: Downloading build directory" && \
-  #       buildkite-agent artifact download "build.tar.gz" . --step ":aws: 1 Build" && \
-  #       tar -zxf build.tar.gz && \
-  #       echo "--- :m: Starting MongoDB" && \
-  #       ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
-  #       echo "+++ :microscope: Running tests" && \
-  #       cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ~/bin/ctest -j8 -LE _tests --output-on-failure
-  #   label: ":aws: 1 Tests"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   artifact_paths:
-  #     - "mongod.log"
-  #     - "build/genesis.json"
-  #     - "build/config.ini"
-  #   plugins:
-  #     ecr#v1.1.4:
-  #       login: true
-  #       account_ids: "436617320021"
-  #       no-include-email: true
-  #       region: "us-west-2"
-  #     docker#v2.1.0:
-  #       debug: true
-  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:amazonlinux1"
-  #       workdir: /data/job
-  #   timeout: 60
+  - command: |
+        echo "--- :arrow_down: Downloading build directory" && \
+        buildkite-agent artifact download "build.tar.gz" . --step ":aws: 1 Build" && \
+        tar -zxf build.tar.gz && \
+        echo "--- :m: Starting MongoDB" && \
+        ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
+        echo "+++ :microscope: Running tests" && \
+        cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ~/bin/ctest -j8 -LE _tests --output-on-failure
+    label: ":aws: 1 Tests"
+    agents:
+      queue: "automation-large-builder-fleet"
+    artifact_paths:
+      - "mongod.log"
+      - "build/genesis.json"
+      - "build/config.ini"
+    plugins:
+      ecr#v1.1.4:
+        login: true
+        account_ids: "436617320021"
+        no-include-email: true
+        region: "us-west-2"
+      docker#v2.1.0:
+        debug: true
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:amazonlinux1"
+        workdir: /data/job
+    timeout: 60
 
-  # - command: |
-  #       echo "--- :arrow_down: Downloading build directory" && \
-  #       buildkite-agent artifact download "build.tar.gz" . --step ":aws: 1 Build" && \
-  #       tar -zxf build.tar.gz && \
-  #       echo "--- :m: Starting MongoDB" && \
-  #       ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
-  #       echo "+++ :microscope: Running tests" && \
-  #       cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ~/bin/ctest -L nonparallelizable_tests --output-on-failure
-  #   label: ":aws: 1 NP Tests"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   artifact_paths:
-  #     - "mongod.log"
-  #     - "build/genesis.json"
-  #     - "build/config.ini"
-  #   plugins:
-  #     ecr#v1.1.4:
-  #       login: true
-  #       account_ids: "436617320021"
-  #       no-include-email: true
-  #       region: "us-west-2"
-  #     docker#v2.1.0:
-  #       debug: true
-  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:amazonlinux1"
-  #       workdir: /data/job
-  #   timeout: 60
-
-  # - command: |
-  #       echo "--- :arrow_down: Downloading build directory" && \
-  #       buildkite-agent artifact download "build.tar.gz" . --step ":aws: 2 Build" && \
-  #       tar -zxf build.tar.gz && \
-  #       echo "--- :m: Starting MongoDB" && \
-  #       ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
-  #       echo "+++ :microscope: Running tests" && \
-  #       cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ~/bin/ctest -j8 -LE _tests --output-on-failure
-  #   label: ":aws: 2 Tests"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   artifact_paths:
-  #     - "mongod.log"
-  #     - "build/genesis.json"
-  #     - "build/config.ini"
-  #   plugins:
-  #     ecr#v1.1.4:
-  #       login: true
-  #       account_ids: "436617320021"
-  #       no-include-email: true
-  #       region: "us-west-2"
-  #     docker#v2.1.0:
-  #       debug: true
-  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:amazonlinux2_2-1"
-  #       workdir: /data/job
-  #   timeout: 60
-
-  # - command: |
-  #       echo "--- :arrow_down: Downloading build directory" && \
-  #       buildkite-agent artifact download "build.tar.gz" . --step ":aws: 2 Build" && \
-  #       tar -zxf build.tar.gz && \
-  #       echo "--- :m: Starting MongoDB" && \
-  #       ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
-  #       echo "+++ :microscope: Running tests" && \
-  #       cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ~/bin/ctest -L nonparallelizable_tests --output-on-failure
-  #   label: ":aws: 2 NP Tests"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   artifact_paths:
-  #     - "mongod.log"
-  #     - "build/genesis.json"
-  #     - "build/config.ini"
-  #   plugins:
-  #     ecr#v1.1.4:
-  #       login: true
-  #       account_ids: "436617320021"
-  #       no-include-email: true
-  #       region: "us-west-2"
-  #     docker#v2.1.0:
-  #       debug: true
-  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:amazonlinux2_2-1"
-  #       workdir: /data/job
-  #   timeout: 60
+  - command: |
+        echo "--- :arrow_down: Downloading build directory" && \
+        buildkite-agent artifact download "build.tar.gz" . --step ":aws: 1 Build" && \
+        tar -zxf build.tar.gz && \
+        echo "--- :m: Starting MongoDB" && \
+        ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
+        echo "+++ :microscope: Running tests" && \
+        cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ~/bin/ctest -L nonparallelizable_tests --output-on-failure
+    label: ":aws: 1 NP Tests"
+    agents:
+      queue: "automation-large-builder-fleet"
+    artifact_paths:
+      - "mongod.log"
+      - "build/genesis.json"
+      - "build/config.ini"
+    plugins:
+      ecr#v1.1.4:
+        login: true
+        account_ids: "436617320021"
+        no-include-email: true
+        region: "us-west-2"
+      docker#v2.1.0:
+        debug: true
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:amazonlinux1"
+        workdir: /data/job
+    timeout: 60
 
   - command: |
         echo "--- :arrow_down: Downloading build directory" && \
@@ -502,293 +448,347 @@ steps:
         workdir: /data/job
     timeout: 60
 
-  # - command: |
-  #       echo "--- :arrow_down: Downloading build directory" && \
-  #       buildkite-agent artifact download "build.tar.gz" . --step ":fedora: 27 Build" && \
-  #       tar -zxf build.tar.gz && \
-  #       echo "--- :m: Starting MongoDB" && \
-  #       ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
-  #       echo "+++ :microscope: Running tests" && \
-  #       cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ~/bin/ctest -j8 -LE _tests --output-on-failure
-  #   label: ":fedora: 27 Tests"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   artifact_paths:
-  #     - "mongod.log"
-  #     - "build/genesis.json"
-  #     - "build/config.ini"
-  #   plugins:
-  #     ecr#v1.1.4:
-  #       login: true
-  #       account_ids: "436617320021"
-  #       no-include-email: true
-  #       region: "us-west-2"
-  #     docker#v2.1.0:
-  #       debug: true
-  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:fedora27"
-  #       workdir: /data/job
-  #   timeout: 60
+  - command: |
+        echo "--- :arrow_down: Downloading build directory" && \
+        buildkite-agent artifact download "build.tar.gz" . --step ":aws: 2 Build" && \
+        tar -zxf build.tar.gz && \
+        echo "--- :m: Starting MongoDB" && \
+        ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
+        echo "+++ :microscope: Running tests" && \
+        cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ~/bin/ctest -j8 -LE _tests --output-on-failure
+    label: ":aws: 2 Tests"
+    agents:
+      queue: "automation-large-builder-fleet"
+    artifact_paths:
+      - "mongod.log"
+      - "build/genesis.json"
+      - "build/config.ini"
+    plugins:
+      ecr#v1.1.4:
+        login: true
+        account_ids: "436617320021"
+        no-include-email: true
+        region: "us-west-2"
+      docker#v2.1.0:
+        debug: true
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:amazonlinux2_2-1"
+        workdir: /data/job
+    timeout: 60
 
-  # - command: |
-  #       echo "--- :arrow_down: Downloading build directory" && \
-  #       buildkite-agent artifact download "build.tar.gz" . --step ":fedora: 27 Build" && \
-  #       tar -zxf build.tar.gz && \
-  #       echo "--- :m: Starting MongoDB" && \
-  #       ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
-  #       echo "+++ :microscope: Running tests" && \
-  #       cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ~/bin/ctest -L nonparallelizable_tests --output-on-failure
-  #   label: ":fedora: 27 NP Tests"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   artifact_paths:
-  #     - "mongod.log"
-  #     - "build/genesis.json"
-  #     - "build/config.ini"
-  #   plugins:
-  #     ecr#v1.1.4:
-  #       login: true
-  #       account_ids: "436617320021"
-  #       no-include-email: true
-  #       region: "us-west-2"
-  #     docker#v2.1.0:
-  #       debug: true
-  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:fedora27"
-  #       workdir: /data/job
-  #   timeout: 60
+  - command: |
+        echo "--- :arrow_down: Downloading build directory" && \
+        buildkite-agent artifact download "build.tar.gz" . --step ":aws: 2 Build" && \
+        tar -zxf build.tar.gz && \
+        echo "--- :m: Starting MongoDB" && \
+        ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
+        echo "+++ :microscope: Running tests" && \
+        cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ~/bin/ctest -L nonparallelizable_tests --output-on-failure
+    label: ":aws: 2 NP Tests"
+    agents:
+      queue: "automation-large-builder-fleet"
+    artifact_paths:
+      - "mongod.log"
+      - "build/genesis.json"
+      - "build/config.ini"
+    plugins:
+      ecr#v1.1.4:
+        login: true
+        account_ids: "436617320021"
+        no-include-email: true
+        region: "us-west-2"
+      docker#v2.1.0:
+        debug: true
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:amazonlinux2_2-1"
+        workdir: /data/job
+    timeout: 60
 
-  # - command: |
-  #       echo "--- :arrow_down: Downloading build directory" && \
-  #       buildkite-agent artifact download "build.tar.gz" . --step ":darwin: High Sierra Build" && \
-  #       tar -zxf build.tar.gz && \
-  #       echo "--- :m: Starting MongoDB" && \
-  #       ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
-  #       echo "+++ :microscope: Running tests" && \
-  #       ln -s "$(pwd)" /data/job && cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ctest -j8 -LE _tests --output-on-failure
-  #   label: ":darwin: High Sierra Tests"
-  #   agents:
-  #     - "role=tester-v2"
-  #     - "os=high-sierra"
-  #   artifact_paths:
-  #     - "mongod.log"
-  #     - "build/genesis.json"
-  #     - "build/config.ini"
-  #   timeout: 60
+  - command: |
+        echo "--- :arrow_down: Downloading build directory" && \
+        buildkite-agent artifact download "build.tar.gz" . --step ":fedora: 27 Build" && \
+        tar -zxf build.tar.gz && \
+        echo "--- :m: Starting MongoDB" && \
+        ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
+        echo "+++ :microscope: Running tests" && \
+        cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ~/bin/ctest -j8 -LE _tests --output-on-failure
+    label: ":fedora: 27 Tests"
+    agents:
+      queue: "automation-large-builder-fleet"
+    artifact_paths:
+      - "mongod.log"
+      - "build/genesis.json"
+      - "build/config.ini"
+    plugins:
+      ecr#v1.1.4:
+        login: true
+        account_ids: "436617320021"
+        no-include-email: true
+        region: "us-west-2"
+      docker#v2.1.0:
+        debug: true
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:fedora27"
+        workdir: /data/job
+    timeout: 60
 
-  # - command: |
-  #       echo "--- :arrow_down: Downloading build directory" && \
-  #       buildkite-agent artifact download "build.tar.gz" . --step ":darwin: High Sierra Build" && \
-  #       tar -zxf build.tar.gz && \
-  #       echo "--- :m: Starting MongoDB" && \
-  #       ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
-  #       echo "+++ :microscope: Running tests" && \
-  #       ln -s "$(pwd)" /data/job && cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ctest -L nonparallelizable_tests --output-on-failure
-  #   label: ":darwin: High Sierra NP Tests"
-  #   agents:
-  #     - "role=tester-v2"
-  #     - "os=high-sierra"
-  #   artifact_paths:
-  #     - "mongod.log"
-  #     - "build/genesis.json"
-  #     - "build/config.ini"
-  #   timeout: 60
+  - command: |
+        echo "--- :arrow_down: Downloading build directory" && \
+        buildkite-agent artifact download "build.tar.gz" . --step ":fedora: 27 Build" && \
+        tar -zxf build.tar.gz && \
+        echo "--- :m: Starting MongoDB" && \
+        ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
+        echo "+++ :microscope: Running tests" && \
+        cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ~/bin/ctest -L nonparallelizable_tests --output-on-failure
+    label: ":fedora: 27 NP Tests"
+    agents:
+      queue: "automation-large-builder-fleet"
+    artifact_paths:
+      - "mongod.log"
+      - "build/genesis.json"
+      - "build/config.ini"
+    plugins:
+      ecr#v1.1.4:
+        login: true
+        account_ids: "436617320021"
+        no-include-email: true
+        region: "us-west-2"
+      docker#v2.1.0:
+        debug: true
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:fedora27"
+        workdir: /data/job
+    timeout: 60
 
-  # - command: |
-  #       echo "--- :arrow_down: Downloading build directory" && \
-  #       buildkite-agent artifact download "build.tar.gz" . --step ":darwin: Mojave Build" && \
-  #       tar -zxf build.tar.gz && \
-  #       echo "--- :m: Starting MongoDB" && \
-  #       ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
-  #       echo "+++ :microscope: Running tests" && \
-  #       ln -s "$(pwd)" /data/job && cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ctest -j8 -LE _tests --output-on-failure
-  #   label: ":darwin: Mojave Tests"
-  #   agents:
-  #     - "role=tester-v2"
-  #     - "os=mojave"
-  #   artifact_paths:
-  #     - "mongod.log"
-  #     - "build/genesis.json"
-  #     - "build/config.ini"
-  #   timeout: 60
+  - command: |
+        echo "--- :arrow_down: Downloading build directory" && \
+        buildkite-agent artifact download "build.tar.gz" . --step ":darwin: High Sierra Build" && \
+        tar -zxf build.tar.gz && \
+        echo "--- :m: Starting MongoDB" && \
+        ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
+        echo "+++ :microscope: Running tests" && \
+        ln -s "$(pwd)" /data/job && cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ctest -j8 -LE _tests --output-on-failure
+    label: ":darwin: High Sierra Tests"
+    agents:
+      - "role=tester-v2"
+      - "os=high-sierra"
+    artifact_paths:
+      - "mongod.log"
+      - "build/genesis.json"
+      - "build/config.ini"
+    timeout: 60
 
-  # - command: |
-  #       echo "--- :arrow_down: Downloading build directory" && \
-  #       buildkite-agent artifact download "build.tar.gz" . --step ":darwin: Mojave Build" && \
-  #       tar -zxf build.tar.gz && \
-  #       echo "--- :m: Starting MongoDB" && \
-  #       ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
-  #       echo "+++ :microscope: Running tests" && \
-  #       ln -s "$(pwd)" /data/job && cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ctest -L nonparallelizable_tests --output-on-failure
-  #   label: ":darwin: Mojave NP Tests"
-  #   agents:
-  #     - "role=tester-v2"
-  #     - "os=mojave"
-  #   artifact_paths:
-  #     - "mongod.log"
-  #     - "build/genesis.json"
-  #     - "build/config.ini"
-  #   timeout: 60
+  - command: |
+        echo "--- :arrow_down: Downloading build directory" && \
+        buildkite-agent artifact download "build.tar.gz" . --step ":darwin: High Sierra Build" && \
+        tar -zxf build.tar.gz && \
+        echo "--- :m: Starting MongoDB" && \
+        ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
+        echo "+++ :microscope: Running tests" && \
+        ln -s "$(pwd)" /data/job && cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ctest -L nonparallelizable_tests --output-on-failure
+    label: ":darwin: High Sierra NP Tests"
+    agents:
+      - "role=tester-v2"
+      - "os=high-sierra"
+    artifact_paths:
+      - "mongod.log"
+      - "build/genesis.json"
+      - "build/config.ini"
+    timeout: 60
+
+  - command: |
+        echo "--- :arrow_down: Downloading build directory" && \
+        buildkite-agent artifact download "build.tar.gz" . --step ":darwin: Mojave Build" && \
+        tar -zxf build.tar.gz && \
+        echo "--- :m: Starting MongoDB" && \
+        ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
+        echo "+++ :microscope: Running tests" && \
+        ln -s "$(pwd)" /data/job && cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ctest -j8 -LE _tests --output-on-failure
+    label: ":darwin: Mojave Tests"
+    agents:
+      - "role=tester-v2"
+      - "os=mojave"
+    artifact_paths:
+      - "mongod.log"
+      - "build/genesis.json"
+      - "build/config.ini"
+    timeout: 60
+
+  - command: |
+        echo "--- :arrow_down: Downloading build directory" && \
+        buildkite-agent artifact download "build.tar.gz" . --step ":darwin: Mojave Build" && \
+        tar -zxf build.tar.gz && \
+        echo "--- :m: Starting MongoDB" && \
+        ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
+        echo "+++ :microscope: Running tests" && \
+        ln -s "$(pwd)" /data/job && cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ctest -L nonparallelizable_tests --output-on-failure
+    label: ":darwin: Mojave NP Tests"
+    agents:
+      - "role=tester-v2"
+      - "os=mojave"
+    artifact_paths:
+      - "mongod.log"
+      - "build/genesis.json"
+      - "build/config.ini"
+    timeout: 60
     
-  # - wait
+  - wait
 
-  # - command: |
-  #       echo "--- :arrow_down: Downloading build directory" && \
-  #       buildkite-agent artifact download "build.tar.gz" . --step ":darwin: High Sierra Build" && \
-  #       tar -zxf build.tar.gz && \
-  #       echo "+++ :microscope: Starting package build" && \
-  #       ln -s "$(pwd)" /data/job && cd /data/job/build/packages && bash generate_package.sh brew
-  #   label: ":darwin: High Sierra Package Builder"
-  #   agents:
-  #     - "role=builder-v2"
-  #     - "os=high-sierra"
-  #   artifact_paths:
-  #     - "build/packages/*.tar.gz"
-  #     - "build/packages/*.rb"
-  #   timeout: 60
+  - command: |
+        echo "--- :arrow_down: Downloading build directory" && \
+        buildkite-agent artifact download "build.tar.gz" . --step ":darwin: High Sierra Build" && \
+        tar -zxf build.tar.gz && \
+        echo "+++ :microscope: Starting package build" && \
+        ln -s "$(pwd)" /data/job && cd /data/job/build/packages && bash generate_package.sh brew
+    label: ":darwin: High Sierra Package Builder"
+    agents:
+      - "role=builder-v2"
+      - "os=high-sierra"
+    artifact_paths:
+      - "build/packages/*.tar.gz"
+      - "build/packages/*.rb"
+    timeout: 60
 
-  # - command: |
-  #       echo "--- :arrow_down: Downloading build directory" && \
-  #       buildkite-agent artifact download "build.tar.gz" . --step ":darwin: Mojave Build" && \
-  #       tar -zxf build.tar.gz && \
-  #       echo "+++ :microscope: Starting package build" && \
-  #       ln -s "$(pwd)" /data/job && cd /data/job/build/packages && bash generate_package.sh brew
-  #   label: ":darwin: Mojave Package Builder"
-  #   agents:
-  #     - "role=builder-v2"
-  #     - "os=mojave"
-  #   artifact_paths:
-  #     - "build/packages/*.tar.gz"
-  #     - "build/packages/*.rb"
-  #   timeout: 60
+  - command: |
+        echo "--- :arrow_down: Downloading build directory" && \
+        buildkite-agent artifact download "build.tar.gz" . --step ":darwin: Mojave Build" && \
+        tar -zxf build.tar.gz && \
+        echo "+++ :microscope: Starting package build" && \
+        ln -s "$(pwd)" /data/job && cd /data/job/build/packages && bash generate_package.sh brew
+    label: ":darwin: Mojave Package Builder"
+    agents:
+      - "role=builder-v2"
+      - "os=mojave"
+    artifact_paths:
+      - "build/packages/*.tar.gz"
+      - "build/packages/*.rb"
+    timeout: 60
 
-  # - command: |
-  #       echo "--- :arrow_down: Downloading build directory" && \
-  #       buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 16.04 Build" && \
-  #       tar -zxf build.tar.gz && \
-  #       echo "+++ :microscope: Starting package build" && \
-  #       cd /data/job/build/packages && bash generate_package.sh deb
-  #   label: ":ubuntu: 16.04 Package builder"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   artifact_paths:
-  #     - "build/packages/*.deb"
-  #   plugins:
-  #     ecr#v1.1.4:
-  #       login: true
-  #       account_ids: "436617320021"
-  #       no-include-email: true
-  #       region: "us-west-2"
-  #     docker#v2.1.0:
-  #       debug: true
-  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu16"
-  #       workdir: /data/job
-  #   env:
-  #     OS: "ubuntu-16.04"
-  #     PKGTYPE: "deb"
-  #   timeout: 60
+  - command: |
+        echo "--- :arrow_down: Downloading build directory" && \
+        buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 16.04 Build" && \
+        tar -zxf build.tar.gz && \
+        echo "+++ :microscope: Starting package build" && \
+        cd /data/job/build/packages && bash generate_package.sh deb
+    label: ":ubuntu: 16.04 Package builder"
+    agents:
+      queue: "automation-large-builder-fleet"
+    artifact_paths:
+      - "build/packages/*.deb"
+    plugins:
+      ecr#v1.1.4:
+        login: true
+        account_ids: "436617320021"
+        no-include-email: true
+        region: "us-west-2"
+      docker#v2.1.0:
+        debug: true
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu16"
+        workdir: /data/job
+    env:
+      OS: "ubuntu-16.04"
+      PKGTYPE: "deb"
+    timeout: 60
 
-  # - command: |
-  #       echo "--- :arrow_down: Downloading build directory" && \
-  #       buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 18.04 Build" && \
-  #       tar -zxf build.tar.gz && \
-  #       echo "+++ :microscope: Starting package build" && \
-  #       cd /data/job/build/packages && bash generate_package.sh deb
-  #   label: ":ubuntu: 18.04 Package builder"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   artifact_paths:
-  #     - "build/packages/*.deb"
-  #   plugins:
-  #     ecr#v1.1.4:
-  #       login: true
-  #       account_ids: "436617320021"
-  #       no-include-email: true
-  #       region: "us-west-2"
-  #     docker#v2.1.0:
-  #       debug: true
-  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu18"
-  #       workdir: /data/job
-  #   env:
-  #     OS: "ubuntu-18.04"
-  #     PKGTYPE: "deb"
-  #   timeout: 60
+  - command: |
+        echo "--- :arrow_down: Downloading build directory" && \
+        buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 18.04 Build" && \
+        tar -zxf build.tar.gz && \
+        echo "+++ :microscope: Starting package build" && \
+        cd /data/job/build/packages && bash generate_package.sh deb
+    label: ":ubuntu: 18.04 Package builder"
+    agents:
+      queue: "automation-large-builder-fleet"
+    artifact_paths:
+      - "build/packages/*.deb"
+    plugins:
+      ecr#v1.1.4:
+        login: true
+        account_ids: "436617320021"
+        no-include-email: true
+        region: "us-west-2"
+      docker#v2.1.0:
+        debug: true
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu18"
+        workdir: /data/job
+    env:
+      OS: "ubuntu-18.04"
+      PKGTYPE: "deb"
+    timeout: 60
 
-  # - command: |
-  #       echo "--- :arrow_down: Downloading build directory" && \
-  #       buildkite-agent artifact download "build.tar.gz" . --step ":fedora: 27 Build" && \
-  #       tar -zxf build.tar.gz && \
-  #       echo "+++ :microscope: Starting package build" && \
-  #       yum install -y rpm-build && \
-  #       mkdir -p /root/rpmbuild/BUILD && \
-  #       mkdir -p /root/rpmbuild/BUILDROOT && \
-  #       mkdir -p /root/rpmbuild/RPMS && \
-  #       mkdir -p /root/rpmbuild/SOURCES && \
-  #       mkdir -p /root/rpmbuild/SPECS && \
-  #       mkdir -p /root/rpmbuild/SRPMS && \
-  #       cd /data/job/build/packages && bash generate_package.sh rpm
-  #   label: ":fedora: 27 Package builder"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   artifact_paths:
-  #     - "build/packages/*.rpm"
-  #   plugins:
-  #     ecr#v1.1.4:
-  #       login: true
-  #       account_ids: "436617320021"
-  #       no-include-email: true
-  #       region: "us-west-2"
-  #     docker#v2.1.0:
-  #       debug: true
-  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:fedora27"
-  #       workdir: /data/job
-  #   env:
-  #     OS: "fc27"
-  #     PKGTYPE: "rpm"
-  #   timeout: 60
+  - command: |
+        echo "--- :arrow_down: Downloading build directory" && \
+        buildkite-agent artifact download "build.tar.gz" . --step ":fedora: 27 Build" && \
+        tar -zxf build.tar.gz && \
+        echo "+++ :microscope: Starting package build" && \
+        yum install -y rpm-build && \
+        mkdir -p /root/rpmbuild/BUILD && \
+        mkdir -p /root/rpmbuild/BUILDROOT && \
+        mkdir -p /root/rpmbuild/RPMS && \
+        mkdir -p /root/rpmbuild/SOURCES && \
+        mkdir -p /root/rpmbuild/SPECS && \
+        mkdir -p /root/rpmbuild/SRPMS && \
+        cd /data/job/build/packages && bash generate_package.sh rpm
+    label: ":fedora: 27 Package builder"
+    agents:
+      queue: "automation-large-builder-fleet"
+    artifact_paths:
+      - "build/packages/*.rpm"
+    plugins:
+      ecr#v1.1.4:
+        login: true
+        account_ids: "436617320021"
+        no-include-email: true
+        region: "us-west-2"
+      docker#v2.1.0:
+        debug: true
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:fedora27"
+        workdir: /data/job
+    env:
+      OS: "fc27"
+      PKGTYPE: "rpm"
+    timeout: 60
 
-  # - command: |
-  #       echo "--- :arrow_down: Downloading build directory" && \
-  #       buildkite-agent artifact download "build.tar.gz" . --step ":centos: 7 Build" && \
-  #       tar -zxf build.tar.gz && \
-  #       echo "+++ :microscope: Starting package build" && \
-  #       yum install -y rpm-build && \
-  #       mkdir -p /root/rpmbuild/BUILD && \
-  #       mkdir -p /root/rpmbuild/BUILDROOT && \
-  #       mkdir -p /root/rpmbuild/RPMS && \
-  #       mkdir -p /root/rpmbuild/SOURCES && \
-  #       mkdir -p /root/rpmbuild/SPECS && \
-  #       mkdir -p /root/rpmbuild/SRPMS && \
-  #       cd /data/job/build/packages && bash generate_package.sh rpm
-  #   label: ":centos: 7 Package builder"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   artifact_paths:
-  #     - "build/packages/*.rpm"
-  #   plugins:
-  #     ecr#v1.1.4:
-  #       login: true
-  #       account_ids: "436617320021"
-  #       no-include-email: true
-  #       region: "us-west-2"
-  #     docker#v2.1.0:
-  #       debug: true
-  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:centos7"
-  #       workdir: /data/job
-  #   env:
-  #     OS: "el7"
-  #     PKGTYPE: "rpm"
-  #   timeout: 60
+  - command: |
+        echo "--- :arrow_down: Downloading build directory" && \
+        buildkite-agent artifact download "build.tar.gz" . --step ":centos: 7 Build" && \
+        tar -zxf build.tar.gz && \
+        echo "+++ :microscope: Starting package build" && \
+        yum install -y rpm-build && \
+        mkdir -p /root/rpmbuild/BUILD && \
+        mkdir -p /root/rpmbuild/BUILDROOT && \
+        mkdir -p /root/rpmbuild/RPMS && \
+        mkdir -p /root/rpmbuild/SOURCES && \
+        mkdir -p /root/rpmbuild/SPECS && \
+        mkdir -p /root/rpmbuild/SRPMS && \
+        cd /data/job/build/packages && bash generate_package.sh rpm
+    label: ":centos: 7 Package builder"
+    agents:
+      queue: "automation-large-builder-fleet"
+    artifact_paths:
+      - "build/packages/*.rpm"
+    plugins:
+      ecr#v1.1.4:
+        login: true
+        account_ids: "436617320021"
+        no-include-email: true
+        region: "us-west-2"
+      docker#v2.1.0:
+        debug: true
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:centos7"
+        workdir: /data/job
+    env:
+      OS: "el7"
+      PKGTYPE: "rpm"
+    timeout: 60
 
-  # - wait
+  - wait
 
-  # - command: |
-  #       echo "--- :arrow_down: Downloading brew files" && \
-  #       buildkite-agent artifact download "build/packages/eosio.rb" . --step ":darwin: High Sierra Package Builder" && \
-  #       mv build/packages/eosio.rb build/packages/eosio_highsierra.rb && \
-  #       buildkite-agent artifact download "build/packages/eosio.rb" . --step ":darwin: Mojave Package Builder"
-  #   label: ":darwin: Brew Updater"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   artifact_paths:
-  #     - "build/packages/eosio_highsierra.rb"
-  #     - "build/packages/eosio.rb"
-  #   timeout: 60
+  - command: |
+        echo "--- :arrow_down: Downloading brew files" && \
+        buildkite-agent artifact download "build/packages/eosio.rb" . --step ":darwin: High Sierra Package Builder" && \
+        mv build/packages/eosio.rb build/packages/eosio_highsierra.rb && \
+        buildkite-agent artifact download "build/packages/eosio.rb" . --step ":darwin: Mojave Package Builder"
+    label: ":darwin: Brew Updater"
+    agents:
+      queue: "automation-large-builder-fleet"
+    artifact_paths:
+      - "build/packages/eosio_highsierra.rb"
+      - "build/packages/eosio.rb"
+    timeout: 60

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -380,33 +380,6 @@ steps:
         echo "--- :m: Starting MongoDB" && \
         ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
         echo "+++ :microscope: Running tests" && \
-        cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ~/bin/ctest -j8 -LE _tests --output-on-failure
-    label: ":aws: 2 Tests"
-    agents:
-      queue: "automation-large-builder-fleet"
-    artifact_paths:
-      - "mongod.log"
-      - "build/genesis.json"
-      - "build/config.ini"
-    plugins:
-      ecr#v1.1.4:
-        login: true
-        account_ids: "436617320021"
-        no-include-email: true
-        region: "us-west-2"
-      docker#v2.1.0:
-        debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:amazonlinux2_2-1"
-        workdir: /data/job
-    timeout: 60
-
-  - command: |
-        echo "--- :arrow_down: Downloading build directory" && \
-        buildkite-agent artifact download "build.tar.gz" . --step ":aws: 2 Build" && \
-        tar -zxf build.tar.gz && \
-        echo "--- :m: Starting MongoDB" && \
-        ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
-        echo "+++ :microscope: Running tests" && \
         cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ctest -j8 -LE _tests --output-on-failure
     label: ":aws: 2 Tests"
     agents:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -17,7 +17,7 @@ steps:
         region: "us-west-2"
       docker#v2.1.0:
         debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu16"
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu16_2-1"
         workdir: /data/job
     timeout: 60
 
@@ -38,7 +38,7 @@ steps:
         region: "us-west-2"
       docker#v2.1.0:
         debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu18"
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu18_2-1"
         workdir: /data/job
     timeout: 60
 
@@ -59,7 +59,7 @@ steps:
         region: "us-west-2"
       docker#v2.1.0:
         debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:centos7"
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:centos7_2-1"
         workdir: /data/job
     timeout: 60
 
@@ -80,30 +80,30 @@ steps:
         region: "us-west-2"
       docker#v2.1.0:
         debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:amazonlinux1"
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:amazonlinux1_2-1"
         workdir: /data/job
     timeout: 60
 
-  - command: |
-        echo "+++ :hammer: Building" && \
-        ./scripts/eosio_build.sh -y && \
-        echo "--- :compression: Compressing build directory" && \
-        tar -pczf build.tar.gz build/
-    label: ":aws: 2 Build"
-    agents:
-      queue: "automation-large-builder-fleet"
-    artifact_paths: "build.tar.gz"
-    plugins:
-      ecr#v1.1.4:
-        login: true
-        account_ids: "436617320021"
-        no-include-email: true
-        region: "us-west-2"
-      docker#v2.1.0:
-        debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:amazonlinux2_2-1"
-        workdir: /data/job
-    timeout: 60
+  # - command: |
+  #       echo "+++ :hammer: Building" && \
+  #       ./scripts/eosio_build.sh -y && \
+  #       echo "--- :compression: Compressing build directory" && \
+  #       tar -pczf build.tar.gz build/
+  #   label: ":aws: 2 Build"
+  #   agents:
+  #     queue: "automation-large-builder-fleet"
+  #   artifact_paths: "build.tar.gz"
+  #   plugins:
+  #     ecr#v1.1.4:
+  #       login: true
+  #       account_ids: "436617320021"
+  #       no-include-email: true
+  #       region: "us-west-2"
+  #     docker#v2.1.0:
+  #       debug: true
+  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:amazonlinux2_2-1"
+  #       workdir: /data/job
+  #   timeout: 60
 
   - command: |
         echo "+++ :hammer: Building" && \
@@ -122,7 +122,7 @@ steps:
         region: "us-west-2"
       docker#v2.1.0:
         debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:fedora27"
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:fedora27_2-1"
         workdir: /data/job
     timeout: 60
 
@@ -135,7 +135,7 @@ steps:
       tar -pczf build.tar.gz build/
     label: ":darwin: Mojave Build"
     agents:
-      - "role=builder-v2"
+      - "role=builder-v2-1"
       - "os=mojave"
     artifact_paths: "build.tar.gz"
     timeout: 60
@@ -149,7 +149,7 @@ steps:
       tar -pczf build.tar.gz build/
     label: ":darwin: High Sierra Build"
     agents:
-      - "role=builder-v2"
+      - "role=builder-v2-1"
       - "os=high-sierra"
     artifact_paths: "build.tar.gz"
     timeout: 60
@@ -179,7 +179,7 @@ steps:
         region: "us-west-2"
       docker#v2.1.0:
         debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu16"
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu16_2-1"
         workdir: /data/job
     timeout: 60
 
@@ -206,7 +206,7 @@ steps:
         region: "us-west-2"
       docker#v2.1.0:
         debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu16"
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu16_2-1"
         workdir: /data/job
     timeout: 60
   
@@ -233,7 +233,7 @@ steps:
         region: "us-west-2"
       docker#v2.1.0:
         debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu18"
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu18_2-1"
         workdir: /data/job
     timeout: 60
 
@@ -260,7 +260,7 @@ steps:
         region: "us-west-2"
       docker#v2.1.0:
         debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu18"
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu18_2-1"
         workdir: /data/job
     timeout: 60
 
@@ -288,7 +288,7 @@ steps:
         region: "us-west-2"
       docker#v2.1.0:
         debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:centos7"
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:centos7_2-1"
         workdir: /data/job
     timeout: 60
 
@@ -315,7 +315,7 @@ steps:
         region: "us-west-2"
       docker#v2.1.0:
         debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:centos7"
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:centos7_2-1"
         workdir: /data/job
     timeout: 60
 
@@ -342,7 +342,7 @@ steps:
         region: "us-west-2"
       docker#v2.1.0:
         debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:amazonlinux1"
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:amazonlinux1_2-1"
         workdir: /data/job
     timeout: 60
 
@@ -369,63 +369,63 @@ steps:
         region: "us-west-2"
       docker#v2.1.0:
         debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:amazonlinux1"
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:amazonlinux1_2-1"
         workdir: /data/job
     timeout: 60
 
-  - command: |
-        echo "--- :arrow_down: Downloading build directory" && \
-        buildkite-agent artifact download "build.tar.gz" . --step ":aws: 2 Build" && \
-        tar -zxf build.tar.gz && \
-        echo "--- :m: Starting MongoDB" && \
-        ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
-        echo "+++ :microscope: Running tests" && \
-        cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ctest -j8 -LE _tests --output-on-failure
-    label: ":aws: 2 Tests"
-    agents:
-      queue: "automation-large-builder-fleet"
-    artifact_paths:
-      - "mongod.log"
-      - "build/genesis.json"
-      - "build/config.ini"
-    plugins:
-      ecr#v1.1.4:
-        login: true
-        account_ids: "436617320021"
-        no-include-email: true
-        region: "us-west-2"
-      docker#v2.1.0:
-        debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:amazonlinux2_2-1"
-        workdir: /data/job
-    timeout: 60
+  # - command: |
+  #       echo "--- :arrow_down: Downloading build directory" && \
+  #       buildkite-agent artifact download "build.tar.gz" . --step ":aws: 2 Build" && \
+  #       tar -zxf build.tar.gz && \
+  #       echo "--- :m: Starting MongoDB" && \
+  #       ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
+  #       echo "+++ :microscope: Running tests" && \
+  #       cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ctest -j8 -LE _tests --output-on-failure
+  #   label: ":aws: 2 Tests"
+  #   agents:
+  #     queue: "automation-large-builder-fleet"
+  #   artifact_paths:
+  #     - "mongod.log"
+  #     - "build/genesis.json"
+  #     - "build/config.ini"
+  #   plugins:
+  #     ecr#v1.1.4:
+  #       login: true
+  #       account_ids: "436617320021"
+  #       no-include-email: true
+  #       region: "us-west-2"
+  #     docker#v2.1.0:
+  #       debug: true
+  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:amazonlinux2_2-1"
+  #       workdir: /data/job
+  #   timeout: 60
 
-  - command: |
-        echo "--- :arrow_down: Downloading build directory" && \
-        buildkite-agent artifact download "build.tar.gz" . --step ":aws: 2 Build" && \
-        tar -zxf build.tar.gz && \
-        echo "--- :m: Starting MongoDB" && \
-        ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
-        echo "+++ :microscope: Running tests" && \
-        cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ctest -L nonparallelizable_tests --output-on-failure
-    label: ":aws: 2 NP Tests"
-    agents:
-      queue: "automation-large-builder-fleet"
-    artifact_paths:
-      - "mongod.log"
-      - "build/genesis.json"
-      - "build/config.ini"
-    plugins:
-      ecr#v1.1.4:
-        login: true
-        account_ids: "436617320021"
-        no-include-email: true
-        region: "us-west-2"
-      docker#v2.1.0:
-        debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:amazonlinux2_2-1"
-        workdir: /data/job
-    timeout: 60
+  # - command: |
+  #       echo "--- :arrow_down: Downloading build directory" && \
+  #       buildkite-agent artifact download "build.tar.gz" . --step ":aws: 2 Build" && \
+  #       tar -zxf build.tar.gz && \
+  #       echo "--- :m: Starting MongoDB" && \
+  #       ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
+  #       echo "+++ :microscope: Running tests" && \
+  #       cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ctest -L nonparallelizable_tests --output-on-failure
+  #   label: ":aws: 2 NP Tests"
+  #   agents:
+  #     queue: "automation-large-builder-fleet"
+  #   artifact_paths:
+  #     - "mongod.log"
+  #     - "build/genesis.json"
+  #     - "build/config.ini"
+  #   plugins:
+  #     ecr#v1.1.4:
+  #       login: true
+  #       account_ids: "436617320021"
+  #       no-include-email: true
+  #       region: "us-west-2"
+  #     docker#v2.1.0:
+  #       debug: true
+  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:amazonlinux2_2-1"
+  #       workdir: /data/job
+  #   timeout: 60
 
   - command: |
         echo "--- :arrow_down: Downloading build directory" && \
@@ -450,7 +450,7 @@ steps:
         region: "us-west-2"
       docker#v2.1.0:
         debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:fedora27"
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:fedora27_2-1"
         workdir: /data/job
     timeout: 60
 
@@ -477,7 +477,7 @@ steps:
         region: "us-west-2"
       docker#v2.1.0:
         debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:fedora27"
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:fedora27_2-1"
         workdir: /data/job
     timeout: 60
 
@@ -491,7 +491,7 @@ steps:
         ln -s "$(pwd)" /data/job && cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ctest -j8 -LE _tests --output-on-failure
     label: ":darwin: High Sierra Tests"
     agents:
-      - "role=tester-v2"
+      - "role=tester-v2-1"
       - "os=high-sierra"
     artifact_paths:
       - "mongod.log"
@@ -509,7 +509,7 @@ steps:
         ln -s "$(pwd)" /data/job && cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ctest -L nonparallelizable_tests --output-on-failure
     label: ":darwin: High Sierra NP Tests"
     agents:
-      - "role=tester-v2"
+      - "role=tester-v2-1"
       - "os=high-sierra"
     artifact_paths:
       - "mongod.log"
@@ -527,7 +527,7 @@ steps:
         ln -s "$(pwd)" /data/job && cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ctest -j8 -LE _tests --output-on-failure
     label: ":darwin: Mojave Tests"
     agents:
-      - "role=tester-v2"
+      - "role=tester-v2-1"
       - "os=mojave"
     artifact_paths:
       - "mongod.log"
@@ -545,7 +545,7 @@ steps:
         ln -s "$(pwd)" /data/job && cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ctest -L nonparallelizable_tests --output-on-failure
     label: ":darwin: Mojave NP Tests"
     agents:
-      - "role=tester-v2"
+      - "role=tester-v2-1"
       - "os=mojave"
     artifact_paths:
       - "mongod.log"
@@ -563,7 +563,7 @@ steps:
         ln -s "$(pwd)" /data/job && cd /data/job/build/packages && bash generate_package.sh brew
     label: ":darwin: High Sierra Package Builder"
     agents:
-      - "role=builder-v2"
+      - "role=builder-v2-1"
       - "os=high-sierra"
     artifact_paths:
       - "build/packages/*.tar.gz"
@@ -578,7 +578,7 @@ steps:
         ln -s "$(pwd)" /data/job && cd /data/job/build/packages && bash generate_package.sh brew
     label: ":darwin: Mojave Package Builder"
     agents:
-      - "role=builder-v2"
+      - "role=builder-v2-1"
       - "os=mojave"
     artifact_paths:
       - "build/packages/*.tar.gz"
@@ -604,7 +604,7 @@ steps:
         region: "us-west-2"
       docker#v2.1.0:
         debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu16"
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu16_2-1"
         workdir: /data/job
     env:
       OS: "ubuntu-16.04"
@@ -630,7 +630,7 @@ steps:
         region: "us-west-2"
       docker#v2.1.0:
         debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu18"
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu18_2-1"
         workdir: /data/job
     env:
       OS: "ubuntu-18.04"
@@ -663,7 +663,7 @@ steps:
         region: "us-west-2"
       docker#v2.1.0:
         debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:fedora27"
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:fedora27_2-1"
         workdir: /data/job
     env:
       OS: "fc27"
@@ -696,7 +696,7 @@ steps:
         region: "us-west-2"
       docker#v2.1.0:
         debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:centos7"
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:centos7_2-1"
         workdir: /data/job
     env:
       OS: "el7"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -84,26 +84,26 @@ steps:
         workdir: /data/job
     timeout: 60
 
-  # - command: |
-  #       echo "+++ :hammer: Building" && \
-  #       ./scripts/eosio_build.sh -y && \
-  #       echo "--- :compression: Compressing build directory" && \
-  #       tar -pczf build.tar.gz build/
-  #   label: ":aws: 2 Build"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   artifact_paths: "build.tar.gz"
-  #   plugins:
-  #     ecr#v1.1.4:
-  #       login: true
-  #       account_ids: "436617320021"
-  #       no-include-email: true
-  #       region: "us-west-2"
-  #     docker#v2.1.0:
-  #       debug: true
-  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:amazonlinux2_2-1"
-  #       workdir: /data/job
-  #   timeout: 60
+  - command: |
+        echo "+++ :hammer: Building" && \
+        ./scripts/eosio_build.sh -y && \
+        echo "--- :compression: Compressing build directory" && \
+        tar -pczf build.tar.gz build/
+    label: ":aws: 2 Build"
+    agents:
+      queue: "automation-large-builder-fleet"
+    artifact_paths: "build.tar.gz"
+    plugins:
+      ecr#v1.1.4:
+        login: true
+        account_ids: "436617320021"
+        no-include-email: true
+        region: "us-west-2"
+      docker#v2.1.0:
+        debug: true
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:amazonlinux2_2-1"
+        workdir: /data/job
+    timeout: 60
 
   - command: |
         echo "+++ :hammer: Building" && \
@@ -373,59 +373,59 @@ steps:
         workdir: /data/job
     timeout: 60
 
-  # - command: |
-  #       echo "--- :arrow_down: Downloading build directory" && \
-  #       buildkite-agent artifact download "build.tar.gz" . --step ":aws: 2 Build" && \
-  #       tar -zxf build.tar.gz && \
-  #       echo "--- :m: Starting MongoDB" && \
-  #       ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
-  #       echo "+++ :microscope: Running tests" && \
-  #       cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ctest -j8 -LE _tests --output-on-failure
-  #   label: ":aws: 2 Tests"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   artifact_paths:
-  #     - "mongod.log"
-  #     - "build/genesis.json"
-  #     - "build/config.ini"
-  #   plugins:
-  #     ecr#v1.1.4:
-  #       login: true
-  #       account_ids: "436617320021"
-  #       no-include-email: true
-  #       region: "us-west-2"
-  #     docker#v2.1.0:
-  #       debug: true
-  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:amazonlinux2_2-1"
-  #       workdir: /data/job
-  #   timeout: 60
+  - command: |
+        echo "--- :arrow_down: Downloading build directory" && \
+        buildkite-agent artifact download "build.tar.gz" . --step ":aws: 2 Build" && \
+        tar -zxf build.tar.gz && \
+        echo "--- :m: Starting MongoDB" && \
+        ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
+        echo "+++ :microscope: Running tests" && \
+        cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ctest -j8 -LE _tests --output-on-failure
+    label: ":aws: 2 Tests"
+    agents:
+      queue: "automation-large-builder-fleet"
+    artifact_paths:
+      - "mongod.log"
+      - "build/genesis.json"
+      - "build/config.ini"
+    plugins:
+      ecr#v1.1.4:
+        login: true
+        account_ids: "436617320021"
+        no-include-email: true
+        region: "us-west-2"
+      docker#v2.1.0:
+        debug: true
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:amazonlinux2_2-1"
+        workdir: /data/job
+    timeout: 60
 
-  # - command: |
-  #       echo "--- :arrow_down: Downloading build directory" && \
-  #       buildkite-agent artifact download "build.tar.gz" . --step ":aws: 2 Build" && \
-  #       tar -zxf build.tar.gz && \
-  #       echo "--- :m: Starting MongoDB" && \
-  #       ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
-  #       echo "+++ :microscope: Running tests" && \
-  #       cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ctest -L nonparallelizable_tests --output-on-failure
-  #   label: ":aws: 2 NP Tests"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   artifact_paths:
-  #     - "mongod.log"
-  #     - "build/genesis.json"
-  #     - "build/config.ini"
-  #   plugins:
-  #     ecr#v1.1.4:
-  #       login: true
-  #       account_ids: "436617320021"
-  #       no-include-email: true
-  #       region: "us-west-2"
-  #     docker#v2.1.0:
-  #       debug: true
-  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:amazonlinux2_2-1"
-  #       workdir: /data/job
-  #   timeout: 60
+  - command: |
+        echo "--- :arrow_down: Downloading build directory" && \
+        buildkite-agent artifact download "build.tar.gz" . --step ":aws: 2 Build" && \
+        tar -zxf build.tar.gz && \
+        echo "--- :m: Starting MongoDB" && \
+        ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
+        echo "+++ :microscope: Running tests" && \
+        cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ctest -L nonparallelizable_tests --output-on-failure
+    label: ":aws: 2 NP Tests"
+    agents:
+      queue: "automation-large-builder-fleet"
+    artifact_paths:
+      - "mongod.log"
+      - "build/genesis.json"
+      - "build/config.ini"
+    plugins:
+      ecr#v1.1.4:
+        login: true
+        account_ids: "436617320021"
+        no-include-email: true
+        region: "us-west-2"
+      docker#v2.1.0:
+        debug: true
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:amazonlinux2_2-1"
+        workdir: /data/job
+    timeout: 60
 
   - command: |
         echo "--- :arrow_down: Downloading build directory" && \

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,88 +1,88 @@
 steps:
 
-  - command: |
-        echo "+++ :hammer: Building" && \
-        ./scripts/eosio_build.sh -y && \
-        echo "--- :compression: Compressing build directory" && \
-        tar -pczf build.tar.gz build/
-    label: ":ubuntu: 16.04 Build"
-    agents:
-      queue: "automation-large-builder-fleet"
-    artifact_paths: "build.tar.gz"
-    plugins:
-      ecr#v1.1.4:
-        login: true
-        account_ids: "436617320021"
-        no-include-email: true
-        region: "us-west-2"
-      docker#v2.1.0:
-        debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu16_2-1"
-        workdir: /data/job
-    timeout: 60
+  # - command: |
+  #       echo "+++ :hammer: Building" && \
+  #       ./scripts/eosio_build.sh -y && \
+  #       echo "--- :compression: Compressing build directory" && \
+  #       tar -pczf build.tar.gz build/
+  #   label: ":ubuntu: 16.04 Build"
+  #   agents:
+  #     queue: "automation-large-builder-fleet"
+  #   artifact_paths: "build.tar.gz"
+  #   plugins:
+  #     ecr#v1.1.4:
+  #       login: true
+  #       account_ids: "436617320021"
+  #       no-include-email: true
+  #       region: "us-west-2"
+  #     docker#v2.1.0:
+  #       debug: true
+  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu16"
+  #       workdir: /data/job
+  #   timeout: 60
 
-  - command: |
-        echo "+++ :hammer: Building" && \
-        ./scripts/eosio_build.sh -y && \
-        echo "--- :compression: Compressing build directory" && \
-        tar -pczf build.tar.gz build/
-    label: ":ubuntu: 18.04 Build"
-    agents:
-      queue: "automation-large-builder-fleet"
-    artifact_paths: "build.tar.gz"
-    plugins:
-      ecr#v1.1.4:
-        login: true
-        account_ids: "436617320021"
-        no-include-email: true
-        region: "us-west-2"
-      docker#v2.1.0:
-        debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu18_2-1"
-        workdir: /data/job
-    timeout: 60
+  # - command: |
+  #       echo "+++ :hammer: Building" && \
+  #       ./scripts/eosio_build.sh -y && \
+  #       echo "--- :compression: Compressing build directory" && \
+  #       tar -pczf build.tar.gz build/
+  #   label: ":ubuntu: 18.04 Build"
+  #   agents:
+  #     queue: "automation-large-builder-fleet"
+  #   artifact_paths: "build.tar.gz"
+  #   plugins:
+  #     ecr#v1.1.4:
+  #       login: true
+  #       account_ids: "436617320021"
+  #       no-include-email: true
+  #       region: "us-west-2"
+  #     docker#v2.1.0:
+  #       debug: true
+  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu18"
+  #       workdir: /data/job
+  #   timeout: 60
 
-  - command: |
-        echo "+++ :hammer: Building" && \
-        ./scripts/eosio_build.sh -y && \
-        echo "--- :compression: Compressing build directory" && \
-        tar -pczf build.tar.gz build/
-    label: ":centos: 7 Build"
-    agents:
-      queue: "automation-large-builder-fleet"
-    artifact_paths: "build.tar.gz"
-    plugins:
-      ecr#v1.1.4:
-        login: true
-        account_ids: "436617320021"
-        no-include-email: true
-        region: "us-west-2"
-      docker#v2.1.0:
-        debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:centos7_2-1"
-        workdir: /data/job
-    timeout: 60
+  # - command: |
+  #       echo "+++ :hammer: Building" && \
+  #       ./scripts/eosio_build.sh -y && \
+  #       echo "--- :compression: Compressing build directory" && \
+  #       tar -pczf build.tar.gz build/
+  #   label: ":centos: 7 Build"
+  #   agents:
+  #     queue: "automation-large-builder-fleet"
+  #   artifact_paths: "build.tar.gz"
+  #   plugins:
+  #     ecr#v1.1.4:
+  #       login: true
+  #       account_ids: "436617320021"
+  #       no-include-email: true
+  #       region: "us-west-2"
+  #     docker#v2.1.0:
+  #       debug: true
+  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:centos7"
+  #       workdir: /data/job
+  #   timeout: 60
 
-  - command: |
-        echo "+++ :hammer: Building" && \
-        ./scripts/eosio_build.sh -y && \
-        echo "--- :compression: Compressing build directory" && \
-        tar -pczf build.tar.gz build/
-    label: ":aws: 1 Build"
-    agents:
-      queue: "automation-large-builder-fleet"
-    artifact_paths: "build.tar.gz"
-    plugins:
-      ecr#v1.1.4:
-        login: true
-        account_ids: "436617320021"
-        no-include-email: true
-        region: "us-west-2"
-      docker#v2.1.0:
-        debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:amazonlinux1_2-1"
-        workdir: /data/job
-    timeout: 60
+  # - command: |
+  #       echo "+++ :hammer: Building" && \
+  #       ./scripts/eosio_build.sh -y && \
+  #       echo "--- :compression: Compressing build directory" && \
+  #       tar -pczf build.tar.gz build/
+  #   label: ":aws: 1 Build"
+  #   agents:
+  #     queue: "automation-large-builder-fleet"
+  #   artifact_paths: "build.tar.gz"
+  #   plugins:
+  #     ecr#v1.1.4:
+  #       login: true
+  #       account_ids: "436617320021"
+  #       no-include-email: true
+  #       region: "us-west-2"
+  #     docker#v2.1.0:
+  #       debug: true
+  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:amazonlinux1"
+  #       workdir: /data/job
+  #   timeout: 60
 
   # - command: |
   #       echo "+++ :hammer: Building" && \
@@ -110,7 +110,7 @@ steps:
         ./scripts/eosio_build.sh -y && \
         echo "--- :compression: Compressing build directory" && \
         tar -pczf build.tar.gz build/
-    label: ":fedora: 27 Build"
+    label: ":aws: 2 Build"
     agents:
       queue: "automation-large-builder-fleet"
     artifact_paths: "build.tar.gz"
@@ -122,256 +122,277 @@ steps:
         region: "us-west-2"
       docker#v2.1.0:
         debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:fedora27_2-1"
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:amazonlinux2_2-1"
         workdir: /data/job
     timeout: 60
 
-  - command: |
-      echo "--- Creating symbolic link to job directory :file_folder:" && \
-      sleep 5 && ln -s "$(pwd)" /data/job && cd /data/job && \
-      echo "+++ Building :hammer:" && \
-      ./scripts/eosio_build.sh -y && \
-      echo "--- Compressing build directory :compression:" && \
-      tar -pczf build.tar.gz build/
-    label: ":darwin: Mojave Build"
-    agents:
-      - "role=builder-v2-1"
-      - "os=mojave"
-    artifact_paths: "build.tar.gz"
-    timeout: 60
+  # - command: |
+  #       echo "+++ :hammer: Building" && \
+  #       ./scripts/eosio_build.sh -y && \
+  #       echo "--- :compression: Compressing build directory" && \
+  #       tar -pczf build.tar.gz build/
+  #   label: ":fedora: 27 Build"
+  #   agents:
+  #     queue: "automation-large-builder-fleet"
+  #   artifact_paths: "build.tar.gz"
+  #   plugins:
+  #     ecr#v1.1.4:
+  #       login: true
+  #       account_ids: "436617320021"
+  #       no-include-email: true
+  #       region: "us-west-2"
+  #     docker#v2.1.0:
+  #       debug: true
+  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:fedora27"
+  #       workdir: /data/job
+  #   timeout: 60
 
-  - command: |
-      echo "--- Creating symbolic link to job directory :file_folder:" && \
-      sleep 5 && ln -s "$(pwd)" /data/job && cd /data/job && \
-      echo "+++ Building :hammer:" && \
-      ./scripts/eosio_build.sh -y && \
-      echo "--- Compressing build directory :compression:" && \
-      tar -pczf build.tar.gz build/
-    label: ":darwin: High Sierra Build"
-    agents:
-      - "role=builder-v2-1"
-      - "os=high-sierra"
-    artifact_paths: "build.tar.gz"
-    timeout: 60
+  # - command: |
+  #     echo "--- Creating symbolic link to job directory :file_folder:" && \
+  #     sleep 5 && ln -s "$(pwd)" /data/job && cd /data/job && \
+  #     echo "+++ Building :hammer:" && \
+  #     ./scripts/eosio_build.sh -y && \
+  #     echo "--- Compressing build directory :compression:" && \
+  #     tar -pczf build.tar.gz build/
+  #   label: ":darwin: Mojave Build"
+  #   agents:
+  #     - "role=builder-v2"
+  #     - "os=mojave"
+  #   artifact_paths: "build.tar.gz"
+  #   timeout: 60
+
+  # - command: |
+  #     echo "--- Creating symbolic link to job directory :file_folder:" && \
+  #     sleep 5 && ln -s "$(pwd)" /data/job && cd /data/job && \
+  #     echo "+++ Building :hammer:" && \
+  #     ./scripts/eosio_build.sh -y && \
+  #     echo "--- Compressing build directory :compression:" && \
+  #     tar -pczf build.tar.gz build/
+  #   label: ":darwin: High Sierra Build"
+  #   agents:
+  #     - "role=builder-v2"
+  #     - "os=high-sierra"
+  #   artifact_paths: "build.tar.gz"
+  #   timeout: 60
 
   - wait
 
-  - command: |
-        echo "--- :arrow_down: Downloading build directory" && \
-        buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 16.04 Build" && \
-        tar -zxf build.tar.gz && \
-        echo "--- :m: Starting MongoDB" && \
-        ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
-        echo "+++ :microscope: Running tests" && \
-        cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ~/bin/ctest -j8 -LE _tests --output-on-failure
-    label: ":ubuntu: 16.04 Tests"
-    agents:
-      queue: "automation-large-builder-fleet"
-    artifact_paths:
-      - "mongod.log"
-      - "build/genesis.json"
-      - "build/config.ini"
-    plugins:
-      ecr#v1.1.4:
-        login: true
-        account_ids: "436617320021"
-        no-include-email: true
-        region: "us-west-2"
-      docker#v2.1.0:
-        debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu16_2-1"
-        workdir: /data/job
-    timeout: 60
+  # - command: |
+  #       echo "--- :arrow_down: Downloading build directory" && \
+  #       buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 16.04 Build" && \
+  #       tar -zxf build.tar.gz && \
+  #       echo "--- :m: Starting MongoDB" && \
+  #       ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
+  #       echo "+++ :microscope: Running tests" && \
+  #       cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ~/bin/ctest -j8 -LE _tests --output-on-failure
+  #   label: ":ubuntu: 16.04 Tests"
+  #   agents:
+  #     queue: "automation-large-builder-fleet"
+  #   artifact_paths:
+  #     - "mongod.log"
+  #     - "build/genesis.json"
+  #     - "build/config.ini"
+  #   plugins:
+  #     ecr#v1.1.4:
+  #       login: true
+  #       account_ids: "436617320021"
+  #       no-include-email: true
+  #       region: "us-west-2"
+  #     docker#v2.1.0:
+  #       debug: true
+  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu16"
+  #       workdir: /data/job
+  #   timeout: 60
 
-  - command: |
-        echo "--- :arrow_down: Downloading build directory" && \
-        buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 16.04 Build" && \
-        tar -zxf build.tar.gz && \
-        echo "--- :m: Starting MongoDB" && \
-        ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
-        echo "+++ :microscope: Running tests" && \
-        cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ~/bin/ctest -L nonparallelizable_tests --output-on-failure
-    label: ":ubuntu: 16.04 NP Tests"
-    agents:
-      queue: "automation-large-builder-fleet"
-    artifact_paths:
-      - "mongod.log"
-      - "build/genesis.json"
-      - "build/config.ini"
-    plugins:
-      ecr#v1.1.4:
-        login: true
-        account_ids: "436617320021"
-        no-include-email: true
-        region: "us-west-2"
-      docker#v2.1.0:
-        debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu16_2-1"
-        workdir: /data/job
-    timeout: 60
+  # - command: |
+  #       echo "--- :arrow_down: Downloading build directory" && \
+  #       buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 16.04 Build" && \
+  #       tar -zxf build.tar.gz && \
+  #       echo "--- :m: Starting MongoDB" && \
+  #       ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
+  #       echo "+++ :microscope: Running tests" && \
+  #       cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ~/bin/ctest -L nonparallelizable_tests --output-on-failure
+  #   label: ":ubuntu: 16.04 NP Tests"
+  #   agents:
+  #     queue: "automation-large-builder-fleet"
+  #   artifact_paths:
+  #     - "mongod.log"
+  #     - "build/genesis.json"
+  #     - "build/config.ini"
+  #   plugins:
+  #     ecr#v1.1.4:
+  #       login: true
+  #       account_ids: "436617320021"
+  #       no-include-email: true
+  #       region: "us-west-2"
+  #     docker#v2.1.0:
+  #       debug: true
+  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu16"
+  #       workdir: /data/job
+  #   timeout: 60
   
-  - command: |
-        echo "--- :arrow_down: Downloading build directory" && \
-        buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 18.04 Build" && \
-        tar -zxf build.tar.gz && \
-        echo "--- :m: Starting MongoDB" && \
-        ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
-        echo "+++ :microscope: Running tests" && \
-        cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ~/bin/ctest -j8 -LE _tests --output-on-failure
-    label: ":ubuntu: 18.04 Tests"
-    agents:
-      queue: "automation-large-builder-fleet"
-    artifact_paths:
-      - "mongod.log"
-      - "build/genesis.json"
-      - "build/config.ini"
-    plugins:
-      ecr#v1.1.4:
-        login: true
-        account_ids: "436617320021"
-        no-include-email: true
-        region: "us-west-2"
-      docker#v2.1.0:
-        debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu18_2-1"
-        workdir: /data/job
-    timeout: 60
+  # - command: |
+  #       echo "--- :arrow_down: Downloading build directory" && \
+  #       buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 18.04 Build" && \
+  #       tar -zxf build.tar.gz && \
+  #       echo "--- :m: Starting MongoDB" && \
+  #       ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
+  #       echo "+++ :microscope: Running tests" && \
+  #       cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ~/bin/ctest -j8 -LE _tests --output-on-failure
+  #   label: ":ubuntu: 18.04 Tests"
+  #   agents:
+  #     queue: "automation-large-builder-fleet"
+  #   artifact_paths:
+  #     - "mongod.log"
+  #     - "build/genesis.json"
+  #     - "build/config.ini"
+  #   plugins:
+  #     ecr#v1.1.4:
+  #       login: true
+  #       account_ids: "436617320021"
+  #       no-include-email: true
+  #       region: "us-west-2"
+  #     docker#v2.1.0:
+  #       debug: true
+  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu18"
+  #       workdir: /data/job
+  #   timeout: 60
 
-  - command: |
-        echo "--- :arrow_down: Downloading build directory" && \
-        buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 18.04 Build" && \
-        tar -zxf build.tar.gz && \
-        echo "--- :m: Starting MongoDB" && \
-        ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
-        echo "+++ :microscope: Running tests" && \
-        cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ~/bin/ctest -L nonparallelizable_tests --output-on-failure
-    label: ":ubuntu: 18.04 NP Tests"
-    agents:
-      queue: "automation-large-builder-fleet"
-    artifact_paths:
-      - "mongod.log"
-      - "build/genesis.json"
-      - "build/config.ini"
-    plugins:
-      ecr#v1.1.4:
-        login: true
-        account_ids: "436617320021"
-        no-include-email: true
-        region: "us-west-2"
-      docker#v2.1.0:
-        debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu18_2-1"
-        workdir: /data/job
-    timeout: 60
+  # - command: |
+  #       echo "--- :arrow_down: Downloading build directory" && \
+  #       buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 18.04 Build" && \
+  #       tar -zxf build.tar.gz && \
+  #       echo "--- :m: Starting MongoDB" && \
+  #       ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
+  #       echo "+++ :microscope: Running tests" && \
+  #       cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ~/bin/ctest -L nonparallelizable_tests --output-on-failure
+  #   label: ":ubuntu: 18.04 NP Tests"
+  #   agents:
+  #     queue: "automation-large-builder-fleet"
+  #   artifact_paths:
+  #     - "mongod.log"
+  #     - "build/genesis.json"
+  #     - "build/config.ini"
+  #   plugins:
+  #     ecr#v1.1.4:
+  #       login: true
+  #       account_ids: "436617320021"
+  #       no-include-email: true
+  #       region: "us-west-2"
+  #     docker#v2.1.0:
+  #       debug: true
+  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu18"
+  #       workdir: /data/job
+  #   timeout: 60
 
 
-  - command: |
-        echo "--- :arrow_down: Downloading build directory" && \
-        buildkite-agent artifact download "build.tar.gz" . --step ":centos: 7 Build" && \
-        tar -zxf build.tar.gz && \
-        echo "--- :m: Starting MongoDB" && \
-        ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
-        echo "+++ :microscope: Running tests" && \
-        cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ~/bin/ctest -j8 -LE _tests --output-on-failure
-    label: ":centos: 7 Tests"
-    agents:
-      queue: "automation-large-builder-fleet"
-    artifact_paths:
-      - "mongod.log"
-      - "build/genesis.json"
-      - "build/config.ini"
-    plugins:
-      ecr#v1.1.4:
-        login: true
-        account_ids: "436617320021"
-        no-include-email: true
-        region: "us-west-2"
-      docker#v2.1.0:
-        debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:centos7_2-1"
-        workdir: /data/job
-    timeout: 60
+  # - command: |
+  #       echo "--- :arrow_down: Downloading build directory" && \
+  #       buildkite-agent artifact download "build.tar.gz" . --step ":centos: 7 Build" && \
+  #       tar -zxf build.tar.gz && \
+  #       echo "--- :m: Starting MongoDB" && \
+  #       ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
+  #       echo "+++ :microscope: Running tests" && \
+  #       cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ~/bin/ctest -j8 -LE _tests --output-on-failure
+  #   label: ":centos: 7 Tests"
+  #   agents:
+  #     queue: "automation-large-builder-fleet"
+  #   artifact_paths:
+  #     - "mongod.log"
+  #     - "build/genesis.json"
+  #     - "build/config.ini"
+  #   plugins:
+  #     ecr#v1.1.4:
+  #       login: true
+  #       account_ids: "436617320021"
+  #       no-include-email: true
+  #       region: "us-west-2"
+  #     docker#v2.1.0:
+  #       debug: true
+  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:centos7"
+  #       workdir: /data/job
+  #   timeout: 60
 
-  - command: |
-        echo "--- :arrow_down: Downloading build directory" && \
-        buildkite-agent artifact download "build.tar.gz" . --step ":centos: 7 Build" && \
-        tar -zxf build.tar.gz && \
-        echo "--- :m: Starting MongoDB" && \
-        ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
-        echo "+++ :microscope: Running tests" && \
-        cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ~/bin/ctest -L nonparallelizable_tests --output-on-failure
-    label: ":centos: 7 NP Tests"
-    agents:
-      queue: "automation-large-builder-fleet"
-    artifact_paths:
-      - "mongod.log"
-      - "build/genesis.json"
-      - "build/config.ini"
-    plugins:
-      ecr#v1.1.4:
-        login: true
-        account_ids: "436617320021"
-        no-include-email: true
-        region: "us-west-2"
-      docker#v2.1.0:
-        debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:centos7_2-1"
-        workdir: /data/job
-    timeout: 60
+  # - command: |
+  #       echo "--- :arrow_down: Downloading build directory" && \
+  #       buildkite-agent artifact download "build.tar.gz" . --step ":centos: 7 Build" && \
+  #       tar -zxf build.tar.gz && \
+  #       echo "--- :m: Starting MongoDB" && \
+  #       ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
+  #       echo "+++ :microscope: Running tests" && \
+  #       cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ~/bin/ctest -L nonparallelizable_tests --output-on-failure
+  #   label: ":centos: 7 NP Tests"
+  #   agents:
+  #     queue: "automation-large-builder-fleet"
+  #   artifact_paths:
+  #     - "mongod.log"
+  #     - "build/genesis.json"
+  #     - "build/config.ini"
+  #   plugins:
+  #     ecr#v1.1.4:
+  #       login: true
+  #       account_ids: "436617320021"
+  #       no-include-email: true
+  #       region: "us-west-2"
+  #     docker#v2.1.0:
+  #       debug: true
+  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:centos7"
+  #       workdir: /data/job
+  #   timeout: 60
 
-  - command: |
-        echo "--- :arrow_down: Downloading build directory" && \
-        buildkite-agent artifact download "build.tar.gz" . --step ":aws: 1 Build" && \
-        tar -zxf build.tar.gz && \
-        echo "--- :m: Starting MongoDB" && \
-        ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
-        echo "+++ :microscope: Running tests" && \
-        cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ~/bin/ctest -j8 -LE _tests --output-on-failure
-    label: ":aws: 1 Tests"
-    agents:
-      queue: "automation-large-builder-fleet"
-    artifact_paths:
-      - "mongod.log"
-      - "build/genesis.json"
-      - "build/config.ini"
-    plugins:
-      ecr#v1.1.4:
-        login: true
-        account_ids: "436617320021"
-        no-include-email: true
-        region: "us-west-2"
-      docker#v2.1.0:
-        debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:amazonlinux1_2-1"
-        workdir: /data/job
-    timeout: 60
+  # - command: |
+  #       echo "--- :arrow_down: Downloading build directory" && \
+  #       buildkite-agent artifact download "build.tar.gz" . --step ":aws: 1 Build" && \
+  #       tar -zxf build.tar.gz && \
+  #       echo "--- :m: Starting MongoDB" && \
+  #       ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
+  #       echo "+++ :microscope: Running tests" && \
+  #       cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ~/bin/ctest -j8 -LE _tests --output-on-failure
+  #   label: ":aws: 1 Tests"
+  #   agents:
+  #     queue: "automation-large-builder-fleet"
+  #   artifact_paths:
+  #     - "mongod.log"
+  #     - "build/genesis.json"
+  #     - "build/config.ini"
+  #   plugins:
+  #     ecr#v1.1.4:
+  #       login: true
+  #       account_ids: "436617320021"
+  #       no-include-email: true
+  #       region: "us-west-2"
+  #     docker#v2.1.0:
+  #       debug: true
+  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:amazonlinux1"
+  #       workdir: /data/job
+  #   timeout: 60
 
-  - command: |
-        echo "--- :arrow_down: Downloading build directory" && \
-        buildkite-agent artifact download "build.tar.gz" . --step ":aws: 1 Build" && \
-        tar -zxf build.tar.gz && \
-        echo "--- :m: Starting MongoDB" && \
-        ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
-        echo "+++ :microscope: Running tests" && \
-        cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ~/bin/ctest -L nonparallelizable_tests --output-on-failure
-    label: ":aws: 1 NP Tests"
-    agents:
-      queue: "automation-large-builder-fleet"
-    artifact_paths:
-      - "mongod.log"
-      - "build/genesis.json"
-      - "build/config.ini"
-    plugins:
-      ecr#v1.1.4:
-        login: true
-        account_ids: "436617320021"
-        no-include-email: true
-        region: "us-west-2"
-      docker#v2.1.0:
-        debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:amazonlinux1_2-1"
-        workdir: /data/job
-    timeout: 60
+  # - command: |
+  #       echo "--- :arrow_down: Downloading build directory" && \
+  #       buildkite-agent artifact download "build.tar.gz" . --step ":aws: 1 Build" && \
+  #       tar -zxf build.tar.gz && \
+  #       echo "--- :m: Starting MongoDB" && \
+  #       ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
+  #       echo "+++ :microscope: Running tests" && \
+  #       cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ~/bin/ctest -L nonparallelizable_tests --output-on-failure
+  #   label: ":aws: 1 NP Tests"
+  #   agents:
+  #     queue: "automation-large-builder-fleet"
+  #   artifact_paths:
+  #     - "mongod.log"
+  #     - "build/genesis.json"
+  #     - "build/config.ini"
+  #   plugins:
+  #     ecr#v1.1.4:
+  #       login: true
+  #       account_ids: "436617320021"
+  #       no-include-email: true
+  #       region: "us-west-2"
+  #     docker#v2.1.0:
+  #       debug: true
+  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:amazonlinux1"
+  #       workdir: /data/job
+  #   timeout: 60
 
   # - command: |
   #       echo "--- :arrow_down: Downloading build directory" && \
@@ -429,13 +450,13 @@ steps:
 
   - command: |
         echo "--- :arrow_down: Downloading build directory" && \
-        buildkite-agent artifact download "build.tar.gz" . --step ":fedora: 27 Build" && \
+        buildkite-agent artifact download "build.tar.gz" . --step ":aws: 2 Build" && \
         tar -zxf build.tar.gz && \
         echo "--- :m: Starting MongoDB" && \
         ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
         echo "+++ :microscope: Running tests" && \
         cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ~/bin/ctest -j8 -LE _tests --output-on-failure
-    label: ":fedora: 27 Tests"
+    label: ":aws: 2 Tests"
     agents:
       queue: "automation-large-builder-fleet"
     artifact_paths:
@@ -450,19 +471,19 @@ steps:
         region: "us-west-2"
       docker#v2.1.0:
         debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:fedora27_2-1"
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:amazonlinux2_2-1"
         workdir: /data/job
     timeout: 60
 
   - command: |
         echo "--- :arrow_down: Downloading build directory" && \
-        buildkite-agent artifact download "build.tar.gz" . --step ":fedora: 27 Build" && \
+        buildkite-agent artifact download "build.tar.gz" . --step ":aws: 2 Build" && \
         tar -zxf build.tar.gz && \
         echo "--- :m: Starting MongoDB" && \
         ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
         echo "+++ :microscope: Running tests" && \
         cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ~/bin/ctest -L nonparallelizable_tests --output-on-failure
-    label: ":fedora: 27 NP Tests"
+    label: ":aws: 2 NP Tests"
     agents:
       queue: "automation-large-builder-fleet"
     artifact_paths:
@@ -477,243 +498,297 @@ steps:
         region: "us-west-2"
       docker#v2.1.0:
         debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:fedora27_2-1"
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:amazonlinux2_2-1"
         workdir: /data/job
     timeout: 60
 
-  - command: |
-        echo "--- :arrow_down: Downloading build directory" && \
-        buildkite-agent artifact download "build.tar.gz" . --step ":darwin: High Sierra Build" && \
-        tar -zxf build.tar.gz && \
-        echo "--- :m: Starting MongoDB" && \
-        ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
-        echo "+++ :microscope: Running tests" && \
-        ln -s "$(pwd)" /data/job && cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ctest -j8 -LE _tests --output-on-failure
-    label: ":darwin: High Sierra Tests"
-    agents:
-      - "role=tester-v2-1"
-      - "os=high-sierra"
-    artifact_paths:
-      - "mongod.log"
-      - "build/genesis.json"
-      - "build/config.ini"
-    timeout: 60
+  # - command: |
+  #       echo "--- :arrow_down: Downloading build directory" && \
+  #       buildkite-agent artifact download "build.tar.gz" . --step ":fedora: 27 Build" && \
+  #       tar -zxf build.tar.gz && \
+  #       echo "--- :m: Starting MongoDB" && \
+  #       ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
+  #       echo "+++ :microscope: Running tests" && \
+  #       cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ~/bin/ctest -j8 -LE _tests --output-on-failure
+  #   label: ":fedora: 27 Tests"
+  #   agents:
+  #     queue: "automation-large-builder-fleet"
+  #   artifact_paths:
+  #     - "mongod.log"
+  #     - "build/genesis.json"
+  #     - "build/config.ini"
+  #   plugins:
+  #     ecr#v1.1.4:
+  #       login: true
+  #       account_ids: "436617320021"
+  #       no-include-email: true
+  #       region: "us-west-2"
+  #     docker#v2.1.0:
+  #       debug: true
+  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:fedora27"
+  #       workdir: /data/job
+  #   timeout: 60
 
-  - command: |
-        echo "--- :arrow_down: Downloading build directory" && \
-        buildkite-agent artifact download "build.tar.gz" . --step ":darwin: High Sierra Build" && \
-        tar -zxf build.tar.gz && \
-        echo "--- :m: Starting MongoDB" && \
-        ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
-        echo "+++ :microscope: Running tests" && \
-        ln -s "$(pwd)" /data/job && cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ctest -L nonparallelizable_tests --output-on-failure
-    label: ":darwin: High Sierra NP Tests"
-    agents:
-      - "role=tester-v2-1"
-      - "os=high-sierra"
-    artifact_paths:
-      - "mongod.log"
-      - "build/genesis.json"
-      - "build/config.ini"
-    timeout: 60
+  # - command: |
+  #       echo "--- :arrow_down: Downloading build directory" && \
+  #       buildkite-agent artifact download "build.tar.gz" . --step ":fedora: 27 Build" && \
+  #       tar -zxf build.tar.gz && \
+  #       echo "--- :m: Starting MongoDB" && \
+  #       ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
+  #       echo "+++ :microscope: Running tests" && \
+  #       cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ~/bin/ctest -L nonparallelizable_tests --output-on-failure
+  #   label: ":fedora: 27 NP Tests"
+  #   agents:
+  #     queue: "automation-large-builder-fleet"
+  #   artifact_paths:
+  #     - "mongod.log"
+  #     - "build/genesis.json"
+  #     - "build/config.ini"
+  #   plugins:
+  #     ecr#v1.1.4:
+  #       login: true
+  #       account_ids: "436617320021"
+  #       no-include-email: true
+  #       region: "us-west-2"
+  #     docker#v2.1.0:
+  #       debug: true
+  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:fedora27"
+  #       workdir: /data/job
+  #   timeout: 60
 
-  - command: |
-        echo "--- :arrow_down: Downloading build directory" && \
-        buildkite-agent artifact download "build.tar.gz" . --step ":darwin: Mojave Build" && \
-        tar -zxf build.tar.gz && \
-        echo "--- :m: Starting MongoDB" && \
-        ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
-        echo "+++ :microscope: Running tests" && \
-        ln -s "$(pwd)" /data/job && cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ctest -j8 -LE _tests --output-on-failure
-    label: ":darwin: Mojave Tests"
-    agents:
-      - "role=tester-v2-1"
-      - "os=mojave"
-    artifact_paths:
-      - "mongod.log"
-      - "build/genesis.json"
-      - "build/config.ini"
-    timeout: 60
+  # - command: |
+  #       echo "--- :arrow_down: Downloading build directory" && \
+  #       buildkite-agent artifact download "build.tar.gz" . --step ":darwin: High Sierra Build" && \
+  #       tar -zxf build.tar.gz && \
+  #       echo "--- :m: Starting MongoDB" && \
+  #       ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
+  #       echo "+++ :microscope: Running tests" && \
+  #       ln -s "$(pwd)" /data/job && cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ctest -j8 -LE _tests --output-on-failure
+  #   label: ":darwin: High Sierra Tests"
+  #   agents:
+  #     - "role=tester-v2"
+  #     - "os=high-sierra"
+  #   artifact_paths:
+  #     - "mongod.log"
+  #     - "build/genesis.json"
+  #     - "build/config.ini"
+  #   timeout: 60
 
-  - command: |
-        echo "--- :arrow_down: Downloading build directory" && \
-        buildkite-agent artifact download "build.tar.gz" . --step ":darwin: Mojave Build" && \
-        tar -zxf build.tar.gz && \
-        echo "--- :m: Starting MongoDB" && \
-        ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
-        echo "+++ :microscope: Running tests" && \
-        ln -s "$(pwd)" /data/job && cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ctest -L nonparallelizable_tests --output-on-failure
-    label: ":darwin: Mojave NP Tests"
-    agents:
-      - "role=tester-v2-1"
-      - "os=mojave"
-    artifact_paths:
-      - "mongod.log"
-      - "build/genesis.json"
-      - "build/config.ini"
-    timeout: 60
+  # - command: |
+  #       echo "--- :arrow_down: Downloading build directory" && \
+  #       buildkite-agent artifact download "build.tar.gz" . --step ":darwin: High Sierra Build" && \
+  #       tar -zxf build.tar.gz && \
+  #       echo "--- :m: Starting MongoDB" && \
+  #       ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
+  #       echo "+++ :microscope: Running tests" && \
+  #       ln -s "$(pwd)" /data/job && cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ctest -L nonparallelizable_tests --output-on-failure
+  #   label: ":darwin: High Sierra NP Tests"
+  #   agents:
+  #     - "role=tester-v2"
+  #     - "os=high-sierra"
+  #   artifact_paths:
+  #     - "mongod.log"
+  #     - "build/genesis.json"
+  #     - "build/config.ini"
+  #   timeout: 60
+
+  # - command: |
+  #       echo "--- :arrow_down: Downloading build directory" && \
+  #       buildkite-agent artifact download "build.tar.gz" . --step ":darwin: Mojave Build" && \
+  #       tar -zxf build.tar.gz && \
+  #       echo "--- :m: Starting MongoDB" && \
+  #       ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
+  #       echo "+++ :microscope: Running tests" && \
+  #       ln -s "$(pwd)" /data/job && cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ctest -j8 -LE _tests --output-on-failure
+  #   label: ":darwin: Mojave Tests"
+  #   agents:
+  #     - "role=tester-v2"
+  #     - "os=mojave"
+  #   artifact_paths:
+  #     - "mongod.log"
+  #     - "build/genesis.json"
+  #     - "build/config.ini"
+  #   timeout: 60
+
+  # - command: |
+  #       echo "--- :arrow_down: Downloading build directory" && \
+  #       buildkite-agent artifact download "build.tar.gz" . --step ":darwin: Mojave Build" && \
+  #       tar -zxf build.tar.gz && \
+  #       echo "--- :m: Starting MongoDB" && \
+  #       ~/bin/mongod --fork --dbpath ~/data/mongodb -f ~/etc/mongod.conf --logpath "$(pwd)"/mongod.log && \
+  #       echo "+++ :microscope: Running tests" && \
+  #       ln -s "$(pwd)" /data/job && cd /data/job/build && PATH=\$PATH:~/opt/mongodb/bin ctest -L nonparallelizable_tests --output-on-failure
+  #   label: ":darwin: Mojave NP Tests"
+  #   agents:
+  #     - "role=tester-v2"
+  #     - "os=mojave"
+  #   artifact_paths:
+  #     - "mongod.log"
+  #     - "build/genesis.json"
+  #     - "build/config.ini"
+  #   timeout: 60
     
-  - wait
+  # - wait
 
-  - command: |
-        echo "--- :arrow_down: Downloading build directory" && \
-        buildkite-agent artifact download "build.tar.gz" . --step ":darwin: High Sierra Build" && \
-        tar -zxf build.tar.gz && \
-        echo "+++ :microscope: Starting package build" && \
-        ln -s "$(pwd)" /data/job && cd /data/job/build/packages && bash generate_package.sh brew
-    label: ":darwin: High Sierra Package Builder"
-    agents:
-      - "role=builder-v2-1"
-      - "os=high-sierra"
-    artifact_paths:
-      - "build/packages/*.tar.gz"
-      - "build/packages/*.rb"
-    timeout: 60
+  # - command: |
+  #       echo "--- :arrow_down: Downloading build directory" && \
+  #       buildkite-agent artifact download "build.tar.gz" . --step ":darwin: High Sierra Build" && \
+  #       tar -zxf build.tar.gz && \
+  #       echo "+++ :microscope: Starting package build" && \
+  #       ln -s "$(pwd)" /data/job && cd /data/job/build/packages && bash generate_package.sh brew
+  #   label: ":darwin: High Sierra Package Builder"
+  #   agents:
+  #     - "role=builder-v2"
+  #     - "os=high-sierra"
+  #   artifact_paths:
+  #     - "build/packages/*.tar.gz"
+  #     - "build/packages/*.rb"
+  #   timeout: 60
 
-  - command: |
-        echo "--- :arrow_down: Downloading build directory" && \
-        buildkite-agent artifact download "build.tar.gz" . --step ":darwin: Mojave Build" && \
-        tar -zxf build.tar.gz && \
-        echo "+++ :microscope: Starting package build" && \
-        ln -s "$(pwd)" /data/job && cd /data/job/build/packages && bash generate_package.sh brew
-    label: ":darwin: Mojave Package Builder"
-    agents:
-      - "role=builder-v2-1"
-      - "os=mojave"
-    artifact_paths:
-      - "build/packages/*.tar.gz"
-      - "build/packages/*.rb"
-    timeout: 60
+  # - command: |
+  #       echo "--- :arrow_down: Downloading build directory" && \
+  #       buildkite-agent artifact download "build.tar.gz" . --step ":darwin: Mojave Build" && \
+  #       tar -zxf build.tar.gz && \
+  #       echo "+++ :microscope: Starting package build" && \
+  #       ln -s "$(pwd)" /data/job && cd /data/job/build/packages && bash generate_package.sh brew
+  #   label: ":darwin: Mojave Package Builder"
+  #   agents:
+  #     - "role=builder-v2"
+  #     - "os=mojave"
+  #   artifact_paths:
+  #     - "build/packages/*.tar.gz"
+  #     - "build/packages/*.rb"
+  #   timeout: 60
 
-  - command: |
-        echo "--- :arrow_down: Downloading build directory" && \
-        buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 16.04 Build" && \
-        tar -zxf build.tar.gz && \
-        echo "+++ :microscope: Starting package build" && \
-        cd /data/job/build/packages && bash generate_package.sh deb
-    label: ":ubuntu: 16.04 Package builder"
-    agents:
-      queue: "automation-large-builder-fleet"
-    artifact_paths:
-      - "build/packages/*.deb"
-    plugins:
-      ecr#v1.1.4:
-        login: true
-        account_ids: "436617320021"
-        no-include-email: true
-        region: "us-west-2"
-      docker#v2.1.0:
-        debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu16_2-1"
-        workdir: /data/job
-    env:
-      OS: "ubuntu-16.04"
-      PKGTYPE: "deb"
-    timeout: 60
+  # - command: |
+  #       echo "--- :arrow_down: Downloading build directory" && \
+  #       buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 16.04 Build" && \
+  #       tar -zxf build.tar.gz && \
+  #       echo "+++ :microscope: Starting package build" && \
+  #       cd /data/job/build/packages && bash generate_package.sh deb
+  #   label: ":ubuntu: 16.04 Package builder"
+  #   agents:
+  #     queue: "automation-large-builder-fleet"
+  #   artifact_paths:
+  #     - "build/packages/*.deb"
+  #   plugins:
+  #     ecr#v1.1.4:
+  #       login: true
+  #       account_ids: "436617320021"
+  #       no-include-email: true
+  #       region: "us-west-2"
+  #     docker#v2.1.0:
+  #       debug: true
+  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu16"
+  #       workdir: /data/job
+  #   env:
+  #     OS: "ubuntu-16.04"
+  #     PKGTYPE: "deb"
+  #   timeout: 60
 
-  - command: |
-        echo "--- :arrow_down: Downloading build directory" && \
-        buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 18.04 Build" && \
-        tar -zxf build.tar.gz && \
-        echo "+++ :microscope: Starting package build" && \
-        cd /data/job/build/packages && bash generate_package.sh deb
-    label: ":ubuntu: 18.04 Package builder"
-    agents:
-      queue: "automation-large-builder-fleet"
-    artifact_paths:
-      - "build/packages/*.deb"
-    plugins:
-      ecr#v1.1.4:
-        login: true
-        account_ids: "436617320021"
-        no-include-email: true
-        region: "us-west-2"
-      docker#v2.1.0:
-        debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu18_2-1"
-        workdir: /data/job
-    env:
-      OS: "ubuntu-18.04"
-      PKGTYPE: "deb"
-    timeout: 60
+  # - command: |
+  #       echo "--- :arrow_down: Downloading build directory" && \
+  #       buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 18.04 Build" && \
+  #       tar -zxf build.tar.gz && \
+  #       echo "+++ :microscope: Starting package build" && \
+  #       cd /data/job/build/packages && bash generate_package.sh deb
+  #   label: ":ubuntu: 18.04 Package builder"
+  #   agents:
+  #     queue: "automation-large-builder-fleet"
+  #   artifact_paths:
+  #     - "build/packages/*.deb"
+  #   plugins:
+  #     ecr#v1.1.4:
+  #       login: true
+  #       account_ids: "436617320021"
+  #       no-include-email: true
+  #       region: "us-west-2"
+  #     docker#v2.1.0:
+  #       debug: true
+  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu18"
+  #       workdir: /data/job
+  #   env:
+  #     OS: "ubuntu-18.04"
+  #     PKGTYPE: "deb"
+  #   timeout: 60
 
-  - command: |
-        echo "--- :arrow_down: Downloading build directory" && \
-        buildkite-agent artifact download "build.tar.gz" . --step ":fedora: 27 Build" && \
-        tar -zxf build.tar.gz && \
-        echo "+++ :microscope: Starting package build" && \
-        yum install -y rpm-build && \
-        mkdir -p /root/rpmbuild/BUILD && \
-        mkdir -p /root/rpmbuild/BUILDROOT && \
-        mkdir -p /root/rpmbuild/RPMS && \
-        mkdir -p /root/rpmbuild/SOURCES && \
-        mkdir -p /root/rpmbuild/SPECS && \
-        mkdir -p /root/rpmbuild/SRPMS && \
-        cd /data/job/build/packages && bash generate_package.sh rpm
-    label: ":fedora: 27 Package builder"
-    agents:
-      queue: "automation-large-builder-fleet"
-    artifact_paths:
-      - "build/packages/*.rpm"
-    plugins:
-      ecr#v1.1.4:
-        login: true
-        account_ids: "436617320021"
-        no-include-email: true
-        region: "us-west-2"
-      docker#v2.1.0:
-        debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:fedora27_2-1"
-        workdir: /data/job
-    env:
-      OS: "fc27"
-      PKGTYPE: "rpm"
-    timeout: 60
+  # - command: |
+  #       echo "--- :arrow_down: Downloading build directory" && \
+  #       buildkite-agent artifact download "build.tar.gz" . --step ":fedora: 27 Build" && \
+  #       tar -zxf build.tar.gz && \
+  #       echo "+++ :microscope: Starting package build" && \
+  #       yum install -y rpm-build && \
+  #       mkdir -p /root/rpmbuild/BUILD && \
+  #       mkdir -p /root/rpmbuild/BUILDROOT && \
+  #       mkdir -p /root/rpmbuild/RPMS && \
+  #       mkdir -p /root/rpmbuild/SOURCES && \
+  #       mkdir -p /root/rpmbuild/SPECS && \
+  #       mkdir -p /root/rpmbuild/SRPMS && \
+  #       cd /data/job/build/packages && bash generate_package.sh rpm
+  #   label: ":fedora: 27 Package builder"
+  #   agents:
+  #     queue: "automation-large-builder-fleet"
+  #   artifact_paths:
+  #     - "build/packages/*.rpm"
+  #   plugins:
+  #     ecr#v1.1.4:
+  #       login: true
+  #       account_ids: "436617320021"
+  #       no-include-email: true
+  #       region: "us-west-2"
+  #     docker#v2.1.0:
+  #       debug: true
+  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:fedora27"
+  #       workdir: /data/job
+  #   env:
+  #     OS: "fc27"
+  #     PKGTYPE: "rpm"
+  #   timeout: 60
 
-  - command: |
-        echo "--- :arrow_down: Downloading build directory" && \
-        buildkite-agent artifact download "build.tar.gz" . --step ":centos: 7 Build" && \
-        tar -zxf build.tar.gz && \
-        echo "+++ :microscope: Starting package build" && \
-        yum install -y rpm-build && \
-        mkdir -p /root/rpmbuild/BUILD && \
-        mkdir -p /root/rpmbuild/BUILDROOT && \
-        mkdir -p /root/rpmbuild/RPMS && \
-        mkdir -p /root/rpmbuild/SOURCES && \
-        mkdir -p /root/rpmbuild/SPECS && \
-        mkdir -p /root/rpmbuild/SRPMS && \
-        cd /data/job/build/packages && bash generate_package.sh rpm
-    label: ":centos: 7 Package builder"
-    agents:
-      queue: "automation-large-builder-fleet"
-    artifact_paths:
-      - "build/packages/*.rpm"
-    plugins:
-      ecr#v1.1.4:
-        login: true
-        account_ids: "436617320021"
-        no-include-email: true
-        region: "us-west-2"
-      docker#v2.1.0:
-        debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:centos7_2-1"
-        workdir: /data/job
-    env:
-      OS: "el7"
-      PKGTYPE: "rpm"
-    timeout: 60
+  # - command: |
+  #       echo "--- :arrow_down: Downloading build directory" && \
+  #       buildkite-agent artifact download "build.tar.gz" . --step ":centos: 7 Build" && \
+  #       tar -zxf build.tar.gz && \
+  #       echo "+++ :microscope: Starting package build" && \
+  #       yum install -y rpm-build && \
+  #       mkdir -p /root/rpmbuild/BUILD && \
+  #       mkdir -p /root/rpmbuild/BUILDROOT && \
+  #       mkdir -p /root/rpmbuild/RPMS && \
+  #       mkdir -p /root/rpmbuild/SOURCES && \
+  #       mkdir -p /root/rpmbuild/SPECS && \
+  #       mkdir -p /root/rpmbuild/SRPMS && \
+  #       cd /data/job/build/packages && bash generate_package.sh rpm
+  #   label: ":centos: 7 Package builder"
+  #   agents:
+  #     queue: "automation-large-builder-fleet"
+  #   artifact_paths:
+  #     - "build/packages/*.rpm"
+  #   plugins:
+  #     ecr#v1.1.4:
+  #       login: true
+  #       account_ids: "436617320021"
+  #       no-include-email: true
+  #       region: "us-west-2"
+  #     docker#v2.1.0:
+  #       debug: true
+  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:centos7"
+  #       workdir: /data/job
+  #   env:
+  #     OS: "el7"
+  #     PKGTYPE: "rpm"
+  #   timeout: 60
 
-  - wait
+  # - wait
 
-  - command: |
-        echo "--- :arrow_down: Downloading brew files" && \
-        buildkite-agent artifact download "build/packages/eosio.rb" . --step ":darwin: High Sierra Package Builder" && \
-        mv build/packages/eosio.rb build/packages/eosio_highsierra.rb && \
-        buildkite-agent artifact download "build/packages/eosio.rb" . --step ":darwin: Mojave Package Builder"
-    label: ":darwin: Brew Updater"
-    agents:
-      queue: "automation-large-builder-fleet"
-    artifact_paths:
-      - "build/packages/eosio_highsierra.rb"
-      - "build/packages/eosio.rb"
-    timeout: 60
+  # - command: |
+  #       echo "--- :arrow_down: Downloading brew files" && \
+  #       buildkite-agent artifact download "build/packages/eosio.rb" . --step ":darwin: High Sierra Package Builder" && \
+  #       mv build/packages/eosio.rb build/packages/eosio_highsierra.rb && \
+  #       buildkite-agent artifact download "build/packages/eosio.rb" . --step ":darwin: Mojave Package Builder"
+  #   label: ":darwin: Brew Updater"
+  #   agents:
+  #     queue: "automation-large-builder-fleet"
+  #   artifact_paths:
+  #     - "build/packages/eosio_highsierra.rb"
+  #     - "build/packages/eosio.rb"
+  #   timeout: 60

--- a/scripts/full_uninstaller.sh
+++ b/scripts/full_uninstaller.sh
@@ -8,9 +8,9 @@ if [ -d "/usr/local/include/eosio" ] || [ -d "$HOME/opt/eosio" ] || [ $FORCED ==
    elif [ $1 == 1 ] || [ $FORCED == 1 ]; then
       ANSWER=1
    fi
-   echo "Uninstalling..."
    case $ANSWER in
       1 | [Yy]* )
+         echo "Uninstalling..."
          if [ -d "$HOME/opt/eosio" ] || [[ $1 == "force-new" ]]; then
             if [ $( uname ) == "Darwin" ]; then
                # gettext and other brew packages are not modified as they can be dependencies for things other than eosio
@@ -128,7 +128,6 @@ if [ -d "/usr/local/include/eosio" ] || [ -d "$HOME/opt/eosio" ] || [ $FORCED ==
       ;;
       [Nn]* )
          printf "Skipping\n\n"
-         exit 0
       ;;
    esac
 fi

--- a/tests/testUtils.py
+++ b/tests/testUtils.py
@@ -223,8 +223,8 @@ class Utils:
         # pylint: disable=deprecated-method
         # pgrep differs on different platform (amazonlinux1 and 2 for example). We need to check if pgrep -h has -a available and add that if so:
         try:
-            pgrepHelp = re.search('-a', subprocess.Popen("pgrep --help 2>/dev/null", shell=True, stdout=subprocess.PIPE).stdout.read())
-	        pgrepOutput = pgrepHelp.group(0)
+            pgrepHelp = re.search('-a', subprocess.Popen("pgrep --help 2>/dev/null", shell=True, stdout=subprocess.PIPE).stdout.read().decode('utf-8'))
+            pgrepHelp.group(0) # group() errors if -a is not found, so we don't need to do anything else special here.
             pgrepOpts="-a"
         except AttributeError as error:
             # If no -a, AttributeError: 'NoneType' object has no attribute 'group'

--- a/tests/testUtils.py
+++ b/tests/testUtils.py
@@ -1,3 +1,4 @@
+import re
 import errno
 import subprocess
 import time
@@ -222,9 +223,9 @@ class Utils:
         pgrepOpts="-fl"
         # pylint: disable=deprecated-method
         # pgrep differs on different platform (amazonlinux1 and 2 for example). We need to check if pgrep -h has -a available and add that if so:
-        pgrep-output = re.search('-a', subprocess.Popen("pgrep -h", shell=True, stdout=subprocess.PIPE).stdout.read())
         try:
-	        pgrepresult.group(0)
+            pgrepHelp = re.search('-a', subprocess.Popen("pgrep --help 2>/dev/null", shell=True, stdout=subprocess.PIPE).stdout.read())
+	        pgrepHelp.group(0)
             pgrepOpts="-a"
         except AttributeError as error:
             # If no -a, AttributeError: 'NoneType' object has no attribute 'group'

--- a/tests/testUtils.py
+++ b/tests/testUtils.py
@@ -221,8 +221,14 @@ class Utils:
     def pgrepCmd(serverName):
         pgrepOpts="-fl"
         # pylint: disable=deprecated-method
-        if platform.linux_distribution()[0] in ["Ubuntu", "LinuxMint", "Fedora","CentOS Linux","arch"]:
+        # pgrep differs on different platform (amazonlinux1 and 2 for example). We need to check if pgrep -h has -a available and add that if so:
+        pgrep-output = re.search('-a', subprocess.Popen("pgrep -h", shell=True, stdout=subprocess.PIPE).stdout.read())
+        try:
+	        pgrepresult.group(0)
             pgrepOpts="-a"
+        except AttributeError as error:
+            # If no -a, AttributeError: 'NoneType' object has no attribute 'group'
+            pass
 
         return "pgrep %s %s" % (pgrepOpts, serverName)
 

--- a/tests/testUtils.py
+++ b/tests/testUtils.py
@@ -220,16 +220,15 @@ class Utils:
 
     @staticmethod
     def pgrepCmd(serverName):
-        pgrepOpts="-fl"
         # pylint: disable=deprecated-method
         # pgrep differs on different platform (amazonlinux1 and 2 for example). We need to check if pgrep -h has -a available and add that if so:
         try:
             pgrepHelp = re.search('-a', subprocess.Popen("pgrep --help 2>/dev/null", shell=True, stdout=subprocess.PIPE).stdout.read())
-	        pgrepHelp.group(0)
+	        pgrepOutput = pgrepHelp.group(0)
             pgrepOpts="-a"
         except AttributeError as error:
             # If no -a, AttributeError: 'NoneType' object has no attribute 'group'
-            pass
+            pgrepOpts="-fl"
 
         return "pgrep %s %s" % (pgrepOpts, serverName)
 


### PR DESCRIPTION
We currently only support amazonlinux1. These changes support amazonlinux2 in pipelines.

A fairly large change to some workaround code for differing pgrep version. This will help us prevent having to modify the test file in the future.