### PR TITLE
fix bug in apply_block that constructed and committed blocks with missing signatures in the protocol-feature-foundations branch

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1399,7 +1399,7 @@ struct controller_impl {
 
          auto bsp = std::make_shared<block_state>(
                         std::move( ab._pending_block_header_state ),
-                        std::move( ab._unsigned_block ),
+                        b,
                         std::move( ab._trx_metas ),
                         true // signature should have already been verified (assuming untrusted) prior to apply_block
                     );

--- a/libraries/chain/include/eosio/chain/block_state.hpp
+++ b/libraries/chain/include/eosio/chain/block_state.hpp
@@ -18,9 +18,9 @@ namespace eosio { namespace chain {
                  );
 
       block_state( pending_block_header_state&& cur,
-                  signed_block_ptr&& b, // unsigned block
-                  vector<transaction_metadata_ptr>&& trx_metas,
-                  const std::function<signature_type(const digest_type&)>& signer
+                   signed_block_ptr&& b, // unsigned block
+                   vector<transaction_metadata_ptr>&& trx_metas,
+                   const std::function<signature_type(const digest_type&)>& signer
                 );
 
       block_state( pending_block_header_state&& cur,


### PR DESCRIPTION
## Change Description

Resolves #6851.

Fixes a bug in `apply_block` which constructed a completed block state with a missing signature in the block. The invalid block was then committed into the reversible block database. Also the `block_state` containing the invalid block  was emitted with the `accepted_block` signal which the `net_plugin` uses to broadcast the (invalid) block, leading to issues like the one described in #6851.

This PR also adds a unit test to check for this case.

## Consensus Changes


## API Changes


## Documentation Additions

