### PR TITLE
Fix build with Xcode 10.2 (in beta); disable experimental string_view

### DIFF
--- a/.pipelinebranch
+++ b/.pipelinebranch
@@ -1,0 +1,1 @@
+no_experimental_string_view

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,8 +122,10 @@ FIND_PACKAGE(Boost 1.67 REQUIRED COMPONENTS
     locale
     iostreams)
 
-# Some new stdlibc++s will #error on <experimental/string_view>
-add_definitions(-DBOOST_ASIO_DISABLE_STD_EXPERIMENTAL_STRING_VIEW)
+# Some new stdlibc++s will #error on <experimental/string_view>; a problem for boost pre-1.69
+if( APPLE AND UNIX )
+   add_definitions(-DBOOST_ASIO_DISABLE_STD_EXPERIMENTAL_STRING_VIEW)
+endif()
 
 if( WIN32 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,9 @@ FIND_PACKAGE(Boost 1.67 REQUIRED COMPONENTS
     locale
     iostreams)
 
+# Some new stdlibc++s will #error on <experimental/string_view>
+add_definitions(-DBOOST_ASIO_DISABLE_STD_EXPERIMENTAL_STRING_VIEW)
+
 if( WIN32 )
 
     message( STATUS "Configuring EOSIO on WIN32")

--- a/scripts/eosio_build.sh
+++ b/scripts/eosio_build.sh
@@ -63,12 +63,6 @@ export MONGO_C_DRIVER_VERSION=1.13.0
 export MONGO_C_DRIVER_ROOT=${SRC_LOCATION}/mongo-c-driver-${MONGO_C_DRIVER_VERSION}
 export MONGO_CXX_DRIVER_VERSION=3.4.0
 export MONGO_CXX_DRIVER_ROOT=${SRC_LOCATION}/mongo-cxx-driver-r${MONGO_CXX_DRIVER_VERSION}
-export BOOST_VERSION_MAJOR=1
-export BOOST_VERSION_MINOR=67
-export BOOST_VERSION_PATCH=0
-export BOOST_VERSION=${BOOST_VERSION_MAJOR}_${BOOST_VERSION_MINOR}_${BOOST_VERSION_PATCH}
-export BOOST_ROOT=${SRC_LOCATION}/boost_${BOOST_VERSION}
-export BOOST_LINK_LOCATION=${OPT_LOCATION}/boost
 export LLVM_VERSION=release_40
 export LLVM_ROOT=${OPT_LOCATION}/llvm
 export LLVM_DIR=${LLVM_ROOT}/lib/cmake/llvm
@@ -261,7 +255,20 @@ if [ "$ARCH" == "Darwin" ]; then
    CXX_COMPILER=clang++
    C_COMPILER=clang
    OPENSSL_ROOT_DIR=/usr/local/opt/openssl
+   
+   # temporarily upgrade to 1.68 for OSX to address issues with xcode 10.2
+   export BOOST_VERSION_MAJOR=1
+   export BOOST_VERSION_MINOR=68
+   export BOOST_VERSION_PATCH=0
+else
+   export BOOST_VERSION_MAJOR=1
+   export BOOST_VERSION_MINOR=67
+   export BOOST_VERSION_PATCH=0
 fi
+
+export BOOST_VERSION=${BOOST_VERSION_MAJOR}_${BOOST_VERSION_MINOR}_${BOOST_VERSION_PATCH}
+export BOOST_ROOT=${SRC_LOCATION}/boost_${BOOST_VERSION}
+export BOOST_LINK_LOCATION=${OPT_LOCATION}/boost
 
 # Cleanup old installation
 . ./scripts/full_uninstaller.sh $NONINTERACTIVE

--- a/scripts/eosio_build_darwin.sh
+++ b/scripts/eosio_build_darwin.sh
@@ -171,7 +171,7 @@ if [ "${BOOSTVERSION}" != "${BOOST_VERSION_MAJOR}0${BOOST_VERSION_MINOR}0${BOOST
 	&& tar -xjf boost_$BOOST_VERSION.tar.bz2 \
 	&& cd $BOOST_ROOT \
 	&& ./bootstrap.sh --prefix=$BOOST_ROOT \
-	&& ./b2 -q -j$(sysctl -in machdep.cpu.core_count) install \
+	&& ./b2 -q -j$(sysctl -in machdep.cpu.core_count) link=static,shared --layout=tagged threading=multi,single cxxflags=-std=c++14 cxxflags=-stdlib=libc++ linkflags=-stdlib=libc++ cxxflags=-DBOOST_ASIO_DISABLE_STD_EXPERIMENTAL_STRING_VIEW install \
 	&& cd .. \
 	&& rm -f boost_$BOOST_VERSION.tar.bz2 \
 	&& rm -rf $BOOST_LINK_LOCATION \


### PR DESCRIPTION

<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
The stdc++ lib that is included in Xcode 10.2 has an #error when including <experimental/string_view>. Boost asio, at least in 1.68 the latest on homebrew, will use  <experimental/string_view> when it exists and when compiling in c++14 mode.

Disable usage of  <experimental/string_view> for boost asio

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
