### PR TITLE
Http configurable logging

### DIFF
--- a/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
@@ -79,6 +79,7 @@ namespace eosio {
         void plugin_initialize(const variables_map& options);
         void plugin_startup();
         void plugin_shutdown();
+        void handle_sighup() override;
 
         void add_handler(const string& url, const url_handler&);
         void add_api(const api_description& api) {

--- a/programs/nodeos/logging.json
+++ b/programs/nodeos/logging.json
@@ -65,8 +65,26 @@
         "net"
       ]
     },{
+      "name": "http_plugin",
+      "level": "debug",
+      "enabled": true,
+      "additivity": false,
+      "appenders": [
+        "stderr",
+        "net"
+      ]
+    },{
       "name": "producer_plugin",
       "level": "debug",
+      "enabled": true,
+      "additivity": false,
+      "appenders": [
+        "stderr",
+        "net"
+      ]
+    },{
+      "name": "transaction_tracing",
+      "level": "info",
       "enabled": true,
       "additivity": false,
       "appenders": [


### PR DESCRIPTION
## Change Description

- Add configurable logging to `http_plugin` controlled by `"http_plugin"` log name.
- A `logging.json` file will now need to be provided to get logging previously provided by default.
- See example `logging.json` in `./programs/nodeos` directory.

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ x ] Documentation Additions

- Documentation portraying expected nodeos output may need to be adapted to match the new less verbose output. Either that or the documentation should describe adding a logging.json with debug settings.