### PR TITLE
startup catchup test not killing node

### DIFF
--- a/tests/nodeos_startup_catchup.py
+++ b/tests/nodeos_startup_catchup.py
@@ -165,7 +165,7 @@ try:
         catchupNode.interruptAndVerifyExitStatus(60)
 
         Print("Restart catchup node")
-        catchupNode.relaunch(catchupNodeNum)
+        catchupNode.relaunch(catchupNodeNum, cachePopen=True)
         waitForNodeStarted(catchupNode)
         lastCatchupLibNum=lib(catchupNode)
 


### PR DESCRIPTION
## Change Description

- The startup catchup test was not killing the relaunched node causing exhaustion of resources on the build/test machines.

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
