### PR TITLE
Remove unwinding frames from WAVM code generation

### DIFF
--- a/libraries/chain/include/eosio/chain/webassembly/wavm.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/wavm.hpp
@@ -312,7 +312,12 @@ struct intrinsic_invoker_impl<Ret, std::tuple<>, std::tuple<Translated...>> {
 
    template<next_method_type Method>
    static native_to_wasm_t<Ret> invoke(Translated... translated) {
-      return convert_native_to_wasm(the_running_instance_context, Method(the_running_instance_context, translated...));
+      try {
+         return convert_native_to_wasm(the_running_instance_context, Method(the_running_instance_context, translated...));
+      }
+      catch(...) {
+         Platform::immediately_exit(std::current_exception());
+      }
    }
 
    template<next_method_type Method>
@@ -331,7 +336,12 @@ struct intrinsic_invoker_impl<void_type, std::tuple<>, std::tuple<Translated...>
 
    template<next_method_type Method>
    static void invoke(Translated... translated) {
-      Method(the_running_instance_context, translated...);
+      try {
+         Method(the_running_instance_context, translated...);
+      }
+      catch(...) {
+         Platform::immediately_exit(std::current_exception());
+      }
    }
 
    template<next_method_type Method>

--- a/libraries/chain/webassembly/wavm.cpp
+++ b/libraries/chain/webassembly/wavm.cpp
@@ -131,7 +131,7 @@ void wavm_runtime::immediately_exit_currently_running_module() {
 #ifdef _WIN32
    throw wasm_exit();
 #else
-   Platform::immediately_exit();
+   Platform::immediately_exit(nullptr);
 #endif
 }
 

--- a/libraries/wasm-jit/Include/Platform/Platform.h
+++ b/libraries/wasm-jit/Include/Platform/Platform.h
@@ -134,7 +134,7 @@ namespace Platform
 		Uptr& outTrapOperand,
 		const std::function<void()>& thunk
 		);
-	PLATFORM_API void immediately_exit(std::exception_ptr except) __attribute__((noreturn));
+	PLATFORM_API [[noreturn]] void immediately_exit(std::exception_ptr except);
 
 	//
 	// Threading

--- a/libraries/wasm-jit/Include/Platform/Platform.h
+++ b/libraries/wasm-jit/Include/Platform/Platform.h
@@ -134,7 +134,7 @@ namespace Platform
 		Uptr& outTrapOperand,
 		const std::function<void()>& thunk
 		);
-	PLATFORM_API void immediately_exit();
+	PLATFORM_API void immediately_exit(std::exception_ptr except) __attribute__((noreturn));
 
 	//
 	// Threading

--- a/libraries/wasm-jit/Source/Platform/Windows.cpp
+++ b/libraries/wasm-jit/Source/Platform/Windows.cpp
@@ -359,6 +359,10 @@ namespace Platform
 	{
 		errorUnless(SetEvent(reinterpret_cast<HANDLE>(event)));
 	}
+
+	void immediately_exit(std::exception_ptr except) {
+		std::rethrow_exception(except);
+	}
 }
 
 #endif

--- a/libraries/wasm-jit/Source/Runtime/LLVMJIT.cpp
+++ b/libraries/wasm-jit/Source/Runtime/LLVMJIT.cpp
@@ -112,15 +112,9 @@ namespace LLVMJIT
 		
 		void registerEHFrames(U8* addr, U64 loadAddr,uintptr_t numBytes) override
 		{
-			llvm::RTDyldMemoryManager::registerEHFrames(addr,loadAddr,numBytes);
-			hasRegisteredEHFrames = true;
-			ehFramesAddr = addr;
-			ehFramesLoadAddr = loadAddr;
-			ehFramesNumBytes = numBytes;
 		}
 		void deregisterEHFrames(U8* addr, U64 loadAddr,uintptr_t numBytes) override
 		{
-			llvm::RTDyldMemoryManager::deregisterEHFrames(addr,loadAddr,numBytes);
 		}
 		
 		virtual bool needsToReserveAllocationSpace() override { return true; }

--- a/libraries/wasm-jit/Source/Runtime/WAVMIntrinsics.cpp
+++ b/libraries/wasm-jit/Source/Runtime/WAVMIntrinsics.cpp
@@ -8,6 +8,11 @@
 
 namespace Runtime
 {
+	static void causeIntrensicException(Exception::Cause cause) {
+		Platform::immediately_exit(std::make_exception_ptr(Exception{cause, std::vector<std::string>()}));
+		__builtin_unreachable();
+   }
+
 	template<typename Float>
 	Float quietNaN(Float value)
 	{
@@ -104,11 +109,11 @@ namespace Runtime
 	{
 		if(sourceValue != sourceValue)
 		{
-			causeException(Exception::Cause::invalidFloatOperation);
+			causeIntrensicException(Exception::Cause::invalidFloatOperation);
 		}
 		else if(sourceValue >= maxValue || (isMinInclusive ? sourceValue <= minValue : sourceValue < minValue))
 		{
-			causeException(Exception::Cause::integerDivideByZeroOrIntegerOverflow);
+			causeIntrensicException(Exception::Cause::integerDivideByZeroOrIntegerOverflow);
 		}
 		return (Dest)sourceValue;
 	}
@@ -125,17 +130,17 @@ namespace Runtime
 
 	DEFINE_INTRINSIC_FUNCTION0(wavmIntrinsics,divideByZeroOrIntegerOverflowTrap,divideByZeroOrIntegerOverflowTrap,none)
 	{
-		causeException(Exception::Cause::integerDivideByZeroOrIntegerOverflow);
+		causeIntrensicException(Exception::Cause::integerDivideByZeroOrIntegerOverflow);
 	}
 
 	DEFINE_INTRINSIC_FUNCTION0(wavmIntrinsics,unreachableTrap,unreachableTrap,none)
 	{
-		causeException(Exception::Cause::reachedUnreachable);
+		causeIntrensicException(Exception::Cause::reachedUnreachable);
 	}
 	
 	DEFINE_INTRINSIC_FUNCTION0(wavmIntrinsics,accessViolationTrap,accessViolationTrap,none)
 	{
-		causeException(Exception::Cause::accessViolation);
+		causeIntrensicException(Exception::Cause::accessViolation);
 	}
 
 	DEFINE_INTRINSIC_FUNCTION3(wavmIntrinsics,indirectCallSignatureMismatch,indirectCallSignatureMismatch,none,i32,index,i64,expectedSignatureBits,i64,tableBits)
@@ -152,18 +157,19 @@ namespace Runtime
 			actualSignature ? asString(actualSignature).c_str() : "nullptr",
 			ipDescription.c_str()
 			);
-		causeException(elementValue == nullptr ? Exception::Cause::undefinedTableElement : Exception::Cause::indirectCallSignatureMismatch);
+		causeIntrensicException(elementValue == nullptr ? Exception::Cause::undefinedTableElement : Exception::Cause::indirectCallSignatureMismatch);
 	}
 
 	DEFINE_INTRINSIC_FUNCTION0(wavmIntrinsics,indirectCallIndexOutOfBounds,indirectCallIndexOutOfBounds,none)
 	{
-		causeException(Exception::Cause::undefinedTableElement);
+		causeIntrensicException(Exception::Cause::undefinedTableElement);
 	}
 
 	DEFINE_INTRINSIC_FUNCTION2(wavmIntrinsics,_growMemory,growMemory,i32,i32,deltaPages,i64,memoryBits)
 	{
 		MemoryInstance* memory = reinterpret_cast<MemoryInstance*>(memoryBits);
-		WAVM_ASSERT_THROW(memory);
+		if(!memory)
+			causeIntrensicException(Exception::Cause::outOfMemory);
 		const Iptr numPreviousMemoryPages = growMemory(memory,(Uptr)deltaPages);
 		if(numPreviousMemoryPages + (Uptr)deltaPages > IR::maxMemoryPages) { return -1; }
 		else { return (I32)numPreviousMemoryPages; }
@@ -172,7 +178,8 @@ namespace Runtime
 	DEFINE_INTRINSIC_FUNCTION1(wavmIntrinsics,_currentMemory,currentMemory,i32,i64,memoryBits)
 	{
 		MemoryInstance* memory = reinterpret_cast<MemoryInstance*>(memoryBits);
-		WAVM_ASSERT_THROW(memory);
+		if(!memory)
+			causeIntrensicException(Exception::Cause::outOfMemory);
 		Uptr numMemoryPages = getMemoryNumPages(memory);
 		if(numMemoryPages > UINT32_MAX) { numMemoryPages = UINT32_MAX; }
 		return (U32)numMemoryPages;


### PR DESCRIPTION


<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
WAVM, via LLVM, generates unwinding frames for each wasm that is instantiated. This allows exceptions to unwind through the JITed code. Unfortunately when hundreds or thousands of these unwinding frames are registered exception unwinding becomes exceptionally slow.

This change removes generation of the unwinding frames. Because exceptions can no longer unwind through WAVM’s compiled code, all exceptions must be caught before unwinding reaches the compiled code. This means none of the intrinsics — either the ones we register or the ones wavm registers itself — can allow an exception to escape. Instead, the exception_ptr is stored and we longjmp through the compiled code.

This can provide substantial performance improvement when there are thousands of wasm instances active at once.

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
