### PR TITLE
Added functionality to skip rows when calling get table

### DIFF
--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -286,6 +286,7 @@ public:
       string      lower_bound;
       string      upper_bound;
       uint32_t    limit = 10;
+      uint64_t    skip = 0;
       string      key_type;  // type of key specified by index_position
       string      index_position; // 1 - primary (first), 2 - secondary index (in order defined by multi_index), 3 - third index, etc
       string      encode_type{"dec"}; //dec, hex , default=dec
@@ -487,12 +488,13 @@ public:
             }
          };
 
+         auto skip = p.skip > 0 ? p.skip : 0;
          auto lower = secidx.lower_bound( lower_bound_lookup_tuple );
          auto upper = secidx.upper_bound( upper_bound_lookup_tuple );
          if( p.reverse && *p.reverse ) {
-            walk_table_row_range( boost::make_reverse_iterator(upper), boost::make_reverse_iterator(lower) );
+            walk_table_row_range( std::next(boost::make_reverse_iterator(upper), skip), boost::make_reverse_iterator(lower) );
          } else {
-            walk_table_row_range( lower, upper );
+            walk_table_row_range( std::next(lower, skip), upper );
          }
       }
       return result;
@@ -561,12 +563,13 @@ public:
             }
          };
 
+         auto skip = p.skip > 0 ? p.skip : 0;
          auto lower = idx.lower_bound( lower_bound_lookup_tuple );
          auto upper = idx.upper_bound( upper_bound_lookup_tuple );
          if( p.reverse && *p.reverse ) {
-            walk_table_row_range( boost::make_reverse_iterator(upper), boost::make_reverse_iterator(lower) );
+            walk_table_row_range( std::next(boost::make_reverse_iterator(upper), skip), boost::make_reverse_iterator(lower) );
          } else {
-            walk_table_row_range( lower, upper );
+            walk_table_row_range( std::next(lower, skip), upper );
          }
       }
       return result;

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -2598,6 +2598,7 @@ int main( int argc, char** argv ) {
    string encode_type{"dec"};
    bool binary = false;
    uint32_t limit = 10;
+   uint64_t skip = 0;
    string index_position;
    bool reverse = false;
    bool show_payer = false;
@@ -2607,6 +2608,7 @@ int main( int argc, char** argv ) {
    getTable->add_option( "table", table, localized("The name of the table as specified by the contract abi") )->required();
    getTable->add_option( "-b,--binary", binary, localized("Return the value as BINARY rather than using abi to interpret as JSON") );
    getTable->add_option( "-l,--limit", limit, localized("The maximum number of rows to return") );
+   getTable->add_option( "-s,--skip", skip, localized("The number of rows to skip") );
    getTable->add_option( "-k,--key", table_key, localized("Deprecated") );
    getTable->add_option( "-L,--lower", lower, localized("JSON representation of lower bound value of key, defaults to first") );
    getTable->add_option( "-U,--upper", upper, localized("JSON representation of upper bound value of key, defaults to last") );
@@ -2632,6 +2634,7 @@ int main( int argc, char** argv ) {
                          ("lower_bound",lower)
                          ("upper_bound",upper)
                          ("limit",limit)
+                         ("skip",skip)
                          ("key_type",key_type)
                          ("index_position", index_position)
                          ("encode_type", encode_type)

--- a/tests/get_table_tests.cpp
+++ b/tests/get_table_tests.cpp
@@ -315,6 +315,56 @@ BOOST_FIXTURE_TEST_CASE( get_table_test, TESTER ) try {
       BOOST_REQUIRE_EQUAL("7777.0000 CCC", result.rows[0]["balance"].as_string());
    }
 
+   // get table: normal case, with limit & skip
+   p.lower_bound = p.upper_bound = "";
+   p.limit = 1;
+   p.skip = 2;
+   p.reverse = false;
+   result = plugin.read_only::get_table_rows(p);
+   BOOST_REQUIRE_EQUAL(1u, result.rows.size());
+   BOOST_REQUIRE_EQUAL(true, result.more);
+   if (result.rows.size() >= 1) {
+      BOOST_REQUIRE_EQUAL("7777.0000 CCC", result.rows[0]["balance"].as_string());
+   }
+
+   // get table: reverse case, with limit & skip
+   p.lower_bound = p.upper_bound = "";
+   p.limit = 1;
+   p.skip = 2;
+   p.reverse = true;
+   result = plugin.read_only::get_table_rows(p);
+   BOOST_REQUIRE_EQUAL(1u, result.rows.size());
+   BOOST_REQUIRE_EQUAL(true, result.more);
+   if (result.rows.size() >= 1) {
+      BOOST_REQUIRE_EQUAL("8888.0000 BBB", result.rows[0]["balance"].as_string());
+   }
+
+   // get table: normal case, with bound, limit & skip
+   p.lower_bound = "AAA";
+   p.upper_bound = "CCC";
+   p.limit = 1;
+   p.skip = 1;
+   p.reverse = false;
+   result = plugin.read_only::get_table_rows(p);
+   BOOST_REQUIRE_EQUAL(1u, result.rows.size());
+   BOOST_REQUIRE_EQUAL(true, result.more);
+   if (result.rows.size() >= 1) {
+      BOOST_REQUIRE_EQUAL("8888.0000 BBB", result.rows[0]["balance"].as_string());
+   }
+
+   // get table: reverse case, with bound, limit & skip
+   p.lower_bound = "AAA";
+   p.upper_bound = "CCC";
+   p.limit = 1;
+   p.skip = 1;
+   p.reverse = true;
+   result = plugin.read_only::get_table_rows(p);
+   BOOST_REQUIRE_EQUAL(1u, result.rows.size());
+   BOOST_REQUIRE_EQUAL(true, result.more);
+   if (result.rows.size() >= 1) {
+      BOOST_REQUIRE_EQUAL("8888.0000 BBB", result.rows[0]["balance"].as_string());
+   }
+
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( get_table_by_seckey_test, TESTER ) try {


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
The change introduces the ability to skip table rows, thus enabling the ability to paginate results. The skip functionality is independent of the lower & upper bounds. A primary example is iterating over all rows in a table, where there could be thousands, in a controlled manner by utilising skip & limit parameters.


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [x] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->
A skip parameter has been added, as this is an addition there should be no breaking changes.


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
