### PR TITLE
Move json::to_string response processing to http thread pool

### DIFF
--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -28,10 +28,10 @@ chain_api_plugin::~chain_api_plugin(){}
 void chain_api_plugin::set_program_options(options_description&, options_description&) {}
 void chain_api_plugin::plugin_initialize(const variables_map&) {}
 
-struct async_result_visitor : public fc::visitor<std::string> {
+struct async_result_visitor : public fc::visitor<fc::variant> {
    template<typename T>
-   std::string operator()(const T& v) const {
-      return fc::json::to_string(v);
+   fc::variant operator()(const T& v) const {
+      return fc::variant(v);
    }
 };
 
@@ -41,8 +41,8 @@ struct async_result_visitor : public fc::visitor<std::string> {
           api_handle.validate(); \
           try { \
              if (body.empty()) body = "{}"; \
-             auto result = api_handle.call_name(fc::json::from_string(body).as<api_namespace::call_name ## _params>()); \
-             cb(http_response_code, fc::json::to_string(result)); \
+             fc::variant result( api_handle.call_name(fc::json::from_string(body).as<api_namespace::call_name ## _params>()) ); \
+             cb(http_response_code, std::move(result)); \
           } catch (...) { \
              http_plugin::handle_exception(#api_name, #call_name, body, cb); \
           } \

--- a/plugins/db_size_api_plugin/db_size_api_plugin.cpp
+++ b/plugins/db_size_api_plugin/db_size_api_plugin.cpp
@@ -18,7 +18,7 @@ using namespace eosio;
           try { \
              if (body.empty()) body = "{}"; \
              INVOKE \
-             cb(http_response_code, fc::json::to_string(result)); \
+             cb(http_response_code, fc::variant(result)); \
           } catch (...) { \
              http_plugin::handle_exception(#api_name, #call_name, body, cb); \
           } \

--- a/plugins/faucet_testnet_plugin/faucet_testnet_plugin.cpp
+++ b/plugins/faucet_testnet_plugin/faucet_testnet_plugin.cpp
@@ -60,7 +60,7 @@ using results_pair = std::pair<uint32_t,fc::variant>;
           try { \
              if (body.empty()) body = "{}"; \
              const auto result = api_handle->invoke_cb(body); \
-             response_cb(result.first, fc::json::to_string(result.second)); \
+             response_cb(result.first, fc::variant(result.second)); \
           } catch (...) { \
              http_plugin::handle_exception(#api_name, #call_name, body, response_cb); \
           } \

--- a/plugins/history_api_plugin/history_api_plugin.cpp
+++ b/plugins/history_api_plugin/history_api_plugin.cpp
@@ -24,8 +24,8 @@ void history_api_plugin::plugin_initialize(const variables_map&) {}
    [api_handle](string, string body, url_response_callback cb) mutable { \
           try { \
              if (body.empty()) body = "{}"; \
-             auto result = api_handle.call_name(fc::json::from_string(body).as<api_namespace::call_name ## _params>()); \
-             cb(200, fc::json::to_string(result)); \
+             fc::variant result( api_handle.call_name(fc::json::from_string(body).as<api_namespace::call_name ## _params>()) ); \
+             cb(200, std::move(result)); \
           } catch (...) { \
              http_plugin::handle_exception(#api_name, #call_name, body, cb); \
           } \

--- a/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
@@ -17,7 +17,7 @@ namespace eosio {
     *
     * Arguments: response_code, response_body
     */
-   using url_response_callback = std::function<void(int,string)>;
+   using url_response_callback = std::function<void(int,fc::variant)>;
 
    /**
     * @brief Callback type for a URL handler

--- a/plugins/login_plugin/login_plugin.cpp
+++ b/plugins/login_plugin/login_plugin.cpp
@@ -68,8 +68,8 @@ void login_plugin::plugin_initialize(const variables_map& options) {
          try {                                                                                                         \
             if (body.empty())                                                                                          \
                body = "{}";                                                                                            \
-            auto result = call_name(fc::json::from_string(body).as<login_plugin::call_name##_params>());               \
-            cb(http_response_code, fc::json::to_string(result));                                                       \
+            fc::variant result( call_name(fc::json::from_string(body).as<login_plugin::call_name##_params>()) );       \
+            cb(http_response_code, std::move(result));                                                                 \
          } catch (...) {                                                                                               \
             http_plugin::handle_exception("login", #call_name, body, cb);                                              \
          }                                                                                                             \

--- a/plugins/net_api_plugin/net_api_plugin.cpp
+++ b/plugins/net_api_plugin/net_api_plugin.cpp
@@ -29,7 +29,7 @@ using namespace eosio;
           try { \
              if (body.empty()) body = "{}"; \
              INVOKE \
-             cb(http_response_code, fc::json::to_string(result)); \
+             cb(http_response_code, fc::variant(result)); \
           } catch (...) { \
              http_plugin::handle_exception(#api_name, #call_name, body, cb); \
           } \

--- a/plugins/producer_api_plugin/producer_api_plugin.cpp
+++ b/plugins/producer_api_plugin/producer_api_plugin.cpp
@@ -30,7 +30,7 @@ using namespace eosio;
           try { \
              if (body.empty()) body = "{}"; \
              INVOKE \
-             cb(http_response_code, fc::json::to_string(result)); \
+             cb(http_response_code, fc::variant(result)); \
           } catch (...) { \
              http_plugin::handle_exception(#api_name, #call_name, body, cb); \
           } \

--- a/plugins/test_control_api_plugin/test_control_api_plugin.cpp
+++ b/plugins/test_control_api_plugin/test_control_api_plugin.cpp
@@ -40,8 +40,8 @@ struct async_result_visitor : public fc::visitor<std::string> {
    [api_handle](string, string body, url_response_callback cb) mutable { \
           try { \
              if (body.empty()) body = "{}"; \
-             auto result = api_handle.call_name(fc::json::from_string(body).as<api_namespace::call_name ## _params>()); \
-             cb(http_response_code, fc::json::to_string(result)); \
+             fc::variant result( api_handle.call_name(fc::json::from_string(body).as<api_namespace::call_name ## _params>()) ); \
+             cb(http_response_code, std::move(result)); \
           } catch (...) { \
              http_plugin::handle_exception(#api_name, #call_name, body, cb); \
           } \

--- a/plugins/txn_test_gen_plugin/txn_test_gen_plugin.cpp
+++ b/plugins/txn_test_gen_plugin/txn_test_gen_plugin.cpp
@@ -45,7 +45,7 @@ using io_work_t = boost::asio::executor_work_guard<boost::asio::io_context::exec
           try { \
              if (body.empty()) body = "{}"; \
              INVOKE \
-             cb(http_response_code, fc::json::to_string(result)); \
+             cb(http_response_code, fc::variant(result)); \
           } catch (...) { \
              http_plugin::handle_exception(#api_name, #call_name, body, cb); \
           } \
@@ -77,7 +77,7 @@ using io_work_t = boost::asio::executor_work_guard<boost::asio::io_context::exec
                http_plugin::handle_exception(#api_name, #call_name, body, cb);\
             }\
          } else {\
-            cb(http_response_code, fc::json::to_string(eosio::detail::txn_test_gen_empty())); \
+            cb(http_response_code, fc::variant(eosio::detail::txn_test_gen_empty())); \
          }\
       };\
       INVOKE \

--- a/plugins/wallet_api_plugin/wallet_api_plugin.cpp
+++ b/plugins/wallet_api_plugin/wallet_api_plugin.cpp
@@ -30,7 +30,7 @@ using namespace eosio;
           try { \
              if (body.empty()) body = "{}"; \
              INVOKE \
-             cb(http_response_code, fc::json::to_string(result)); \
+             cb(http_response_code, fc::variant(result)); \
           } catch (...) { \
              http_plugin::handle_exception(#api_name, #call_name, body, cb); \
           } \

--- a/programs/keosd/main.cpp
+++ b/programs/keosd/main.cpp
@@ -48,7 +48,7 @@ int main(int argc, char** argv)
       if(!app().initialize<wallet_plugin, wallet_api_plugin, http_plugin>(argc, argv))
          return -1;
       auto& http = app().get_plugin<http_plugin>();
-      http.add_handler("/v1/keosd/stop", [](string, string, url_response_callback cb) { cb(200, "{}"); std::raise(SIGTERM); } );
+      http.add_handler("/v1/keosd/stop", [](string, string, url_response_callback cb) { cb(200, fc::variant(fc::variant_object())); std::raise(SIGTERM); } );
       app().startup();
       app().exec();
    } catch (const fc::exception& e) {


### PR DESCRIPTION
## Change Description

- Resolves #6891 
- Move the conversion from `fc::variant` to JSON string reponse into the http thread pool to reduce the amount of work done on the application thread.

## Consensus Changes
## API Changes

- The http_plugin `url_response_callback` changed from `std::function<void(int,std::string)>` to `std::function<void(int,fc::variant)>`
-- Code calling the url_response_callback is now expected to provide a `fc::variant` instead of a string. This means the the type must be setup with `FC_REFLECT` so it can be converted to variant. This was already the case for all plugins in `eos` repo, but if external plugins were doing their own json conversion then that will no longer work.

## Documentation Additions
