### PR TITLE
Increase timeout for nodeos_startup_catchup_lr_test

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -103,6 +103,7 @@ add_test(NAME nodeos_under_min_avail_ram_lr_test COMMAND tests/nodeos_under_min_
 set_property(TEST nodeos_under_min_avail_ram_lr_test PROPERTY LABELS long_running_tests)
 
 add_test(NAME nodeos_startup_catchup_lr_test COMMAND tests/nodeos_startup_catchup.py -v --clean-run --dump-error-detail WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+set_tests_properties(nodeos_startup_catchup_lr_test PROPERTIES TIMEOUT 3000)
 set_property(TEST nodeos_startup_catchup_lr_test PROPERTY LABELS long_running_tests)
 
 if(ENABLE_COVERAGE_TESTING)


### PR DESCRIPTION
## Change Description

- Increase the timeout for nodeos_startup_catchup_lr_test from default of 1500 to 3000 seconds.

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
