### PR TITLE
link to icu or sasl2 when appropriate for mongo

### DIFF
--- a/plugins/mongo_db_plugin/CMakeLists.txt
+++ b/plugins/mongo_db_plugin/CMakeLists.txt
@@ -29,11 +29,28 @@ if(BUILD_MONGO_DB_PLUGIN)
     PRIVATE ${LIBMONGOCXX_STATIC_DEFINITIONS} ${LIBBSONCXX_STATIC_DEFINITIONS}
     )
 
+  # We can't just use *_STATIC_LIBRARIES variables to link against because the static
+  # variants of these may try to static link against libraries we don't want (like a system
+  # libc/c++). But we need to know if mongo c driver was built with ICU or SASL2 support so
+  # that we can continue to link to those. This certainly is a bit on the fragile side but
+  # try to parse what is included in MONGOC_STATIC_LIBRARIES to see what we should link to
+  foreach(MONGO_S_LIB ${MONGOC_STATIC_LIBRARIES})
+    string(REGEX MATCH "libsasl2\\${CMAKE_SHARED_LIBRARY_SUFFIX}$" REGOUT ${MONGO_S_LIB})
+    if(REGOUT)
+      set(LINK_SASL "sasl2")
+    endif()
+
+    string(REGEX MATCH "libicuuc\\${CMAKE_SHARED_LIBRARY_SUFFIX}$" REGOUT ${MONGO_S_LIB})
+    if(REGOUT)
+      set(LINK_ICU "icuuc")
+    endif()
+  endforeach()
+
   target_link_libraries(mongo_db_plugin
           PUBLIC chain_plugin eosio_chain appbase
           ${LIBMONGOCXX_STATIC_LIBRARY_PATH} ${LIBBSONCXX_STATIC_LIBRARY_PATH}
           ${MONGOC_STATIC_LIBRARY} ${BSON_STATIC_LIBRARY}
-          resolv
+          resolv ${LINK_SASL} ${LINK_ICU}
           )
                
 else()


### PR DESCRIPTION


<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
mongo-c-driver could require linkage to libicu or libsasl2 depending on how it was configured when built. We can't just use MONGOC_STATIC_LIBRARIES variables from its cmake file because these static variants may try to static link against libraries we don't want (like a system libc/c++). But we need to know if mongo c driver was built with ICU or SASL2 support so hat we can continue to link to those. This certainly is a bit on the fragile side but try to parse what is included in MONGOC_STATIC_LIBRARIES to see what we should link to
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
