### PR TITLE
Add EOS mainnet history API from MEET.ONE

### DIFF
--- a/plugins/COMMUNITY.md
+++ b/plugins/COMMUNITY.md
@@ -17,6 +17,7 @@ Third parties are encouraged to make pull requests to this file (`develop` branc
 | Chintai ZMQ Watcher | https://github.com/acoutts/chintai-zeromq-watcher-plugin |
 | Mongo History API | https://github.com/CryptoLions/EOS-mongo-history-API |
 | State History API | https://github.com/acoutts/EOS-state-history-API |
+| Mainnet History API | https://github.com/meet-one/EOS-mainnet-history-API |
 
 ## DISCLAIMER:
 


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- Give your PR a title that is sufficient to understand what is being changed. -->

## Change Description
Add EOS mainnet history API from MEET.ONE to plugins/COMMUNITY.md

## Consensus Changes
None

## API Changes
None

## Documentation Additions
This plugin should be mentioned in the doc portal here
[https://developers.eos.io/eosio-nodeos/docs/monitoring-with-3rd-party-plugins](https://developers.eos.io/eosio-nodeos/docs/monitoring-with-3rd-party-plugins)
