### PR TITLE
Block log util#6884

### DIFF
--- a/libraries/chain/include/eosio/chain/exceptions.hpp
+++ b/libraries/chain/include/eosio/chain/exceptions.hpp
@@ -483,7 +483,7 @@ namespace eosio { namespace chain {
       FC_DECLARE_DERIVED_EXCEPTION( block_index_not_found, block_log_exception,
                                     3190005, "block index can not be found"  )
 
-      FC_DECLARE_DERIVED_EXCEPTION( http_exception, chain_exception,
+   FC_DECLARE_DERIVED_EXCEPTION( http_exception, chain_exception,
                                  3200000, "http exception" )
       FC_DECLARE_DERIVED_EXCEPTION( invalid_http_client_root_cert,    http_exception,
                                     3200001, "invalid http client root certificate" )

--- a/libraries/chain/include/eosio/chain/exceptions.hpp
+++ b/libraries/chain/include/eosio/chain/exceptions.hpp
@@ -480,8 +480,10 @@ namespace eosio { namespace chain {
                                     3190003, "block log can not be found" )
       FC_DECLARE_DERIVED_EXCEPTION( block_log_backup_dir_exist, block_log_exception,
                                     3190004, "block log backup dir already exists" )
+      FC_DECLARE_DERIVED_EXCEPTION( block_index_not_found, block_log_exception,
+                                    3190005, "block index can not be found"  )
 
-   FC_DECLARE_DERIVED_EXCEPTION( http_exception, chain_exception,
+      FC_DECLARE_DERIVED_EXCEPTION( http_exception, chain_exception,
                                  3200000, "http exception" )
       FC_DECLARE_DERIVED_EXCEPTION( invalid_http_client_root_cert,    http_exception,
                                     3200001, "invalid http client root certificate" )

--- a/programs/eosio-blocklog/main.cpp
+++ b/programs/eosio-blocklog/main.cpp
@@ -2,6 +2,7 @@
  *  @file
  *  @copyright defined in eosio/LICENSE.txt
  */
+#include <memory>
 #include <eosio/chain/abi_serializer.hpp>
 #include <eosio/chain/block_log.hpp>
 #include <eosio/chain/config.hpp>
@@ -140,10 +141,10 @@ void blocklog::set_program_options(options_description& cli)
          ("blocks-dir", bpo::value<bfs::path>()->default_value("blocks"),
           "the location of the blocks directory (absolute path or relative to the current directory)")
          ("output-file,o", bpo::value<bfs::path>(),
-          "the file to write the block log output to (absolute or relative path).  If not specified then output is to stdout.")
-         ("first", bpo::value<uint32_t>(&first_block)->default_value(1),
+          "the file to write the output to (absolute or relative path).  If not specified then output is to stdout.")
+         ("first,f", bpo::value<uint32_t>(&first_block)->default_value(1),
           "the first block number to log")
-         ("last", bpo::value<uint32_t>(&last_block)->default_value(std::numeric_limits<uint32_t>::max()),
+         ("last,l", bpo::value<uint32_t>(&last_block)->default_value(std::numeric_limits<uint32_t>::max()),
           "the last block number (inclusive) to log")
          ("no-pretty-print", bpo::bool_switch(&no_pretty_print)->default_value(false),
           "Do not pretty print the output.  Useful if piping to jq to improve performance.")
@@ -151,9 +152,9 @@ void blocklog::set_program_options(options_description& cli)
           "Print out json blocks wrapped in json array (otherwise the output is free-standing json objects).")
          ("make-index", bpo::bool_switch(&make_index)->default_value(false),
           "Create blocks.index from blocks.log. Must give 'blocks-dir'. Give 'output-file' relative to blocks-dir (default is blocks.index).")
-         ("trim-block-log", bpo::bool_switch(&make_index)->default_value(false),
+         ("trim-blocklog", bpo::bool_switch(&make_index)->default_value(false),
           "Trim blocks.log and blocks.index in place. Must give 'blocks-dir' and 'last' (else nothing is done).")
-         ("help", "Print this help message and exit.")
+         ("help,h", "Print this help message and exit.")
          ;
 }
 
@@ -176,174 +177,192 @@ void blocklog::initialize(const variables_map& options) {
 
 }
 
-//struct used by truncBlockLog() and makeIndex() to read first 18 bytes of a block from blocks.log
-struct __attribute__((packed)) BlockStart {    //first 18 bytes of each block
+//struct used by trunc_blocklog() and make_index() to read first 18 bytes of a block from blocks.log
+struct __attribute__((packed)) Block_Start {    //first 18 bytes of each block (must match block_header)
    block_timestamp_type timestamp;
    account_name         prodname;
    uint16_t             confirmed;
    uint32_t             blknum;     //low 32 bits of previous blockid, is big endian block number of previous block
-} blkStart;
+} blk_start;
+static_assert( sizeof(Block_Start) == 18, "Update block_start if block_header changes");
 
-int truncBlockLog(bfs::path blockDir, uint32_t n) {          //n is last block to keep
+int trunc_blocklog(bfs::path block_dir, uint32_t n) {       //n is last block to keep
    using namespace std;
-   cout << "Will truncate blocks.log and blocks.index after block " << n << '\n';
-
    //read blocks.log to see if version 1 or 2 and get first block number
-   filebuf fin0;
-   string blockFileName= (blockDir/"blocks.log").generic_string();
-   fin0.open(blockFileName.c_str(), ios::in|ios::binary);
-   EOS_ASSERT( fin0.is_open(), block_log_not_found, "cannot read blocks.log" );
-   uint32_t version=0, firstBlock;
-   fin0.sgetn((char*)&version,sizeof(version));
-   EOS_ASSERT( version==1 || version==2, block_log_unsupported_version, "unsupported version of block log" );
+   filebuf fin_blocks;
+   cout << "In directory " << block_dir << " will truncate blocks.log and blocks.index after block " << n << '\n';
+   string block_file_name= (block_dir/"blocks.log").generic_string();
+   fin_blocks.open(block_file_name, ios::in|ios::binary);
+   EOS_ASSERT( fin_blocks.is_open(), block_log_not_found, "cannot read ${file}", ("file",block_file_name) );
+   uint32_t version=0, first_block;
+   fin_blocks.sgetn((char*)&version,sizeof(version));
+   cout << "block log version= " << version << '\n';
+   EOS_ASSERT( version==1 || version==2, block_log_unsupported_version, "block log version ${v} is not supported", ("v",version));
    if (version == 1)
-      firstBlock= 1;
+      first_block= 1;
    else
-      fin0.sgetn((char*)&firstBlock,sizeof(firstBlock));
-   cout << "version= " << version << "\nfirst block= " << firstBlock << '\n';
-   if (n <= firstBlock) {
-      cout << n << " is before first block so nothing to do\n";
+      fin_blocks.sgetn((char*)&first_block,sizeof(first_block));
+   cout << "first block= " << first_block << '\n';
+   if (n <= first_block) {
+      cerr << n << " is before first block so nothing to do\n";
       return 2;
    }
 
-   //open blocks.index and get blocks.log position for block 'n'
-   filebuf fin1;
-   string indexFileName= (blockDir/"blocks.index").generic_string();
-   fin1.open(indexFileName.c_str(),ios::in|ios::binary);
-   EOS_ASSERT( fin1.is_open(), block_index_not_found, "cannot read blocks.index" );
-   uint64_t indexPos= 8*(n-firstBlock);
-   uint64_t pos= fin1.pubseekoff(indexPos,ios::beg,ios::in);
-   EOS_ASSERT( pos==indexPos, block_log_exception, "cannot read blocks.index entry for trim-after-block" );
+   //open blocks.index, get last_block and blocks.log position for block 'n'
+   filebuf fin_index;
+   string index_file_name= (block_dir/"blocks.index").generic_string();
+   fin_index.open(index_file_name,ios::in|ios::binary);
+   EOS_ASSERT( fin_index.is_open(), block_index_not_found, "cannot read ${file}", ("file",index_file_name) );
+   uint64_t file_end= fin_index.pubseekoff(0,ios::end,ios::in);
+   uint32_t last_block= file_end/sizeof(uint64_t);
+   cout << "last block=  " << last_block << '\n';
+   if (n >= last_block) {
+      cerr << n << " is not before last block so nothing to do\n";
+      return 2;
+   }
+   uint64_t index_pos= sizeof(uint64_t)*(n-first_block);
+   uint64_t pos= fin_index.pubseekoff(index_pos,ios::beg,ios::in);
+   EOS_ASSERT( pos==index_pos, block_log_exception, "cannot read blocks.index entry for block ${b}", ("b",n) );
    uint64_t fpos0, fpos1;                                   //filepos of block n and block n+1, will read from blocks.index
-   fin1.sgetn((char*)&fpos0,sizeof(fpos0));
-   fin1.sgetn((char*)&fpos1,sizeof(fpos1));
-   fin1.close();
+   fin_index.sgetn((char*)&fpos0,sizeof(fpos0));
+   fin_index.sgetn((char*)&fpos1,sizeof(fpos1));
+   fin_index.close();
    cout << "According to blocks.index:\n";
    cout << "    block " << n << " starts at position " << fpos0 << '\n';
    cout << "    block " << n+1 << " starts at position " << fpos1 << '\n';
 
    //read blocks.log and verify block number n is found at file position fpos0
-   fin0.pubseekoff(fpos0,ios::beg,ios::in);
-   fin0.sgetn((char*)&blkStart,sizeof(blkStart));
-   fin0.close();
-   uint32_t bnum= endian_reverse_u32(blkStart.blknum)+1;    //convert from big endian to little endian, add 1 since prior block
+   fin_blocks.pubseekoff(fpos0,ios::beg,ios::in);
+   fin_blocks.sgetn((char*)&blk_start,sizeof(blk_start));   //read first 18 bytes of block
+   fin_blocks.close();
+   uint32_t bnum= endian_reverse_u32(blk_start.blknum)+1;   //convert from big endian to little endian, add 1 since prior block
+   cout << "At position " << fpos0 << " in blocks.log find block " << bnum << (bnum==n? " as expected\n": " - not good!\n");
    EOS_ASSERT( bnum==n, block_log_exception, "blocks.index does not agree with blocks.log" );
-   cout << "In blocks.log at position " << fpos0 << " find block " << bnum << " as expected\n";
-   EOS_ASSERT( truncate(blockFileName.c_str(),fpos1)==0, block_log_exception, "truncate blocks.log fails");
-   indexPos+= sizeof(uint64_t);                             //advance to after record for block n
-   EOS_ASSERT( truncate(indexFileName.c_str(),indexPos)==0, block_log_exception, "truncate blocks.index fails");
+   EOS_ASSERT( truncate(block_file_name.c_str(),fpos1)==0, block_log_exception, "truncate blocks.log fails");
+   index_pos+= sizeof(uint64_t);                            //advance to after record for block n
+   EOS_ASSERT( truncate(index_file_name.c_str(),index_pos)==0, block_log_exception, "truncate blocks.index fails");
    cout << "blocks.log has been truncated to " << fpos1 << " bytes\n";
-   cout << "blocks.index has been truncated to " << indexPos << " bytes\n";
+   cout << "blocks.index has been truncated to " << index_pos << " bytes\n";
    return 0;
 }
 
-int makeIndex(bfs::path blockDir, string outFile) {
+int make_index(bfs::path block_dir, string out_file) {
    //this code makes blocks.index much faster than nodeos (in recent test 80 seconds vs. 90 minutes)
    using namespace std;
-   cout << "Will make blocks.index from blocks.log\n";
-   string blockFileName= (blockDir / "blocks.log").generic_string();
-   string outFileName=   (blockDir / outFile     ).generic_string();
-   int fin = open(blockFileName.c_str(), O_RDONLY);
-   EOS_ASSERT( fin>0, block_log_not_found, "cannot read blocks.log" );
+   string block_file_name= (block_dir / "blocks.log").generic_string();
+   string out_file_name=   (block_dir / out_file     ).generic_string();
+   cout << "Will read blocks.log file " << block_file_name << '\n';
+   cout << "Will write blocks.index file " << out_file_name << '\n';
+   int fin = open(block_file_name.c_str(), O_RDONLY);
+   EOS_ASSERT( fin>0, block_log_not_found, "cannot read block file ${file}", ("file",block_file_name) );
 
-   //will read big chunks of blocks.log into buf, will fill fposList with file positions before write to blocks.index
+   //will read big chunks of blocks.log into buf, will fill fpos_list with file positions before write to blocks.index
    constexpr uint32_t bufLen{1U<<24};                       //bufLen must be power of 2 >= largest possible block == one MByte
-   char* buf= new char[bufLen+8];                           //first 8 bytes of prior buf are put past end of current buf
-   constexpr uint64_t fposListLen{1U<<22};                  //length of fposList[] in bytes
-   uint64_t* fposList= new uint64_t[fposListLen>>3];
+   auto buffer= make_unique<char[]>(bufLen+8);              //first 8 bytes of prior buf are put past end of current buf
+   char* buf= buffer.get();
+   constexpr uint64_t fpos_list_len{1U<<22};                //length of fpos_list[] in bytes
+   auto fpos_buffer= make_unique<uint64_t[]>(fpos_list_len>>3);
+   uint64_t* fpos_list= fpos_buffer.get();
 
-   //read blocks.log to see if version 1 or 2 and get firstblocknum (implicit 1 if version 1)
-   uint32_t version=0, firstBlock;
+   //read blocks.log to see if version 1 or 2 and get first_blocknum (implicit 1 if version 1)
+   uint32_t version=0, first_block;
    read(fin,(char*)&version,sizeof(version));
-   EOS_ASSERT( version==1 || version==2, block_log_unsupported_version, "unsupported version of block log" );
-   if (version == 1)
-      firstBlock= 1;
-   else
-      read(fin,(char*)&firstBlock,sizeof(firstBlock));
    cout << "block log version= " << version << '\n';
-   cout << "first block= " << firstBlock << '\n';
+   EOS_ASSERT( version==1 || version==2, block_log_unsupported_version, "block log version ${v} is not supported", ("v",version));
+   if (version == 1)
+      first_block= 1;
+   else
+      read(fin,(char*)&first_block,sizeof(first_block));
+   cout << "first block= " << first_block << '\n';
 
-   uint64_t pos= lseek(fin,0,ios::end);                     //get blocks.log file length
-   uint64_t lastBufLen= pos & ((uint64_t)bufLen-1);         //bufLen is a power of 2 so -1 creates low bits all 1
-   if (!lastBufLen)                                         //will read integral number of bufLen and one time read lastBufLen
-      lastBufLen= bufLen;
-   pos= lseek(fin,-(uint64_t)lastBufLen,ios::end);
-   uint64_t didread= read(fin,buf,lastBufLen);              //read tail of file into buf
-   EOS_ASSERT( didread==lastBufLen, block_log_exception, "blocks.log read fails" );
+   uint64_t pos= lseek(fin,0,SEEK_END);                     //get blocks.log file length
+   uint64_t last_buf_len= pos & ((uint64_t)bufLen-1);       //bufLen is a power of 2 so -1 creates low bits all 1
+   if (!last_buf_len)                                       //will read integral number of bufLen and one time read last_buf_len
+      last_buf_len= bufLen;
+   pos= lseek(fin,-(uint64_t)last_buf_len,SEEK_END);
+   uint64_t did_read= read(fin,buf,last_buf_len);           //read tail of file into buf
+   EOS_ASSERT( did_read==last_buf_len, block_log_exception, "blocks.log read fails" );
 
-   uint32_t indexStart;                                     //buf index for block start
-   uint32_t indexEnd;                                       //buf index for block end == buf index for block start file position
-   uint64_t filePos;                                        //file pos of block start
-   BlockStart* bst;                                         //pointer to BlockStart
+   uint32_t index_start;                                    //buf index for block start
+   uint32_t index_end;                                      //buf index for block end == buf index for block start file position
+   uint64_t file_pos;                                       //file pos of block start
+   uint64_t last_file_pos;                                  //used to check that file_pos is strictly decreasing
+   Block_Start* bst;                                        //pointer to Block_Start
 
-   indexStart= lastBufLen;                                  //pretend a block starts just past end of buf then read prior block
-   indexEnd= indexStart-8;                                  //index in buf where block ends and block file position starts
-   filePos= *(uint64_t*)(buf+indexEnd);                     //file pos of block start
-   indexStart= filePos - pos;                               //buf index for block start
-   bst= (BlockStart*)(buf+indexStart);                      //pointer to BlockStart
-   uint32_t lastBlock= endian_reverse_u32(bst->blknum);     //convert from big endian to little endian
-   uint32_t bnum= ++lastBlock;                              //add 1 since took block number from prior block id
-   cout << "last block=  " << lastBlock << '\n';
+   index_start= last_buf_len;                               //pretend a block starts just past end of buf then read prior block
+   index_end= index_start-8;                                //index in buf where block ends and block file position starts
+   last_file_pos= file_pos= *(uint64_t*)(buf+index_end);    //file pos of block start
+   index_start= file_pos - pos;                             //buf index for block start
+   bst= (Block_Start*)(buf+index_start);                    //pointer to Block_Start
+   uint32_t last_block= endian_reverse_u32(bst->blknum);    //convert from big endian to little endian
+   uint32_t bnum= ++last_block;                             //add 1 since took block number from prior block id
+   cout << "last block=  " << last_block << '\n';
    cout << '\n';
-   cout << "block " << setw(10) << bnum << "    filePos " << setw(14) << filePos << '\n';  //first progress indicator
+   cout << "block " << setw(10) << bnum << "    file_pos " << setw(14) << file_pos << '\n';  //first progress indicator
 
    //we use low level file IO because it is distinctly faster than C++ filebuf or iostream
    mode_t mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH;     //if create file permissions will be 644
-   int fout = open(outFileName.c_str(), O_WRONLY|O_CREAT|O_TRUNC, mode); //create if no exists, truncate if does exist
+   int fout = open(out_file_name.c_str(), O_WRONLY|O_CREAT|O_TRUNC, mode); //create if no exists, truncate if does exist
    EOS_ASSERT( fout>0, block_index_not_found, "cannot write blocks.index" );
 
-   uint64_t indFileLen= bnum<<3;                            //index file holds 8 bytes per block in blocks.log
-   uint64_t lastIndBufLen= indFileLen & (fposListLen-1);    //fposListLen is a power of 2 so -1 creates low bits all 1
-   if (!lastIndBufLen)                                      //will write integral number of bufLen and lastIndBufLen one time to index file
-      lastIndBufLen= bufLen;
-   uint64_t indPos= lseek(fout,indFileLen-lastIndBufLen,ios::beg);
-   uint64_t blkBase= (indPos>>3) + firstBlock;              //first entry in fposList is for block blkBase
-   //cout << "indPos= " << indPos << "  blkBase= " << blkBase << '\n';
-   fposList[bnum-blkBase]= filePos;                         //write filepos for block bnum
+   uint64_t ind_file_len= bnum<<3;                          //index file holds 8 bytes per block in blocks.log
+   uint64_t last_ind_buf_len= ind_file_len & (fpos_list_len-1);    //fpos_list_len is a power of 2 so -1 creates low bits all 1
+   if (!last_ind_buf_len)                                   //will write integral number of bufLen and last_ind_buf_len one time to index file
+      last_ind_buf_len= bufLen;
+   uint64_t ind_pos= lseek(fout,ind_file_len-last_ind_buf_len,SEEK_SET);
+   uint64_t blk_base= (ind_pos>>3) + first_block;           //first entry in fpos_list is for block blk_base
+   //cout << "ind_pos= " << ind_pos << "  blk_base= " << blk_base << '\n';
+   fpos_list[bnum-blk_base]= file_pos;                      //write filepos for block bnum
 
    for (;;) {
-      if (bnum==blkBase) {                                  //if fposList is full
-         write(fout,(char*)fposList,lastIndBufLen); //write fposList to index file
-         if (indPos==0) {                                   //if done writing index file
-            cout << "block " << setw(10) << bnum << "    filePos " << setw(14) << filePos << '\n';  //last progress indicator
-            EOS_ASSERT( bnum == firstBlock, block_log_exception, "blocks.log does not contain consecutive block numbers" );
+      if (bnum==blk_base) {                                 //if fpos_list is full
+         write(fout,(char*)fpos_list,last_ind_buf_len);     //write fpos_list to index file
+         if (ind_pos==0) {                                  //if done writing index file
+            cout << "block " << setw(10) << bnum << "    file_pos " << setw(14) << file_pos << '\n';  //last progress indicator
+            EOS_ASSERT( bnum == first_block, block_log_exception, "blocks.log does not contain consecutive block numbers" );
             break;
          }
-         indPos-= fposListLen;
-         blkBase-= fposListLen>>3;
-         didread= lseek(fout,indPos,ios::beg);
-         EOS_ASSERT( didread==indPos, block_log_exception, "blocks.log seek fails" );
-         lastIndBufLen= fposListLen;                        //from now on all writes to index file write a full fposList[]
+         ind_pos-= fpos_list_len;
+         blk_base-= fpos_list_len>>3;
+         did_read= lseek(fout,ind_pos,SEEK_SET);
+         EOS_ASSERT( did_read==ind_pos, block_log_exception, "blocks.log seek fails" );
+         last_ind_buf_len= fpos_list_len;                   //from now on all writes to index file write a full fpos_list[]
       }
-      if (indexStart < 8) {                                 //if block start is split across buf boundary
+      if (index_start < 8) {                                //if block start is split across buf boundary
          memcpy(buf+bufLen,buf,8);                          //copy portion at start of buf to past end of buf
          pos-= bufLen;                                      //file position of buf
-         lseek(fin,pos,ios::beg);
-         didread= read(fin,buf,bufLen);                     //read next buf
-         EOS_ASSERT( didread==bufLen, block_log_exception, "blocks.log read fails" );
-         indexStart+= bufLen;
+         lseek(fin,pos,SEEK_SET);
+         did_read= read(fin,buf,bufLen);                    //read next buf
+         EOS_ASSERT( did_read==bufLen, block_log_exception, "blocks.log read fails" );
+         index_start+= bufLen;
       }
-      indexEnd= indexStart-8;                               //index in buf where block ends and block file position starts
-      filePos= *(uint64_t*)(buf+indexEnd);                  //file pos of block start
-      if (filePos < pos) {                                  //if block start is in prior buf
+      --bnum;                                               //now move index_start and index_end to prior block
+      index_end= index_start-8;                             //index in buf where block ends and block file position starts
+      file_pos= *(uint64_t*)(buf+index_end);                //file pos of block start
+      if (file_pos >= last_file_pos) {                      //file_pos will decrease if linked list is not corrupt
+         cout << '\n';
+         cout << "file pos for block " << bnum+1 << " is " << last_file_pos << '\n';
+         cout << "file pos for block " << bnum   << " is " <<      file_pos << '\n';
+         cout << "The linked list of blocks in blocks.log should run from last block to first block in reverse order\n";
+         EOS_ASSERT( file_pos<last_file_pos, block_log_exception, "blocks.log linked list of blocks is corrupt" );
+      }
+      last_file_pos= file_pos;
+      if (file_pos < pos) {                                 //if block start is in prior buf
          pos-= bufLen;                                      //file position of buf
-         lseek(fin,pos,ios::beg);
-         didread= read(fin,buf,bufLen);                     //read next buf
-         EOS_ASSERT( didread==bufLen, block_log_exception, "blocks.log read fails" );
-         indexEnd+= bufLen;
+         lseek(fin,pos,SEEK_SET);
+         did_read= read(fin,buf,bufLen);                    //read next buf
+         EOS_ASSERT( did_read==bufLen, block_log_exception, "blocks.log read fails" );
+         index_end+= bufLen;
       }
-      indexStart= filePos - pos;                            //buf index for block start
-      --bnum;
-      fposList[bnum-blkBase]= filePos;                      //write filepos for block bnum
+      index_start= file_pos - pos;                          //buf index for block start
+       fpos_list[bnum-blk_base]= file_pos;                  //write filepos for block bnum
       if ((bnum & 0xfffff) == 0)                            //periodically print a progress indicator
-         cout << "block " << setw(10) << bnum << "    filePos " << setw(14) << filePos << '\n';
+         cout << "block " << setw(10) << bnum << "    file_pos " << setw(14) << file_pos << '\n';
    }
 
    close(fout);
    close(fin);
-   delete[] buf;
-   delete[] fposList;
-   cout << "\nwrote " << lastBlock << " file positions to " << outFileName << '\n';
+   cout << "\nwrote " << last_block << " file positions to " << out_file_name << '\n';
    return 0;
 }
 
@@ -361,17 +380,17 @@ int main(int argc, char** argv)
         cli.print(std::cerr);
         return 0;
       }
-      if (vmap.at("trim-block-log").as<bool>()) {
+      if (vmap.at("trim-blocklog").as<bool>()) {
          uint32_t last= vmap.at("last").as<uint32_t>();
          if (last == std::numeric_limits<uint32_t>::max()) {   //if 'last' was not given on command line
-            std::cout << "'trim-block-log' does nothing unless specify 'last' block.";
+            std::cout << "'trim-block-blocklog' does nothing unless specify 'last' block.";
             return -1;
          }
-         return truncBlockLog(vmap.at("blocks-dir").as<bfs::path>(), last);
+         return trunc_blocklog(vmap.at("blocks-dir").as<bfs::path>(), last);
       }
       if (vmap.at("make-index").as<bool>()) {
-         string outFile{vmap.count("output-file")==0? string("blocks.index"): vmap.at("output-file").as<bfs::path>().generic_string()};
-         return makeIndex(vmap.at("blocks-dir").as<bfs::path>(), outFile);
+         string out_file{vmap.count("output-file")==0? string("blocks.index"): vmap.at("output-file").as<bfs::path>().generic_string()};
+         return make_index(vmap.at("blocks-dir").as<bfs::path>(), out_file);
       }
       blog.initialize(vmap);
       blog.read_log();

--- a/programs/eosio-blocklog/main.cpp
+++ b/programs/eosio-blocklog/main.cpp
@@ -178,7 +178,7 @@ void blocklog::initialize(const variables_map& options) {
 }
 
 //struct used by trunc_blocklog() and make_index() to read first 18 bytes of a block from blocks.log
-struct __attribute__((packed)) Block_Start {    //first 18 bytes of each block (must match block_header)
+struct __attribute__((__packed__)) Block_Start {    //first 18 bytes of each block (must match block_header)
    block_timestamp_type timestamp;
    account_name         prodname;
    uint16_t             confirmed;

--- a/programs/eosio-blocklog/main.cpp
+++ b/programs/eosio-blocklog/main.cpp
@@ -36,14 +36,14 @@ struct blocklog {
 
    bfs::path                        blocks_dir;
    bfs::path                        output_file;
-   uint32_t                         first_block;
-   uint32_t                         last_block;
-   bool                             no_pretty_print;
-   bool                             as_json_array;
-   bool                             make_index;
-   bool                             trim_log;
-   bool                             smoke_test;
-   bool                             help;
+   uint32_t                         first_block = 0;
+   uint32_t                         last_block = std::numeric_limits<uint32_t>::max();
+   bool                             no_pretty_print = false;
+   bool                             as_json_array = false;
+   bool                             make_index = false;
+   bool                             trim_log = false;
+   bool                             smoke_test = false;
+   bool                             help = false;
 };
 
 struct report_time {
@@ -215,13 +215,15 @@ struct trim_data {            //used by trim_blocklog_front(), trim_blocklog_end
    }
    void find_block_pos(uint32_t n);
    bfs::path block_file_name, index_file_name;        //full pathname for blocks.log and blocks.index
-   uint32_t version;                                  //blocklog version (1 or 2)
-   uint32_t first_block, last_block;                  //first and last block in blocks.log
-   FILE* blk_in;                                      //C style files for reading blocks.log and blocks.index
-   FILE* ind_in;                                      //C style files for reading blocks.log and blocks.index
+   uint32_t version = 0;                              //blocklog version (1 or 2)
+   uint32_t first_block = 0;                          //first block in blocks.log
+   uint32_t last_block = 0;                          //last block in blocks.log
+   FILE* blk_in = nullptr;                            //C style files for reading blocks.log and blocks.index
+   FILE* ind_in = nullptr;                            //C style files for reading blocks.log and blocks.index
    //we use low level file IO because it is distinctly faster than C++ filebuf or iostream
-   uint64_t index_pos;                                //filepos in blocks.index for block n, +8 for block n+1
-   uint64_t fpos0, fpos1;                             //filepos in blocks.log for block n and block n+1
+   uint64_t index_pos = 0;                            //filepos in blocks.index for block n, +8 for block n+1
+   uint64_t fpos0 = 0;                                //filepos in blocks.log for block n and block n+1
+   uint64_t fpos1 = 0;                                //filepos in blocks.log for block n and block n+1
 };
 
 

--- a/programs/eosio-blocklog/main.cpp
+++ b/programs/eosio-blocklog/main.cpp
@@ -10,6 +10,7 @@
 #include <fc/io/json.hpp>
 #include <fc/filesystem.hpp>
 #include <fc/variant.hpp>
+#include <fc/bitutil.hpp>
 
 #include <boost/exception/diagnostic_information.hpp>
 #include <boost/program_options.hpp>
@@ -36,6 +37,8 @@ struct blocklog {
    uint32_t                         last_block;
    bool                             no_pretty_print;
    bool                             as_json_array;
+   bool                             make_index;
+   uint32_t                         trim_block;
 };
 
 void blocklog::read_log() {
@@ -44,6 +47,7 @@ void blocklog::read_log() {
    EOS_ASSERT( end, block_log_exception, "No blocks found in block log" );
    EOS_ASSERT( end->block_num() > 1, block_log_exception, "Only one block found in block log" );
 
+   //fix message below, first block might not be 1, first_block_num is not set yet
    ilog( "existing block log contains block num 1 through block num ${n}", ("n",end->block_num()) );
 
    optional<chainbase::database> reversible_blocks;
@@ -145,9 +149,12 @@ void blocklog::set_program_options(options_description& cli)
           "Do not pretty print the output.  Useful if piping to jq to improve performance.")
          ("as-json-array", bpo::bool_switch(&as_json_array)->default_value(false),
           "Print out json blocks wrapped in json array (otherwise the output is free-standing json objects).")
+         ("make-index", bpo::bool_switch(&make_index)->default_value(false),
+          "Create blocks.index from blocks.log. Must give 'blocks-dir'. Give 'output-file' relative to blocks-dir (default is blocks.index).")
+         ("trim-block-log", bpo::bool_switch(&make_index)->default_value(false),
+          "Trim blocks.log and blocks.index in place. Must give 'blocks-dir' and 'last' (else nothing is done).")
          ("help", "Print this help message and exit.")
          ;
-
 }
 
 void blocklog::initialize(const variables_map& options) {
@@ -169,6 +176,176 @@ void blocklog::initialize(const variables_map& options) {
 
 }
 
+//struct used by truncBlockLog() and makeIndex() to read first 18 bytes of a block from blocks.log
+struct __attribute__((packed)) BlockStart {    //first 18 bytes of each block
+   block_timestamp_type timestamp;
+   account_name         prodname;
+   uint16_t             confirmed;
+   uint32_t             blknum;     //low 32 bits of previous blockid, is big endian block number of previous block
+} blkStart;
+
+int truncBlockLog(bfs::path blockDir, uint32_t n) {          //n is last block to keep
+   using namespace std;
+   cout << "Will truncate blocks.log and blocks.index after block " << n << '\n';
+
+   //read blocks.log to see if version 1 or 2 and get first block number
+   filebuf fin0;
+   string blockFileName= (blockDir/"blocks.log").generic_string();
+   fin0.open(blockFileName.c_str(), ios::in|ios::binary);
+   EOS_ASSERT( fin0.is_open(), block_log_not_found, "cannot read blocks.log" );
+   uint32_t version=0, firstBlock;
+   fin0.sgetn((char*)&version,sizeof(version));
+   EOS_ASSERT( version==1 || version==2, block_log_unsupported_version, "unsupported version of block log" );
+   if (version == 1)
+      firstBlock= 1;
+   else
+      fin0.sgetn((char*)&firstBlock,sizeof(firstBlock));
+   cout << "version= " << version << "\nfirst block= " << firstBlock << '\n';
+   if (n <= firstBlock) {
+      cout << n << " is before first block so nothing to do\n";
+      return 2;
+   }
+
+   //open blocks.index and get blocks.log position for block 'n'
+   filebuf fin1;
+   string indexFileName= (blockDir/"blocks.index").generic_string();
+   fin1.open(indexFileName.c_str(),ios::in|ios::binary);
+   EOS_ASSERT( fin1.is_open(), block_index_not_found, "cannot read blocks.index" );
+   uint64_t indexPos= 8*(n-firstBlock);
+   uint64_t pos= fin1.pubseekoff(indexPos,ios::beg,ios::in);
+   EOS_ASSERT( pos==indexPos, block_log_exception, "cannot read blocks.index entry for trim-after-block" );
+   uint64_t fpos0, fpos1;                                   //filepos of block n and block n+1, will read from blocks.index
+   fin1.sgetn((char*)&fpos0,sizeof(fpos0));
+   fin1.sgetn((char*)&fpos1,sizeof(fpos1));
+   fin1.close();
+   cout << "According to blocks.index:\n";
+   cout << "    block " << n << " starts at position " << fpos0 << '\n';
+   cout << "    block " << n+1 << " starts at position " << fpos1 << '\n';
+
+   //read blocks.log and verify block number n is found at file position fpos0
+   fin0.pubseekoff(fpos0,ios::beg,ios::in);
+   fin0.sgetn((char*)&blkStart,sizeof(blkStart));
+   fin0.close();
+   uint32_t bnum= endian_reverse_u32(blkStart.blknum)+1;    //convert from big endian to little endian, add 1 since prior block
+   EOS_ASSERT( bnum==n, block_log_exception, "blocks.index does not agree with blocks.log" );
+   cout << "In blocks.log at position " << fpos0 << " find block " << bnum << " as expected\n";
+   EOS_ASSERT( truncate(blockFileName.c_str(),fpos1)==0, block_log_exception, "truncate blocks.log fails");
+   indexPos+= sizeof(uint64_t);                             //advance to after record for block n
+   EOS_ASSERT( truncate(indexFileName.c_str(),indexPos)==0, block_log_exception, "truncate blocks.index fails");
+   cout << "blocks.log has been truncated to " << fpos1 << " bytes\n";
+   cout << "blocks.index has been truncated to " << indexPos << " bytes\n";
+   return 0;
+}
+
+int makeIndex(bfs::path blockDir, string outFile) {
+   //this code makes blocks.index much faster than nodeos (in recent test 80 seconds vs. 90 minutes)
+   using namespace std;
+   cout << "Will make blocks.index from blocks.log\n";
+   string blockFileName= (blockDir / "blocks.log").generic_string();
+   string outFileName=   (blockDir / outFile     ).generic_string();
+   int fin = open(blockFileName.c_str(), O_RDONLY);
+   EOS_ASSERT( fin>0, block_log_not_found, "cannot read blocks.log" );
+
+   //will read big chunks of blocks.log into buf, will fill fposList with file positions before write to blocks.index
+   constexpr uint32_t bufLen{1U<<24};                       //bufLen must be power of 2 >= largest possible block == one MByte
+   char* buf= new char[bufLen+8];                           //first 8 bytes of prior buf are put past end of current buf
+   constexpr uint64_t fposListLen{1U<<22};                  //length of fposList[] in bytes
+   uint64_t* fposList= new uint64_t[fposListLen>>3];
+
+   //read blocks.log to see if version 1 or 2 and get firstblocknum (implicit 1 if version 1)
+   uint32_t version=0, firstBlock;
+   read(fin,(char*)&version,sizeof(version));
+   EOS_ASSERT( version==1 || version==2, block_log_unsupported_version, "unsupported version of block log" );
+   if (version == 1)
+      firstBlock= 1;
+   else
+      read(fin,(char*)&firstBlock,sizeof(firstBlock));
+   cout << "block log version= " << version << '\n';
+   cout << "first block= " << firstBlock << '\n';
+
+   uint64_t pos= lseek(fin,0,ios::end);                     //get blocks.log file length
+   uint64_t lastBufLen= pos & ((uint64_t)bufLen-1);         //bufLen is a power of 2 so -1 creates low bits all 1
+   if (!lastBufLen)                                         //will read integral number of bufLen and one time read lastBufLen
+      lastBufLen= bufLen;
+   pos= lseek(fin,-(uint64_t)lastBufLen,ios::end);
+   uint64_t didread= read(fin,buf,lastBufLen);              //read tail of file into buf
+   EOS_ASSERT( didread==lastBufLen, block_log_exception, "blocks.log read fails" );
+
+   uint32_t indexStart;                                     //buf index for block start
+   uint32_t indexEnd;                                       //buf index for block end == buf index for block start file position
+   uint64_t filePos;                                        //file pos of block start
+   BlockStart* bst;                                         //pointer to BlockStart
+
+   indexStart= lastBufLen;                                  //pretend a block starts just past end of buf then read prior block
+   indexEnd= indexStart-8;                                  //index in buf where block ends and block file position starts
+   filePos= *(uint64_t*)(buf+indexEnd);                     //file pos of block start
+   indexStart= filePos - pos;                               //buf index for block start
+   bst= (BlockStart*)(buf+indexStart);                      //pointer to BlockStart
+   uint32_t lastBlock= endian_reverse_u32(bst->blknum);     //convert from big endian to little endian
+   uint32_t bnum= ++lastBlock;                              //add 1 since took block number from prior block id
+   cout << "last block=  " << lastBlock << '\n';
+   cout << '\n';
+   cout << "block " << setw(10) << bnum << "    filePos " << setw(14) << filePos << '\n';  //first progress indicator
+
+   //we use low level file IO because it is distinctly faster than C++ filebuf or iostream
+   mode_t mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH;     //if create file permissions will be 644
+   int fout = open(outFileName.c_str(), O_WRONLY|O_CREAT|O_TRUNC, mode); //create if no exists, truncate if does exist
+   EOS_ASSERT( fout>0, block_index_not_found, "cannot write blocks.index" );
+
+   uint64_t indFileLen= bnum<<3;                            //index file holds 8 bytes per block in blocks.log
+   uint64_t lastIndBufLen= indFileLen & (fposListLen-1);    //fposListLen is a power of 2 so -1 creates low bits all 1
+   if (!lastIndBufLen)                                      //will write integral number of bufLen and lastIndBufLen one time to index file
+      lastIndBufLen= bufLen;
+   uint64_t indPos= lseek(fout,indFileLen-lastIndBufLen,ios::beg);
+   uint64_t blkBase= (indPos>>3) + firstBlock;              //first entry in fposList is for block blkBase
+   //cout << "indPos= " << indPos << "  blkBase= " << blkBase << '\n';
+   fposList[bnum-blkBase]= filePos;                         //write filepos for block bnum
+
+   for (;;) {
+      if (bnum==blkBase) {                                  //if fposList is full
+         write(fout,(char*)fposList,lastIndBufLen); //write fposList to index file
+         if (indPos==0) {                                   //if done writing index file
+            cout << "block " << setw(10) << bnum << "    filePos " << setw(14) << filePos << '\n';  //last progress indicator
+            EOS_ASSERT( bnum == firstBlock, block_log_exception, "blocks.log does not contain consecutive block numbers" );
+            break;
+         }
+         indPos-= fposListLen;
+         blkBase-= fposListLen>>3;
+         didread= lseek(fout,indPos,ios::beg);
+         EOS_ASSERT( didread==indPos, block_log_exception, "blocks.log seek fails" );
+         lastIndBufLen= fposListLen;                        //from now on all writes to index file write a full fposList[]
+      }
+      if (indexStart < 8) {                                 //if block start is split across buf boundary
+         memcpy(buf+bufLen,buf,8);                          //copy portion at start of buf to past end of buf
+         pos-= bufLen;                                      //file position of buf
+         lseek(fin,pos,ios::beg);
+         didread= read(fin,buf,bufLen);                     //read next buf
+         EOS_ASSERT( didread==bufLen, block_log_exception, "blocks.log read fails" );
+         indexStart+= bufLen;
+      }
+      indexEnd= indexStart-8;                               //index in buf where block ends and block file position starts
+      filePos= *(uint64_t*)(buf+indexEnd);                  //file pos of block start
+      if (filePos < pos) {                                  //if block start is in prior buf
+         pos-= bufLen;                                      //file position of buf
+         lseek(fin,pos,ios::beg);
+         didread= read(fin,buf,bufLen);                     //read next buf
+         EOS_ASSERT( didread==bufLen, block_log_exception, "blocks.log read fails" );
+         indexEnd+= bufLen;
+      }
+      indexStart= filePos - pos;                            //buf index for block start
+      --bnum;
+      fposList[bnum-blkBase]= filePos;                      //write filepos for block bnum
+      if ((bnum & 0xfffff) == 0)                            //periodically print a progress indicator
+         cout << "block " << setw(10) << bnum << "    filePos " << setw(14) << filePos << '\n';
+   }
+
+   close(fout);
+   close(fin);
+   delete[] buf;
+   delete[] fposList;
+   cout << "\nwrote " << lastBlock << " file positions to " << outFileName << '\n';
+   return 0;
+}
 
 int main(int argc, char** argv)
 {
@@ -183,6 +360,18 @@ int main(int argc, char** argv)
       if (vmap.count("help") > 0) {
         cli.print(std::cerr);
         return 0;
+      }
+      if (vmap.at("trim-block-log").as<bool>()) {
+         uint32_t last= vmap.at("last").as<uint32_t>();
+         if (last == std::numeric_limits<uint32_t>::max()) {   //if 'last' was not given on command line
+            std::cout << "'trim-block-log' does nothing unless specify 'last' block.";
+            return -1;
+         }
+         return truncBlockLog(vmap.at("blocks-dir").as<bfs::path>(), last);
+      }
+      if (vmap.at("make-index").as<bool>()) {
+         string outFile{vmap.count("output-file")==0? string("blocks.index"): vmap.at("output-file").as<bfs::path>().generic_string()};
+         return makeIndex(vmap.at("blocks-dir").as<bfs::path>(), outFile);
       }
       blog.initialize(vmap);
       blog.read_log();

--- a/programs/eosio-blocklog/main.cpp
+++ b/programs/eosio-blocklog/main.cpp
@@ -47,7 +47,7 @@ struct blocklog {
 };
 
 struct report_time {
-    report_time(std::string& desc)
+    report_time(std::string desc)
     : _start(std::chrono::high_resolution_clock::now())
     , _desc(desc) {
     }

--- a/programs/eosio-blocklog/main.cpp
+++ b/programs/eosio-blocklog/main.cpp
@@ -39,7 +39,9 @@ struct blocklog {
    bool                             no_pretty_print;
    bool                             as_json_array;
    bool                             make_index;
-   uint32_t                         trim_block;
+   bool                             trim_log;
+   bool                             smoke_test;
+   bool                             help;
 };
 
 void blocklog::read_log() {
@@ -142,19 +144,21 @@ void blocklog::set_program_options(options_description& cli)
           "the location of the blocks directory (absolute path or relative to the current directory)")
          ("output-file,o", bpo::value<bfs::path>(),
           "the file to write the output to (absolute or relative path).  If not specified then output is to stdout.")
-         ("first,f", bpo::value<uint32_t>(&first_block)->default_value(1),
-          "the first block number to log")
+         ("first,f", bpo::value<uint32_t>(&first_block)->default_value(0),
+          "the first block number to log or the first to keep if trim-blocklog")
          ("last,l", bpo::value<uint32_t>(&last_block)->default_value(std::numeric_limits<uint32_t>::max()),
-          "the last block number (inclusive) to log")
+          "the last block number to log or the last to keep if trim-blocklog")
          ("no-pretty-print", bpo::bool_switch(&no_pretty_print)->default_value(false),
           "Do not pretty print the output.  Useful if piping to jq to improve performance.")
          ("as-json-array", bpo::bool_switch(&as_json_array)->default_value(false),
           "Print out json blocks wrapped in json array (otherwise the output is free-standing json objects).")
          ("make-index", bpo::bool_switch(&make_index)->default_value(false),
           "Create blocks.index from blocks.log. Must give 'blocks-dir'. Give 'output-file' relative to blocks-dir (default is blocks.index).")
-         ("trim-blocklog", bpo::bool_switch(&make_index)->default_value(false),
-          "Trim blocks.log and blocks.index in place. Must give 'blocks-dir' and 'last' (else nothing is done).")
-         ("help,h", "Print this help message and exit.")
+         ("trim-blocklog", bpo::bool_switch(&trim_log)->default_value(false),
+          "Trim blocks.log and blocks.index. Must give 'blocks-dir' and 'first and/or 'last'.")
+         ("smoke-test", bpo::bool_switch(&smoke_test)->default_value(false),
+          "Quick test that blocks.log and blocks.index are well formed and agree with each other.")
+         ("help,h", bpo::bool_switch(&help)->default_value(false), "Print this help message and exit.")
          ;
 }
 
@@ -177,95 +181,280 @@ void blocklog::initialize(const variables_map& options) {
 
 }
 
-//struct used by trunc_blocklog() and make_index() to read first 18 bytes of a block from blocks.log
-struct __attribute__((__packed__)) Block_Start {    //first 18 bytes of each block (must match block_header)
-   block_timestamp_type timestamp;
-   account_name         prodname;
-   uint16_t             confirmed;
-   uint32_t             blknum;     //low 32 bits of previous blockid, is big endian block number of previous block
-} blk_start;
-static_assert( sizeof(Block_Start) == 18, "Update block_start if block_header changes");
+constexpr int blknum_offset{14};                      //offset from start of block to 4 byte block number
+//this offset is valid for version 1 and 2 blocklogs, version is checked before using blknum_offset
 
-int trunc_blocklog(bfs::path block_dir, uint32_t n) {       //n is last block to keep
+//to derive blknum_offset==14 see block_header.hpp and note on disk struct is packed
+//   block_timestamp_type timestamp;                  //bytes 0:3
+//   account_name         producer;                   //bytes 4:11
+//   uint16_t             confirmed;                  //bytes 12:13
+//   block_id_type        previous;                   //bytes 14:45, low 4 bytes is big endian block number of previous block
+
+struct trim_data {            //used by trim_blocklog_front(), trim_blocklog_end(), and smoke_test()
+   trim_data(bfs::path block_dir);
+   ~trim_data() {
+      close(blk_in);
+      close(ind_in);
+   }
+   void find_block_pos(uint32_t n);
+   std::string block_file_name, index_file_name;      //full pathname for blocks.log and blocks.index
+   uint32_t version;                                  //blocklog version (1 or 2)
+   uint32_t first_block, last_block;                  //first and last block in blocks.log
+   int blk_in, ind_in;                                //C style file descriptors for reading blocks.log and blocks.index
+   //we use low level file IO because it is distinctly faster than C++ filebuf or iostream
+   uint64_t index_pos;                                //filepos in blocks.index for block n, +8 for block n+1
+   uint64_t fpos0, fpos1;                             //filepos in blocks.log for block n and block n+1
+};
+
+
+trim_data::trim_data(bfs::path block_dir) {
    using namespace std;
-   //read blocks.log to see if version 1 or 2 and get first block number
-   filebuf fin_blocks;
-   cout << "In directory " << block_dir << " will truncate blocks.log and blocks.index after block " << n << '\n';
-   string block_file_name= (block_dir/"blocks.log").generic_string();
-   fin_blocks.open(block_file_name, ios::in|ios::binary);
-   EOS_ASSERT( fin_blocks.is_open(), block_log_not_found, "cannot read ${file}", ("file",block_file_name) );
-   uint32_t version=0, first_block;
-   fin_blocks.sgetn((char*)&version,sizeof(version));
+   block_file_name= (block_dir/"blocks.log").generic_string();
+   index_file_name= (block_dir/"blocks.index").generic_string();
+   blk_in = open(block_file_name.c_str(), O_RDONLY);
+   EOS_ASSERT( blk_in>0, block_log_not_found, "cannot read file ${file}", ("file",block_file_name) );
+   ind_in = open(index_file_name.c_str(), O_RDONLY);
+   EOS_ASSERT( ind_in>0, block_log_not_found, "cannot read file ${file}", ("file",index_file_name) );
+   read(blk_in,(char*)&version,sizeof(version));
    cout << "block log version= " << version << '\n';
    EOS_ASSERT( version==1 || version==2, block_log_unsupported_version, "block log version ${v} is not supported", ("v",version));
    if (version == 1)
       first_block= 1;
    else
-      fin_blocks.sgetn((char*)&first_block,sizeof(first_block));
+      read(blk_in,(char*)&first_block,sizeof(first_block));
    cout << "first block= " << first_block << '\n';
-   if (n <= first_block) {
-      cerr << n << " is before first block so nothing to do\n";
-      return 2;
-   }
-
-   //open blocks.index, get last_block and blocks.log position for block 'n'
-   filebuf fin_index;
-   string index_file_name= (block_dir/"blocks.index").generic_string();
-   fin_index.open(index_file_name,ios::in|ios::binary);
-   EOS_ASSERT( fin_index.is_open(), block_index_not_found, "cannot read ${file}", ("file",index_file_name) );
-   uint64_t file_end= fin_index.pubseekoff(0,ios::end,ios::in);
-   uint32_t last_block= file_end/sizeof(uint64_t);
+   uint64_t file_end= lseek(ind_in,0,SEEK_END);                //get length of blocks.index (gives number of blocks)
+   last_block= first_block + file_end/sizeof(uint64_t) - 1;
    cout << "last block=  " << last_block << '\n';
-   if (n >= last_block) {
-      cerr << n << " is not before last block so nothing to do\n";
-      return 2;
-   }
-   uint64_t index_pos= sizeof(uint64_t)*(n-first_block);
-   uint64_t pos= fin_index.pubseekoff(index_pos,ios::beg,ios::in);
-   EOS_ASSERT( pos==index_pos, block_log_exception, "cannot read blocks.index entry for block ${b}", ("b",n) );
-   uint64_t fpos0, fpos1;                                   //filepos of block n and block n+1, will read from blocks.index
-   fin_index.sgetn((char*)&fpos0,sizeof(fpos0));
-   fin_index.sgetn((char*)&fpos1,sizeof(fpos1));
-   fin_index.close();
+}
+
+void trim_data::find_block_pos(uint32_t n) {
+   //get file position of block n from blocks.index then confirm block n is found in blocks.log at that position
+   //sets fpos0 and fpos1, throws exception if block at fpos0 is not block n
+   using namespace std;
+   index_pos= sizeof(uint64_t)*(n-first_block);
+   uint64_t pos= lseek(ind_in,index_pos,SEEK_SET);
+   EOS_ASSERT( pos==index_pos, block_log_exception, "cannot seek to blocks.index entry for block ${b}", ("b",n) );
+   read(ind_in,(char*)&fpos0,sizeof(fpos0));                   //filepos of block n
+   read(ind_in,(char*)&fpos1,sizeof(fpos1));                   //filepos of block n+1
    cout << "According to blocks.index:\n";
    cout << "    block " << n << " starts at position " << fpos0 << '\n';
-   cout << "    block " << n+1 << " starts at position " << fpos1 << '\n';
-
+   cout << "    block " << n+1;
+   if (n!=last_block)
+      cout << " starts at position " << fpos1 << '\n';
+   else
+      cout << " is past end\n";
    //read blocks.log and verify block number n is found at file position fpos0
-   fin_blocks.pubseekoff(fpos0,ios::beg,ios::in);
-   fin_blocks.sgetn((char*)&blk_start,sizeof(blk_start));   //read first 18 bytes of block
-   fin_blocks.close();
-   uint32_t bnum= endian_reverse_u32(blk_start.blknum)+1;   //convert from big endian to little endian, add 1 since prior block
+   lseek(blk_in,fpos0+blknum_offset,SEEK_SET);
+   uint32_t prior_blknum;
+   read(blk_in,(char*)&prior_blknum,sizeof(prior_blknum));     //read bigendian block number of prior block
+   uint32_t bnum= endian_reverse_u32(prior_blknum)+1;          //convert to little endian, add 1 since prior block
    cout << "At position " << fpos0 << " in blocks.log find block " << bnum << (bnum==n? " as expected\n": " - not good!\n");
    EOS_ASSERT( bnum==n, block_log_exception, "blocks.index does not agree with blocks.log" );
-   EOS_ASSERT( truncate(block_file_name.c_str(),fpos1)==0, block_log_exception, "truncate blocks.log fails");
-   index_pos+= sizeof(uint64_t);                            //advance to after record for block n
-   EOS_ASSERT( truncate(index_file_name.c_str(),index_pos)==0, block_log_exception, "truncate blocks.index fails");
-   cout << "blocks.log has been truncated to " << fpos1 << " bytes\n";
-   cout << "blocks.index has been truncated to " << index_pos << " bytes\n";
+}
+
+int trim_blocklog_end(bfs::path block_dir, uint32_t n) {       //n is last block to keep (remove later blocks)
+   using namespace std;
+   cout << "\nIn directory " << block_dir << " will trim all blocks after block " << n << " from blocks.log and blocks.index.\n";
+   trim_data td(block_dir);
+   if (n < td.first_block) {
+      cerr << "All blocks are after block " << n << " so do nothing (trim_end would delete entire blocks.log)\n";
+      return 1;
+   }
+   if (n >= td.last_block) {
+      cerr << "There are no blocks after block " << n << " so do nothing\n";
+      return 2;
+   }
+   td.find_block_pos(n);
+   EOS_ASSERT( truncate(td.block_file_name.c_str(),td.fpos1)==0, block_log_exception, "truncate blocks.log fails");
+   uint64_t index_end= td.index_pos+sizeof(uint64_t);             //advance past record for block n
+   EOS_ASSERT( truncate(td.index_file_name.c_str(),index_end)==0, block_log_exception, "truncate blocks.index fails");
+   cout << "blocks.log has been trimmed to " << td.fpos1 << " bytes\n";
+   cout << "blocks.index has been trimmed to " << index_end << " bytes\n";
    return 0;
 }
+
+int trim_blocklog_front(bfs::path block_dir, uint32_t n) {        //n is first block to keep (remove prior blocks)
+   using namespace std;
+   cout << "\nIn directory " << block_dir << " will trim all blocks before block " << n << " from blocks.log and blocks.index.\n";
+   trim_data td(block_dir);
+   if (n <= td.first_block) {
+      cerr << "There are no blocks before block " << n << " so do nothing\n";
+      return 1;
+   }
+   if (n > td.last_block) {
+      cerr << "All blocks are before block " << n << " so do nothing (trim_front would delete entire blocks.log)\n";
+      return 2;
+   }
+   td.find_block_pos(n);
+
+   constexpr uint32_t buf_len{1U<<24};                            //buf_len must be a power of 2
+   auto buffer=  make_unique<char[]>(buf_len);                    //read big chunks of old blocks.log into this buffer
+   char* buf=  buffer.get();
+
+   string block_out_filename= (block_dir/"blocks.out").generic_string();
+   mode_t mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH;           //if create file the permissions will be 644
+   int blk_out = open(block_out_filename.c_str(), O_WRONLY|O_CREAT|O_TRUNC, mode);
+   EOS_ASSERT( blk_out>0, block_log_not_found, "cannot write ${file}", ("file",block_out_filename) );
+
+   //in version 1 file: version number, no first block number, rest of header length 0x6e, at 0x72 first block
+   //in version 2 file: version number, first block number,    rest of header length 0x6e, at 0x76 totem,  at 0x7e first block
+   *(uint32_t*)buf= 2;
+   write(blk_out,buf,sizeof(uint32_t));                           //write version number 2
+   write(blk_out,(char*)&n,sizeof(n));                            //write first block number
+
+   lseek(td.blk_in,td.version==1? 4: 8,SEEK_SET) ;                //position past version number and maybe block number
+   read(td.blk_in,buf,0x6e);                                      //copy rest of header length 0x6e
+   memset(buf+0x6e,0xff,8);                                       //totem is 8 bytes of 0xff
+   write(blk_out,buf,0x6e + 8);                                   //write header and totem
+
+   //pos_delta is the amount to subtract from every file position record in blocks.log because the blocks < n are removed
+   uint64_t pos_delta= td.fpos0 - 0x7e;                           //bytes removed from the blocklog
+   //bytes removed is file position of block n minus file position 'where file header ends'
+   //even if version 1 blocklog 'where file header ends' is where the new version 2 file header of length 0x7e ends
+
+   //read big chunks of blocks.log into buf, update the file position records, then write to blk_out
+   uint64_t pos= lseek(td.blk_in,0,SEEK_END);                     //get blocks.log file length
+   uint32_t last_buf_len= (pos-td.fpos0 >= buf_len)? buf_len: pos-td.fpos0; //bytes to read from blk_in
+   pos= lseek(td.blk_in,-(uint64_t)last_buf_len,SEEK_END);        //pos is where read last buf from blk_in
+   uint64_t did_read= read(td.blk_in,buf,last_buf_len);           //read tail of blocks.log file into buf
+   cout << "seek blocks.log to " << pos << " read " << last_buf_len << " bytes\n";//debug
+   EOS_ASSERT( did_read==last_buf_len, block_log_exception, "blocks.log read fails" );
+
+   //prepare to write index_out_filename
+   uint64_t total_fpos_len= (td.last_block+1-n)*sizeof(uint64_t);
+   auto fpos_buffer= make_unique<uint64_t[]>(buf_len);
+   uint64_t* fpos_list= fpos_buffer.get();                        //list of file positions, periodically write to blocks.index
+   string index_out_filename= (block_dir/"index.out" ).generic_string();
+   int ind_out = open(index_out_filename.c_str(), O_WRONLY|O_CREAT|O_TRUNC, mode);
+   EOS_ASSERT( ind_out>0, block_log_not_found, "cannot write ${file}", ("file",index_out_filename) );
+   uint64_t last_fpos_len= total_fpos_len & ((uint64_t)buf_len-1);//buf_len is a power of 2 so -1 creates low bits all 1
+   if (!last_fpos_len)                                            //will write integral number of buf_len and one time write last_fpos_len
+      last_fpos_len= buf_len;
+   uint32_t blk_base= td.last_block + 1 - (last_fpos_len>>3);     //first entry in fpos_list is for block blk_base
+   cout << "******filling index buf blk_base " << blk_base << " last_fpos_len " << last_fpos_len << '\n';//debug
+
+   //as we traverse linked list of blocks in buf (from end toward start), for each block we know this:
+   int32_t index_start;                                           //buf index for block start
+   int32_t index_end;                                             //buf index for block end == buf index for block start file position
+   uint64_t file_pos;                                             //file position of block start
+   uint32_t bnum;                                                 //block number
+
+   //some code here is repeated in the loop below but we do it twice so can print a status message before the loop starts
+   index_end= last_buf_len-8;                                     //buf index where last block ends and the block file position starts
+   file_pos= *(uint64_t*)(buf+index_end);                         //file pos of block start
+   index_start= file_pos - pos;                                   //buf index for block start
+   bnum= *(uint32_t*)(buf + index_start + blknum_offset);         //block number of previous block (is big endian)
+   bnum= endian_reverse_u32(bnum)+1;                              //convert from big endian to little endian and add 1
+   EOS_ASSERT( bnum==td.last_block, block_log_exception, "last block from blocks.index ${ind} != last block from blocks.log ${log}", ("ind", td.last_block) ("log", bnum) );
+
+   cout << '\n';                                                  //print header for periodic update messages
+   cout << setw(10) << "block" << setw(16) << "old file pos" << setw(16) << "new file pos" << '\n';
+   cout << setw(10) << bnum << setw(16) << file_pos << setw(16) << file_pos-pos_delta << '\n';
+   uint64_t last_file_pos= file_pos+1;                            //used to check that file_pos is strictly decreasing
+   constexpr uint32_t fk{4096};                                   //buffer shift that keeps buf disk block aligned
+
+   for (;;) {        //invariant: at top of loop index_end and bnum are set and index_end is >= 0
+      file_pos = *(uint64_t *) (buf + index_end);                 //get file pos of block start
+      if (file_pos >= last_file_pos) {                            //check that file_pos decreases
+         cout << '\n';
+         cout << "file pos for block " << bnum + 1 << " is " << last_file_pos << '\n';
+         cout << "file pos for block " << bnum << " is " << file_pos << '\n';
+         EOS_ASSERT(file_pos < last_file_pos, block_log_exception, "blocks.log linked list of blocks is corrupt");
+      }
+      last_file_pos = file_pos;
+      *(uint64_t *) (buf + index_end) = file_pos - pos_delta;     //update file position in buf
+      fpos_list[bnum - blk_base] = file_pos - pos_delta;          //save updated file position for new index file
+      index_start = file_pos - pos;                               //will go negative when pass first block in buf
+
+      if ((bnum & 0xfffff) == 0)                                  //periodic progress indicator
+         cout << setw(10) << bnum << setw(16) << file_pos << setw(16) << file_pos-pos_delta << '\n';
+
+      if (bnum == blk_base) {                                     //if fpos_list is full write it to file
+         cout << "****** bnum=" << bnum << " blk_base= " << blk_base << " so write index buf seek to " << (blk_base - n) * sizeof(uint64_t) << " write len " << last_fpos_len << '\n';//debug
+         lseek(ind_out, (blk_base - n) * sizeof(uint64_t), SEEK_SET);
+         write(ind_out, (char *) fpos_list, last_fpos_len);       //write fpos_list to index file
+         last_fpos_len = buf_len;
+         if (bnum == n) {                                         //if done with all blocks >= block n
+            cout << setw(10) << bnum << setw(16) << file_pos << setw(16) << file_pos-pos_delta << '\n';
+            EOS_ASSERT( index_start==0, block_log_exception, "block ${n} found with unexpected index_start ${s}", ("n",n) ("s",index_start));
+            EOS_ASSERT( pos==td.fpos0, block_log_exception, "block ${n} found at unexpected file position ${p}", ("n",n) ("p",file_pos));
+            lseek(blk_out, pos-pos_delta, SEEK_SET);
+            write(blk_out, buf, last_buf_len);
+            break;
+         } else {
+            blk_base -= (buf_len>>3);
+            cout << "******filling index buf blk_base " << blk_base << " fpos_len " << buf_len << '\n';//debug
+         }
+      }
+
+      if (index_start <= 0) {                                     //if buf is ready to write (all file pos are updated)
+         //cout << "index_start = " << index_start << " so write buf len " << last_buf_len << " bnum= " << bnum << '\n';//debug
+         EOS_ASSERT(file_pos>td.fpos0, block_log_exception, "reverse scan of blocks.log did not halt at block ${n}",("n",n));
+         lseek(blk_out, pos-pos_delta, SEEK_SET);
+         write(blk_out, buf, last_buf_len);
+         last_buf_len= (pos-td.fpos0 > buf_len)? buf_len: pos-td.fpos0;
+         pos -= last_buf_len;
+         index_start += last_buf_len;
+         //cout << "seek blocks to " << pos << " read " << last_buf_len << " bytes\n";//debug
+         lseek(td.blk_in, pos, SEEK_SET);
+         did_read = read(td.blk_in, buf, last_buf_len);           //read next buf from blocklog
+         EOS_ASSERT(did_read == last_buf_len, block_log_exception, "blocks.log read fails");
+      }
+
+      index_end = index_start - sizeof(uint64_t);                 //move to prior block in buf
+      --bnum;
+
+      if (index_end < 0) {                                        //the file pos record straddles buf boundary
+         cout << "****  index_end= " << index_end << " so save buf-4K len= " << last_buf_len-fk << " bnum= " << bnum << '\n';//debug
+         lseek(blk_out, pos-pos_delta+fk, SEEK_SET);
+         write(blk_out, buf + fk, last_buf_len - fk);             //skip first 4K of buf write out the rest
+         last_buf_len= (pos-td.fpos0 >= buf_len-fk)? buf_len-fk: pos-td.fpos0;   //bytes to read from blk_in
+         memcpy(buf + last_buf_len, buf, fk);                     //move first 4K of buf after zone will read
+         pos-= last_buf_len;
+         index_end += last_buf_len;cout << "seek blocks to " << pos << " read " << last_buf_len << " bytes before saved 4k\n";//debug
+         lseek(td.blk_in, pos, SEEK_SET);
+         did_read = read(td.blk_in, buf, last_buf_len);
+         EOS_ASSERT(did_read == last_buf_len, block_log_exception, "blocks.log read fails");
+         last_buf_len+= fk;                                       //bytes in buf will eventually write to disk
+      }
+   }
+
+   close(blk_out);
+   close(ind_out);
+   string old_log= (block_dir/"old.log").generic_string();
+   string old_ind= (block_dir/"old.index").generic_string();
+   rename(td.block_file_name,old_log);
+   rename(td.index_file_name,old_ind);
+   rename(block_out_filename,td.block_file_name);
+   rename(index_out_filename,td.index_file_name);
+   cout << "The new blocks.log and blocks.index files contain blocks " << n << " through " << td.last_block << '\n';
+   cout << "The original (before trim front) files have been renamed to old.log and old.index.\n";
+   return 0;
+}
+
 
 int make_index(bfs::path block_dir, string out_file) {
    //this code makes blocks.index much faster than nodeos (in recent test 80 seconds vs. 90 minutes)
    using namespace std;
    string block_file_name= (block_dir / "blocks.log").generic_string();
    string out_file_name=   (block_dir / out_file     ).generic_string();
-   cout << "Will read blocks.log file " << block_file_name << '\n';
-   cout << "Will write blocks.index file " << out_file_name << '\n';
+   cout << '\n';
+   cout << "Will read existing blocks.log file " << block_file_name << '\n';
+   cout << "Will write new blocks.index file " << out_file_name << '\n';
    int fin = open(block_file_name.c_str(), O_RDONLY);
    EOS_ASSERT( fin>0, block_log_not_found, "cannot read block file ${file}", ("file",block_file_name) );
 
    //will read big chunks of blocks.log into buf, will fill fpos_list with file positions before write to blocks.index
-   constexpr uint32_t bufLen{1U<<24};                       //bufLen must be power of 2 >= largest possible block == one MByte
-   auto buffer= make_unique<char[]>(bufLen+8);              //first 8 bytes of prior buf are put past end of current buf
+   constexpr uint32_t buf_len{1U<<24};                      //buf_len must be power of 2 >= largest possible block == one MByte
+   auto buffer= make_unique<char[]>(buf_len+8);             //can write up to 8 bytes past end of buf
    char* buf= buffer.get();
    constexpr uint64_t fpos_list_len{1U<<22};                //length of fpos_list[] in bytes
    auto fpos_buffer= make_unique<uint64_t[]>(fpos_list_len>>3);
    uint64_t* fpos_list= fpos_buffer.get();
 
    //read blocks.log to see if version 1 or 2 and get first_blocknum (implicit 1 if version 1)
-   uint32_t version=0, first_block;
+   uint32_t version=0, first_block=0;
    read(fin,(char*)&version,sizeof(version));
    cout << "block log version= " << version << '\n';
    EOS_ASSERT( version==1 || version==2, block_log_unsupported_version, "block log version ${v} is not supported", ("v",version));
@@ -276,39 +465,39 @@ int make_index(bfs::path block_dir, string out_file) {
    cout << "first block= " << first_block << '\n';
 
    uint64_t pos= lseek(fin,0,SEEK_END);                     //get blocks.log file length
-   uint64_t last_buf_len= pos & ((uint64_t)bufLen-1);       //bufLen is a power of 2 so -1 creates low bits all 1
-   if (!last_buf_len)                                       //will read integral number of bufLen and one time read last_buf_len
-      last_buf_len= bufLen;
-   pos= lseek(fin,-(uint64_t)last_buf_len,SEEK_END);
-   uint64_t did_read= read(fin,buf,last_buf_len);           //read tail of file into buf
+   uint64_t last_buf_len= pos & ((uint64_t)buf_len-1);      //buf_len is a power of 2 so -1 creates low bits all 1
+   if (!last_buf_len)                                       //will read integral number of buf_len and one time read last_buf_len
+      last_buf_len= buf_len;
+   pos= lseek(fin,-(uint64_t)last_buf_len,SEEK_END);        //one time read last_buf_len
+   uint64_t did_read= read(fin,buf,last_buf_len);           //read tail of blocks.log file into buf
    EOS_ASSERT( did_read==last_buf_len, block_log_exception, "blocks.log read fails" );
 
+   //we traverse linked list of blocks in buf (from end to start), for each block we know this:
    uint32_t index_start;                                    //buf index for block start
    uint32_t index_end;                                      //buf index for block end == buf index for block start file position
    uint64_t file_pos;                                       //file pos of block start
-   uint64_t last_file_pos;                                  //used to check that file_pos is strictly decreasing
-   Block_Start* bst;                                        //pointer to Block_Start
+   uint32_t bnum;                                           //block number
 
-   index_start= last_buf_len;                               //pretend a block starts just past end of buf then read prior block
-   index_end= index_start-8;                                //index in buf where block ends and block file position starts
-   last_file_pos= file_pos= *(uint64_t*)(buf+index_end);    //file pos of block start
+   index_end= last_buf_len-8;                               //index in buf where last block ends and block file position starts
+   file_pos= *(uint64_t*)(buf+index_end);                   //file pos of block start
    index_start= file_pos - pos;                             //buf index for block start
-   bst= (Block_Start*)(buf+index_start);                    //pointer to Block_Start
-   uint32_t last_block= endian_reverse_u32(bst->blknum);    //convert from big endian to little endian
-   uint32_t bnum= ++last_block;                             //add 1 since took block number from prior block id
-   cout << "last block=  " << last_block << '\n';
+   bnum= *(uint32_t*)(buf + index_start + blknum_offset);   //block number of previous block (is big endian)
+   bnum= endian_reverse_u32(bnum)+1;                        //convert from big endian to little endian and add 1
+   cout << "last block=  " << bnum << '\n';
    cout << '\n';
    cout << "block " << setw(10) << bnum << "    file_pos " << setw(14) << file_pos << '\n';  //first progress indicator
+   uint64_t last_file_pos= file_pos;                        //used to check that file_pos is strictly decreasing
+   uint32_t end_block{bnum};                                //save for message at end
 
    //we use low level file IO because it is distinctly faster than C++ filebuf or iostream
    mode_t mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH;     //if create file permissions will be 644
-   int fout = open(out_file_name.c_str(), O_WRONLY|O_CREAT|O_TRUNC, mode); //create if no exists, truncate if does exist
+   int fout = open(out_file_name.c_str(), O_WRONLY|O_CREAT|O_TRUNC, mode);
    EOS_ASSERT( fout>0, block_index_not_found, "cannot write blocks.index" );
 
-   uint64_t ind_file_len= bnum<<3;                          //index file holds 8 bytes per block in blocks.log
+   uint64_t ind_file_len= (bnum+1-first_block)<<3;                 //index file holds 8 bytes for each block in blocks.log
    uint64_t last_ind_buf_len= ind_file_len & (fpos_list_len-1);    //fpos_list_len is a power of 2 so -1 creates low bits all 1
-   if (!last_ind_buf_len)                                   //will write integral number of bufLen and last_ind_buf_len one time to index file
-      last_ind_buf_len= bufLen;
+   if (!last_ind_buf_len)                                   //will write integral number of buf_len and last_ind_buf_len one time to index file
+      last_ind_buf_len= buf_len;
    uint64_t ind_pos= lseek(fout,ind_file_len-last_ind_buf_len,SEEK_SET);
    uint64_t blk_base= (ind_pos>>3) + first_block;           //first entry in fpos_list is for block blk_base
    //cout << "ind_pos= " << ind_pos << "  blk_base= " << blk_base << '\n';
@@ -323,18 +512,18 @@ int make_index(bfs::path block_dir, string out_file) {
             break;
          }
          ind_pos-= fpos_list_len;
-         blk_base-= fpos_list_len>>3;
+         blk_base-= (fpos_list_len>>3);
          did_read= lseek(fout,ind_pos,SEEK_SET);
          EOS_ASSERT( did_read==ind_pos, block_log_exception, "blocks.log seek fails" );
          last_ind_buf_len= fpos_list_len;                   //from now on all writes to index file write a full fpos_list[]
       }
       if (index_start < 8) {                                //if block start is split across buf boundary
-         memcpy(buf+bufLen,buf,8);                          //copy portion at start of buf to past end of buf
-         pos-= bufLen;                                      //file position of buf
+         memcpy(buf+buf_len,buf,8);                         //copy portion at start of buf to past end of buf
+         pos-= buf_len;                                     //file position of buf
          lseek(fin,pos,SEEK_SET);
-         did_read= read(fin,buf,bufLen);                    //read next buf
-         EOS_ASSERT( did_read==bufLen, block_log_exception, "blocks.log read fails" );
-         index_start+= bufLen;
+         did_read= read(fin,buf,buf_len);                   //read next buf
+         EOS_ASSERT( did_read==buf_len, block_log_exception, "blocks.log read fails" );
+         index_start+= buf_len;
       }
       --bnum;                                               //now move index_start and index_end to prior block
       index_end= index_start-8;                             //index in buf where block ends and block file position starts
@@ -348,26 +537,52 @@ int make_index(bfs::path block_dir, string out_file) {
       }
       last_file_pos= file_pos;
       if (file_pos < pos) {                                 //if block start is in prior buf
-         pos-= bufLen;                                      //file position of buf
+         pos-= buf_len;                                     //file position of buf
          lseek(fin,pos,SEEK_SET);
-         did_read= read(fin,buf,bufLen);                    //read next buf
-         EOS_ASSERT( did_read==bufLen, block_log_exception, "blocks.log read fails" );
-         index_end+= bufLen;
+         did_read= read(fin,buf,buf_len);                   //read next buf
+         EOS_ASSERT( did_read==buf_len, block_log_exception, "blocks.log read fails" );
+         index_end+= buf_len;
       }
       index_start= file_pos - pos;                          //buf index for block start
-       fpos_list[bnum-blk_base]= file_pos;                  //write filepos for block bnum
+      fpos_list[bnum-blk_base]= file_pos;                   //write filepos for block bnum
       if ((bnum & 0xfffff) == 0)                            //periodically print a progress indicator
          cout << "block " << setw(10) << bnum << "    file_pos " << setw(14) << file_pos << '\n';
    }
 
    close(fout);
    close(fin);
-   cout << "\nwrote " << last_block << " file positions to " << out_file_name << '\n';
+   cout << "\nwrote " << (end_block+1-first_block) << " file positions to " << out_file_name << '\n';
    return 0;
 }
 
-int main(int argc, char** argv)
-{
+void smoke_test(bfs::path block_dir) {
+   using namespace std;
+   cout << "\nSmoke test of blocks.log and blocks.index in directory " << block_dir << '\n';
+   trim_data td(block_dir);
+   lseek(td.blk_in,-sizeof(uint64_t),SEEK_END);             //get last_block from blocks.log, compare to from blocks.index
+   uint64_t file_pos;
+   read(td.blk_in,&file_pos,sizeof(uint64_t));
+   lseek(td.blk_in,file_pos+blknum_offset,SEEK_SET);
+   uint32_t bnum;
+   read(td.blk_in,&bnum,sizeof(uint32_t));
+   bnum= endian_reverse_u32(bnum)+1;                        //convert from big endian to little endian and add 1
+   EOS_ASSERT( td.last_block==bnum, block_log_exception, "blocks.log says last block is ${lb} which disagrees with blocks.index", ("lb",bnum) );
+   cout << "blocks.log and blocks.index agree on number of blocks\n";
+   uint32_t delta= (td.last_block+8-td.first_block)>>3;
+   if (delta<1)
+      delta= 1;
+   for (uint32_t n= td.first_block; ; n+= delta) {
+      if (n>td.last_block)
+         n= td.last_block;
+      cout << '\n';
+      td.find_block_pos(n);                                 //check block 'n' is where blocks.index says
+      if (n==td.last_block)
+         break;
+   }
+   cout << "\nno problems found\n";                         //if get here there were no exceptions
+}
+
+int main(int argc, char** argv) {
    std::ios::sync_with_stdio(false); // for potential performance boost for large block log files
    options_description cli ("eosio-blocklog command line options");
    try {
@@ -376,22 +591,34 @@ int main(int argc, char** argv)
       variables_map vmap;
       bpo::store(bpo::parse_command_line(argc, argv, cli), vmap);
       bpo::notify(vmap);
-      if (vmap.count("help") > 0) {
-        cli.print(std::cerr);
-        return 0;
+      if (blog.help) {
+         cli.print(std::cerr);
+         return 0;
       }
-      if (vmap.at("trim-blocklog").as<bool>()) {
-         uint32_t last= vmap.at("last").as<uint32_t>();
-         if (last == std::numeric_limits<uint32_t>::max()) {   //if 'last' was not given on command line
-            std::cout << "'trim-block-blocklog' does nothing unless specify 'last' block.";
+      if (blog.smoke_test) {
+         smoke_test(vmap.at("blocks-dir").as<bfs::path>());
+         return 0;
+      }
+      if (blog.trim_log) {
+         if (blog.first_block==0 && blog.last_block==std::numeric_limits<uint32_t>::max()) {
+            std::cerr << "trim-blocklog does nothing unless specify first and/or last block.";
             return -1;
          }
-         return trunc_blocklog(vmap.at("blocks-dir").as<bfs::path>(), last);
+         if (blog.last_block != std::numeric_limits<uint32_t>::max()) {
+            if (trim_blocklog_end(vmap.at("blocks-dir").as<bfs::path>(), blog.last_block) != 0)
+               return -1;
+         }
+         if (blog.first_block != 0) {
+            if (trim_blocklog_front(vmap.at("blocks-dir").as<bfs::path>(), blog.first_block) != 0)
+               return -1;
+         }
+         return 0;
       }
-      if (vmap.at("make-index").as<bool>()) {
+      if (blog.make_index) {
          string out_file{vmap.count("output-file")==0? string("blocks.index"): vmap.at("output-file").as<bfs::path>().generic_string()};
          return make_index(vmap.at("blocks-dir").as<bfs::path>(), out_file);
       }
+      //else print blocks.log as JSON
       blog.initialize(vmap);
       blog.read_log();
    } catch( const fc::exception& e ) {

--- a/programs/eosio-blocklog/main.cpp
+++ b/programs/eosio-blocklog/main.cpp
@@ -210,14 +210,15 @@ constexpr int blknum_offset{14};                      //offset from start of blo
 struct trim_data {            //used by trim_blocklog_front(), trim_blocklog_end(), and smoke_test()
    trim_data(bfs::path block_dir);
    ~trim_data() {
-      close(blk_in);
-      close(ind_in);
+      fclose(blk_in);
+      fclose(ind_in);
    }
    void find_block_pos(uint32_t n);
-   std::string block_file_name, index_file_name;      //full pathname for blocks.log and blocks.index
+   bfs::path block_file_name, index_file_name;        //full pathname for blocks.log and blocks.index
    uint32_t version;                                  //blocklog version (1 or 2)
    uint32_t first_block, last_block;                  //first and last block in blocks.log
-   int blk_in, ind_in;                                //C style file descriptors for reading blocks.log and blocks.index
+   FILE* blk_in;                                      //C style files for reading blocks.log and blocks.index
+   FILE* ind_in;                                      //C style files for reading blocks.log and blocks.index
    //we use low level file IO because it is distinctly faster than C++ filebuf or iostream
    uint64_t index_pos;                                //filepos in blocks.index for block n, +8 for block n+1
    uint64_t fpos0, fpos1;                             //filepos in blocks.log for block n and block n+1
@@ -227,22 +228,27 @@ struct trim_data {            //used by trim_blocklog_front(), trim_blocklog_end
 trim_data::trim_data(bfs::path block_dir) {
    report_time rt;
    using namespace std;
-   block_file_name= (block_dir/"blocks.log").generic_string();
-   index_file_name= (block_dir/"blocks.index").generic_string();
-   blk_in = open(block_file_name.c_str(), O_RDONLY);
-   EOS_ASSERT( blk_in>0, block_log_not_found, "cannot read file ${file}", ("file",block_file_name) );
-   ind_in = open(index_file_name.c_str(), O_RDONLY);
-   EOS_ASSERT( ind_in>0, block_log_not_found, "cannot read file ${file}", ("file",index_file_name) );
-   read(blk_in,(char*)&version,sizeof(version));
+   block_file_name = block_dir / "blocks.log";
+   blk_in = fopen(block_file_name.c_str(), "r");
+   EOS_ASSERT( blk_in != nullptr, block_log_not_found, "cannot read file ${file}", ("file",block_file_name.string()) );
+   ind_in = fopen(index_file_name.c_str(), "r");
+   EOS_ASSERT( ind_in != nullptr, block_log_not_found, "cannot read file ${file}", ("file",index_file_name.string()) );
+   auto size = fread((void*)&version,sizeof(version), 1, blk_in);
+   EOS_ASSERT( size == 1, block_log_unsupported_version, "invalid format for file ${file}", ("file",block_file_name.string()));
    cout << "block log version= " << version << '\n';
-   EOS_ASSERT( version==1 || version==2, block_log_unsupported_version, "block log version ${v} is not supported", ("v",version));
+   EOS_ASSERT( version == 1 || version == 2, block_log_unsupported_version, "block log version ${v} is not supported", ("v",version));
    if (version == 1)
-      first_block= 1;
-   else
-      read(blk_in,(char*)&first_block,sizeof(first_block));
+      first_block = 1;
+   else {
+      size = fread((void *) &first_block, sizeof(first_block), 1, blk_in);
+      EOS_ASSERT(size == 1, block_log_exception, "invalid format for file ${file}",
+                 ("file", block_file_name.string()));
+   }
    cout << "first block= " << first_block << '\n';
-   uint64_t file_end= lseek(ind_in,0,SEEK_END);                //get length of blocks.index (gives number of blocks)
-   last_block= first_block + file_end/sizeof(uint64_t) - 1;
+   const auto status = fseek(ind_in, 0, SEEK_END);                //get length of blocks.index (gives number of blocks)
+   EOS_ASSERT( status == 0, block_log_exception, "cannot seek to ${file} end", ("file", index_file_name.string()) );
+   const uint64_t file_end = ftell(ind_in);                //get length of blocks.index (gives number of blocks)
+   last_block = first_block + file_end/sizeof(uint64_t) - 1;
    cout << "last block=  " << last_block << '\n';
    rt.report();
 }
@@ -252,33 +258,44 @@ void trim_data::find_block_pos(uint32_t n) {
    //sets fpos0 and fpos1, throws exception if block at fpos0 is not block n
    report_time rt;
    using namespace std;
-   index_pos= sizeof(uint64_t)*(n-first_block);
-   uint64_t pos= lseek(ind_in,index_pos,SEEK_SET);
-   EOS_ASSERT( pos==index_pos, block_log_exception, "cannot seek to blocks.index entry for block ${b}", ("b",n) );
-   read(ind_in,(char*)&fpos0,sizeof(fpos0));                   //filepos of block n
-   read(ind_in,(char*)&fpos1,sizeof(fpos1));                   //filepos of block n+1
+   index_pos = sizeof(uint64_t) * (n - first_block);
+   auto status = fseek(ind_in, index_pos, SEEK_SET);
+   EOS_ASSERT( status == 0, block_log_exception, "cannot seek to ${file} ${pos} from beginning of file for block ${b}", ("file", index_file_name.string())("pos", index_pos)("b",n) );
+   const uint64_t pos = ftell(ind_in);
+   EOS_ASSERT( pos == index_pos, block_log_exception, "cannot seek to ${file} entry for block ${b}", ("file", index_file_name.string())("b",n) );
+   auto size = fread((void*)&fpos0, sizeof(fpos0), 1, ind_in);                   //filepos of block n
+   EOS_ASSERT( size == 1, block_log_exception, "cannot read ${file} entry for block ${b}", ("file", index_file_name.string())("b",n) );
+   size = fread((void*)&fpos1,sizeof(fpos1), 1, ind_in);                   //filepos of block n+1
+   EOS_ASSERT( size == 1, block_log_exception, "cannot read ${file} entry for block ${b}", ("file", index_file_name.string())("b",n + 1) );
+
    cout << "According to blocks.index:\n";
    cout << "    block " << n << " starts at position " << fpos0 << '\n';
-   cout << "    block " << n+1;
+   cout << "    block " << n + 1;
+
    if (n!=last_block)
       cout << " starts at position " << fpos1 << '\n';
    else
       cout << " is past end\n";
+
    //read blocks.log and verify block number n is found at file position fpos0
-   lseek(blk_in,fpos0+blknum_offset,SEEK_SET);
+   status = fseek(blk_in, fpos0 + blknum_offset, SEEK_SET);
+   EOS_ASSERT( status == 0, block_log_exception, "cannot seek to ${file} ${pos} from beginning of file", ("file", block_file_name.string())("pos", fpos0 + blknum_offset) );
+   const uint64_t block_offset_pos = ftell(blk_in);
+   EOS_ASSERT( block_offset_pos == fpos0 + blknum_offset, block_log_exception, "cannot seek to ${file} ${pos} from beginning of file", ("file", block_file_name.string())("pos", fpos0 + blknum_offset) );
    uint32_t prior_blknum;
-   read(blk_in,(char*)&prior_blknum,sizeof(prior_blknum));     //read bigendian block number of prior block
-   uint32_t bnum= endian_reverse_u32(prior_blknum)+1;          //convert to little endian, add 1 since prior block
-   cout << "At position " << fpos0 << " in blocks.log find block " << bnum << (bnum==n? " as expected\n": " - not good!\n");
-   EOS_ASSERT( bnum==n, block_log_exception, "blocks.index does not agree with blocks.log" );
+   size = fread((void*)&prior_blknum, sizeof(prior_blknum), 1, blk_in);     //read bigendian block number of prior block
+   EOS_ASSERT( size == 1, block_log_exception, "cannot read prior block");
+   const uint32_t bnum = endian_reverse_u32(prior_blknum) + 1;          //convert to little endian, add 1 since prior block
+   cout << "At position " << fpos0 << " in " << index_file_name << " find block " << bnum << (bnum == n ? " as expected\n": " - not good!\n");
+   EOS_ASSERT( bnum == n, block_log_exception, "${index} does not agree with ${blocks}", ("index", index_file_name.string())("blocks", block_file_name.string()) );
    rt.report();
 }
 
 int trim_blocklog_end(bfs::path block_dir, uint32_t n) {       //n is last block to keep (remove later blocks)
    report_time rt;
    using namespace std;
-   cout << "\nIn directory " << block_dir << " will trim all blocks after block " << n << " from blocks.log and blocks.index.\n";
    trim_data td(block_dir);
+   cout << "\nIn directory " << block_dir << " will trim all blocks after block " << n << " from " << td.block_file_name << " and " << td.index_file_name << ".\n";
    if (n < td.first_block) {
       cerr << "All blocks are after block " << n << " so do nothing (trim_end would delete entire blocks.log)\n";
       return 1;
@@ -288,10 +305,9 @@ int trim_blocklog_end(bfs::path block_dir, uint32_t n) {       //n is last block
       return 2;
    }
    td.find_block_pos(n);
-   EOS_ASSERT( truncate(td.block_file_name.c_str(),td.fpos1)==0, block_log_exception, "truncate blocks.log fails");
-   uint64_t index_end= td.index_pos+sizeof(uint64_t);             //advance past record for block n
-   EOS_ASSERT( truncate(td.index_file_name.c_str(),index_end)==0, block_log_exception, "truncate blocks.index fails");
-   cout << "blocks.log has been trimmed to " << td.fpos1 << " bytes\n";
+   bfs::resize_file(td.block_file_name, td.fpos1);
+   uint64_t index_end= td.index_pos + sizeof(uint64_t);             //advance past record for block n
+   bfs::resize_file(td.index_file_name, index_end);
    cout << "blocks.index has been trimmed to " << index_end << " bytes\n";
    rt.report();
    return 0;
@@ -313,49 +329,61 @@ int trim_blocklog_front(bfs::path block_dir, uint32_t n) {        //n is first b
    td.find_block_pos(n);
 
    constexpr uint32_t buf_len{1U<<24};                            //buf_len must be a power of 2
-   auto buffer=  make_unique<char[]>(buf_len);                    //read big chunks of old blocks.log into this buffer
-   char* buf=  buffer.get();
+   auto buffer =  make_unique<char[]>(buf_len);                   //read big chunks of old blocks.log into this buffer
+   char* buf =  buffer.get();
 
-   string block_out_filename= (block_dir/"blocks.out").generic_string();
-   mode_t mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH;           //if create file the permissions will be 644
-   int blk_out = open(block_out_filename.c_str(), O_WRONLY|O_CREAT|O_TRUNC, mode);
-   EOS_ASSERT( blk_out>0, block_log_not_found, "cannot write ${file}", ("file",block_out_filename) );
+   bfs::path block_out_filename = block_dir / "blocks.out";
+   FILE* blk_out = fopen(block_out_filename.c_str(), "w");
+   EOS_ASSERT( blk_out != nullptr, block_log_not_found, "cannot write ${file}", ("file", block_out_filename.string()) );
 
    //in version 1 file: version number, no first block number, rest of header length 0x6e, at 0x72 first block
    //in version 2 file: version number, first block number,    rest of header length 0x6e, at 0x76 totem,  at 0x7e first block
-   *(uint32_t*)buf= 2;
-   write(blk_out,buf,sizeof(uint32_t));                           //write version number 2
-   write(blk_out,(char*)&n,sizeof(n));                            //write first block number
+   *(uint32_t*)buf = 2;
+   auto size = fwrite((void*)buf, sizeof(uint32_t), 1, blk_out);                           //write version number 2
+   EOS_ASSERT( size == 1, block_log_exception, "blocks.out write fails" );
+   size = fwrite((void*)&n, sizeof(n), 1, blk_out);                            //write first block number
+   EOS_ASSERT( size == 1, block_log_exception, "blocks.out write fails" );
 
-   lseek(td.blk_in,td.version==1? 4: 8,SEEK_SET) ;                //position past version number and maybe block number
-   read(td.blk_in,buf,0x6e);                                      //copy rest of header length 0x6e
-   memset(buf+0x6e,0xff,8);                                       //totem is 8 bytes of 0xff
-   write(blk_out,buf,0x6e + 8);                                   //write header and totem
+   const auto past_version_offset = (td.version == 1) ? 4 : 8;
+   auto status = fseek(td.blk_in, past_version_offset, SEEK_SET) ;                //position past version number and maybe block number
+   EOS_ASSERT( status == 0, block_log_exception, "cannot seek to ${file} ${pos} from beginning of file", ("file", td.block_file_name.string())("pos", past_version_offset) );
+   const auto header_len = 0x6e;
+   size = fread((void*)buf, header_len, 1, td.blk_in);
+   EOS_ASSERT( size == 1, block_log_exception, "blocks.log read fails" );
+   const auto totem_len = 8; //copy rest of header length 0x6e
+   memset(buf + header_len, 0xff, totem_len);                                       //totem is 8 bytes of 0xff
+   size = fwrite(buf, header_len + totem_len, 1, blk_out);                          //write header and totem
+   EOS_ASSERT( size == 1, block_log_exception, "blocks.out write fails" );
 
    //pos_delta is the amount to subtract from every file position record in blocks.log because the blocks < n are removed
-   uint64_t pos_delta= td.fpos0 - 0x7e;                           //bytes removed from the blocklog
+   uint64_t pos_delta = td.fpos0 - 0x7e;                           //bytes removed from the blocklog
    //bytes removed is file position of block n minus file position 'where file header ends'
    //even if version 1 blocklog 'where file header ends' is where the new version 2 file header of length 0x7e ends
 
    //read big chunks of blocks.log into buf, update the file position records, then write to blk_out
-   uint64_t pos= lseek(td.blk_in,0,SEEK_END);                     //get blocks.log file length
-   uint32_t last_buf_len= (pos-td.fpos0 >= buf_len)? buf_len: pos-td.fpos0; //bytes to read from blk_in
-   pos= lseek(td.blk_in,-(uint64_t)last_buf_len,SEEK_END);        //pos is where read last buf from blk_in
-   uint64_t did_read= read(td.blk_in,buf,last_buf_len);           //read tail of blocks.log file into buf
-   cout << "seek blocks.log to " << pos << " read " << last_buf_len << " bytes\n";//debug
-   EOS_ASSERT( did_read==last_buf_len, block_log_exception, "blocks.log read fails" );
+   status = fseek(td.blk_in, 0, SEEK_END);                     //get blocks.log file length
+   EOS_ASSERT( status == 0, block_log_exception, "cannot seek to ${file} ${pos} from end of file", ("file", td.block_file_name.string())("pos", 0) );
+   const uint64_t end = ftell(td.blk_in);
+   uint32_t last_buf_len = (end - td.fpos0 >= buf_len)? buf_len : end - td.fpos0; //bytes to read from blk_in
+   status = fseek(td.blk_in, -(uint64_t)last_buf_len, SEEK_END);        //pos is where read last buf from blk_in
+   EOS_ASSERT( status == 0, block_log_exception, "cannot seek to ${file} ${pos} from end of file", ("file", td.block_file_name.string())("pos", last_buf_len) );
+   uint64_t pos = ftell(td.blk_in);
+   EOS_ASSERT( pos == end - last_buf_len, block_log_exception, "cannot seek to ${file} ${pos} from end of file", ("file", td.block_file_name.string())("pos", last_buf_len) );
+   uint64_t did_read = fread((void*)buf, last_buf_len, 1, td.blk_in);           //read tail of blocks.log file into buf
+   cout << "seek " << td.block_file_name << " to " << pos << " read " << last_buf_len << " bytes\n";//debug
+   EOS_ASSERT( did_read == 1, block_log_exception, "${file} read fails", ("file", td.block_file_name.string()) );
 
    //prepare to write index_out_filename
-   uint64_t total_fpos_len= (td.last_block+1-n)*sizeof(uint64_t);
-   auto fpos_buffer= make_unique<uint64_t[]>(buf_len);
-   uint64_t* fpos_list= fpos_buffer.get();                        //list of file positions, periodically write to blocks.index
-   string index_out_filename= (block_dir/"index.out" ).generic_string();
-   int ind_out = open(index_out_filename.c_str(), O_WRONLY|O_CREAT|O_TRUNC, mode);
-   EOS_ASSERT( ind_out>0, block_log_not_found, "cannot write ${file}", ("file",index_out_filename) );
-   uint64_t last_fpos_len= total_fpos_len & ((uint64_t)buf_len-1);//buf_len is a power of 2 so -1 creates low bits all 1
+   uint64_t total_fpos_len = (td.last_block + 1 - n) * sizeof(uint64_t);
+   auto fpos_buffer = make_unique<uint64_t[]>(buf_len);
+   uint64_t* fpos_list = fpos_buffer.get();                        //list of file positions, periodically write to blocks.index
+   bfs::path index_out_filename = block_dir / "index.out";
+   FILE* ind_out = fopen(index_out_filename.c_str(), "w");
+   EOS_ASSERT( ind_out != nullptr, block_log_not_found, "cannot write ${file}", ("file",index_out_filename.string()) );
+   uint64_t last_fpos_len = total_fpos_len & ((uint64_t)buf_len - 1);//buf_len is a power of 2 so -1 creates low bits all 1
    if (!last_fpos_len)                                            //will write integral number of buf_len and one time write last_fpos_len
-      last_fpos_len= buf_len;
-   uint32_t blk_base= td.last_block + 1 - (last_fpos_len>>3);     //first entry in fpos_list is for block blk_base
+      last_fpos_len = buf_len;
+   uint32_t blk_base = td.last_block + 1 - (last_fpos_len >> 3);     //first entry in fpos_list is for block blk_base
    cout << "******filling index buf blk_base " << blk_base << " last_fpos_len " << last_fpos_len << '\n';//debug
 
    //as we traverse linked list of blocks in buf (from end toward start), for each block we know this:
@@ -365,17 +393,17 @@ int trim_blocklog_front(bfs::path block_dir, uint32_t n) {        //n is first b
    uint32_t bnum;                                                 //block number
 
    //some code here is repeated in the loop below but we do it twice so can print a status message before the loop starts
-   index_end= last_buf_len-8;                                     //buf index where last block ends and the block file position starts
-   file_pos= *(uint64_t*)(buf+index_end);                         //file pos of block start
-   index_start= file_pos - pos;                                   //buf index for block start
-   bnum= *(uint32_t*)(buf + index_start + blknum_offset);         //block number of previous block (is big endian)
-   bnum= endian_reverse_u32(bnum)+1;                              //convert from big endian to little endian and add 1
-   EOS_ASSERT( bnum==td.last_block, block_log_exception, "last block from blocks.index ${ind} != last block from blocks.log ${log}", ("ind", td.last_block) ("log", bnum) );
+   index_end = last_buf_len - 8;                                     //buf index where last block ends and the block file position starts
+   file_pos = *(uint64_t*)(buf + index_end);                         //file pos of block start
+   index_start = file_pos - pos;                                   //buf index for block start
+   bnum = *(uint32_t*)(buf + index_start + blknum_offset);         //block number of previous block (is big endian)
+   bnum = endian_reverse_u32(bnum) + 1;                              //convert from big endian to little endian and add 1
+   EOS_ASSERT( bnum == td.last_block, block_log_exception, "last block from ${index} ${ind} != last block from ${block} ${log}", ("index", td.index_file_name.string())("ind", td.last_block)("block", td.block_file_name.string())("log", bnum) );
 
    cout << '\n';                                                  //print header for periodic update messages
    cout << setw(10) << "block" << setw(16) << "old file pos" << setw(16) << "new file pos" << '\n';
    cout << setw(10) << bnum << setw(16) << file_pos << setw(16) << file_pos-pos_delta << '\n';
-   uint64_t last_file_pos= file_pos+1;                            //used to check that file_pos is strictly decreasing
+   uint64_t last_file_pos = file_pos + 1;                            //used to check that file_pos is strictly decreasing
    constexpr uint32_t fk{4096};                                   //buffer shift that keeps buf disk block aligned
 
    for (;;) {        //invariant: at top of loop index_end and bnum are set and index_end is >= 0
@@ -384,7 +412,7 @@ int trim_blocklog_front(bfs::path block_dir, uint32_t n) {        //n is first b
          cout << '\n';
          cout << "file pos for block " << bnum + 1 << " is " << last_file_pos << '\n';
          cout << "file pos for block " << bnum << " is " << file_pos << '\n';
-         EOS_ASSERT(file_pos < last_file_pos, block_log_exception, "blocks.log linked list of blocks is corrupt");
+         EOS_ASSERT(file_pos < last_file_pos, block_log_exception, "${file} linked list of blocks is corrupt", ("file", td.index_file_name.string()) );
       }
       last_file_pos = file_pos;
       *(uint64_t *) (buf + index_end) = file_pos - pos_delta;     //update file position in buf
@@ -396,15 +424,19 @@ int trim_blocklog_front(bfs::path block_dir, uint32_t n) {        //n is first b
 
       if (bnum == blk_base) {                                     //if fpos_list is full write it to file
          cout << "****** bnum=" << bnum << " blk_base= " << blk_base << " so write index buf seek to " << (blk_base - n) * sizeof(uint64_t) << " write len " << last_fpos_len << '\n';//debug
-         lseek(ind_out, (blk_base - n) * sizeof(uint64_t), SEEK_SET);
-         write(ind_out, (char *) fpos_list, last_fpos_len);       //write fpos_list to index file
+         status = fseek(ind_out, (blk_base - n) * sizeof(uint64_t), SEEK_SET);
+         EOS_ASSERT( status == 0, block_log_exception, "cannot seek to ${file} ${pos} from end of file", ("file", index_out_filename.string())("pos", last_buf_len) );
+         size = fwrite((void *) fpos_list, last_fpos_len, 1, ind_out);       //write fpos_list to index file
+         EOS_ASSERT( size == 1, block_log_exception, "${file} write fails", ("file", index_out_filename.string()) );
          last_fpos_len = buf_len;
          if (bnum == n) {                                         //if done with all blocks >= block n
             cout << setw(10) << bnum << setw(16) << file_pos << setw(16) << file_pos-pos_delta << '\n';
             EOS_ASSERT( index_start==0, block_log_exception, "block ${n} found with unexpected index_start ${s}", ("n",n) ("s",index_start));
             EOS_ASSERT( pos==td.fpos0, block_log_exception, "block ${n} found at unexpected file position ${p}", ("n",n) ("p",file_pos));
-            lseek(blk_out, pos-pos_delta, SEEK_SET);
-            write(blk_out, buf, last_buf_len);
+            status = fseek(blk_out, pos - pos_delta, SEEK_SET);
+            EOS_ASSERT( status == 0, block_log_exception, "cannot seek to ${file} ${pos} from beginning of file", ("file", index_out_filename.string())("pos", pos - pos_delta) );
+            size = fwrite((void*)buf, last_buf_len, 1, blk_out);
+            EOS_ASSERT( size == 1, block_log_exception, "${file} write fails", ("file", block_out_filename.string()) );
             break;
          } else {
             blk_base -= (buf_len>>3);
@@ -414,16 +446,19 @@ int trim_blocklog_front(bfs::path block_dir, uint32_t n) {        //n is first b
 
       if (index_start <= 0) {                                     //if buf is ready to write (all file pos are updated)
          //cout << "index_start = " << index_start << " so write buf len " << last_buf_len << " bnum= " << bnum << '\n';//debug
-         EOS_ASSERT(file_pos>td.fpos0, block_log_exception, "reverse scan of blocks.log did not halt at block ${n}",("n",n));
-         lseek(blk_out, pos-pos_delta, SEEK_SET);
-         write(blk_out, buf, last_buf_len);
-         last_buf_len= (pos-td.fpos0 > buf_len)? buf_len: pos-td.fpos0;
+         EOS_ASSERT(file_pos > td.fpos0, block_log_exception, "reverse scan of ${file} did not halt at block ${n}", ("file", td.block_file_name.string())("n",n));
+         status = fseek(blk_out, pos - pos_delta, SEEK_SET);
+         EOS_ASSERT( status == 0, block_log_exception, "cannot seek to ${file} ${pos} from end of file", ("file", block_out_filename.string())("pos", pos - pos_delta) );
+         size = fwrite((void*)buf, last_buf_len, 1, blk_out);
+         EOS_ASSERT( size == 1, block_log_exception, "${file} write fails", ("file", block_out_filename.string()) );
+         last_buf_len = (pos - td.fpos0 > buf_len) ? buf_len : pos - td.fpos0;
          pos -= last_buf_len;
          index_start += last_buf_len;
          //cout << "seek blocks to " << pos << " read " << last_buf_len << " bytes\n";//debug
-         lseek(td.blk_in, pos, SEEK_SET);
-         did_read = read(td.blk_in, buf, last_buf_len);           //read next buf from blocklog
-         EOS_ASSERT(did_read == last_buf_len, block_log_exception, "blocks.log read fails");
+         status = fseek(td.blk_in, pos, SEEK_SET);
+         EOS_ASSERT( status == 0, block_log_exception, "cannot seek to ${file} ${pos} from end of file", ("file", td.block_file_name.string())("pos", pos) );
+         did_read = fread((void*)buf, last_buf_len, 1, td.blk_in);           //read next buf from blocklog
+         EOS_ASSERT(did_read == 1, block_log_exception, "${file} read fails", ("file", td.index_file_name.string()));
       }
 
       index_end = index_start - sizeof(uint64_t);                 //move to prior block in buf
@@ -431,72 +466,83 @@ int trim_blocklog_front(bfs::path block_dir, uint32_t n) {        //n is first b
 
       if (index_end < 0) {                                        //the file pos record straddles buf boundary
          cout << "****  index_end= " << index_end << " so save buf-4K len= " << last_buf_len-fk << " bnum= " << bnum << '\n';//debug
-         lseek(blk_out, pos-pos_delta+fk, SEEK_SET);
-         write(blk_out, buf + fk, last_buf_len - fk);             //skip first 4K of buf write out the rest
-         last_buf_len= (pos-td.fpos0 >= buf_len-fk)? buf_len-fk: pos-td.fpos0;   //bytes to read from blk_in
+         status = fseek(blk_out, pos - pos_delta + fk, SEEK_SET);
+         EOS_ASSERT( status == 0, block_log_exception, "cannot seek to ${file} ${pos} from end of file", ("file", index_out_filename.string())("pos", pos - pos_delta + fk) );
+         size = fwrite((void*)(buf + fk), last_buf_len - fk, 1, blk_out);             //skip first 4K of buf write out the rest
+         EOS_ASSERT( size == 1, block_log_exception, "${file} write fails", ("file", index_out_filename.string()) );
+         last_buf_len = (pos - td.fpos0 >= buf_len - fk) ? buf_len - fk : pos - td.fpos0;   //bytes to read from blk_in
          memcpy(buf + last_buf_len, buf, fk);                     //move first 4K of buf after zone will read
          pos-= last_buf_len;
-         index_end += last_buf_len;cout << "seek blocks to " << pos << " read " << last_buf_len << " bytes before saved 4k\n";//debug
-         lseek(td.blk_in, pos, SEEK_SET);
-         did_read = read(td.blk_in, buf, last_buf_len);
-         EOS_ASSERT(did_read == last_buf_len, block_log_exception, "blocks.log read fails");
-         last_buf_len+= fk;                                       //bytes in buf will eventually write to disk
+         index_end += last_buf_len;
+         cout << "seek blocks to " << pos << " read " << last_buf_len << " bytes before saved 4k\n";//debug
+         status = fseek(td.blk_in, pos, SEEK_SET);
+         EOS_ASSERT( status == 0, block_log_exception, "cannot seek to ${file} ${pos} from end of file", ("file", td.block_file_name.string())("pos", pos) );
+         did_read = fread(buf, last_buf_len, 1, td.blk_in);
+         EOS_ASSERT(did_read == 1, block_log_exception, "${file} read fails", ("file", td.block_file_name.string()) );
+         last_buf_len += fk;                                       //bytes in buf will eventually write to disk
       }
    }
 
-   close(blk_out);
-   close(ind_out);
-   string old_log= (block_dir/"old.log").generic_string();
-   string old_ind= (block_dir/"old.index").generic_string();
-   rename(td.block_file_name,old_log);
-   rename(td.index_file_name,old_ind);
-   rename(block_out_filename,td.block_file_name);
-   rename(index_out_filename,td.index_file_name);
-   cout << "The new blocks.log and blocks.index files contain blocks " << n << " through " << td.last_block << '\n';
-   cout << "The original (before trim front) files have been renamed to old.log and old.index.\n";
+   fclose(blk_out);
+   fclose(ind_out);
+   bfs::path old_log = block_dir / "old.log";
+   bfs::path old_ind = block_dir / "old.index";
+   rename(td.block_file_name.c_str(), old_log.c_str());
+   rename(td.index_file_name.c_str(), old_ind.c_str());
+   rename(block_out_filename.c_str(), td.block_file_name.c_str());
+   rename(index_out_filename.c_str(), td.index_file_name.c_str());
+   cout << "The new " << td.block_file_name << " and " << td.index_file_name << " files contain blocks " << n << " through " << td.last_block << '\n';
+   cout << "The original (before trim front) files have been renamed to " << old_log << " and " << old_ind << ".\n";
    rt.report();
    return 0;
 }
 
 
-int make_index(bfs::path block_dir, string out_file) {
+int make_index(const bfs::path& block_dir, const bfs::path& out_file) {
    report_time rt;
    //this code makes blocks.index much faster than nodeos (in recent test 80 seconds vs. 90 minutes)
    using namespace std;
-   string block_file_name= (block_dir / "blocks.log").generic_string();
-   string out_file_name=   (block_dir / out_file     ).generic_string();
+   bfs::path block_file_name = block_dir / "blocks.log";
+   bfs::path out_file_name = block_dir / out_file;
    cout << '\n';
    cout << "Will read existing blocks.log file " << block_file_name << '\n';
    cout << "Will write new blocks.index file " << out_file_name << '\n';
-   int fin = open(block_file_name.c_str(), O_RDONLY);
-   EOS_ASSERT( fin>0, block_log_not_found, "cannot read block file ${file}", ("file",block_file_name) );
+   FILE* fin = fopen(block_file_name.c_str(), "r");
+   EOS_ASSERT( fin != nullptr, block_log_not_found, "cannot read block file ${file}", ("file", block_file_name.string()) );
 
    //will read big chunks of blocks.log into buf, will fill fpos_list with file positions before write to blocks.index
-   constexpr uint32_t buf_len{1U<<24};                      //buf_len must be power of 2 >= largest possible block == one MByte
-   auto buffer= make_unique<char[]>(buf_len+8);             //can write up to 8 bytes past end of buf
-   char* buf= buffer.get();
-   constexpr uint64_t fpos_list_len{1U<<22};                //length of fpos_list[] in bytes
-   auto fpos_buffer= make_unique<uint64_t[]>(fpos_list_len>>3);
-   uint64_t* fpos_list= fpos_buffer.get();
+   constexpr uint32_t buf_len{1U << 24};                      //buf_len must be power of 2 >= largest possible block == one MByte
+   auto buffer = make_unique<char[]>(buf_len + 8);            //can write up to 8 bytes past end of buf
+   char* buf = buffer.get();
+   constexpr uint64_t fpos_list_len{1U << 22};                //length of fpos_list[] in bytes
+   auto fpos_buffer = make_unique<uint64_t[]>(fpos_list_len >> 3);
+   uint64_t* fpos_list = fpos_buffer.get();
 
    //read blocks.log to see if version 1 or 2 and get first_blocknum (implicit 1 if version 1)
-   uint32_t version=0, first_block=0;
-   read(fin,(char*)&version,sizeof(version));
+   uint32_t version = 0, first_block = 0;
+   auto size = fread((char*)&version, sizeof(version), 1, fin);
+   EOS_ASSERT( size == 1, block_log_exception, "${file} read fails", ("file", block_file_name.string()) );
    cout << "block log version= " << version << '\n';
-   EOS_ASSERT( version==1 || version==2, block_log_unsupported_version, "block log version ${v} is not supported", ("v",version));
+   EOS_ASSERT( version == 1 || version == 2, block_log_unsupported_version, "block log version ${v} is not supported", ("v",version));
    if (version == 1)
-      first_block= 1;
-   else
-      read(fin,(char*)&first_block,sizeof(first_block));
+      first_block = 1;
+   else {
+      size = fread((void*)&first_block, sizeof(first_block), 1, fin);
+      EOS_ASSERT( size == 1, block_log_exception, "${file} read fails", ("file", block_file_name.string()) );
+   }
    cout << "first block= " << first_block << '\n';
 
-   uint64_t pos= lseek(fin,0,SEEK_END);                     //get blocks.log file length
-   uint64_t last_buf_len= pos & ((uint64_t)buf_len-1);      //buf_len is a power of 2 so -1 creates low bits all 1
+   auto status = fseek(fin, 0, SEEK_END);                    //get blocks.log file length
+   EOS_ASSERT( status == 0, block_log_exception, "cannot seek to ${file} ${pos} from end of file", ("file", block_file_name.string())("pos", 0) );
+   uint64_t pos = ftell(fin);
+   uint64_t last_buf_len = pos & ((uint64_t)buf_len-1);     //buf_len is a power of 2 so -1 creates low bits all 1
    if (!last_buf_len)                                       //will read integral number of buf_len and one time read last_buf_len
-      last_buf_len= buf_len;
-   pos= lseek(fin,-(uint64_t)last_buf_len,SEEK_END);        //one time read last_buf_len
-   uint64_t did_read= read(fin,buf,last_buf_len);           //read tail of blocks.log file into buf
-   EOS_ASSERT( did_read==last_buf_len, block_log_exception, "blocks.log read fails" );
+      last_buf_len = buf_len;
+   status = fseek(fin, -(uint64_t)last_buf_len, SEEK_END);     //one time read last_buf_len
+   EOS_ASSERT( status == 0, block_log_exception, "cannot seek to ${file} ${pos} from end of file", ("file", block_file_name.string())("pos", last_buf_len) );
+   pos = ftell(fin);
+   uint64_t did_read = fread((void*)buf, last_buf_len, 1, fin);//read tail of blocks.log file into buf
+   EOS_ASSERT( did_read == 1, block_log_exception, "blocks.log read fails" );
 
    //we traverse linked list of blocks in buf (from end to start), for each block we know this:
    uint32_t index_start;                                    //buf index for block start
@@ -504,79 +550,88 @@ int make_index(bfs::path block_dir, string out_file) {
    uint64_t file_pos;                                       //file pos of block start
    uint32_t bnum;                                           //block number
 
-   index_end= last_buf_len-8;                               //index in buf where last block ends and block file position starts
-   file_pos= *(uint64_t*)(buf+index_end);                   //file pos of block start
-   index_start= file_pos - pos;                             //buf index for block start
-   bnum= *(uint32_t*)(buf + index_start + blknum_offset);   //block number of previous block (is big endian)
-   bnum= endian_reverse_u32(bnum)+1;                        //convert from big endian to little endian and add 1
+   index_end = last_buf_len - 8;                            //index in buf where last block ends and block file position starts
+   cout << "last_buf_len=" << last_buf_len << " index_end=" << index_end <<  '\n';
+   file_pos = *(uint64_t*)(buf + index_end);                //file pos of block start
+   cout << "file_pos=" << file_pos << " buf=" << (uint64_t)buf <<  '\n';
+   index_start = file_pos - pos;                            //buf index for block start
+   bnum = *(uint32_t*)(buf + index_start + blknum_offset);  //block number of previous block (is big endian)
+   bnum = endian_reverse_u32(bnum) + 1;                     //convert from big endian to little endian and add 1
    cout << "last block=  " << bnum << '\n';
    cout << '\n';
    cout << "block " << setw(10) << bnum << "    file_pos " << setw(14) << file_pos << '\n';  //first progress indicator
-   uint64_t last_file_pos= file_pos;                        //used to check that file_pos is strictly decreasing
+   uint64_t last_file_pos = file_pos;                       //used to check that file_pos is strictly decreasing
    uint32_t end_block{bnum};                                //save for message at end
 
    //we use low level file IO because it is distinctly faster than C++ filebuf or iostream
-   mode_t mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH;     //if create file permissions will be 644
-   int fout = open(out_file_name.c_str(), O_WRONLY|O_CREAT|O_TRUNC, mode);
-   EOS_ASSERT( fout>0, block_index_not_found, "cannot write blocks.index" );
+   FILE* fout = fopen(out_file_name.c_str(), "w");
+   EOS_ASSERT( fout != nullptr, block_index_not_found, "cannot write blocks.index" );
 
-   uint64_t ind_file_len= (bnum+1-first_block)<<3;                 //index file holds 8 bytes for each block in blocks.log
-   uint64_t last_ind_buf_len= ind_file_len & (fpos_list_len-1);    //fpos_list_len is a power of 2 so -1 creates low bits all 1
-   if (!last_ind_buf_len)                                   //will write integral number of buf_len and last_ind_buf_len one time to index file
-      last_ind_buf_len= buf_len;
-   uint64_t ind_pos= lseek(fout,ind_file_len-last_ind_buf_len,SEEK_SET);
-   uint64_t blk_base= (ind_pos>>3) + first_block;           //first entry in fpos_list is for block blk_base
-   //cout << "ind_pos= " << ind_pos << "  blk_base= " << blk_base << '\n';
-   fpos_list[bnum-blk_base]= file_pos;                      //write filepos for block bnum
+   uint64_t ind_file_len = (bnum + 1 - first_block)<<3;            //index file holds 8 bytes for each block in blocks.log
+   uint64_t last_ind_buf_len = ind_file_len & (fpos_list_len - 1); //fpos_list_len is a power of 2 so -1 creates low bits all 1
+   if (!last_ind_buf_len)                                          //will write integral number of buf_len and last_ind_buf_len one time to index file
+      last_ind_buf_len = buf_len;
+   status = fseek(fout, ind_file_len - last_ind_buf_len, SEEK_SET);
+   EOS_ASSERT( status == 0, block_log_exception, "cannot seek to ${file} ${pos} from beginning of file", ("file", out_file_name.string())("pos", ind_file_len - last_ind_buf_len) );
+   uint64_t ind_pos = ftell(fout);
+   EOS_ASSERT( ind_pos == ind_file_len - last_ind_buf_len, block_log_exception, "cannot seek to ${file} ${pos} from beginning of file", ("file", out_file_name.string())("pos", ind_file_len - last_ind_buf_len) );
+   uint64_t blk_base = (ind_pos >> 3) + first_block;              //first entry in fpos_list is for block blk_base
+   cout << "ind_pos= " << ind_pos << "  blk_base= " << blk_base << '\n';
+   fpos_list[bnum - blk_base] = file_pos;                         //write filepos for block bnum
 
    for (;;) {
-      if (bnum==blk_base) {                                 //if fpos_list is full
-         write(fout,(char*)fpos_list,last_ind_buf_len);     //write fpos_list to index file
-         if (ind_pos==0) {                                  //if done writing index file
+      if (bnum == blk_base) {                                        //if fpos_list is full
+         size = fwrite((void*)fpos_list, last_ind_buf_len, 1, fout); //write fpos_list to index file
+         EOS_ASSERT( size == 1, block_log_exception, "${file} read fails", ("file", out_file_name.string()) );
+         if (ind_pos == 0) {                                         //if done writing index file
             cout << "block " << setw(10) << bnum << "    file_pos " << setw(14) << file_pos << '\n';  //last progress indicator
             EOS_ASSERT( bnum == first_block, block_log_exception, "blocks.log does not contain consecutive block numbers" );
             break;
          }
-         ind_pos-= fpos_list_len;
-         blk_base-= (fpos_list_len>>3);
-         did_read= lseek(fout,ind_pos,SEEK_SET);
-         EOS_ASSERT( did_read==ind_pos, block_log_exception, "blocks.log seek fails" );
-         last_ind_buf_len= fpos_list_len;                   //from now on all writes to index file write a full fpos_list[]
+         ind_pos -= fpos_list_len;
+         blk_base -= (fpos_list_len>>3);
+         status = fseek(fout, ind_pos, SEEK_SET);
+         EOS_ASSERT( status == 0, block_log_exception, "cannot seek to ${file} ${pos} from beginning of file", ("file", out_file_name.string())("pos", ind_pos) );
+         did_read = ftell(fout);
+         EOS_ASSERT( did_read == ind_pos, block_log_exception, "${file} seek fails", ("file", out_file_name.string()) );
+         last_ind_buf_len = fpos_list_len;                           //from now on all writes to index file write a full fpos_list[]
       }
       if (index_start < 8) {                                //if block start is split across buf boundary
-         memcpy(buf+buf_len,buf,8);                         //copy portion at start of buf to past end of buf
-         pos-= buf_len;                                     //file position of buf
-         lseek(fin,pos,SEEK_SET);
-         did_read= read(fin,buf,buf_len);                   //read next buf
-         EOS_ASSERT( did_read==buf_len, block_log_exception, "blocks.log read fails" );
-         index_start+= buf_len;
+         memcpy(buf + buf_len, buf, 8);                     //copy portion at start of buf to past end of buf
+         pos -= buf_len;                                    //file position of buf
+         status = fseek(fin, pos, SEEK_SET);
+         EOS_ASSERT( status == 0, block_log_exception, "cannot seek to ${file} ${pos} from beginning of file", ("file", block_file_name.string())("pos", pos) );
+         did_read = fread((void*)buf, buf_len, 1, fin);     //read next buf
+         EOS_ASSERT( did_read == 1, block_log_exception, "blocks.log read fails" );
+         index_start += buf_len;
       }
       --bnum;                                               //now move index_start and index_end to prior block
-      index_end= index_start-8;                             //index in buf where block ends and block file position starts
-      file_pos= *(uint64_t*)(buf+index_end);                //file pos of block start
+      index_end = index_start - 8;                          //index in buf where block ends and block file position starts
+      file_pos = *(uint64_t*)(buf + index_end);             //file pos of block start
       if (file_pos >= last_file_pos) {                      //file_pos will decrease if linked list is not corrupt
          cout << '\n';
          cout << "file pos for block " << bnum+1 << " is " << last_file_pos << '\n';
          cout << "file pos for block " << bnum   << " is " <<      file_pos << '\n';
          cout << "The linked list of blocks in blocks.log should run from last block to first block in reverse order\n";
-         EOS_ASSERT( file_pos<last_file_pos, block_log_exception, "blocks.log linked list of blocks is corrupt" );
+         EOS_ASSERT( file_pos < last_file_pos, block_log_exception, "blocks.log linked list of blocks is corrupt" );
       }
-      last_file_pos= file_pos;
+      last_file_pos = file_pos;
       if (file_pos < pos) {                                 //if block start is in prior buf
-         pos-= buf_len;                                     //file position of buf
-         lseek(fin,pos,SEEK_SET);
-         did_read= read(fin,buf,buf_len);                   //read next buf
-         EOS_ASSERT( did_read==buf_len, block_log_exception, "blocks.log read fails" );
-         index_end+= buf_len;
+         pos -= buf_len;                                    //file position of buf
+         status = fseek(fin, pos, SEEK_SET);
+         EOS_ASSERT( status == 0, block_log_exception, "cannot seek to ${file} ${pos} from beginning of file", ("file", block_file_name.string())("pos", pos) );
+         did_read = fread(buf, buf_len, 1, fin);            //read next buf
+         EOS_ASSERT( did_read == 1, block_log_exception, "blocks.log read fails" );
+         index_end += buf_len;
       }
-      index_start= file_pos - pos;                          //buf index for block start
-      fpos_list[bnum-blk_base]= file_pos;                   //write filepos for block bnum
-      if ((bnum & 0xfffff) == 0)                            //periodically print a progress indicator
+      index_start = file_pos - pos;                          //buf index for block start
+      fpos_list[bnum - blk_base]= file_pos;                  //write filepos for block bnum
+      if ((bnum & 0xfffff) == 0)                             //periodically print a progress indicator
          cout << "block " << setw(10) << bnum << "    file_pos " << setw(14) << file_pos << '\n';
    }
 
-   close(fout);
-   close(fin);
+   fclose(fout);
+   fclose(fin);
    cout << "\nwrote " << (end_block+1-first_block) << " file positions to " << out_file_name << '\n';
    rt.report();
    return 0;
@@ -586,24 +641,28 @@ void smoke_test(bfs::path block_dir) {
    using namespace std;
    cout << "\nSmoke test of blocks.log and blocks.index in directory " << block_dir << '\n';
    trim_data td(block_dir);
-   lseek(td.blk_in,-sizeof(uint64_t),SEEK_END);             //get last_block from blocks.log, compare to from blocks.index
+   auto status = fseek(td.blk_in, -sizeof(uint64_t), SEEK_END);             //get last_block from blocks.log, compare to from blocks.index
+   EOS_ASSERT( status == 0, block_log_exception, "cannot seek to ${file} ${pos} from beginning of file", ("file", td.block_file_name.string())("pos", sizeof(uint64_t)) );
    uint64_t file_pos;
-   read(td.blk_in,&file_pos,sizeof(uint64_t));
-   lseek(td.blk_in,file_pos+blknum_offset,SEEK_SET);
+   auto size = fread((void*)&file_pos, sizeof(uint64_t), 1, td.blk_in);
+   EOS_ASSERT( size == 1, block_log_exception, "${file} read fails", ("file", td.block_file_name.string()) );
+   status = fseek(td.blk_in, file_pos + blknum_offset, SEEK_SET);
+   EOS_ASSERT( status == 0, block_log_exception, "cannot seek to ${file} ${pos} from beginning of file", ("file", td.block_file_name.string())("pos", file_pos + blknum_offset) );
    uint32_t bnum;
-   read(td.blk_in,&bnum,sizeof(uint32_t));
-   bnum= endian_reverse_u32(bnum)+1;                        //convert from big endian to little endian and add 1
-   EOS_ASSERT( td.last_block==bnum, block_log_exception, "blocks.log says last block is ${lb} which disagrees with blocks.index", ("lb",bnum) );
+   size = fread((void*)&bnum, sizeof(uint32_t), 1, td.blk_in);
+   EOS_ASSERT( size == 1, block_log_exception, "${file} read fails", ("file", td.block_file_name.string()) );
+   bnum = endian_reverse_u32(bnum) + 1;                       //convert from big endian to little endian and add 1
+   EOS_ASSERT( td.last_block == bnum, block_log_exception, "blocks.log says last block is ${lb} which disagrees with blocks.index", ("lb", bnum) );
    cout << "blocks.log and blocks.index agree on number of blocks\n";
-   uint32_t delta= (td.last_block+8-td.first_block)>>3;
-   if (delta<1)
-      delta= 1;
-   for (uint32_t n= td.first_block; ; n+= delta) {
-      if (n>td.last_block)
-         n= td.last_block;
+   uint32_t delta = (td.last_block + 8 - td.first_block) >> 3;
+   if (delta < 1)
+      delta = 1;
+   for (uint32_t n = td.first_block; ; n += delta) {
+      if (n > td.last_block)
+         n = td.last_block;
       cout << '\n';
       td.find_block_pos(n);                                 //check block 'n' is where blocks.index says
-      if (n==td.last_block)
+      if (n == td.last_block)
          break;
    }
    cout << "\nno problems found\n";                         //if get here there were no exceptions
@@ -627,7 +686,7 @@ int main(int argc, char** argv) {
          return 0;
       }
       if (blog.trim_log) {
-         if (blog.first_block==0 && blog.last_block==std::numeric_limits<uint32_t>::max()) {
+         if (blog.first_block == 0 && blog.last_block == std::numeric_limits<uint32_t>::max()) {
             std::cerr << "trim-blocklog does nothing unless specify first and/or last block.";
             return -1;
          }
@@ -642,7 +701,9 @@ int main(int argc, char** argv) {
          return 0;
       }
       if (blog.make_index) {
-         string out_file{vmap.count("output-file")==0? string("blocks.index"): vmap.at("output-file").as<bfs::path>().generic_string()};
+         bfs::path out_file = "blocks.index";
+         if (vmap.count("output-file") == 0)
+             out_file = vmap.at("output-file").as<bfs::path>();
          return make_index(vmap.at("blocks-dir").as<bfs::path>(), out_file);
       }
       //else print blocks.log as JSON

--- a/programs/eosio-blocklog/main.cpp
+++ b/programs/eosio-blocklog/main.cpp
@@ -439,7 +439,7 @@ int trim_blocklog_front(bfs::path block_dir, uint32_t n) {        //n is first b
             EOS_ASSERT( size == 1, block_log_exception, "${file} write fails", ("file", block_out_filename.string()) );
             break;
          } else {
-            blk_base -= (buf_len>>3);
+            blk_base -= (buf_len >> 3);
             cout << "******filling index buf blk_base " << blk_base << " fpos_len " << buf_len << '\n';//debug
          }
       }
@@ -567,7 +567,7 @@ int make_index(const bfs::path& block_dir, const bfs::path& out_file) {
    FILE* fout = fopen(out_file_name.c_str(), "w");
    EOS_ASSERT( fout != nullptr, block_index_not_found, "cannot write blocks.index" );
 
-   uint64_t ind_file_len = (bnum + 1 - first_block)<<3;            //index file holds 8 bytes for each block in blocks.log
+   uint64_t ind_file_len = (bnum + 1 - first_block) << 3;            //index file holds 8 bytes for each block in blocks.log
    uint64_t last_ind_buf_len = ind_file_len & (fpos_list_len - 1); //fpos_list_len is a power of 2 so -1 creates low bits all 1
    if (!last_ind_buf_len)                                          //will write integral number of buf_len and last_ind_buf_len one time to index file
       last_ind_buf_len = buf_len;
@@ -589,7 +589,7 @@ int make_index(const bfs::path& block_dir, const bfs::path& out_file) {
             break;
          }
          ind_pos -= fpos_list_len;
-         blk_base -= (fpos_list_len>>3);
+         blk_base -= (fpos_list_len >> 3);
          status = fseek(fout, ind_pos, SEEK_SET);
          EOS_ASSERT( status == 0, block_log_exception, "cannot seek to ${file} ${pos} from beginning of file", ("file", out_file_name.string())("pos", ind_pos) );
          did_read = ftell(fout);

--- a/unittests/misc_tests.cpp
+++ b/unittests/misc_tests.cpp
@@ -13,6 +13,7 @@
 #include <fc/io/json.hpp>
 #include <fc/log/logger_config.hpp>
 #include <appbase/execution_priority_queue.hpp>
+#include <fc/bitutil.hpp>
 
 #include <boost/test/unit_test.hpp>
 
@@ -118,6 +119,14 @@ static constexpr uint64_t name_suffix( uint64_t n ) {
 }
 
 BOOST_AUTO_TEST_SUITE(misc_tests)
+
+BOOST_AUTO_TEST_CASE(reverse_endian_tests)
+{
+    BOOST_CHECK_EQUAL( endian_reverse_u64(0x0123456789abcdef), 0xefcdab8967452301 );
+    BOOST_CHECK_EQUAL( endian_reverse_u64(0x0102030405060708), 0x0807060504030201 );
+    BOOST_CHECK_EQUAL( endian_reverse_u32(0x01234567), 0x67452301 );
+    BOOST_CHECK_EQUAL( endian_reverse_u32(0x01020304), 0x04030201 );
+}
 
 BOOST_AUTO_TEST_CASE(name_suffix_tests)
 {


### PR DESCRIPTION
Added two new options to program eosio-blocklog:

1)   --trim-block-log  --last 'blkNum'
     This truncates the files blocks.log and blocks.index so last block is 'blkNum'.
     Runtime is < 1 second. Nodeos trim block log option can take over 1 hour.

2)  --make-index
     This creates blocks.index from blocks.log. Can specify output file if do not want to
      overwrite existing blocks.index.  Runtime for a recent test with 42e6 blocks in blocks.log
      was 80 seconds. Nodeos took 90 minutes to create the same blocks.index file.

I also added BOOST_AUTO_TEST_CASE(reverse_endian_tests) to unittests/misc_tests.cpp. I wrote a slightly smaller and faster implementation of endian_reverse_u64 and endian_reverse_u32 and initially updated fc/bitutil.hpp with this code and added the test to go with it. In the end I decided to not change the endian_reverse code because it was being done the most common way and future compilers might recognize what the intention was and provide highly optimized code. So I removed my slightly faster implementation (for one compiler at one point in time) but left the test in place.


In the future it might be a good idea to rename eosio-blocklog to eosio-nodeos-utils so additional new functions can be added.



