### PR TITLE
Fix bug in get_block of chain_plugin that would lead to unnecessary failures for some block numbers

### DIFF
--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1124,7 +1124,7 @@ uint64_t convert_to_type(const string& str, const string& desc) {
    try {
       return boost::lexical_cast<uint64_t>(str.c_str(), str.size());
    } catch( ... ) { }
-   
+
    try {
       auto trimmed_str = str;
       boost::trim(trimmed_str);
@@ -1138,7 +1138,7 @@ uint64_t convert_to_type(const string& str, const string& desc) {
          return symb.value();
       } catch( ... ) { }
    }
-   
+
    try {
       return ( eosio::chain::string_to_symbol( 0, str.c_str() ) >> 8 );
    } catch( ... ) {
@@ -1529,14 +1529,24 @@ read_only::get_scheduled_transactions( const read_only::get_scheduled_transactio
 
 fc::variant read_only::get_block(const read_only::get_block_params& params) const {
    signed_block_ptr block;
-   EOS_ASSERT(!params.block_num_or_id.empty() && params.block_num_or_id.size() <= 64, chain::block_id_type_exception, "Invalid Block number or ID, must be greater than 0 and less than 64 characters" );
-   try {
-      block = db.fetch_block_by_id(fc::variant(params.block_num_or_id).as<block_id_type>());
-      if (!block) {
-         block = db.fetch_block_by_number(fc::to_uint64(params.block_num_or_id));
-      }
+   optional<uint64_t> block_num;
 
-   } EOS_RETHROW_EXCEPTIONS(chain::block_id_type_exception, "Invalid block ID: ${block_num_or_id}", ("block_num_or_id", params.block_num_or_id))
+   EOS_ASSERT( !params.block_num_or_id.empty() && params.block_num_or_id.size() <= 64,
+               chain::block_id_type_exception,
+               "Invalid Block number or ID, must be greater than 0 and less than 64 characters"
+   );
+
+   try {
+      block_num = fc::to_uint64(params.block_num_or_id);
+   } catch( ... ) {}
+
+   if( block_num.valid() ) {
+      block = db.fetch_block_by_number( *block_num );
+   } else {
+      try {
+         block = db.fetch_block_by_id( fc::variant(params.block_num_or_id).as<block_id_type>() );
+      } EOS_RETHROW_EXCEPTIONS(chain::block_id_type_exception, "Invalid block ID: ${block_num_or_id}", ("block_num_or_id", params.block_num_or_id))
+   }
 
    EOS_ASSERT( block, unknown_block_exception, "Could not find block: ${block}", ("block", params.block_num_or_id));
 


### PR DESCRIPTION
## Change Description

This PR fixes a bug in `get_block` of chain_plugin that could lead to unnecessary failure when requesting a block by number. This PR also updates the fc submodule to the latest master.

The `get_block` logic first tried to convert the `block_num_or_id` string input into a block ID and use it to try to find the block. If it failed to find the block, it would then attempt interpret the string as a block number and try to find the block that way.

But the request should not just fail if the string input does not make a valid ID when it could make a perfectly valid block number. This was the failure mode that was being triggered in one of the tests after the fc submodule update. EOSIO/fc#64 added stricter validation rules to conversions from `fc::variant` to `vector<char>`, which `fc::variant` conversions to `block_id_type` uses, to disallow odd-length hex strings. So with these fc changes, the original logic of `get_block` would fail requests made with block numbers that when represented as a decimal string were of odd-length. 

The new logic is aligned with how `get_block_header_state` already worked. It will try to interpret `block_num_or_id` as a number. If it can, it will try to lookup the block by the number. If it cannot interpret `block_num_or_id` as a number, it will then try to convert the string to a block ID (failing the request if not possible) and then use that ID to try to lookup the block.

## Consensus Changes


## API Changes


## Documentation Additions

