### PR TITLE
Write snapshots to a temporary file until the block they represent is final

### DIFF
--- a/libraries/chain/include/eosio/chain/exceptions.hpp
+++ b/libraries/chain/include/eosio/chain/exceptions.hpp
@@ -460,6 +460,8 @@ namespace eosio { namespace chain {
                                     3170007, "The configured snapshot directory does not exist" )
       FC_DECLARE_DERIVED_EXCEPTION( snapshot_exists_exception,  producer_exception,
                                     3170008, "The requested snapshot already exists" )
+      FC_DECLARE_DERIVED_EXCEPTION( snapshot_finalization_exception,   producer_exception,
+                                    3170009, "Snapshot Finalization Exception" )
 
    FC_DECLARE_DERIVED_EXCEPTION( reversible_blocks_exception,           chain_exception,
                                  3180000, "Reversible Blocks exception" )

--- a/plugins/producer_plugin/include/eosio/producer_plugin/producer_plugin.hpp
+++ b/plugins/producer_plugin/include/eosio/producer_plugin/producer_plugin.hpp
@@ -51,6 +51,9 @@ public:
       std::string          snapshot_name;
    };
 
+   template<typename T>
+   using next_function = std::function<void(const fc::static_variant<fc::exception_ptr, T>&)>;
+
    producer_plugin();
    virtual ~producer_plugin();
 
@@ -81,7 +84,7 @@ public:
    void set_whitelist_blacklist(const whitelist_blacklist& params);
 
    integrity_hash_information get_integrity_hash() const;
-   snapshot_information create_snapshot() const;
+   void create_snapshot(next_function<snapshot_information> next);
 
    signal<void(const chain::producer_confirmation&)> confirmed_block;
 private:

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -88,6 +88,63 @@ using transaction_id_with_expiry_index = multi_index_container<
    >
 >;
 
+struct by_height;
+
+class pending_snapshot {
+public:
+   using next_t = producer_plugin::next_function<producer_plugin::snapshot_information>;
+
+   pending_snapshot(const block_id_type& block_id, next_t& next, std::string temp_path, std::string final_path)
+   : block_id(block_id)
+   , next(next)
+   , temp_path(temp_path)
+   , final_path(final_path)
+   {}
+
+   uint32_t get_height() const {
+      return block_header::num_from_id(block_id);
+   }
+
+   static bfs::path get_final_path(const block_id_type& block_id, const bfs::path& snapshots_dir) {
+      return snapshots_dir / fc::format_string("snapshot-${id}.bin", fc::mutable_variant_object()("id", block_id));
+   }
+
+   static bfs::path get_temp_path(const block_id_type& block_id, const bfs::path& snapshots_dir) {
+      return snapshots_dir / fc::format_string(".pending-snapshot-${id}.bin", fc::mutable_variant_object()("id", block_id));
+   }
+
+   producer_plugin::snapshot_information finalize( const chain::controller& chain ) const {
+      auto in_chain = (bool)chain.fetch_block_by_id( block_id );
+      boost::system::error_code ec;
+
+      EOS_ASSERT(in_chain, snapshot_finalization_exception,
+                 "Snapshotted block was forked out of the chain.  ID: ${block_id}",
+                 ("block_id", block_id));
+
+      bfs::rename(bfs::path(temp_path), bfs::path(final_path), ec);
+      EOS_ASSERT(!ec, snapshot_finalization_exception,
+                 "Unable to finalize valid snapshot of block number ${bn}: [code: ${ec}] ${message}",
+                 ("bn", get_height())
+                 ("ec", ec.value())
+                 ("message",ec.message()));
+
+      return {block_id, final_path};
+   }
+
+   block_id_type     block_id;
+   next_t            next;
+   std::string       temp_path;
+   std::string       final_path;
+};
+
+using pending_snapshot_index = multi_index_container<
+   pending_snapshot,
+   indexed_by<
+      hashed_unique<tag<by_id>, BOOST_MULTI_INDEX_MEMBER(pending_snapshot, block_id_type, block_id)>,
+      ordered_non_unique<tag<by_height>, BOOST_MULTI_INDEX_CONST_MEM_FUN( pending_snapshot, uint32_t, get_height)>
+   >
+>;
+
 enum class pending_block_mode {
    producing,
    speculating
@@ -160,6 +217,7 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
       incoming::methods::transaction_async::method_type::handle _incoming_transaction_async_provider;
 
       transaction_id_with_expiry_index                         _blacklisted_transactions;
+      pending_snapshot_index                                   _pending_snapshot_index;
 
       fc::optional<scoped_connection>                          _accepted_block_connection;
       fc::optional<scoped_connection>                          _irreversible_block_connection;
@@ -249,6 +307,22 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
 
       void on_irreversible_block( const signed_block_ptr& lib ) {
          _irreversible_block_time = lib->timestamp.to_time_point();
+         const chain::controller& chain = chain_plug->chain();
+
+         // promote any pending snapshots
+         auto& snapshots_by_height = _pending_snapshot_index.get<by_height>();
+         uint32_t lib_height = lib->block_num();
+
+         while (!snapshots_by_height.empty() && snapshots_by_height.begin()->get_height() <= lib_height) {
+            const auto& pending = snapshots_by_height.begin();
+            auto next = pending->next;
+
+            try {
+               next(pending->finalize(chain));
+            } CATCH_AND_CALL(next);
+
+            snapshots_by_height.erase(snapshots_by_height.begin());
+         }
       }
 
       template<typename Type, typename Channel, typename F>
@@ -938,35 +1012,60 @@ producer_plugin::integrity_hash_information producer_plugin::get_integrity_hash(
    return {chain.head_block_id(), chain.calculate_integrity_hash()};
 }
 
-producer_plugin::snapshot_information producer_plugin::create_snapshot() const {
+
+
+void producer_plugin::create_snapshot(producer_plugin::next_function<producer_plugin::snapshot_information> next) {
    chain::controller& chain = my->chain_plug->chain();
 
-   auto reschedule = fc::make_scoped_exit([this](){
-      my->schedule_production_loop();
-   });
+   auto head_id = chain.head_block_id();
+   std::string snapshot_path = (pending_snapshot::get_final_path(head_id, my->_snapshots_dir)).generic_string();
 
-   if (chain.pending_block_state()) {
-      // abort the pending block
-      chain.abort_block();
-   } else {
-      reschedule.cancel();
+   // maintain legacy exception if the snapshot exists
+   if( fc::is_regular_file(snapshot_path) ) {
+      auto ex = snapshot_exists_exception( FC_LOG_MESSAGE( error, "snapshot named ${name} already exists", ("name", snapshot_path) ) );
+      next(ex.dynamic_copy_exception());
+      return;
    }
 
-   auto head_id = chain.head_block_id();
-   std::string snapshot_path = (my->_snapshots_dir / fc::format_string("snapshot-${id}.bin", fc::mutable_variant_object()("id", head_id))).generic_string();
+   // determine if this snapshot is already in-flight
+   auto& pending_by_id = my->_pending_snapshot_index.get<by_id>();
+   auto existing = pending_by_id.find(head_id);
+   if( existing != pending_by_id.end() ) {
+      // if a snapshot at this block is already pending, attach this requests handler to it
+      pending_by_id.modify(existing, [&next]( auto& entry ){
+         entry.next = [prev = entry.next, next](const fc::static_variant<fc::exception_ptr, producer_plugin::snapshot_information>& res){
+            prev(res);
+            next(res);
+         };
+      });
+   } else {
+      // write a new temp snapshot
+      std::string temp_path = (pending_snapshot::get_temp_path(head_id, my->_snapshots_dir)).generic_string();
+      std::string final_path = (pending_snapshot::get_final_path(head_id, my->_snapshots_dir)).generic_string();
+      bool written = false;
 
-   EOS_ASSERT( !fc::is_regular_file(snapshot_path), snapshot_exists_exception,
-               "snapshot named ${name} already exists", ("name", snapshot_path));
+      try {
+         auto reschedule = fc::make_scoped_exit([this](){
+            my->schedule_production_loop();
+         });
 
+         if (chain.pending_block_state()) {
+            // abort the pending block
+            chain.abort_block();
+         } else {
+            reschedule.cancel();
+         }
 
-   auto snap_out = std::ofstream(snapshot_path, (std::ios::out | std::ios::binary));
-   auto writer = std::make_shared<ostream_snapshot_writer>(snap_out);
-   chain.write_snapshot(writer);
-   writer->finalize();
-   snap_out.flush();
-   snap_out.close();
-
-   return {head_id, snapshot_path};
+         // create a new pending snapshot
+         auto snap_out = std::ofstream(temp_path, (std::ios::out | std::ios::binary));
+         auto writer = std::make_shared<ostream_snapshot_writer>(snap_out);
+         chain.write_snapshot(writer);
+         writer->finalize();
+         snap_out.flush();
+         snap_out.close();
+         my->_pending_snapshot_index.emplace(head_id, next, temp_path, final_path);
+      } CATCH_AND_CALL (next);
+   }
 }
 
 optional<fc::time_point> producer_plugin_impl::calculate_next_block_time(const account_name& producer_name, const block_timestamp_type& current_block_time) const {


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description

This resolves #6984 

When a request for a snapshot is received, `nodeos` will now write the snapshot data to a temporary file and create an internal tracking record.  As this block becomes final OR finality passes it on a competing fork, `nodeos` will either rename the temporary file to the expected snapshot name OR delete the temporary file and return an error indicating that the snapshot was unusable. 

Temporary files are written to the same directory as final snapshots with a different prefix.  Notably this prefix contains a leading `.` so, on some OS's it they will be hidden.  

This change will hold the RPC request (and its associated HTTP session) open until the temporary snapshot is either finalized or removed.  Any subsequent requests for the same snapshot will be attached to the future response and no longer return an error code stating that the snapshot already exists. 

This should eliminate situations where operators would rarely get snapshots that were invalid due to microforks and also prevent situations where the block.log and the snapshot were not immediately usable once the snapshot was written.

### NOTES

Tracking of temporary snapshots is ephemeral, meaning that if the `nodeos` process is terminated while snapshots are outstanding it may leave the temporary files on disk and will not clean them up or promote them upon the next invocation.  If this becomes a pain point, in the future we can consider durable ways of maintaining the tracking so that future invocations can resume the management of promoting snapshots produced from earlier invocations.

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [x] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->

### `/v1/producer/create_snapshot` 

This endpoint used to return an error code if you made redundant requests for a snapshot before the head block had changed.  Now, all requests for a snapshot at that head block will remain open pending the determination of that blocks finality.  At that time, all pending requests for that snapshot's creation will receive the same affirmative or error response.


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
