### PR TITLE
Fix Catchup Test Validation

### DIFF
--- a/tests/nodeos_startup_catchup.py
+++ b/tests/nodeos_startup_catchup.py
@@ -92,11 +92,24 @@ try:
     def head(node):
         return node.getBlockNum(BlockType.head)
 
+    def waitForBlock(node, blockNum, blockType=BlockType.head, timeout=None, reportInterval=20):
+        if not node.waitForBlock(blockNum, timeout=timeout, blockType=blockType, reportInterval=reportInterval):
+            info=node.getInfo()
+            headBlockNum=info["head_block_num"]
+            libBlockNum=info["last_irreversible_block_num"]
+            Utils.errorExit("Failed to get to %s block number %d. Last had head block number %d and lib %d" % (blockType, blockNum, headBlockNum, libBlockNum))
+
+    def waitForNodeStarted(node):
+        sleepTime=0
+        while sleepTime < 10 and node.getInfo(silentErrors=True) is None:
+            time.sleep(1)
+            sleepTime+=1
+
     node0=cluster.getNode(0)
 
     Print("Wait for account creation to be irreversible")
     blockNum=head(node0)
-    node0.waitForBlock(blockNum, blockType=BlockType.lib)
+    waitForBlock(node0, blockNum, blockType=BlockType.lib)
 
     Print("Startup txn generation")
     period=1500
@@ -114,7 +127,7 @@ try:
     startBlockNum=blockNum+steadyStateWait
     numBlocks=20
     endBlockNum=startBlockNum+numBlocks
-    node0.waitForBlock(endBlockNum)
+    waitForBlock(node0, endBlockNum)
     transactions=0
     avg=0
     for blockNum in range(startBlockNum, endBlockNum):
@@ -133,32 +146,33 @@ try:
         Print("Start catchup node")
         cluster.launchUnstarted(cachePopen=True)
         lastLibNum=lib(node0)
-        time.sleep(2)
         # verify producer lib is still advancing
-        node0.waitForBlock(lastLibNum+1, timeout=twoRounds/2, blockType=BlockType.lib)
+        waitForBlock(node0, lastLibNum+1, timeout=twoRounds/2, blockType=BlockType.lib)
 
         catchupNode=cluster.getNodes()[-1]
         catchupNodeNum=cluster.getNodes().index(catchupNode)
+        waitForNodeStarted(catchupNode)
         lastCatchupLibNum=lib(catchupNode)
 
         Print("Verify catchup node %s's LIB is advancing" % (catchupNodeNum))
         # verify lib is advancing (before we wait for it to have to catchup with producer)
-        catchupNode.waitForBlock(lastCatchupLibNum+1, timeout=twoRounds/2, blockType=BlockType.lib)
+        waitForBlock(catchupNode, lastCatchupLibNum+1, timeout=twoRounds/2, blockType=BlockType.lib)
 
         Print("Verify catchup node is advancing to producer")
         numBlocksToCatchup=(lastLibNum-lastCatchupLibNum-1)+twoRounds
-        catchupNode.waitForBlock(lastLibNum, timeout=(numBlocksToCatchup)/2, blockType=BlockType.lib)
+        waitForBlock(catchupNode, lastLibNum, timeout=(numBlocksToCatchup)/2, blockType=BlockType.lib)
 
         Print("Shutdown catchup node and validate exit code")
         catchupNode.interruptAndVerifyExitStatus(60)
 
         Print("Restart catchup node")
         catchupNode.relaunch(catchupNodeNum)
+        waitForNodeStarted(catchupNode)
         lastCatchupLibNum=lib(catchupNode)
 
         Print("Verify catchup node is advancing")
         # verify catchup node is advancing to producer
-        catchupNode.waitForBlock(lastCatchupLibNum+1, timeout=twoRounds/2, blockType=BlockType.lib)
+        waitForBlock(catchupNode, lastCatchupLibNum+1, timeout=twoRounds/2, blockType=BlockType.lib)
 
         Print("Verify producer is still advancing LIB")
         lastLibNum=lib(node0)
@@ -167,8 +181,8 @@ try:
 
         Print("Verify catchup node is advancing to producer")
         # verify catchup node is advancing to producer
-        catchupNode.waitForBlock(lastLibNum, timeout=(numBlocksToCatchup)/2, blockType=BlockType.lib)
-        catchupNode.kill(signal.SIGTERM)
+        waitForBlock(catchupNode, lastLibNum, timeout=(numBlocksToCatchup)/2, blockType=BlockType.lib)
+        catchupNode.interruptAndVerifyExitStatus(60)
         catchupNode.popenProc=None
 
     testSuccessful=True

--- a/tests/testUtils.py
+++ b/tests/testUtils.py
@@ -142,7 +142,7 @@ class Utils:
         Utils.Print(msg)
 
     @staticmethod
-    def waitForObj(lam, timeout=None):
+    def waitForObj(lam, timeout=None, reporter=None):
         if timeout is None:
             timeout=60
 
@@ -161,6 +161,8 @@ class Utils:
                     stdout.write('.')
                     stdout.flush()
                     needsNewLine=True
+                if reporter is not None:
+                    reporter()
                 time.sleep(sleepTime)
         finally:
             if needsNewLine:
@@ -169,9 +171,9 @@ class Utils:
         return None
 
     @staticmethod
-    def waitForBool(lam, timeout=None):
+    def waitForBool(lam, timeout=None, reporter=None):
         myLam = lambda: True if lam() else None
-        ret=Utils.waitForObj(myLam, timeout)
+        ret=Utils.waitForObj(myLam, timeout, reporter=reporter)
         return False if ret is None else ret
 
     @staticmethod


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
Test calls Node.waitForBlock which has a timeout.  It was assumed that this failed the test when it reached the timeout without getting the expected block number, but it does not.  Added function to ensure that the block was found and to report more info when it is not.  Also added diagnostics to waitForBlock so that the current head and lib are reported at certain intervals while waiting for the node to get a certain block.

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
