### PR TITLE
Use shared_future - v1.7.x

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -999,9 +999,10 @@ struct controller_impl {
          auto start = fc::time_point::now();
          const bool check_auth = !self.skip_auth_check() && !trx->implicit;
          // call recover keys so that trx->sig_cpu_usage is set correctly
-         const flat_set<public_key_type>& recovered_keys = check_auth ? trx->recover_keys( chain_id ) : flat_set<public_key_type>();
+         const fc::microseconds sig_cpu_usage = check_auth ? std::get<0>( trx->recover_keys( chain_id ) ) : fc::microseconds();
+         const flat_set<public_key_type>& recovered_keys = check_auth ? std::get<1>( trx->recover_keys( chain_id ) ) : flat_set<public_key_type>();
          if( !explicit_billed_cpu_time ) {
-            fc::microseconds already_consumed_time( EOS_PERCENT(trx->sig_cpu_usage.count(), conf.sig_cpu_bill_pct) );
+            fc::microseconds already_consumed_time( EOS_PERCENT(sig_cpu_usage.count(), conf.sig_cpu_bill_pct) );
 
             if( start.time_since_epoch() <  already_consumed_time ) {
                start = fc::time_point();
@@ -1199,7 +1200,7 @@ struct controller_impl {
                auto& pt = receipt.trx.get<packed_transaction>();
                auto mtrx = std::make_shared<transaction_metadata>( std::make_shared<packed_transaction>( pt ) );
                if( !self.skip_auth_check() ) {
-                  transaction_metadata::create_signing_keys_future( mtrx, thread_pool, chain_id, microseconds::maximum() );
+                  transaction_metadata::start_recover_keys( mtrx, thread_pool, chain_id, microseconds::maximum() );
                }
                packed_transactions.emplace_back( std::move( mtrx ) );
             }

--- a/libraries/chain/include/eosio/chain/transaction_metadata.hpp
+++ b/libraries/chain/include/eosio/chain/transaction_metadata.hpp
@@ -15,7 +15,8 @@ namespace eosio { namespace chain {
 
 class transaction_metadata;
 using transaction_metadata_ptr = std::shared_ptr<transaction_metadata>;
-using signing_keys_future_type = std::shared_future<std::tuple<chain_id_type, fc::microseconds, flat_set<public_key_type>>>;
+using signing_keys_future_value_type = std::tuple<chain_id_type, fc::microseconds, flat_set<public_key_type>>;
+using signing_keys_future_type = std::shared_future<signing_keys_future_value_type>;
 using recovery_keys_type = std::pair<fc::microseconds, const flat_set<public_key_type>&>;
 
 /**

--- a/libraries/chain/include/eosio/chain/transaction_metadata.hpp
+++ b/libraries/chain/include/eosio/chain/transaction_metadata.hpp
@@ -16,6 +16,8 @@ namespace eosio { namespace chain {
 class transaction_metadata;
 using transaction_metadata_ptr = std::shared_ptr<transaction_metadata>;
 using signing_keys_future_type = std::shared_future<std::tuple<chain_id_type, fc::microseconds, flat_set<public_key_type>>>;
+using recovery_keys_type = std::pair<fc::microseconds, const flat_set<public_key_type>&>;
+
 /**
  *  This data structure should store context-free cached data about a transaction such as
  *  packed/unpacked/compressed and recovered keys
@@ -25,8 +27,6 @@ class transaction_metadata {
       transaction_id_type                                        id;
       transaction_id_type                                        signed_id;
       packed_transaction_ptr                                     packed_trx;
-      fc::microseconds                                           sig_cpu_usage;
-      optional<pair<chain_id_type, flat_set<public_key_type>>>   signing_keys;
       signing_keys_future_type                                   signing_keys_future;
       bool                                                       accepted = false;
       bool                                                       implicit = false;
@@ -50,13 +50,14 @@ class transaction_metadata {
          signed_id = digest_type::hash(*packed_trx);
       }
 
-      const flat_set<public_key_type>& recover_keys( const chain_id_type& chain_id );
-
       // must be called from main application thread
-      // signing_keys_future should only be accessed by main application thread
       static signing_keys_future_type
-      create_signing_keys_future( const transaction_metadata_ptr& mtrx, boost::asio::thread_pool& thread_pool,
-                                  const chain_id_type& chain_id, fc::microseconds time_limit );
+      start_recover_keys( const transaction_metadata_ptr& mtrx, boost::asio::thread_pool& thread_pool,
+                          const chain_id_type& chain_id, fc::microseconds time_limit );
+
+      // start_recover_keys must be called first
+      recovery_keys_type recover_keys( const chain_id_type& chain_id );
+
 
 };
 

--- a/libraries/chain/include/eosio/chain/transaction_metadata.hpp
+++ b/libraries/chain/include/eosio/chain/transaction_metadata.hpp
@@ -15,6 +15,7 @@ namespace eosio { namespace chain {
 
 class transaction_metadata;
 using transaction_metadata_ptr = std::shared_ptr<transaction_metadata>;
+using signing_keys_future_type = std::shared_future<std::tuple<chain_id_type, fc::microseconds, flat_set<public_key_type>>>;
 /**
  *  This data structure should store context-free cached data about a transaction such as
  *  packed/unpacked/compressed and recovered keys
@@ -26,8 +27,7 @@ class transaction_metadata {
       packed_transaction_ptr                                     packed_trx;
       fc::microseconds                                           sig_cpu_usage;
       optional<pair<chain_id_type, flat_set<public_key_type>>>   signing_keys;
-      std::future<std::tuple<chain_id_type, fc::microseconds, flat_set<public_key_type>>>
-                                                                 signing_keys_future;
+      signing_keys_future_type                                   signing_keys_future;
       bool                                                       accepted = false;
       bool                                                       implicit = false;
       bool                                                       scheduled = false;
@@ -52,8 +52,11 @@ class transaction_metadata {
 
       const flat_set<public_key_type>& recover_keys( const chain_id_type& chain_id );
 
-      static void create_signing_keys_future( const transaction_metadata_ptr& mtrx, boost::asio::thread_pool& thread_pool,
-                                              const chain_id_type& chain_id, fc::microseconds time_limit );
+      // must be called from main application thread
+      // signing_keys_future should only be accessed by main application thread
+      static signing_keys_future_type
+      create_signing_keys_future( const transaction_metadata_ptr& mtrx, boost::asio::thread_pool& thread_pool,
+                                  const chain_id_type& chain_id, fc::microseconds time_limit );
 
 };
 

--- a/libraries/chain/transaction_metadata.cpp
+++ b/libraries/chain/transaction_metadata.cpp
@@ -23,10 +23,11 @@ const flat_set<public_key_type>& transaction_metadata::recover_keys( const chain
    return signing_keys->second;
 }
 
-void transaction_metadata::create_signing_keys_future( const transaction_metadata_ptr& mtrx,
-      boost::asio::thread_pool& thread_pool, const chain_id_type& chain_id, fc::microseconds time_limit ) {
+signing_keys_future_type transaction_metadata::create_signing_keys_future( const transaction_metadata_ptr& mtrx,
+      boost::asio::thread_pool& thread_pool, const chain_id_type& chain_id, fc::microseconds time_limit )
+{
    if( mtrx->signing_keys_future.valid() || mtrx->signing_keys.valid() ) // already created
-      return;
+      return mtrx->signing_keys_future;
 
    std::weak_ptr<transaction_metadata> mtrx_wp = mtrx;
    mtrx->signing_keys_future = async_thread_pool( thread_pool, [time_limit, chain_id, mtrx_wp]() {
@@ -41,6 +42,8 @@ void transaction_metadata::create_signing_keys_future( const transaction_metadat
       }
       return std::make_tuple( chain_id, cpu_usage, std::move( recovered_pub_keys ));
    } );
+
+   return mtrx->signing_keys_future;
 }
 
 

--- a/plugins/mongo_db_plugin/mongo_db_plugin.cpp
+++ b/plugins/mongo_db_plugin/mongo_db_plugin.cpp
@@ -779,8 +779,8 @@ void mongo_db_plugin_impl::_process_accepted_transaction( const chain::transacti
    }
 
    string signing_keys_json;
-   if( t->signing_keys.valid() ) {
-      signing_keys_json = fc::json::to_string( t->signing_keys->second );
+   if( t->signing_keys_future.valid() ) {
+      signing_keys_json = fc::json::to_string( std::get<2>( t->signing_keys_future.get() ) );
    } else {
       flat_set<public_key_type> keys;
       trx.get_signature_keys( *chain_id, fc::time_point::maximum(), keys, false );

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -351,10 +351,12 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
       void on_incoming_transaction_async(const transaction_metadata_ptr& trx, bool persist_until_expired, next_function<transaction_trace_ptr> next) {
          chain::controller& chain = chain_plug->chain();
          const auto& cfg = chain.get_global_properties().configuration;
-         transaction_metadata::create_signing_keys_future( trx, *_thread_pool, chain.get_chain_id(), fc::microseconds( cfg.max_transaction_cpu_usage ) );
-         boost::asio::post( *_thread_pool, [self = this, trx, persist_until_expired, next]() {
-            if( trx->signing_keys_future.valid() )
-               trx->signing_keys_future.wait();
+         signing_keys_future_type future =
+               transaction_metadata::create_signing_keys_future( trx, *_thread_pool, chain.get_chain_id(),
+                     fc::microseconds( cfg.max_transaction_cpu_usage ) );
+         boost::asio::post( *_thread_pool, [self = this, future, trx, persist_until_expired, next]() {
+            if( future.valid() )
+               future.wait();
             app().post(priority::low, [self, trx, persist_until_expired, next]() {
                self->process_incoming_transaction_async( trx, persist_until_expired, next );
             });

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -351,9 +351,8 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
       void on_incoming_transaction_async(const transaction_metadata_ptr& trx, bool persist_until_expired, next_function<transaction_trace_ptr> next) {
          chain::controller& chain = chain_plug->chain();
          const auto& cfg = chain.get_global_properties().configuration;
-         signing_keys_future_type future =
-               transaction_metadata::create_signing_keys_future( trx, *_thread_pool, chain.get_chain_id(),
-                     fc::microseconds( cfg.max_transaction_cpu_usage ) );
+         signing_keys_future_type future = transaction_metadata::start_recover_keys( trx, *_thread_pool,
+               chain.get_chain_id(), fc::microseconds( cfg.max_transaction_cpu_usage ) );
          boost::asio::post( *_thread_pool, [self = this, future, trx, persist_until_expired, next]() {
             if( future.valid() )
                future.wait();

--- a/unittests/misc_tests.cpp
+++ b/unittests/misc_tests.cpp
@@ -856,6 +856,17 @@ BOOST_AUTO_TEST_CASE(transaction_metadata_test) { try {
       BOOST_CHECK_EQUAL(1u, keys3.second.size());
       BOOST_CHECK_EQUAL(public_key, *keys3.second.begin());
 
+      // recover keys without first calling start_recover_keys
+      transaction_metadata_ptr mtrx4 = std::make_shared<transaction_metadata>( std::make_shared<packed_transaction>( trx, packed_transaction::none) );
+      transaction_metadata_ptr mtrx5 = std::make_shared<transaction_metadata>( std::make_shared<packed_transaction>( trx, packed_transaction::zlib) );
+
+      auto keys4 = mtrx4->recover_keys( test.control->get_chain_id() );
+      BOOST_CHECK_EQUAL(1u, keys4.second.size());
+      BOOST_CHECK_EQUAL(public_key, *keys4.second.begin());
+
+      auto keys5 = mtrx5->recover_keys( test.control->get_chain_id() );
+      BOOST_CHECK_EQUAL(1u, keys5.second.size());
+      BOOST_CHECK_EQUAL(public_key, *keys5.second.begin());
 
 } FC_LOG_AND_RETHROW() }
 

--- a/unittests/misc_tests.cpp
+++ b/unittests/misc_tests.cpp
@@ -833,28 +833,28 @@ BOOST_AUTO_TEST_CASE(transaction_metadata_test) { try {
       BOOST_CHECK( !mtrx->signing_keys_future.valid() );
       BOOST_CHECK( !mtrx2->signing_keys_future.valid() );
 
-      transaction_metadata::create_signing_keys_future( mtrx, thread_pool, test.control->get_chain_id(), fc::microseconds::maximum() );
-      transaction_metadata::create_signing_keys_future( mtrx2, thread_pool, test.control->get_chain_id(), fc::microseconds::maximum() );
+      transaction_metadata::start_recover_keys( mtrx, thread_pool, test.control->get_chain_id(), fc::microseconds::maximum() );
+      transaction_metadata::start_recover_keys( mtrx2, thread_pool, test.control->get_chain_id(), fc::microseconds::maximum() );
 
       BOOST_CHECK( mtrx->signing_keys_future.valid() );
       BOOST_CHECK( mtrx2->signing_keys_future.valid() );
 
       // no-op
-      transaction_metadata::create_signing_keys_future( mtrx, thread_pool, test.control->get_chain_id(), fc::microseconds::maximum() );
-      transaction_metadata::create_signing_keys_future( mtrx2, thread_pool, test.control->get_chain_id(), fc::microseconds::maximum() );
+      transaction_metadata::start_recover_keys( mtrx, thread_pool, test.control->get_chain_id(), fc::microseconds::maximum() );
+      transaction_metadata::start_recover_keys( mtrx2, thread_pool, test.control->get_chain_id(), fc::microseconds::maximum() );
 
       auto keys = mtrx->recover_keys( test.control->get_chain_id() );
-      BOOST_CHECK_EQUAL(1u, keys.size());
-      BOOST_CHECK_EQUAL(public_key, *keys.begin());
+      BOOST_CHECK_EQUAL(1u, keys.second.size());
+      BOOST_CHECK_EQUAL(public_key, *keys.second.begin());
 
       // again
-      keys = mtrx->recover_keys( test.control->get_chain_id() );
-      BOOST_CHECK_EQUAL(1u, keys.size());
-      BOOST_CHECK_EQUAL(public_key, *keys.begin());
+      auto keys2 = mtrx->recover_keys( test.control->get_chain_id() );
+      BOOST_CHECK_EQUAL(1u, keys2.second.size());
+      BOOST_CHECK_EQUAL(public_key, *keys2.second.begin());
 
-      auto keys2 = mtrx2->recover_keys( test.control->get_chain_id() );
-      BOOST_CHECK_EQUAL(1u, keys.size());
-      BOOST_CHECK_EQUAL(public_key, *keys.begin());
+      auto keys3 = mtrx2->recover_keys( test.control->get_chain_id() );
+      BOOST_CHECK_EQUAL(1u, keys3.second.size());
+      BOOST_CHECK_EQUAL(public_key, *keys3.second.begin());
 
 
 } FC_LOG_AND_RETHROW() }


### PR DESCRIPTION
## Change Description

- Since `transaction_metadata` future is accessed from multiple threads, use a `shared_future` which is thread safe.
- Simplified `recover_key` usage and removed storage of `sig_cpu_usage` and `signing_keys` since they are stored in the `shared_future`.

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
