### PR TITLE
Fix EosioTester to only generate one CTest "target"

### DIFF
--- a/CMakeModules/EosioTester.cmake.in
+++ b/CMakeModules/EosioTester.cmake.in
@@ -128,7 +128,6 @@ macro(add_eosio_test_executable test_name)
        ${PLATFORM_SPECIFIC_LIBS}
       )
 
-   #### TODO /usr/local/include is a hack for fc and some other includes
    target_include_directories( ${test_name} PUBLIC
                                ${Boost_INCLUDE_DIRS}
                                @OPENSSL_INCLUDE_DIR@
@@ -137,11 +136,13 @@ macro(add_eosio_test_executable test_name)
                                @CMAKE_INSTALL_FULL_INCLUDEDIR@/wasm-jit
                                @CMAKE_INSTALL_FULL_INCLUDEDIR@/softfloat )
 
-   #Manually run unit_test for all supported runtimes
-   #To run unit_test with all log from blockchain displayed, put --verbose after --, i.e. unit_test -- --verbose
 endmacro()
 
 macro(add_eosio_test test_name)
    add_eosio_test_executable( ${test_name} ${ARGN} )
+   #This will generate a test with the default runtime
    add_test(NAME ${test_name} COMMAND ${test_name} --report_level=detailed --color_output)
+
+   #Manually run unit_test for all supported runtimes
+   #To run unit_test with all log from blockchain displayed, put --verbose after --, i.e. unit_test -- --verbose
 endmacro()

--- a/CMakeModules/EosioTester.cmake.in
+++ b/CMakeModules/EosioTester.cmake.in
@@ -73,7 +73,7 @@ find_library(GMP_LIBRARIES NAMES libgmp.a gmp.lib gmp libgmp-10 mpir
     DOC "Path to the GMP library"
 )
 
-macro(add_eosio_test test_name)
+macro(add_eosio_test_executable test_name)
    add_executable( ${test_name} ${ARGN} )
    target_link_libraries( ${test_name}
        ${LLVM}
@@ -139,8 +139,9 @@ macro(add_eosio_test test_name)
 
    #Manually run unit_test for all supported runtimes
    #To run unit_test with all log from blockchain displayed, put --verbose after --, i.e. unit_test -- --verbose
-   add_test(NAME ${test_name}_binaryen COMMAND ${test_name}
-    --report_level=detailed --color_output -- --binaryen)
-   add_test(NAME ${test_name}_wavm COMMAND ${test_name}
-    --report_level=detailed --color_output --catch_system_errors=no -- --wavm)
+endmacro()
+
+macro(add_eosio_test test_name)
+   add_eosio_test_executable( ${test_name} ${ARGN} )
+   add_test(NAME ${test_name} COMMAND ${test_name} --report_level=detailed --color_output)
 endmacro()

--- a/CMakeModules/EosioTesterBuild.cmake.in
+++ b/CMakeModules/EosioTesterBuild.cmake.in
@@ -138,18 +138,14 @@ macro(add_eosio_test_executable test_name)
                                @CMAKE_SOURCE_DIR@/libraries/chainbase/include
                                @CMAKE_SOURCE_DIR@/libraries/testing/include
                                @CMAKE_SOURCE_DIR@/libraries/wasm-jit/Include )
-                            #
-   #Manually run unit_test for all supported runtimes
-   #To run unit_test with all log from blockchain displayed, put --verbose after --, i.e. unit_test -- --verbose
-   add_test(NAME ${test_name}_binaryen COMMAND ${test_name}
-    --report_level=detailed --color_output -- --binaryen)
-   add_test(NAME ${test_name}_wavm COMMAND ${test_name}
-    --report_level=detailed --color_output --catch_system_errors=no -- --wavm)
 endmacro()
 
 macro(add_eosio_test test_name)
    add_eosio_test_executable( ${test_name} ${ARGN} )
+   #This will generate a test with the default runtime
    add_test(NAME ${test_name} COMMAND ${test_name} --report_level=detailed --color_output)
+   #Manually run unit_test for all supported runtimes
+   #To run unit_test with all log from blockchain displayed, put --verbose after --, i.e. unit_test -- --verbose
 endmacro()
 
 if(ENABLE_COVERAGE_TESTING)

--- a/CMakeModules/EosioTesterBuild.cmake.in
+++ b/CMakeModules/EosioTesterBuild.cmake.in
@@ -72,7 +72,7 @@ find_library(GMP_LIBRARIES NAMES libgmp.a gmp.lib gmp libgmp-10 mpir
     DOC "Path to the GMP library"
 )
 
-macro(add_eosio_test test_name)
+macro(add_eosio_test_executable test_name)
    add_executable( ${test_name} ${ARGN} )
    target_link_libraries( ${test_name}
        ${LLVM}
@@ -145,6 +145,11 @@ macro(add_eosio_test test_name)
     --report_level=detailed --color_output -- --binaryen)
    add_test(NAME ${test_name}_wavm COMMAND ${test_name}
     --report_level=detailed --color_output --catch_system_errors=no -- --wavm)
+endmacro()
+
+macro(add_eosio_test test_name)
+   add_eosio_test_executable( ${test_name} ${ARGN} )
+   add_test(NAME ${test_name} COMMAND ${test_name} --report_level=detailed --color_output)
 endmacro()
 
 if(ENABLE_COVERAGE_TESTING)


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
Fix EosioTester to only generate one CTest label and added a new macro to create the test executable without creating any CTest labels.


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
