### PR TITLE
Added eosio-nightly-builds pipeline to pipeline.jsonc

### DIFF
--- a/pipeline.jsonc
+++ b/pipeline.jsonc
@@ -2,5 +2,9 @@
     "eosio-lrt":
     {
         "pipeline-branch": "legacy-os"
+    },
+    "eosio-nightly-builds":
+    {
+        "pipeline-branch": "legacy-os"
     }
 }


### PR DESCRIPTION
## Change Description
In [pull request 7258](https://github.com/EOSIO/eos/pull/7258), I created a universal pipeline configuration file which defines the behavior of our CI/CD automated test pipelines. This pipeline configuration file requires pipelines to be explicitly called out, whereas our old `.pipelinebranch` configuration file applied indiscriminately to all pipelines.    
   
This pull request sets the `eosio-nightly-builds` pipeline back to running on the `legacy-os` branch.  
  
Tested working in [build 405](https://buildkite.com/EOSIO/eosio-nightly-builds/builds/405).  
  
## Consensus Changes
- [ ] Consensus Changes
None.

## API Changes
- [ ] API Changes
None.

## Documentation Additions
- [ ] Documentation Additions
None.