### PR TITLE
Added uint64_t scope_value member to get_table_by_scope_result_row

### DIFF
--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1235,7 +1235,7 @@ read_only::get_table_by_scope_result read_only::get_table_by_scope( const read_o
       for( unsigned int count = 0; cur_time <= end_time && count < p.limit && itr != end_itr; ++itr, cur_time = fc::time_point::now() ) {
          if( p.table && itr->table != p.table ) continue;
 
-         result.rows.push_back( {itr->code, itr->scope, itr->table, itr->payer, itr->count} );
+         result.rows.push_back( {itr->code, itr->scope, itr->scope.value, itr->table, itr->payer, itr->count} );
 
          ++count;
       }

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -294,6 +294,7 @@ public:
    struct get_table_by_scope_result_row {
       name        code;
       name        scope;
+      uint64_t    scope_value;
       name        table;
       name        payer;
       uint32_t    count;

--- a/tests/get_table_tests.cpp
+++ b/tests/get_table_tests.cpp
@@ -78,13 +78,17 @@ BOOST_FIXTURE_TEST_CASE( get_scope_test, TESTER ) try {
    if (result.rows.size() >= 4) {
       BOOST_REQUIRE_EQUAL(name(N(eosio.token)), result.rows[0].code);
       BOOST_REQUIRE_EQUAL(name(N(inita)), result.rows[0].scope);
+      BOOST_REQUIRE_EQUAL(name(N(inita)).value, result.rows[0].scope_value);
       BOOST_REQUIRE_EQUAL(name(N(accounts)), result.rows[0].table);
       BOOST_REQUIRE_EQUAL(name(N(eosio)), result.rows[0].payer);
       BOOST_REQUIRE_EQUAL(1u, result.rows[0].count);
 
       BOOST_REQUIRE_EQUAL(name(N(initb)), result.rows[1].scope);
+      BOOST_REQUIRE_EQUAL(name(N(initb)).value, result.rows[1].scope_value);
       BOOST_REQUIRE_EQUAL(name(N(initc)), result.rows[2].scope);
+      BOOST_REQUIRE_EQUAL(name(N(initc)).value, result.rows[2].scope_value);
       BOOST_REQUIRE_EQUAL(name(N(initd)), result.rows[3].scope);
+      BOOST_REQUIRE_EQUAL(name(N(initd)).value, result.rows[3].scope_value);
    }
 
    param.lower_bound = "initb";
@@ -94,7 +98,9 @@ BOOST_FIXTURE_TEST_CASE( get_scope_test, TESTER ) try {
    BOOST_REQUIRE_EQUAL("", result.more);
    if (result.rows.size() >= 2) {
       BOOST_REQUIRE_EQUAL(name(N(initb)), result.rows[0].scope);
+      BOOST_REQUIRE_EQUAL(name(N(initb)).value, result.rows[0].scope_value);
       BOOST_REQUIRE_EQUAL(name(N(initc)), result.rows[1].scope);
+      BOOST_REQUIRE_EQUAL(name(N(initc)).value, result.rows[1].scope_value);
    }
 
    param.limit = 1;


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
**Issue:** GH-7087

Expose the `uint64_t` value when iterating over table scopes. This removes the requirement to convert the currently returned `scope` name object to a `uint64_t`.

**Use case:**
Using `available_primary_key()` in one table and that value as the scope of another table for data reference purposes. You can then iterate over the scopes and, without additional processing, get the actual scope value being used. This allows actions to accept `ACTION addrow(uint64_t scope, ...);` as an argument without the need for any kind of conversion between `name` & `uint64_t`.

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [x] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->
Additional `scope_value` provided by `get_table_by_scope` for each table scope, no breaking changes introduced.

```
{
  "rows": [{
      "code": "acc111111111",
      "scope": "",
      "scope_value": 0,
      "table": "mytable",
      "payer": "acc111111111",
      "count": 2
    },{
      "code": "acc111111111",
      "scope": "............1",
      "scope_value": 1,
      "table": "mytable",
      "payer": "acc111111111",
      "count": 2
    },{
      "code": "acc111111111",
      "scope": "............2",
      "scope_value": 2,
      "table": "mytable",
      "payer": "acc111111111",
      "count": 4
    }
  ],
  "more": ""
}
```


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
