### PR TITLE
Make bnet plugin optional, on by default.  #6930

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,7 @@ endif()
 set(CMAKE_EXPORT_COMPILE_COMMANDS "ON")
 set(BUILD_DOXYGEN FALSE CACHE BOOL "Build doxygen documentation on every make")
 set(BUILD_MONGO_DB_PLUGIN FALSE CACHE BOOL "Build mongo database plugin")
+option(ENABLE_bnet_plugin "Build bnet plugin" ON)
 
 # add defaults for openssl
 if ("${OPENSSL_ROOT_DIR}" STREQUAL "")

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -1,4 +1,6 @@
-add_subdirectory(bnet_plugin)
+if(ENABLE_bnet_plugin)
+  add_subdirectory(bnet_plugin)
+endif()
 add_subdirectory(net_plugin)
 add_subdirectory(net_api_plugin)
 add_subdirectory(http_plugin)

--- a/programs/nodeos/CMakeLists.txt
+++ b/programs/nodeos/CMakeLists.txt
@@ -52,7 +52,6 @@ target_link_libraries( ${NODE_EXECUTABLE_NAME}
         PRIVATE -Wl,${whole_archive_flag} login_plugin               -Wl,${no_whole_archive_flag}
         PRIVATE -Wl,${whole_archive_flag} history_plugin             -Wl,${no_whole_archive_flag}
         PRIVATE -Wl,${whole_archive_flag} state_history_plugin       -Wl,${no_whole_archive_flag}
-        PRIVATE -Wl,${whole_archive_flag} bnet_plugin                -Wl,${no_whole_archive_flag}
         PRIVATE -Wl,${whole_archive_flag} history_api_plugin         -Wl,${no_whole_archive_flag}
         PRIVATE -Wl,${whole_archive_flag} chain_api_plugin           -Wl,${no_whole_archive_flag}
         PRIVATE -Wl,${whole_archive_flag} net_plugin                 -Wl,${no_whole_archive_flag}
@@ -66,6 +65,10 @@ target_link_libraries( ${NODE_EXECUTABLE_NAME}
         PRIVATE -Wl,${build_id_flag}
         PRIVATE chain_plugin http_plugin producer_plugin http_client_plugin
         PRIVATE eosio_chain fc ${CMAKE_DL_LIBS} ${PLATFORM_SPECIFIC_LIBS} )
+
+if(ENABLE_bnet_plugin)
+  target_link_libraries( ${NODE_EXECUTABLE_NAME} PRIVATE -Wl,${whole_archive_flag} bnet_plugin -Wl,${no_whole_archive_flag})
+endif()
 
 if(BUILD_MONGO_DB_PLUGIN)
   target_link_libraries( ${NODE_EXECUTABLE_NAME} PRIVATE -Wl,${whole_archive_flag} mongo_db_plugin -Wl,${no_whole_archive_flag} )


### PR DESCRIPTION
## Change Description
bnet plugin is largely unused.  Make building it optional.  Part of #6930.

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes


## Documentation Additions
- [x] Documentation Additions

CMake flag to make compiling and linking bnet plugin now defined: `ENABLE_bnet_plugin`.  Defaults to `ON`.  May be turned off with `cmake -DENABLE_bnet_plugin=OFF`