### PR TITLE
Reduce logging of complete object when unable to serialize - v.1.6.x

### DIFF
--- a/libraries/chain/include/eosio/chain/abi_serializer.hpp
+++ b/libraries/chain/include/eosio/chain/abi_serializer.hpp
@@ -680,7 +680,7 @@ void abi_serializer::to_variant( const T& o, variant& vo, Resolver resolver, con
    impl::abi_traverse_context ctx(max_serialization_time);
    impl::abi_to_variant::add(mvo, "_", o, resolver, ctx);
    vo = std::move(mvo["_"]);
-} FC_RETHROW_EXCEPTIONS(error, "Failed to serialize type", ("type", typeid(o).name() ))
+} FC_RETHROW_EXCEPTIONS(error, "Failed to serialize: ${type}", ("type", boost::core::demangle( typeid(o).name() ) ))
 
 template<typename T, typename Resolver>
 void abi_serializer::from_variant( const variant& v, T& o, Resolver resolver, const fc::microseconds& max_serialization_time ) try {

--- a/libraries/chain/include/eosio/chain/abi_serializer.hpp
+++ b/libraries/chain/include/eosio/chain/abi_serializer.hpp
@@ -680,7 +680,7 @@ void abi_serializer::to_variant( const T& o, variant& vo, Resolver resolver, con
    impl::abi_traverse_context ctx(max_serialization_time);
    impl::abi_to_variant::add(mvo, "_", o, resolver, ctx);
    vo = std::move(mvo["_"]);
-} FC_RETHROW_EXCEPTIONS(error, "Failed to serialize type", ("object",o))
+} FC_RETHROW_EXCEPTIONS(error, "Failed to serialize type", ("type", typeid(o).name() ))
 
 template<typename T, typename Resolver>
 void abi_serializer::from_variant( const variant& v, T& o, Resolver resolver, const fc::microseconds& max_serialization_time ) try {


### PR DESCRIPTION
## Change Description

- Report type that is unable to be serialized instead of the complete object.

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
