### PR TITLE
 Clean up wasm cache entries based on irreversibility & fix wavm module cleanup 

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -295,6 +295,8 @@ struct controller_impl {
          }
          emit(self.irreversible_block, s);
       }
+
+      wasmif.prune_wasm_cache(s->block_num);
    }
 
    void replay(std::function<bool()> shutdown) {

--- a/libraries/chain/eosio_contract.cpp
+++ b/libraries/chain/eosio_contract.cpp
@@ -150,6 +150,8 @@ void apply_eosio_setcode(apply_context& context) {
 
    EOS_ASSERT( account.code_version != code_id, set_exact_code, "contract is already running this version of code" );
 
+   context.control.get_wasm_interface().account_code_change(account.code_version, code_id, context.control.head_block_num());
+
    db.modify( account, [&]( auto& a ) {
       /** TODO: consider whether a microsecond level local timestamp is sufficient to detect code version changes*/
       // TODO: update setcode message to include the hash, then validate it in validate

--- a/libraries/chain/include/eosio/chain/wasm_interface.hpp
+++ b/libraries/chain/include/eosio/chain/wasm_interface.hpp
@@ -62,6 +62,12 @@ namespace eosio { namespace chain {
          //validates code -- does a WASM validation pass and checks the wasm against EOSIO specific constraints
          static void validate(const controller& control, const bytes& code);
 
+         //indicate when code has changed on an account, effectively reducing the reference count on
+         //the old one and increasing the reference count on the new one
+         void account_code_change(const digest_type& from, const digest_type& to, const uint32_t pending_block_num);
+
+         void prune_wasm_cache(const uint32_t through_block_num);
+
          //Calls apply or error on a given code
          void apply(const digest_type& code_id, const shared_string& code, apply_context& context);
 

--- a/libraries/chain/include/eosio/chain/webassembly/wavm.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/wavm.hpp
@@ -23,14 +23,6 @@ class wavm_runtime : public eosio::chain::wasm_runtime_interface {
       std::unique_ptr<wasm_instantiated_module_interface> instantiate_module(const char* code_bytes, size_t code_size, std::vector<uint8_t> initial_memory) override;
 
       void immediately_exit_currently_running_module() override;
-
-      struct runtime_guard {
-         runtime_guard();
-         ~runtime_guard();
-      };
-
-   private:
-      std::shared_ptr<runtime_guard> _runtime_guard;
 };
 
 //This is a temporary hack for the single threaded implementation


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
wasm cache entries have previously remained indefinitely creating a sort of memory leak. If using the wavm runtime this also creates a performance drag. This change is a naive fix to clean the wasm cache. It improves upon #2701 in that it waits for irreversibility before cleaning the cache (reducing cache thrashing around forks), and it also implements the garbage collection tracking for wavm so that wavm will actually free its instances.

Unfortunately there are still problems with this naive approach that makes this change not acceptable. For one, code instantiated on a fork that is thrown out is never pruned. More severely, code that is shared by multiple accounts tends to be overly pruned because getting a reference count of code used upon nodeos startup is required to avoid that.

This is mainly be put up as draft at this time to judge improvement with #6909. Unfortunately we still leave a _lot_ of performance on the table with wavm (nearly 50%) even with this fix but it should at least not grind to a halt any longer.


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
