### PR TITLE
add libicu as dependency for .deb packages

### DIFF
--- a/scripts/generate_deb.sh
+++ b/scripts/generate_deb.sh
@@ -23,9 +23,9 @@ else
 fi
 
 if [ ${DISTRIB_RELEASE} = "16.04" ]; then
-  LIBSSL="libssl1.0.0"
+  RELEASE_SPECIFIC_DEPS="libssl1.0.0, libicu55"
 elif [ ${DISTRIB_RELEASE} = "18.04" ]; then
-  LIBSSL="libssl1.1"
+  RELEASE_SPECIFIC_DEPS="libssl1.1, libicu60"
 else
   echo "Unrecognized Ubuntu version.  Update generate_deb.sh.  Not generating .deb file."
   exit 1
@@ -37,7 +37,7 @@ echo "Package: ${PROJECT}
 Version: ${VERSION_NO_SUFFIX}-${RELEASE}
 Section: devel
 Priority: optional
-Depends: libc6, libgcc1, ${LIBSSL}, libstdc++6, libtinfo5, zlib1g, libusb-1.0-0, libcurl3-gnutls
+Depends: libc6, libgcc1, ${RELEASE_SPECIFIC_DEPS}, libstdc++6, libtinfo5, zlib1g, libusb-1.0-0, libcurl3-gnutls
 Architecture: amd64
 Homepage: ${URL}
 Maintainer: ${EMAIL}


### PR DESCRIPTION


<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
Somewhere along the line nodeos picked up a dependency on libicuuc

This is the same fix that went in pre-1.7 release. I delayed it here because I thought we could use cpack by now. But here we are.

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
