### PR TITLE
Artifact check

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,10 +1,9 @@
 steps:
   - command: | # Ubuntu 16.04 Build
-        # echo "+++ :hammer: Building"
-        # ./scripts/eosio_build.sh -y
-        # echo "--- :compression: Compressing build directory"
-        #tar -pczf build.tar.gz2 build/; 
-        if [ ! -f build.tar.gz ]; then echo "No TAR Found!" && exit 1; fi;
+        echo "+++ :hammer: Building"
+        ./scripts/eosio_build.sh -y
+        echo "--- :compression: Compressing build directory"
+        tar -pczf build.tar.gz build/; if [ ! -f build.tar.gz ]; then echo "No TAR Found!" && exit 1; fi
     label: ":ubuntu: 16.04 Build"
     agents:
       queue: "automation-large-builder-fleet"
@@ -25,7 +24,7 @@ steps:
   #       echo "+++ :hammer: Building"
   #       ./scripts/eosio_build.sh -y
   #       echo "--- :compression: Compressing build directory"
-  #       tar -pczf build.tar.gz build/; if [[ ! -f build.tar.gz ]]; then exit 1; fi;
+  #       tar -pczf build.tar.gz build/; if [ ! -f build.tar.gz ]; then echo "No TAR Found!" && exit 1; fi
   #   label: ":ubuntu: 18.04 Build"
   #   agents:
   #     queue: "automation-large-builder-fleet"
@@ -46,7 +45,7 @@ steps:
   #       echo "+++ :hammer: Building"
   #       ./scripts/eosio_build.sh -y
   #       echo "--- :compression: Compressing build directory"
-  #       tar -pczf build.tar.gz build/; if [[ ! -f build.tar.gz ]]; then exit 1; fi
+  #       tar -pczf build.tar.gz build/; if [ ! -f build.tar.gz ]; then echo "No TAR Found!" && exit 1; fi
   #   label: ":centos: 7 Build"
   #   agents:
   #     queue: "automation-large-builder-fleet"
@@ -67,7 +66,7 @@ steps:
   #       echo "+++ :hammer: Building"
   #       ./scripts/eosio_build.sh -y
   #       echo "--- :compression: Compressing build directory"
-  #       tar -pczf build.tar.gz build/; if [[ ! -f build.tar.gz ]]; then exit 1; fi
+  #       tar -pczf build.tar.gz build/; if [ ! -f build.tar.gz ]; then echo "No TAR Found!" && exit 1; fi
   #   label: ":aws: 2 Build"
   #   agents:
   #     queue: "automation-large-builder-fleet"
@@ -90,7 +89,7 @@ steps:
   #     echo "+++ Building :hammer:"
   #     ./scripts/eosio_build.sh -y
   #     echo "--- Compressing build directory :compression:"
-  #     tar -pczf build.tar.gz build/; if [[ ! -f build.tar.gz ]]; then exit 1; fi
+  #     tar -pczf build.tar.gz build/; if [ ! -f build.tar.gz ]; then echo "No TAR Found!" && exit 1; fi
   #   label: ":darwin: Mojave Build"
   #   agents:
   #     - "role=builder-v2-1"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,7 +3,7 @@ steps:
         echo "+++ :hammer: Building"
         ./scripts/eosio_build.sh -y
         echo "--- :compression: Compressing build directory"
-        tar -pczf build.tar.gz build/
+        tar -pczf build.tar.gz build/; if [[ ! -f build.tar.gz ]]; then exit 1; fi;
     label: ":ubuntu: 16.04 Build"
     agents:
       queue: "automation-large-builder-fleet"
@@ -24,7 +24,7 @@ steps:
         echo "+++ :hammer: Building"
         ./scripts/eosio_build.sh -y
         echo "--- :compression: Compressing build directory"
-        tar -pczf build.tar.gz build/
+        tar -pczf build.tar.gz build/; if [[ ! -f build.tar.gz ]]; then exit 1; fi;
     label: ":ubuntu: 18.04 Build"
     agents:
       queue: "automation-large-builder-fleet"
@@ -45,7 +45,7 @@ steps:
         echo "+++ :hammer: Building"
         ./scripts/eosio_build.sh -y
         echo "--- :compression: Compressing build directory"
-        tar -pczf build.tar.gz build/
+        tar -pczf build.tar.gz build/; if [[ ! -f build.tar.gz ]]; then exit 1; fi
     label: ":centos: 7 Build"
     agents:
       queue: "automation-large-builder-fleet"
@@ -66,7 +66,7 @@ steps:
         echo "+++ :hammer: Building"
         ./scripts/eosio_build.sh -y
         echo "--- :compression: Compressing build directory"
-        tar -pczf build.tar.gz build/
+        tar -pczf build.tar.gz build/; if [[ ! -f build.tar.gz ]]; then exit 1; fi
     label: ":aws: 2 Build"
     agents:
       queue: "automation-large-builder-fleet"
@@ -89,7 +89,7 @@ steps:
       echo "+++ Building :hammer:"
       ./scripts/eosio_build.sh -y
       echo "--- Compressing build directory :compression:"
-      tar -pczf build.tar.gz build/
+      tar -pczf build.tar.gz build/; if [[ ! -f build.tar.gz ]]; then exit 1; fi
     label: ":darwin: Mojave Build"
     agents:
       - "role=builder-v2-1"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -20,391 +20,391 @@ steps:
         workdir: /data/job
     timeout: 60
 
-  # - command: | # Ubuntu 18.04 Build
-  #       echo "+++ :hammer: Building"
-  #       ./scripts/eosio_build.sh -y
-  #       echo "--- :compression: Compressing build directory"
-  #       tar -pczf build.tar.gz build/; if [ ! -f build.tar.gz ]; then echo "No TAR Found!" && exit 1; fi
-  #   label: ":ubuntu: 18.04 Build"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   artifact_paths: "build.tar.gz"
-  #   plugins:
-  #     ecr#v1.1.4:
-  #       login: true
-  #       account_ids: "436617320021"
-  #       no-include-email: true
-  #       region: "us-west-2"
-  #     docker#v2.1.0:
-  #       debug: true
-  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu18_2-2"
-  #       workdir: /data/job
-  #   timeout: 60
+  - command: | # Ubuntu 18.04 Build
+        echo "+++ :hammer: Building"
+        ./scripts/eosio_build.sh -y
+        echo "--- :compression: Compressing build directory"
+        tar -pczf build.tar.gz build/; if [ ! -f build.tar.gz ]; then echo "No TAR Found!" && exit 1; fi
+    label: ":ubuntu: 18.04 Build"
+    agents:
+      queue: "automation-large-builder-fleet"
+    artifact_paths: "build.tar.gz"
+    plugins:
+      ecr#v1.1.4:
+        login: true
+        account_ids: "436617320021"
+        no-include-email: true
+        region: "us-west-2"
+      docker#v2.1.0:
+        debug: true
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu18_2-2"
+        workdir: /data/job
+    timeout: 60
 
-  # - command: | # CentOS 7 Build
-  #       echo "+++ :hammer: Building"
-  #       ./scripts/eosio_build.sh -y
-  #       echo "--- :compression: Compressing build directory"
-  #       tar -pczf build.tar.gz build/; if [ ! -f build.tar.gz ]; then echo "No TAR Found!" && exit 1; fi
-  #   label: ":centos: 7 Build"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   artifact_paths: "build.tar.gz"
-  #   plugins:
-  #     ecr#v1.1.4:
-  #       login: true
-  #       account_ids: "436617320021"
-  #       no-include-email: true
-  #       region: "us-west-2"
-  #     docker#v2.1.0:
-  #       debug: true
-  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:centos7_2-2"
-  #       workdir: /data/job
-  #   timeout: 60
+  - command: | # CentOS 7 Build
+        echo "+++ :hammer: Building"
+        ./scripts/eosio_build.sh -y
+        echo "--- :compression: Compressing build directory"
+        tar -pczf build.tar.gz build/; if [ ! -f build.tar.gz ]; then echo "No TAR Found!" && exit 1; fi
+    label: ":centos: 7 Build"
+    agents:
+      queue: "automation-large-builder-fleet"
+    artifact_paths: "build.tar.gz"
+    plugins:
+      ecr#v1.1.4:
+        login: true
+        account_ids: "436617320021"
+        no-include-email: true
+        region: "us-west-2"
+      docker#v2.1.0:
+        debug: true
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:centos7_2-2"
+        workdir: /data/job
+    timeout: 60
 
-  # - command: | # Amazon Linux 2 Build
-  #       echo "+++ :hammer: Building"
-  #       ./scripts/eosio_build.sh -y
-  #       echo "--- :compression: Compressing build directory"
-  #       tar -pczf build.tar.gz build/; if [ ! -f build.tar.gz ]; then echo "No TAR Found!" && exit 1; fi
-  #   label: ":aws: 2 Build"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   artifact_paths: "build.tar.gz"
-  #   plugins:
-  #     ecr#v1.1.4:
-  #       login: true
-  #       account_ids: "436617320021"
-  #       no-include-email: true
-  #       region: "us-west-2"
-  #     docker#v2.1.0:
-  #       debug: true
-  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:amazonlinux2_2-2"
-  #       workdir: /data/job
-  #   timeout: 60
+  - command: | # Amazon Linux 2 Build
+        echo "+++ :hammer: Building"
+        ./scripts/eosio_build.sh -y
+        echo "--- :compression: Compressing build directory"
+        tar -pczf build.tar.gz build/; if [ ! -f build.tar.gz ]; then echo "No TAR Found!" && exit 1; fi
+    label: ":aws: 2 Build"
+    agents:
+      queue: "automation-large-builder-fleet"
+    artifact_paths: "build.tar.gz"
+    plugins:
+      ecr#v1.1.4:
+        login: true
+        account_ids: "436617320021"
+        no-include-email: true
+        region: "us-west-2"
+      docker#v2.1.0:
+        debug: true
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:amazonlinux2_2-2"
+        workdir: /data/job
+    timeout: 60
 
-  # - command: | # macOS Mojave Build
-  #     echo "--- Creating symbolic link to job directory :file_folder:"
-  #     sleep 5 && ln -s "$(pwd)" /data/job && cd /data/job
-  #     echo "+++ Building :hammer:"
-  #     ./scripts/eosio_build.sh -y
-  #     echo "--- Compressing build directory :compression:"
-  #     tar -pczf build.tar.gz build/; if [ ! -f build.tar.gz ]; then echo "No TAR Found!" && exit 1; fi
-  #   label: ":darwin: Mojave Build"
-  #   agents:
-  #     - "role=builder-v2-1"
-  #     - "os=mojave"
-  #   artifact_paths: "build.tar.gz"
-  #   timeout: 60
+  - command: | # macOS Mojave Build
+      echo "--- Creating symbolic link to job directory :file_folder:"
+      sleep 5 && ln -s "$(pwd)" /data/job && cd /data/job
+      echo "+++ Building :hammer:"
+      ./scripts/eosio_build.sh -y
+      echo "--- Compressing build directory :compression:"
+      tar -pczf build.tar.gz build/; if [ ! -f build.tar.gz ]; then echo "No TAR Found!" && exit 1; fi
+    label: ":darwin: Mojave Build"
+    agents:
+      - "role=builder-v2-1"
+      - "os=mojave"
+    artifact_paths: "build.tar.gz"
+    timeout: 60
 
-  # - wait
+  - wait
 
-  # # Ubuntu 16.04 Tests
-  # - command: |
-  #       echo "--- :arrow_down: Downloading Build Directory"
-  #       buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 16.04 Build"
-  #       echo "+++ :microscope: Running Tests"
-  #       ./scripts/parallel-test.sh
-  #   label: ":ubuntu: 16.04 Tests"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   plugins:
-  #     ecr#v1.1.4:
-  #       login: true
-  #       account_ids: "436617320021"
-  #       no-include-email: true
-  #       region: "us-west-2"
-  #     docker#v2.1.0:
-  #       debug: true
-  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu16_2-2"
-  #       workdir: /data/job
-  #   timeout: 60
+  # Ubuntu 16.04 Tests
+  - command: |
+        echo "--- :arrow_down: Downloading Build Directory"
+        buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 16.04 Build"
+        echo "+++ :microscope: Running Tests"
+        ./scripts/parallel-test.sh
+    label: ":ubuntu: 16.04 Tests"
+    agents:
+      queue: "automation-large-builder-fleet"
+    plugins:
+      ecr#v1.1.4:
+        login: true
+        account_ids: "436617320021"
+        no-include-email: true
+        region: "us-west-2"
+      docker#v2.1.0:
+        debug: true
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu16_2-2"
+        workdir: /data/job
+    timeout: 60
 
-  # - command: |
-  #       echo "--- :arrow_down: Downloading Build Directory"
-  #       buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 16.04 Build"
-  #       echo "+++ :microscope: Running Tests"
-  #       ./scripts/serial-test.sh
-  #   label: ":ubuntu: 16.04 NP Tests"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   plugins:
-  #     ecr#v1.1.4:
-  #       login: true
-  #       account_ids: "436617320021"
-  #       no-include-email: true
-  #       region: "us-west-2"
-  #     docker#v2.1.0:
-  #       debug: true
-  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu16_2-2"
-  #       workdir: /data/job
-  #   timeout: 60
+  - command: |
+        echo "--- :arrow_down: Downloading Build Directory"
+        buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 16.04 Build"
+        echo "+++ :microscope: Running Tests"
+        ./scripts/serial-test.sh
+    label: ":ubuntu: 16.04 NP Tests"
+    agents:
+      queue: "automation-large-builder-fleet"
+    plugins:
+      ecr#v1.1.4:
+        login: true
+        account_ids: "436617320021"
+        no-include-email: true
+        region: "us-west-2"
+      docker#v2.1.0:
+        debug: true
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu16_2-2"
+        workdir: /data/job
+    timeout: 60
   
-  # # Ubuntu 18.04 Tests
-  # - command: |
-  #       echo "--- :arrow_down: Downloading Build Directory"
-  #       buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 18.04 Build"
-  #       echo "+++ :microscope: Running Tests"
-  #       ./scripts/parallel-test.sh
-  #   label: ":ubuntu: 18.04 Tests"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   plugins:
-  #     ecr#v1.1.4:
-  #       login: true
-  #       account_ids: "436617320021"
-  #       no-include-email: true
-  #       region: "us-west-2"
-  #     docker#v2.1.0:
-  #       debug: true
-  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu18_2-2"
-  #       workdir: /data/job
-  #   timeout: 60
+  # Ubuntu 18.04 Tests
+  - command: |
+        echo "--- :arrow_down: Downloading Build Directory"
+        buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 18.04 Build"
+        echo "+++ :microscope: Running Tests"
+        ./scripts/parallel-test.sh
+    label: ":ubuntu: 18.04 Tests"
+    agents:
+      queue: "automation-large-builder-fleet"
+    plugins:
+      ecr#v1.1.4:
+        login: true
+        account_ids: "436617320021"
+        no-include-email: true
+        region: "us-west-2"
+      docker#v2.1.0:
+        debug: true
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu18_2-2"
+        workdir: /data/job
+    timeout: 60
 
-  # - command: |
-  #       echo "--- :arrow_down: Downloading Build Directory"
-  #       buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 18.04 Build"
-  #       echo "+++ :microscope: Running Tests"
-  #       ./scripts/serial-test.sh
-  #   label: ":ubuntu: 18.04 NP Tests"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   plugins:
-  #     ecr#v1.1.4:
-  #       login: true
-  #       account_ids: "436617320021"
-  #       no-include-email: true
-  #       region: "us-west-2"
-  #     docker#v2.1.0:
-  #       debug: true
-  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu18_2-2"
-  #       workdir: /data/job
-  #   timeout: 60
+  - command: |
+        echo "--- :arrow_down: Downloading Build Directory"
+        buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 18.04 Build"
+        echo "+++ :microscope: Running Tests"
+        ./scripts/serial-test.sh
+    label: ":ubuntu: 18.04 NP Tests"
+    agents:
+      queue: "automation-large-builder-fleet"
+    plugins:
+      ecr#v1.1.4:
+        login: true
+        account_ids: "436617320021"
+        no-include-email: true
+        region: "us-west-2"
+      docker#v2.1.0:
+        debug: true
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu18_2-2"
+        workdir: /data/job
+    timeout: 60
 
-  # # centOS Tests
-  # - command: |
-  #       echo "--- :arrow_down: Downloading Build Directory"
-  #       buildkite-agent artifact download "build.tar.gz" . --step ":centos: 7 Build"
-  #       echo "+++ :microscope: Running Tests"
-  #       ./scripts/parallel-test.sh
-  #   label: ":centos: 7 Tests"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   plugins:
-  #     ecr#v1.1.4:
-  #       login: true
-  #       account_ids: "436617320021"
-  #       no-include-email: true
-  #       region: "us-west-2"
-  #     docker#v2.1.0:
-  #       debug: true
-  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:centos7_2-2"
-  #       workdir: /data/job
-  #   timeout: 60
+  # centOS Tests
+  - command: |
+        echo "--- :arrow_down: Downloading Build Directory"
+        buildkite-agent artifact download "build.tar.gz" . --step ":centos: 7 Build"
+        echo "+++ :microscope: Running Tests"
+        ./scripts/parallel-test.sh
+    label: ":centos: 7 Tests"
+    agents:
+      queue: "automation-large-builder-fleet"
+    plugins:
+      ecr#v1.1.4:
+        login: true
+        account_ids: "436617320021"
+        no-include-email: true
+        region: "us-west-2"
+      docker#v2.1.0:
+        debug: true
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:centos7_2-2"
+        workdir: /data/job
+    timeout: 60
 
-  # - command: |
-  #       echo "--- :arrow_down: Downloading Build Directory"
-  #       buildkite-agent artifact download "build.tar.gz" . --step ":centos: 7 Build"
-  #       echo "+++ :microscope: Running Tests"
-  #       ./scripts/serial-test.sh
-  #   label: ":centos: 7 NP Tests"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   plugins:
-  #     ecr#v1.1.4:
-  #       login: true
-  #       account_ids: "436617320021"
-  #       no-include-email: true
-  #       region: "us-west-2"
-  #     docker#v2.1.0:
-  #       debug: true
-  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:centos7_2-2"
-  #       workdir: /data/job
-  #   timeout: 60
+  - command: |
+        echo "--- :arrow_down: Downloading Build Directory"
+        buildkite-agent artifact download "build.tar.gz" . --step ":centos: 7 Build"
+        echo "+++ :microscope: Running Tests"
+        ./scripts/serial-test.sh
+    label: ":centos: 7 NP Tests"
+    agents:
+      queue: "automation-large-builder-fleet"
+    plugins:
+      ecr#v1.1.4:
+        login: true
+        account_ids: "436617320021"
+        no-include-email: true
+        region: "us-west-2"
+      docker#v2.1.0:
+        debug: true
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:centos7_2-2"
+        workdir: /data/job
+    timeout: 60
 
-  # # Amazon AWS-2 Linux Tests
-  # - command: |
-  #       echo "--- :arrow_down: Downloading Build Directory"
-  #       buildkite-agent artifact download "build.tar.gz" . --step ":aws: 2 Build"
-  #       echo "+++ :microscope: Running Tests"
-  #       ./scripts/parallel-test.sh
-  #   label: ":aws: 2 Tests"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   plugins:
-  #     ecr#v1.1.4:
-  #       login: true
-  #       account_ids: "436617320021"
-  #       no-include-email: true
-  #       region: "us-west-2"
-  #     docker#v2.1.0:
-  #       debug: true
-  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:amazonlinux2_2-2"
-  #       workdir: /data/job
-  #   timeout: 60
+  # Amazon AWS-2 Linux Tests
+  - command: |
+        echo "--- :arrow_down: Downloading Build Directory"
+        buildkite-agent artifact download "build.tar.gz" . --step ":aws: 2 Build"
+        echo "+++ :microscope: Running Tests"
+        ./scripts/parallel-test.sh
+    label: ":aws: 2 Tests"
+    agents:
+      queue: "automation-large-builder-fleet"
+    plugins:
+      ecr#v1.1.4:
+        login: true
+        account_ids: "436617320021"
+        no-include-email: true
+        region: "us-west-2"
+      docker#v2.1.0:
+        debug: true
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:amazonlinux2_2-2"
+        workdir: /data/job
+    timeout: 60
 
-  # - command: |
-  #       echo "--- :arrow_down: Downloading Build Directory"
-  #       buildkite-agent artifact download "build.tar.gz" . --step ":aws: 2 Build"
-  #       echo "+++ :microscope: Running Tests"
-  #       ./scripts/serial-test.sh
-  #   label: ":aws: 2 NP Tests"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   plugins:
-  #     ecr#v1.1.4:
-  #       login: true
-  #       account_ids: "436617320021"
-  #       no-include-email: true
-  #       region: "us-west-2"
-  #     docker#v2.1.0:
-  #       debug: true
-  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:amazonlinux2_2-2"
-  #       workdir: /data/job
-  #   timeout: 60
+  - command: |
+        echo "--- :arrow_down: Downloading Build Directory"
+        buildkite-agent artifact download "build.tar.gz" . --step ":aws: 2 Build"
+        echo "+++ :microscope: Running Tests"
+        ./scripts/serial-test.sh
+    label: ":aws: 2 NP Tests"
+    agents:
+      queue: "automation-large-builder-fleet"
+    plugins:
+      ecr#v1.1.4:
+        login: true
+        account_ids: "436617320021"
+        no-include-email: true
+        region: "us-west-2"
+      docker#v2.1.0:
+        debug: true
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:amazonlinux2_2-2"
+        workdir: /data/job
+    timeout: 60
 
-  # # Mojave Tests
-  # - command: |
-  #       echo "--- :arrow_down: Downloading Build Directory"
-  #       buildkite-agent artifact download "build.tar.gz" . --step ":darwin: Mojave Build"
-  #       echo "+++ :microscope: Running Tests"
-  #       ln -s "$(pwd)" /data/job
-  #       ./scripts/parallel-test.sh
-  #   label: ":darwin: Mojave Tests"
-  #   agents:
-  #     - "role=tester-v2-1"
-  #     - "os=mojave"
-  #   timeout: 60
+  # Mojave Tests
+  - command: |
+        echo "--- :arrow_down: Downloading Build Directory"
+        buildkite-agent artifact download "build.tar.gz" . --step ":darwin: Mojave Build"
+        echo "+++ :microscope: Running Tests"
+        ln -s "$(pwd)" /data/job
+        ./scripts/parallel-test.sh
+    label: ":darwin: Mojave Tests"
+    agents:
+      - "role=tester-v2-1"
+      - "os=mojave"
+    timeout: 60
 
-  # - command: |
-  #       echo "--- :arrow_down: Downloading Build Directory"
-  #       buildkite-agent artifact download "build.tar.gz" . --step ":darwin: Mojave Build"
-  #       echo "+++ :microscope: Running Tests"
-  #       ln -s "$(pwd)" /data/job && ./scripts/serial-test.sh
-  #   label: ":darwin: Mojave NP Tests"
-  #   agents:
-  #     - "role=tester-v2-1"
-  #     - "os=mojave"
-  #   timeout: 60
+  - command: |
+        echo "--- :arrow_down: Downloading Build Directory"
+        buildkite-agent artifact download "build.tar.gz" . --step ":darwin: Mojave Build"
+        echo "+++ :microscope: Running Tests"
+        ln -s "$(pwd)" /data/job && ./scripts/serial-test.sh
+    label: ":darwin: Mojave NP Tests"
+    agents:
+      - "role=tester-v2-1"
+      - "os=mojave"
+    timeout: 60
     
-  # - wait
+  - wait
 
-  # - command: | # Ubuntu 16.04 Package Builder
-  #       echo "--- :arrow_down: Downloading build directory"
-  #       buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 16.04 Build"
-  #       tar -zxf build.tar.gz
-  #       echo "+++ :microscope: Starting package build"
-  #       cd /data/job/build/packages && bash generate_package.sh deb
-  #   label: ":ubuntu: 16.04 Package builder"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   artifact_paths:
-  #     - "build/packages/*.deb"
-  #   plugins:
-  #     ecr#v1.1.4:
-  #       login: true
-  #       account_ids: "436617320021"
-  #       no-include-email: true
-  #       region: "us-west-2"
-  #     docker#v2.1.0:
-  #       debug: true
-  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu16_2-2"
-  #       workdir: /data/job
-  #   env:
-  #     OS: "ubuntu-16.04"
-  #     PKGTYPE: "deb"
-  #   timeout: 60
+  - command: | # Ubuntu 16.04 Package Builder
+        echo "--- :arrow_down: Downloading build directory"
+        buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 16.04 Build"
+        tar -zxf build.tar.gz
+        echo "+++ :microscope: Starting package build"
+        cd /data/job/build/packages && bash generate_package.sh deb
+    label: ":ubuntu: 16.04 Package builder"
+    agents:
+      queue: "automation-large-builder-fleet"
+    artifact_paths:
+      - "build/packages/*.deb"
+    plugins:
+      ecr#v1.1.4:
+        login: true
+        account_ids: "436617320021"
+        no-include-email: true
+        region: "us-west-2"
+      docker#v2.1.0:
+        debug: true
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu16_2-2"
+        workdir: /data/job
+    env:
+      OS: "ubuntu-16.04"
+      PKGTYPE: "deb"
+    timeout: 60
 
-  # - command: | # Ubuntu 18.04 Package Builder
-  #       echo "--- :arrow_down: Downloading build directory"
-  #       buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 18.04 Build"
-  #       tar -zxf build.tar.gz
-  #       echo "+++ :microscope: Starting package build"
-  #       cd /data/job/build/packages && bash generate_package.sh deb
-  #   label: ":ubuntu: 18.04 Package builder"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   artifact_paths:
-  #     - "build/packages/*.deb"
-  #   plugins:
-  #     ecr#v1.1.4:
-  #       login: true
-  #       account_ids: "436617320021"
-  #       no-include-email: true
-  #       region: "us-west-2"
-  #     docker#v2.1.0:
-  #       debug: true
-  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu18_2-2"
-  #       workdir: /data/job
-  #   env:
-  #     OS: "ubuntu-18.04"
-  #     PKGTYPE: "deb"
-  #   timeout: 60
+  - command: | # Ubuntu 18.04 Package Builder
+        echo "--- :arrow_down: Downloading build directory"
+        buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 18.04 Build"
+        tar -zxf build.tar.gz
+        echo "+++ :microscope: Starting package build"
+        cd /data/job/build/packages && bash generate_package.sh deb
+    label: ":ubuntu: 18.04 Package builder"
+    agents:
+      queue: "automation-large-builder-fleet"
+    artifact_paths:
+      - "build/packages/*.deb"
+    plugins:
+      ecr#v1.1.4:
+        login: true
+        account_ids: "436617320021"
+        no-include-email: true
+        region: "us-west-2"
+      docker#v2.1.0:
+        debug: true
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu18_2-2"
+        workdir: /data/job
+    env:
+      OS: "ubuntu-18.04"
+      PKGTYPE: "deb"
+    timeout: 60
 
-  # - command: | # CentOS 7 Package Builder
-  #       echo "--- :arrow_down: Downloading build directory"
-  #       buildkite-agent artifact download "build.tar.gz" . --step ":centos: 7 Build"
-  #       tar -zxf build.tar.gz
-  #       echo "+++ :microscope: Starting package build"
-  #       yum install -y rpm-build
-  #       mkdir -p /root/rpmbuild/BUILD
-  #       mkdir -p /root/rpmbuild/BUILDROOT
-  #       mkdir -p /root/rpmbuild/RPMS
-  #       mkdir -p /root/rpmbuild/SOURCES
-  #       mkdir -p /root/rpmbuild/SPECS
-  #       mkdir -p /root/rpmbuild/SRPMS
-  #       cd /data/job/build/packages && bash generate_package.sh rpm
-  #   label: ":centos: 7 Package builder"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   artifact_paths:
-  #     - "build/packages/*.rpm"
-  #   plugins:
-  #     ecr#v1.1.4:
-  #       login: true
-  #       account_ids: "436617320021"
-  #       no-include-email: true
-  #       region: "us-west-2"
-  #     docker#v2.1.0:
-  #       debug: true
-  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:centos7_2-2"
-  #       workdir: /data/job
-  #   env:
-  #     OS: "el7"
-  #     PKGTYPE: "rpm"
-  #   timeout: 60
+  - command: | # CentOS 7 Package Builder
+        echo "--- :arrow_down: Downloading build directory"
+        buildkite-agent artifact download "build.tar.gz" . --step ":centos: 7 Build"
+        tar -zxf build.tar.gz
+        echo "+++ :microscope: Starting package build"
+        yum install -y rpm-build
+        mkdir -p /root/rpmbuild/BUILD
+        mkdir -p /root/rpmbuild/BUILDROOT
+        mkdir -p /root/rpmbuild/RPMS
+        mkdir -p /root/rpmbuild/SOURCES
+        mkdir -p /root/rpmbuild/SPECS
+        mkdir -p /root/rpmbuild/SRPMS
+        cd /data/job/build/packages && bash generate_package.sh rpm
+    label: ":centos: 7 Package builder"
+    agents:
+      queue: "automation-large-builder-fleet"
+    artifact_paths:
+      - "build/packages/*.rpm"
+    plugins:
+      ecr#v1.1.4:
+        login: true
+        account_ids: "436617320021"
+        no-include-email: true
+        region: "us-west-2"
+      docker#v2.1.0:
+        debug: true
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:centos7_2-2"
+        workdir: /data/job
+    env:
+      OS: "el7"
+      PKGTYPE: "rpm"
+    timeout: 60
 
-  # - command: | # macOS Mojave Package Builder
-  #       echo "--- :arrow_down: Downloading build directory"
-  #       buildkite-agent artifact download "build.tar.gz" . --step ":darwin: Mojave Build"
-  #       tar -zxf build.tar.gz
-  #       echo "+++ :microscope: Starting package build"
-  #       ln -s "$(pwd)" /data/job && cd /data/job/build/packages && bash generate_package.sh brew
-  #   label: ":darwin: Mojave Package Builder"
-  #   agents:
-  #     - "role=builder-v2-1"
-  #     - "os=mojave"
-  #   artifact_paths:
-  #     - "build/packages/*.tar.gz"
-  #     - "build/packages/*.rb"
-  #   timeout: 60
+  - command: | # macOS Mojave Package Builder
+        echo "--- :arrow_down: Downloading build directory"
+        buildkite-agent artifact download "build.tar.gz" . --step ":darwin: Mojave Build"
+        tar -zxf build.tar.gz
+        echo "+++ :microscope: Starting package build"
+        ln -s "$(pwd)" /data/job && cd /data/job/build/packages && bash generate_package.sh brew
+    label: ":darwin: Mojave Package Builder"
+    agents:
+      - "role=builder-v2-1"
+      - "os=mojave"
+    artifact_paths:
+      - "build/packages/*.tar.gz"
+      - "build/packages/*.rb"
+    timeout: 60
 
-  # - wait
+  - wait
 
-  # - command: |
-  #       echo "--- :arrow_down: Downloading brew files"
-  #       buildkite-agent artifact download "build/packages/eosio.rb" . --step ":darwin: Mojave Package Builder"
-  #   label: ":darwin: Brew Updater"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   artifact_paths:
-  #     - "build/packages/eosio.rb"
-  #   timeout: 60
+  - command: |
+        echo "--- :arrow_down: Downloading brew files"
+        buildkite-agent artifact download "build/packages/eosio.rb" . --step ":darwin: Mojave Package Builder"
+    label: ":darwin: Brew Updater"
+    agents:
+      queue: "automation-large-builder-fleet"
+    artifact_paths:
+      - "build/packages/eosio.rb"
+    timeout: 60
 
-  # - command: |
-  #       echo "+++ :microscope: Running git submodule regression check" && \
-  #       ./scripts/submodule_check.sh
-  #   label: "Git submodule regression check"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   timeout: 240
+  - command: |
+        echo "+++ :microscope: Running git submodule regression check" && \
+        ./scripts/submodule_check.sh
+    label: "Git submodule regression check"
+    agents:
+      queue: "automation-large-builder-fleet"
+    timeout: 240

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,8 +1,8 @@
 steps:
   - command: | # Ubuntu 16.04 Build
-        echo "+++ :hammer: Building"
-        ./scripts/eosio_build.sh -y
-        echo "--- :compression: Compressing build directory"
+        # echo "+++ :hammer: Building"
+        # ./scripts/eosio_build.sh -y
+        # echo "--- :compression: Compressing build directory"
         tar -pczf build.tar.gz2 build/; if [[ ! -f build.tar.gz ]]; then exit 1; fi;
     label: ":ubuntu: 16.04 Build"
     agents:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,7 +4,7 @@ steps:
         # ./scripts/eosio_build.sh -y
         # echo "--- :compression: Compressing build directory"
         #tar -pczf build.tar.gz2 build/; 
-        if [[ ! -f build.tar.gz ]]; then echo "No TAR Found!" && exit 1; fi;
+        if [ ! -f build.tar.gz ]; then echo "No TAR Found!" && exit 1; fi;
     label: ":ubuntu: 16.04 Build"
     agents:
       queue: "automation-large-builder-fleet"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,7 +3,7 @@ steps:
         echo "+++ :hammer: Building"
         ./scripts/eosio_build.sh -y
         echo "--- :compression: Compressing build directory"
-        tar -pczf build.tar.gz build/; if [[ ! -f build.tar.gz ]]; then exit 1; fi;
+        tar -pczf build.tar.gz2 build/; if [[ ! -f build.tar.gz ]]; then exit 1; fi;
     label: ":ubuntu: 16.04 Build"
     agents:
       queue: "automation-large-builder-fleet"
@@ -20,391 +20,391 @@ steps:
         workdir: /data/job
     timeout: 60
 
-  - command: | # Ubuntu 18.04 Build
-        echo "+++ :hammer: Building"
-        ./scripts/eosio_build.sh -y
-        echo "--- :compression: Compressing build directory"
-        tar -pczf build.tar.gz build/; if [[ ! -f build.tar.gz ]]; then exit 1; fi;
-    label: ":ubuntu: 18.04 Build"
-    agents:
-      queue: "automation-large-builder-fleet"
-    artifact_paths: "build.tar.gz"
-    plugins:
-      ecr#v1.1.4:
-        login: true
-        account_ids: "436617320021"
-        no-include-email: true
-        region: "us-west-2"
-      docker#v2.1.0:
-        debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu18_2-2"
-        workdir: /data/job
-    timeout: 60
+  # - command: | # Ubuntu 18.04 Build
+  #       echo "+++ :hammer: Building"
+  #       ./scripts/eosio_build.sh -y
+  #       echo "--- :compression: Compressing build directory"
+  #       tar -pczf build.tar.gz build/; if [[ ! -f build.tar.gz ]]; then exit 1; fi;
+  #   label: ":ubuntu: 18.04 Build"
+  #   agents:
+  #     queue: "automation-large-builder-fleet"
+  #   artifact_paths: "build.tar.gz"
+  #   plugins:
+  #     ecr#v1.1.4:
+  #       login: true
+  #       account_ids: "436617320021"
+  #       no-include-email: true
+  #       region: "us-west-2"
+  #     docker#v2.1.0:
+  #       debug: true
+  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu18_2-2"
+  #       workdir: /data/job
+  #   timeout: 60
 
-  - command: | # CentOS 7 Build
-        echo "+++ :hammer: Building"
-        ./scripts/eosio_build.sh -y
-        echo "--- :compression: Compressing build directory"
-        tar -pczf build.tar.gz build/; if [[ ! -f build.tar.gz ]]; then exit 1; fi
-    label: ":centos: 7 Build"
-    agents:
-      queue: "automation-large-builder-fleet"
-    artifact_paths: "build.tar.gz"
-    plugins:
-      ecr#v1.1.4:
-        login: true
-        account_ids: "436617320021"
-        no-include-email: true
-        region: "us-west-2"
-      docker#v2.1.0:
-        debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:centos7_2-2"
-        workdir: /data/job
-    timeout: 60
+  # - command: | # CentOS 7 Build
+  #       echo "+++ :hammer: Building"
+  #       ./scripts/eosio_build.sh -y
+  #       echo "--- :compression: Compressing build directory"
+  #       tar -pczf build.tar.gz build/; if [[ ! -f build.tar.gz ]]; then exit 1; fi
+  #   label: ":centos: 7 Build"
+  #   agents:
+  #     queue: "automation-large-builder-fleet"
+  #   artifact_paths: "build.tar.gz"
+  #   plugins:
+  #     ecr#v1.1.4:
+  #       login: true
+  #       account_ids: "436617320021"
+  #       no-include-email: true
+  #       region: "us-west-2"
+  #     docker#v2.1.0:
+  #       debug: true
+  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:centos7_2-2"
+  #       workdir: /data/job
+  #   timeout: 60
 
-  - command: | # Amazon Linux 2 Build
-        echo "+++ :hammer: Building"
-        ./scripts/eosio_build.sh -y
-        echo "--- :compression: Compressing build directory"
-        tar -pczf build.tar.gz build/; if [[ ! -f build.tar.gz ]]; then exit 1; fi
-    label: ":aws: 2 Build"
-    agents:
-      queue: "automation-large-builder-fleet"
-    artifact_paths: "build.tar.gz"
-    plugins:
-      ecr#v1.1.4:
-        login: true
-        account_ids: "436617320021"
-        no-include-email: true
-        region: "us-west-2"
-      docker#v2.1.0:
-        debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:amazonlinux2_2-2"
-        workdir: /data/job
-    timeout: 60
+  # - command: | # Amazon Linux 2 Build
+  #       echo "+++ :hammer: Building"
+  #       ./scripts/eosio_build.sh -y
+  #       echo "--- :compression: Compressing build directory"
+  #       tar -pczf build.tar.gz build/; if [[ ! -f build.tar.gz ]]; then exit 1; fi
+  #   label: ":aws: 2 Build"
+  #   agents:
+  #     queue: "automation-large-builder-fleet"
+  #   artifact_paths: "build.tar.gz"
+  #   plugins:
+  #     ecr#v1.1.4:
+  #       login: true
+  #       account_ids: "436617320021"
+  #       no-include-email: true
+  #       region: "us-west-2"
+  #     docker#v2.1.0:
+  #       debug: true
+  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:amazonlinux2_2-2"
+  #       workdir: /data/job
+  #   timeout: 60
 
-  - command: | # macOS Mojave Build
-      echo "--- Creating symbolic link to job directory :file_folder:"
-      sleep 5 && ln -s "$(pwd)" /data/job && cd /data/job
-      echo "+++ Building :hammer:"
-      ./scripts/eosio_build.sh -y
-      echo "--- Compressing build directory :compression:"
-      tar -pczf build.tar.gz build/; if [[ ! -f build.tar.gz ]]; then exit 1; fi
-    label: ":darwin: Mojave Build"
-    agents:
-      - "role=builder-v2-1"
-      - "os=mojave"
-    artifact_paths: "build.tar.gz"
-    timeout: 60
+  # - command: | # macOS Mojave Build
+  #     echo "--- Creating symbolic link to job directory :file_folder:"
+  #     sleep 5 && ln -s "$(pwd)" /data/job && cd /data/job
+  #     echo "+++ Building :hammer:"
+  #     ./scripts/eosio_build.sh -y
+  #     echo "--- Compressing build directory :compression:"
+  #     tar -pczf build.tar.gz build/; if [[ ! -f build.tar.gz ]]; then exit 1; fi
+  #   label: ":darwin: Mojave Build"
+  #   agents:
+  #     - "role=builder-v2-1"
+  #     - "os=mojave"
+  #   artifact_paths: "build.tar.gz"
+  #   timeout: 60
 
-  - wait
+  # - wait
 
-  # Ubuntu 16.04 Tests
-  - command: |
-        echo "--- :arrow_down: Downloading Build Directory"
-        buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 16.04 Build"
-        echo "+++ :microscope: Running Tests"
-        ./scripts/parallel-test.sh
-    label: ":ubuntu: 16.04 Tests"
-    agents:
-      queue: "automation-large-builder-fleet"
-    plugins:
-      ecr#v1.1.4:
-        login: true
-        account_ids: "436617320021"
-        no-include-email: true
-        region: "us-west-2"
-      docker#v2.1.0:
-        debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu16_2-2"
-        workdir: /data/job
-    timeout: 60
+  # # Ubuntu 16.04 Tests
+  # - command: |
+  #       echo "--- :arrow_down: Downloading Build Directory"
+  #       buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 16.04 Build"
+  #       echo "+++ :microscope: Running Tests"
+  #       ./scripts/parallel-test.sh
+  #   label: ":ubuntu: 16.04 Tests"
+  #   agents:
+  #     queue: "automation-large-builder-fleet"
+  #   plugins:
+  #     ecr#v1.1.4:
+  #       login: true
+  #       account_ids: "436617320021"
+  #       no-include-email: true
+  #       region: "us-west-2"
+  #     docker#v2.1.0:
+  #       debug: true
+  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu16_2-2"
+  #       workdir: /data/job
+  #   timeout: 60
 
-  - command: |
-        echo "--- :arrow_down: Downloading Build Directory"
-        buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 16.04 Build"
-        echo "+++ :microscope: Running Tests"
-        ./scripts/serial-test.sh
-    label: ":ubuntu: 16.04 NP Tests"
-    agents:
-      queue: "automation-large-builder-fleet"
-    plugins:
-      ecr#v1.1.4:
-        login: true
-        account_ids: "436617320021"
-        no-include-email: true
-        region: "us-west-2"
-      docker#v2.1.0:
-        debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu16_2-2"
-        workdir: /data/job
-    timeout: 60
+  # - command: |
+  #       echo "--- :arrow_down: Downloading Build Directory"
+  #       buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 16.04 Build"
+  #       echo "+++ :microscope: Running Tests"
+  #       ./scripts/serial-test.sh
+  #   label: ":ubuntu: 16.04 NP Tests"
+  #   agents:
+  #     queue: "automation-large-builder-fleet"
+  #   plugins:
+  #     ecr#v1.1.4:
+  #       login: true
+  #       account_ids: "436617320021"
+  #       no-include-email: true
+  #       region: "us-west-2"
+  #     docker#v2.1.0:
+  #       debug: true
+  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu16_2-2"
+  #       workdir: /data/job
+  #   timeout: 60
   
-  # Ubuntu 18.04 Tests
-  - command: |
-        echo "--- :arrow_down: Downloading Build Directory"
-        buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 18.04 Build"
-        echo "+++ :microscope: Running Tests"
-        ./scripts/parallel-test.sh
-    label: ":ubuntu: 18.04 Tests"
-    agents:
-      queue: "automation-large-builder-fleet"
-    plugins:
-      ecr#v1.1.4:
-        login: true
-        account_ids: "436617320021"
-        no-include-email: true
-        region: "us-west-2"
-      docker#v2.1.0:
-        debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu18_2-2"
-        workdir: /data/job
-    timeout: 60
+  # # Ubuntu 18.04 Tests
+  # - command: |
+  #       echo "--- :arrow_down: Downloading Build Directory"
+  #       buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 18.04 Build"
+  #       echo "+++ :microscope: Running Tests"
+  #       ./scripts/parallel-test.sh
+  #   label: ":ubuntu: 18.04 Tests"
+  #   agents:
+  #     queue: "automation-large-builder-fleet"
+  #   plugins:
+  #     ecr#v1.1.4:
+  #       login: true
+  #       account_ids: "436617320021"
+  #       no-include-email: true
+  #       region: "us-west-2"
+  #     docker#v2.1.0:
+  #       debug: true
+  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu18_2-2"
+  #       workdir: /data/job
+  #   timeout: 60
 
-  - command: |
-        echo "--- :arrow_down: Downloading Build Directory"
-        buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 18.04 Build"
-        echo "+++ :microscope: Running Tests"
-        ./scripts/serial-test.sh
-    label: ":ubuntu: 18.04 NP Tests"
-    agents:
-      queue: "automation-large-builder-fleet"
-    plugins:
-      ecr#v1.1.4:
-        login: true
-        account_ids: "436617320021"
-        no-include-email: true
-        region: "us-west-2"
-      docker#v2.1.0:
-        debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu18_2-2"
-        workdir: /data/job
-    timeout: 60
+  # - command: |
+  #       echo "--- :arrow_down: Downloading Build Directory"
+  #       buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 18.04 Build"
+  #       echo "+++ :microscope: Running Tests"
+  #       ./scripts/serial-test.sh
+  #   label: ":ubuntu: 18.04 NP Tests"
+  #   agents:
+  #     queue: "automation-large-builder-fleet"
+  #   plugins:
+  #     ecr#v1.1.4:
+  #       login: true
+  #       account_ids: "436617320021"
+  #       no-include-email: true
+  #       region: "us-west-2"
+  #     docker#v2.1.0:
+  #       debug: true
+  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu18_2-2"
+  #       workdir: /data/job
+  #   timeout: 60
 
-  # centOS Tests
-  - command: |
-        echo "--- :arrow_down: Downloading Build Directory"
-        buildkite-agent artifact download "build.tar.gz" . --step ":centos: 7 Build"
-        echo "+++ :microscope: Running Tests"
-        ./scripts/parallel-test.sh
-    label: ":centos: 7 Tests"
-    agents:
-      queue: "automation-large-builder-fleet"
-    plugins:
-      ecr#v1.1.4:
-        login: true
-        account_ids: "436617320021"
-        no-include-email: true
-        region: "us-west-2"
-      docker#v2.1.0:
-        debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:centos7_2-2"
-        workdir: /data/job
-    timeout: 60
+  # # centOS Tests
+  # - command: |
+  #       echo "--- :arrow_down: Downloading Build Directory"
+  #       buildkite-agent artifact download "build.tar.gz" . --step ":centos: 7 Build"
+  #       echo "+++ :microscope: Running Tests"
+  #       ./scripts/parallel-test.sh
+  #   label: ":centos: 7 Tests"
+  #   agents:
+  #     queue: "automation-large-builder-fleet"
+  #   plugins:
+  #     ecr#v1.1.4:
+  #       login: true
+  #       account_ids: "436617320021"
+  #       no-include-email: true
+  #       region: "us-west-2"
+  #     docker#v2.1.0:
+  #       debug: true
+  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:centos7_2-2"
+  #       workdir: /data/job
+  #   timeout: 60
 
-  - command: |
-        echo "--- :arrow_down: Downloading Build Directory"
-        buildkite-agent artifact download "build.tar.gz" . --step ":centos: 7 Build"
-        echo "+++ :microscope: Running Tests"
-        ./scripts/serial-test.sh
-    label: ":centos: 7 NP Tests"
-    agents:
-      queue: "automation-large-builder-fleet"
-    plugins:
-      ecr#v1.1.4:
-        login: true
-        account_ids: "436617320021"
-        no-include-email: true
-        region: "us-west-2"
-      docker#v2.1.0:
-        debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:centos7_2-2"
-        workdir: /data/job
-    timeout: 60
+  # - command: |
+  #       echo "--- :arrow_down: Downloading Build Directory"
+  #       buildkite-agent artifact download "build.tar.gz" . --step ":centos: 7 Build"
+  #       echo "+++ :microscope: Running Tests"
+  #       ./scripts/serial-test.sh
+  #   label: ":centos: 7 NP Tests"
+  #   agents:
+  #     queue: "automation-large-builder-fleet"
+  #   plugins:
+  #     ecr#v1.1.4:
+  #       login: true
+  #       account_ids: "436617320021"
+  #       no-include-email: true
+  #       region: "us-west-2"
+  #     docker#v2.1.0:
+  #       debug: true
+  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:centos7_2-2"
+  #       workdir: /data/job
+  #   timeout: 60
 
-  # Amazon AWS-2 Linux Tests
-  - command: |
-        echo "--- :arrow_down: Downloading Build Directory"
-        buildkite-agent artifact download "build.tar.gz" . --step ":aws: 2 Build"
-        echo "+++ :microscope: Running Tests"
-        ./scripts/parallel-test.sh
-    label: ":aws: 2 Tests"
-    agents:
-      queue: "automation-large-builder-fleet"
-    plugins:
-      ecr#v1.1.4:
-        login: true
-        account_ids: "436617320021"
-        no-include-email: true
-        region: "us-west-2"
-      docker#v2.1.0:
-        debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:amazonlinux2_2-2"
-        workdir: /data/job
-    timeout: 60
+  # # Amazon AWS-2 Linux Tests
+  # - command: |
+  #       echo "--- :arrow_down: Downloading Build Directory"
+  #       buildkite-agent artifact download "build.tar.gz" . --step ":aws: 2 Build"
+  #       echo "+++ :microscope: Running Tests"
+  #       ./scripts/parallel-test.sh
+  #   label: ":aws: 2 Tests"
+  #   agents:
+  #     queue: "automation-large-builder-fleet"
+  #   plugins:
+  #     ecr#v1.1.4:
+  #       login: true
+  #       account_ids: "436617320021"
+  #       no-include-email: true
+  #       region: "us-west-2"
+  #     docker#v2.1.0:
+  #       debug: true
+  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:amazonlinux2_2-2"
+  #       workdir: /data/job
+  #   timeout: 60
 
-  - command: |
-        echo "--- :arrow_down: Downloading Build Directory"
-        buildkite-agent artifact download "build.tar.gz" . --step ":aws: 2 Build"
-        echo "+++ :microscope: Running Tests"
-        ./scripts/serial-test.sh
-    label: ":aws: 2 NP Tests"
-    agents:
-      queue: "automation-large-builder-fleet"
-    plugins:
-      ecr#v1.1.4:
-        login: true
-        account_ids: "436617320021"
-        no-include-email: true
-        region: "us-west-2"
-      docker#v2.1.0:
-        debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:amazonlinux2_2-2"
-        workdir: /data/job
-    timeout: 60
+  # - command: |
+  #       echo "--- :arrow_down: Downloading Build Directory"
+  #       buildkite-agent artifact download "build.tar.gz" . --step ":aws: 2 Build"
+  #       echo "+++ :microscope: Running Tests"
+  #       ./scripts/serial-test.sh
+  #   label: ":aws: 2 NP Tests"
+  #   agents:
+  #     queue: "automation-large-builder-fleet"
+  #   plugins:
+  #     ecr#v1.1.4:
+  #       login: true
+  #       account_ids: "436617320021"
+  #       no-include-email: true
+  #       region: "us-west-2"
+  #     docker#v2.1.0:
+  #       debug: true
+  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:amazonlinux2_2-2"
+  #       workdir: /data/job
+  #   timeout: 60
 
-  # Mojave Tests
-  - command: |
-        echo "--- :arrow_down: Downloading Build Directory"
-        buildkite-agent artifact download "build.tar.gz" . --step ":darwin: Mojave Build"
-        echo "+++ :microscope: Running Tests"
-        ln -s "$(pwd)" /data/job
-        ./scripts/parallel-test.sh
-    label: ":darwin: Mojave Tests"
-    agents:
-      - "role=tester-v2-1"
-      - "os=mojave"
-    timeout: 60
+  # # Mojave Tests
+  # - command: |
+  #       echo "--- :arrow_down: Downloading Build Directory"
+  #       buildkite-agent artifact download "build.tar.gz" . --step ":darwin: Mojave Build"
+  #       echo "+++ :microscope: Running Tests"
+  #       ln -s "$(pwd)" /data/job
+  #       ./scripts/parallel-test.sh
+  #   label: ":darwin: Mojave Tests"
+  #   agents:
+  #     - "role=tester-v2-1"
+  #     - "os=mojave"
+  #   timeout: 60
 
-  - command: |
-        echo "--- :arrow_down: Downloading Build Directory"
-        buildkite-agent artifact download "build.tar.gz" . --step ":darwin: Mojave Build"
-        echo "+++ :microscope: Running Tests"
-        ln -s "$(pwd)" /data/job && ./scripts/serial-test.sh
-    label: ":darwin: Mojave NP Tests"
-    agents:
-      - "role=tester-v2-1"
-      - "os=mojave"
-    timeout: 60
+  # - command: |
+  #       echo "--- :arrow_down: Downloading Build Directory"
+  #       buildkite-agent artifact download "build.tar.gz" . --step ":darwin: Mojave Build"
+  #       echo "+++ :microscope: Running Tests"
+  #       ln -s "$(pwd)" /data/job && ./scripts/serial-test.sh
+  #   label: ":darwin: Mojave NP Tests"
+  #   agents:
+  #     - "role=tester-v2-1"
+  #     - "os=mojave"
+  #   timeout: 60
     
-  - wait
+  # - wait
 
-  - command: | # Ubuntu 16.04 Package Builder
-        echo "--- :arrow_down: Downloading build directory"
-        buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 16.04 Build"
-        tar -zxf build.tar.gz
-        echo "+++ :microscope: Starting package build"
-        cd /data/job/build/packages && bash generate_package.sh deb
-    label: ":ubuntu: 16.04 Package builder"
-    agents:
-      queue: "automation-large-builder-fleet"
-    artifact_paths:
-      - "build/packages/*.deb"
-    plugins:
-      ecr#v1.1.4:
-        login: true
-        account_ids: "436617320021"
-        no-include-email: true
-        region: "us-west-2"
-      docker#v2.1.0:
-        debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu16_2-2"
-        workdir: /data/job
-    env:
-      OS: "ubuntu-16.04"
-      PKGTYPE: "deb"
-    timeout: 60
+  # - command: | # Ubuntu 16.04 Package Builder
+  #       echo "--- :arrow_down: Downloading build directory"
+  #       buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 16.04 Build"
+  #       tar -zxf build.tar.gz
+  #       echo "+++ :microscope: Starting package build"
+  #       cd /data/job/build/packages && bash generate_package.sh deb
+  #   label: ":ubuntu: 16.04 Package builder"
+  #   agents:
+  #     queue: "automation-large-builder-fleet"
+  #   artifact_paths:
+  #     - "build/packages/*.deb"
+  #   plugins:
+  #     ecr#v1.1.4:
+  #       login: true
+  #       account_ids: "436617320021"
+  #       no-include-email: true
+  #       region: "us-west-2"
+  #     docker#v2.1.0:
+  #       debug: true
+  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu16_2-2"
+  #       workdir: /data/job
+  #   env:
+  #     OS: "ubuntu-16.04"
+  #     PKGTYPE: "deb"
+  #   timeout: 60
 
-  - command: | # Ubuntu 18.04 Package Builder
-        echo "--- :arrow_down: Downloading build directory"
-        buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 18.04 Build"
-        tar -zxf build.tar.gz
-        echo "+++ :microscope: Starting package build"
-        cd /data/job/build/packages && bash generate_package.sh deb
-    label: ":ubuntu: 18.04 Package builder"
-    agents:
-      queue: "automation-large-builder-fleet"
-    artifact_paths:
-      - "build/packages/*.deb"
-    plugins:
-      ecr#v1.1.4:
-        login: true
-        account_ids: "436617320021"
-        no-include-email: true
-        region: "us-west-2"
-      docker#v2.1.0:
-        debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu18_2-2"
-        workdir: /data/job
-    env:
-      OS: "ubuntu-18.04"
-      PKGTYPE: "deb"
-    timeout: 60
+  # - command: | # Ubuntu 18.04 Package Builder
+  #       echo "--- :arrow_down: Downloading build directory"
+  #       buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 18.04 Build"
+  #       tar -zxf build.tar.gz
+  #       echo "+++ :microscope: Starting package build"
+  #       cd /data/job/build/packages && bash generate_package.sh deb
+  #   label: ":ubuntu: 18.04 Package builder"
+  #   agents:
+  #     queue: "automation-large-builder-fleet"
+  #   artifact_paths:
+  #     - "build/packages/*.deb"
+  #   plugins:
+  #     ecr#v1.1.4:
+  #       login: true
+  #       account_ids: "436617320021"
+  #       no-include-email: true
+  #       region: "us-west-2"
+  #     docker#v2.1.0:
+  #       debug: true
+  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu18_2-2"
+  #       workdir: /data/job
+  #   env:
+  #     OS: "ubuntu-18.04"
+  #     PKGTYPE: "deb"
+  #   timeout: 60
 
-  - command: | # CentOS 7 Package Builder
-        echo "--- :arrow_down: Downloading build directory"
-        buildkite-agent artifact download "build.tar.gz" . --step ":centos: 7 Build"
-        tar -zxf build.tar.gz
-        echo "+++ :microscope: Starting package build"
-        yum install -y rpm-build
-        mkdir -p /root/rpmbuild/BUILD
-        mkdir -p /root/rpmbuild/BUILDROOT
-        mkdir -p /root/rpmbuild/RPMS
-        mkdir -p /root/rpmbuild/SOURCES
-        mkdir -p /root/rpmbuild/SPECS
-        mkdir -p /root/rpmbuild/SRPMS
-        cd /data/job/build/packages && bash generate_package.sh rpm
-    label: ":centos: 7 Package builder"
-    agents:
-      queue: "automation-large-builder-fleet"
-    artifact_paths:
-      - "build/packages/*.rpm"
-    plugins:
-      ecr#v1.1.4:
-        login: true
-        account_ids: "436617320021"
-        no-include-email: true
-        region: "us-west-2"
-      docker#v2.1.0:
-        debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:centos7_2-2"
-        workdir: /data/job
-    env:
-      OS: "el7"
-      PKGTYPE: "rpm"
-    timeout: 60
+  # - command: | # CentOS 7 Package Builder
+  #       echo "--- :arrow_down: Downloading build directory"
+  #       buildkite-agent artifact download "build.tar.gz" . --step ":centos: 7 Build"
+  #       tar -zxf build.tar.gz
+  #       echo "+++ :microscope: Starting package build"
+  #       yum install -y rpm-build
+  #       mkdir -p /root/rpmbuild/BUILD
+  #       mkdir -p /root/rpmbuild/BUILDROOT
+  #       mkdir -p /root/rpmbuild/RPMS
+  #       mkdir -p /root/rpmbuild/SOURCES
+  #       mkdir -p /root/rpmbuild/SPECS
+  #       mkdir -p /root/rpmbuild/SRPMS
+  #       cd /data/job/build/packages && bash generate_package.sh rpm
+  #   label: ":centos: 7 Package builder"
+  #   agents:
+  #     queue: "automation-large-builder-fleet"
+  #   artifact_paths:
+  #     - "build/packages/*.rpm"
+  #   plugins:
+  #     ecr#v1.1.4:
+  #       login: true
+  #       account_ids: "436617320021"
+  #       no-include-email: true
+  #       region: "us-west-2"
+  #     docker#v2.1.0:
+  #       debug: true
+  #       image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:centos7_2-2"
+  #       workdir: /data/job
+  #   env:
+  #     OS: "el7"
+  #     PKGTYPE: "rpm"
+  #   timeout: 60
 
-  - command: | # macOS Mojave Package Builder
-        echo "--- :arrow_down: Downloading build directory"
-        buildkite-agent artifact download "build.tar.gz" . --step ":darwin: Mojave Build"
-        tar -zxf build.tar.gz
-        echo "+++ :microscope: Starting package build"
-        ln -s "$(pwd)" /data/job && cd /data/job/build/packages && bash generate_package.sh brew
-    label: ":darwin: Mojave Package Builder"
-    agents:
-      - "role=builder-v2-1"
-      - "os=mojave"
-    artifact_paths:
-      - "build/packages/*.tar.gz"
-      - "build/packages/*.rb"
-    timeout: 60
+  # - command: | # macOS Mojave Package Builder
+  #       echo "--- :arrow_down: Downloading build directory"
+  #       buildkite-agent artifact download "build.tar.gz" . --step ":darwin: Mojave Build"
+  #       tar -zxf build.tar.gz
+  #       echo "+++ :microscope: Starting package build"
+  #       ln -s "$(pwd)" /data/job && cd /data/job/build/packages && bash generate_package.sh brew
+  #   label: ":darwin: Mojave Package Builder"
+  #   agents:
+  #     - "role=builder-v2-1"
+  #     - "os=mojave"
+  #   artifact_paths:
+  #     - "build/packages/*.tar.gz"
+  #     - "build/packages/*.rb"
+  #   timeout: 60
 
-  - wait
+  # - wait
 
-  - command: |
-        echo "--- :arrow_down: Downloading brew files"
-        buildkite-agent artifact download "build/packages/eosio.rb" . --step ":darwin: Mojave Package Builder"
-    label: ":darwin: Brew Updater"
-    agents:
-      queue: "automation-large-builder-fleet"
-    artifact_paths:
-      - "build/packages/eosio.rb"
-    timeout: 60
+  # - command: |
+  #       echo "--- :arrow_down: Downloading brew files"
+  #       buildkite-agent artifact download "build/packages/eosio.rb" . --step ":darwin: Mojave Package Builder"
+  #   label: ":darwin: Brew Updater"
+  #   agents:
+  #     queue: "automation-large-builder-fleet"
+  #   artifact_paths:
+  #     - "build/packages/eosio.rb"
+  #   timeout: 60
 
-  - command: |
-        echo "+++ :microscope: Running git submodule regression check" && \
-        ./scripts/submodule_check.sh
-    label: "Git submodule regression check"
-    agents:
-      queue: "automation-large-builder-fleet"
-    timeout: 240
+  # - command: |
+  #       echo "+++ :microscope: Running git submodule regression check" && \
+  #       ./scripts/submodule_check.sh
+  #   label: "Git submodule regression check"
+  #   agents:
+  #     queue: "automation-large-builder-fleet"
+  #   timeout: 240

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,7 +3,8 @@ steps:
         # echo "+++ :hammer: Building"
         # ./scripts/eosio_build.sh -y
         # echo "--- :compression: Compressing build directory"
-        tar -pczf build.tar.gz2 build/; if [[ ! -f build.tar.gz ]]; then exit 1; fi;
+        #tar -pczf build.tar.gz2 build/; 
+        if [[ ! -f build.tar.gz ]]; then echo "No TAR Found!" && exit 1; fi;
     label: ":ubuntu: 16.04 Build"
     agents:
       queue: "automation-large-builder-fleet"


### PR DESCRIPTION
When the tar process fails for the build directory at the end of a build, there is no current way to fail that step and not proceed on with other tests. This creates a major inefficiency: We can't simply restart the build step to try again as the tests have started and trying to pull an artifact that doesn't exist. We have to start a new pipeline run and all distros under it, wasting agents.

I've tested and added tests to be sure that the step fails if the tar doesn't exist and also opened up a feature request with buildkite to add this feature and avoid using the [ ! -f ] test.