### PR TITLE
[TEST] Add socket shutdown before close

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -805,7 +805,7 @@ namespace eosio {
    void connection::close() {
       if(socket) {
          boost::system::error_code ec;
-         socket->shutdown( tcp::socket::shutdown_both, ec )
+         socket->shutdown( tcp::socket::shutdown_both, ec );
          socket->close();
       }
       else {

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -1855,6 +1855,7 @@ namespace eosio {
       ++endpoint_itr;
       c->connecting = true;
       c->pending_message_buffer.reset();
+      c->socket = std::make_shared<tcp::socket>( std::ref( *my_impl->server_ioc ));
       connection_wptr weak_conn = c;
       c->socket->async_connect( current_endpoint, boost::asio::bind_executor( c->strand,
             [weak_conn, endpoint_itr, this]( const boost::system::error_code& err ) {

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -804,6 +804,8 @@ namespace eosio {
 
    void connection::close() {
       if(socket) {
+         boost::system::error_code ec;
+         socket->shutdown( tcp::socket::shutdown_both, ec )
          socket->close();
       }
       else {


### PR DESCRIPTION
## Change Description

-  Boost docs recommend calling `shutdown` before close.

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
