### PR TITLE
Modify the tester to activate builtin protocol features during init

### DIFF
--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -296,7 +296,7 @@ namespace eosio { namespace testing {
 
          void schedule_protocol_features_wo_preactivation(const vector<digest_type> feature_digests);
          void preactivate_protocol_features(const vector<digest_type> feature_digests);
-         void schedule_all_builtin_protocol_features();
+         void preactivate_all_builtin_protocol_features();
 
       protected:
          signed_block_ptr _produce_block( fc::microseconds skip_time, bool skip_pending_trxs = false, uint32_t skip_flag = 0 );

--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -92,7 +92,7 @@ namespace eosio { namespace testing {
 
          virtual ~base_tester() {};
 
-         void              init(const setup_policy policy = setup_policy::old_bios_only, db_read_mode read_mode = db_read_mode::SPECULATIVE);
+         void              init(const setup_policy policy = setup_policy::full, db_read_mode read_mode = db_read_mode::SPECULATIVE);
          void              init(controller::config config, const snapshot_reader_ptr& snapshot = nullptr);
          void              init(controller::config config, protocol_feature_manager&& pfm, const snapshot_reader_ptr& snapshot = nullptr);
          void              execute_setup_policy(const setup_policy policy);
@@ -319,7 +319,7 @@ namespace eosio { namespace testing {
 
    class tester : public base_tester {
    public:
-      tester(setup_policy policy = setup_policy::old_bios_only, db_read_mode read_mode = db_read_mode::SPECULATIVE ) {
+      tester(setup_policy policy = setup_policy::full, db_read_mode read_mode = db_read_mode::SPECULATIVE ) {
          init(policy, read_mode);
       }
 

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -79,11 +79,35 @@ namespace eosio { namespace testing {
       memcpy( data.data(), obj.value.data(), obj.value.size() );
    }
 
+   protocol_feature_manager make_protocol_feature_manager() {
+      protocol_feature_manager pfm;
+
+      set<builtin_protocol_feature_t> visited_builtins;
+
+      std::function<void(builtin_protocol_feature_t)> add_builtins =
+      [&pfm, &visited_builtins, &add_builtins]( builtin_protocol_feature_t codename ) -> void {
+         auto res = visited_builtins.emplace( codename );
+         if( !res.second ) return;
+
+         auto f = pfm.make_default_builtin_protocol_feature( codename, [&add_builtins]( builtin_protocol_feature_t d ) {
+            add_builtins( d );
+         } );
+
+         pfm.add_feature( f );
+      };
+
+      for( const auto& p : builtin_protocol_feature_codenames ) {
+         add_builtins( p.first );
+      }
+
+      return pfm;
+   }
+
    bool base_tester::is_same_chain( base_tester& other ) {
      return control->head_block_id() == other.control->head_block_id();
    }
 
-   void base_tester::init(bool push_genesis, db_read_mode read_mode) {
+   void base_tester::init(const setup_policy policy, db_read_mode read_mode) {
       cfg.blocks_dir      = tempdir.path() / config::default_blocks_dir_name;
       cfg.state_dir  = tempdir.path() / config::default_state_dir_name;
       cfg.state_size = 1024*1024*8;
@@ -104,31 +128,82 @@ namespace eosio { namespace testing {
       }
 
       open(nullptr);
-
-      if (push_genesis)
-         push_genesis_block();
+      execute_setup_policy(policy);
    }
-
 
    void base_tester::init(controller::config config, const snapshot_reader_ptr& snapshot) {
       cfg = config;
       open(snapshot);
    }
 
-   void base_tester::init(controller::config config, protocol_feature_manager&& pfm, const snapshot_reader_ptr& snapshot ) {
+   void base_tester::init(controller::config config, protocol_feature_manager&& pfm, const snapshot_reader_ptr& snapshot) {
       cfg = config;
       open(std::move(pfm), snapshot);
    }
 
+   void base_tester::execute_setup_policy(const setup_policy policy) {
+      const auto& pfm = control->get_protocol_feature_manager();
+
+      auto schedule_preactivate_protocol_feature = [&]() {
+         auto preactivate_feature_digest = pfm.get_builtin_digest(builtin_protocol_feature_t::preactivate_feature);
+         schedule_protocol_features_wo_preactivation({*preactivate_feature_digest});
+      };
+
+      auto schedule_all_builtin_protocol_features = [&]() {
+         const auto& head_block_num = control->head_block_num();
+         // Check all builtins and split them based on whether a preactivation is required or not
+         vector<digest_type> require_preactivation, without_preactivation;
+         for (auto itr = builtin_protocol_feature_codenames.begin(); itr != builtin_protocol_feature_codenames.end(); itr++) {
+            const auto& codename = itr->first;
+            if (pfm.is_builtin_activated(codename, head_block_num) || !itr->second.subjective_restrictions.enabled) continue;
+            const digest_type digest = *pfm.get_builtin_digest(codename);
+            if (itr->second.subjective_restrictions.preactivation_required) {
+               require_preactivation.emplace_back(digest);
+            } else {
+               without_preactivation.emplace_back(digest);
+            }
+         }
+         preactivate_protocol_features(require_preactivation);
+         schedule_protocol_features_wo_preactivation(without_preactivation);
+      };
+
+      switch (policy) {
+         case setup_policy::old_bios_only: {
+            set_before_preactivate_bios_contract();
+            break;
+         }
+         case setup_policy::preactivate_feature_only: {
+            schedule_preactivate_protocol_feature();
+            produce_block(); // block production is required to activate protocol feature
+            break;
+         }
+         case setup_policy::preactivate_feature_and_new_bios: {
+            schedule_preactivate_protocol_feature();
+            produce_block();
+            set_bios_contract();
+            break;
+         }
+         case setup_policy::full: {
+            schedule_preactivate_protocol_feature();
+            produce_block();
+            set_bios_contract();
+            schedule_all_builtin_protocol_features();
+            produce_block();
+            break;
+         }
+         case setup_policy::none:
+         default:
+            break;
+      };
+   }
 
    void base_tester::close() {
       control.reset();
       chain_transactions.clear();
    }
 
-
-   void base_tester::open( const snapshot_reader_ptr& snapshot) {
-      open( protocol_feature_manager{}, snapshot );
+   void base_tester::open( const snapshot_reader_ptr& snapshot ) {
+      open( make_protocol_feature_manager(), snapshot );
    }
 
    void base_tester::open( protocol_feature_manager&& pfm, const snapshot_reader_ptr& snapshot ) {
@@ -209,7 +284,26 @@ namespace eosio { namespace testing {
       }
 
       control->abort_block();
-      control->start_block( block_time, head_block_number - last_produced_block_num );
+
+      vector<digest_type> feature_to_be_activated;
+      // First add protocol features to be activated WITHOUT preactivation
+      feature_to_be_activated.insert(
+         feature_to_be_activated.end(),
+         protocol_features_to_be_activated_wo_preactivation.begin(),
+         protocol_features_to_be_activated_wo_preactivation.end()
+      );
+      // Then add protocol features to be activated WITH preactivation
+      const auto preactivated_protocol_features = control->get_preactivated_protocol_features();
+      feature_to_be_activated.insert(
+         feature_to_be_activated.end(),
+         preactivated_protocol_features.begin(),
+         preactivated_protocol_features.end()
+      );
+
+      control->start_block( block_time, head_block_number - last_produced_block_num, feature_to_be_activated );
+
+      // Clear the list, if start block finishes successfuly, the protocol features should be assumed to be activated
+      protocol_features_to_be_activated_wo_preactivation.clear();
    }
 
    signed_block_ptr base_tester::_finish_block() {
@@ -835,10 +929,16 @@ namespace eosio { namespace testing {
       sync_dbs(other, *this);
    }
 
-   void base_tester::push_genesis_block() {
+   void base_tester::set_before_preactivate_bios_contract() {
+      set_code(config::system_account_name, contracts::before_preactivate_eosio_bios_wasm());
+      set_abi(config::system_account_name, contracts::before_preactivate_eosio_bios_abi().data());
+   }
+
+   void base_tester::set_bios_contract() {
       set_code(config::system_account_name, contracts::eosio_bios_wasm());
       set_abi(config::system_account_name, contracts::eosio_bios_abi().data());
    }
+
 
    vector<producer_key> base_tester::get_producer_keys( const vector<account_name>& producer_names )const {
        // Create producer schedule
@@ -860,6 +960,41 @@ namespace eosio { namespace testing {
    const table_id_object* base_tester::find_table( name code, name scope, name table ) {
       auto tid = control->db().find<table_id_object, by_code_scope_table>(boost::make_tuple(code, scope, table));
       return tid;
+   }
+
+   void base_tester::schedule_protocol_features_wo_preactivation(const vector<digest_type> feature_digests) {
+      protocol_features_to_be_activated_wo_preactivation.insert(
+         protocol_features_to_be_activated_wo_preactivation.end(),
+         feature_digests.begin(),
+         feature_digests.end()
+      );
+   }
+
+   void base_tester::preactivate_protocol_features(const vector<digest_type> feature_digests) {
+      for (auto& feature_digest: feature_digests) {
+         push_action(config::system_account_name, N(preactivate_feature), N(eosio), fc::mutable_variant_object()("feature_digest", feature_digest));
+      }
+   }
+
+   void base_tester::schedule_all_builtin_protocol_features() {
+      const auto&pfm = control->get_protocol_feature_manager();
+      const auto& head_block_num = control->head_block_num();
+      // Check all builtins and split them based on whether a preactivation is required or not
+      vector<digest_type> require_preactivation;
+      vector<digest_type> without_preactivation;
+      for (auto itr = builtin_protocol_feature_codenames.begin(); itr != builtin_protocol_feature_codenames.end(); itr++) {
+         const auto& codename = itr->first;
+         if (pfm.is_builtin_activated(codename, head_block_num) || !itr->second.subjective_restrictions.enabled) continue;
+         const digest_type digest = *pfm.get_builtin_digest(codename);
+         if (itr->second.subjective_restrictions.preactivation_required) {
+            require_preactivation.emplace_back(digest);
+         } else {
+            without_preactivation.emplace_back(digest);
+         }
+      }
+
+      preactivate_protocol_features(require_preactivation);
+      schedule_protocol_features_wo_preactivation(without_preactivation);
    }
 
    bool fc_exception_message_is::operator()( const fc::exception& ex ) {

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -146,7 +146,7 @@ namespace eosio { namespace testing {
 
       auto schedule_preactivate_protocol_feature = [&]() {
          auto preactivate_feature_digest = pfm.get_builtin_digest(builtin_protocol_feature_t::preactivate_feature);
-         schedule_protocol_features_wo_preactivation({*preactivate_feature_digest});
+         schedule_protocol_features_wo_preactivation( { *preactivate_feature_digest } );
       };
 
       auto schedule_all_builtin_protocol_features = [&]() {

--- a/testnet.template
+++ b/testnet.template
@@ -75,7 +75,9 @@ wcmd create --to-console -n ignition
 # ------ DO NOT ALTER THE NEXT LINE -------
 ###INSERT prodkeys
 
-ecmd set contract eosio unittests/contracts/eosio.bios eosio.bios.wasm eosio.bios.abi
+# Use old bios contract for now (switch to new after adding changes to activate PREACTIVATE_FEATURE)
+ecmd set contract eosio unittests/contracts/old_versions/v1.6.0-rc3/eosio.bios eosio.bios.wasm eosio.bios.abi
+#ecmd set contract eosio unittests/contracts/eosio.bios eosio.bios.wasm eosio.bios.abi
 
 # Create required system accounts
 ecmd create key --to-console

--- a/tests/Cluster.py
+++ b/tests/Cluster.py
@@ -960,7 +960,8 @@ class Cluster(object):
             return None
 
         contract="eosio.bios"
-        contractDir="unittests/contracts/%s" % (contract)
+        #contractDir="unittests/contracts/%s" % (contract)
+        contractDir="unittests/contracts/old_versions/v1.6.0-rc3/%s" % (contract) # use old eosio.bios for now
         wasmFile="%s.wasm" % (contract)
         abiFile="%s.abi" % (contract)
         Utils.Print("Publish %s contract" % (contract))

--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -387,10 +387,10 @@ BOOST_FIXTURE_TEST_CASE(action_receipt_tests, TESTER) { try {
       BOOST_CHECK_EQUAL( m.begin()->second, base_test_auth_seq_num + 4 );
    } );
 
-   set_code( config::system_account_name, contracts::eosio_bios_wasm() );
+   set_code( config::system_account_name, contracts::before_preactivate_eosio_bios_wasm() );
 
-   set_code( N(test), contracts::eosio_bios_wasm() );
-   set_abi( N(test), contracts::eosio_bios_abi().data() );
+   set_code( N(test), contracts::before_preactivate_eosio_bios_wasm() );
+   set_abi( N(test), contracts::before_preactivate_eosio_bios_abi().data() );
 	set_code( N(test), contracts::payloadless_wasm() );
 
    call_doit_and_check( N(test), N(test), [&]( const transaction_trace_ptr& res ) {

--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -387,10 +387,10 @@ BOOST_FIXTURE_TEST_CASE(action_receipt_tests, TESTER) { try {
       BOOST_CHECK_EQUAL( m.begin()->second, base_test_auth_seq_num + 4 );
    } );
 
-   set_code( config::system_account_name, contracts::before_preactivate_eosio_bios_wasm() );
+   set_code( config::system_account_name, contracts::eosio_bios_wasm() );
 
-   set_code( N(test), contracts::before_preactivate_eosio_bios_wasm() );
-   set_abi( N(test), contracts::before_preactivate_eosio_bios_abi().data() );
+   set_code( N(test), contracts::eosio_bios_wasm() );
+   set_abi( N(test), contracts::eosio_bios_abi().data() );
 	set_code( N(test), contracts::payloadless_wasm() );
 
    call_doit_and_check( N(test), N(test), [&]( const transaction_trace_ptr& res ) {

--- a/unittests/forked_tests.cpp
+++ b/unittests/forked_tests.cpp
@@ -391,17 +391,17 @@ BOOST_AUTO_TEST_CASE( read_modes ) try {
    auto head_block_num = c.control->head_block_num();
    auto last_irreversible_block_num = c.control->last_irreversible_block_num();
 
-   tester head(true, db_read_mode::HEAD);
+   tester head(setup_policy::old_bios_only, db_read_mode::HEAD);
    push_blocks(c, head);
    BOOST_CHECK_EQUAL(head_block_num, head.control->fork_db_head_block_num());
    BOOST_CHECK_EQUAL(head_block_num, head.control->head_block_num());
 
-   tester read_only(false, db_read_mode::READ_ONLY);
+   tester read_only(setup_policy::none, db_read_mode::READ_ONLY);
    push_blocks(c, read_only);
    BOOST_CHECK_EQUAL(head_block_num, read_only.control->fork_db_head_block_num());
    BOOST_CHECK_EQUAL(head_block_num, read_only.control->head_block_num());
 
-   tester irreversible(true, db_read_mode::IRREVERSIBLE);
+   tester irreversible(setup_policy::old_bios_only, db_read_mode::IRREVERSIBLE);
    push_blocks(c, irreversible);
    BOOST_CHECK_EQUAL(head_block_num, irreversible.control->fork_db_pending_head_block_num());
    BOOST_CHECK_EQUAL(last_irreversible_block_num, irreversible.control->fork_db_head_block_num());
@@ -475,7 +475,7 @@ BOOST_AUTO_TEST_CASE( irreversible_mode ) try {
    BOOST_REQUIRE( hbn4 > hbn3 );
    BOOST_REQUIRE( lib4 < hbn1 );
 
-   tester irreversible(false, db_read_mode::IRREVERSIBLE);
+   tester irreversible(setup_policy::none, db_read_mode::IRREVERSIBLE);
 
    push_blocks( main, irreversible, hbn1 );
 

--- a/unittests/forked_tests.cpp
+++ b/unittests/forked_tests.cpp
@@ -136,8 +136,9 @@ BOOST_AUTO_TEST_CASE( fork_with_bad_block ) try {
 
 BOOST_AUTO_TEST_CASE( forking ) try {
    tester c;
-   c.produce_block();
-   c.produce_block();
+   while (c.control->head_block_num() < 3) {
+      c.produce_block();
+   }
    auto r = c.create_accounts( {N(dan),N(sam),N(pam)} );
    wdump((fc::json::to_pretty_string(r)));
    c.produce_block();
@@ -287,7 +288,9 @@ BOOST_AUTO_TEST_CASE( forking ) try {
  */
 BOOST_AUTO_TEST_CASE( prune_remove_branch ) try {
    tester c;
-   c.produce_blocks(10);
+   while (c.control->head_block_num() < 11) {
+      c.produce_block();
+   }
    auto r = c.create_accounts( {N(dan),N(sam),N(pam),N(scott)} );
    auto res = c.set_producers( {N(dan),N(sam),N(pam),N(scott)} );
    wlog("set producer schedule to [dan,sam,pam,scott]");
@@ -357,9 +360,7 @@ BOOST_AUTO_TEST_CASE( validator_accepts_valid_blocks ) try {
    block_state_ptr first_block;
 
    auto c = n2.control->accepted_block.connect( [&]( const block_state_ptr& bsp) {
-      if( bsp->block_num == 2 ) {
-         first_block = bsp;
-      }
+      first_block = bsp;
    } );
 
    push_blocks( n1, n2 );

--- a/unittests/producer_schedule_tests.cpp
+++ b/unittests/producer_schedule_tests.cpp
@@ -204,7 +204,9 @@ BOOST_AUTO_TEST_SUITE(producer_schedule_tests)
 
 BOOST_FIXTURE_TEST_CASE( producer_schedule_promotion_test, TESTER ) try {
    create_accounts( {N(alice),N(bob),N(carol)} );
-   produce_block();
+   while (control->head_block_num() < 3) {
+      produce_block();
+   }
 
    auto compare_schedules = [&]( const vector<producer_key>& a, const producer_schedule_type& b ) {
       return std::equal( a.begin(), a.end(), b.producers.begin(), b.producers.end() );
@@ -228,7 +230,7 @@ BOOST_FIXTURE_TEST_CASE( producer_schedule_promotion_test, TESTER ) try {
    produce_block(); // Starts new block which promotes the pending schedule to active
    BOOST_CHECK_EQUAL( control->active_producers().version, 1u );
    BOOST_CHECK_EQUAL( true, compare_schedules( sch1, control->active_producers() ) );
-   produce_blocks(7);
+   produce_blocks(6);
 
    res = set_producers( {N(alice),N(bob),N(carol)} );
    vector<producer_key> sch2 = {
@@ -267,7 +269,9 @@ BOOST_FIXTURE_TEST_CASE( producer_schedule_promotion_test, TESTER ) try {
 
 BOOST_FIXTURE_TEST_CASE( producer_schedule_reduction, tester ) try {
    create_accounts( {N(alice),N(bob),N(carol)} );
-   produce_block();
+   while (control->head_block_num() < 3) {
+      produce_block();
+   }
 
    auto compare_schedules = [&]( const vector<producer_key>& a, const producer_schedule_type& b ) {
       return std::equal( a.begin(), a.end(), b.producers.begin(), b.producers.end() );
@@ -291,7 +295,7 @@ BOOST_FIXTURE_TEST_CASE( producer_schedule_reduction, tester ) try {
    produce_block(); // Starts new block which promotes the pending schedule to active
    BOOST_CHECK_EQUAL( control->active_producers().version, 1u );
    BOOST_CHECK_EQUAL( true, compare_schedules( sch1, control->active_producers() ) );
-   produce_blocks(7);
+   produce_blocks(6);
 
    res = set_producers( {N(alice),N(bob)} );
    vector<producer_key> sch2 = {
@@ -324,7 +328,9 @@ BOOST_FIXTURE_TEST_CASE( producer_schedule_reduction, tester ) try {
 
 BOOST_FIXTURE_TEST_CASE( empty_producer_schedule_has_no_effect, tester ) try {
    create_accounts( {N(alice),N(bob),N(carol)} );
-   produce_block();
+   while (control->head_block_num() < 3) {
+      produce_block();
+   }
 
    auto compare_schedules = [&]( const vector<producer_key>& a, const producer_schedule_type& b ) {
       return std::equal( a.begin(), a.end(), b.producers.begin(), b.producers.end() );
@@ -350,7 +356,7 @@ BOOST_FIXTURE_TEST_CASE( empty_producer_schedule_has_no_effect, tester ) try {
    produce_block();
    BOOST_CHECK_EQUAL( control->active_producers().version, 1u );
    BOOST_CHECK_EQUAL( true, compare_schedules( sch1, control->active_producers() ) );
-   produce_blocks(7);
+   produce_blocks(6);
 
    res = set_producers( {} );
    wlog("set producer schedule to []");

--- a/unittests/protocol_feature_tests.cpp
+++ b/unittests/protocol_feature_tests.cpp
@@ -46,9 +46,7 @@ protocol_feature_manager make_protocol_feature_manager() {
 BOOST_AUTO_TEST_SUITE(protocol_feature_tests)
 
 BOOST_AUTO_TEST_CASE( activate_preactivate_feature ) try {
-   tester c(false, db_read_mode::SPECULATIVE);
-   c.close();
-   c.open( make_protocol_feature_manager(), nullptr );
+   tester c(setup_policy::none, db_read_mode::SPECULATIVE);
 
    const auto& pfm = c.control->get_protocol_feature_manager();
 
@@ -74,8 +72,7 @@ BOOST_AUTO_TEST_CASE( activate_preactivate_feature ) try {
    BOOST_REQUIRE( d );
 
    // Activate PREACTIVATE_FEATURE.
-   c.control->start_block( t, 0, { *d } );
-   c.finish_block();
+   c.schedule_protocol_features_wo_preactivation({ *d });
    c.produce_block();
 
    // Now the latest bios contract can be set.
@@ -98,10 +95,7 @@ BOOST_AUTO_TEST_CASE( activate_preactivate_feature ) try {
 
    // Ensure validator node accepts the blockchain
 
-   tester c2(false, db_read_mode::SPECULATIVE);
-   c2.close();
-   c2.open( make_protocol_feature_manager(), nullptr );
-
+   tester c2(setup_policy::none, db_read_mode::SPECULATIVE);
    push_blocks( c, c2 );
 
 } FC_LOG_AND_RETHROW()

--- a/unittests/protocol_feature_tests.cpp
+++ b/unittests/protocol_feature_tests.cpp
@@ -19,30 +19,6 @@
 using namespace eosio::chain;
 using namespace eosio::testing;
 
-protocol_feature_manager make_protocol_feature_manager() {
-   protocol_feature_manager pfm;
-
-   set<builtin_protocol_feature_t> visited_builtins;
-
-   std::function<void(builtin_protocol_feature_t)> add_builtins =
-   [&pfm, &visited_builtins, &add_builtins]( builtin_protocol_feature_t codename ) -> void {
-      auto res = visited_builtins.emplace( codename );
-      if( !res.second ) return;
-
-      auto f = pfm.make_default_builtin_protocol_feature( codename, [&add_builtins]( builtin_protocol_feature_t d ) {
-         add_builtins( d );
-      } );
-
-      pfm.add_feature( f );
-   };
-
-   for( const auto& p : builtin_protocol_feature_codenames ) {
-      add_builtins( p.first );
-   }
-
-   return pfm;
-}
-
 BOOST_AUTO_TEST_SUITE(protocol_feature_tests)
 
 BOOST_AUTO_TEST_CASE( activate_preactivate_feature ) try {


### PR DESCRIPTION
## Change Description

Modify the tester to activate builtin protocol features during init.
This change introduces different setup policy for the tester which are:
- none = do nothing extra during init
- old_bios_only = set the bios without preactivate_feature intrinsic during init
- preactivate_feature_only = activate PREACTIVATE_FEATURE protocol feature during init  (this will result in a side effect where an extra block is produced after the init)
- preactivate_feature_and_new_bios = same as preactivate_feature_only and then set the bios with preactivate_feature intrinsic after that (this will result in a side effect where an extra block is produced after the init)
- full = same as preactivate_feature_and_new_bios and then activate the remaining builtin protocol features after that (this will result in a side effect where two extra blocks are produced after the init)

The default setup policy will be full. Because two extra blocks are produced when the setup policy is full, this will break existing test cases that assume the initial block num is 1 (i.e. producer schedule test). This PR also performs any necessary modification to fix the breaking unit tests.

## Consensus Changes

No


## API Changes

No


## Documentation Additions

No
