### PR TITLE
restrict range of error codes that contracts are allowed to emit

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -3030,9 +3030,11 @@ bool controller::all_subjective_mitigations_disabled()const {
 }
 
 fc::optional<uint64_t> controller::convert_exception_to_error_code( const fc::exception& e ) {
-   const eosio_assert_code_exception* e_ptr = dynamic_cast<const eosio_assert_code_exception*>( &e );
+   const chain_exception* e_ptr = dynamic_cast<const chain_exception*>( &e );
 
    if( e_ptr == nullptr ) return {};
+
+   if( !e_ptr->error_code ) return static_cast<uint64_t>(system_error_code::generic_system_error);
 
    return e_ptr->error_code;
 }

--- a/libraries/chain/include/eosio/chain/exceptions.hpp
+++ b/libraries/chain/include/eosio/chain/exceptions.hpp
@@ -106,6 +106,12 @@
 
 namespace eosio { namespace chain {
 
+   enum class system_error_code : uint64_t {
+      default_system_error = 10000000000000000000ULL,
+      contract_restricted_error_code, //< contract used an error code reserved for system usage
+   };
+
+
    FC_DECLARE_EXCEPTION( chain_exception,
                          3000000, "blockchain exception" )
    /**

--- a/libraries/chain/include/eosio/chain/exceptions.hpp
+++ b/libraries/chain/include/eosio/chain/exceptions.hpp
@@ -107,13 +107,13 @@
 namespace eosio { namespace chain {
 
    enum class system_error_code : uint64_t {
-      default_system_error = 10000000000000000000ULL,
+      generic_system_error = 10000000000000000000ULL,
       contract_restricted_error_code, //< contract used an error code reserved for system usage
    };
 
 
-   FC_DECLARE_EXCEPTION( chain_exception,
-                         3000000, "blockchain exception" )
+   FC_DECLARE_DERIVED_EXCEPTION_WITH_ERROR_CODE( chain_exception, fc::exception,
+                                                 3000000, "blockchain exception" )
    /**
     *  chain_exception
     *   |- chain_type_exception
@@ -255,7 +255,7 @@ namespace eosio { namespace chain {
                                     3050002, "Invalid Action Arguments" )
       FC_DECLARE_DERIVED_EXCEPTION( eosio_assert_message_exception, action_validate_exception,
                                     3050003, "eosio_assert_message assertion failure" )
-      FC_DECLARE_DERIVED_EXCEPTION_WITH_ERROR_CODE( eosio_assert_code_exception, action_validate_exception,
+      FC_DECLARE_DERIVED_EXCEPTION( eosio_assert_code_exception, action_validate_exception,
                                     3050004, "eosio_assert_code assertion failure" )
       FC_DECLARE_DERIVED_EXCEPTION( action_not_found_exception, action_validate_exception,
                                     3050005, "Action can not be found" )
@@ -269,6 +269,8 @@ namespace eosio { namespace chain {
                                     3050009, "Inline Action exceeds maximum size limit" )
       FC_DECLARE_DERIVED_EXCEPTION( unauthorized_ram_usage_increase, action_validate_exception,
                                     3050010, "Action attempts to increase RAM usage of account without authorization" )
+      FC_DECLARE_DERIVED_EXCEPTION( restricted_error_code_exception, action_validate_exception,
+                                    3050011, "eosio_assert_code assertion failure uses restricted error code value" )
 
    FC_DECLARE_DERIVED_EXCEPTION( database_exception, chain_exception,
                                  3060000, "Database exception" )

--- a/libraries/chain/wasm_interface.cpp
+++ b/libraries/chain/wasm_interface.cpp
@@ -975,14 +975,23 @@ public:
 
    void eosio_assert_code( bool condition, uint64_t error_code ) {
       if( BOOST_UNLIKELY( !condition ) ) {
-         eosio_assert_code_exception e( FC_LOG_MESSAGE( error,
-                                                        "assertion failure with error code: ${error_code}",
-                                                        ("error_code", error_code)
-                                                      ) );
-         e.error_code = ( error_code >= static_cast<uint64_t>(system_error_code::default_system_error) )
-                           ? static_cast<uint64_t>(system_error_code::contract_restricted_error_code)
-                           : error_code;
-         throw e;
+         if( error_code >= static_cast<uint64_t>(system_error_code::generic_system_error) ) {
+            restricted_error_code_exception e( FC_LOG_MESSAGE(
+                                                   error,
+                                                   "eosio_assert_code called with reserved error code: ${error_code}",
+                                                   ("error_code", error_code)
+            ) );
+            e.error_code = static_cast<uint64_t>(system_error_code::contract_restricted_error_code);
+            throw e;
+         } else {
+            eosio_assert_code_exception e( FC_LOG_MESSAGE(
+                                             error,
+                                             "assertion failure with error code: ${error_code}",
+                                             ("error_code", error_code)
+            ) );
+            e.error_code = error_code;
+            throw e;
+         }
       }
    }
 

--- a/libraries/chain/wasm_interface.cpp
+++ b/libraries/chain/wasm_interface.cpp
@@ -979,7 +979,9 @@ public:
                                                         "assertion failure with error code: ${error_code}",
                                                         ("error_code", error_code)
                                                       ) );
-         e.error_code = error_code;
+         e.error_code = ( error_code >= static_cast<uint64_t>(system_error_code::default_system_error) )
+                           ? static_cast<uint64_t>(system_error_code::contract_restricted_error_code)
+                           : error_code;
          throw e;
       }
    }

--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -2277,7 +2277,7 @@ BOOST_FIXTURE_TEST_CASE(eosio_assert_code_tests, TESTER) { try {
 
    auto trace2 = CALL_TEST_FUNCTION_NO_THROW(
                   *this, "test_action", "test_assert_code",
-                  fc::raw::pack( static_cast<uint64_t>(system_error_code::default_system_error) )
+                  fc::raw::pack( static_cast<uint64_t>(system_error_code::generic_system_error) )
    );
    BOOST_REQUIRE( trace2 );
    BOOST_REQUIRE( trace2->except );

--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -2275,6 +2275,21 @@ BOOST_FIXTURE_TEST_CASE(eosio_assert_code_tests, TESTER) { try {
 
    produce_block();
 
+   auto trace2 = CALL_TEST_FUNCTION_NO_THROW(
+                  *this, "test_action", "test_assert_code",
+                  fc::raw::pack( static_cast<uint64_t>(system_error_code::default_system_error) )
+   );
+   BOOST_REQUIRE( trace2 );
+   BOOST_REQUIRE( trace2->except );
+   BOOST_REQUIRE( trace2->error_code );
+   BOOST_REQUIRE_EQUAL( *trace2->error_code, static_cast<uint64_t>(system_error_code::contract_restricted_error_code) );
+   BOOST_REQUIRE_EQUAL( trace2->action_traces.size(), 1 );
+   BOOST_REQUIRE( trace2->action_traces[0].except );
+   BOOST_REQUIRE( trace2->action_traces[0].error_code );
+   BOOST_REQUIRE_EQUAL( *trace2->action_traces[0].error_code, static_cast<uint64_t>(system_error_code::contract_restricted_error_code) );
+
+   produce_block();
+
    BOOST_REQUIRE_EQUAL( validate(), true );
 } FC_LOG_AND_RETHROW() }
 


### PR DESCRIPTION
## Change Description

A contract is allowed to fail with a `uint64_t` error code using the `eosio_assert_code` intrinsic. This is an alternative to the other variants of assert intrinsics which take string error messages that allows for reductions in contract WASM size.

Contracts  are allowed to choose error code values and assign meaning to them specific to their contract, however they should not be allowed the full range of a `uint64_t`. The values greater than or equal to 10,000,000,000,000,000,000 are reserved by the EOSIO system for its own error codes to be used in the future.

This PR makes a change to the `eosio_assert_code` intrinsic implementation to disallow a contract from passing through an error code in the restricted range into the trace, thereby reserving the range to allow the system to unambiguously signal system errors via the `error_code` field of the trace. 

To avoid changing consensus rules, a call to `eosio_assert_code` with a restricted `error_code` value is allowed if the `condition` is true; it is still a no-op in that case. It is only when the `condition` is false that the restriction on the `error_code` value is enforced. The transaction still fails but with a different error code (`system_error_code::contract_restricted_error_code`) to signal that the contract called `eosio_assert_code` with a restricted error code value.

Any chain exceptions that do not have a more specific error code defined will use the error code of the `generic_system_error`, which is the value at the start of the range of error codes restricted for system errors.

## Consensus Changes
- [ ] Consensus Changes


## API Changes
- [ ] API Changes


## Documentation Additions
- [x] Documentation Additions

Contracts are able to use `uint64_t` error codes as an alternative (and cheaper) means of signaling error conditions as opposed to string error messages. However, EOSIO and EOSIO.CDT reserve certain ranges of the `uint64_t` value space for their own purposes. They assume that the contract develop respects the following restrictions:

- 0 (inclusive) to 5,000,000,000,000,000,000 (exclusive): Available for contract developers to use to signal errors specific to their contracts.
-  5,000,000,000,000,000,000 (inclusive) to 8,000,000,000,000,000,000 (exclusive): Reserved for the EOSIO.CDT compiler to allocate as appropriate. Although the WASM code generated by the EOSIO.CDT compiler may use error code values that were automatically generated from within this range, the error codes in this range are meant to have meaning specific to the particular compiled contract (the meaning would typically be conveyed through the mapping between the error code value and strings in the associated generated ABI file).
-  8,000,000,000,000,000,000 (inclusive) to 10,000,000,000,000,000,000 (exclusive): Reserved for the EOSIO.CDT compiler to allocate as appropriate. The error codes in this range are not specific to any contract but rather are used to convey general runtime error conditions associated with the generated code by EOSIO.CDT.
- 10,000,000,000,000,000,000 (inclusive) to 18,446,744,073,709,551,615 (inclusive): Reserved for EOSIO to represent system-level error conditions. EOSIO will actually enforce this by restricting the ability for `eosio_assert_code` to be used to fail with error code values used within this range.

