### PR TITLE
Fix bugs in block_log - v1.7.x

### DIFF
--- a/libraries/chain/block_log.cpp
+++ b/libraries/chain/block_log.cpp
@@ -142,7 +142,11 @@ namespace eosio { namespace chain {
          }
 
          my->head = read_head();
-         my->head_id = my->head->id();
+         if( my->head ) {
+            my->head_id = my->head->id();
+         } else {
+            my->head_id = {};
+         }
 
          if (index_size) {
             ilog("Index is nonempty");
@@ -314,6 +318,12 @@ namespace eosio { namespace chain {
 
       my->block_stream.seekg(-sizeof( uint64_t), std::ios::end);
       my->block_stream.read((char*)&end_pos, sizeof(end_pos));
+
+      if( end_pos == npos ) {
+         ilog( "Block log contains no blocks. No need to construct index." );
+         return;
+      }
+
       signed_block tmp;
 
       uint64_t pos = 0;


### PR DESCRIPTION
## Change Description

This PR fixes two bugs in `block_log`. 

First, it allows opening a non-empty block log that contains no blocks. This actually fixes undefined behavior that would lead to a segmentation fault when attempting to open a block log that contained no blocks.

Second, a check is added to `construct_index` to prevent an attempt to read a block when the block log is known to not contain any blocks. In this situation, instead of throwing an exception, `construct_index` will now correctly leave an empty index file.

## Consensus Changes
- [ ] Consensus Changes


## API Changes
- [ ] API Changes


## Documentation Additions
- [ ] Documentation Additions
