### PR TITLE
Fix for close() called while async_read in-flight - v1.7.x

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -826,7 +826,6 @@ namespace eosio {
       fc_dlog(logger, "canceling wait on ${p}", ("p",peer_name()));
       cancel_wait();
       if( read_delay_timer ) read_delay_timer->cancel();
-      pending_message_buffer.reset();
    }
 
    void connection::txn_send_pending(const vector<transaction_id_type>& ids) {
@@ -1876,6 +1875,7 @@ namespace eosio {
       auto current_endpoint = *endpoint_itr;
       ++endpoint_itr;
       c->connecting = true;
+      c->pending_message_buffer.reset();
       connection_wptr weak_conn = c;
       c->socket->async_connect( current_endpoint, boost::asio::bind_executor( c->strand,
             [weak_conn, endpoint_itr, this]( const boost::system::error_code& err ) {
@@ -2051,7 +2051,7 @@ namespace eosio {
             [this,weak_conn]( boost::system::error_code ec, std::size_t bytes_transferred ) {
             app().post( priority::medium, [this,weak_conn, ec, bytes_transferred]() {
                auto conn = weak_conn.lock();
-               if (!conn) {
+               if (!conn || !conn->connected()) {
                   return;
                }
 

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2051,7 +2051,7 @@ namespace eosio {
             [this,weak_conn]( boost::system::error_code ec, std::size_t bytes_transferred ) {
             app().post( priority::medium, [this,weak_conn, ec, bytes_transferred]() {
                auto conn = weak_conn.lock();
-               if (!conn || !conn->connected()) {
+               if (!conn || !conn->socket || !conn->socket->is_open()) {
                   return;
                }
 


### PR DESCRIPTION
## Change Description

- Some high load tests failing after close of connection while async_read still in progress. This fix removes the reset of the `pending_message_buffer` from `close()` so that the buffer is still available for the in-flight `async_read`. Also added a quick exit if no longer connected in `async_read` handler.

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
