### PR TITLE
Remove setting CMAKE_OSX_SYSROOT - 1.7.x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,14 +14,8 @@ endif()
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/libraries/fc/CMakeModules")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules")
 
-if (UNIX)
-   if (APPLE)
-      execute_process(COMMAND xcrun --show-sdk-path
-                      OUTPUT_VARIABLE CMAKE_OSX_SYSROOT
-                      OUTPUT_STRIP_TRAILING_WHITESPACE)
-      list(APPEND CMAKE_PREFIX_PATH "/usr/local/opt/llvm@4")
-      list(APPEND CMAKE_PREFIX_PATH "/usr/local/opt/gettext")
-   endif()
+if (UNIX AND APPLE)
+   list(APPEND CMAKE_PREFIX_PATH "/usr/local/opt/llvm@4" "/usr/local/opt/gettext")
 endif()
 
 include( GNUInstallDirs )


### PR DESCRIPTION


<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
Setting CMAKE_OSX_SYSROOT has shown to cause build failures on fresh macos 10.13 installs

I don't consider this something that would typically go in to a dot release. However, our CI fresh builds will continue to fail without it.

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
