### PR TITLE
Implement DISALLOW_EMPTY_PRODUCER_SCHEDULE protocol feature

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -2670,6 +2670,10 @@ int64_t controller::set_proposed_producers( vector<producer_key> producers ) {
    const auto& gpo = get_global_properties();
    auto cur_block_num = head_block_num() + 1;
 
+   if( producers.size() == 0 && is_builtin_activated( builtin_protocol_feature_t::disallow_empty_producer_schedule ) ) {
+      return -1;
+   }
+
    if( gpo.proposed_schedule_block_num.valid() ) {
       if( *gpo.proposed_schedule_block_num != cur_block_num )
          return -1; // there is already a proposed schedule set in a previous block, wait for it to become pending

--- a/libraries/chain/include/eosio/chain/protocol_feature_manager.hpp
+++ b/libraries/chain/include/eosio/chain/protocol_feature_manager.hpp
@@ -17,7 +17,8 @@ enum class builtin_protocol_feature_t : uint32_t {
    preactivate_feature,
    only_link_to_existing_permission,
    replace_deferred,
-   fix_linkauth_restriction
+   fix_linkauth_restriction,
+   disallow_empty_producer_schedule
 };
 
 struct protocol_feature_subjective_restrictions {

--- a/libraries/chain/protocol_feature_manager.cpp
+++ b/libraries/chain/protocol_feature_manager.cpp
@@ -65,6 +65,17 @@ updateauth, deleteauth, linkauth, unlinkauth, or canceldelay.
 */
             {}
          } )
+         (  builtin_protocol_feature_t::disallow_empty_producer_schedule, builtin_protocol_feature_spec{
+            "DISALLOW_EMPTY_PRODUCER_SCHEDULE",
+            fc::variant("2853617cec3eabd41881eb48882e6fc5e81a0db917d375057864b3befbe29acd").as<digest_type>(),
+            // SHA256 hash of the raw message below within the comment delimiters (do not modify message below).
+/*
+Builtin protocol feature: DISALLOW_EMPTY_PRODUCER_SCHEDULE
+
+Disallows proposing an empty producer schedule.
+*/
+            {}
+         } )
    ;
 
 

--- a/libraries/chain/wasm_interface.cpp
+++ b/libraries/chain/wasm_interface.cpp
@@ -168,6 +168,13 @@ class privileged_api : public context_aware_api {
          datastream<const char*> ds( packed_producer_schedule, datalen );
          vector<producer_key> producers;
          fc::raw::unpack(ds, producers);
+         EOS_ASSERT( producers.size() > 0
+                        || !context.control.is_builtin_activated(
+                              builtin_protocol_feature_t::disallow_empty_producer_schedule
+                           ),
+                     wasm_execution_error,
+                     "Producer schedule cannot be empty"
+         );
          EOS_ASSERT(producers.size() <= config::max_producers, wasm_execution_error, "Producer schedule exceeds the maximum producer count for this chain");
          // check that producers are unique
          std::set<account_name> unique_producers;

--- a/unittests/protocol_feature_tests.cpp
+++ b/unittests/protocol_feature_tests.cpp
@@ -485,4 +485,74 @@ BOOST_AUTO_TEST_CASE( replace_deferred_test ) try {
 
 } FC_LOG_AND_RETHROW()
 
+BOOST_AUTO_TEST_CASE( fix_linkauth_restriction ) { try {
+   tester chain( setup_policy::preactivate_feature_and_new_bios );
+
+   const auto& tester_account = N(tester);
+
+   chain.produce_blocks();
+   chain.create_account(N(currency));
+   chain.create_account(tester_account);
+   chain.produce_blocks();
+   
+   chain.push_action(config::system_account_name, updateauth::get_name(), tester_account, fc::mutable_variant_object()
+           ("account", name(tester_account).to_string())
+           ("permission", "first")
+           ("parent", "active")
+           ("auth",  authority(chain.get_public_key(tester_account, "first"), 5))
+   );
+
+   auto validate_disallow = [&] (const char *code, const char *type) {
+      BOOST_REQUIRE_EXCEPTION(
+         chain.push_action(config::system_account_name, linkauth::get_name(), tester_account, fc::mutable_variant_object()
+               ("account", name(tester_account).to_string())
+               ("code", code)
+               ("type", type)
+               ("requirement", "first")),
+         action_validate_exception,
+         fc_exception_message_is(std::string("Cannot link eosio::") + std::string(type) + std::string(" to a minimum permission"))
+      );
+   };
+
+   validate_disallow("eosio", "linkauth");
+   validate_disallow("eosio", "unlinkauth");
+   validate_disallow("eosio", "deleteauth");
+   validate_disallow("eosio", "updateauth");
+   validate_disallow("eosio", "canceldelay");
+
+   validate_disallow("currency", "linkauth");
+   validate_disallow("currency", "unlinkauth");
+   validate_disallow("currency", "deleteauth");
+   validate_disallow("currency", "updateauth");
+   validate_disallow("currency", "canceldelay");
+
+   const auto& pfm = chain.control->get_protocol_feature_manager();
+   auto d = pfm.get_builtin_digest( builtin_protocol_feature_t::fix_linkauth_restriction );
+   BOOST_REQUIRE( d );
+
+   chain.preactivate_protocol_features( {*d} );
+   chain.produce_block();
+
+   auto validate_allowed = [&] (const char *code, const char *type) {
+     chain.push_action(config::system_account_name, linkauth::get_name(), tester_account, fc::mutable_variant_object()
+            ("account", name(tester_account).to_string())
+            ("code", code)
+            ("type", type)
+            ("requirement", "first"));
+   };
+
+   validate_disallow("eosio", "linkauth");
+   validate_disallow("eosio", "unlinkauth");
+   validate_disallow("eosio", "deleteauth");
+   validate_disallow("eosio", "updateauth");
+   validate_disallow("eosio", "canceldelay");
+
+   validate_allowed("currency", "linkauth");
+   validate_allowed("currency", "unlinkauth");
+   validate_allowed("currency", "deleteauth");
+   validate_allowed("currency", "updateauth");
+   validate_allowed("currency", "canceldelay");
+
+} FC_LOG_AND_RETHROW() }
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/unittests/protocol_feature_tests.cpp
+++ b/unittests/protocol_feature_tests.cpp
@@ -494,7 +494,7 @@ BOOST_AUTO_TEST_CASE( fix_linkauth_restriction ) { try {
    chain.create_account(N(currency));
    chain.create_account(tester_account);
    chain.produce_blocks();
-   
+
    chain.push_action(config::system_account_name, updateauth::get_name(), tester_account, fc::mutable_variant_object()
            ("account", name(tester_account).to_string())
            ("permission", "first")
@@ -552,6 +552,33 @@ BOOST_AUTO_TEST_CASE( fix_linkauth_restriction ) { try {
    validate_allowed("currency", "deleteauth");
    validate_allowed("currency", "updateauth");
    validate_allowed("currency", "canceldelay");
+
+} FC_LOG_AND_RETHROW() }
+
+BOOST_AUTO_TEST_CASE( disallow_empty_producer_schedule_test ) { try {
+   tester c( setup_policy::preactivate_feature_and_new_bios );
+
+   const auto& pfm = c.control->get_protocol_feature_manager();
+   const auto& d = pfm.get_builtin_digest( builtin_protocol_feature_t::disallow_empty_producer_schedule );
+   BOOST_REQUIRE( d );
+
+   // Before activation, it is allowed to set empty producer schedule
+   c.set_producers( {} );
+
+   // After activation, it should not be allowed
+   c.preactivate_protocol_features( {*d} );
+   c.produce_block();
+   BOOST_REQUIRE_EXCEPTION( c.set_producers( {} ),
+                            wasm_execution_error,
+                            fc_exception_message_is( "Producer schedule cannot be empty" ) );
+
+   // Setting non empty producer schedule should still be fine
+   vector<name> producer_names = {N(alice),N(bob),N(carol)};
+   c.create_accounts( producer_names );
+   c.set_producers( producer_names );
+   c.produce_blocks(2);
+   const auto& schedule = c.get_producer_keys( producer_names );
+   BOOST_CHECK( std::equal( schedule.begin(), schedule.end(), c.control->active_producers().producers.begin()) );
 
 } FC_LOG_AND_RETHROW() }
 


### PR DESCRIPTION
## Change Description

Resolves #6458.

This PR adds support for the `DISALLOW_EMPTY_PRODUCER_SCHEDULE` protocol feature which disallows proposing an empty producer schedule.

## Consensus Changes
- [x] Consensus Changes

Makes the `DISALLOW_EMPTY_PRODUCER_SCHEDULE` protocol feature available. See above description and #6458 for details.

## API Changes
- [ ] API Changes


## Documentation Additions
- [ ] Documentation Additions

