### PR TITLE
Removed Deprecated Operating Systems from Buildkite Pipelines

### DIFF
--- a/.buildkite/long_running_tests.yml
+++ b/.buildkite/long_running_tests.yml
@@ -1,6 +1,5 @@
 steps:
-
-  - command: |
+  - command: | # Ubuntu 16.04 Build
         echo "+++ :hammer: Building"
         ./scripts/eosio_build.sh -y
         echo "--- :compression: Compressing build directory"
@@ -21,7 +20,7 @@ steps:
         workdir: /data/job
     timeout: 60
 
-  - command: |
+  - command: | # Ubuntu 18.04 Build
         echo "+++ :hammer: Building"
         ./scripts/eosio_build.sh -y
         echo "--- :compression: Compressing build directory"
@@ -42,7 +41,7 @@ steps:
         workdir: /data/job
     timeout: 60
 
-  - command: |
+  - command: | # CentOS 7 Build
         echo "+++ :hammer: Building"
         ./scripts/eosio_build.sh -y
         echo "--- :compression: Compressing build directory"
@@ -63,28 +62,7 @@ steps:
         workdir: /data/job
     timeout: 60
 
-  - command: |
-        echo "+++ :hammer: Building"
-        ./scripts/eosio_build.sh -y
-        echo "--- :compression: Compressing build directory"
-        tar -pczf build.tar.gz build/
-    label: ":aws: 1 Build"
-    agents:
-      queue: "automation-large-builder-fleet"
-    artifact_paths: "build.tar.gz"
-    plugins:
-      ecr#v1.1.4:
-        login: true
-        account_ids: "436617320021"
-        no-include-email: true
-        region: "us-west-2"
-      docker#v2.1.0:
-        debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:amazonlinux1_2-2"
-        workdir: /data/job
-    timeout: 60
-
-  - command: |
+  - command: | # Amazon Linux 2 Build
         echo "+++ :hammer: Building"
         ./scripts/eosio_build.sh -y
         echo "--- :compression: Compressing build directory"
@@ -105,28 +83,7 @@ steps:
         workdir: /data/job
     timeout: 60
 
-  - command: |
-        echo "+++ :hammer: Building"
-        ./scripts/eosio_build.sh -y
-        echo "--- :compression: Compressing build directory"
-        tar -pczf build.tar.gz build/
-    label: ":fedora: 27 Build"
-    agents:
-      queue: "automation-large-builder-fleet"
-    artifact_paths: "build.tar.gz"
-    plugins:
-      ecr#v1.1.4:
-        login: true
-        account_ids: "436617320021"
-        no-include-email: true
-        region: "us-west-2"
-      docker#v2.1.0:
-        debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:fedora27_2-2"
-        workdir: /data/job
-    timeout: 60
-
-  - command: |
+  - command: | # macOS Mojave Build
       echo "--- Creating symbolic link to job directory :file_folder:"
       sleep 5 && ln -s "$(pwd)" /data/job && cd /data/job
       echo "+++ Building :hammer:"
@@ -137,20 +94,6 @@ steps:
     agents:
       - "role=builder-v2-1"
       - "os=mojave"
-    artifact_paths: "build.tar.gz"
-    timeout: 60
-
-  - command: |
-      echo "--- Creating symbolic link to job directory :file_folder:"
-      sleep 5 && ln -s "$(pwd)" /data/job && cd /data/job
-      echo "+++ Building :hammer:"
-      ./scripts/eosio_build.sh -y
-      echo "--- Compressing build directory :compression:"
-      tar -pczf build.tar.gz build/
-    label: ":darwin: High Sierra Build"
-    agents:
-      - "role=builder-v2-1"
-      - "os=high-sierra"
     artifact_paths: "build.tar.gz"
     timeout: 60
 
@@ -216,26 +159,6 @@ steps:
         workdir: /data/job
     timeout: 90
 
-  - command: | # Amazon AWS-1 Linux Tests
-        echo "--- :arrow_down: Downloading Build Directory"
-        buildkite-agent artifact download "build.tar.gz" . --step ":aws: 1 Build"
-        echo "+++ :microscope: Running LR Tests"
-        ./scripts/long-running-test.sh
-    label: ":aws: 1 LR Tests"
-    agents:
-      queue: "automation-large-builder-fleet"
-    plugins:
-      ecr#v1.1.4:
-        login: true
-        account_ids: "436617320021"
-        no-include-email: true
-        region: "us-west-2"
-      docker#v2.1.0:
-        debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:amazonlinux1_2-2"
-        workdir: /data/job
-    timeout: 90
-
   - command: | # Amazon AWS-2 Linux Tests
         echo "--- :arrow_down: Downloading Build Directory"
         buildkite-agent artifact download "build.tar.gz" . --step ":aws: 2 Build"
@@ -254,37 +177,6 @@ steps:
         debug: true
         image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:amazonlinux2_2-2"
         workdir: /data/job
-    timeout: 90
-
-  - command: | # Fedora Tests
-        echo "--- :arrow_down: Downloading Build Directory"
-        buildkite-agent artifact download "build.tar.gz" . --step ":fedora: 27 Build"
-        echo "+++ :microscope: Running LR Tests"
-        ./scripts/long-running-test.sh
-    label: ":fedora: 27 LR Tests"
-    agents:
-      queue: "automation-large-builder-fleet"
-    plugins:
-      ecr#v1.1.4:
-        login: true
-        account_ids: "436617320021"
-        no-include-email: true
-        region: "us-west-2"
-      docker#v2.1.0:
-        debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:fedora27_2-2"
-        workdir: /data/job
-    timeout: 90
-
-  - command: | # High Sierra Tests
-        echo "--- :arrow_down: Downloading Build Directory"
-        buildkite-agent artifact download "build.tar.gz" . --step ":darwin: High Sierra Build"
-        echo "+++ :microscope: Running LR Tests"
-        ln -s "$(pwd)" /data/job && ./scripts/long-running-test.sh
-    label: ":darwin: High Sierra LR Tests"
-    agents:
-      - "role=tester-v2-1"
-      - "os=high-sierra"
     timeout: 90
 
   - command: | # Mojave Tests

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -375,19 +375,19 @@ steps:
     timeout: 60
 
   - command: | # macOS Mojave Package Builder
-      echo "--- :arrow_down: Downloading build directory"
-      buildkite-agent artifact download "build.tar.gz" . --step ":darwin: Mojave Build"
-      tar -zxf build.tar.gz
-      echo "+++ :microscope: Starting package build"
-      ln -s "$(pwd)" /data/job && cd /data/job/build/packages && bash generate_package.sh brew
-  label: ":darwin: Mojave Package Builder"
-  agents:
-    - "role=builder-v2-1"
-    - "os=mojave"
-  artifact_paths:
-    - "build/packages/*.tar.gz"
-    - "build/packages/*.rb"
-  timeout: 60
+        echo "--- :arrow_down: Downloading build directory"
+        buildkite-agent artifact download "build.tar.gz" . --step ":darwin: Mojave Build"
+        tar -zxf build.tar.gz
+        echo "+++ :microscope: Starting package build"
+        ln -s "$(pwd)" /data/job && cd /data/job/build/packages && bash generate_package.sh brew
+    label: ":darwin: Mojave Package Builder"
+    agents:
+      - "role=builder-v2-1"
+      - "os=mojave"
+    artifact_paths:
+      - "build/packages/*.tar.gz"
+      - "build/packages/*.rb"
+    timeout: 60
 
   - wait
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,5 @@
 steps:
-
-  - command: |
+  - command: | # Ubuntu 16.04 Build
         echo "+++ :hammer: Building"
         ./scripts/eosio_build.sh -y
         echo "--- :compression: Compressing build directory"
@@ -21,7 +20,7 @@ steps:
         workdir: /data/job
     timeout: 60
 
-  - command: |
+  - command: | # Ubuntu 18.04 Build
         echo "+++ :hammer: Building"
         ./scripts/eosio_build.sh -y
         echo "--- :compression: Compressing build directory"
@@ -42,7 +41,7 @@ steps:
         workdir: /data/job
     timeout: 60
 
-  - command: |
+  - command: | # CentOS 7 Build
         echo "+++ :hammer: Building"
         ./scripts/eosio_build.sh -y
         echo "--- :compression: Compressing build directory"
@@ -63,28 +62,7 @@ steps:
         workdir: /data/job
     timeout: 60
 
-  - command: |
-        echo "+++ :hammer: Building"
-        ./scripts/eosio_build.sh -y
-        echo "--- :compression: Compressing build directory"
-        tar -pczf build.tar.gz build/
-    label: ":aws: 1 Build"
-    agents:
-      queue: "automation-large-builder-fleet"
-    artifact_paths: "build.tar.gz"
-    plugins:
-      ecr#v1.1.4:
-        login: true
-        account_ids: "436617320021"
-        no-include-email: true
-        region: "us-west-2"
-      docker#v2.1.0:
-        debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:amazonlinux1_2-2"
-        workdir: /data/job
-    timeout: 60
-
-  - command: |
+  - command: | # Amazon Linux 2 Build
         echo "+++ :hammer: Building"
         ./scripts/eosio_build.sh -y
         echo "--- :compression: Compressing build directory"
@@ -105,28 +83,7 @@ steps:
         workdir: /data/job
     timeout: 60
 
-  - command: |
-        echo "+++ :hammer: Building"
-        ./scripts/eosio_build.sh -y
-        echo "--- :compression: Compressing build directory"
-        tar -pczf build.tar.gz build/
-    label: ":fedora: 27 Build"
-    agents:
-      queue: "automation-large-builder-fleet"
-    artifact_paths: "build.tar.gz"
-    plugins:
-      ecr#v1.1.4:
-        login: true
-        account_ids: "436617320021"
-        no-include-email: true
-        region: "us-west-2"
-      docker#v2.1.0:
-        debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:fedora27_2-2"
-        workdir: /data/job
-    timeout: 60
-
-  - command: |
+  - command: | # macOS Mojave Build
       echo "--- Creating symbolic link to job directory :file_folder:"
       sleep 5 && ln -s "$(pwd)" /data/job && cd /data/job
       echo "+++ Building :hammer:"
@@ -137,20 +94,6 @@ steps:
     agents:
       - "role=builder-v2-1"
       - "os=mojave"
-    artifact_paths: "build.tar.gz"
-    timeout: 60
-
-  - command: |
-      echo "--- Creating symbolic link to job directory :file_folder:"
-      sleep 5 && ln -s "$(pwd)" /data/job && cd /data/job
-      echo "+++ Building :hammer:"
-      ./scripts/eosio_build.sh -y
-      echo "--- Compressing build directory :compression:"
-      tar -pczf build.tar.gz build/
-    label: ":darwin: High Sierra Build"
-    agents:
-      - "role=builder-v2-1"
-      - "os=high-sierra"
     artifact_paths: "build.tar.gz"
     timeout: 60
 
@@ -279,47 +222,6 @@ steps:
         workdir: /data/job
     timeout: 60
 
-  # Amazon AWS-1 Linux Tests
-  - command: |
-        echo "--- :arrow_down: Downloading Build Directory"
-        buildkite-agent artifact download "build.tar.gz" . --step ":aws: 1 Build"
-        echo "+++ :microscope: Running Tests"
-        ./scripts/parallel-test.sh
-    label: ":aws: 1 Tests"
-    agents:
-      queue: "automation-large-builder-fleet"
-    plugins:
-      ecr#v1.1.4:
-        login: true
-        account_ids: "436617320021"
-        no-include-email: true
-        region: "us-west-2"
-      docker#v2.1.0:
-        debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:amazonlinux1_2-2"
-        workdir: /data/job
-    timeout: 60
-
-  - command: |
-        echo "--- :arrow_down: Downloading Build Directory"
-        buildkite-agent artifact download "build.tar.gz" . --step ":aws: 1 Build"
-        echo "+++ :microscope: Running Tests"
-        ./scripts/serial-test.sh
-    label: ":aws: 1 NP Tests"
-    agents:
-      queue: "automation-large-builder-fleet"
-    plugins:
-      ecr#v1.1.4:
-        login: true
-        account_ids: "436617320021"
-        no-include-email: true
-        region: "us-west-2"
-      docker#v2.1.0:
-        debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:amazonlinux1_2-2"
-        workdir: /data/job
-    timeout: 60
-
   # Amazon AWS-2 Linux Tests
   - command: |
         echo "--- :arrow_down: Downloading Build Directory"
@@ -361,71 +263,6 @@ steps:
         workdir: /data/job
     timeout: 60
 
-  # Fedora Tests
-  - command: |
-        echo "--- :arrow_down: Downloading Build Directory"
-        buildkite-agent artifact download "build.tar.gz" . --step ":fedora: 27 Build"
-        echo "+++ :microscope: Running Tests"
-        ./scripts/parallel-test.sh
-    label: ":fedora: 27 Tests"
-    agents:
-      queue: "automation-large-builder-fleet"
-    plugins:
-      ecr#v1.1.4:
-        login: true
-        account_ids: "436617320021"
-        no-include-email: true
-        region: "us-west-2"
-      docker#v2.1.0:
-        debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:fedora27_2-2"
-        workdir: /data/job
-    timeout: 60
-
-  - command: |
-        echo "--- :arrow_down: Downloading Build Directory"
-        buildkite-agent artifact download "build.tar.gz" . --step ":fedora: 27 Build"
-        echo "+++ :microscope: Running Tests"
-        ./scripts/serial-test.sh
-    label: ":fedora: 27 NP Tests"
-    agents:
-      queue: "automation-large-builder-fleet"
-    plugins:
-      ecr#v1.1.4:
-        login: true
-        account_ids: "436617320021"
-        no-include-email: true
-        region: "us-west-2"
-      docker#v2.1.0:
-        debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:fedora27_2-2"
-        workdir: /data/job
-    timeout: 60
-
-  # High Sierra Tests
-  - command: |
-        echo "--- :arrow_down: Downloading Build Directory"
-        buildkite-agent artifact download "build.tar.gz" . --step ":darwin: High Sierra Build"
-        echo "+++ :microscope: Running Tests"
-        ln -s "$(pwd)" /data/job
-        ./scripts/parallel-test.sh
-    label: ":darwin: High Sierra Tests"
-    agents:
-      - "role=tester-v2-1"
-      - "os=high-sierra"
-    timeout: 60
-
-  - command: |
-        echo "--- :arrow_down: Downloading Build Directory"
-        buildkite-agent artifact download "build.tar.gz" . --step ":darwin: High Sierra Build"
-        echo "+++ :microscope: Running Tests"
-        ln -s "$(pwd)" /data/job && ./scripts/serial-test.sh
-    label: ":darwin: High Sierra NP Tests"
-    agents:
-      - "role=tester-v2-1"
-      - "os=high-sierra"
-    timeout: 60
-
   # Mojave Tests
   - command: |
         echo "--- :arrow_down: Downloading Build Directory"
@@ -452,37 +289,7 @@ steps:
     
   - wait
 
-  - command: |
-        echo "--- :arrow_down: Downloading build directory"
-        buildkite-agent artifact download "build.tar.gz" . --step ":darwin: High Sierra Build"
-        tar -zxf build.tar.gz
-        echo "+++ :microscope: Starting package build"
-        ln -s "$(pwd)" /data/job && cd /data/job/build/packages && bash generate_package.sh brew
-    label: ":darwin: High Sierra Package Builder"
-    agents:
-      - "role=builder-v2-1"
-      - "os=high-sierra"
-    artifact_paths:
-      - "build/packages/*.tar.gz"
-      - "build/packages/*.rb"
-    timeout: 60
-
-  - command: |
-        echo "--- :arrow_down: Downloading build directory"
-        buildkite-agent artifact download "build.tar.gz" . --step ":darwin: Mojave Build"
-        tar -zxf build.tar.gz
-        echo "+++ :microscope: Starting package build"
-        ln -s "$(pwd)" /data/job && cd /data/job/build/packages && bash generate_package.sh brew
-    label: ":darwin: Mojave Package Builder"
-    agents:
-      - "role=builder-v2-1"
-      - "os=mojave"
-    artifact_paths:
-      - "build/packages/*.tar.gz"
-      - "build/packages/*.rb"
-    timeout: 60
-
-  - command: |
+  - command: | # Ubuntu 16.04 Package Builder
         echo "--- :arrow_down: Downloading build directory"
         buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 16.04 Build"
         tar -zxf build.tar.gz
@@ -508,7 +315,7 @@ steps:
       PKGTYPE: "deb"
     timeout: 60
 
-  - command: |
+  - command: | # Ubuntu 18.04 Package Builder
         echo "--- :arrow_down: Downloading build directory"
         buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 18.04 Build"
         tar -zxf build.tar.gz
@@ -534,40 +341,7 @@ steps:
       PKGTYPE: "deb"
     timeout: 60
 
-  - command: |
-        echo "--- :arrow_down: Downloading build directory"
-        buildkite-agent artifact download "build.tar.gz" . --step ":fedora: 27 Build"
-        tar -zxf build.tar.gz
-        echo "+++ :microscope: Starting package build"
-        yum install -y rpm-build
-        mkdir -p /root/rpmbuild/BUILD
-        mkdir -p /root/rpmbuild/BUILDROOT
-        mkdir -p /root/rpmbuild/RPMS
-        mkdir -p /root/rpmbuild/SOURCES
-        mkdir -p /root/rpmbuild/SPECS
-        mkdir -p /root/rpmbuild/SRPMS
-        cd /data/job/build/packages && bash generate_package.sh rpm
-    label: ":fedora: 27 Package builder"
-    agents:
-      queue: "automation-large-builder-fleet"
-    artifact_paths:
-      - "build/packages/*.rpm"
-    plugins:
-      ecr#v1.1.4:
-        login: true
-        account_ids: "436617320021"
-        no-include-email: true
-        region: "us-west-2"
-      docker#v2.1.0:
-        debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:fedora27_2-2"
-        workdir: /data/job
-    env:
-      OS: "fc27"
-      PKGTYPE: "rpm"
-    timeout: 60
-
-  - command: |
+  - command: | # CentOS 7 Package Builder
         echo "--- :arrow_down: Downloading build directory"
         buildkite-agent artifact download "build.tar.gz" . --step ":centos: 7 Build"
         tar -zxf build.tar.gz
@@ -600,18 +374,30 @@ steps:
       PKGTYPE: "rpm"
     timeout: 60
 
+  - command: | # macOS Mojave Package Builder
+      echo "--- :arrow_down: Downloading build directory"
+      buildkite-agent artifact download "build.tar.gz" . --step ":darwin: Mojave Build"
+      tar -zxf build.tar.gz
+      echo "+++ :microscope: Starting package build"
+      ln -s "$(pwd)" /data/job && cd /data/job/build/packages && bash generate_package.sh brew
+  label: ":darwin: Mojave Package Builder"
+  agents:
+    - "role=builder-v2-1"
+    - "os=mojave"
+  artifact_paths:
+    - "build/packages/*.tar.gz"
+    - "build/packages/*.rb"
+  timeout: 60
+
   - wait
 
   - command: |
         echo "--- :arrow_down: Downloading brew files"
-        buildkite-agent artifact download "build/packages/eosio.rb" . --step ":darwin: High Sierra Package Builder"
-        mv build/packages/eosio.rb build/packages/eosio_highsierra.rb
         buildkite-agent artifact download "build/packages/eosio.rb" . --step ":darwin: Mojave Package Builder"
     label: ":darwin: Brew Updater"
     agents:
       queue: "automation-large-builder-fleet"
     artifact_paths:
-      - "build/packages/eosio_highsierra.rb"
       - "build/packages/eosio.rb"
     timeout: 60
 


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
With [release 1.7.1](https://github.com/EOSIO/eos/releases/tag/v1.7.1) we have announced the deprecation of support for the following operating systems:
- Mint 18
- Fedora 27
- Amazon Linux 1
- macOS High Sierra

Since develop is working towards 1.8, I have removed these operating systems from the Buildkite Pipelines.

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->
None.

## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->
None.

## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
None.