### PR TITLE
use protocol-features-sync-nodes branch for LRT pipeline - v1.8.x

### DIFF
--- a/pipeline.jsonc
+++ b/pipeline.jsonc
@@ -3,6 +3,10 @@
     {
         "pipeline-branch": "protocol-features-sync-nodes"
     },
+    "eosio-lrt":
+    {
+        "pipeline-branch": "protocol-features-sync-nodes"
+    },
     "eos-multiversion-tests":
     {
         "pipeline-branch": "protocol-features-sync-nodes",


### PR DESCRIPTION
## Change Description

PR #7242 removed the .pipelinebranch in favor of the new pipeline.jsonc file. However that file was missing the custom pipeline branch for the long running tests pipeline, which is now causing the long running tests to fail to build on some platforms. This PR makes modifications to pipeline.jsonc so that the `protocol-features-sync-nodes` branch is used once again for the long running tests pipeline.

## Consensus Changes
- [ ] Consensus Changes


## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
