### PR TITLE
add debug_mode to state history plugin

### DIFF
--- a/libraries/chain/include/eosio/chain/resource_limits.hpp
+++ b/libraries/chain/include/eosio/chain/resource_limits.hpp
@@ -14,7 +14,7 @@ namespace eosio { namespace chain { namespace resource_limits {
          T denominator;
 
          friend inline bool operator ==( const ratio& lhs, const ratio& rhs ) {
-            return std::tie(lhs.numerator, lhs.numerator) == std::tie(rhs.numerator, rhs.denominator);
+            return std::tie(lhs.numerator, lhs.denominator) == std::tie(rhs.numerator, rhs.denominator);
          }
 
          friend inline bool operator !=( const ratio& lhs, const ratio& rhs ) {

--- a/libraries/chain/include/eosio/chain/resource_limits.hpp
+++ b/libraries/chain/include/eosio/chain/resource_limits.hpp
@@ -14,7 +14,7 @@ namespace eosio { namespace chain { namespace resource_limits {
          T denominator;
 
          friend inline bool operator ==( const ratio& lhs, const ratio& rhs ) {
-            return std::tie(lhs.numerator, rhs.numerator) == std::tie(rhs.numerator, rhs.denominator);
+            return std::tie(lhs.numerator, lhs.numerator) == std::tie(rhs.numerator, rhs.denominator);
          }
 
          friend inline bool operator !=( const ratio& lhs, const ratio& rhs ) {

--- a/libraries/chain/include/eosio/chain/resource_limits.hpp
+++ b/libraries/chain/include/eosio/chain/resource_limits.hpp
@@ -12,6 +12,14 @@ namespace eosio { namespace chain { namespace resource_limits {
          static_assert(std::is_integral<T>::value, "ratios must have integral types");
          T numerator;
          T denominator;
+
+         friend inline bool operator ==( const ratio& lhs, const ratio& rhs ) {
+            return std::tie(lhs.numerator, rhs.numerator) == std::tie(rhs.numerator, rhs.denominator);
+         }
+
+         friend inline bool operator !=( const ratio& lhs, const ratio& rhs ) {
+            return (lhs != rhs);
+         }
       };
    }
 
@@ -27,6 +35,15 @@ namespace eosio { namespace chain { namespace resource_limits {
       ratio    expand_rate;       // the rate at which an uncongested resource expands its limits
 
       void validate()const; // throws if the parameters do not satisfy basic sanity checks
+
+      friend inline bool operator ==( const elastic_limit_parameters& lhs, const elastic_limit_parameters& rhs ) {
+         return std::tie(lhs.target, lhs.max, lhs.periods, lhs.max_multiplier, lhs.contract_rate, lhs.expand_rate)
+                  == std::tie(rhs.target, rhs.max, rhs.periods, rhs.max_multiplier, rhs.contract_rate, rhs.expand_rate);
+      }
+
+      friend inline bool operator !=( const elastic_limit_parameters& lhs, const elastic_limit_parameters& rhs ) {
+         return (lhs != rhs);
+      }
    };
 
    struct account_resource_limit {

--- a/libraries/chain/include/eosio/chain/resource_limits.hpp
+++ b/libraries/chain/include/eosio/chain/resource_limits.hpp
@@ -18,7 +18,7 @@ namespace eosio { namespace chain { namespace resource_limits {
          }
 
          friend inline bool operator !=( const ratio& lhs, const ratio& rhs ) {
-            return (lhs != rhs);
+            return !(lhs == rhs);
          }
       };
    }
@@ -42,7 +42,7 @@ namespace eosio { namespace chain { namespace resource_limits {
       }
 
       friend inline bool operator !=( const elastic_limit_parameters& lhs, const elastic_limit_parameters& rhs ) {
-         return (lhs != rhs);
+         return !(lhs == rhs);
       }
    };
 

--- a/libraries/chain/resource_limits.cpp
+++ b/libraries/chain/resource_limits.cpp
@@ -102,6 +102,8 @@ void resource_limits_manager::set_block_parameters(const elastic_limit_parameter
    cpu_limit_parameters.validate();
    net_limit_parameters.validate();
    const auto& config = _db.get<resource_limits_config_object>();
+   if( config.cpu_limit_parameters == cpu_limit_parameters && config.net_limit_parameters == net_limit_parameters )
+      return;
    _db.modify(config, [&](resource_limits_config_object& c){
       c.cpu_limit_parameters = cpu_limit_parameters;
       c.net_limit_parameters = net_limit_parameters;


### PR DESCRIPTION
## Change Description

This PR adds a debug mode to the state history plugin. If the state history plugin is not in debug mode, which is the default behavior, it will now modify certain subjective values before writing to disk (and therefore also making it available through the state history API). If the state history plugin is in debug mode (by setting the `trace-history-debug-mode` to true), it will continue to write all values out the same way it has up to this point.

The following values are modified when state history is not in debug mode:

- The `console` field of action traces is set to the empty string (regardless of whether `contracts-console` is enabled). (While the contract print calls are deterministic, the actual string appended to the console log is allowed to vary from node to node and the existing reference implementation of nodeos may output different strings when printing floating point values on different machines.) 
- The `elapsed` field of both the transaction and action traces is set to 0. (The `elapsed` time is measured wall-clock time for processing the action/transaction on the local node and therefore will vary from node to node.)
- The `except` field of both the transaction and action traces is kept as is if a value is not present, otherwise the value of the field is set to the one-character string `"Y"`. (Nodes are allowed to change the descriptive messages of EOSIO system errors and therefore it can act as a source of subjectivity in the state history logs.)
- The `error_code` field of both the transaction and action traces is kept as is if a value is not present, otherwise it may be modified to enforce a cap of 10,000,000,000,000,000,000 on the value. (Similar to how the descriptive messages of EOSIO system errors are allowed to change, currently we have reserved the flexibility to change the error codes for EOSIO system errors, which are [allowed to only have a value of at least 10,000,000,000,000,000,000](https://github.com/EOSIO/eos/pull/7274). The lower range of values for error codes are reserved for use by contracts and the emission of those error code values should be deterministic.) 

By making these changes, it becomes possible for the trace and table delta logs of the state history plugin to be  identical across nodes assuming the logs end at the same head block and were generated with a state history plugin operating at the same (effective) version and with debug mode set to false all throughout the creation of the log. 

This PR also includes an optimization to avoid updating `resource_limits_config_object` on each block if the values to do not change.

## Consensus Changes
- [ ] Consensus Changes


## API Changes
- [x] API Changes

The behavior of the state history remains the same as it was before if the new `trace-history-debug-mode` boolean option is set to true. However, if the `trace-history-debug-mode` option is kept at its default value of false, there may be changes to some of the values in the `transaction_trace` and `action_trace` objects returned by the state history plugin. Read the description above to see which fields are changed and how. 

## Documentation Additions
- [x] Documentation Additions

See "API Changes" section above.