### PR TITLE
when unable to find mongo driver stop cmake - 1.8

### DIFF
--- a/plugins/mongo_db_plugin/CMakeLists.txt
+++ b/plugins/mongo_db_plugin/CMakeLists.txt
@@ -10,7 +10,7 @@ if(BUILD_MONGO_DB_PLUGIN)
       find_package(libbson-static-1.0 REQUIRED)
 
   else()
-      message("Could NOT find MongoDB. mongo_db_plugin with MongoDB support will not be included.")
+      message(FATAL_ERROR "Could NOT find mongo-c-driver. Disable mongo support or ensure mongo-c-driver and mongo-cxx-driver is built and installed")
       return()
   endif()
 


### PR DESCRIPTION
Previously the mongo plugin cmake would simply print a message that it couldn't find a mongo c driver and carry on. But this means compilation of nodeos will fail because BUILD_MONGO_DB_PLUGIN is still set to ON so nodeos cmake will try to link against the plugin that is not built.

Can't just set BUILD_MONGO_DB_PLUGIN to OFF here because of cmake scoping rules

Might as well just error out; I don't think many people will set this to ON and then want the build to plow ahead anyways

<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
