### PR TITLE
Validate producer signature providers

### DIFF
--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -676,6 +676,7 @@ void producer_plugin::plugin_initialize(const boost::program_options::variables_
       chain::controller& chain = my->chain_plug->chain();
       const auto& permissions = chain.db().get_index<permission_index,by_owner>();
       auto perm = permissions.lower_bound( boost::make_tuple( producer ) );
+      if( perm == permissions.end() || perm->owner != producer ) continue; // Account does not yet exist
       while( perm != permissions.end() && perm->owner == producer ) {
          for(const auto& keyweight : perm->auth.keys) {
             signature_available |= is_producer_key(keyweight.key);

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -683,7 +683,8 @@ void producer_plugin::plugin_initialize(const boost::program_options::variables_
          }
          ++perm;
       }
-      EOS_ASSERT(signature_available, plugin_config_exception, "Missing signature-provider for producer ${prod}", ("prod", producer));
+      if(!signature_available)
+         wlog("Missing signature-provider for producer ${prod}", ("prod", producer));
    }
 
    my->_keosd_provider_timeout_us = fc::milliseconds(options.at("keosd-provider-timeout").as<int32_t>());


### PR DESCRIPTION
## Change Description

This change ensures that any configuration specifying `producer-name` also specifies a corresponding `signature-provider` (or `private-key`).  Any permission with a matching key is accepted.  No attempt is made to validate the permission weight configuration.  Resolves #6768.

## Consensus Changes

N/A

## API Changes

N/A

## Documentation Additions

N/A