### PR TITLE
reduction of wavm memory usage

### DIFF
--- a/libraries/chain/webassembly/wavm.cpp
+++ b/libraries/chain/webassembly/wavm.cpp
@@ -31,7 +31,7 @@ class wavm_instantiated_module : public wasm_instantiated_module_interface {
          // that didn't declare "memory", getDefaultMemory() won't see it. It would also be possible
          // to say something like if(module->memories.size()) here I believe
          if(getDefaultMemory(_instance))
-            _initial_memory_config = module->memories.defs[0].type;
+            _initial_memory_config = module->memories.defs.at(0).type;
       }
 
       void apply(apply_context& context) override {

--- a/libraries/chain/webassembly/wavm.cpp
+++ b/libraries/chain/webassembly/wavm.cpp
@@ -25,9 +25,14 @@ class wavm_instantiated_module : public wasm_instantiated_module_interface {
    public:
       wavm_instantiated_module(ModuleInstance* instance, std::unique_ptr<Module> module, std::vector<uint8_t> initial_mem) :
          _initial_memory(initial_mem),
-         _instance(instance),
-         _module(std::move(module))
-      {}
+         _instance(instance)
+      {
+         //The memory instance is reused across all wavm_instantiated_modules, but for wasm instances
+         // that didn't declare "memory", getDefaultMemory() won't see it. It would also be possible
+         // to say something like if(module->memories.size()) here I believe
+         if(getDefaultMemory(_instance))
+            _initial_memory_config = module->memories.defs[0].type;
+      }
 
       void apply(apply_context& context) override {
          vector<Value> args = {Value(uint64_t(context.receiver)),
@@ -52,7 +57,7 @@ class wavm_instantiated_module : public wasm_instantiated_module_interface {
             if(default_mem) {
                //reset memory resizes the sandbox'ed memory to the module's init memory size and then
                // (effectively) memzeros it all
-               resetMemory(default_mem, _module->memories.defs[0].type);
+               resetMemory(default_mem, _initial_memory_config);
 
                char* memstart = &memoryRef<char>(getDefaultMemory(_instance), 0);
                memcpy(memstart, _initial_memory.data(), _initial_memory.size());
@@ -78,7 +83,7 @@ class wavm_instantiated_module : public wasm_instantiated_module_interface {
       //naked pointer because ModuleInstance is opaque
       //_instance is deleted via WAVM's object garbage collection when wavm_rutime is deleted
       ModuleInstance*          _instance;
-      std::unique_ptr<Module>  _module;
+      MemoryType               _initial_memory_config;
 };
 
 

--- a/libraries/wasm-jit/Source/Runtime/LLVMJIT.cpp
+++ b/libraries/wasm-jit/Source/Runtime/LLVMJIT.cpp
@@ -290,13 +290,6 @@ namespace LLVMJIT
 		JITModule(ModuleInstance* inModuleInstance): moduleInstance(inModuleInstance) {}
 		~JITModule() override
 		{
-			// Delete the module's symbols, and remove them from the global address-to-symbol map.
-			Platform::Lock addressToSymbolMapLock(addressToSymbolMapMutex);
-			for(auto symbol : functionDefSymbols)
-			{
-				addressToSymbolMap.erase(addressToSymbolMap.find(symbol->baseAddress + symbol->numBytes));
-				delete symbol;
-			}
 		}
 
 		void notifySymbolLoaded(const char* name,Uptr baseAddress,Uptr numBytes,std::map<U32,U32>&& offsetToOpIndexMap) override
@@ -308,14 +301,7 @@ namespace LLVMJIT
 				WAVM_ASSERT_THROW(moduleInstance);
 				WAVM_ASSERT_THROW(functionDefIndex < moduleInstance->functionDefs.size());
 				FunctionInstance* functionInstance = moduleInstance->functionDefs[functionDefIndex];
-				auto symbol = new JITSymbol(functionInstance,baseAddress,numBytes,std::move(offsetToOpIndexMap));
-				functionDefSymbols.push_back(symbol);
 				functionInstance->nativeFunction = reinterpret_cast<void*>(baseAddress);
-
-				{
-					Platform::Lock addressToSymbolMapLock(addressToSymbolMapMutex);
-					addressToSymbolMap[baseAddress + numBytes] = symbol;
-				}
 			}
 		}
 	};
@@ -492,9 +478,6 @@ namespace LLVMJIT
 			llvm::object::ObjectFile* object = jitUnit->loadedObjects[objectIndex].object;
 			llvm::RuntimeDyld::LoadedObjectInfo* loadedObject = jitUnit->loadedObjects[objectIndex].loadedObject;
 
-			// Create a DWARF context to interpret the debug information in this compilation unit.
-			auto dwarfContext = llvm::make_unique<llvm::DWARFContextInMemory>(*object,loadedObject);
-
 			// Iterate over the functions in the loaded object.
 			for(auto symbolSizePair : llvm::object::computeSymbolSizes(*object))
 			{
@@ -514,16 +497,12 @@ namespace LLVMJIT
 						loadedAddress += (Uptr)loadedObject->getSectionLoadAddress(*symbolSection.get());
 					}
 
-					// Get the DWARF line info for this symbol, which maps machine code addresses to WebAssembly op indices.
-					llvm::DILineInfoTable lineInfoTable = dwarfContext->getLineInfoForAddressRange(loadedAddress,symbolSizePair.second);
-					std::map<U32,U32> offsetToOpIndexMap;
-					for(auto lineInfo : lineInfoTable) { offsetToOpIndexMap.emplace(U32(lineInfo.first - loadedAddress),lineInfo.second.Line); }
-					
 					#if PRINT_DISASSEMBLY
 					Log::printf(Log::Category::error,"Disassembly for function %s\n",name.get().data());
 					disassembleFunction(reinterpret_cast<U8*>(loadedAddress),Uptr(symbolSizePair.second));
 					#endif
 
+					std::map<U32,U32> offsetToOpIndexMap;
 					// Notify the JIT unit that the symbol was loaded.
 					WAVM_ASSERT_THROW(symbolSizePair.second <= UINTPTR_MAX);
 					jitUnit->notifySymbolLoaded(

--- a/libraries/wasm-jit/Source/Runtime/LLVMJIT.h
+++ b/libraries/wasm-jit/Source/Runtime/LLVMJIT.h
@@ -49,8 +49,6 @@
 #include "llvm/Support/DynamicLibrary.h"
 #include "llvm/Transforms/Scalar.h"
 #include "llvm/IR/DIBuilder.h"
-#include "llvm/DebugInfo/DIContext.h"
-#include "llvm/DebugInfo/DWARF/DWARFContext.h"
 #include <cctype>
 #include <string>
 #include <vector>


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
wavm tends to cause significant memory usage even when fixes like #6983 are in place. This PR includes two changes that reduce the memory usage of WAVM by a large margin. First: avoid generation of debug information; this was actually done at a per-wasm-opcode resolution so it was very memory intensive and also tended to wedge things in to a global cache that would never be freed. Second: free the WAVM Module after we no longer need it once a ModuleInstance is created from it
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
