### PR TITLE
commit db during replays when replay optimizations are disabled

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1846,6 +1846,11 @@ struct controller_impl {
             // On replay, log_irreversible is not called and so no irreversible_block signal is emittted.
             // So emit it explicitly here.
             emit( self.irreversible_block, bsp );
+
+            if (!self.skip_db_sessions(s)) {
+               db.commit(bsp->block_num);
+            }
+
          } else {
             EOS_ASSERT( read_mode != db_read_mode::IRREVERSIBLE, block_validate_exception,
                         "invariant failure: cannot replay reversible blocks while in irreversible mode" );


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description

when replay optimizations are disabled (`disable-replay-opts`) we still created database sessions however, we were never committing those database sessions leaving lots of stale undo states around until the very end of the replay.

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
