### PR TITLE
add get_account_ram_corrections to producer API

### DIFF
--- a/plugins/producer_api_plugin/producer_api_plugin.cpp
+++ b/plugins/producer_api_plugin/producer_api_plugin.cpp
@@ -126,6 +126,8 @@ void producer_api_plugin::plugin_startup() {
        CALL(producer, producer, get_supported_protocol_features,
             INVOKE_R_R(producer, get_supported_protocol_features,
                                  producer_plugin::get_supported_protocol_features_params), 201),
+       CALL(producer, producer, get_account_ram_corrections,
+            INVOKE_R_R(producer, get_account_ram_corrections, producer_plugin::get_account_ram_corrections_params), 201),
    });
 }
 

--- a/plugins/producer_plugin/include/eosio/producer_plugin/producer_plugin.hpp
+++ b/plugins/producer_plugin/include/eosio/producer_plugin/producer_plugin.hpp
@@ -60,6 +60,18 @@ public:
       bool exclude_unactivatable = false;
    };
 
+   struct get_account_ram_corrections_params {
+      optional<account_name>  lower_bound;
+      optional<account_name>  upper_bound;
+      uint32_t                limit = 10;
+      bool                    reverse = false;
+   };
+
+   struct get_account_ram_corrections_result {
+      std::vector<fc::variant> rows;
+      optional<account_name>   more;
+   };
+
    template<typename T>
    using next_function = std::function<void(const fc::static_variant<fc::exception_ptr, T>&)>;
 
@@ -100,6 +112,8 @@ public:
 
    fc::variants get_supported_protocol_features( const get_supported_protocol_features_params& params ) const;
 
+   get_account_ram_corrections_result  get_account_ram_corrections( const get_account_ram_corrections_params& params ) const;
+
    signal<void(const chain::producer_confirmation&)> confirmed_block;
 private:
    std::shared_ptr<class producer_plugin_impl> my;
@@ -114,3 +128,5 @@ FC_REFLECT(eosio::producer_plugin::integrity_hash_information, (head_block_id)(i
 FC_REFLECT(eosio::producer_plugin::snapshot_information, (head_block_id)(snapshot_name))
 FC_REFLECT(eosio::producer_plugin::scheduled_protocol_feature_activations, (protocol_features_to_activate))
 FC_REFLECT(eosio::producer_plugin::get_supported_protocol_features_params, (exclude_disabled)(exclude_unactivatable))
+FC_REFLECT(eosio::producer_plugin::get_account_ram_corrections_params, (lower_bound)(upper_bound)(limit)(reverse))
+FC_REFLECT(eosio::producer_plugin::get_account_ram_corrections_result, (rows)(more))


### PR DESCRIPTION
## Change Description

This PR adds a new RPC, `get_account_ram_corrections`, to the `producer_api_plugin` which allows the node operator to inspect the state of the `account_ram_correction_index`. This API can help operators validate which accounts will be affected upon activation of the `REPLACE_DEFERRED` protocol feature (#6997).

## Consensus Changes
- [ ] Consensus Changes


## API Changes
- [x] API Changes

### `/v1/producer/get_account_ram_corrections` 

Takes optional inputs `lower_bound`, `upper_bound` (keys for both are account names), limit (defaults to 10), and reverse (defaults to false), similar to the API calls to get table rows. 

Returns the sequence of rows requested by the query in the `rows` array field of the result. The result may optionally include a `more` field which will contain the account name for the next row that was not returned.

## Documentation Additions
- [ ] Documentation Additions

