### PR TITLE
Fix testee tester brew

### DIFF
--- a/scripts/eosio_build_centos.sh
+++ b/scripts/eosio_build_centos.sh
@@ -157,7 +157,7 @@ if [ "${COUNT}" -gt 1 ]; then
 		* ) echo "Please type 'y' for yes or 'n' for no."; exit;;
 	esac
 else
-	printf " - No required YUM dependencies to install.\\n"
+	printf " - No required YUM dependencies to install.\\n\\n"
 fi
 
 if [ -d /opt/rh/python33 ]; then

--- a/scripts/eosio_build_darwin.sh
+++ b/scripts/eosio_build_darwin.sh
@@ -94,12 +94,6 @@ printf "\\nChecking dependencies...\\n"
 var_ifs="${IFS}"
 IFS=","
 while read -r name tester testee brewname uri; do
-	# For directories, we want to be able to wildcard match versions to prevent upgraded brew packages (minor or patch changes to python for example) from not being seen
-	if [ $tester == '-d' ] && [ $(echo $testee | grep -c '*') -gt 0 ]; then
-		for DIR in $testee; do
-			testee=$(echo $DIR | sed 's/\\//g')
-		done
-	fi
 	if [ $tester $testee ]; then
 		printf " - ${name} found!\\n"
 		continue

--- a/scripts/eosio_build_darwin.sh
+++ b/scripts/eosio_build_darwin.sh
@@ -161,7 +161,7 @@ if [ $COUNT -gt 1 ]; then
 		* ) echo "Please type 'y' for yes or 'n' for no."; exit;;
 	esac
 else
-	printf "\\n - No required Home Brew dependencies to install.\\n"
+	printf " - No required Home Brew dependencies to install.\\n"
 fi
 
 

--- a/scripts/eosio_build_darwin_deps
+++ b/scripts/eosio_build_darwin_deps
@@ -5,8 +5,8 @@ OpenSSL,-f,/usr/local/opt/openssl/lib/libssl.a,openssl,https://www.openssl.org/s
 wget,-x,/usr/local/bin/wget,wget,https://ftp.gnu.org/gnu/wget/wget-1.19.2.tar.gz
 GMP,-f,/usr/local/opt/gmp/include/gmpxx.h,gmp,https://ftp.gnu.org/gnu/gmp/gmp-6.1.2.tar.bz2
 llvm,-d,/usr/local/opt/llvm@4,llvm@4,http://releases.llvm.org/4.0.1/llvm-4.0.1.src.tar.xz
-python,-d,/usr/local/Cellar/python/3\*,python,https://www.python.org/ftp/python/3.7.2/Python-3.7.2.tgz
-python@2,-d,/usr/local/Cellar/python@2/2\*,python@2,https://www.python.org/ftp/python/2.7.13/Python-2.7.13.tgz
+python,-d,/usr/local/Cellar/python,python,https://www.python.org/ftp/python/3.7.2/Python-3.7.2.tgz
+python@2,-d,/usr/local/Cellar/python@2,python@2,https://www.python.org/ftp/python/2.7.13/Python-2.7.13.tgz
 doxygen,-f,/usr/local/bin/doxygen,doxygen,http://ftp.stack.nl/pub/users/dimitri/doxygen-1.8.14.src.tar.gz
 graphviz,-d,/usr/local/opt/graphviz,graphviz,https://fossies.org/linux/misc/graphviz-2.40.1.tar.gz
 libusb,-f,/usr/local/lib/libusb-1.0.0.dylib,libusb,https://github.com/libusb/libusb/releases/download/v1.0.22/libusb-1.0.22.tar.bz2

--- a/scripts/eosio_build_darwin_deps
+++ b/scripts/eosio_build_darwin_deps
@@ -5,8 +5,8 @@ OpenSSL,-f,/usr/local/opt/openssl/lib/libssl.a,openssl,https://www.openssl.org/s
 wget,-x,/usr/local/bin/wget,wget,https://ftp.gnu.org/gnu/wget/wget-1.19.2.tar.gz
 GMP,-f,/usr/local/opt/gmp/include/gmpxx.h,gmp,https://ftp.gnu.org/gnu/gmp/gmp-6.1.2.tar.bz2
 llvm,-d,/usr/local/opt/llvm@4,llvm@4,http://releases.llvm.org/4.0.1/llvm-4.0.1.src.tar.xz
-python,-d,/usr/local/Cellar/python,python,https://www.python.org/ftp/python/3.7.2/Python-3.7.2.tgz
-python@2,-d,/usr/local/Cellar/python@2,python@2,https://www.python.org/ftp/python/2.7.13/Python-2.7.13.tgz
+python,-d,/usr/local/opt/python3,python,https://www.python.org/ftp/python/3.7.2/Python-3.7.2.tgz
+python@2,-d,/usr/local/opt/python2,python@2,https://www.python.org/ftp/python/2.7.13/Python-2.7.13.tgz
 doxygen,-f,/usr/local/bin/doxygen,doxygen,http://ftp.stack.nl/pub/users/dimitri/doxygen-1.8.14.src.tar.gz
 graphviz,-d,/usr/local/opt/graphviz,graphviz,https://fossies.org/linux/misc/graphviz-2.40.1.tar.gz
 libusb,-f,/usr/local/lib/libusb-1.0.0.dylib,libusb,https://github.com/libusb/libusb/releases/download/v1.0.22/libusb-1.0.22.tar.bz2

--- a/scripts/eosio_build_darwin_deps
+++ b/scripts/eosio_build_darwin_deps
@@ -4,9 +4,9 @@ Libtool,-x,/usr/local/bin/glibtool,libtool,http://gnu.askapache.com/libtool/libt
 OpenSSL,-f,/usr/local/opt/openssl/lib/libssl.a,openssl,https://www.openssl.org/source/openssl-1.0.2n.tar.gz
 wget,-x,/usr/local/bin/wget,wget,https://ftp.gnu.org/gnu/wget/wget-1.19.2.tar.gz
 GMP,-f,/usr/local/opt/gmp/include/gmpxx.h,gmp,https://ftp.gnu.org/gnu/gmp/gmp-6.1.2.tar.bz2
-llvm,-x,/usr/local/opt/llvm@4/bin/clang-4.0,llvm@4,http://releases.llvm.org/4.0.1/llvm-4.0.1.src.tar.xz
-python,-d,/usr/local/Cellar/python/3.7.2_1,python,https://www.python.org/ftp/python/3.7.2/Python-3.7.2.tgz
-python@2,-d,/usr/local/Cellar/python@2/2.7.15_2,python@2,https://www.python.org/ftp/python/2.7.13/Python-2.7.13.tgz
+llvm,-d,/usr/local/opt/llvm@4,llvm@4,http://releases.llvm.org/4.0.1/llvm-4.0.1.src.tar.xz
+python,-d,/usr/local/Cellar/python/3\*,python,https://www.python.org/ftp/python/3.7.2/Python-3.7.2.tgz
+python@2,-d,/usr/local/Cellar/python@2/2\*,python@2,https://www.python.org/ftp/python/2.7.13/Python-2.7.13.tgz
 doxygen,-f,/usr/local/bin/doxygen,doxygen,http://ftp.stack.nl/pub/users/dimitri/doxygen-1.8.14.src.tar.gz
 graphviz,-d,/usr/local/opt/graphviz,graphviz,https://fossies.org/linux/misc/graphviz-2.40.1.tar.gz
 libusb,-f,/usr/local/lib/libusb-1.0.0.dylib,libusb,https://github.com/libusb/libusb/releases/download/v1.0.22/libusb-1.0.22.tar.bz2

--- a/scripts/eosio_build_ubuntu.sh
+++ b/scripts/eosio_build_ubuntu.sh
@@ -126,7 +126,7 @@ if [ "${COUNT}" -gt 1 ]; then
 		* ) echo "Please type 'y' for yes or 'n' for no."; exit;;
 	esac
 else 
-	printf " - No required APT dependencies to install."
+	printf " - No required APT dependencies to install.\\n"
 fi
 
 


### PR DESCRIPTION
Upgrades to python, which change the version minor or patch, cause the build script to think it's missing (we look for the specific version folder existence).

I've modified the build script to support wildcard matching for folders.