### PR TITLE
fix pending_schedule_hash

### DIFF
--- a/libraries/chain/block_header_state.cpp
+++ b/libraries/chain/block_header_state.cpp
@@ -239,7 +239,7 @@ namespace eosio { namespace chain {
 
       if( h.new_producers ) {
          result.pending_schedule.schedule            = *h.new_producers;
-         result.pending_schedule.schedule_hash       = digest_type::hash( result.pending_schedule );
+         result.pending_schedule.schedule_hash       = digest_type::hash( *h.new_producers );
          result.pending_schedule.schedule_lib_num    = block_number;
       } else {
          if( was_pending_promoted ) {


### PR DESCRIPTION
## Change Description

fix pending_schdule_hash that results in apply_block error in old version of nodeos, for #6429

## Consensus Changes
no

## API Changes
no

## Documentation Additions
no