### PR TITLE
Fix db_modes_test to not use http

### DIFF
--- a/tests/db_modes_test.sh
+++ b/tests/db_modes_test.sh
@@ -32,7 +32,7 @@ EOSIO_STUFF_DIR=$(mktemp -d)
 trap "rm -rf $EOSIO_STUFF_DIR" EXIT
 NODEOS_LAUNCH_PARAMS="./programs/nodeos/nodeos -d $EOSIO_STUFF_DIR --config-dir $EOSIO_STUFF_DIR \
 --chain-state-db-size-mb 8 --chain-state-db-guard-size-mb 0 --reversible-blocks-db-size-mb 1 \
---reversible-blocks-db-guard-size-mb 0 --https-server-address "''" --p2p-listen-endpoint "''" -e -peosio"
+--reversible-blocks-db-guard-size-mb 0 --http-server-address "''" --p2p-listen-endpoint "''" -e -peosio"
 
 run_nodeos() {
    if (( $VERBOSE == 0 )); then


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- Give your PR a title that is sufficient to understand what is being changed. -->

## Change Description
Typo here meant db_modes_test was still trying to bring up HTTP server which could interfere with other nodeos.
<!-- Describe the change you made, the motivation for it, and the impact it will have. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

## Consensus Changes

<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes

<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions

<!-- List all the information that needs to be added to the documentation after merge. -->
