### PR TITLE
store all wasm code in a separate index

### DIFF
--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -8,6 +8,7 @@
 #include <eosio/chain/authorization_manager.hpp>
 #include <eosio/chain/resource_limits.hpp>
 #include <eosio/chain/account_object.hpp>
+#include <eosio/chain/code_object.hpp>
 #include <eosio/chain/global_property_object.hpp>
 #include <boost/container/flat_set.hpp>
 
@@ -70,7 +71,7 @@ void apply_context::exec_one()
             (*native)( *this );
          }
 
-         if( (a.code.size() > 0) &&
+         if( ( a.code_version != digest_type() ) &&
                ( control.is_builtin_activated( builtin_protocol_feature_t::forward_setcode )
                   || !( act->account == config::system_account_name
                         && act->name == N( setcode )
@@ -82,7 +83,7 @@ void apply_context::exec_one()
                control.check_action_list( act->account, act->name );
             }
             try {
-               control.get_wasm_interface().apply( a.code_version, a.code, *this );
+               control.get_wasm_interface().apply( db.get<code_object, by_code_id>(a.code_version), *this );
             } catch( const wasm_exit& ) {}
          }
       } FC_RETHROW_EXCEPTIONS( warn, "pending console output: ${console}", ("console", _pending_console_output) )

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -6,6 +6,7 @@
 #include <eosio/chain/exceptions.hpp>
 
 #include <eosio/chain/account_object.hpp>
+#include <eosio/chain/code_object.hpp>
 #include <eosio/chain/block_summary_object.hpp>
 #include <eosio/chain/eosio_contract.hpp>
 #include <eosio/chain/global_property_object.hpp>
@@ -43,7 +44,8 @@ using controller_index_set = index_set<
    block_summary_multi_index,
    transaction_multi_index,
    generated_transaction_multi_index,
-   table_id_multi_index
+   table_id_multi_index,
+   code_index
 >;
 
 using contract_database_index_set = index_set<

--- a/libraries/chain/include/eosio/chain/account_object.hpp
+++ b/libraries/chain/include/eosio/chain/account_object.hpp
@@ -13,7 +13,7 @@
 namespace eosio { namespace chain {
 
    class account_object : public chainbase::object<account_object_type, account_object> {
-      OBJECT_CTOR(account_object,(code)(abi))
+      OBJECT_CTOR(account_object,(abi))
 
       id_type              id;
       account_name         name;
@@ -25,7 +25,6 @@ namespace eosio { namespace chain {
       digest_type          code_version;
       block_timestamp_type creation_date;
 
-      shared_blob    code;
       shared_blob    abi;
 
       void set_abi( const eosio::chain::abi_def& a ) {
@@ -100,6 +99,6 @@ CHAINBASE_SET_INDEX_TYPE(eosio::chain::account_sequence_object, eosio::chain::ac
 CHAINBASE_SET_INDEX_TYPE(eosio::chain::account_ram_correction_object, eosio::chain::account_ram_correction_index)
 
 
-FC_REFLECT(eosio::chain::account_object, (name)(vm_type)(vm_version)(privileged)(last_code_update)(code_version)(creation_date)(code)(abi))
+FC_REFLECT(eosio::chain::account_object, (name)(vm_type)(vm_version)(privileged)(last_code_update)(code_version)(creation_date)(abi))
 FC_REFLECT(eosio::chain::account_sequence_object, (name)(recv_sequence)(auth_sequence)(code_sequence)(abi_sequence))
 FC_REFLECT(eosio::chain::account_ram_correction_object, (name)(ram_correction))

--- a/libraries/chain/include/eosio/chain/code_object.hpp
+++ b/libraries/chain/include/eosio/chain/code_object.hpp
@@ -1,0 +1,35 @@
+/**
+ *  @file
+ *  @copyright defined in eos/LICENSE
+ */
+#pragma once
+#include <eosio/chain/database_utils.hpp>
+
+#include "multi_index_includes.hpp"
+
+namespace eosio { namespace chain {
+
+   class code_object : public chainbase::object<code_object_type, code_object> {
+      OBJECT_CTOR(code_object, (code))
+
+      id_type      id;
+      digest_type  code_id;
+      shared_blob  code;
+      uint64_t     code_ref_count;
+      uint32_t     first_block_used;
+   };
+
+   struct by_code_id;
+   using code_index = chainbase::shared_multi_index_container<
+      code_object,
+      indexed_by<
+         ordered_unique<tag<by_id>, member<code_object, code_object::id_type, &code_object::id>>,
+         ordered_unique<tag<by_code_id>, member<code_object, digest_type, &code_object::code_id>>
+      >
+   >;
+
+} } // eosio::chain
+
+CHAINBASE_SET_INDEX_TYPE(eosio::chain::code_object, eosio::chain::code_index)
+
+FC_REFLECT(eosio::chain::code_object, (code_id)(code)(code_ref_count)(first_block_used))

--- a/libraries/chain/include/eosio/chain/types.hpp
+++ b/libraries/chain/include/eosio/chain/types.hpp
@@ -191,6 +191,7 @@ namespace eosio { namespace chain {
       reversible_block_object_type,
       protocol_state_object_type,
       account_ram_correction_object_type,
+      code_object_type,
       OBJECT_TYPE_COUNT ///< Sentry value which contains the number of different object types
    };
 

--- a/libraries/chain/include/eosio/chain/wasm_interface.hpp
+++ b/libraries/chain/include/eosio/chain/wasm_interface.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <eosio/chain/code_object.hpp>
 #include <eosio/chain/types.hpp>
 #include <eosio/chain/whitelisted_intrinsics.hpp>
 #include <eosio/chain/exceptions.hpp>
@@ -82,7 +83,7 @@ namespace eosio { namespace chain {
          static void validate(const controller& control, const bytes& code);
 
          //Calls apply or error on a given code
-         void apply(const digest_type& code_id, const shared_string& code, apply_context& context);
+         void apply(const code_object& code, apply_context& context);
 
          //Immediately exits currently running wasm. UB is called when no wasm running
          void exit();

--- a/libraries/chain/wasm_interface.cpp
+++ b/libraries/chain/wasm_interface.cpp
@@ -57,8 +57,8 @@ namespace eosio { namespace chain {
       //Hard: Kick off instantiation in a separate thread at this location
 	 }
 
-   void wasm_interface::apply( const digest_type& code_id, const shared_string& code, apply_context& context ) {
-      my->get_instantiated_module(code_id, code, context.trx_context)->apply(context);
+   void wasm_interface::apply( const code_object& code, apply_context& context ) {
+      my->get_instantiated_module(code, context.trx_context)->apply(context);
    }
 
    void wasm_interface::exit() {

--- a/plugins/state_history_plugin/include/eosio/state_history_plugin/state_history_serialization.hpp
+++ b/plugins/state_history_plugin/include/eosio/state_history_plugin/state_history_serialization.hpp
@@ -112,7 +112,6 @@ datastream<ST>& operator<<(datastream<ST>& ds, const history_serial_wrapper<eosi
    fc::raw::pack(ds, as_type<fc::time_point>(obj.obj.last_code_update));
    fc::raw::pack(ds, as_type<eosio::chain::digest_type>(obj.obj.code_version));
    fc::raw::pack(ds, as_type<eosio::chain::block_timestamp_type>(obj.obj.creation_date));
-   fc::raw::pack(ds, as_type<eosio::chain::shared_string>(obj.obj.code));
    fc::raw::pack(ds, as_type<eosio::chain::shared_string>(obj.obj.abi));
    return ds;
 }


### PR DESCRIPTION
Store all WASM code in a separate index outside of the account index. This allows for deduplication of identical code in memory and will also allow greater accuracy in pruning the WASM instantiation cache because reference counts are updated via the DB

Leaving this as draft at the moment because:
* state_history needs attention
* Unsure what to do about vm_type/vm_version

<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
