### PR TITLE
immediately return created snapshot in irreversible mode 

### DIFF
--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1023,14 +1023,56 @@ void producer_plugin::create_snapshot(producer_plugin::next_function<producer_pl
    chain::controller& chain = my->chain_plug->chain();
 
    auto head_id = chain.head_block_id();
-   std::string snapshot_path = (pending_snapshot::get_final_path(head_id, my->_snapshots_dir)).generic_string();
+   const auto& snapshot_path = pending_snapshot::get_final_path(head_id, my->_snapshots_dir);
+   const auto& temp_path     = pending_snapshot::get_temp_path(head_id, my->_snapshots_dir);
 
    // maintain legacy exception if the snapshot exists
    if( fc::is_regular_file(snapshot_path) ) {
-      auto ex = snapshot_exists_exception( FC_LOG_MESSAGE( error, "snapshot named ${name} already exists", ("name", snapshot_path) ) );
+      auto ex = snapshot_exists_exception( FC_LOG_MESSAGE( error, "snapshot named ${name} already exists", ("name", snapshot_path.generic_string()) ) );
       next(ex.dynamic_copy_exception());
       return;
    }
+
+   auto write_snapshot = [&]( const bfs::path& p ) -> void {
+      auto reschedule = fc::make_scoped_exit([this](){
+         my->schedule_production_loop();
+      });
+
+      if (chain.is_building_block()) {
+         // abort the pending block
+         chain.abort_block();
+      } else {
+         reschedule.cancel();
+      }
+
+      // create the snapshot
+      auto snap_out = std::ofstream(p.generic_string(), (std::ios::out | std::ios::binary));
+      auto writer = std::make_shared<ostream_snapshot_writer>(snap_out);
+      chain.write_snapshot(writer);
+      writer->finalize();
+      snap_out.flush();
+      snap_out.close();
+   };
+
+   // If in irreversible mode, create snapshot and return path to snapshot immediately.
+   if( chain.get_read_mode() == db_read_mode::IRREVERSIBLE ) {
+      try {
+         write_snapshot( temp_path );
+
+         boost::system::error_code ec;
+         bfs::rename(temp_path, snapshot_path, ec);
+         EOS_ASSERT(!ec, snapshot_finalization_exception,
+               "Unable to finalize valid snapshot of block number ${bn}: [code: ${ec}] ${message}",
+               ("bn", chain.head_block_num())
+               ("ec", ec.value())
+               ("message", ec.message()));
+
+         next( producer_plugin::snapshot_information{head_id, snapshot_path.generic_string()} );
+      } CATCH_AND_CALL (next);
+      return;
+   }
+
+   // Otherwise, the result will be returned when the snapshot becomes irreversible.
 
    // determine if this snapshot is already in-flight
    auto& pending_by_id = my->_pending_snapshot_index.get<by_id>();
@@ -1044,31 +1086,10 @@ void producer_plugin::create_snapshot(producer_plugin::next_function<producer_pl
          };
       });
    } else {
-      // write a new temp snapshot
-      std::string temp_path = (pending_snapshot::get_temp_path(head_id, my->_snapshots_dir)).generic_string();
-      std::string pending_path = (pending_snapshot::get_pending_path(head_id, my->_snapshots_dir)).generic_string();
-      std::string final_path = (pending_snapshot::get_final_path(head_id, my->_snapshots_dir)).generic_string();
-      bool written = false;
+      const auto& pending_path = pending_snapshot::get_pending_path(head_id, my->_snapshots_dir);
 
       try {
-         auto reschedule = fc::make_scoped_exit([this](){
-            my->schedule_production_loop();
-         });
-
-         if (chain.is_building_block()) {
-            // abort the pending block
-            chain.abort_block();
-         } else {
-            reschedule.cancel();
-         }
-
-         // create a new pending snapshot
-         auto snap_out = std::ofstream(temp_path, (std::ios::out | std::ios::binary));
-         auto writer = std::make_shared<ostream_snapshot_writer>(snap_out);
-         chain.write_snapshot(writer);
-         writer->finalize();
-         snap_out.flush();
-         snap_out.close();
+         write_snapshot( temp_path ); // create a new pending snapshot
 
          boost::system::error_code ec;
          bfs::rename(temp_path, pending_path, ec);
@@ -1078,7 +1099,7 @@ void producer_plugin::create_snapshot(producer_plugin::next_function<producer_pl
                ("ec", ec.value())
                ("message", ec.message()));
 
-         my->_pending_snapshot_index.emplace(head_id, next, pending_path, final_path);
+         my->_pending_snapshot_index.emplace(head_id, next, pending_path.generic_string(), snapshot_path.generic_string());
       } CATCH_AND_CALL (next);
    }
 }

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1045,6 +1045,8 @@ void producer_plugin::create_snapshot(producer_plugin::next_function<producer_pl
          reschedule.cancel();
       }
 
+      bfs::create_directory( p.parent_path() );
+
       // create the snapshot
       auto snap_out = std::ofstream(p.generic_string(), (std::ios::out | std::ios::binary));
       auto writer = std::make_shared<ostream_snapshot_writer>(snap_out);


### PR DESCRIPTION
## Change Description

PR #7119 made changes to the `create_snapshot` RPC of the `producer_plugin` to wait until the created snapshot becomes final (i.e. the block for which the snapshot was taken becomes irreversible) before returning the final path of the snapshot to the caller. This means blocks need to continue to be produced on the blockchain network for LIB (last irreversible block) to advance past the block for which the snapshot was taken, otherwise the `create_snapshot` RPC will forever hang.

The new behavior of `create_snapshot` implemented in PR #7119 works okay with the new irreversible enabled in PR #6624, if blocks are being produced. However, if it is in irreversible mode, `create_snapshot` should be able to immediately return with the final snapshot path even if there are no further blocks produced. This PR makes changes to make that happen.

This PR also includes a small change to create the snapshots directory if it doesn't already exist.

## Consensus Changes
- [ ] Consensus Changes


## API Changes
- [x] API Changes

### `/v1/producer/create_snapshot` 

This endpoint now again returns immediately with the snapshot path when the node is in irreversible read mode. It still maintains the delayed return behavior introduced in #7119 when in a read mode other than irreversible.

## Documentation Additions
- [ ] Documentation Additions

