### PR TITLE
restrict range of error codes that contracts are allowed to emit

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -3030,9 +3030,11 @@ bool controller::all_subjective_mitigations_disabled()const {
 }
 
 fc::optional<uint64_t> controller::convert_exception_to_error_code( const fc::exception& e ) {
-   const eosio_assert_code_exception* e_ptr = dynamic_cast<const eosio_assert_code_exception*>( &e );
+   const chain_exception* e_ptr = dynamic_cast<const chain_exception*>( &e );
 
    if( e_ptr == nullptr ) return {};
+
+   if( !e_ptr->error_code ) return static_cast<uint64_t>(system_error_code::generic_system_error);
 
    return e_ptr->error_code;
 }

--- a/libraries/chain/include/eosio/chain/exceptions.hpp
+++ b/libraries/chain/include/eosio/chain/exceptions.hpp
@@ -106,6 +106,12 @@
 
 namespace eosio { namespace chain {
 
+   enum class system_error_code : uint64_t {
+      default_system_error = 10000000000000000000ULL,
+      contract_restricted_error_code, //< contract used an error code reserved for system usage
+   };
+
+
    FC_DECLARE_EXCEPTION( chain_exception,
                          3000000, "blockchain exception" )
    /**

--- a/libraries/chain/include/eosio/chain/exceptions.hpp
+++ b/libraries/chain/include/eosio/chain/exceptions.hpp
@@ -107,13 +107,13 @@
 namespace eosio { namespace chain {
 
    enum class system_error_code : uint64_t {
-      default_system_error = 10000000000000000000ULL,
+      generic_system_error = 10000000000000000000ULL,
       contract_restricted_error_code, //< contract used an error code reserved for system usage
    };
 
 
-   FC_DECLARE_EXCEPTION( chain_exception,
-                         3000000, "blockchain exception" )
+   FC_DECLARE_DERIVED_EXCEPTION_WITH_ERROR_CODE( chain_exception, fc::exception,
+                                                 3000000, "blockchain exception" )
    /**
     *  chain_exception
     *   |- chain_type_exception
@@ -255,7 +255,7 @@ namespace eosio { namespace chain {
                                     3050002, "Invalid Action Arguments" )
       FC_DECLARE_DERIVED_EXCEPTION( eosio_assert_message_exception, action_validate_exception,
                                     3050003, "eosio_assert_message assertion failure" )
-      FC_DECLARE_DERIVED_EXCEPTION_WITH_ERROR_CODE( eosio_assert_code_exception, action_validate_exception,
+      FC_DECLARE_DERIVED_EXCEPTION( eosio_assert_code_exception, action_validate_exception,
                                     3050004, "eosio_assert_code assertion failure" )
       FC_DECLARE_DERIVED_EXCEPTION( action_not_found_exception, action_validate_exception,
                                     3050005, "Action can not be found" )
@@ -269,6 +269,8 @@ namespace eosio { namespace chain {
                                     3050009, "Inline Action exceeds maximum size limit" )
       FC_DECLARE_DERIVED_EXCEPTION( unauthorized_ram_usage_increase, action_validate_exception,
                                     3050010, "Action attempts to increase RAM usage of account without authorization" )
+      FC_DECLARE_DERIVED_EXCEPTION( restricted_error_code_exception, action_validate_exception,
+                                    3050011, "eosio_assert_code assertion failure uses restricted error code value" )
 
    FC_DECLARE_DERIVED_EXCEPTION( database_exception, chain_exception,
                                  3060000, "Database exception" )

--- a/libraries/chain/wasm_interface.cpp
+++ b/libraries/chain/wasm_interface.cpp
@@ -975,14 +975,23 @@ public:
 
    void eosio_assert_code( bool condition, uint64_t error_code ) {
       if( BOOST_UNLIKELY( !condition ) ) {
-         eosio_assert_code_exception e( FC_LOG_MESSAGE( error,
-                                                        "assertion failure with error code: ${error_code}",
-                                                        ("error_code", error_code)
-                                                      ) );
-         e.error_code = ( error_code >= static_cast<uint64_t>(system_error_code::default_system_error) )
-                           ? static_cast<uint64_t>(system_error_code::contract_restricted_error_code)
-                           : error_code;
-         throw e;
+         if( error_code >= static_cast<uint64_t>(system_error_code::generic_system_error) ) {
+            restricted_error_code_exception e( FC_LOG_MESSAGE(
+                                                   error,
+                                                   "eosio_assert_code called with reserved error code: ${error_code}",
+                                                   ("error_code", error_code)
+            ) );
+            e.error_code = static_cast<uint64_t>(system_error_code::contract_restricted_error_code);
+            throw e;
+         } else {
+            eosio_assert_code_exception e( FC_LOG_MESSAGE(
+                                             error,
+                                             "assertion failure with error code: ${error_code}",
+                                             ("error_code", error_code)
+            ) );
+            e.error_code = error_code;
+            throw e;
+         }
       }
    }
 

--- a/libraries/chain/wasm_interface.cpp
+++ b/libraries/chain/wasm_interface.cpp
@@ -979,7 +979,9 @@ public:
                                                         "assertion failure with error code: ${error_code}",
                                                         ("error_code", error_code)
                                                       ) );
-         e.error_code = error_code;
+         e.error_code = ( error_code >= static_cast<uint64_t>(system_error_code::default_system_error) )
+                           ? static_cast<uint64_t>(system_error_code::contract_restricted_error_code)
+                           : error_code;
          throw e;
       }
    }

--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -2094,6 +2094,21 @@ BOOST_FIXTURE_TEST_CASE(eosio_assert_code_tests, TESTER) { try {
 
    produce_block();
 
+   auto trace2 = CALL_TEST_FUNCTION_NO_THROW(
+                  *this, "test_action", "test_assert_code",
+                  fc::raw::pack( static_cast<uint64_t>(system_error_code::default_system_error) )
+   );
+   BOOST_REQUIRE( trace2 );
+   BOOST_REQUIRE( trace2->except );
+   BOOST_REQUIRE( trace2->error_code );
+   BOOST_REQUIRE_EQUAL( *trace2->error_code, static_cast<uint64_t>(system_error_code::contract_restricted_error_code) );
+   BOOST_REQUIRE_EQUAL( trace2->action_traces.size(), 1 );
+   BOOST_REQUIRE( trace2->action_traces[0].except );
+   BOOST_REQUIRE( trace2->action_traces[0].error_code );
+   BOOST_REQUIRE_EQUAL( *trace2->action_traces[0].error_code, static_cast<uint64_t>(system_error_code::contract_restricted_error_code) );
+
+   produce_block();
+
    BOOST_REQUIRE_EQUAL( validate(), true );
 } FC_LOG_AND_RETHROW() }
 

--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -2096,7 +2096,7 @@ BOOST_FIXTURE_TEST_CASE(eosio_assert_code_tests, TESTER) { try {
 
    auto trace2 = CALL_TEST_FUNCTION_NO_THROW(
                   *this, "test_action", "test_assert_code",
-                  fc::raw::pack( static_cast<uint64_t>(system_error_code::default_system_error) )
+                  fc::raw::pack( static_cast<uint64_t>(system_error_code::generic_system_error) )
    );
    BOOST_REQUIRE( trace2 );
    BOOST_REQUIRE( trace2->except );


### PR DESCRIPTION
## Change Description

Port #7274 to develop.

## Consensus Changes
- [ ] Consensus Changes


## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions

See #7274.
