### PR TITLE
Make the submodule regression check more robust

### DIFF
--- a/scripts/submodule_check.sh
+++ b/scripts/submodule_check.sh
@@ -29,7 +29,13 @@ for k in "${!BASE_MAP[@]}"; do
   echo "  timestamp on $BUILDKITE_BRANCH: $pr_ts"
   echo "  timestamp on $BUILDKITE_PULL_REQUEST_BASE_BRANCH: $base_ts"
   if (( $pr_ts < $base_ts)); then
-    echo "ERROR: $k is older on $BUILDKITE_BRANCH than $BUILDKITE_PULL_REQUEST_BASE_BRANCH"
-    exit 1
+    echo "$k is older on $BUILDKITE_BRANCH than $BUILDKITE_PULL_REQUEST_BASE_BRANCH; investigating..."
+
+    if for c in `git log $BUILDKITE_BRANCH ^$BUILDKITE_PULL_REQUEST_BASE_BRANCH --pretty=format:"%H"`; do git show --pretty="" --name-only $c; done | grep -q "^$k$"; then
+      echo "ERROR: $k has regressed"
+      exit 1
+    else
+      echo "$k was not in the diff; no regression detected"
+    fi
   fi
 done


### PR DESCRIPTION
## Change Description

Previously, the git submodule regression check was based on the commit timestamp alone. There are cases where a pull request was branched off an old version of the base branch that would trigger this check, even though the submodule itself was not changed. Now, if the timestamp-based check detects the submodule is out-of-date, the branch's diff is checked as well to see if the submodule was modified.

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions