### PR TITLE
try to fix relaunch error in nodeos_irreversible_mode_lr_test

### DIFF
--- a/tests/Node.py
+++ b/tests/Node.py
@@ -1393,7 +1393,7 @@ class Node(object):
                 pass
             return False
 
-        isAlive=Utils.waitForBool(isNodeAlive, timeout)
+        isAlive=Utils.waitForBool(isNodeAlive, timeout, sleepTime=1)
         if isAlive:
             Utils.Print("Node relaunch was successfull.")
         else:

--- a/tests/nodeos_irreversible_mode_test.py
+++ b/tests/nodeos_irreversible_mode_test.py
@@ -27,7 +27,7 @@ import shutil
 Print = Utils.Print
 errorExit = Utils.errorExit
 cmdError = Utils.cmdError
-relaunchTimeout = 5
+relaunchTimeout = 10
 numOfProducers = 4
 totalNodes = 10
 


### PR DESCRIPTION
## Change Description
This increase the timeout and check frequency for relaunching the node in test case nodeos_irreversible_mode_lr_test, possible fixing the "Fail to relaunch" error.

## Consensus Changes
No.

## API Changes
No.

## Documentation Additions
No.