### PR TITLE
database memory locking & hugepage support

### DIFF
--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -2,6 +2,7 @@
 #include <eosio/chain/block_state.hpp>
 #include <eosio/chain/trace.hpp>
 #include <eosio/chain/genesis_state.hpp>
+#include <chainbase/pinnable_mapped_file.hpp>
 #include <boost/signals2/signal.hpp>
 
 #include <eosio/chain/abi_serializer.hpp>
@@ -25,6 +26,7 @@ namespace eosio { namespace chain {
 
    struct controller_impl;
    using chainbase::database;
+   using chainbase::pinnable_mapped_file;
    using boost::signals2::signal;
 
    class dynamic_global_property_object;
@@ -79,6 +81,9 @@ namespace eosio { namespace chain {
 
             db_read_mode             read_mode              = db_read_mode::SPECULATIVE;
             validation_mode          block_validation_mode  = validation_mode::FULL;
+
+            pinnable_mapped_file::map_mode db_map_mode      = pinnable_mapped_file::map_mode::mapped;
+            vector<string>           db_hugepage_paths;
 
             flat_set<account_name>   resource_greylist;
             flat_set<account_name>   trusted_producers;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/nodeos_voting_test.py ${CMAKE_CURRENT
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/consensus-validation-malicious-producers.py ${CMAKE_CURRENT_BINARY_DIR}/consensus-validation-malicious-producers.py COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/validate-dirty-db.py ${CMAKE_CURRENT_BINARY_DIR}/validate-dirty-db.py COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/launcher_test.py ${CMAKE_CURRENT_BINARY_DIR}/launcher_test.py COPYONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/db_modes_test.sh ${CMAKE_CURRENT_BINARY_DIR}/db_modes_test.sh COPYONLY)
 
 #To run plugin_test with all log from blockchain displayed, put --verbose after --, i.e. plugin_test -- --verbose
 add_test(NAME plugin_test COMMAND plugin_test --report_level=detailed --color_output)
@@ -78,6 +79,7 @@ add_test(NAME validate_dirty_db_test COMMAND tests/validate-dirty-db.py -v --cle
 set_property(TEST validate_dirty_db_test PROPERTY LABELS nonparallelizable_tests)
 add_test(NAME launcher_test COMMAND tests/launcher_test.py -v --clean-run --dump-error-detail WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 set_property(TEST launcher_test PROPERTY LABELS nonparallelizable_tests)
+add_test(NAME db_modes_test COMMAND tests/db_modes_test.sh WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 
 # Long running tests
 add_test(NAME nodeos_sanity_lr_test COMMAND tests/nodeos_run_test.py -v --sanity-test --clean-run --dump-error-detail WORKING_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/tests/db_modes_test.sh
+++ b/tests/db_modes_test.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+
+# This test is intended to verify that switching between DB modes "just works". Addtionally
+# it tries to make sure the dirty bit behaves as expected even in heap mode.
+
+set -euo pipefail
+
+VERBOSE=0
+TEST_LOCKED_MODE=0
+
+while getopts ":lv" opt; do
+   case ${opt} in
+      l)
+         TEST_LOCKED_MODE=1
+         ;;
+      v)
+         VERBOSE=1
+         set -o xtrace
+         ;;
+      \?)
+         echo "Use -v for verbose; -l to enable test of locked mode"
+         exit 1;
+         ;;
+      :)
+         echo "Invalid option"
+         exit 1;
+         ;;
+   esac
+done
+
+EOSIO_STUFF_DIR=$(mktemp -d)
+trap "rm -rf $EOSIO_STUFF_DIR" EXIT
+NODEOS_LAUNCH_PARAMS="./programs/nodeos/nodeos -d $EOSIO_STUFF_DIR --config-dir $EOSIO_STUFF_DIR \
+--chain-state-db-size-mb 8 --chain-state-db-guard-size-mb 0 --reversible-blocks-db-size-mb 1 \
+--reversible-blocks-db-guard-size-mb 0 --https-server-address "''" --p2p-listen-endpoint "''" -e -peosio"
+
+run_nodeos() {
+   if (( $VERBOSE == 0 )); then
+      $NODEOS_LAUNCH_PARAMS "$@" 2>/dev/null &
+   else
+      $NODEOS_LAUNCH_PARAMS "$@" &
+   fi
+}
+
+run_expect_success() {
+   run_nodeos "$@"
+   local NODEOS_PID=$!
+   sleep 5
+   kill $NODEOS_PID
+   wait $NODEOS_PID
+}
+
+run_and_kill() {
+   run_nodeos "$@"
+   local NODEOS_PID=$!
+   sleep 5
+   kill -KILL $NODEOS_PID
+   ! wait $NODEOS_PID
+}
+
+run_expect_failure() {
+   run_nodeos "$@"
+   local NODEOS_PID=$!
+   MYPID=$$
+   (sleep 10; kill -ALRM $MYPID) & local TIMER_PID=$!
+   trap "kill $NODEOS_PID; wait $NODEOS_PID; exit 1" ALRM
+   sleep 5
+   if wait $NODEOS_PID; then exit 1; fi
+   kill $TIMER_PID
+   trap ALRM
+}
+
+#new chain with mapped mode
+run_expect_success --delete-all-blocks
+#use previous DB with heap mode
+run_expect_success --database-map-mode heap
+#test lock mode if enabled
+if (( $TEST_LOCKED_MODE == 1 )); then
+   run_expect_success --database-map-mode locked
+fi
+#locked mode should fail when it's not possible to lock anything
+ulimit -l 0
+run_expect_failure --database-map-mode locked
+#But shouldn't result in the dirty flag staying set; so next launch should run
+run_expect_success
+#Try killing with KILL
+run_and_kill
+#should be dirty now
+run_expect_failure
+#should also still be dirty in heap mode
+run_expect_failure --database-map-mode heap
+
+#start over again! but this time start with heap mode
+run_expect_success --delete-all-blocks  --database-map-mode heap
+#Then switch back to mapped
+run_expect_success
+#try killing it while in heap mode
+run_and_kill --database-map-mode heap
+#should be dirty if we run in either mode node
+run_expect_failure --database-map-mode heap
+run_expect_failure

--- a/unittests/resource_limits_test.cpp
+++ b/unittests/resource_limits_test.cpp
@@ -14,7 +14,7 @@ using namespace eosio::chain::resource_limits;
 using namespace eosio::testing;
 using namespace eosio::chain;
 
-class resource_limits_fixture: private chainbase_fixture<512*1024>, public resource_limits_manager
+class resource_limits_fixture: private chainbase_fixture<1024*1024>, public resource_limits_manager
 {
    public:
       resource_limits_fixture()


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- Give your PR a title that is sufficient to understand what is being changed. -->

## Change Description

nodeos has historically only had one built-in way to use its database state files: as a memory mapped file. This PR adds two new modes of operation along with hugepage support on Linux. Users can switch between the three modes of operation on nodeos startup and all modes are compatible with each other such that no replay is required when switching modes. Motivation for this change is that database performance increases over 10% when using 1GB hugepages. There are some other interesting use cases too though, such as _heap_ mode making it more practical to run nodeos on a HDD.

The modes of operation are:
* **mapped**: The classic behavior and still the default.
* **heap**: Preloads the entire database in to swappable memory.
* **locked**: Preloads the entire database in to non-swappable memory and optionally allows use of hugepages on Linux.

Both _heap_ and _locked_ mode will require nodeos to write out entire database files on shutdown in addition to loading the entire database file on startup. These operations could take considerable time depending on database size and speed of storage.

### Hugepage usage
By far the most interesting aspect of this change is hugepage support. Remember that hugepage support is only available on Linux and only available in _locked_ mode of operation. Despite (at the moment) hugepages on Linux being non-swappable, nodeos still expects the `mlock()` call to succeed on the hugepages and thus the ulimit of the process will need to be set accordingly. 

nodeos will make use of the largest hugepage size it can without "over-committing". Some of examples of configuration:

```
database-map-mode = locked 
chain-state-db-size-mb = 4096
reversible-blocks-db-size-mb = 340
database-hugepage-path = /dev/hugepages     #contains hugepagefs with 1GB page size
```
On startup will see the output below because the 340MB size of the reversible database is not a multiple of the 1GB hugepage size:
```
CHAINBASE: Database "state" using 1073741824 byte pages
CHAINBASE: Database "reversible" not using huge pages
```
If we were to change this configuration to 
```
database-map-mode = locked 
chain-state-db-size-mb = 4096
reversible-blocks-db-size-mb = 1024
database-hugepage-path = /dev/hugepages     #contains hugepagefs with 1GB page size
```
Then, since the reversible database is now a multiple of 1GB, on startup will see:
```
CHAINBASE: Database "state" using 1073741824 byte pages
CHAINBASE: Database "reversible" using 1073741824 byte pages 
```
Another option though would be to specify multiple hugepage sizes:
```
database-map-mode = locked 
chain-state-db-size-mb = 4096
reversible-blocks-db-size-mb = 340
database-hugepage-path = /dev/hugepages1G     #contains hugepagefs with 1GB page size
database-hugepage-path = /dev/hugepages2M     #contains hugepagefs with 2MB page size
```
Upon startup will see different page sizes being used:
```
CHAINBASE: Database "state" using 1073741824 byte pages
CHAINBASE: Database "reversible" using 2097152 byte pages
```

This PR waiting on EOSIO/chainbase#33 first.

A note on the unit test: While I'm generally against POSIX stuff being added to the code base, the impression I got looking at some of the python unit tests is that there is some considerable dependency on POSIX behaviors there. The unit test here is a shell script which of course won't run on Win32... but much of the python unit tests won't either.

Closes out #6694

<!-- Describe the change you made, the motivation for it, and the impact it will have. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

## Consensus Changes

<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes

<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions

<!-- List all the information that needs to be added to the documentation after merge. -->
