### PR TITLE
Gives a timeout for bios node check pulse and also minor cleanup on Cluster.py

### DIFF
--- a/tests/Cluster.py
+++ b/tests/Cluster.py
@@ -403,8 +403,8 @@ class Cluster(object):
         if unstartedNodes > 0:
             self.unstartedNodes=self.discoverUnstartedLocalNodes(unstartedNodes, totalNodes)
 
-        biosNode=self.discoverBiosNode()
-        if not biosNode or not biosNode.checkPulse():
+        biosNode=self.discoverBiosNode(timeout=Utils.systemWaitTimeout)
+        if not biosNode or not Utils.waitForBool(biosNode.checkPulse, Utils.systemWaitTimeout):
             Utils.Print("ERROR: Bios node doesn't appear to be running...")
             return False
 
@@ -1332,7 +1332,7 @@ class Cluster(object):
             psOutDisplay=psOut[:6660]+"..."
         if Utils.Debug: Utils.Print("pgrep output: \"%s\"" % psOutDisplay)
         for i in range(0, totalNodes):
-            instance=self.discoverLocalNode(i, psOut)
+            instance=self.discoverLocalNode(i, psOut, timeout)
             if instance is None:
                 break
             nodes.append(instance)
@@ -1341,12 +1341,12 @@ class Cluster(object):
         return nodes
 
     # Populate a node matched to actual running instance
-    def discoverLocalNode(self, nodeNum, psOut=None):
+    def discoverLocalNode(self, nodeNum, psOut=None, timeout=None):
         if psOut is None:
             psOut=Cluster.pgrepEosServers(timeout)
         if psOut is None:
             Utils.Print("ERROR: No nodes discovered.")
-            return nodes
+            return None
         pattern=Cluster.pgrepEosServerPattern(nodeNum)
         m=re.search(pattern, psOut, re.MULTILINE)
         if m is None:


### PR DESCRIPTION
Gives a timeout for biosNode.checkPulse as I occasionally see the test fails with `ERROR: Bios node doesn't appear to be running...` error message

And also minor cleanup on Cluster.py. discoverLocalNode was using undefined timeout variable previously and returned inappropriate type when it fails to pgrep the process

<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
