### PR TITLE
commit db during replays when replay optimizations are disabled (1.7 backport)

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1324,8 +1324,13 @@ struct controller_impl {
          }
 
          // on replay irreversible is not emitted by fork database, so emit it explicitly here
-         if( s == controller::block_status::irreversible )
+         if( s == controller::block_status::irreversible ) {
             emit( self.irreversible_block, new_header_state );
+
+            if (!self.skip_db_sessions(s)) {
+               db.commit(new_header_state->block_num);
+            }
+         }
 
       } FC_LOG_AND_RETHROW( )
    }


### PR DESCRIPTION

<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description

porting fix made to develop for committing database on replay with disable-replay-opts


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
