### PR TITLE
Limit ubuntu versions eosio_build.sh runs on to 16.04 & 18.04

### DIFF
--- a/scripts/eosio_build_ubuntu.sh
+++ b/scripts/eosio_build_ubuntu.sh
@@ -40,9 +40,10 @@ case "${OS_NAME}" in
 		fi
 	;;
 	"Ubuntu")
-		if [ "${OS_MAJ}" -lt 16 ]; then
-			printf "You must be running Ubuntu 16.04.x or higher to install EOSIO.\\n"
-			printf "Exiting now.\\n"
+		. /etc/lsb-release
+		if [ "${DISTRIB_CODENAME}" != "xenial" -a "${DISTRIB_CODENAME}" != "bionic" ]; then
+			echo "The only Ubuntu versions this script supports are Ubuntu 16.04 and 18.04"
+			echo "Exiting now."
 			exit 1
 		fi
 		# UBUNTU 18 doesn't have MONGODB 3.6.3


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
The script is known to not work on 18.10 (see #7066) and it's pretty clear it's not going to work on 19.04. Limit the ubuntu versions that the script runs as I don't anticipate anyone fixing it before 1.8

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
