### PR TITLE
Added lib64 to CMAKE_MODULE_PATH

### DIFF
--- a/CMakeModules/eosio-config.cmake.in
+++ b/CMakeModules/eosio-config.cmake.in
@@ -2,6 +2,7 @@ if(EOSIO_ROOT STREQUAL "" OR NOT EOSIO_ROOT)
    set(EOSIO_ROOT "@EOS_ROOT_DIR@")
 endif()
 list(APPEND CMAKE_MODULE_PATH ${EOSIO_ROOT}/lib/cmake/eosio)
+list(APPEND CMAKE_MODULE_PATH ${EOSIO_ROOT}/lib64/cmake/eosio)
 include(EosioTester)
 
 function(EXTRACT_MAJOR_MINOR_FROM_VERSION version success major minor)


### PR DESCRIPTION
## Change Description
I am working on [adding integration tests to the CDT Buildkite pipeline](https://github.com/EOSIO/eosio.cdt/pull/494). I got Ubuntu working, but CentOS is not working because the build/install scripts for EOSIO put CMake modules in `$HOME/opt/eosio/lib64/` instead of `$HOME/opt/eosio/lib/`, but CMake is not configured to look in that directory for `EosioTester.cmake`. `EosioTester.cmake` is required for CDT to build integration tests.    
  
In order to get the CDT integration tests working, I have configured CMake to check both lib and lib64 for CMake modules.

This pull request is in draft while I test against this branch to ensure that it does in fact build the CDT integration tests in [CDT build 173](https://buildkite.com/EOSIO/eosio-dot-cdt/builds/173).

## Consensus Changes
- [ ] Consensus Changes
None.

## API Changes
- [ ] API Changes
None.

## Documentation Additions
- [ ] Documentation Additions
None.