### PR TITLE
Allow cleos to query an API node behind Cloudflare

### DIFF
--- a/programs/cleos/httpc.cpp
+++ b/programs/cleos/httpc.cpp
@@ -90,20 +90,19 @@ namespace eosio { namespace client { namespace http {
             response_content_length = std::stoi(match[1]);
       }
 
-      std::stringstream re;
-      if( response_content_length >= 0 ) {
-         // Write whatever content we already have to output.
+      // Attempt to read the response body using the length indicated by the
+      // Content-length header. If the header was not present just read all available bytes.
+      if( response_content_length != -1 ) {
          response_content_length -= response.size();
-         if (response.size() > 0)
-            re << &response;
-
-         boost::asio::read(socket, response, boost::asio::transfer_exactly(response_content_length));
+         if( response_content_length > 0 )
+            boost::asio::read(socket, response, boost::asio::transfer_exactly(response_content_length));
       } else {
          boost::system::error_code ec;
          boost::asio::read(socket, response, boost::asio::transfer_all(), ec);
          EOS_ASSERT(!ec || ec == boost::asio::ssl::error::stream_truncated, http_exception, "Unable to read http response: ${err}", ("err",ec.message()));
       }
 
+      std::stringstream re;
       re << &response;
       return re.str();
    }


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

Having _Content-Length_ header as mandatory for a valid http response prevents **cleos** from querying an API node which is behind Cloudflare.

Cloudflare treats **/v1/chain** endpoint as a dynamic resource so it will compress the content and
remove the _Content-Length_ header from the nodeos response.

https://support.cloudflare.com/hc/en-us/articles/200168386-Why-is-my-dynamic-content-being-sent-with-chunked-encoding-