### PR TITLE
Explicit name

### DIFF
--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -880,7 +880,7 @@ action_name apply_context::get_sender() const {
       const action_trace& creator_trace = trx_context.get_action_trace( trace.creator_action_ordinal );
       return creator_trace.receiver;
    }
-   return 0;
+   return action_name();
 }
 
 } } /// eosio::chain

--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -648,11 +648,11 @@ int apply_context::get_context_free_data( uint32_t index, char* buffer, size_t b
    return copy_size;
 }
 
-int apply_context::db_store_i64( uint64_t scope, uint64_t table, const account_name& payer, uint64_t id, const char* buffer, size_t buffer_size ) {
+int apply_context::db_store_i64( name scope, name table, const account_name& payer, uint64_t id, const char* buffer, size_t buffer_size ) {
    return db_store_i64( receiver, scope, table, payer, id, buffer, buffer_size);
 }
 
-int apply_context::db_store_i64( uint64_t code, uint64_t scope, uint64_t table, const account_name& payer, uint64_t id, const char* buffer, size_t buffer_size ) {
+int apply_context::db_store_i64( name code, name scope, name table, const account_name& payer, uint64_t id, const char* buffer, size_t buffer_size ) {
 //   require_write_lock( scope );
    const auto& tab = find_or_create_table( code, scope, table, payer );
    auto tableid = tab.id;
@@ -788,7 +788,7 @@ int apply_context::db_previous_i64( int iterator, uint64_t& primary ) {
    return keyval_cache.add(*itr);
 }
 
-int apply_context::db_find_i64( uint64_t code, uint64_t scope, uint64_t table, uint64_t id ) {
+int apply_context::db_find_i64( name code, name scope, name table, uint64_t id ) {
    //require_read_lock( code, scope ); // redundant?
 
    const auto* tab = find_table( code, scope, table );
@@ -802,7 +802,7 @@ int apply_context::db_find_i64( uint64_t code, uint64_t scope, uint64_t table, u
    return keyval_cache.add( *obj );
 }
 
-int apply_context::db_lowerbound_i64( uint64_t code, uint64_t scope, uint64_t table, uint64_t id ) {
+int apply_context::db_lowerbound_i64( name code, name scope, name table, uint64_t id ) {
    //require_read_lock( code, scope ); // redundant?
 
    const auto* tab = find_table( code, scope, table );
@@ -818,7 +818,7 @@ int apply_context::db_lowerbound_i64( uint64_t code, uint64_t scope, uint64_t ta
    return keyval_cache.add( *itr );
 }
 
-int apply_context::db_upperbound_i64( uint64_t code, uint64_t scope, uint64_t table, uint64_t id ) {
+int apply_context::db_upperbound_i64( name code, name scope, name table, uint64_t id ) {
    //require_read_lock( code, scope ); // redundant?
 
    const auto* tab = find_table( code, scope, table );
@@ -834,7 +834,7 @@ int apply_context::db_upperbound_i64( uint64_t code, uint64_t scope, uint64_t ta
    return keyval_cache.add( *itr );
 }
 
-int apply_context::db_end_i64( uint64_t code, uint64_t scope, uint64_t table ) {
+int apply_context::db_end_i64( name code, name scope, name table ) {
    //require_read_lock( code, scope ); // redundant?
 
    const auto* tab = find_table( code, scope, table );

--- a/libraries/chain/authorization_manager.cpp
+++ b/libraries/chain/authorization_manager.cpp
@@ -238,7 +238,7 @@ namespace eosio { namespace chain {
          auto link = _db.find<permission_link_object, by_action_name>(key);
          // If no specific link found, check for a contract-wide default
          if (link == nullptr) {
-            boost::get<2>(key) = "";
+            boost::get<2>(key) = {};
             link = _db.find<permission_link_object, by_action_name>(key);
          }
 

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -319,7 +319,8 @@ struct controller_impl {
 
 
 #define SET_APP_HANDLER( receiver, contract, action) \
-   set_apply_handler( #receiver, #contract, #action, &BOOST_PP_CAT(apply_, BOOST_PP_CAT(contract, BOOST_PP_CAT(_,action) ) ) )
+   set_apply_handler( account_name(#receiver), account_name(#contract), action_name(#action), \
+                      &BOOST_PP_CAT(apply_, BOOST_PP_CAT(contract, BOOST_PP_CAT(_,action) ) ) )
 
    SET_APP_HANDLER( eosio, eosio, newaccount );
    SET_APP_HANDLER( eosio, eosio, setcode );

--- a/libraries/chain/eosio_contract.cpp
+++ b/libraries/chain/eosio_contract.cpp
@@ -313,7 +313,7 @@ void apply_eosio_deleteauth(apply_context& context) {
       auto range = index.equal_range(boost::make_tuple(remove.account, remove.permission));
       EOS_ASSERT(range.first == range.second, action_validate_exception,
                  "Cannot delete a linked authority. Unlink the authority first. This authority is linked to ${code}::${type}.",
-                 ("code", string(range.first->code))("type", string(range.first->message_type)));
+                 ("code", range.first->code)("type", range.first->message_type));
    }
 
    const auto& permission = authorization.get_permission({remove.account, remove.permission});

--- a/libraries/chain/include/eosio/chain/apply_context.hpp
+++ b/libraries/chain/include/eosio/chain/apply_context.hpp
@@ -514,16 +514,16 @@ class apply_context {
 
       void update_db_usage( const account_name& payer, int64_t delta );
 
-      int  db_store_i64( uint64_t scope, uint64_t table, const account_name& payer, uint64_t id, const char* buffer, size_t buffer_size );
+      int  db_store_i64( name scope, name table, const account_name& payer, uint64_t id, const char* buffer, size_t buffer_size );
       void db_update_i64( int iterator, account_name payer, const char* buffer, size_t buffer_size );
       void db_remove_i64( int iterator );
       int  db_get_i64( int iterator, char* buffer, size_t buffer_size );
       int  db_next_i64( int iterator, uint64_t& primary );
       int  db_previous_i64( int iterator, uint64_t& primary );
-      int  db_find_i64( uint64_t code, uint64_t scope, uint64_t table, uint64_t id );
-      int  db_lowerbound_i64( uint64_t code, uint64_t scope, uint64_t table, uint64_t id );
-      int  db_upperbound_i64( uint64_t code, uint64_t scope, uint64_t table, uint64_t id );
-      int  db_end_i64( uint64_t code, uint64_t scope, uint64_t table );
+      int  db_find_i64( name code, name scope, name table, uint64_t id );
+      int  db_lowerbound_i64( name code, name scope, name table, uint64_t id );
+      int  db_upperbound_i64( name code, name scope, name table, uint64_t id );
+      int  db_end_i64( name code, name scope, name table );
 
    private:
 
@@ -531,7 +531,7 @@ class apply_context {
       const table_id_object& find_or_create_table( name code, name scope, name table, const account_name &payer );
       void                   remove_table( const table_id_object& tid );
 
-      int  db_store_i64( uint64_t code, uint64_t scope, uint64_t table, const account_name& payer, uint64_t id, const char* buffer, size_t buffer_size );
+      int  db_store_i64( name code, name scope, name table, const account_name& payer, uint64_t id, const char* buffer, size_t buffer_size );
 
 
    /// Misc methods:

--- a/libraries/chain/include/eosio/chain/apply_context.hpp
+++ b/libraries/chain/include/eosio/chain/apply_context.hpp
@@ -184,7 +184,7 @@ class apply_context {
 
 //               context.require_write_lock( scope );
 
-               const auto& tab = context.find_or_create_table( context.receiver, scope, table, payer );
+               const auto& tab = context.find_or_create_table( context.receiver, name(scope), name(table), payer );
 
                const auto& obj = context.db.create<ObjectType>( [&]( auto& o ){
                   o.t_id          = tab.id;
@@ -248,7 +248,7 @@ class apply_context {
             }
 
             int find_secondary( uint64_t code, uint64_t scope, uint64_t table, secondary_key_proxy_const_type secondary, uint64_t& primary ) {
-               auto tab = context.find_table( code, scope, table );
+               auto tab = context.find_table( name(code), name(scope), name(table) );
                if( !tab ) return -1;
 
                auto table_end_itr = itr_cache.cache_table( *tab );
@@ -262,7 +262,7 @@ class apply_context {
             }
 
             int lowerbound_secondary( uint64_t code, uint64_t scope, uint64_t table, secondary_key_proxy_type secondary, uint64_t& primary ) {
-               auto tab = context.find_table( code, scope, table );
+               auto tab = context.find_table( name(code), name(scope), name(table) );
                if( !tab ) return -1;
 
                auto table_end_itr = itr_cache.cache_table( *tab );
@@ -279,7 +279,7 @@ class apply_context {
             }
 
             int upperbound_secondary( uint64_t code, uint64_t scope, uint64_t table, secondary_key_proxy_type secondary, uint64_t& primary ) {
-               auto tab = context.find_table( code, scope, table );
+               auto tab = context.find_table( name(code), name(scope), name(table) );
                if( !tab ) return -1;
 
                auto table_end_itr = itr_cache.cache_table( *tab );
@@ -296,7 +296,7 @@ class apply_context {
             }
 
             int end_secondary( uint64_t code, uint64_t scope, uint64_t table ) {
-               auto tab = context.find_table( code, scope, table );
+               auto tab = context.find_table( name(code), name(scope), name(table) );
                if( !tab ) return -1;
 
                return itr_cache.cache_table( *tab );
@@ -350,7 +350,7 @@ class apply_context {
             }
 
             int find_primary( uint64_t code, uint64_t scope, uint64_t table, secondary_key_proxy_type secondary, uint64_t primary ) {
-               auto tab = context.find_table( code, scope, table );
+               auto tab = context.find_table( name(code), name(scope), name(table) );
                if( !tab ) return -1;
 
                auto table_end_itr = itr_cache.cache_table( *tab );
@@ -363,7 +363,7 @@ class apply_context {
             }
 
             int lowerbound_primary( uint64_t code, uint64_t scope, uint64_t table, uint64_t primary ) {
-               auto tab = context.find_table( code, scope, table );
+               auto tab = context.find_table( name(code), name(scope), name(table) );
                if (!tab) return -1;
 
                auto table_end_itr = itr_cache.cache_table( *tab );
@@ -377,7 +377,7 @@ class apply_context {
             }
 
             int upperbound_primary( uint64_t code, uint64_t scope, uint64_t table, uint64_t primary ) {
-               auto tab = context.find_table( code, scope, table );
+               auto tab = context.find_table( name(code), name(scope), name(table) );
                if ( !tab ) return -1;
 
                auto table_end_itr = itr_cache.cache_table( *tab );

--- a/libraries/chain/include/eosio/chain/config.hpp
+++ b/libraries/chain/include/eosio/chain/config.hpp
@@ -23,21 +23,21 @@ const static auto default_state_size            = 1*1024*1024*1024ll;
 const static auto default_state_guard_size      =    128*1024*1024ll;
 
 
-const static uint64_t system_account_name    = N(eosio);
-const static uint64_t null_account_name      = N(eosio.null);
-const static uint64_t producers_account_name = N(eosio.prods);
+const static name system_account_name    { N(eosio) };
+const static name null_account_name      { N(eosio.null) };
+const static name producers_account_name { N(eosio.prods) };
 
 // Active permission of producers account requires greater than 2/3 of the producers to authorize
-const static uint64_t majority_producers_permission_name = N(prod.major); // greater than 1/2 of producers needed to authorize
-const static uint64_t minority_producers_permission_name = N(prod.minor); // greater than 1/3 of producers needed to authorize0
+const static name majority_producers_permission_name { N(prod.major) }; // greater than 1/2 of producers needed to authorize
+const static name minority_producers_permission_name { N(prod.minor) }; // greater than 1/3 of producers needed to authorize0
 
-const static uint64_t eosio_auth_scope       = N(eosio.auth);
-const static uint64_t eosio_all_scope        = N(eosio.all);
+const static name eosio_auth_scope       { N(eosio.auth) };
+const static name eosio_all_scope        { N(eosio.all) };
 
-const static uint64_t active_name = N(active);
-const static uint64_t owner_name  = N(owner);
-const static uint64_t eosio_any_name = N(eosio.any);
-const static uint64_t eosio_code_name = N(eosio.code);
+const static name active_name     { N(active) };
+const static name owner_name      { N(owner) };
+const static name eosio_any_name  { N(eosio.any) };
+const static name eosio_code_name { N(eosio.code) };
 
 const static int      block_interval_ms = 500;
 const static int      block_interval_us = block_interval_ms*1000;

--- a/libraries/chain/include/eosio/chain/contract_table_objects.hpp
+++ b/libraries/chain/include/eosio/chain/contract_table_objects.hpp
@@ -61,7 +61,7 @@ namespace eosio { namespace chain {
       id_type               id;
       table_id              t_id; //< t_id should not be changed within a chainbase modifier lambda
       uint64_t              primary_key; //< primary_key should not be changed within a chainbase modifier lambda
-      account_name          payer = 0;
+      account_name          payer;
       shared_blob           value;
    };
 
@@ -92,7 +92,7 @@ namespace eosio { namespace chain {
          typename chainbase::object<ObjectTypeId,index_object>::id_type       id;
          table_id      t_id; //< t_id should not be changed within a chainbase modifier lambda
          uint64_t      primary_key; //< primary_key should not be changed within a chainbase modifier lambda
-         account_name  payer = 0;
+         account_name  payer;
          SecondaryKey  secondary_key; //< secondary_key should not be changed within a chainbase modifier lambda
       };
 

--- a/libraries/chain/include/eosio/chain/contract_types.hpp
+++ b/libraries/chain/include/eosio/chain/contract_types.hpp
@@ -16,7 +16,7 @@ struct newaccount {
    authority                        active;
 
    static account_name get_account() {
-      return account_name( config::system_account_name );
+      return config::system_account_name;
    }
 
    static action_name get_name() {
@@ -31,7 +31,7 @@ struct setcode {
    bytes                            code;
 
    static account_name get_account() {
-      return account_name( config::system_account_name );
+      return config::system_account_name;
    }
 
    static action_name get_name() {
@@ -44,7 +44,7 @@ struct setabi {
    bytes                            abi;
 
    static account_name get_account() {
-      return account_name( config::system_account_name );
+      return config::system_account_name;
    }
 
    static action_name get_name() {
@@ -60,7 +60,7 @@ struct updateauth {
    authority                         auth;
 
    static account_name get_account() {
-      return account_name( config::system_account_name );
+      return config::system_account_name;
    }
 
    static action_name get_name() {
@@ -78,7 +78,7 @@ struct deleteauth {
    permission_name                   permission;
 
    static account_name get_account() {
-      return account_name( config::system_account_name );
+      return config::system_account_name;
    }
 
    static action_name get_name() {
@@ -98,7 +98,7 @@ struct linkauth {
    permission_name                   requirement;
 
    static account_name get_account() {
-      return account_name( config::system_account_name );
+      return config::system_account_name;
    }
 
    static action_name get_name() {
@@ -117,7 +117,7 @@ struct unlinkauth {
    action_name                       type;
 
    static account_name get_account() {
-      return account_name( config::system_account_name );
+      return config::system_account_name;
    }
 
    static action_name get_name() {
@@ -130,7 +130,7 @@ struct canceldelay {
    transaction_id_type   trx_id;
 
    static account_name get_account() {
-      return account_name( config::system_account_name );
+      return config::system_account_name;
    }
 
    static action_name get_name() {
@@ -146,7 +146,7 @@ struct onerror {
    :sender_id(sid),sent_trx(data,data+len){}
 
    static account_name get_account() {
-      return account_name( config::system_account_name );
+      return config::system_account_name;
    }
 
    static action_name get_name() {

--- a/libraries/chain/include/eosio/chain/contract_types.hpp
+++ b/libraries/chain/include/eosio/chain/contract_types.hpp
@@ -20,7 +20,7 @@ struct newaccount {
    }
 
    static action_name get_name() {
-      return action_name( N(newaccount) );
+      return N(newaccount);
    }
 };
 
@@ -35,7 +35,7 @@ struct setcode {
    }
 
    static action_name get_name() {
-      return action_name( N(setcode) );
+      return N(setcode);
    }
 };
 
@@ -48,7 +48,7 @@ struct setabi {
    }
 
    static action_name get_name() {
-      return action_name( N(setabi) );
+      return N(setabi);
    }
 };
 
@@ -64,7 +64,7 @@ struct updateauth {
    }
 
    static action_name get_name() {
-      return action_name( N(updateauth) );
+      return N(updateauth);
    }
 };
 
@@ -82,7 +82,7 @@ struct deleteauth {
    }
 
    static action_name get_name() {
-      return action_name( N(deleteauth) );
+      return N(deleteauth);
    }
 };
 
@@ -102,7 +102,7 @@ struct linkauth {
    }
 
    static action_name get_name() {
-      return action_name( N(linkauth) );
+      return N(linkauth);
    }
 };
 
@@ -121,7 +121,7 @@ struct unlinkauth {
    }
 
    static action_name get_name() {
-      return action_name( N(unlinkauth) );
+      return N(unlinkauth);
    }
 };
 
@@ -134,7 +134,7 @@ struct canceldelay {
    }
 
    static action_name get_name() {
-      return action_name( N(canceldelay) );
+      return N(canceldelay);
    }
 };
 
@@ -150,7 +150,7 @@ struct onerror {
    }
 
    static action_name get_name() {
-      return action_name( N(onerror) );
+      return N(onerror);
    }
 };
 

--- a/libraries/chain/include/eosio/chain/contract_types.hpp
+++ b/libraries/chain/include/eosio/chain/contract_types.hpp
@@ -16,11 +16,11 @@ struct newaccount {
    authority                        active;
 
    static account_name get_account() {
-      return config::system_account_name;
+      return account_name( config::system_account_name );
    }
 
    static action_name get_name() {
-      return N(newaccount);
+      return action_name( N(newaccount) );
    }
 };
 
@@ -31,11 +31,11 @@ struct setcode {
    bytes                            code;
 
    static account_name get_account() {
-      return config::system_account_name;
+      return account_name( config::system_account_name );
    }
 
    static action_name get_name() {
-      return N(setcode);
+      return action_name( N(setcode) );
    }
 };
 
@@ -44,11 +44,11 @@ struct setabi {
    bytes                            abi;
 
    static account_name get_account() {
-      return config::system_account_name;
+      return account_name( config::system_account_name );
    }
 
    static action_name get_name() {
-      return N(setabi);
+      return action_name( N(setabi) );
    }
 };
 
@@ -60,11 +60,11 @@ struct updateauth {
    authority                         auth;
 
    static account_name get_account() {
-      return config::system_account_name;
+      return account_name( config::system_account_name );
    }
 
    static action_name get_name() {
-      return N(updateauth);
+      return action_name( N(updateauth) );
    }
 };
 
@@ -78,11 +78,11 @@ struct deleteauth {
    permission_name                   permission;
 
    static account_name get_account() {
-      return config::system_account_name;
+      return account_name( config::system_account_name );
    }
 
    static action_name get_name() {
-      return N(deleteauth);
+      return action_name( N(deleteauth) );
    }
 };
 
@@ -98,11 +98,11 @@ struct linkauth {
    permission_name                   requirement;
 
    static account_name get_account() {
-      return config::system_account_name;
+      return account_name( config::system_account_name );
    }
 
    static action_name get_name() {
-      return N(linkauth);
+      return action_name( N(linkauth) );
    }
 };
 
@@ -117,11 +117,11 @@ struct unlinkauth {
    action_name                       type;
 
    static account_name get_account() {
-      return config::system_account_name;
+      return account_name( config::system_account_name );
    }
 
    static action_name get_name() {
-      return N(unlinkauth);
+      return action_name( N(unlinkauth) );
    }
 };
 
@@ -130,11 +130,11 @@ struct canceldelay {
    transaction_id_type   trx_id;
 
    static account_name get_account() {
-      return config::system_account_name;
+      return account_name( config::system_account_name );
    }
 
    static action_name get_name() {
-      return N(canceldelay);
+      return action_name( N(canceldelay) );
    }
 };
 
@@ -146,11 +146,11 @@ struct onerror {
    :sender_id(sid),sent_trx(data,data+len){}
 
    static account_name get_account() {
-      return config::system_account_name;
+      return account_name( config::system_account_name );
    }
 
    static action_name get_name() {
-      return N(onerror);
+      return action_name( N(onerror) );
    }
 };
 

--- a/libraries/chain/include/eosio/chain/name.hpp
+++ b/libraries/chain/include/eosio/chain/name.hpp
@@ -3,9 +3,16 @@
 #include <fc/reflect/reflect.hpp>
 #include <iosfwd>
 
-namespace eosio { namespace chain {
-   using std::string;
+namespace eosio::chain {
+  struct name;
+}
+namespace fc {
+  class variant;
+  void to_variant(const eosio::chain::name& c, fc::variant& v);
+  void from_variant(const fc::variant& v, eosio::chain::name& check);
+} // fc
 
+namespace eosio::chain {
    static constexpr uint64_t char_to_symbol( char c ) {
       if( c >= 'a' && c <= 'z' )
          return (c - 'a') + 6;
@@ -14,84 +21,74 @@ namespace eosio { namespace chain {
       return 0;
    }
 
-   // Each char of the string is encoded into 5-bit chunk and left-shifted
-   // to its 5-bit slot starting with the highest slot for the first char.
-   // The 13th char, if str is long enough, is encoded into 4-bit chunk
-   // and placed in the lowest 4 bits. 64 = 12 * 5 + 4
-   static constexpr uint64_t string_to_name( const char* str )
-   {
-      uint64_t name = 0;
+   static constexpr uint64_t string_to_uint64_t( std::string_view str ) {
+      uint64_t n = 0;
       int i = 0;
       for ( ; str[i] && i < 12; ++i) {
-          // NOTE: char_to_symbol() returns char type, and without this explicit
-          // expansion to uint64 type, the compilation fails at the point of usage
-          // of string_to_name(), where the usage requires constant (compile time) expression.
-           name |= (char_to_symbol(str[i]) & 0x1f) << (64 - 5 * (i + 1));
-       }
+         // NOTE: char_to_symbol() returns char type, and without this explicit
+         // expansion to uint64 type, the compilation fails at the point of usage
+         // of string_to_name(), where the usage requires constant (compile time) expression.
+         n |= (char_to_symbol(str[i]) & 0x1f) << (64 - 5 * (i + 1));
+      }
 
       // The for-loop encoded up to 60 high bits into uint64 'name' variable,
       // if (strlen(str) > 12) then encode str[12] into the low (remaining)
       // 4 bits of 'name'
       if (i == 12)
-          name |= char_to_symbol(str[12]) & 0x0F;
-      return name;
+         n |= char_to_symbol(str[12]) & 0x0F;
+      return n;
+   }
+
+   /// Immutable except for fc::from_variant.
+   struct name {
+   private:
+      uint64_t value = 0;
+
+      friend struct fc::reflector<name>;
+      friend void fc::from_variant(const fc::variant& v, eosio::chain::name& check);
+
+      void set( std::string_view str );
+
+   public:
+      constexpr bool empty()const { return 0 == value; }
+      constexpr bool good()const  { return !empty();   }
+
+      explicit name( std::string_view str ) { set( str ); }
+      constexpr explicit name( uint64_t v ) : value(v) {}
+      constexpr name() = default;
+
+      std::string to_string()const;
+      constexpr uint64_t to_uint64_t()const { return value; }
+
+      friend std::ostream& operator << ( std::ostream& out, const name& n ) {
+         return out << n.to_string();
+      }
+
+      friend constexpr bool operator < ( const name& a, const name& b ) { return a.value < b.value; }
+      friend constexpr bool operator > ( const name& a, const name& b ) { return a.value > b.value; }
+      friend constexpr bool operator <= ( const name& a, const name& b ) { return a.value <= b.value; }
+      friend constexpr bool operator >= ( const name& a, const name& b ) { return a.value >= b.value; }
+      friend constexpr bool operator == ( const name& a, const name& b ) { return a.value == b.value; }
+      friend constexpr bool operator != ( const name& a, const name& b ) { return a.value != b.value; }
+
+      friend constexpr bool operator == ( const name& a, uint64_t b ) { return a.value == b; }
+      friend constexpr bool operator != ( const name& a, uint64_t b ) { return a.value != b; }
+
+      constexpr explicit operator bool()const { return value != 0; }
+   };
+
+   // Each char of the string is encoded into 5-bit chunk and left-shifted
+   // to its 5-bit slot starting with the highest slot for the first char.
+   // The 13th char, if str is long enough, is encoded into 4-bit chunk
+   // and placed in the lowest 4 bits. 64 = 12 * 5 + 4
+   static constexpr name string_to_name( std::string_view str )
+   {
+      return name( string_to_uint64_t( str ) );
    }
 
 #define N(X) eosio::chain::string_to_name(#X)
 
-   struct name {
-      uint64_t value = 0;
-      bool empty()const { return 0 == value; }
-      bool good()const  { return !empty();   }
-
-      name( const char* str )   { set(str);           } 
-      name( const string& str ) { set( str.c_str() ); }
-
-      void set( const char* str );
-
-      template<typename T>
-      name( T v ):value(v){}
-      name(){}
-
-      explicit operator string()const;
-
-      string to_string() const { return string(*this); }
-
-      name& operator=( uint64_t v ) {
-         value = v;
-         return *this;
-      }
-
-      name& operator=( const string& n ) {
-         value = name(n).value;
-         return *this;
-      }
-      name& operator=( const char* n ) {
-         value = name(n).value;
-         return *this;
-      }
-
-      friend std::ostream& operator << ( std::ostream& out, const name& n ) {
-         return out << string(n);
-      }
-
-      friend bool operator < ( const name& a, const name& b ) { return a.value < b.value; }
-      friend bool operator <= ( const name& a, const name& b ) { return a.value <= b.value; }
-      friend bool operator > ( const name& a, const name& b ) { return a.value > b.value; }
-      friend bool operator >=( const name& a, const name& b ) { return a.value >= b.value; }
-      friend bool operator == ( const name& a, const name& b ) { return a.value == b.value; }
-
-      friend bool operator == ( const name& a, uint64_t b ) { return a.value == b; }
-      friend bool operator != ( const name& a, uint64_t b ) { return a.value != b; }
-
-      friend bool operator != ( const name& a, const name& b ) { return a.value != b.value; }
-
-      operator bool()const            { return value; }
-      operator uint64_t()const        { return value; }
-      operator unsigned __int128()const       { return value; }
-   };
-
-} } // eosio::chain
+} // eosio::chain
 
 namespace std {
    template<> struct hash<eosio::chain::name> : private hash<uint64_t> {
@@ -99,16 +96,9 @@ namespace std {
       typedef typename hash<uint64_t>::result_type result_type;
       result_type operator()(const argument_type& name) const noexcept
       {
-         return hash<uint64_t>::operator()(name.value);
+         return hash<uint64_t>::operator()(name.to_uint64_t());
       }
    };
 };
-
-namespace fc {
-  class variant;
-  void to_variant(const eosio::chain::name& c, fc::variant& v);
-  void from_variant(const fc::variant& v, eosio::chain::name& check);
-} // fc
-
 
 FC_REFLECT( eosio::chain::name, (value) )

--- a/libraries/chain/include/eosio/chain/webassembly/wabt.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/wabt.hpp
@@ -188,7 +188,7 @@ inline auto convert_native_to_literal(const wabt_apply_instance_vars&, const dou
 
 inline auto convert_native_to_literal(const wabt_apply_instance_vars&, const name &val) {
    TypedValue tv(Type::I64);
-   tv.set_i64(val.value);
+   tv.set_i64(val.to_uint64_t());
    return tv;
 }
 

--- a/libraries/chain/include/eosio/chain/webassembly/wavm.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/wavm.hpp
@@ -151,7 +151,7 @@ inline auto convert_native_to_wasm(const running_instance_context& ctx, T val) {
 }
 
 inline auto convert_native_to_wasm(const running_instance_context& ctx, const name &val) {
-   return native_to_wasm_t<const name &>(val.value);
+   return native_to_wasm_t<const name &>(val.to_uint64_t());
 }
 
 inline auto convert_native_to_wasm(const running_instance_context& ctx, const fc::time_point_sec& val) {

--- a/libraries/chain/name.cpp
+++ b/libraries/chain/name.cpp
@@ -4,22 +4,22 @@
 #include <fc/exception/exception.hpp>
 #include <eosio/chain/exceptions.hpp>
 
-namespace eosio { namespace chain { 
+namespace eosio::chain {
 
-   void name::set( const char* str ) {
-      const auto len = strnlen(str, 14);
-      EOS_ASSERT(len <= 13, name_type_exception, "Name is longer than 13 characters (${name}) ", ("name", string(str)));
-      value = string_to_name(str);
-      EOS_ASSERT(to_string() == string(str), name_type_exception,
+   void name::set( std::string_view str ) {
+      const auto len = str.size();
+      EOS_ASSERT(len <= 13, name_type_exception, "Name is longer than 13 characters (${name}) ", ("name", std::string(str)));
+      value = string_to_uint64_t(str);
+      EOS_ASSERT(to_string() == str, name_type_exception,
                  "Name not properly normalized (name: ${name}, normalized: ${normalized}) ",
-                 ("name", string(str))("normalized", to_string()));
+                 ("name", std::string(str))("normalized", to_string()));
    }
 
    // keep in sync with name::to_string() in contract definition for name
-   name::operator string()const {
+   std::string name::to_string()const {
      static const char* charmap = ".12345abcdefghijklmnopqrstuvwxyz";
 
-      string str(13,'.');
+      std::string str(13,'.');
 
       uint64_t tmp = value;
       for( uint32_t i = 0; i <= 12; ++i ) {
@@ -32,9 +32,9 @@ namespace eosio { namespace chain {
       return str;
    }
 
-} } /// eosio::chain
+} // eosio::chain
 
 namespace fc {
-  void to_variant(const eosio::chain::name& c, fc::variant& v) { v = std::string(c); }
-  void from_variant(const fc::variant& v, eosio::chain::name& check) { check = v.get_string(); }
+  void to_variant(const eosio::chain::name& c, fc::variant& v) { v = c.to_string(); }
+  void from_variant(const fc::variant& v, eosio::chain::name& check) { check.set( v.get_string() ); }
 } // fc

--- a/libraries/chain/wasm_interface.cpp
+++ b/libraries/chain/wasm_interface.cpp
@@ -1163,7 +1163,7 @@ class console_api : public context_aware_api {
 
 #define DB_API_METHOD_WRAPPERS_SIMPLE_SECONDARY(IDX, TYPE)\
       int db_##IDX##_store( uint64_t scope, uint64_t table, uint64_t payer, uint64_t id, const TYPE& secondary ) {\
-         return context.IDX.store( scope, table, payer, id, secondary );\
+         return context.IDX.store( name(scope), name(table,) name(payer), id, secondary );\
       }\
       void db_##IDX##_update( int iterator, uint64_t payer, const TYPE& secondary ) {\
          return context.IDX.update( iterator, payer, secondary );\
@@ -1172,19 +1172,19 @@ class console_api : public context_aware_api {
          return context.IDX.remove( iterator );\
       }\
       int db_##IDX##_find_secondary( uint64_t code, uint64_t scope, uint64_t table, const TYPE& secondary, uint64_t& primary ) {\
-         return context.IDX.find_secondary(code, scope, table, secondary, primary);\
+         return context.IDX.find_secondary(name(code), name(scope), name(table), secondary, primary);\
       }\
       int db_##IDX##_find_primary( uint64_t code, uint64_t scope, uint64_t table, TYPE& secondary, uint64_t primary ) {\
-         return context.IDX.find_primary(code, scope, table, secondary, primary);\
+         return context.IDX.find_primary(name(code), name(scope), name(table), secondary, primary);\
       }\
       int db_##IDX##_lowerbound( uint64_t code, uint64_t scope, uint64_t table,  TYPE& secondary, uint64_t& primary ) {\
-         return context.IDX.lowerbound_secondary(code, scope, table, secondary, primary);\
+         return context.IDX.lowerbound_secondary(name(code), name(scope), name(table), secondary, primary);\
       }\
       int db_##IDX##_upperbound( uint64_t code, uint64_t scope, uint64_t table,  TYPE& secondary, uint64_t& primary ) {\
-         return context.IDX.upperbound_secondary(code, scope, table, secondary, primary);\
+         return context.IDX.upperbound_secondary(name(code), name(scope), name(table), secondary, primary);\
       }\
       int db_##IDX##_end( uint64_t code, uint64_t scope, uint64_t table ) {\
-         return context.IDX.end_secondary(code, scope, table);\
+         return context.IDX.end_secondary(name(code), name(scope), name(table));\
       }\
       int db_##IDX##_next( int iterator, uint64_t& primary  ) {\
          return context.IDX.next_secondary(iterator, primary);\
@@ -1291,10 +1291,10 @@ class database_api : public context_aware_api {
       using context_aware_api::context_aware_api;
 
       int db_store_i64( uint64_t scope, uint64_t table, uint64_t payer, uint64_t id, array_ptr<const char> buffer, size_t buffer_size ) {
-         return context.db_store_i64( scope, table, payer, id, buffer, buffer_size );
+         return context.db_store_i64( name(scope), name(table), name(payer), id, buffer, buffer_size );
       }
       void db_update_i64( int itr, uint64_t payer, array_ptr<const char> buffer, size_t buffer_size ) {
-         context.db_update_i64( itr, payer, buffer, buffer_size );
+         context.db_update_i64( itr, name(payer), buffer, buffer_size );
       }
       void db_remove_i64( int itr ) {
          context.db_remove_i64( itr );
@@ -1309,16 +1309,16 @@ class database_api : public context_aware_api {
          return context.db_previous_i64(itr, primary);
       }
       int db_find_i64( uint64_t code, uint64_t scope, uint64_t table, uint64_t id ) {
-         return context.db_find_i64( code, scope, table, id );
+         return context.db_find_i64( name(code), name(scope), name(table), id );
       }
       int db_lowerbound_i64( uint64_t code, uint64_t scope, uint64_t table, uint64_t id ) {
-         return context.db_lowerbound_i64( code, scope, table, id );
+         return context.db_lowerbound_i64( name(code), name(scope), name(table), id );
       }
       int db_upperbound_i64( uint64_t code, uint64_t scope, uint64_t table, uint64_t id ) {
-         return context.db_upperbound_i64( code, scope, table, id );
+         return context.db_upperbound_i64( name(code), name(scope), name(table), id );
       }
       int db_end_i64( uint64_t code, uint64_t scope, uint64_t table ) {
-         return context.db_end_i64( code, scope, table );
+         return context.db_end_i64( name(code), name(scope), name(table) );
       }
 
       DB_API_METHOD_WRAPPERS_SIMPLE_SECONDARY(idx64,  uint64_t)

--- a/libraries/chain/wasm_interface.cpp
+++ b/libraries/chain/wasm_interface.cpp
@@ -1163,28 +1163,28 @@ class console_api : public context_aware_api {
 
 #define DB_API_METHOD_WRAPPERS_SIMPLE_SECONDARY(IDX, TYPE)\
       int db_##IDX##_store( uint64_t scope, uint64_t table, uint64_t payer, uint64_t id, const TYPE& secondary ) {\
-         return context.IDX.store( name(scope), name(table,) name(payer), id, secondary );\
+         return context.IDX.store( scope, table, account_name(payer), id, secondary );\
       }\
       void db_##IDX##_update( int iterator, uint64_t payer, const TYPE& secondary ) {\
-         return context.IDX.update( iterator, payer, secondary );\
+         return context.IDX.update( iterator, account_name(payer), secondary );\
       }\
       void db_##IDX##_remove( int iterator ) {\
          return context.IDX.remove( iterator );\
       }\
       int db_##IDX##_find_secondary( uint64_t code, uint64_t scope, uint64_t table, const TYPE& secondary, uint64_t& primary ) {\
-         return context.IDX.find_secondary(name(code), name(scope), name(table), secondary, primary);\
+         return context.IDX.find_secondary(code, scope, table, secondary, primary);\
       }\
       int db_##IDX##_find_primary( uint64_t code, uint64_t scope, uint64_t table, TYPE& secondary, uint64_t primary ) {\
-         return context.IDX.find_primary(name(code), name(scope), name(table), secondary, primary);\
+         return context.IDX.find_primary(code, scope, table, secondary, primary);\
       }\
       int db_##IDX##_lowerbound( uint64_t code, uint64_t scope, uint64_t table,  TYPE& secondary, uint64_t& primary ) {\
-         return context.IDX.lowerbound_secondary(name(code), name(scope), name(table), secondary, primary);\
+         return context.IDX.lowerbound_secondary(code, scope, table, secondary, primary);\
       }\
       int db_##IDX##_upperbound( uint64_t code, uint64_t scope, uint64_t table,  TYPE& secondary, uint64_t& primary ) {\
-         return context.IDX.upperbound_secondary(name(code), name(scope), name(table), secondary, primary);\
+         return context.IDX.upperbound_secondary(code, scope, table, secondary, primary);\
       }\
       int db_##IDX##_end( uint64_t code, uint64_t scope, uint64_t table ) {\
-         return context.IDX.end_secondary(name(code), name(scope), name(table));\
+         return context.IDX.end_secondary(code, scope, table);\
       }\
       int db_##IDX##_next( int iterator, uint64_t& primary  ) {\
          return context.IDX.next_secondary(iterator, primary);\
@@ -1199,14 +1199,14 @@ class console_api : public context_aware_api {
                     db_api_exception,\
                     "invalid size of secondary key array for " #IDX ": given ${given} bytes but expected ${expected} bytes",\
                     ("given",data_len)("expected",ARR_SIZE) );\
-         return context.IDX.store(scope, table, payer, id, data.value);\
+         return context.IDX.store(scope, table, account_name(payer), id, data.value);\
       }\
       void db_##IDX##_update( int iterator, uint64_t payer, array_ptr<const ARR_ELEMENT_TYPE> data, size_t data_len ) {\
          EOS_ASSERT( data_len == ARR_SIZE,\
                     db_api_exception,\
                     "invalid size of secondary key array for " #IDX ": given ${given} bytes but expected ${expected} bytes",\
                     ("given",data_len)("expected",ARR_SIZE) );\
-         return context.IDX.update(iterator, payer, data.value);\
+         return context.IDX.update(iterator, account_name(payer), data.value);\
       }\
       void db_##IDX##_remove( int iterator ) {\
          return context.IDX.remove(iterator);\
@@ -1252,11 +1252,11 @@ class console_api : public context_aware_api {
 #define DB_API_METHOD_WRAPPERS_FLOAT_SECONDARY(IDX, TYPE)\
       int db_##IDX##_store( uint64_t scope, uint64_t table, uint64_t payer, uint64_t id, const TYPE& secondary ) {\
          EOS_ASSERT( !softfloat_api::is_nan( secondary ), transaction_exception, "NaN is not an allowed value for a secondary key" );\
-         return context.IDX.store( scope, table, payer, id, secondary );\
+         return context.IDX.store( scope, table, account_name(payer), id, secondary );\
       }\
       void db_##IDX##_update( int iterator, uint64_t payer, const TYPE& secondary ) {\
          EOS_ASSERT( !softfloat_api::is_nan( secondary ), transaction_exception, "NaN is not an allowed value for a secondary key" );\
-         return context.IDX.update( iterator, payer, secondary );\
+         return context.IDX.update( iterator, account_name(payer), secondary );\
       }\
       void db_##IDX##_remove( int iterator ) {\
          return context.IDX.remove( iterator );\
@@ -1291,10 +1291,10 @@ class database_api : public context_aware_api {
       using context_aware_api::context_aware_api;
 
       int db_store_i64( uint64_t scope, uint64_t table, uint64_t payer, uint64_t id, array_ptr<const char> buffer, size_t buffer_size ) {
-         return context.db_store_i64( name(scope), name(table), name(payer), id, buffer, buffer_size );
+         return context.db_store_i64( name(scope), name(table), account_name(payer), id, buffer, buffer_size );
       }
       void db_update_i64( int itr, uint64_t payer, array_ptr<const char> buffer, size_t buffer_size ) {
-         context.db_update_i64( itr, name(payer), buffer, buffer_size );
+         context.db_update_i64( itr, account_name(payer), buffer, buffer_size );
       }
       void db_remove_i64( int itr ) {
          context.db_remove_i64( itr );

--- a/libraries/chain/webassembly/wabt.cpp
+++ b/libraries/chain/webassembly/wabt.cpp
@@ -50,9 +50,9 @@ class wabt_instantiated_module : public wasm_instantiated_module_interface {
             memcpy(memory->data.data(), _initial_memory.data(), _initial_memory.size());
          }
 
-         _params[0].set_i64(uint64_t(context.get_receiver()));
-         _params[1].set_i64(uint64_t(context.get_action().account));
-         _params[2].set_i64(uint64_t(context.get_action().name));
+         _params[0].set_i64(context.get_receiver().to_uint64_t());
+         _params[1].set_i64(context.get_action().account.to_uint64_t());
+         _params[2].set_i64(context.get_action().name.to_uint64_t());
 
          ExecResult res = _executor.RunStartFunction(_instatiated_module);
          EOS_ASSERT( res.result == interp::Result::Ok, wasm_execution_error, "wabt start function failure (${s})", ("s", ResultToString(res.result)) );

--- a/libraries/chain/webassembly/wavm.cpp
+++ b/libraries/chain/webassembly/wavm.cpp
@@ -74,9 +74,9 @@ class wavm_instantiated_module : public wasm_instantiated_module_interface {
       }
 
       void apply(apply_context& context) override {
-         vector<Value> args = {Value(uint64_t(context.get_receiver())),
-	                            Value(uint64_t(context.get_action().account)),
-                               Value(uint64_t(context.get_action().name))};
+         vector<Value> args = {Value(context.get_receiver().to_uint64_t()),
+	                            Value(context.get_action().account.to_uint64_t()),
+                               Value(context.get_action().name.to_uint64_t())};
 
          call("apply", args, context);
       }

--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -172,8 +172,8 @@ namespace eosio { namespace testing {
          vector<producer_key>  get_producer_keys( const vector<account_name>& producer_names )const;
          transaction_trace_ptr set_producers(const vector<account_name>& producer_names);
 
-         void link_authority( account_name account, account_name code,  permission_name req, action_name type = "" );
-         void unlink_authority( account_name account, account_name code, action_name type = "" );
+         void link_authority( account_name account, account_name code,  permission_name req, action_name type = {} );
+         void unlink_authority( account_name account, account_name code, action_name type = {} );
          void set_authority( account_name account, permission_name perm, authority auth,
                                      permission_name parent, const vector<permission_level>& auths, const vector<private_key_type>& keys );
          void set_authority( account_name account, permission_name perm, authority auth,
@@ -212,7 +212,7 @@ namespace eosio { namespace testing {
 
          template< typename KeyType = fc::ecc::private_key_shim >
          static private_key_type get_private_key( name keyname, string role = "owner" ) {
-            return private_key_type::regenerate<KeyType>(fc::sha256::hash(string(keyname)+role));
+            return private_key_type::regenerate<KeyType>(fc::sha256::hash(keyname.to_string()+role));
          }
 
          template< typename KeyType = fc::ecc::private_key_shim >
@@ -231,7 +231,7 @@ namespace eosio { namespace testing {
                                                              const symbol&       asset_symbol,
                                                              const account_name& account ) const;
 
-         vector<char> get_row_by_account( uint64_t code, uint64_t scope, uint64_t table, const account_name& act ) const;
+         vector<char> get_row_by_account( name code, name scope, name table, const account_name& act ) const;
 
          map<account_name, block_id_type> get_last_produced_block_map()const { return last_produced_block; };
          void set_last_produced_block_map( const map<account_name, block_id_type>& lpb ) { last_produced_block = lpb; }

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -489,12 +489,12 @@ namespace eosio { namespace testing {
    typename base_tester::action_result base_tester::push_action(action&& act, uint64_t authorizer) {
       signed_transaction trx;
       if (authorizer) {
-         act.authorization = vector<permission_level>{{authorizer, config::active_name}};
+         act.authorization = vector<permission_level>{{account_name(authorizer), config::active_name}};
       }
       trx.actions.emplace_back(std::move(act));
       set_transaction_headers(trx);
       if (authorizer) {
-         trx.sign(get_private_key(authorizer, "active"), control->get_chain_id());
+         trx.sign(get_private_key(account_name(authorizer), "active"), control->get_chain_id());
       }
       try {
          push_transaction(trx);
@@ -863,7 +863,7 @@ namespace eosio { namespace testing {
    }
 
 
-   vector<char> base_tester::get_row_by_account( uint64_t code, uint64_t scope, uint64_t table, const account_name& act ) const {
+   vector<char> base_tester::get_row_by_account( name code, name scope, name table, const account_name& act ) const {
       vector<char> data;
       const auto& db = control->db();
       const auto* t_id = db.find<chain::table_id_object, chain::by_code_scope_table>( boost::make_tuple( code, scope, table ) );
@@ -874,8 +874,8 @@ namespace eosio { namespace testing {
 
       const auto& idx = db.get_index<chain::key_value_index, chain::by_scope_primary>();
 
-      auto itr = idx.lower_bound( boost::make_tuple( t_id->id, act ) );
-      if ( itr == idx.end() || itr->t_id != t_id->id || act.value != itr->primary_key ) {
+      auto itr = idx.lower_bound( boost::make_tuple( t_id->id, act.to_uint64_t() ) );
+      if ( itr == idx.end() || itr->t_id != t_id->id || act.to_uint64_t() != itr->primary_key ) {
          return data;
       }
 

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -308,10 +308,12 @@ void chain_plugin::set_program_options(options_description& cli, options_descrip
 
 }
 
-#define LOAD_VALUE_SET(options, name, container) \
-if( options.count(name) ) { \
-   const std::vector<std::string>& ops = options[name].as<std::vector<std::string>>(); \
-   std::copy(ops.begin(), ops.end(), std::inserter(container, container.end())); \
+#define LOAD_VALUE_SET(options, op_name, container) \
+if( options.count(op_name) ) { \
+   const std::vector<std::string>& ops = options[op_name].as<std::vector<std::string>>(); \
+   for( const auto& v : ops ) { \
+      container.emplace( eosio::chain::name( v ) ); \
+   } \
 }
 
 fc::time_point calculate_genesis_timestamp( string tstr ) {
@@ -582,7 +584,7 @@ void chain_plugin::plugin_initialize(const variables_map& options) {
             EOS_ASSERT( pos != std::string::npos, plugin_config_exception, "Invalid entry in action-blacklist: '${a}'", ("a", a));
             account_name code( a.substr( 0, pos ));
             action_name act( a.substr( pos + 2 ));
-            list.emplace( code.value, act.value );
+            list.emplace( code, act );
          }
       }
 
@@ -1371,7 +1373,7 @@ read_only::get_activated_protocol_features( const read_only::get_activated_proto
 uint64_t read_only::get_table_index_name(const read_only::get_table_rows_params& p, bool& primary) {
    using boost::algorithm::starts_with;
    // see multi_index packing of index name
-   const uint64_t table = p.table;
+   const uint64_t table = p.table.to_uint64_t();
    uint64_t index = table & 0xFFFFFFFFFFFFFFF0ULL;
    EOS_ASSERT( index == table, chain::contract_table_query_exception, "Unsupported table name: ${n}", ("n", p.table) );
 
@@ -1424,7 +1426,7 @@ uint64_t convert_to_type(const string& str, const string& desc) {
       auto trimmed_str = str;
       boost::trim(trimmed_str);
       name s(trimmed_str);
-      return s.value;
+      return s.to_uint64_t();
    } catch( ... ) { }
 
    if (str.find(',') != string::npos) { // fix #6274 only match formats like 4,EOS
@@ -1540,18 +1542,18 @@ read_only::get_table_by_scope_result read_only::get_table_by_scope( const read_o
    const auto& d = db.db();
 
    const auto& idx = d.get_index<chain::table_id_multi_index, chain::by_code_scope_table>();
-   auto lower_bound_lookup_tuple = std::make_tuple( p.code.value, std::numeric_limits<uint64_t>::lowest(), p.table.value );
-   auto upper_bound_lookup_tuple = std::make_tuple( p.code.value, std::numeric_limits<uint64_t>::max(),
-                                                    (p.table.empty() ? std::numeric_limits<uint64_t>::max() : p.table.value) );
+   auto lower_bound_lookup_tuple = std::make_tuple( p.code, name(std::numeric_limits<uint64_t>::lowest()), p.table );
+   auto upper_bound_lookup_tuple = std::make_tuple( p.code, name(std::numeric_limits<uint64_t>::max()),
+                                                    (p.table.empty() ? name(std::numeric_limits<uint64_t>::max()) : p.table) );
 
    if( p.lower_bound.size() ) {
       uint64_t scope = convert_to_type<uint64_t>(p.lower_bound, "lower_bound scope");
-      std::get<1>(lower_bound_lookup_tuple) = scope;
+      std::get<1>(lower_bound_lookup_tuple) = name(scope);
    }
 
    if( p.upper_bound.size() ) {
       uint64_t scope = convert_to_type<uint64_t>(p.upper_bound, "upper_bound scope");
-      std::get<1>(upper_bound_lookup_tuple) = scope;
+      std::get<1>(upper_bound_lookup_tuple) = name(scope);
    }
 
    if( upper_bound_lookup_tuple < lower_bound_lookup_tuple )
@@ -1568,7 +1570,7 @@ read_only::get_table_by_scope_result read_only::get_table_by_scope( const read_o
          ++count;
       }
       if( itr != end_itr ) {
-         result.more = string(itr->scope);
+         result.more = itr->scope.to_string();
       }
    };
 
@@ -1586,7 +1588,7 @@ read_only::get_table_by_scope_result read_only::get_table_by_scope( const read_o
 vector<asset> read_only::get_currency_balance( const read_only::get_currency_balance_params& p )const {
 
    const abi_def abi = eosio::chain_apis::get_abi( db, p.code );
-   (void)get_table_type( abi, "accounts" );
+   (void)get_table_type( abi, name("accounts") );
 
    vector<asset> results;
    walk_key_value_table(p.code, p.account, N(accounts), [&](const key_value_object& obj){
@@ -1613,11 +1615,11 @@ fc::variant read_only::get_currency_stats( const read_only::get_currency_stats_p
    fc::mutable_variant_object results;
 
    const abi_def abi = eosio::chain_apis::get_abi( db, p.code );
-   (void)get_table_type( abi, "stat" );
+   (void)get_table_type( abi, name("stat") );
 
    uint64_t scope = ( eosio::chain::string_to_symbol( 0, boost::algorithm::to_upper_copy(p.symbol).c_str() ) >> 8 );
 
-   walk_key_value_table(p.code, scope, N(stat), [&](const key_value_object& obj){
+   walk_key_value_table(p.code, name(scope), N(stat), [&](const key_value_object& obj){
       EOS_ASSERT( obj.value.size() >= sizeof(read_only::get_currency_stats_result), chain::asset_type_exception, "Invalid data on table");
 
       fc::datastream<const char *> ds(obj.value.data(), obj.value.size());
@@ -1642,7 +1644,7 @@ fc::variant get_global_row( const database& db, const abi_def& abi, const abi_se
    EOS_ASSERT(table_id, chain::contract_table_query_exception, "Missing table global");
 
    const auto& kv_index = db.get_index<key_value_index, by_scope_primary>();
-   const auto it = kv_index.find(boost::make_tuple(table_id->id, N(global)));
+   const auto it = kv_index.find(boost::make_tuple(table_id->id, N(global).to_uint64_t()));
    EOS_ASSERT(it != kv_index.end(), chain::contract_table_query_exception, "Missing row in table global");
 
    vector<char> data;
@@ -1663,7 +1665,7 @@ read_only::get_producers_result read_only::get_producers( const read_only::get_p
    const auto* const table_id = d.find<chain::table_id_object, chain::by_code_scope_table>(
            boost::make_tuple(config::system_account_name, config::system_account_name, N(producers)));
    const auto* const secondary_table_id = d.find<chain::table_id_object, chain::by_code_scope_table>(
-           boost::make_tuple(config::system_account_name, config::system_account_name, N(producers) | secondary_index_num));
+           boost::make_tuple(config::system_account_name, config::system_account_name, name(N(producers).to_uint64_t() | secondary_index_num)));
    EOS_ASSERT(table_id && secondary_table_id, chain::contract_table_query_exception, "Missing producers table");
 
    const auto& kv_index = d.get_index<key_value_index, by_scope_primary>();
@@ -1676,13 +1678,13 @@ read_only::get_producers_result read_only::get_producers( const read_only::get_p
    vector<char> data;
 
    auto it = [&]{
-      if(lower.value == 0)
+      if(lower.to_uint64_t() == 0)
          return secondary_index_by_secondary.lower_bound(
             boost::make_tuple(secondary_table_id->id, to_softfloat64(std::numeric_limits<double>::lowest()), 0));
       else
          return secondary_index.project<by_secondary>(
             secondary_index_by_primary.lower_bound(
-               boost::make_tuple(secondary_table_id->id, lower.value)));
+               boost::make_tuple(secondary_table_id->id, lower.to_uint64_t())));
    }();
 
    for( ; it != secondary_index_by_secondary.end() && it->t_id == secondary_table_id->id; ++it ) {
@@ -2193,7 +2195,7 @@ read_only::get_account_results read_only::get_account( const get_account_params&
       t_id = d.find<chain::table_id_object, chain::by_code_scope_table>(boost::make_tuple( config::system_account_name, params.account_name, N(userres) ));
       if (t_id != nullptr) {
          const auto &idx = d.get_index<key_value_index, by_scope_primary>();
-         auto it = idx.find(boost::make_tuple( t_id->id, params.account_name ));
+         auto it = idx.find(boost::make_tuple( t_id->id, params.account_name.to_uint64_t() ));
          if ( it != idx.end() ) {
             vector<char> data;
             copy_inline_row(*it, data);
@@ -2204,7 +2206,7 @@ read_only::get_account_results read_only::get_account( const get_account_params&
       t_id = d.find<chain::table_id_object, chain::by_code_scope_table>(boost::make_tuple( config::system_account_name, params.account_name, N(delband) ));
       if (t_id != nullptr) {
          const auto &idx = d.get_index<key_value_index, by_scope_primary>();
-         auto it = idx.find(boost::make_tuple( t_id->id, params.account_name ));
+         auto it = idx.find(boost::make_tuple( t_id->id, params.account_name.to_uint64_t() ));
          if ( it != idx.end() ) {
             vector<char> data;
             copy_inline_row(*it, data);
@@ -2215,7 +2217,7 @@ read_only::get_account_results read_only::get_account( const get_account_params&
       t_id = d.find<chain::table_id_object, chain::by_code_scope_table>(boost::make_tuple( config::system_account_name, params.account_name, N(refunds) ));
       if (t_id != nullptr) {
          const auto &idx = d.get_index<key_value_index, by_scope_primary>();
-         auto it = idx.find(boost::make_tuple( t_id->id, params.account_name ));
+         auto it = idx.find(boost::make_tuple( t_id->id, params.account_name.to_uint64_t() ));
          if ( it != idx.end() ) {
             vector<char> data;
             copy_inline_row(*it, data);
@@ -2226,7 +2228,7 @@ read_only::get_account_results read_only::get_account( const get_account_params&
       t_id = d.find<chain::table_id_object, chain::by_code_scope_table>(boost::make_tuple( config::system_account_name, config::system_account_name, N(voters) ));
       if (t_id != nullptr) {
          const auto &idx = d.get_index<key_value_index, by_scope_primary>();
-         auto it = idx.find(boost::make_tuple( t_id->id, params.account_name ));
+         auto it = idx.find(boost::make_tuple( t_id->id, params.account_name.to_uint64_t() ));
          if ( it != idx.end() ) {
             vector<char> data;
             copy_inline_row(*it, data);

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -302,7 +302,7 @@ public:
 
    struct get_table_by_scope_params {
       name        code; // mandatory
-      name        table = 0; // optional, act as filter
+      name        table; // optional, act as filter
       string      lower_bound; // lower bound of scope, optional
       string      upper_bound; // upper bound of scope, optional
       uint32_t    limit = 10;
@@ -413,14 +413,14 @@ public:
       read_only::get_table_rows_result result;
       const auto& d = db.db();
 
-      uint64_t scope = convert_to_type<uint64_t>(p.scope, "scope");
+      name scope{ convert_to_type<uint64_t>(p.scope, "scope") };
 
       abi_serializer abis;
       abis.set_abi(abi, abi_serializer_max_time);
       bool primary = false;
       const uint64_t table_with_index = get_table_index_name(p, primary);
       const auto* t_id = d.find<chain::table_id_object, chain::by_code_scope_table>(boost::make_tuple(p.code, scope, p.table));
-      const auto* index_t_id = d.find<chain::table_id_object, chain::by_code_scope_table>(boost::make_tuple(p.code, scope, table_with_index));
+      const auto* index_t_id = d.find<chain::table_id_object, chain::by_code_scope_table>(boost::make_tuple(p.code, scope, name(table_with_index)));
       if( t_id != nullptr && index_t_id != nullptr ) {
          using secondary_key_type = std::result_of_t<decltype(conv)(SecKeyType)>;
          static_assert( std::is_same<typename IndexType::value_type::secondary_key_type, secondary_key_type>::value, "Return type of conv does not match type of secondary key for IndexType" );
@@ -507,7 +507,7 @@ public:
 
       abi_serializer abis;
       abis.set_abi(abi, abi_serializer_max_time);
-      const auto* t_id = d.find<chain::table_id_object, chain::by_code_scope_table>(boost::make_tuple(p.code, scope, p.table));
+      const auto* t_id = d.find<chain::table_id_object, chain::by_code_scope_table>(boost::make_tuple(p.code, name(scope), p.table));
       if( t_id != nullptr ) {
          const auto& idx = d.get_index<IndexType, chain::by_scope_primary>();
          auto lower_bound_lookup_tuple = std::make_tuple( t_id->id, std::numeric_limits<uint64_t>::lowest() );
@@ -516,7 +516,7 @@ public:
          if( p.lower_bound.size() ) {
             if( p.key_type == "name" ) {
                name s(p.lower_bound);
-               std::get<1>(lower_bound_lookup_tuple) = s.value;
+               std::get<1>(lower_bound_lookup_tuple) = s.to_uint64_t();
             } else {
                auto lv = convert_to_type<typename IndexType::value_type::key_type>( p.lower_bound, "lower_bound" );
                std::get<1>(lower_bound_lookup_tuple) = lv;
@@ -526,7 +526,7 @@ public:
          if( p.upper_bound.size() ) {
             if( p.key_type == "name" ) {
                name s(p.upper_bound);
-               std::get<1>(upper_bound_lookup_tuple) = s.value;
+               std::get<1>(upper_bound_lookup_tuple) = s.to_uint64_t();
             } else {
                auto uv = convert_to_type<typename IndexType::value_type::key_type>( p.upper_bound, "upper_bound" );
                std::get<1>(upper_bound_lookup_tuple) = uv;

--- a/plugins/history_plugin/history_plugin.cpp
+++ b/plugins/history_plugin/history_plugin.cpp
@@ -148,14 +148,14 @@ namespace eosio {
             if (bypass_filter) {
               pass_on = true;
             }
-            if (filter_on.find({ act.receiver, 0, 0 }) != filter_on.end()) {
+            if (filter_on.find({ act.receiver, {}, {} }) != filter_on.end()) {
               pass_on = true;
             }
-            if (filter_on.find({ act.receiver, act.act.name, 0 }) != filter_on.end()) {
+            if (filter_on.find({ act.receiver, act.act.name, {} }) != filter_on.end()) {
               pass_on = true;
             }
             for (const auto& a : act.act.authorization) {
-              if (filter_on.find({ act.receiver, 0, a.actor }) != filter_on.end()) {
+              if (filter_on.find({ act.receiver, {}, a.actor }) != filter_on.end()) {
                 pass_on = true;
               }
               if (filter_on.find({ act.receiver, act.act.name, a.actor }) != filter_on.end()) {
@@ -165,14 +165,14 @@ namespace eosio {
 
             if (!pass_on) {  return false;  }
 
-            if (filter_out.find({ act.receiver, 0, 0 }) != filter_out.end()) {
+            if (filter_out.find({ act.receiver, {}, {} }) != filter_out.end()) {
               return false;
             }
-            if (filter_out.find({ act.receiver, act.act.name, 0 }) != filter_out.end()) {
+            if (filter_out.find({ act.receiver, act.act.name, {} }) != filter_out.end()) {
               return false;
             }
             for (const auto& a : act.act.authorization) {
-              if (filter_out.find({ act.receiver, 0, a.actor }) != filter_out.end()) {
+              if (filter_out.find({ act.receiver, {}, a.actor }) != filter_out.end()) {
                 return false;
               }
               if (filter_out.find({ act.receiver, act.act.name, a.actor }) != filter_out.end()) {
@@ -189,13 +189,13 @@ namespace eosio {
             result.insert( act.receiver );
             for( const auto& a : act.act.authorization ) {
                if( bypass_filter ||
-                   filter_on.find({ act.receiver, 0, 0}) != filter_on.end() ||
-                   filter_on.find({ act.receiver, 0, a.actor}) != filter_on.end() ||
-                   filter_on.find({ act.receiver, act.act.name, 0}) != filter_on.end() ||
+                   filter_on.find({ act.receiver, {}, {}}) != filter_on.end() ||
+                   filter_on.find({ act.receiver, {}, a.actor}) != filter_on.end() ||
+                   filter_on.find({ act.receiver, act.act.name, {}}) != filter_on.end() ||
                    filter_on.find({ act.receiver, act.act.name, a.actor }) != filter_on.end() ) {
-                 if ((filter_out.find({ act.receiver, 0, 0 }) == filter_out.end()) &&
-                     (filter_out.find({ act.receiver, 0, a.actor }) == filter_out.end()) &&
-                     (filter_out.find({ act.receiver, act.act.name, 0 }) == filter_out.end()) &&
+                 if ((filter_out.find({ act.receiver, {}, {} }) == filter_out.end()) &&
+                     (filter_out.find({ act.receiver, {}, a.actor }) == filter_out.end()) &&
+                     (filter_out.find({ act.receiver, act.act.name, {} }) == filter_out.end()) &&
                      (filter_out.find({ act.receiver, act.act.name, a.actor }) == filter_out.end())) {
                    result.insert( a.actor );
                  }
@@ -209,7 +209,7 @@ namespace eosio {
             chainbase::database& db = const_cast<chainbase::database&>( chain.db() ); // Override read-only access to state DB (highly unrecommended practice!)
 
             const auto& idx = db.get_index<account_history_index, by_account_action_seq>();
-            auto itr = idx.lower_bound( boost::make_tuple( name(n.value+1), 0 ) );
+            auto itr = idx.lower_bound( boost::make_tuple( name(n.to_uint64_t()+1), 0 ) );
 
             uint64_t asn = 0;
             if( itr != idx.begin() ) --itr;
@@ -320,8 +320,8 @@ namespace eosio {
                std::vector<std::string> v;
                boost::split( v, s, boost::is_any_of( ":" ));
                EOS_ASSERT( v.size() == 3, fc::invalid_arg_exception, "Invalid value ${s} for --filter-on", ("s", s));
-               filter_entry fe{v[0], v[1], v[2]};
-               EOS_ASSERT( fe.receiver.value, fc::invalid_arg_exception,
+               filter_entry fe{eosio::chain::name(v[0]), eosio::chain::name(v[1]), eosio::chain::name(v[2])};
+               EOS_ASSERT( fe.receiver.to_uint64_t(), fc::invalid_arg_exception,
                            "Invalid value ${s} for --filter-on", ("s", s));
                my->filter_on.insert( fe );
             }
@@ -332,8 +332,8 @@ namespace eosio {
                std::vector<std::string> v;
                boost::split( v, s, boost::is_any_of( ":" ));
                EOS_ASSERT( v.size() == 3, fc::invalid_arg_exception, "Invalid value ${s} for --filter-out", ("s", s));
-               filter_entry fe{v[0], v[1], v[2]};
-               EOS_ASSERT( fe.receiver.value, fc::invalid_arg_exception,
+               filter_entry fe{eosio::chain::name(v[0]), eosio::chain::name(v[1]), eosio::chain::name(v[2])};
+               EOS_ASSERT( fe.receiver.to_uint64_t(), fc::invalid_arg_exception,
                            "Invalid value ${s} for --filter-out", ("s", s));
                my->filter_out.insert( fe );
             }
@@ -383,7 +383,7 @@ namespace eosio {
         auto n = params.account_name;
         idump((pos));
         if( pos == -1 ) {
-            auto itr = idx.lower_bound( boost::make_tuple( name(n.value+1), 0 ) );
+            auto itr = idx.lower_bound( boost::make_tuple( name(n.to_uint64_t()+1), 0 ) );
             if( itr == idx.begin() ) {
                if( itr->account == n )
                   pos = itr->account_sequence_num+1;

--- a/plugins/mongo_db_plugin/mongo_db_plugin.cpp
+++ b/plugins/mongo_db_plugin/mongo_db_plugin.cpp
@@ -58,9 +58,9 @@ struct filter_entry {
 
    //            receiver          action       actor
    bool match( const name& rr, const name& an, const name& ar ) const {
-      return (receiver.value == 0 || receiver == rr) &&
-             (action.value == 0 || action == an) &&
-             (actor.value == 0 || actor == ar);
+      return (receiver.to_uint64_t() == 0 || receiver == rr) &&
+             (action.to_uint64_t() == 0 || action == an) &&
+             (actor.to_uint64_t() == 0 || actor == ar);
    }
 };
 
@@ -229,7 +229,7 @@ bool mongo_db_plugin_impl::filter_include( const account_name& receiver, const a
       include = true;
    } else {
       auto itr = std::find_if( filter_on.cbegin(), filter_on.cend(), [&receiver, &act_name]( const auto& filter ) {
-         return filter.match( receiver, act_name, 0 );
+         return filter.match( receiver, act_name, {} );
       } );
       if( itr != filter_on.cend() ) {
          include = true;
@@ -250,7 +250,7 @@ bool mongo_db_plugin_impl::filter_include( const account_name& receiver, const a
    if( filter_out.empty() ) { return true; }
 
    auto itr = std::find_if( filter_out.cbegin(), filter_out.cend(), [&receiver, &act_name]( const auto& filter ) {
-      return filter.match( receiver, act_name, 0 );
+      return filter.match( receiver, act_name, {} );
    } );
    if( itr != filter_out.cend() ) { return false; }
 
@@ -1598,7 +1598,7 @@ void mongo_db_plugin::plugin_initialize(const variables_map& options)
                std::vector<std::string> v;
                boost::split( v, s, boost::is_any_of( ":" ));
                EOS_ASSERT( v.size() == 3, fc::invalid_arg_exception, "Invalid value ${s} for --mongodb-filter-on", ("s", s));
-               filter_entry fe{v[0], v[1], v[2]};
+               filter_entry fe{eosio::chain::name(v[0]), eosio::chain::name(v[1]), eosio::chain::name(v[2])};
                my->filter_on.insert( fe );
             }
          } else {
@@ -1610,7 +1610,7 @@ void mongo_db_plugin::plugin_initialize(const variables_map& options)
                std::vector<std::string> v;
                boost::split( v, s, boost::is_any_of( ":" ));
                EOS_ASSERT( v.size() == 3, fc::invalid_arg_exception, "Invalid value ${s} for --mongodb-filter-out", ("s", s));
-               filter_entry fe{v[0], v[1], v[2]};
+               filter_entry fe{eosio::chain::name(v[0]), eosio::chain::name(v[1]), eosio::chain::name(v[2])};
                my->filter_out.insert( fe );
             }
          }

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -674,10 +674,12 @@ T dejsonify(const string& s) {
    return fc::json::from_string(s).as<T>();
 }
 
-#define LOAD_VALUE_SET(options, name, container, type) \
-if( options.count(name) ) { \
-   const std::vector<std::string>& ops = options[name].as<std::vector<std::string>>(); \
-   std::copy(ops.begin(), ops.end(), std::inserter(container, container.end())); \
+#define LOAD_VALUE_SET(options, op_name, container) \
+if( options.count(op_name) ) { \
+   const std::vector<std::string>& ops = options[op_name].as<std::vector<std::string>>(); \
+   for( const auto& v : ops ) { \
+      container.emplace( eosio::chain::name( v ) ); \
+   } \
 }
 
 static producer_plugin_impl::signature_provider_type
@@ -716,7 +718,7 @@ void producer_plugin::plugin_initialize(const boost::program_options::variables_
    my->chain_plug = app().find_plugin<chain_plugin>();
    EOS_ASSERT( my->chain_plug, plugin_config_exception, "chain_plugin not found" );
    my->_options = &options;
-   LOAD_VALUE_SET(options, "producer-name", my->_producers, types::account_name)
+   LOAD_VALUE_SET(options, "producer-name", my->_producers)
 
    if( options.count("private-key") )
    {
@@ -1180,8 +1182,8 @@ producer_plugin::get_account_ram_corrections( const get_account_ram_corrections_
    const auto& db = my->chain_plug->chain().db();
 
    const auto& idx = db.get_index<chain::account_ram_correction_index, chain::by_name>();
-   account_name lower_bound_value = std::numeric_limits<uint64_t>::lowest();
-   account_name upper_bound_value = std::numeric_limits<uint64_t>::max();
+   account_name lower_bound_value{ std::numeric_limits<uint64_t>::lowest() };
+   account_name upper_bound_value{ std::numeric_limits<uint64_t>::max() };
 
    if( params.lower_bound ) {
       lower_bound_value = *params.lower_bound;

--- a/plugins/state_history_plugin/include/eosio/state_history_plugin/state_history_log.hpp
+++ b/plugins/state_history_plugin/include/eosio/state_history_plugin/state_history_log.hpp
@@ -31,8 +31,8 @@ namespace eosio {
  *    payload
  */
 
-inline uint64_t       ship_magic(uint32_t version) { return N(ship) | version; }
-inline bool           is_ship(uint64_t magic) { return (magic & 0xffff'ffff'0000'0000) == N(ship); }
+inline uint64_t       ship_magic(uint32_t version) { return N(ship).to_uint64_t() | version; }
+inline bool           is_ship(uint64_t magic) { return (magic & 0xffff'ffff'0000'0000) == N(ship).to_uint64_t(); }
 inline uint32_t       get_ship_version(uint64_t magic) { return magic; }
 inline bool           is_ship_supported_version(uint64_t magic) { return get_ship_version(magic) == 0; }
 static const uint32_t ship_current_version = 0;

--- a/plugins/state_history_plugin/include/eosio/state_history_plugin/state_history_serialization.hpp
+++ b/plugins/state_history_plugin/include/eosio/state_history_plugin/state_history_serialization.hpp
@@ -106,7 +106,7 @@ datastream<ST>& operator<<(datastream<ST>& ds, const history_serial_wrapper<std:
 template <typename ST>
 datastream<ST>& operator<<(datastream<ST>& ds, const history_serial_wrapper<eosio::chain::account_object>& obj) {
    fc::raw::pack(ds, fc::unsigned_int(0));
-   fc::raw::pack(ds, as_type<uint64_t>(obj.obj.name.value));
+   fc::raw::pack(ds, as_type<uint64_t>(obj.obj.name.to_uint64_t()));
    fc::raw::pack(ds, as_type<eosio::chain::block_timestamp_type>(obj.obj.creation_date));
    fc::raw::pack(ds, as_type<eosio::chain::shared_string>(obj.obj.abi));
    return ds;
@@ -116,7 +116,7 @@ template <typename ST>
 datastream<ST>& operator<<(datastream<ST>&                                                      ds,
                            const history_serial_wrapper<eosio::chain::account_metadata_object>& obj) {
    fc::raw::pack(ds, fc::unsigned_int(0));
-   fc::raw::pack(ds, as_type<uint64_t>(obj.obj.name.value));
+   fc::raw::pack(ds, as_type<uint64_t>(obj.obj.name.to_uint64_t()));
    fc::raw::pack(ds, as_type<bool>(obj.obj.is_privileged()));
    fc::raw::pack(ds, as_type<fc::time_point>(obj.obj.last_code_update));
    bool has_code = obj.obj.code_hash != eosio::chain::digest_type();
@@ -142,10 +142,10 @@ datastream<ST>& operator<<(datastream<ST>& ds, const history_serial_wrapper<eosi
 template <typename ST>
 datastream<ST>& operator<<(datastream<ST>& ds, const history_serial_wrapper<eosio::chain::table_id_object>& obj) {
    fc::raw::pack(ds, fc::unsigned_int(0));
-   fc::raw::pack(ds, as_type<uint64_t>(obj.obj.code.value));
-   fc::raw::pack(ds, as_type<uint64_t>(obj.obj.scope.value));
-   fc::raw::pack(ds, as_type<uint64_t>(obj.obj.table.value));
-   fc::raw::pack(ds, as_type<uint64_t>(obj.obj.payer.value));
+   fc::raw::pack(ds, as_type<uint64_t>(obj.obj.code.to_uint64_t()));
+   fc::raw::pack(ds, as_type<uint64_t>(obj.obj.scope.to_uint64_t()));
+   fc::raw::pack(ds, as_type<uint64_t>(obj.obj.table.to_uint64_t()));
+   fc::raw::pack(ds, as_type<uint64_t>(obj.obj.payer.to_uint64_t()));
    return ds;
 }
 
@@ -154,11 +154,11 @@ datastream<ST>&
 operator<<(datastream<ST>&                                                                                     ds,
            const history_context_wrapper<const eosio::chain::table_id_object, eosio::chain::key_value_object>& obj) {
    fc::raw::pack(ds, fc::unsigned_int(0));
-   fc::raw::pack(ds, as_type<uint64_t>(obj.context.code.value));
-   fc::raw::pack(ds, as_type<uint64_t>(obj.context.scope.value));
-   fc::raw::pack(ds, as_type<uint64_t>(obj.context.table.value));
+   fc::raw::pack(ds, as_type<uint64_t>(obj.context.code.to_uint64_t()));
+   fc::raw::pack(ds, as_type<uint64_t>(obj.context.scope.to_uint64_t()));
+   fc::raw::pack(ds, as_type<uint64_t>(obj.context.table.to_uint64_t()));
    fc::raw::pack(ds, as_type<uint64_t>(obj.obj.primary_key));
-   fc::raw::pack(ds, as_type<uint64_t>(obj.obj.payer.value));
+   fc::raw::pack(ds, as_type<uint64_t>(obj.obj.payer.to_uint64_t()));
    fc::raw::pack(ds, as_type<eosio::chain::shared_string>(obj.obj.value));
    return ds;
 }
@@ -197,11 +197,11 @@ template <typename ST, typename T>
 datastream<ST>& serialize_secondary_index(datastream<ST>& ds, const eosio::chain::table_id_object& context,
                                           const T& obj) {
    fc::raw::pack(ds, fc::unsigned_int(0));
-   fc::raw::pack(ds, as_type<uint64_t>(context.code.value));
-   fc::raw::pack(ds, as_type<uint64_t>(context.scope.value));
-   fc::raw::pack(ds, as_type<uint64_t>(context.table.value));
+   fc::raw::pack(ds, as_type<uint64_t>(context.code.to_uint64_t()));
+   fc::raw::pack(ds, as_type<uint64_t>(context.scope.to_uint64_t()));
+   fc::raw::pack(ds, as_type<uint64_t>(context.table.to_uint64_t()));
    fc::raw::pack(ds, as_type<uint64_t>(obj.primary_key));
-   fc::raw::pack(ds, as_type<uint64_t>(obj.payer.value));
+   fc::raw::pack(ds, as_type<uint64_t>(obj.payer.to_uint64_t()));
    serialize_secondary_index_data(ds, obj.secondary_key);
    return ds;
 }
@@ -243,7 +243,7 @@ datastream<ST>& operator<<(
 
 template <typename ST>
 datastream<ST>& operator<<(datastream<ST>& ds, const history_serial_wrapper<eosio::chain::producer_key>& obj) {
-   fc::raw::pack(ds, as_type<uint64_t>(obj.obj.producer_name.value));
+   fc::raw::pack(ds, as_type<uint64_t>(obj.obj.producer_name.to_uint64_t()));
    fc::raw::pack(ds, as_type<eosio::chain::public_key_type>(obj.obj.block_signing_key));
    return ds;
 }
@@ -296,9 +296,9 @@ template <typename ST>
 datastream<ST>& operator<<(datastream<ST>&                                                           ds,
                            const history_serial_wrapper<eosio::chain::generated_transaction_object>& obj) {
    fc::raw::pack(ds, fc::unsigned_int(0));
-   fc::raw::pack(ds, as_type<uint64_t>(obj.obj.sender.value));
+   fc::raw::pack(ds, as_type<uint64_t>(obj.obj.sender.to_uint64_t()));
    fc::raw::pack(ds, as_type<__uint128_t>(obj.obj.sender_id));
-   fc::raw::pack(ds, as_type<uint64_t>(obj.obj.payer.value));
+   fc::raw::pack(ds, as_type<uint64_t>(obj.obj.payer.to_uint64_t()));
    fc::raw::pack(ds, as_type<eosio::chain::transaction_id_type>(obj.obj.trx_id));
    fc::raw::pack(ds, as_type<eosio::chain::shared_string>(obj.obj.packed_trx));
    return ds;
@@ -330,8 +330,8 @@ datastream<ST>& operator<<(datastream<ST>& ds, const history_serial_wrapper<eosi
 
 template <typename ST>
 datastream<ST>& operator<<(datastream<ST>& ds, const history_serial_wrapper<eosio::chain::permission_level>& obj) {
-   fc::raw::pack(ds, as_type<uint64_t>(obj.obj.actor.value));
-   fc::raw::pack(ds, as_type<uint64_t>(obj.obj.permission.value));
+   fc::raw::pack(ds, as_type<uint64_t>(obj.obj.actor.to_uint64_t()));
+   fc::raw::pack(ds, as_type<uint64_t>(obj.obj.permission.to_uint64_t()));
    return ds;
 }
 
@@ -362,8 +362,8 @@ datastream<ST>& operator<<(datastream<ST>& ds, const history_serial_wrapper<eosi
 template <typename ST>
 datastream<ST>& operator<<(datastream<ST>& ds, const history_serial_wrapper<eosio::chain::permission_object>& obj) {
    fc::raw::pack(ds, fc::unsigned_int(0));
-   fc::raw::pack(ds, as_type<uint64_t>(obj.obj.owner.value));
-   fc::raw::pack(ds, as_type<uint64_t>(obj.obj.name.value));
+   fc::raw::pack(ds, as_type<uint64_t>(obj.obj.owner.to_uint64_t()));
+   fc::raw::pack(ds, as_type<uint64_t>(obj.obj.name.to_uint64_t()));
    if (obj.obj.parent._id) {
       auto&       index  = obj.db.get_index<eosio::chain::permission_index>();
       const auto* parent = index.find(obj.obj.parent);
@@ -374,7 +374,7 @@ datastream<ST>& operator<<(datastream<ST>& ds, const history_serial_wrapper<eosi
                     "can not find parent of permission_object");
          parent = &it->second;
       }
-      fc::raw::pack(ds, as_type<uint64_t>(parent->name.value));
+      fc::raw::pack(ds, as_type<uint64_t>(parent->name.to_uint64_t()));
    } else {
       fc::raw::pack(ds, as_type<uint64_t>(0));
    }
@@ -387,10 +387,10 @@ template <typename ST>
 datastream<ST>& operator<<(datastream<ST>&                                                     ds,
                            const history_serial_wrapper<eosio::chain::permission_link_object>& obj) {
    fc::raw::pack(ds, fc::unsigned_int(0));
-   fc::raw::pack(ds, as_type<uint64_t>(obj.obj.account.value));
-   fc::raw::pack(ds, as_type<uint64_t>(obj.obj.code.value));
-   fc::raw::pack(ds, as_type<uint64_t>(obj.obj.message_type.value));
-   fc::raw::pack(ds, as_type<uint64_t>(obj.obj.required_permission.value));
+   fc::raw::pack(ds, as_type<uint64_t>(obj.obj.account.to_uint64_t()));
+   fc::raw::pack(ds, as_type<uint64_t>(obj.obj.code.to_uint64_t()));
+   fc::raw::pack(ds, as_type<uint64_t>(obj.obj.message_type.to_uint64_t()));
+   fc::raw::pack(ds, as_type<uint64_t>(obj.obj.required_permission.to_uint64_t()));
    return ds;
 }
 
@@ -400,7 +400,7 @@ datastream<ST>& operator<<(datastream<ST>&                                      
    EOS_ASSERT(!obj.obj.pending, eosio::chain::plugin_exception,
               "accepted_block sent while resource_limits_object in pending state");
    fc::raw::pack(ds, fc::unsigned_int(0));
-   fc::raw::pack(ds, as_type<uint64_t>(obj.obj.owner.value));
+   fc::raw::pack(ds, as_type<uint64_t>(obj.obj.owner.to_uint64_t()));
    fc::raw::pack(ds, as_type<int64_t>(obj.obj.net_weight));
    fc::raw::pack(ds, as_type<int64_t>(obj.obj.cpu_weight));
    fc::raw::pack(ds, as_type<int64_t>(obj.obj.ram_bytes));
@@ -421,7 +421,7 @@ template <typename ST>
 datastream<ST>& operator<<(datastream<ST>&                                                                     ds,
                            const history_serial_wrapper<eosio::chain::resource_limits::resource_usage_object>& obj) {
    fc::raw::pack(ds, fc::unsigned_int(0));
-   fc::raw::pack(ds, as_type<uint64_t>(obj.obj.owner.value));
+   fc::raw::pack(ds, as_type<uint64_t>(obj.obj.owner.to_uint64_t()));
    fc::raw::pack(ds, make_history_serial_wrapper(
                          obj.db, as_type<eosio::chain::resource_limits::usage_accumulator>(obj.obj.net_usage)));
    fc::raw::pack(ds, make_history_serial_wrapper(
@@ -489,8 +489,8 @@ operator<<(datastream<ST>&                                                      
 
 template <typename ST>
 datastream<ST>& operator<<(datastream<ST>& ds, const history_serial_wrapper<eosio::chain::action>& obj) {
-   fc::raw::pack(ds, as_type<uint64_t>(obj.obj.account.value));
-   fc::raw::pack(ds, as_type<uint64_t>(obj.obj.name.value));
+   fc::raw::pack(ds, as_type<uint64_t>(obj.obj.account.to_uint64_t()));
+   fc::raw::pack(ds, as_type<uint64_t>(obj.obj.name.to_uint64_t()));
    history_serialize_container(ds, obj.db, as_type<std::vector<eosio::chain::permission_level>>(obj.obj.authorization));
    fc::raw::pack(ds, as_type<eosio::bytes>(obj.obj.data));
    return ds;
@@ -499,7 +499,7 @@ datastream<ST>& operator<<(datastream<ST>& ds, const history_serial_wrapper<eosi
 template <typename ST>
 datastream<ST>& operator<<(datastream<ST>& ds, const history_serial_wrapper<eosio::chain::action_receipt>& obj) {
    fc::raw::pack(ds, fc::unsigned_int(0));
-   fc::raw::pack(ds, as_type<uint64_t>(obj.obj.receiver.value));
+   fc::raw::pack(ds, as_type<uint64_t>(obj.obj.receiver.to_uint64_t()));
    fc::raw::pack(ds, as_type<eosio::chain::digest_type>(obj.obj.act_digest));
    fc::raw::pack(ds, as_type<uint64_t>(obj.obj.global_sequence));
    fc::raw::pack(ds, as_type<uint64_t>(obj.obj.recv_sequence));
@@ -511,7 +511,7 @@ datastream<ST>& operator<<(datastream<ST>& ds, const history_serial_wrapper<eosi
 
 template <typename ST>
 datastream<ST>& operator<<(datastream<ST>& ds, const history_serial_wrapper<eosio::chain::account_delta>& obj) {
-   fc::raw::pack(ds, as_type<uint64_t>(obj.obj.account.value));
+   fc::raw::pack(ds, as_type<uint64_t>(obj.obj.account.to_uint64_t()));
    fc::raw::pack(ds, as_type<int64_t>(obj.obj.delta));
    return ds;
 }
@@ -525,7 +525,7 @@ datastream<ST>& operator<<(datastream<ST>& ds, const history_serial_wrapper<eosi
    if (obj.obj.receipt) {
       fc::raw::pack(ds, make_history_serial_wrapper(obj.db, as_type<eosio::chain::action_receipt>(*obj.obj.receipt)));
    }
-   fc::raw::pack(ds, as_type<uint64_t>(obj.obj.receiver.value));
+   fc::raw::pack(ds, as_type<uint64_t>(obj.obj.receiver.to_uint64_t()));
    fc::raw::pack(ds, make_history_serial_wrapper(obj.db, as_type<eosio::chain::action>(obj.obj.act)));
    fc::raw::pack(ds, as_type<bool>(obj.obj.context_free));
    fc::raw::pack(ds, as_type<int64_t>(obj.obj.elapsed.count()));

--- a/plugins/state_history_plugin/state_history_plugin.cpp
+++ b/plugins/state_history_plugin/state_history_plugin.cpp
@@ -89,7 +89,7 @@ bool include_delta(const eosio::chain::resource_limits::resource_limits_state_ob
 bool include_delta(const eosio::chain::account_metadata_object& old,
                    const eosio::chain::account_metadata_object& curr) {
    return                                               //
-       old.name.value != curr.name.value ||             //
+       old.name != curr.name ||                         //
        old.is_privileged() != curr.is_privileged() ||   //
        old.last_code_update != curr.last_code_update || //
        old.vm_type != curr.vm_type ||                   //

--- a/plugins/txn_test_gen_plugin/txn_test_gen_plugin.cpp
+++ b/plugins/txn_test_gen_plugin/txn_test_gen_plugin.cpp
@@ -166,21 +166,21 @@ struct txn_test_gen_plugin_impl {
             auto owner_auth   = eosio::chain::authority{1, {{txn_text_receiver_A_pub_key, 1}}, {}};
             auto active_auth  = eosio::chain::authority{1, {{txn_text_receiver_A_pub_key, 1}}, {}};
 
-            trx.actions.emplace_back(vector<chain::permission_level>{{creator,"active"}}, newaccount{creator, newaccountA, owner_auth, active_auth});
+            trx.actions.emplace_back(vector<chain::permission_level>{{creator,name("active")}}, newaccount{creator, newaccountA, owner_auth, active_auth});
             }
             //create "B" account
             {
             auto owner_auth   = eosio::chain::authority{1, {{txn_text_receiver_B_pub_key, 1}}, {}};
             auto active_auth  = eosio::chain::authority{1, {{txn_text_receiver_B_pub_key, 1}}, {}};
 
-            trx.actions.emplace_back(vector<chain::permission_level>{{creator,"active"}}, newaccount{creator, newaccountB, owner_auth, active_auth});
+            trx.actions.emplace_back(vector<chain::permission_level>{{creator,name("active")}}, newaccount{creator, newaccountB, owner_auth, active_auth});
             }
             //create "T" account
             {
             auto owner_auth   = eosio::chain::authority{1, {{txn_text_receiver_C_pub_key, 1}}, {}};
             auto active_auth  = eosio::chain::authority{1, {{txn_text_receiver_C_pub_key, 1}}, {}};
 
-            trx.actions.emplace_back(vector<chain::permission_level>{{creator,"active"}}, newaccount{creator, newaccountT, owner_auth, active_auth});
+            trx.actions.emplace_back(vector<chain::permission_level>{{creator,name("active")}}, newaccount{creator, newaccountT, owner_auth, active_auth});
             }
 
             trx.expiration = cc.head_block_time() + fc::seconds(180);
@@ -199,13 +199,13 @@ struct txn_test_gen_plugin_impl {
             handler.account = newaccountT;
             handler.code.assign(wasm.begin(), wasm.end());
 
-            trx.actions.emplace_back( vector<chain::permission_level>{{newaccountT,"active"}}, handler);
+            trx.actions.emplace_back( vector<chain::permission_level>{{newaccountT,name("active")}}, handler);
 
             {
                setabi handler;
                handler.account = newaccountT;
                handler.abi = fc::raw::pack(json::from_string(contracts::eosio_token_abi().data()).as<abi_def>());
-               trx.actions.emplace_back( vector<chain::permission_level>{{newaccountT,"active"}}, handler);
+               trx.actions.emplace_back( vector<chain::permission_level>{{newaccountT,name("active")}}, handler);
             }
 
             {
@@ -368,7 +368,7 @@ struct txn_test_gen_plugin_impl {
          {
          signed_transaction trx;
          trx.actions.push_back(act_a_to_b);
-         trx.context_free_actions.emplace_back(action({}, config::null_account_name, "nonce", fc::raw::pack( std::to_string(nonce_prefix)+std::to_string(nonce++) )));
+         trx.context_free_actions.emplace_back(action({}, config::null_account_name, name("nonce"), fc::raw::pack( std::to_string(nonce_prefix)+std::to_string(nonce++) )));
          trx.set_reference_block(reference_block_id);
          trx.expiration = cc.head_block_time() + fc::seconds(30);
          trx.max_net_usage_words = 100;
@@ -379,7 +379,7 @@ struct txn_test_gen_plugin_impl {
          {
          signed_transaction trx;
          trx.actions.push_back(act_b_to_a);
-         trx.context_free_actions.emplace_back(action({}, config::null_account_name, "nonce", fc::raw::pack( std::to_string(nonce_prefix)+std::to_string(nonce++) )));
+         trx.context_free_actions.emplace_back(action({}, config::null_account_name, name("nonce"), fc::raw::pack( std::to_string(nonce_prefix)+std::to_string(nonce++) )));
          trx.set_reference_block(reference_block_id);
          trx.expiration = cc.head_block_time() + fc::seconds(30);
          trx.max_net_usage_words = 100;
@@ -445,9 +445,9 @@ void txn_test_gen_plugin::plugin_initialize(const variables_map& options) {
       my->txn_reference_block_lag = options.at( "txn-reference-block-lag" ).as<int32_t>();
       my->thread_pool_size = options.at( "txn-test-gen-threads" ).as<uint16_t>();
       const std::string thread_pool_account_prefix = options.at( "txn-test-gen-account-prefix" ).as<std::string>();
-      my->newaccountA = thread_pool_account_prefix + "a";
-      my->newaccountB = thread_pool_account_prefix + "b";
-      my->newaccountT = thread_pool_account_prefix + "t";
+      my->newaccountA = eosio::chain::name(thread_pool_account_prefix + "a");
+      my->newaccountB = eosio::chain::name(thread_pool_account_prefix + "b");
+      my->newaccountT = eosio::chain::name(thread_pool_account_prefix + "t");
       EOS_ASSERT( my->thread_pool_size > 0, chain::plugin_config_exception,
                   "txn-test-gen-threads ${num} must be greater than 0", ("num", my->thread_pool_size) );
    } FC_LOG_AND_RETHROW()

--- a/unittests/abi_tests.cpp
+++ b/unittests/abi_tests.cpp
@@ -818,10 +818,10 @@ BOOST_AUTO_TEST_CASE(linkauth_test)
    auto var = fc::json::from_string(test_data);
 
    auto lauth = var.as<linkauth>();
-   BOOST_TEST("lnkauth.acct" == lauth.account);
-   BOOST_TEST("lnkauth.code" == lauth.code);
-   BOOST_TEST("lnkauth.type" == lauth.type);
-   BOOST_TEST("lnkauth.rqm" == lauth.requirement);
+   BOOST_TEST(name("lnkauth.acct") == lauth.account);
+   BOOST_TEST(name("lnkauth.code") == lauth.code);
+   BOOST_TEST(name("lnkauth.type") == lauth.type);
+   BOOST_TEST(name("lnkauth.rqm") == lauth.requirement);
 
    auto var2 = verify_byte_round_trip_conversion( abis, "linkauth", var );
    auto linkauth2 = var2.as<linkauth>();
@@ -851,9 +851,9 @@ BOOST_AUTO_TEST_CASE(unlinkauth_test)
    auto var = fc::json::from_string(test_data);
 
    auto unlauth = var.as<unlinkauth>();
-   BOOST_TEST("lnkauth.acct" == unlauth.account);
-   BOOST_TEST("lnkauth.code" == unlauth.code);
-   BOOST_TEST("lnkauth.type" == unlauth.type);
+   BOOST_TEST(name("lnkauth.acct") == unlauth.account);
+   BOOST_TEST(name("lnkauth.code") == unlauth.code);
+   BOOST_TEST(name("lnkauth.type") == unlauth.type);
 
    auto var2 = verify_byte_round_trip_conversion( abis, "unlinkauth", var );
    auto unlinkauth2 = var2.as<unlinkauth>();
@@ -890,9 +890,9 @@ BOOST_AUTO_TEST_CASE(updateauth_test)
    auto var = fc::json::from_string(test_data);
 
    auto updauth = var.as<updateauth>();
-   BOOST_TEST("updauth.acct" == updauth.account);
-   BOOST_TEST("updauth.prm" == updauth.permission);
-   BOOST_TEST("updauth.prnt" == updauth.parent);
+   BOOST_TEST(name("updauth.acct") == updauth.account);
+   BOOST_TEST(name("updauth.prm") == updauth.permission);
+   BOOST_TEST(name("updauth.prnt") == updauth.parent);
    BOOST_TEST(2147483145u == updauth.auth.threshold);
 
    BOOST_TEST_REQUIRE(2u == updauth.auth.keys.size());
@@ -902,11 +902,11 @@ BOOST_AUTO_TEST_CASE(updateauth_test)
    BOOST_TEST(57605u == updauth.auth.keys[1].weight);
 
    BOOST_TEST_REQUIRE(2u == updauth.auth.accounts.size());
-   BOOST_TEST("prm.acct1" == updauth.auth.accounts[0].permission.actor);
-   BOOST_TEST("prm.prm1" == updauth.auth.accounts[0].permission.permission);
+   BOOST_TEST(name("prm.acct1") == updauth.auth.accounts[0].permission.actor);
+   BOOST_TEST(name("prm.prm1") == updauth.auth.accounts[0].permission.permission);
    BOOST_TEST(53005u == updauth.auth.accounts[0].weight);
-   BOOST_TEST("prm.acct2" == updauth.auth.accounts[1].permission.actor);
-   BOOST_TEST("prm.prm2" == updauth.auth.accounts[1].permission.permission);
+   BOOST_TEST(name("prm.acct2") == updauth.auth.accounts[1].permission.actor);
+   BOOST_TEST(name("prm.prm2") == updauth.auth.accounts[1].permission.permission);
    BOOST_TEST(53405u == updauth.auth.accounts[1].weight);
 
    auto var2 = verify_byte_round_trip_conversion( abis, "updateauth", var );
@@ -951,8 +951,8 @@ BOOST_AUTO_TEST_CASE(deleteauth_test)
    auto var = fc::json::from_string(test_data);
 
    auto delauth = var.as<deleteauth>();
-   BOOST_TEST("delauth.acct" == delauth.account);
-   BOOST_TEST("delauth.prm" == delauth.permission);
+   BOOST_TEST(name("delauth.acct") == delauth.account);
+   BOOST_TEST(name("delauth.prm") == delauth.permission);
 
    auto var2 = verify_byte_round_trip_conversion( abis, "deleteauth", var );
    auto deleteauth2 = var2.as<deleteauth>();
@@ -994,8 +994,8 @@ BOOST_AUTO_TEST_CASE(newaccount_test)
    auto var = fc::json::from_string(test_data);
 
    auto newacct = var.as<newaccount>();
-   BOOST_TEST("newacct.crtr" == newacct.creator);
-   BOOST_TEST("newacct.name" == newacct.name);
+   BOOST_TEST(name("newacct.crtr") == newacct.creator);
+   BOOST_TEST(name("newacct.name") == newacct.name);
 
    BOOST_TEST(2147483145u == newacct.owner.threshold);
 
@@ -1006,11 +1006,11 @@ BOOST_AUTO_TEST_CASE(newaccount_test)
    BOOST_TEST(57605u == newacct.owner.keys[1].weight);
 
    BOOST_TEST_REQUIRE(2u == newacct.owner.accounts.size());
-   BOOST_TEST("prm.acct1" == newacct.owner.accounts[0].permission.actor);
-   BOOST_TEST("prm.prm1" == newacct.owner.accounts[0].permission.permission);
+   BOOST_TEST(name("prm.acct1") == newacct.owner.accounts[0].permission.actor);
+   BOOST_TEST(name("prm.prm1") == newacct.owner.accounts[0].permission.permission);
    BOOST_TEST(53005u == newacct.owner.accounts[0].weight);
-   BOOST_TEST("prm.acct2" == newacct.owner.accounts[1].permission.actor);
-   BOOST_TEST("prm.prm2" == newacct.owner.accounts[1].permission.permission);
+   BOOST_TEST(name("prm.acct2") == newacct.owner.accounts[1].permission.actor);
+   BOOST_TEST(name("prm.prm2") == newacct.owner.accounts[1].permission.permission);
    BOOST_TEST(53405u == newacct.owner.accounts[1].weight);
 
    BOOST_TEST(2146483145u == newacct.active.threshold);
@@ -1022,11 +1022,11 @@ BOOST_AUTO_TEST_CASE(newaccount_test)
    BOOST_TEST(57605u == newacct.active.keys[1].weight);
 
    BOOST_TEST_REQUIRE(2u == newacct.active.accounts.size());
-   BOOST_TEST("prm.acct1" == newacct.active.accounts[0].permission.actor);
-   BOOST_TEST("prm.prm1" == newacct.active.accounts[0].permission.permission);
+   BOOST_TEST(name("prm.acct1") == newacct.active.accounts[0].permission.actor);
+   BOOST_TEST(name("prm.prm1") == newacct.active.accounts[0].permission.permission);
    BOOST_TEST(53005u == newacct.active.accounts[0].weight);
-   BOOST_TEST("prm.acct2" == newacct.active.accounts[1].permission.actor);
-   BOOST_TEST("prm.prm2" == newacct.active.accounts[1].permission.permission);
+   BOOST_TEST(name("prm.acct2") == newacct.active.accounts[1].permission.actor);
+   BOOST_TEST(name("prm.prm2") == newacct.active.accounts[1].permission.permission);
    BOOST_TEST(53405u == newacct.active.accounts[1].weight);
 
 
@@ -1090,7 +1090,7 @@ BOOST_AUTO_TEST_CASE(setcode_test)
    auto var = fc::json::from_string(test_data);
 
    auto set_code = var.as<setcode>();
-   BOOST_TEST("setcode.acc" == set_code.account);
+   BOOST_TEST(name("setcode.acc") == set_code.account);
    BOOST_TEST(0 == set_code.vmtype);
    BOOST_TEST(0 == set_code.vmversion);
    BOOST_TEST("0061736d0100000001390a60037e7e7f017f60047e7e7f7f017f60017e0060057e7e7e7f7f" == fc::to_hex(set_code.code.data(), set_code.code.size()));
@@ -1335,11 +1335,11 @@ BOOST_AUTO_TEST_CASE(setabi_test)
    BOOST_TEST("uint64" == abi.structs[2].fields[1].type);
 
    BOOST_TEST_REQUIRE(1u == abi.actions.size());
-   BOOST_TEST("transfer" == abi.actions[0].name);
+   BOOST_TEST(name("transfer") == abi.actions[0].name);
    BOOST_TEST("transfer" == abi.actions[0].type);
 
    BOOST_TEST_REQUIRE(1u == abi.tables.size());
-   BOOST_TEST("account" == abi.tables[0].name);
+   BOOST_TEST(name("account") == abi.tables[0].name);
    BOOST_TEST("account" == abi.tables[0].type);
    BOOST_TEST("i64" == abi.tables[0].index_type);
    BOOST_TEST_REQUIRE(1u == abi.tables[0].key_names.size());
@@ -1446,20 +1446,20 @@ struct action2 {
 template<typename T>
 void verify_action_equal(const chain::action& exp, const chain::action& act)
 {
-   BOOST_REQUIRE_EQUAL((std::string)exp.account, (std::string)act.account);
-   BOOST_REQUIRE_EQUAL((std::string)exp.name, (std::string)act.name);
+   BOOST_REQUIRE_EQUAL(exp.account.to_string(), act.account.to_string());
+   BOOST_REQUIRE_EQUAL(exp.name.to_string(), act.name.to_string());
    BOOST_REQUIRE_EQUAL(exp.authorization.size(), act.authorization.size());
    for(unsigned int i = 0; i < exp.authorization.size(); ++i)
    {
-      BOOST_REQUIRE_EQUAL((std::string)exp.authorization[i].actor, (std::string)act.authorization[i].actor);
-      BOOST_REQUIRE_EQUAL((std::string)exp.authorization[i].permission, (std::string)act.authorization[i].permission);
+      BOOST_REQUIRE_EQUAL(exp.authorization[i].actor.to_string(), act.authorization[i].actor.to_string());
+      BOOST_REQUIRE_EQUAL(exp.authorization[i].permission.to_string(), act.authorization[i].permission.to_string());
    }
    BOOST_REQUIRE_EQUAL(exp.data.size(), act.data.size());
    BOOST_REQUIRE(!memcmp(exp.data.data(), act.data.data(), exp.data.size()));
 }
 
 private_key_type get_private_key( name keyname, string role ) {
-   return private_key_type::regenerate<fc::ecc::private_key_shim>(fc::sha256::hash(string(keyname)+role));
+   return private_key_type::regenerate<fc::ecc::private_key_shim>(fc::sha256::hash(keyname.to_string()+role));
 }
 
 public_key_type  get_public_key( name keyname, string role ) {

--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -60,10 +60,10 @@ static constexpr unsigned long long WASM_TEST_ACTION(const char* cls, const char
 }
 
 struct dummy_action {
-   static uint64_t get_name() {
+   static eosio::chain::name get_name() {
       return N(dummyaction);
    }
-   static uint64_t get_account() {
+   static eosio::chain::name get_account() {
       return N(testapi);
    }
 
@@ -77,10 +77,10 @@ struct u128_action {
 };
 
 struct cf_action {
-   static uint64_t get_name() {
+   static eosio::chain::name get_name() {
       return N(cfaction);
    }
-   static uint64_t get_account() {
+   static eosio::chain::name get_account() {
       return N(testapi);
    }
 
@@ -94,13 +94,13 @@ struct dtt_action {
       return WASM_TEST_ACTION("test_transaction", "send_deferred_tx_with_dtt_action");
    }
    static uint64_t get_account() {
-      return N(testapi);
+      return N(testapi).to_uint64_t();
    }
 
-   uint64_t       payer = N(testapi);
-   uint64_t       deferred_account = N(testapi);
+   uint64_t       payer = N(testapi).to_uint64_t();
+   uint64_t       deferred_account = N(testapi).to_uint64_t();
    uint64_t       deferred_action = WASM_TEST_ACTION("test_transaction", "deferred_print");
-   uint64_t       permission_name = N(active);
+   uint64_t       permission_name = N(active).to_uint64_t();
    uint32_t       delay_sec = 2;
 };
 
@@ -604,15 +604,15 @@ BOOST_AUTO_TEST_CASE(ram_billing_in_notify_tests) { try {
    chain.produce_blocks(1);
 
    BOOST_CHECK_EXCEPTION( CALL_TEST_FUNCTION( chain, "test_action", "test_ram_billing_in_notify",
-                                              fc::raw::pack( ((unsigned __int128)N(testapi2) << 64) | N(testapi) ) ),
+                                              fc::raw::pack( ((unsigned __int128)N(testapi2).to_uint64_t() << 64) | N(testapi).to_uint64_t() ) ),
                           subjective_block_production_exception,
                           fc_exception_message_is("Cannot charge RAM to other accounts during notify.")
    );
 
 
-   CALL_TEST_FUNCTION( chain, "test_action", "test_ram_billing_in_notify", fc::raw::pack( ((unsigned __int128)N(testapi2) << 64) | 0 ) );
+   CALL_TEST_FUNCTION( chain, "test_action", "test_ram_billing_in_notify", fc::raw::pack( ((unsigned __int128)N(testapi2).to_uint64_t() << 64) | 0 ) );
 
-   CALL_TEST_FUNCTION( chain, "test_action", "test_ram_billing_in_notify", fc::raw::pack( ((unsigned __int128)N(testapi2) << 64) | N(testapi2) ) );
+   CALL_TEST_FUNCTION( chain, "test_action", "test_ram_billing_in_notify", fc::raw::pack( ((unsigned __int128)N(testapi2).to_uint64_t() << 64) | N(testapi2).to_uint64_t() ) );
 
    BOOST_REQUIRE_EQUAL( chain.validate(), true );
 } FC_LOG_AND_RETHROW() }
@@ -740,7 +740,7 @@ BOOST_FIXTURE_TEST_CASE(cfa_tx_signature, TESTER)  try {
    tx2.context_free_actions.push_back(cfa);
    set_transaction_headers(tx2);
 
-   const private_key_type& priv_key = get_private_key("dummy", "active");
+   const private_key_type& priv_key = get_private_key(name("dummy"), "active");
    BOOST_TEST((std::string)tx1.sign(priv_key, control->get_chain_id()) != (std::string)tx2.sign(priv_key, control->get_chain_id()));
 
    BOOST_REQUIRE_EQUAL( validate(), true );
@@ -1257,27 +1257,27 @@ BOOST_FIXTURE_TEST_CASE(deferred_transaction_tests, TESTER) { try {
       // Trigger a tx which in turn sends a deferred tx with payer != receiver
       // Payer is alice in this case, this tx should fail since we don't have the authorization of alice
       dtt_action dtt_act1;
-      dtt_act1.payer = N(alice);
+      dtt_act1.payer = N(alice).to_uint64_t();
       BOOST_CHECK_THROW(CALL_TEST_FUNCTION(*this, "test_transaction", "send_deferred_tx_with_dtt_action", fc::raw::pack(dtt_act1)), action_validate_exception);
 
       // Send a tx which in turn sends a deferred tx with the deferred tx's receiver != this tx receiver
       // This will include the authorization of the receiver, and impose any related delay associated with the authority
       // We set the authorization delay to be 10 sec here, and since the deferred tx delay is set to be 5 sec, so this tx should fail
       dtt_action dtt_act2;
-      dtt_act2.deferred_account = N(testapi2);
-      dtt_act2.permission_name = N(additional);
+      dtt_act2.deferred_account = N(testapi2).to_uint64_t();
+      dtt_act2.permission_name = N(additional).to_uint64_t();
       dtt_act2.delay_sec = 5;
 
-      auto auth = authority(get_public_key("testapi", name(dtt_act2.permission_name).to_string()), 10);
+      auto auth = authority(get_public_key(name("testapi"), name(dtt_act2.permission_name).to_string()), 10);
       auth.accounts.push_back( permission_level_weight{{N(testapi), config::eosio_code_name}, 1} );
 
-      push_action(config::system_account_name, updateauth::get_name(), "testapi", fc::mutable_variant_object()
+      push_action(config::system_account_name, updateauth::get_name(), name("testapi"), fc::mutable_variant_object()
               ("account", "testapi")
               ("permission", name(dtt_act2.permission_name))
               ("parent", "active")
               ("auth", auth)
       );
-      push_action(config::system_account_name, linkauth::get_name(), "testapi", fc::mutable_variant_object()
+      push_action(config::system_account_name, linkauth::get_name(), name("testapi"), fc::mutable_variant_object()
               ("account", "testapi")
               ("code", name(dtt_act2.deferred_account))
               ("type", name(dtt_act2.deferred_action))
@@ -1292,9 +1292,9 @@ BOOST_FIXTURE_TEST_CASE(deferred_transaction_tests, TESTER) { try {
       // But not anymore. With the RESTRICT_ACTION_TO_SELF protocol feature activated, it should now objectively
       // fail because testapi@additional permission is not unilaterally satisfied by testapi@eosio.code.
       dtt_action dtt_act3;
-      dtt_act3.deferred_account = N(testapi);
-      dtt_act3.permission_name = N(additional);
-      push_action(config::system_account_name, linkauth::get_name(), "testapi", fc::mutable_variant_object()
+      dtt_act3.deferred_account = N(testapi).to_uint64_t();
+      dtt_act3.permission_name = N(additional).to_uint64_t();
+      push_action(config::system_account_name, linkauth::get_name(), name("testapi"), fc::mutable_variant_object()
             ("account", "testapi")
             ("code", name(dtt_act3.deferred_account))
             ("type", name(dtt_act3.deferred_action))
@@ -2327,99 +2327,99 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_test, TESTER) { try {
    BOOST_REQUIRE_EQUAL((int)atrace[0].action_ordinal, 1);
    BOOST_REQUIRE_EQUAL((int)atrace[0].creator_action_ordinal, 0);
    BOOST_REQUIRE_EQUAL((int)atrace[0].closest_unnotified_ancestor_action_ordinal, 0);
-   BOOST_REQUIRE_EQUAL(atrace[0].receiver.value, N(testapi));
-   BOOST_REQUIRE_EQUAL(atrace[0].act.account.value, N(testapi));
-   BOOST_REQUIRE_EQUAL(atrace[0].act.name.value, TEST_METHOD("test_action", "test_action_ordinal1"));
+   BOOST_REQUIRE_EQUAL(atrace[0].receiver, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[0].act.account, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[0].act.name, TEST_METHOD("test_action", "test_action_ordinal1"));
    BOOST_REQUIRE_EQUAL(atrace[0].receipt.valid(), true);
    int start_gseq = atrace[0].receipt->global_sequence;
 
    BOOST_REQUIRE_EQUAL((int)atrace[1].action_ordinal,2);
    BOOST_REQUIRE_EQUAL((int)atrace[1].creator_action_ordinal, 1);
    BOOST_REQUIRE_EQUAL((int)atrace[1].closest_unnotified_ancestor_action_ordinal, 1);
-   BOOST_REQUIRE_EQUAL(atrace[1].receiver.value, N(bob));
-   BOOST_REQUIRE_EQUAL(atrace[1].act.account.value, N(testapi));
-   BOOST_REQUIRE_EQUAL(atrace[1].act.name.value, TEST_METHOD("test_action", "test_action_ordinal1"));
+   BOOST_REQUIRE_EQUAL(atrace[1].receiver, N(bob));
+   BOOST_REQUIRE_EQUAL(atrace[1].act.account, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[1].act.name, TEST_METHOD("test_action", "test_action_ordinal1"));
    BOOST_REQUIRE_EQUAL(atrace[1].receipt.valid(), true);
    BOOST_REQUIRE_EQUAL(atrace[1].receipt->global_sequence, start_gseq + 1);
 
    BOOST_REQUIRE_EQUAL((int)atrace[2].action_ordinal, 3);
    BOOST_REQUIRE_EQUAL((int)atrace[2].creator_action_ordinal, 1);
    BOOST_REQUIRE_EQUAL((int)atrace[2].closest_unnotified_ancestor_action_ordinal, 1);
-   BOOST_REQUIRE_EQUAL(atrace[2].receiver.value, N(testapi));
-   BOOST_REQUIRE_EQUAL(atrace[2].act.account.value, N(testapi));
-   BOOST_REQUIRE_EQUAL(atrace[2].act.name.value, TEST_METHOD("test_action", "test_action_ordinal2"));
+   BOOST_REQUIRE_EQUAL(atrace[2].receiver, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[2].act.account, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[2].act.name, TEST_METHOD("test_action", "test_action_ordinal2"));
    BOOST_REQUIRE_EQUAL(atrace[2].receipt.valid(), true);
    BOOST_REQUIRE_EQUAL(atrace[2].receipt->global_sequence, start_gseq + 4);
 
    BOOST_REQUIRE_EQUAL((int)atrace[3].action_ordinal, 4);
    BOOST_REQUIRE_EQUAL((int)atrace[3].creator_action_ordinal, 1);
    BOOST_REQUIRE_EQUAL((int)atrace[3].closest_unnotified_ancestor_action_ordinal, 1);
-   BOOST_REQUIRE_EQUAL(atrace[3].receiver.value, N(testapi));
-   BOOST_REQUIRE_EQUAL(atrace[3].act.account.value, N(testapi));
-   BOOST_REQUIRE_EQUAL(atrace[3].act.name.value, TEST_METHOD("test_action", "test_action_ordinal3"));
+   BOOST_REQUIRE_EQUAL(atrace[3].receiver, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[3].act.account, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[3].act.name, TEST_METHOD("test_action", "test_action_ordinal3"));
    BOOST_REQUIRE_EQUAL(atrace[3].receipt.valid(), true);
    BOOST_REQUIRE_EQUAL(atrace[3].receipt->global_sequence, start_gseq + 8);
 
    BOOST_REQUIRE_EQUAL((int)atrace[4].action_ordinal, 5);
    BOOST_REQUIRE_EQUAL((int)atrace[4].creator_action_ordinal, 1);
    BOOST_REQUIRE_EQUAL((int)atrace[4].closest_unnotified_ancestor_action_ordinal, 1);
-   BOOST_REQUIRE_EQUAL(atrace[4].receiver.value, N(charlie));
-   BOOST_REQUIRE_EQUAL(atrace[4].act.account.value, N(testapi));
-   BOOST_REQUIRE_EQUAL(atrace[4].act.name.value, TEST_METHOD("test_action", "test_action_ordinal1"));
+   BOOST_REQUIRE_EQUAL(atrace[4].receiver, N(charlie));
+   BOOST_REQUIRE_EQUAL(atrace[4].act.account, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[4].act.name, TEST_METHOD("test_action", "test_action_ordinal1"));
    BOOST_REQUIRE_EQUAL(atrace[4].receipt.valid(), true);
    BOOST_REQUIRE_EQUAL(atrace[4].receipt->global_sequence, start_gseq + 2);
 
    BOOST_REQUIRE_EQUAL((int)atrace[5].action_ordinal, 6);
    BOOST_REQUIRE_EQUAL((int)atrace[5].creator_action_ordinal, 2);
    BOOST_REQUIRE_EQUAL((int)atrace[5].closest_unnotified_ancestor_action_ordinal, 1);
-   BOOST_REQUIRE_EQUAL(atrace[5].receiver.value, N(bob));
-   BOOST_REQUIRE_EQUAL(atrace[5].act.account.value, N(bob));
-   BOOST_REQUIRE_EQUAL(atrace[5].act.name.value, TEST_METHOD("test_action", "test_action_ordinal_foo"));
+   BOOST_REQUIRE_EQUAL(atrace[5].receiver, N(bob));
+   BOOST_REQUIRE_EQUAL(atrace[5].act.account, N(bob));
+   BOOST_REQUIRE_EQUAL(atrace[5].act.name, TEST_METHOD("test_action", "test_action_ordinal_foo"));
    BOOST_REQUIRE_EQUAL(atrace[5].receipt.valid(), true);
    BOOST_REQUIRE_EQUAL(atrace[5].receipt->global_sequence, start_gseq + 9);
 
    BOOST_REQUIRE_EQUAL((int)atrace[6].action_ordinal, 7);
    BOOST_REQUIRE_EQUAL((int)atrace[6].creator_action_ordinal,2);
    BOOST_REQUIRE_EQUAL((int)atrace[6].closest_unnotified_ancestor_action_ordinal, 1);
-   BOOST_REQUIRE_EQUAL(atrace[6].receiver.value, N(david));
-   BOOST_REQUIRE_EQUAL(atrace[6].act.account.value, N(testapi));
-   BOOST_REQUIRE_EQUAL(atrace[6].act.name.value, TEST_METHOD("test_action", "test_action_ordinal1"));
+   BOOST_REQUIRE_EQUAL(atrace[6].receiver, N(david));
+   BOOST_REQUIRE_EQUAL(atrace[6].act.account, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[6].act.name, TEST_METHOD("test_action", "test_action_ordinal1"));
    BOOST_REQUIRE_EQUAL(atrace[6].receipt.valid(), true);
    BOOST_REQUIRE_EQUAL(atrace[6].receipt->global_sequence, start_gseq + 3);
 
    BOOST_REQUIRE_EQUAL((int)atrace[7].action_ordinal, 8);
    BOOST_REQUIRE_EQUAL((int)atrace[7].creator_action_ordinal, 5);
    BOOST_REQUIRE_EQUAL((int)atrace[7].closest_unnotified_ancestor_action_ordinal, 1);
-   BOOST_REQUIRE_EQUAL(atrace[7].receiver.value, N(charlie));
-   BOOST_REQUIRE_EQUAL(atrace[7].act.account.value, N(charlie));
-   BOOST_REQUIRE_EQUAL(atrace[7].act.name.value, TEST_METHOD("test_action", "test_action_ordinal_bar"));
+   BOOST_REQUIRE_EQUAL(atrace[7].receiver, N(charlie));
+   BOOST_REQUIRE_EQUAL(atrace[7].act.account, N(charlie));
+   BOOST_REQUIRE_EQUAL(atrace[7].act.name, TEST_METHOD("test_action", "test_action_ordinal_bar"));
    BOOST_REQUIRE_EQUAL(atrace[7].receipt.valid(), true);
    BOOST_REQUIRE_EQUAL(atrace[7].receipt->global_sequence, start_gseq + 10);
 
    BOOST_REQUIRE_EQUAL((int)atrace[8].action_ordinal, 9);
    BOOST_REQUIRE_EQUAL((int)atrace[8].creator_action_ordinal, 3);
    BOOST_REQUIRE_EQUAL((int)atrace[8].closest_unnotified_ancestor_action_ordinal, 3);
-   BOOST_REQUIRE_EQUAL(atrace[8].receiver.value, N(david));
-   BOOST_REQUIRE_EQUAL(atrace[8].act.account.value, N(testapi));
-   BOOST_REQUIRE_EQUAL(atrace[8].act.name.value, TEST_METHOD("test_action", "test_action_ordinal2"));
+   BOOST_REQUIRE_EQUAL(atrace[8].receiver, N(david));
+   BOOST_REQUIRE_EQUAL(atrace[8].act.account, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[8].act.name, TEST_METHOD("test_action", "test_action_ordinal2"));
    BOOST_REQUIRE_EQUAL(atrace[8].receipt.valid(), true);
    BOOST_REQUIRE_EQUAL(atrace[8].receipt->global_sequence, start_gseq + 5);
 
    BOOST_REQUIRE_EQUAL((int)atrace[9].action_ordinal, 10);
    BOOST_REQUIRE_EQUAL((int)atrace[9].creator_action_ordinal, 3);
    BOOST_REQUIRE_EQUAL((int)atrace[9].closest_unnotified_ancestor_action_ordinal, 3);
-   BOOST_REQUIRE_EQUAL(atrace[9].receiver.value, N(erin));
-   BOOST_REQUIRE_EQUAL(atrace[9].act.account.value, N(testapi));
-   BOOST_REQUIRE_EQUAL(atrace[9].act.name.value, TEST_METHOD("test_action", "test_action_ordinal2"));
+   BOOST_REQUIRE_EQUAL(atrace[9].receiver, N(erin));
+   BOOST_REQUIRE_EQUAL(atrace[9].act.account, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[9].act.name, TEST_METHOD("test_action", "test_action_ordinal2"));
    BOOST_REQUIRE_EQUAL(atrace[9].receipt.valid(), true);
    BOOST_REQUIRE_EQUAL(atrace[9].receipt->global_sequence, start_gseq + 6);
 
    BOOST_REQUIRE_EQUAL((int)atrace[10].action_ordinal, 11);
    BOOST_REQUIRE_EQUAL((int)atrace[10].creator_action_ordinal, 3);
    BOOST_REQUIRE_EQUAL((int)atrace[10].closest_unnotified_ancestor_action_ordinal, 3);
-   BOOST_REQUIRE_EQUAL(atrace[10].receiver.value, N(testapi));
-   BOOST_REQUIRE_EQUAL(atrace[10].act.account.value, N(testapi));
-   BOOST_REQUIRE_EQUAL(atrace[10].act.name.value, TEST_METHOD("test_action", "test_action_ordinal4"));
+   BOOST_REQUIRE_EQUAL(atrace[10].receiver, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[10].act.account, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[10].act.name, TEST_METHOD("test_action", "test_action_ordinal4"));
    BOOST_REQUIRE_EQUAL(atrace[10].receipt.valid(), true);
    BOOST_REQUIRE_EQUAL(atrace[10].receipt->global_sequence, start_gseq + 7);
 } FC_LOG_AND_RETHROW() }
@@ -2464,9 +2464,9 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_failtest1, TESTER) { try {
    BOOST_REQUIRE_EQUAL((int)atrace[0].action_ordinal, 1);
    BOOST_REQUIRE_EQUAL((int)atrace[0].creator_action_ordinal, 0);
    BOOST_REQUIRE_EQUAL((int)atrace[0].closest_unnotified_ancestor_action_ordinal, 0);
-   BOOST_REQUIRE_EQUAL(atrace[0].receiver.value, N(testapi));
-   BOOST_REQUIRE_EQUAL(atrace[0].act.account.value, N(testapi));
-   BOOST_REQUIRE_EQUAL(atrace[0].act.name.value, TEST_METHOD("test_action", "test_action_ordinal1"));
+   BOOST_REQUIRE_EQUAL(atrace[0].receiver, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[0].act.account, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[0].act.name, TEST_METHOD("test_action", "test_action_ordinal1"));
    BOOST_REQUIRE_EQUAL(atrace[0].receipt.valid(), false);
    BOOST_REQUIRE_EQUAL(atrace[0].except.valid(), true);
    BOOST_REQUIRE_EQUAL(atrace[0].except->code(), 3050003);
@@ -2475,9 +2475,9 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_failtest1, TESTER) { try {
    BOOST_REQUIRE_EQUAL((int)atrace[1].action_ordinal, 2);
    BOOST_REQUIRE_EQUAL((int)atrace[1].creator_action_ordinal, 1);
    BOOST_REQUIRE_EQUAL((int)atrace[1].closest_unnotified_ancestor_action_ordinal, 1);
-   BOOST_REQUIRE_EQUAL(atrace[1].receiver.value, N(bob));
-   BOOST_REQUIRE_EQUAL(atrace[1].act.account.value, N(testapi));
-   BOOST_REQUIRE_EQUAL(atrace[1].act.name.value, TEST_METHOD("test_action", "test_action_ordinal1"));
+   BOOST_REQUIRE_EQUAL(atrace[1].receiver, N(bob));
+   BOOST_REQUIRE_EQUAL(atrace[1].act.account, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[1].act.name, TEST_METHOD("test_action", "test_action_ordinal1"));
    BOOST_REQUIRE_EQUAL(atrace[1].receipt.valid(), false);
    BOOST_REQUIRE_EQUAL(atrace[1].except.valid(), false);
 
@@ -2485,9 +2485,9 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_failtest1, TESTER) { try {
    BOOST_REQUIRE_EQUAL((int)atrace[2].action_ordinal, 3);
    BOOST_REQUIRE_EQUAL((int)atrace[2].creator_action_ordinal, 1);
    BOOST_REQUIRE_EQUAL((int)atrace[2].closest_unnotified_ancestor_action_ordinal, 1);
-   BOOST_REQUIRE_EQUAL(atrace[2].receiver.value, N(testapi));
-   BOOST_REQUIRE_EQUAL(atrace[2].act.account.value, N(testapi));
-   BOOST_REQUIRE_EQUAL(atrace[2].act.name.value, TEST_METHOD("test_action", "test_action_ordinal2"));
+   BOOST_REQUIRE_EQUAL(atrace[2].receiver, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[2].act.account, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[2].act.name, TEST_METHOD("test_action", "test_action_ordinal2"));
    BOOST_REQUIRE_EQUAL(atrace[2].receipt.valid(), false);
    BOOST_REQUIRE_EQUAL(atrace[2].except.valid(), false);
 
@@ -2532,9 +2532,9 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_failtest2, TESTER) { try {
    BOOST_REQUIRE_EQUAL((int)atrace[0].action_ordinal, 1);
    BOOST_REQUIRE_EQUAL((int)atrace[0].creator_action_ordinal, 0);
    BOOST_REQUIRE_EQUAL((int)atrace[0].closest_unnotified_ancestor_action_ordinal, 0);
-   BOOST_REQUIRE_EQUAL(atrace[0].receiver.value, N(testapi));
-   BOOST_REQUIRE_EQUAL(atrace[0].act.account.value, N(testapi));
-   BOOST_REQUIRE_EQUAL(atrace[0].act.name.value, TEST_METHOD("test_action", "test_action_ordinal1"));
+   BOOST_REQUIRE_EQUAL(atrace[0].receiver, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[0].act.account, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[0].act.name, TEST_METHOD("test_action", "test_action_ordinal1"));
    BOOST_REQUIRE_EQUAL(atrace[0].receipt.valid(), true);
    BOOST_REQUIRE_EQUAL(atrace[0].except.valid(), false);
    int start_gseq = atrace[0].receipt->global_sequence;
@@ -2543,9 +2543,9 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_failtest2, TESTER) { try {
    BOOST_REQUIRE_EQUAL((int)atrace[1].action_ordinal,2);
    BOOST_REQUIRE_EQUAL((int)atrace[1].creator_action_ordinal, 1);
    BOOST_REQUIRE_EQUAL((int)atrace[1].closest_unnotified_ancestor_action_ordinal, 1);
-   BOOST_REQUIRE_EQUAL(atrace[1].receiver.value, N(bob));
-   BOOST_REQUIRE_EQUAL(atrace[1].act.account.value, N(testapi));
-   BOOST_REQUIRE_EQUAL(atrace[1].act.name.value, TEST_METHOD("test_action", "test_action_ordinal1"));
+   BOOST_REQUIRE_EQUAL(atrace[1].receiver, N(bob));
+   BOOST_REQUIRE_EQUAL(atrace[1].act.account, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[1].act.name, TEST_METHOD("test_action", "test_action_ordinal1"));
    BOOST_REQUIRE_EQUAL(atrace[1].receipt.valid(), true);
    BOOST_REQUIRE_EQUAL(atrace[1].receipt->global_sequence, start_gseq + 1);
 
@@ -2553,9 +2553,9 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_failtest2, TESTER) { try {
    BOOST_REQUIRE_EQUAL((int)atrace[2].action_ordinal, 3);
    BOOST_REQUIRE_EQUAL((int)atrace[2].creator_action_ordinal, 1);
    BOOST_REQUIRE_EQUAL((int)atrace[2].closest_unnotified_ancestor_action_ordinal, 1);
-   BOOST_REQUIRE_EQUAL(atrace[2].receiver.value, N(testapi));
-   BOOST_REQUIRE_EQUAL(atrace[2].act.account.value, N(testapi));
-   BOOST_REQUIRE_EQUAL(atrace[2].act.name.value, TEST_METHOD("test_action", "test_action_ordinal2"));
+   BOOST_REQUIRE_EQUAL(atrace[2].receiver, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[2].act.account, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[2].act.name, TEST_METHOD("test_action", "test_action_ordinal2"));
    BOOST_REQUIRE_EQUAL(atrace[2].receipt.valid(), false);
    BOOST_REQUIRE_EQUAL(atrace[2].except.valid(), false);
 
@@ -2563,9 +2563,9 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_failtest2, TESTER) { try {
    BOOST_REQUIRE_EQUAL((int)atrace[3].action_ordinal, 4);
    BOOST_REQUIRE_EQUAL((int)atrace[3].creator_action_ordinal, 1);
    BOOST_REQUIRE_EQUAL((int)atrace[3].closest_unnotified_ancestor_action_ordinal, 1);
-   BOOST_REQUIRE_EQUAL(atrace[3].receiver.value, N(testapi));
-   BOOST_REQUIRE_EQUAL(atrace[3].act.account.value, N(testapi));
-   BOOST_REQUIRE_EQUAL(atrace[3].act.name.value, TEST_METHOD("test_action", "test_action_ordinal3"));
+   BOOST_REQUIRE_EQUAL(atrace[3].receiver, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[3].act.account, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[3].act.name, TEST_METHOD("test_action", "test_action_ordinal3"));
    BOOST_REQUIRE_EQUAL(atrace[3].receipt.valid(), false);
    BOOST_REQUIRE_EQUAL(atrace[3].except.valid(), false);
 
@@ -2573,9 +2573,9 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_failtest2, TESTER) { try {
    BOOST_REQUIRE_EQUAL((int)atrace[4].action_ordinal, 5);
    BOOST_REQUIRE_EQUAL((int)atrace[4].creator_action_ordinal, 1);
    BOOST_REQUIRE_EQUAL((int)atrace[4].closest_unnotified_ancestor_action_ordinal, 1);
-   BOOST_REQUIRE_EQUAL(atrace[4].receiver.value, N(charlie));
-   BOOST_REQUIRE_EQUAL(atrace[4].act.account.value, N(testapi));
-   BOOST_REQUIRE_EQUAL(atrace[4].act.name.value, TEST_METHOD("test_action", "test_action_ordinal1"));
+   BOOST_REQUIRE_EQUAL(atrace[4].receiver, N(charlie));
+   BOOST_REQUIRE_EQUAL(atrace[4].act.account, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[4].act.name, TEST_METHOD("test_action", "test_action_ordinal1"));
    BOOST_REQUIRE_EQUAL(atrace[4].receipt.valid(), false);
    BOOST_REQUIRE_EQUAL(atrace[4].except.valid(), true);
    BOOST_REQUIRE_EQUAL(atrace[4].except->code(), 3050003);
@@ -2584,9 +2584,9 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_failtest2, TESTER) { try {
    BOOST_REQUIRE_EQUAL((int)atrace[5].action_ordinal, 6);
    BOOST_REQUIRE_EQUAL((int)atrace[5].creator_action_ordinal, 2);
    BOOST_REQUIRE_EQUAL((int)atrace[5].closest_unnotified_ancestor_action_ordinal, 1);
-   BOOST_REQUIRE_EQUAL(atrace[5].receiver.value, N(bob));
-   BOOST_REQUIRE_EQUAL(atrace[5].act.account.value, N(bob));
-   BOOST_REQUIRE_EQUAL(atrace[5].act.name.value, TEST_METHOD("test_action", "test_action_ordinal_foo"));
+   BOOST_REQUIRE_EQUAL(atrace[5].receiver, N(bob));
+   BOOST_REQUIRE_EQUAL(atrace[5].act.account, N(bob));
+   BOOST_REQUIRE_EQUAL(atrace[5].act.name, TEST_METHOD("test_action", "test_action_ordinal_foo"));
    BOOST_REQUIRE_EQUAL(atrace[5].receipt.valid(), false);
    BOOST_REQUIRE_EQUAL(atrace[5].except.valid(), false);
 
@@ -2594,9 +2594,9 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_failtest2, TESTER) { try {
    BOOST_REQUIRE_EQUAL((int)atrace[6].action_ordinal, 7);
    BOOST_REQUIRE_EQUAL((int)atrace[6].creator_action_ordinal,2);
    BOOST_REQUIRE_EQUAL((int)atrace[6].closest_unnotified_ancestor_action_ordinal, 1);
-   BOOST_REQUIRE_EQUAL(atrace[6].receiver.value, N(david));
-   BOOST_REQUIRE_EQUAL(atrace[6].act.account.value, N(testapi));
-   BOOST_REQUIRE_EQUAL(atrace[6].act.name.value, TEST_METHOD("test_action", "test_action_ordinal1"));
+   BOOST_REQUIRE_EQUAL(atrace[6].receiver, N(david));
+   BOOST_REQUIRE_EQUAL(atrace[6].act.account, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[6].act.name, TEST_METHOD("test_action", "test_action_ordinal1"));
    BOOST_REQUIRE_EQUAL(atrace[6].receipt.valid(), false);
    BOOST_REQUIRE_EQUAL(atrace[6].except.valid(), false);
 
@@ -2604,9 +2604,9 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_failtest2, TESTER) { try {
    BOOST_REQUIRE_EQUAL((int)atrace[7].action_ordinal, 8);
    BOOST_REQUIRE_EQUAL((int)atrace[7].creator_action_ordinal, 5);
    BOOST_REQUIRE_EQUAL((int)atrace[7].closest_unnotified_ancestor_action_ordinal, 1);
-   BOOST_REQUIRE_EQUAL(atrace[7].receiver.value, N(charlie));
-   BOOST_REQUIRE_EQUAL(atrace[7].act.account.value, N(charlie));
-   BOOST_REQUIRE_EQUAL(atrace[7].act.name.value, TEST_METHOD("test_action", "test_action_ordinal_bar"));
+   BOOST_REQUIRE_EQUAL(atrace[7].receiver, N(charlie));
+   BOOST_REQUIRE_EQUAL(atrace[7].act.account, N(charlie));
+   BOOST_REQUIRE_EQUAL(atrace[7].act.name, TEST_METHOD("test_action", "test_action_ordinal_bar"));
    BOOST_REQUIRE_EQUAL(atrace[7].receipt.valid(), false);
    BOOST_REQUIRE_EQUAL(atrace[7].except.valid(), false);
 
@@ -2651,9 +2651,9 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_failtest3, TESTER) { try {
    BOOST_REQUIRE_EQUAL((int)atrace[0].action_ordinal, 1);
    BOOST_REQUIRE_EQUAL((int)atrace[0].creator_action_ordinal, 0);
    BOOST_REQUIRE_EQUAL((int)atrace[0].closest_unnotified_ancestor_action_ordinal, 0);
-   BOOST_REQUIRE_EQUAL(atrace[0].receiver.value, N(testapi));
-   BOOST_REQUIRE_EQUAL(atrace[0].act.account.value, N(testapi));
-   BOOST_REQUIRE_EQUAL(atrace[0].act.name.value, TEST_METHOD("test_action", "test_action_ordinal1"));
+   BOOST_REQUIRE_EQUAL(atrace[0].receiver, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[0].act.account, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[0].act.name, TEST_METHOD("test_action", "test_action_ordinal1"));
    BOOST_REQUIRE_EQUAL(atrace[0].receipt.valid(), true);
    BOOST_REQUIRE_EQUAL(atrace[0].except.valid(), false);
    int start_gseq = atrace[0].receipt->global_sequence;
@@ -2662,9 +2662,9 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_failtest3, TESTER) { try {
    BOOST_REQUIRE_EQUAL((int)atrace[1].action_ordinal,2);
    BOOST_REQUIRE_EQUAL((int)atrace[1].creator_action_ordinal, 1);
    BOOST_REQUIRE_EQUAL((int)atrace[1].closest_unnotified_ancestor_action_ordinal, 1);
-   BOOST_REQUIRE_EQUAL(atrace[1].receiver.value, N(bob));
-   BOOST_REQUIRE_EQUAL(atrace[1].act.account.value, N(testapi));
-   BOOST_REQUIRE_EQUAL(atrace[1].act.name.value, TEST_METHOD("test_action", "test_action_ordinal1"));
+   BOOST_REQUIRE_EQUAL(atrace[1].receiver, N(bob));
+   BOOST_REQUIRE_EQUAL(atrace[1].act.account, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[1].act.name, TEST_METHOD("test_action", "test_action_ordinal1"));
    BOOST_REQUIRE_EQUAL(atrace[1].receipt.valid(), true);
    BOOST_REQUIRE_EQUAL(atrace[1].receipt->global_sequence, start_gseq + 1);
 
@@ -2672,9 +2672,9 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_failtest3, TESTER) { try {
    BOOST_REQUIRE_EQUAL((int)atrace[2].action_ordinal, 3);
    BOOST_REQUIRE_EQUAL((int)atrace[2].creator_action_ordinal, 1);
    BOOST_REQUIRE_EQUAL((int)atrace[2].closest_unnotified_ancestor_action_ordinal, 1);
-   BOOST_REQUIRE_EQUAL(atrace[2].receiver.value, N(testapi));
-   BOOST_REQUIRE_EQUAL(atrace[2].act.account.value, N(testapi));
-   BOOST_REQUIRE_EQUAL(atrace[2].act.name.value, TEST_METHOD("test_action", "test_action_ordinal2"));
+   BOOST_REQUIRE_EQUAL(atrace[2].receiver, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[2].act.account, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[2].act.name, TEST_METHOD("test_action", "test_action_ordinal2"));
    BOOST_REQUIRE_EQUAL(atrace[2].receipt.valid(), true);
    BOOST_REQUIRE_EQUAL(atrace[2].receipt->global_sequence, start_gseq + 4);
 
@@ -2682,9 +2682,9 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_failtest3, TESTER) { try {
    BOOST_REQUIRE_EQUAL((int)atrace[3].action_ordinal, 4);
    BOOST_REQUIRE_EQUAL((int)atrace[3].creator_action_ordinal, 1);
    BOOST_REQUIRE_EQUAL((int)atrace[3].closest_unnotified_ancestor_action_ordinal, 1);
-   BOOST_REQUIRE_EQUAL(atrace[3].receiver.value, N(testapi));
-   BOOST_REQUIRE_EQUAL(atrace[3].act.account.value, N(testapi));
-   BOOST_REQUIRE_EQUAL(atrace[3].act.name.value, TEST_METHOD("test_action", "test_action_ordinal3"));
+   BOOST_REQUIRE_EQUAL(atrace[3].receiver, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[3].act.account, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[3].act.name, TEST_METHOD("test_action", "test_action_ordinal3"));
    BOOST_REQUIRE_EQUAL(atrace[3].receipt.valid(), false);
    BOOST_REQUIRE_EQUAL(atrace[3].except.valid(), true);
    BOOST_REQUIRE_EQUAL(atrace[3].except->code(), 3050003);
@@ -2693,9 +2693,9 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_failtest3, TESTER) { try {
    BOOST_REQUIRE_EQUAL((int)atrace[4].action_ordinal, 5);
    BOOST_REQUIRE_EQUAL((int)atrace[4].creator_action_ordinal, 1);
    BOOST_REQUIRE_EQUAL((int)atrace[4].closest_unnotified_ancestor_action_ordinal, 1);
-   BOOST_REQUIRE_EQUAL(atrace[4].receiver.value, N(charlie));
-   BOOST_REQUIRE_EQUAL(atrace[4].act.account.value, N(testapi));
-   BOOST_REQUIRE_EQUAL(atrace[4].act.name.value, TEST_METHOD("test_action", "test_action_ordinal1"));
+   BOOST_REQUIRE_EQUAL(atrace[4].receiver, N(charlie));
+   BOOST_REQUIRE_EQUAL(atrace[4].act.account, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[4].act.name, TEST_METHOD("test_action", "test_action_ordinal1"));
    BOOST_REQUIRE_EQUAL(atrace[4].receipt.valid(), true);
    BOOST_REQUIRE_EQUAL(atrace[4].receipt->global_sequence, start_gseq + 2);
 
@@ -2703,9 +2703,9 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_failtest3, TESTER) { try {
    BOOST_REQUIRE_EQUAL((int)atrace[5].action_ordinal, 6);
    BOOST_REQUIRE_EQUAL((int)atrace[5].creator_action_ordinal, 2);
    BOOST_REQUIRE_EQUAL((int)atrace[5].closest_unnotified_ancestor_action_ordinal, 1);
-   BOOST_REQUIRE_EQUAL(atrace[5].receiver.value, N(bob));
-   BOOST_REQUIRE_EQUAL(atrace[5].act.account.value, N(bob));
-   BOOST_REQUIRE_EQUAL(atrace[5].act.name.value, TEST_METHOD("test_action", "test_action_ordinal_foo"));
+   BOOST_REQUIRE_EQUAL(atrace[5].receiver, N(bob));
+   BOOST_REQUIRE_EQUAL(atrace[5].act.account, N(bob));
+   BOOST_REQUIRE_EQUAL(atrace[5].act.name, TEST_METHOD("test_action", "test_action_ordinal_foo"));
    BOOST_REQUIRE_EQUAL(atrace[5].receipt.valid(), false);
    BOOST_REQUIRE_EQUAL(atrace[5].except.valid(), false);
 
@@ -2713,9 +2713,9 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_failtest3, TESTER) { try {
    BOOST_REQUIRE_EQUAL((int)atrace[6].action_ordinal, 7);
    BOOST_REQUIRE_EQUAL((int)atrace[6].creator_action_ordinal,2);
    BOOST_REQUIRE_EQUAL((int)atrace[6].closest_unnotified_ancestor_action_ordinal, 1);
-   BOOST_REQUIRE_EQUAL(atrace[6].receiver.value, N(david));
-   BOOST_REQUIRE_EQUAL(atrace[6].act.account.value, N(testapi));
-   BOOST_REQUIRE_EQUAL(atrace[6].act.name.value, TEST_METHOD("test_action", "test_action_ordinal1"));
+   BOOST_REQUIRE_EQUAL(atrace[6].receiver, N(david));
+   BOOST_REQUIRE_EQUAL(atrace[6].act.account, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[6].act.name, TEST_METHOD("test_action", "test_action_ordinal1"));
    BOOST_REQUIRE_EQUAL(atrace[6].receipt.valid(), true);
    BOOST_REQUIRE_EQUAL(atrace[6].receipt->global_sequence, start_gseq + 3);
 
@@ -2723,9 +2723,9 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_failtest3, TESTER) { try {
    BOOST_REQUIRE_EQUAL((int)atrace[7].action_ordinal, 8);
    BOOST_REQUIRE_EQUAL((int)atrace[7].creator_action_ordinal, 5);
    BOOST_REQUIRE_EQUAL((int)atrace[7].closest_unnotified_ancestor_action_ordinal, 1);
-   BOOST_REQUIRE_EQUAL(atrace[7].receiver.value, N(charlie));
-   BOOST_REQUIRE_EQUAL(atrace[7].act.account.value, N(charlie));
-   BOOST_REQUIRE_EQUAL(atrace[7].act.name.value, TEST_METHOD("test_action", "test_action_ordinal_bar"));
+   BOOST_REQUIRE_EQUAL(atrace[7].receiver, N(charlie));
+   BOOST_REQUIRE_EQUAL(atrace[7].act.account, N(charlie));
+   BOOST_REQUIRE_EQUAL(atrace[7].act.name, TEST_METHOD("test_action", "test_action_ordinal_bar"));
    BOOST_REQUIRE_EQUAL(atrace[7].receipt.valid(), false);
    BOOST_REQUIRE_EQUAL(atrace[7].except.valid(), false);
 
@@ -2733,9 +2733,9 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_failtest3, TESTER) { try {
    BOOST_REQUIRE_EQUAL((int)atrace[8].action_ordinal, 9);
    BOOST_REQUIRE_EQUAL((int)atrace[8].creator_action_ordinal, 3);
    BOOST_REQUIRE_EQUAL((int)atrace[8].closest_unnotified_ancestor_action_ordinal, 3);
-   BOOST_REQUIRE_EQUAL(atrace[8].receiver.value, N(david));
-   BOOST_REQUIRE_EQUAL(atrace[8].act.account.value, N(testapi));
-   BOOST_REQUIRE_EQUAL(atrace[8].act.name.value, TEST_METHOD("test_action", "test_action_ordinal2"));
+   BOOST_REQUIRE_EQUAL(atrace[8].receiver, N(david));
+   BOOST_REQUIRE_EQUAL(atrace[8].act.account, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[8].act.name, TEST_METHOD("test_action", "test_action_ordinal2"));
    BOOST_REQUIRE_EQUAL(atrace[8].receipt.valid(), true);
    BOOST_REQUIRE_EQUAL(atrace[8].receipt->global_sequence, start_gseq + 5);
 
@@ -2743,9 +2743,9 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_failtest3, TESTER) { try {
    BOOST_REQUIRE_EQUAL((int)atrace[9].action_ordinal, 10);
    BOOST_REQUIRE_EQUAL((int)atrace[9].creator_action_ordinal, 3);
    BOOST_REQUIRE_EQUAL((int)atrace[9].closest_unnotified_ancestor_action_ordinal, 3);
-   BOOST_REQUIRE_EQUAL(atrace[9].receiver.value, N(erin));
-   BOOST_REQUIRE_EQUAL(atrace[9].act.account.value, N(testapi));
-   BOOST_REQUIRE_EQUAL(atrace[9].act.name.value, TEST_METHOD("test_action", "test_action_ordinal2"));
+   BOOST_REQUIRE_EQUAL(atrace[9].receiver, N(erin));
+   BOOST_REQUIRE_EQUAL(atrace[9].act.account, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[9].act.name, TEST_METHOD("test_action", "test_action_ordinal2"));
    BOOST_REQUIRE_EQUAL(atrace[9].receipt.valid(), true);
    BOOST_REQUIRE_EQUAL(atrace[9].receipt->global_sequence, start_gseq + 6);
 
@@ -2753,9 +2753,9 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_failtest3, TESTER) { try {
    BOOST_REQUIRE_EQUAL((int)atrace[10].action_ordinal, 11);
    BOOST_REQUIRE_EQUAL((int)atrace[10].creator_action_ordinal, 3);
    BOOST_REQUIRE_EQUAL((int)atrace[10].closest_unnotified_ancestor_action_ordinal, 3);
-   BOOST_REQUIRE_EQUAL(atrace[10].receiver.value, N(testapi));
-   BOOST_REQUIRE_EQUAL(atrace[10].act.account.value, N(testapi));
-   BOOST_REQUIRE_EQUAL(atrace[10].act.name.value, TEST_METHOD("test_action", "test_action_ordinal4"));
+   BOOST_REQUIRE_EQUAL(atrace[10].receiver, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[10].act.account, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[10].act.name, TEST_METHOD("test_action", "test_action_ordinal4"));
    BOOST_REQUIRE_EQUAL(atrace[10].receipt.valid(), true);
    BOOST_REQUIRE_EQUAL(atrace[10].receipt->global_sequence, start_gseq + 7);
 

--- a/unittests/auth_tests.cpp
+++ b/unittests/auth_tests.cpp
@@ -95,26 +95,26 @@ BOOST_FIXTURE_TEST_CASE( delegate_auth, TESTER ) { try {
 BOOST_AUTO_TEST_CASE(update_auths) {
 try {
    TESTER chain;
-   chain.create_account("alice");
-   chain.create_account("bob");
+   chain.create_account(name("alice"));
+   chain.create_account(name("bob"));
 
    // Deleting active or owner should fail
-   BOOST_CHECK_THROW(chain.delete_authority("alice", "active"), action_validate_exception);
-   BOOST_CHECK_THROW(chain.delete_authority("alice", "owner"), action_validate_exception);
+   BOOST_CHECK_THROW(chain.delete_authority(name("alice"), name("active")), action_validate_exception);
+   BOOST_CHECK_THROW(chain.delete_authority(name("alice"), name("owner")), action_validate_exception);
 
    // Change owner permission
-   const auto new_owner_priv_key = chain.get_private_key("alice", "new_owner");
+   const auto new_owner_priv_key = chain.get_private_key(name("alice"), "new_owner");
    const auto new_owner_pub_key = new_owner_priv_key.get_public_key();
-   chain.set_authority("alice", "owner", authority(new_owner_pub_key), "");
+   chain.set_authority(name("alice"), name("owner"), authority(new_owner_pub_key), {});
    chain.produce_blocks();
 
    // Ensure the permission is updated
    permission_object::id_type owner_id;
    {
-      auto obj = chain.find<permission_object, by_owner>(boost::make_tuple("alice", "owner"));
+      auto obj = chain.find<permission_object, by_owner>(boost::make_tuple(name("alice"), name("owner")));
       BOOST_TEST(obj != nullptr);
-      BOOST_TEST(obj->owner == "alice");
-      BOOST_TEST(obj->name == "owner");
+      BOOST_TEST(obj->owner == name("alice"));
+      BOOST_TEST(obj->name == name("owner"));
       BOOST_TEST(obj->parent == 0);
       owner_id = obj->id;
       auto auth = obj->auth.to_authority();
@@ -126,17 +126,17 @@ try {
    }
 
    // Change active permission, remember that the owner key has been changed
-   const auto new_active_priv_key = chain.get_private_key("alice", "new_active");
+   const auto new_active_priv_key = chain.get_private_key(name("alice"), "new_active");
    const auto new_active_pub_key = new_active_priv_key.get_public_key();
-   chain.set_authority("alice", "active", authority(new_active_pub_key), "owner",
-                       { permission_level{"alice", "active"} }, { chain.get_private_key("alice", "active") });
+   chain.set_authority(name("alice"), name("active"), authority(new_active_pub_key), name("owner"),
+                       { permission_level{name("alice"), name("active")} }, { chain.get_private_key(name("alice"), "active") });
    chain.produce_blocks();
 
    {
-      auto obj = chain.find<permission_object, by_owner>(boost::make_tuple("alice", "active"));
+      auto obj = chain.find<permission_object, by_owner>(boost::make_tuple(name("alice"), name("active")));
       BOOST_TEST(obj != nullptr);
-      BOOST_TEST(obj->owner == "alice");
-      BOOST_TEST(obj->name == "active");
+      BOOST_TEST(obj->owner == name("alice"));
+      BOOST_TEST(obj->name == name("active"));
       BOOST_TEST(obj->parent == owner_id);
       auto auth = obj->auth.to_authority();
       BOOST_TEST(auth.threshold == 1u);
@@ -146,221 +146,222 @@ try {
       BOOST_TEST(auth.keys[0].weight == 1u);
    }
 
-   auto spending_priv_key = chain.get_private_key("alice", "spending");
+   auto spending_priv_key = chain.get_private_key(name("alice"), "spending");
    auto spending_pub_key = spending_priv_key.get_public_key();
-   auto trading_priv_key = chain.get_private_key("alice", "trading");
+   auto trading_priv_key = chain.get_private_key(name("alice"), "trading");
    auto trading_pub_key = trading_priv_key.get_public_key();
 
    // Bob attempts to create new spending auth for Alice
-   BOOST_CHECK_THROW( chain.set_authority( "alice", "spending", authority(spending_pub_key), "active",
-                                           { permission_level{"bob", "active"} }, { chain.get_private_key("bob", "active") } ),
+   BOOST_CHECK_THROW( chain.set_authority( name("alice"), name("spending"), authority(spending_pub_key), name("active"),
+                                           { permission_level{name("bob"), name("active")} },
+                                           { chain.get_private_key(name("bob"), "active") } ),
                       irrelevant_auth_exception );
 
    // Create new spending auth
-   chain.set_authority("alice", "spending", authority(spending_pub_key), "active",
-                       { permission_level{"alice", "active"} }, { new_active_priv_key });
+   chain.set_authority(name("alice"), name("spending"), authority(spending_pub_key), name("active"),
+                       { permission_level{name("alice"), name("active")} }, { new_active_priv_key });
    chain.produce_blocks();
    {
-      auto obj = chain.find<permission_object, by_owner>(boost::make_tuple("alice", "spending"));
+      auto obj = chain.find<permission_object, by_owner>(boost::make_tuple(name("alice"), name("spending")));
       BOOST_TEST(obj != nullptr);
-      BOOST_TEST(obj->owner == "alice");
-      BOOST_TEST(obj->name == "spending");
-      BOOST_TEST(chain.get<permission_object>(obj->parent).owner == "alice");
-      BOOST_TEST(chain.get<permission_object>(obj->parent).name == "active");
+      BOOST_TEST(obj->owner == name("alice"));
+      BOOST_TEST(obj->name == name("spending"));
+      BOOST_TEST(chain.get<permission_object>(obj->parent).owner == name("alice"));
+      BOOST_TEST(chain.get<permission_object>(obj->parent).name == name("active"));
    }
 
    // Update spending auth parent to be its own, should fail
-   BOOST_CHECK_THROW(chain.set_authority("alice", "spending", spending_pub_key, "spending",
-                                         { permission_level{"alice", "spending"} }, { spending_priv_key }), action_validate_exception);
+   BOOST_CHECK_THROW(chain.set_authority(name("alice"), name("spending"), spending_pub_key, name("spending"),
+                                         { permission_level{name("alice"), name("spending")} }, { spending_priv_key }), action_validate_exception);
    // Update spending auth parent to be owner, should fail
-   BOOST_CHECK_THROW(chain.set_authority("alice", "spending", spending_pub_key, "owner",
-                                         { permission_level{"alice", "spending"} }, { spending_priv_key }), action_validate_exception);
+   BOOST_CHECK_THROW(chain.set_authority(name("alice"), name("spending"), spending_pub_key, name("owner"),
+                                         { permission_level{name("alice"), name("spending")} }, { spending_priv_key }), action_validate_exception);
 
    // Remove spending auth
-   chain.delete_authority("alice", "spending", { permission_level{"alice", "active"} }, { new_active_priv_key });
+   chain.delete_authority(name("alice"), name("spending"), { permission_level{name("alice"), name("active")} }, { new_active_priv_key });
    {
-      auto obj = chain.find<permission_object, by_owner>(boost::make_tuple("alice", "spending"));
+      auto obj = chain.find<permission_object, by_owner>(boost::make_tuple(name("alice"), name("spending")));
       BOOST_TEST(obj == nullptr);
    }
    chain.produce_blocks();
 
    // Create new trading auth
-   chain.set_authority("alice", "trading", trading_pub_key, "active",
-                       { permission_level{"alice", "active"} }, { new_active_priv_key });
+   chain.set_authority(name("alice"), name("trading"), trading_pub_key, name("active"),
+                       { permission_level{name("alice"), name("active")} }, { new_active_priv_key });
    // Recreate spending auth again, however this time, it's under trading instead of owner
-   chain.set_authority("alice", "spending", spending_pub_key, "trading",
-                       { permission_level{"alice", "trading"} }, { trading_priv_key });
+   chain.set_authority(name("alice"), name("spending"), spending_pub_key, name("trading"),
+                       { permission_level{name("alice"), name("trading")} }, { trading_priv_key });
    chain.produce_blocks();
 
    // Verify correctness of trading and spending
    {
-      const auto* trading = chain.find<permission_object, by_owner>(boost::make_tuple("alice", "trading"));
-      const auto* spending = chain.find<permission_object, by_owner>(boost::make_tuple("alice", "spending"));
+      const auto* trading = chain.find<permission_object, by_owner>(boost::make_tuple(name("alice"), name("trading")));
+      const auto* spending = chain.find<permission_object, by_owner>(boost::make_tuple(name("alice"), name("spending")));
       BOOST_TEST(trading != nullptr);
       BOOST_TEST(spending != nullptr);
-      BOOST_TEST(trading->owner == "alice");
-      BOOST_TEST(spending->owner == "alice");
-      BOOST_TEST(trading->name == "trading");
-      BOOST_TEST(spending->name == "spending");
+      BOOST_TEST(trading->owner == name("alice"));
+      BOOST_TEST(spending->owner == name("alice"));
+      BOOST_TEST(trading->name == name("trading"));
+      BOOST_TEST(spending->name == name("spending"));
       BOOST_TEST(spending->parent == trading->id);
-      BOOST_TEST(chain.get(trading->parent).owner == "alice");
-      BOOST_TEST(chain.get(trading->parent).name == "active");
+      BOOST_TEST(chain.get(trading->parent).owner == name("alice"));
+      BOOST_TEST(chain.get(trading->parent).name == name("active"));
 
    }
 
    // Delete trading, should fail since it has children (spending)
-   BOOST_CHECK_THROW(chain.delete_authority("alice", "trading",
-                                            { permission_level{"alice", "active"} }, { new_active_priv_key }), action_validate_exception);
+   BOOST_CHECK_THROW(chain.delete_authority(name("alice"), name("trading"),
+                                            { permission_level{name("alice"), name("active")} }, { new_active_priv_key }), action_validate_exception);
    // Update trading parent to be spending, should fail since changing parent authority is not supported
-   BOOST_CHECK_THROW(chain.set_authority("alice", "trading", trading_pub_key, "spending",
-                                         { permission_level{"alice", "trading"} }, { trading_priv_key }), action_validate_exception);
+   BOOST_CHECK_THROW(chain.set_authority(name("alice"), name("trading"), trading_pub_key, name("spending"),
+                                         { permission_level{name("alice"), name("trading")} }, { trading_priv_key }), action_validate_exception);
 
    // Delete spending auth
-   chain.delete_authority("alice", "spending", { permission_level{"alice", "active"} }, { new_active_priv_key });
-   BOOST_TEST((chain.find<permission_object, by_owner>(boost::make_tuple("alice", "spending"))) == nullptr);
+   chain.delete_authority(name("alice"), name("spending"), { permission_level{name("alice"), name("active")} }, { new_active_priv_key });
+   BOOST_TEST((chain.find<permission_object, by_owner>(boost::make_tuple(name("alice"), name("spending")))) == nullptr);
    // Delete trading auth, now it should succeed since it doesn't have any children anymore
-   chain.delete_authority("alice", "trading", { permission_level{"alice", "active"} }, { new_active_priv_key });
-   BOOST_TEST((chain.find<permission_object, by_owner>(boost::make_tuple("alice", "trading"))) == nullptr);
+   chain.delete_authority(name("alice"), name("trading"), { permission_level{name("alice"), name("active")} }, { new_active_priv_key });
+   BOOST_TEST((chain.find<permission_object, by_owner>(boost::make_tuple(name("alice"), name("trading")))) == nullptr);
 
 } FC_LOG_AND_RETHROW() }
 
 BOOST_AUTO_TEST_CASE(link_auths) { try {
    TESTER chain;
 
-   chain.create_accounts({"alice","bob"});
+   chain.create_accounts({name("alice"),name("bob")});
 
-   const auto spending_priv_key = chain.get_private_key("alice", "spending");
+   const auto spending_priv_key = chain.get_private_key(name("alice"), "spending");
    const auto spending_pub_key = spending_priv_key.get_public_key();
-   const auto scud_priv_key = chain.get_private_key("alice", "scud");
+   const auto scud_priv_key = chain.get_private_key(name("alice"), "scud");
    const auto scud_pub_key = scud_priv_key.get_public_key();
 
-   chain.set_authority("alice", "spending", spending_pub_key, "active");
-   chain.set_authority("alice", "scud", scud_pub_key, "spending");
+   chain.set_authority(name("alice"), name("spending"), spending_pub_key, name("active"));
+   chain.set_authority(name("alice"), name("scud"), scud_pub_key, name("spending"));
 
    // Send req auth action with alice's spending key, it should fail
-   BOOST_CHECK_THROW(chain.push_reqauth("alice", { permission_level{N(alice), "spending"} }, { spending_priv_key }), irrelevant_auth_exception);
+   BOOST_CHECK_THROW(chain.push_reqauth(name("alice"), { permission_level{N(alice), name("spending")} }, { spending_priv_key }), irrelevant_auth_exception);
    // Link authority for eosio reqauth action with alice's spending key
-   chain.link_authority("alice", "eosio", "spending",  "reqauth");
+   chain.link_authority(name("alice"), name("eosio"), name("spending"), name("reqauth"));
    // Now, req auth action with alice's spending key should succeed
-   chain.push_reqauth("alice", { permission_level{N(alice), "spending"} }, { spending_priv_key });
+   chain.push_reqauth(name("alice"), { permission_level{N(alice), name("spending")} }, { spending_priv_key });
 
    chain.produce_block();
 
    // Relink the same auth should fail
-   BOOST_CHECK_THROW( chain.link_authority("alice", "eosio", "spending",  "reqauth"), action_validate_exception);
+   BOOST_CHECK_THROW( chain.link_authority(name("alice"), name("eosio"), name("spending"), name("reqauth")), action_validate_exception);
 
    // Unlink alice with eosio reqauth
-   chain.unlink_authority("alice", "eosio", "reqauth");
+   chain.unlink_authority(name("alice"), name("eosio"), name("reqauth"));
    // Now, req auth action with alice's spending key should fail
-   BOOST_CHECK_THROW(chain.push_reqauth("alice", { permission_level{N(alice), "spending"} }, { spending_priv_key }), irrelevant_auth_exception);
+   BOOST_CHECK_THROW(chain.push_reqauth(name("alice"), { permission_level{N(alice), name("spending")} }, { spending_priv_key }), irrelevant_auth_exception);
 
    chain.produce_block();
 
    // Send req auth action with scud key, it should fail
-   BOOST_CHECK_THROW(chain.push_reqauth("alice", { permission_level{N(alice), "scud"} }, { scud_priv_key }), irrelevant_auth_exception);
+   BOOST_CHECK_THROW(chain.push_reqauth(name("alice"), { permission_level{N(alice), name("scud")} }, { scud_priv_key }), irrelevant_auth_exception);
    // Link authority for any eosio action with alice's scud key
-   chain.link_authority("alice", "eosio", "scud");
+   chain.link_authority(name("alice"), name("eosio"), name("scud"));
    // Now, req auth action with alice's scud key should succeed
-   chain.push_reqauth("alice", { permission_level{N(alice), "scud"} }, { scud_priv_key });
+   chain.push_reqauth(name("alice"), { permission_level{N(alice), name("scud")} }, { scud_priv_key });
    // req auth action with alice's spending key should also be fine, since it is the parent of alice's scud key
-   chain.push_reqauth("alice", { permission_level{N(alice), "spending"} }, { spending_priv_key });
+   chain.push_reqauth(name("alice"), { permission_level{N(alice), name("spending")} }, { spending_priv_key });
 
 } FC_LOG_AND_RETHROW() }
 
 BOOST_AUTO_TEST_CASE(link_then_update_auth) { try {
    TESTER chain;
 
-   chain.create_account("alice");
+   chain.create_account(name("alice"));
 
-   const auto first_priv_key = chain.get_private_key("alice", "first");
+   const auto first_priv_key = chain.get_private_key(name("alice"), "first");
    const auto first_pub_key = first_priv_key.get_public_key();
-   const auto second_priv_key = chain.get_private_key("alice", "second");
+   const auto second_priv_key = chain.get_private_key(name("alice"), "second");
    const auto second_pub_key = second_priv_key.get_public_key();
 
-   chain.set_authority("alice", "first", first_pub_key, "active");
+   chain.set_authority(name("alice"), name("first"), first_pub_key, name("active"));
 
-   chain.link_authority("alice", "eosio", "first",  "reqauth");
-   chain.push_reqauth("alice", { permission_level{N(alice), "first"} }, { first_priv_key });
+   chain.link_authority(name("alice"), name("eosio"), name("first"), name("reqauth"));
+   chain.push_reqauth(name("alice"), { permission_level{N(alice), name("first")} }, { first_priv_key });
 
    chain.produce_blocks(13); // Wait at least 6 seconds for first push_reqauth transaction to expire.
 
    // Update "first" auth public key
-   chain.set_authority("alice", "first", second_pub_key, "active");
+   chain.set_authority(name("alice"), name("first"), second_pub_key, name("active"));
    // Authority updated, using previous "first" auth should fail on linked auth
-   BOOST_CHECK_THROW(chain.push_reqauth("alice", { permission_level{N(alice), "first"} }, { first_priv_key }), unsatisfied_authorization);
+   BOOST_CHECK_THROW(chain.push_reqauth(name("alice"), { permission_level{N(alice), name("first")} }, { first_priv_key }), unsatisfied_authorization);
    // Using updated authority, should succeed
-   chain.push_reqauth("alice", { permission_level{N(alice), "first"} }, { second_priv_key });
+   chain.push_reqauth(name("alice"), { permission_level{N(alice), name("first")} }, { second_priv_key });
 
 } FC_LOG_AND_RETHROW() }
 
 BOOST_AUTO_TEST_CASE(create_account) {
 try {
    TESTER chain;
-   chain.create_account("joe");
+   chain.create_account(name("joe"));
    chain.produce_block();
 
    // Verify account created properly
-   const auto& joe_owner_authority = chain.get<permission_object, by_owner>(boost::make_tuple("joe", "owner"));
+   const auto& joe_owner_authority = chain.get<permission_object, by_owner>(boost::make_tuple(name("joe"), name("owner")));
    BOOST_TEST(joe_owner_authority.auth.threshold == 1u);
    BOOST_TEST(joe_owner_authority.auth.accounts.size() == 1u);
    BOOST_TEST(joe_owner_authority.auth.keys.size() == 1u);
-   BOOST_TEST(string(joe_owner_authority.auth.keys[0].key) == string(chain.get_public_key("joe", "owner")));
+   BOOST_TEST(string(joe_owner_authority.auth.keys[0].key) == string(chain.get_public_key(name("joe"), "owner")));
    BOOST_TEST(joe_owner_authority.auth.keys[0].weight == 1u);
 
-   const auto& joe_active_authority = chain.get<permission_object, by_owner>(boost::make_tuple("joe", "active"));
+   const auto& joe_active_authority = chain.get<permission_object, by_owner>(boost::make_tuple(name("joe"), name("active")));
    BOOST_TEST(joe_active_authority.auth.threshold == 1u);
    BOOST_TEST(joe_active_authority.auth.accounts.size() == 1u);
    BOOST_TEST(joe_active_authority.auth.keys.size() == 1u);
-   BOOST_TEST(string(joe_active_authority.auth.keys[0].key) == string(chain.get_public_key("joe", "active")));
+   BOOST_TEST(string(joe_active_authority.auth.keys[0].key) == string(chain.get_public_key(name("joe"), "active")));
    BOOST_TEST(joe_active_authority.auth.keys[0].weight == 1u);
 
    // Create duplicate name
-   BOOST_CHECK_EXCEPTION(chain.create_account("joe"), action_validate_exception,
+   BOOST_CHECK_EXCEPTION(chain.create_account(name("joe")), action_validate_exception,
                          fc_exception_message_is("Cannot create account named joe, as that name is already taken"));
 
    // Creating account with name more than 12 chars
-   BOOST_CHECK_EXCEPTION(chain.create_account("aaaaaaaaaaaaa"), action_validate_exception,
+   BOOST_CHECK_EXCEPTION(chain.create_account(name("aaaaaaaaaaaaa")), action_validate_exception,
                          fc_exception_message_is("account names can only be 12 chars long"));
 
 
    // Creating account with eosio. prefix with privileged account
-   chain.create_account("eosio.test1");
+   chain.create_account(name("eosio.test1"));
 
    // Creating account with eosio. prefix with non-privileged account, should fail
-   BOOST_CHECK_EXCEPTION(chain.create_account("eosio.test2", "joe"), action_validate_exception,
+   BOOST_CHECK_EXCEPTION(chain.create_account(name("eosio.test2"), name("joe")), action_validate_exception,
                          fc_exception_message_is("only privileged accounts can have names that start with 'eosio.'"));
 
 } FC_LOG_AND_RETHROW() }
 
 BOOST_AUTO_TEST_CASE( any_auth ) { try {
    TESTER chain;
-   chain.create_accounts( {"alice","bob"} );
+   chain.create_accounts( {name("alice"), name("bob")} );
    chain.produce_block();
 
-   const auto spending_priv_key = chain.get_private_key("alice", "spending");
+   const auto spending_priv_key = chain.get_private_key(name("alice"), "spending");
    const auto spending_pub_key = spending_priv_key.get_public_key();
-   const auto bob_spending_priv_key = chain.get_private_key("bob", "spending");
+   const auto bob_spending_priv_key = chain.get_private_key(name("bob"), "spending");
    const auto bob_spending_pub_key = spending_priv_key.get_public_key();
 
-   chain.set_authority("alice", "spending", spending_pub_key, "active");
-   chain.set_authority("bob", "spending", bob_spending_pub_key, "active");
+   chain.set_authority(name("alice"), name("spending"), spending_pub_key, name("active"));
+   chain.set_authority(name("bob"), name("spending"), bob_spending_pub_key, name("active"));
 
    /// this should fail because spending is not active which is default for reqauth
-   BOOST_REQUIRE_THROW( chain.push_reqauth("alice", { permission_level{N(alice), "spending"} }, { spending_priv_key }),
+   BOOST_REQUIRE_THROW( chain.push_reqauth(name("alice"), { permission_level{N(alice), name("spending")} }, { spending_priv_key }),
                         irrelevant_auth_exception );
 
    chain.produce_block();
 
    //test.push_reqauth( N(alice), { permission_level{N(alice),"spending"} }, { spending_priv_key });
 
-   chain.link_authority( "alice", "eosio", "eosio.any", "reqauth" );
-   chain.link_authority( "bob", "eosio", "eosio.any", "reqauth" );
+   chain.link_authority( name("alice"), name("eosio"), name("eosio.any"), name("reqauth") );
+   chain.link_authority( name("bob"), name("eosio"), name("eosio.any"), name("reqauth") );
 
    /// this should succeed because eosio::reqauth is linked to any permission
-   chain.push_reqauth("alice", { permission_level{N(alice), "spending"} }, { spending_priv_key });
+   chain.push_reqauth(name("alice"), { permission_level{N(alice), name("spending")} }, { spending_priv_key });
 
    /// this should fail because bob cannot authorize for alice, the permission given must be one-of alices
-   BOOST_REQUIRE_THROW( chain.push_reqauth("alice", { permission_level{N(bob), "spending"} }, { spending_priv_key }),
+   BOOST_REQUIRE_THROW( chain.push_reqauth(name("alice"), { permission_level{N(bob), name("spending")} }, { spending_priv_key }),
                         missing_auth_exception );
 
 
@@ -395,9 +396,9 @@ try {
 
       authority owner_auth =  authority( chain.get_public_key( a, "owner" ) );
 
-      vector<permission_level> pls = {{acc1, "active"}};
-      pls.push_back({acc1, "owner"}); // same account but different permission names
-      pls.push_back({acc1a, "owner"});
+      vector<permission_level> pls = {{acc1, name("active")}};
+      pls.push_back({acc1, name("owner")}); // same account but different permission names
+      pls.push_back({acc1a, name("owner")});
       trx.actions.emplace_back( pls,
                                 newaccount{
                                    .creator  = acc1,
@@ -449,7 +450,7 @@ try {
       authority invalid_auth = authority(threshold, {key_weight{chain.get_public_key( a, "owner" ), 1}}, {permission_level_weight{{creator, config::active_name}, 1}});
 
       vector<permission_level> pls;
-      pls.push_back({creator, "active"});
+      pls.push_back({creator, name("active")});
       trx.actions.emplace_back( pls,
                                 newaccount{
                                    .creator  = creator,

--- a/unittests/bootseq_tests.cpp
+++ b/unittests/bootseq_tests.cpp
@@ -286,7 +286,7 @@ BOOST_FIXTURE_TEST_CASE( bootseq_test, bootseq_tester ) {
         produce_blocks_for_n_rounds(2); // 2 rounds since new producer schedule is set when the first block of next round is irreversible
         auto active_schedule = control->head_block_state()->active_schedule;
         BOOST_TEST(active_schedule.producers.size() == 1u);
-        BOOST_TEST(active_schedule.producers.front().producer_name == "eosio");
+        BOOST_TEST(active_schedule.producers.front().producer_name == name("eosio"));
 
         // Spend some time so the producer pay pool is filled by the inflation rate
         produce_min_num_of_blocks_to_spend_time_wo_inactive_prod(fc::seconds(30 * 24 * 3600)); // 30 days
@@ -301,27 +301,27 @@ BOOST_FIXTURE_TEST_CASE( bootseq_test, bootseq_tester ) {
         produce_blocks_for_n_rounds(2); // 2 rounds since new producer schedule is set when the first block of next round is irreversible
         active_schedule = control->head_block_state()->active_schedule;
         BOOST_REQUIRE(active_schedule.producers.size() == 21);
-        BOOST_TEST(active_schedule.producers.at(0).producer_name == "proda");
-        BOOST_TEST(active_schedule.producers.at(1).producer_name == "prodb");
-        BOOST_TEST(active_schedule.producers.at(2).producer_name == "prodc");
-        BOOST_TEST(active_schedule.producers.at(3).producer_name == "prodd");
-        BOOST_TEST(active_schedule.producers.at(4).producer_name == "prode");
-        BOOST_TEST(active_schedule.producers.at(5).producer_name == "prodf");
-        BOOST_TEST(active_schedule.producers.at(6).producer_name == "prodg");
-        BOOST_TEST(active_schedule.producers.at(7).producer_name == "prodh");
-        BOOST_TEST(active_schedule.producers.at(8).producer_name == "prodi");
-        BOOST_TEST(active_schedule.producers.at(9).producer_name == "prodj");
-        BOOST_TEST(active_schedule.producers.at(10).producer_name == "prodk");
-        BOOST_TEST(active_schedule.producers.at(11).producer_name == "prodl");
-        BOOST_TEST(active_schedule.producers.at(12).producer_name == "prodm");
-        BOOST_TEST(active_schedule.producers.at(13).producer_name == "prodn");
-        BOOST_TEST(active_schedule.producers.at(14).producer_name == "prodo");
-        BOOST_TEST(active_schedule.producers.at(15).producer_name == "prodp");
-        BOOST_TEST(active_schedule.producers.at(16).producer_name == "prodq");
-        BOOST_TEST(active_schedule.producers.at(17).producer_name == "prodr");
-        BOOST_TEST(active_schedule.producers.at(18).producer_name == "prods");
-        BOOST_TEST(active_schedule.producers.at(19).producer_name == "prodt");
-        BOOST_TEST(active_schedule.producers.at(20).producer_name == "produ");
+        BOOST_TEST(active_schedule.producers.at(0).producer_name == name("proda"));
+        BOOST_TEST(active_schedule.producers.at(1).producer_name == name("prodb"));
+        BOOST_TEST(active_schedule.producers.at(2).producer_name == name("prodc"));
+        BOOST_TEST(active_schedule.producers.at(3).producer_name == name("prodd"));
+        BOOST_TEST(active_schedule.producers.at(4).producer_name == name("prode"));
+        BOOST_TEST(active_schedule.producers.at(5).producer_name == name("prodf"));
+        BOOST_TEST(active_schedule.producers.at(6).producer_name == name("prodg"));
+        BOOST_TEST(active_schedule.producers.at(7).producer_name == name("prodh"));
+        BOOST_TEST(active_schedule.producers.at(8).producer_name == name("prodi"));
+        BOOST_TEST(active_schedule.producers.at(9).producer_name == name("prodj"));
+        BOOST_TEST(active_schedule.producers.at(10).producer_name == name("prodk"));
+        BOOST_TEST(active_schedule.producers.at(11).producer_name == name("prodl"));
+        BOOST_TEST(active_schedule.producers.at(12).producer_name == name("prodm"));
+        BOOST_TEST(active_schedule.producers.at(13).producer_name == name("prodn"));
+        BOOST_TEST(active_schedule.producers.at(14).producer_name == name("prodo"));
+        BOOST_TEST(active_schedule.producers.at(15).producer_name == name("prodp"));
+        BOOST_TEST(active_schedule.producers.at(16).producer_name == name("prodq"));
+        BOOST_TEST(active_schedule.producers.at(17).producer_name == name("prodr"));
+        BOOST_TEST(active_schedule.producers.at(18).producer_name == name("prods"));
+        BOOST_TEST(active_schedule.producers.at(19).producer_name == name("prodt"));
+        BOOST_TEST(active_schedule.producers.at(20).producer_name == name("produ"));
 
         // Spend some time so the producer pay pool is filled by the inflation rate
         produce_min_num_of_blocks_to_spend_time_wo_inactive_prod(fc::seconds(30 * 24 * 3600)); // 30 days

--- a/unittests/currency_tests.cpp
+++ b/unittests/currency_tests.cpp
@@ -99,10 +99,10 @@ class currency_tester : public TESTER {
       }
 
       abi_serializer abi_ser;
-      static const std::string eosio_token;
+      static const name eosio_token;
 };
 
-const std::string currency_tester::eosio_token = name(N(eosio.token)).to_string();
+const name currency_tester::eosio_token = N(eosio.token);
 
 BOOST_AUTO_TEST_SUITE(currency_tests)
 

--- a/unittests/database_tests.cpp
+++ b/unittests/database_tests.cpp
@@ -33,18 +33,18 @@ BOOST_AUTO_TEST_SUITE(database_tests)
 
          // Create an account
          db.create<account_object>([](account_object &a) {
-            a.name = "billy";
+            a.name = name("billy");
          });
 
          // Make sure we can retrieve that account by name
-         auto ptr = db.find<account_object, by_name, std::string>("billy");
+         auto ptr = db.find<account_object, by_name>(name("billy"));
          BOOST_TEST(ptr != nullptr);
 
          // Undo creation of the account
          ses.undo();
 
          // Make sure we can no longer find the account
-         ptr = db.find<account_object, by_name, std::string>("billy");
+         ptr = db.find<account_object, by_name>(name("billy"));
          BOOST_TEST(ptr == nullptr);
       } FC_LOG_AND_RETHROW()
    }

--- a/unittests/eosio.token_tests.cpp
+++ b/unittests/eosio.token_tests.cpp
@@ -50,14 +50,14 @@ public:
       act.name    = name;
       act.data    = abi_ser.variant_to_binary( action_type_name, data, abi_serializer_max_time );
 
-      return base_tester::push_action( std::move(act), uint64_t(signer));
+      return base_tester::push_action( std::move(act), signer.to_uint64_t() );
    }
 
    fc::variant get_stats( const string& symbolname )
    {
       auto symb = eosio::chain::symbol::from_string(symbolname);
       auto symbol_code = symb.to_symbol_code().value;
-      vector<char> data = get_row_by_account( N(eosio.token), symbol_code, N(stat), symbol_code );
+      vector<char> data = get_row_by_account( N(eosio.token), name(symbol_code), N(stat), name(symbol_code) );
       return data.empty() ? fc::variant() : abi_ser.binary_to_variant( "currency_stats", data, abi_serializer_max_time );
    }
 
@@ -65,7 +65,7 @@ public:
    {
       auto symb = eosio::chain::symbol::from_string(symbolname);
       auto symbol_code = symb.to_symbol_code().value;
-      vector<char> data = get_row_by_account( N(eosio.token), acc, N(accounts), symbol_code );
+      vector<char> data = get_row_by_account( N(eosio.token), acc, N(accounts), name(symbol_code) );
       return data.empty() ? fc::variant() : abi_ser.binary_to_variant( "account", data, abi_serializer_max_time );
    }
 

--- a/unittests/eosio_system_tester.hpp
+++ b/unittests/eosio_system_tester.hpp
@@ -56,7 +56,7 @@ public:
 
       create_currency( N(eosio.token), config::system_account_name, core_from_string("10000000000.0000") );
       issue(config::system_account_name,      core_from_string("1000000000.0000"));
-      BOOST_REQUIRE_EQUAL( core_from_string("1000000000.0000"), get_balance( "eosio" ) );
+      BOOST_REQUIRE_EQUAL( core_from_string("1000000000.0000"), get_balance( name("eosio") ) );
 
       set_code( config::system_account_name, contracts::eosio_system_wasm() );
       set_abi( config::system_account_name, contracts::eosio_system_abi().data() );
@@ -79,7 +79,8 @@ public:
       create_account_with_resources( N(bob111111111), config::system_account_name, core_from_string("0.4500"), false );
       create_account_with_resources( N(carol1111111), config::system_account_name, core_from_string("1.0000"), false );
 
-      BOOST_REQUIRE_EQUAL( core_from_string("1000000000.0000"), get_balance("eosio")  + get_balance("eosio.ramfee") + get_balance("eosio.stake") + get_balance("eosio.ram") );
+      BOOST_REQUIRE_EQUAL( core_from_string("1000000000.0000"),
+            get_balance(name("eosio")) + get_balance(name("eosio.ramfee")) + get_balance(name("eosio.stake")) + get_balance(name("eosio.ram")) );
    }
 
    action_result open( account_name  owner,
@@ -237,7 +238,8 @@ public:
          act.name = name;
          act.data = abi_ser.variant_to_binary( action_type_name, data, abi_serializer_max_time );
 
-         return base_tester::push_action( std::move(act), auth ? uint64_t(signer) : signer == N(bob111111111) ? N(alice1111111) : N(bob111111111) );
+         return base_tester::push_action( std::move(act), auth ? signer.to_uint64_t() :
+                                                signer == N(bob111111111) ? N(alice1111111).to_uint64_t() : N(bob111111111).to_uint64_t() );
    }
 
    action_result stake( const account_name& from, const account_name& to, const asset& net, const asset& cpu ) {
@@ -335,7 +337,7 @@ public:
    }
 
    asset get_balance( const account_name& act ) {
-      vector<char> data = get_row_by_account( N(eosio.token), act, N(accounts), symbol(CORE_SYMBOL).to_symbol_code().value );
+      vector<char> data = get_row_by_account( N(eosio.token), act, N(accounts), name(symbol(CORE_SYMBOL).to_symbol_code().value) );
       return data.empty() ? asset(0, symbol(CORE_SYMBOL)) : token_abi_ser.binary_to_variant("account", data, abi_serializer_max_time)["balance"].as<asset>();
    }
 
@@ -390,7 +392,7 @@ public:
    fc::variant get_stats( const string& symbolname ) {
       auto symb = eosio::chain::symbol::from_string(symbolname);
       auto symbol_code = symb.to_symbol_code().value;
-      vector<char> data = get_row_by_account( N(eosio.token), symbol_code, N(stat), symbol_code );
+      vector<char> data = get_row_by_account( N(eosio.token), name(symbol_code), N(stat), name(symbol_code) );
       return data.empty() ? fc::variant() : token_abi_ser.binary_to_variant( "currency_stats", data, abi_serializer_max_time );
    }
 
@@ -414,7 +416,7 @@ public:
       abi_serializer msig_abi_ser;
       {
          create_account_with_resources( N(eosio.msig), config::system_account_name );
-         BOOST_REQUIRE_EQUAL( success(), buyram( "eosio", "eosio.msig", core_from_string("5000.0000") ) );
+         BOOST_REQUIRE_EQUAL( success(), buyram( name("eosio"), name("eosio.msig"), core_from_string("5000.0000") ) );
          produce_block();
 
          auto trace = base_tester::push_action(config::system_account_name, N(setpriv),
@@ -437,8 +439,8 @@ public:
 
    vector<name> active_and_vote_producers() {
       //stake more than 15% of total EOS supply to activate chain
-      transfer( "eosio", "alice1111111", core_from_string("650000000.0000"), "eosio" );
-      BOOST_REQUIRE_EQUAL( success(), stake( "alice1111111", "alice1111111", core_from_string("300000000.0000"), core_from_string("300000000.0000") ) );
+      transfer( name("eosio"), name("alice1111111"), core_from_string("650000000.0000"), name("eosio") );
+      BOOST_REQUIRE_EQUAL( success(), stake( name("alice1111111"), name("alice1111111"), core_from_string("300000000.0000"), core_from_string("300000000.0000") ) );
 
       // create accounts {defproducera, defproducerb, ..., defproducerz} and register as producers
       std::vector<account_name> producer_names;
@@ -470,9 +472,9 @@ public:
 
       //vote for producers
       {
-         transfer( config::system_account_name, "alice1111111", core_from_string("100000000.0000"), config::system_account_name );
-         BOOST_REQUIRE_EQUAL(success(), stake( "alice1111111", core_from_string("30000000.0000"), core_from_string("30000000.0000") ) );
-         BOOST_REQUIRE_EQUAL(success(), buyram( "alice1111111", "alice1111111", core_from_string("30000000.0000") ) );
+         transfer( config::system_account_name, name("alice1111111"), core_from_string("100000000.0000"), config::system_account_name );
+         BOOST_REQUIRE_EQUAL(success(), stake( name("alice1111111"), core_from_string("30000000.0000"), core_from_string("30000000.0000") ) );
+         BOOST_REQUIRE_EQUAL(success(), buyram( name("alice1111111"), name("alice1111111"), core_from_string("30000000.0000") ) );
          BOOST_REQUIRE_EQUAL(success(), push_action(N(alice1111111), N(voteproducer), mvo()
                                                     ("voter",  "alice1111111")
                                                     ("proxy", name(0).to_string())

--- a/unittests/fork_test_utilities.cpp
+++ b/unittests/fork_test_utilities.cpp
@@ -5,7 +5,7 @@
 #include "fork_test_utilities.hpp"
 
 private_key_type get_private_key( name keyname, string role ) {
-   return private_key_type::regenerate<fc::ecc::private_key_shim>(fc::sha256::hash(string(keyname)+role));
+   return private_key_type::regenerate<fc::ecc::private_key_shim>(fc::sha256::hash(keyname.to_string()+role));
 }
 
 public_key_type  get_public_key( name keyname, string role ){

--- a/unittests/misc_tests.cpp
+++ b/unittests/misc_tests.cpp
@@ -88,7 +88,8 @@ namespace eosio
 using namespace chain;
 using namespace std;
 
-static constexpr uint64_t name_suffix( uint64_t n ) {
+static constexpr uint64_t name_suffix( name nv ) {
+   uint64_t n = nv.to_uint64_t();
    uint32_t remaining_bits_after_last_actual_dot = 0;
    uint32_t tmp = 0;
    for( int32_t remaining_bits = 59; remaining_bits >= 4; remaining_bits -= 5 ) { // Note: remaining_bits must remain signed integer
@@ -130,7 +131,7 @@ BOOST_AUTO_TEST_CASE(reverse_endian_tests)
 
 BOOST_AUTO_TEST_CASE(name_suffix_tests)
 {
-   BOOST_CHECK_EQUAL( name{name_suffix(0)}, name{0} );
+   BOOST_CHECK_EQUAL( name{name_suffix(name(0))}, name{0} );
    BOOST_CHECK_EQUAL( name{name_suffix(N(abcdehijklmn))}, name{N(abcdehijklmn)} );
    BOOST_CHECK_EQUAL( name{name_suffix(N(abcdehijklmn1))}, name{N(abcdehijklmn1)} );
    BOOST_CHECK_EQUAL( name{name_suffix(N(abc.def))}, name{N(def)} );
@@ -326,9 +327,9 @@ struct permission_visitor {
 BOOST_AUTO_TEST_CASE(authority_checker)
 { try {
    testing::TESTER test;
-   auto a = test.get_public_key("a", "active");
-   auto b = test.get_public_key("b", "active");
-   auto c = test.get_public_key("c", "active");
+   auto a = test.get_public_key(name("a"), "active");
+   auto b = test.get_public_key(name("b"), "active");
+   auto c = test.get_public_key(name("c"), "active");
 
    auto GetNullAuthority = [](auto){abort(); return authority();};
 
@@ -384,7 +385,7 @@ BOOST_AUTO_TEST_CASE(authority_checker)
       return authority(1, {key_weight{c, 1}});
    };
 
-   A = authority(2, {key_weight{a, 2}, key_weight{b, 1}}, {permission_level_weight{{"hello",  "world"}, 1}});
+   A = authority(2, {key_weight{a, 2}, key_weight{b, 1}}, {permission_level_weight{{name("hello"), name("world")}, 1}});
    {
       auto checker = make_auth_checker(GetCAuthority, 2, {a});
       BOOST_TEST(checker.satisfied(A));
@@ -424,7 +425,7 @@ BOOST_AUTO_TEST_CASE(authority_checker)
       BOOST_TEST(checker.unused_keys().count(c) == 1u);
    }
 
-   A = authority(3, {key_weight{a, 2}, key_weight{b, 1}}, {permission_level_weight{{"hello",  "world"}, 3}});
+   A = authority(3, {key_weight{a, 2}, key_weight{b, 1}}, {permission_level_weight{{name("hello"), name("world")}, 3}});
    {
       auto checker = make_auth_checker(GetCAuthority, 2, {a, b});
       BOOST_TEST(checker.satisfied(A));
@@ -441,7 +442,7 @@ BOOST_AUTO_TEST_CASE(authority_checker)
       BOOST_TEST(checker.unused_keys().count(b) == 1u);
    }
 
-   A = authority(2, {key_weight{a, 1}, key_weight{b, 1}}, {permission_level_weight{{"hello",  "world"}, 1}});
+   A = authority(2, {key_weight{a, 1}, key_weight{b, 1}}, {permission_level_weight{{name("hello"), name("world")}, 1}});
    BOOST_TEST(!make_auth_checker(GetCAuthority, 2, {a}).satisfied(A));
    BOOST_TEST(!make_auth_checker(GetCAuthority, 2, {b}).satisfied(A));
    BOOST_TEST(!make_auth_checker(GetCAuthority, 2, {c}).satisfied(A));
@@ -457,7 +458,7 @@ BOOST_AUTO_TEST_CASE(authority_checker)
       BOOST_TEST(checker.unused_keys().count(c) == 1u);
    }
 
-   A = authority(2, {key_weight{a, 1}, key_weight{b, 1}}, {permission_level_weight{{"hello",  "world"}, 2}});
+   A = authority(2, {key_weight{a, 1}, key_weight{b, 1}}, {permission_level_weight{{name("hello"), name("world")}, 2}});
    BOOST_TEST(make_auth_checker(GetCAuthority, 2, {a, b}).satisfied(A));
    BOOST_TEST(make_auth_checker(GetCAuthority, 2, {c}).satisfied(A));
    BOOST_TEST(!make_auth_checker(GetCAuthority, 2, {a}).satisfied(A));
@@ -471,16 +472,16 @@ BOOST_AUTO_TEST_CASE(authority_checker)
       BOOST_TEST(checker.used_keys().count(c) == 1u);
    }
 
-   auto d = test.get_public_key("d", "active");
-   auto e = test.get_public_key("e", "active");
+   auto d = test.get_public_key(name("d"), "active");
+   auto e = test.get_public_key(name("e"), "active");
 
    auto GetAuthority = [d, e] (const permission_level& perm) {
-      if (perm.actor == "top")
-         return authority(2, {key_weight{d, 1}}, {permission_level_weight{{"bottom",  "bottom"}, 1}});
+      if (perm.actor == name("top"))
+         return authority(2, {key_weight{d, 1}}, {permission_level_weight{{name("bottom"), name("bottom")}, 1}});
       return authority{1, {{e, 1}}, {}};
    };
 
-   A = authority(5, {key_weight{a, 2}, key_weight{b, 2}, key_weight{c, 2}}, {permission_level_weight{{"top",  "top"}, 5}});
+   A = authority(5, {key_weight{a, 2}, key_weight{b, 2}, key_weight{c, 2}}, {permission_level_weight{{name("top"), name("top")}, 5}});
    {
       auto checker = make_auth_checker(GetAuthority, 2, {d, e});
       BOOST_TEST(checker.satisfied(A));
@@ -547,38 +548,38 @@ BOOST_AUTO_TEST_CASE(authority_checker)
    }
    {
       auto A2 = authority(4, {key_weight{b, 1}, key_weight{a, 1}, key_weight{c, 1}},
-                          { permission_level_weight{{"a",  "world"},     1},
-                            permission_level_weight{{"hello",  "world"}, 1},
-                            permission_level_weight{{"hi",  "world"},    1}
+                          { permission_level_weight{{name("a"), name("world")},     1},
+                            permission_level_weight{{name("hello"), name("world")}, 1},
+                            permission_level_weight{{name("hi"), name("world")},    1}
                           });
       auto B2 = authority(4, {key_weight{b, 1}, key_weight{a, 1}, key_weight{c, 1}},
-                          {permission_level_weight{{"hello",  "world"}, 1}
+                          {permission_level_weight{{name("hello"), name("world")}, 1}
                           });
       auto C2 = authority(4, {key_weight{b, 1}, key_weight{a, 1}, key_weight{c, 1}},
-                          { permission_level_weight{{"hello",  "there"}, 1},
-                            permission_level_weight{{"hello",  "world"}, 1}
+                          { permission_level_weight{{name("hello"), name("there")}, 1},
+                            permission_level_weight{{name("hello"), name("world")}, 1}
                           });
       // invalid: duplicate
       auto D2 = authority(4, {key_weight{b, 1}, key_weight{a, 1}, key_weight{c, 1}},
-                          { permission_level_weight{{"hello",  "world"}, 1},
-                            permission_level_weight{{"hello",  "world"}, 2}
+                          { permission_level_weight{{name("hello"), name("world")}, 1},
+                            permission_level_weight{{name("hello"), name("world")}, 2}
                           });
       // invalid: wrong order
       auto E2 = authority(4, {key_weight{b, 1}, key_weight{a, 1}, key_weight{c, 1}},
-                          { permission_level_weight{{"hello",  "world"}, 2},
-                            permission_level_weight{{"hello",  "there"}, 1}
+                          { permission_level_weight{{name("hello"), name("world")}, 2},
+                            permission_level_weight{{name("hello"), name("there")}, 1}
                           });
       // invalid: wrong order
       auto F2 = authority(4, {key_weight{b, 1}, key_weight{a, 1}, key_weight{c, 1}},
-                          { permission_level_weight{{"hi",  "world"}, 2},
-                            permission_level_weight{{"hello",  "world"}, 1}
+                          { permission_level_weight{{name("hi"), name("world")}, 2},
+                            permission_level_weight{{name("hello"), name("world")}, 1}
                           });
 
       // invalid: insufficient weight
       auto G2 = authority(7, {key_weight{b, 1}, key_weight{a, 1}, key_weight{c, 1}},
-                             { permission_level_weight{{"a",  "world"},     1},
-                               permission_level_weight{{"hello",  "world"}, 1},
-                               permission_level_weight{{"hi",  "world"},    1}
+                             { permission_level_weight{{name("a"), name("world")},     1},
+                               permission_level_weight{{name("hello"), name("world")}, 1},
+                               permission_level_weight{{name("hi"), name("world")},    1}
                              });
 
       BOOST_TEST(validate(A2));
@@ -623,7 +624,7 @@ BOOST_AUTO_TEST_CASE(alphabetic_sort)
   vector<uint64_t> uwords;
   for(const auto w: words) {
     auto n = name(w.c_str());
-    uwords.push_back(n.value);
+    uwords.push_back(n.to_uint64_t());
   }
 
   std::sort(uwords.begin(), uwords.end(), std::less<uint64_t>());

--- a/unittests/protocol_feature_tests.cpp
+++ b/unittests/protocol_feature_tests.cpp
@@ -236,7 +236,7 @@ BOOST_AUTO_TEST_CASE( only_link_to_existing_permission_test ) try {
       ("account", "alice")
       ("permission", "test")
       ("parent", "active")
-      ("auth", authority(get_public_key("testapi", "test")))
+      ("auth", authority(get_public_key(name("testapi"), "test")))
    );
 
    c.produce_block();
@@ -660,7 +660,7 @@ BOOST_AUTO_TEST_CASE( no_duplicate_deferred_id_test ) try {
 
    check_generation_context( index.begin()->packed_trx,
                              trace2->id,
-                             ((static_cast<unsigned __int128>(N(alice)) << 64) | 1),
+                             ((static_cast<unsigned __int128>(N(alice).to_uint64_t()) << 64) | 1),
                              N(test) );
 
    c.produce_block();
@@ -678,7 +678,7 @@ BOOST_AUTO_TEST_CASE( no_duplicate_deferred_id_test ) try {
 
    check_generation_context( index.begin()->packed_trx,
                              trace3->id,
-                             ((static_cast<unsigned __int128>(N(alice)) << 64) | 1),
+                             ((static_cast<unsigned __int128>(N(alice).to_uint64_t()) << 64) | 1),
                              N(test) );
 
    c.produce_block();

--- a/unittests/ram_tests.cpp
+++ b/unittests/ram_tests.cpp
@@ -36,7 +36,7 @@ BOOST_FIXTURE_TEST_CASE(ram_tests, eosio_system::eosio_system_tester) { try {
    create_account_with_resources(N(testram11111),config::system_account_name, init_request_bytes + 40);
    create_account_with_resources(N(testram22222),config::system_account_name, init_request_bytes + 1190);
    produce_blocks(10);
-   BOOST_REQUIRE_EQUAL( success(), stake( "eosio.stake", "testram11111", core_from_string("10.0000"), core_from_string("5.0000") ) );
+   BOOST_REQUIRE_EQUAL( success(), stake( name("eosio.stake"), name("testram11111"), core_from_string("10.0000"), core_from_string("5.0000") ) );
    produce_blocks(10);
 
    for (auto i = 0; i < 10; ++i) {

--- a/unittests/special_accounts_tests.cpp
+++ b/unittests/special_accounts_tests.cpp
@@ -65,7 +65,7 @@ BOOST_FIXTURE_TEST_CASE(accounts_exists, tester)
       for (size_t i = 0; i < std::max(active_auth.size(), active_producers.producers.size()); ++i) {
          account_name n1 = i < active_auth.size() ? active_auth[i] : (account_name)0;
          account_name n2 = i < active_producers.producers.size() ? active_producers.producers[i].producer_name : (account_name)0;
-         if (n1 != n2) diff.push_back((uint64_t)n2 - (uint64_t)n1);
+         if (n1 != n2) diff.push_back(name(n2.to_uint64_t() - n1.to_uint64_t()));
       }
 
       BOOST_CHECK_EQUAL(diff.size(), 0);

--- a/unittests/wasm_tests.cpp
+++ b/unittests/wasm_tests.cpp
@@ -383,23 +383,23 @@ BOOST_FIXTURE_TEST_CASE( f32_f64_overflow_tests, tester ) try {
    int count = 0;
    auto check = [&](const char *wast_template, const char *op, const char *param) -> bool {
       count+=16;
-      create_accounts( {N(f_tests)+count} );
+      create_accounts( {name(N(f_tests).to_uint64_t()+count)} );
       produce_blocks(1);
       std::vector<char> wast;
       wast.resize(strlen(wast_template) + 128);
       sprintf(&(wast[0]), wast_template, op, param);
-      set_code(N(f_tests)+count, &(wast[0]));
+      set_code(name(N(f_tests).to_uint64_t()+count), &(wast[0]));
       produce_blocks(10);
 
       signed_transaction trx;
       action act;
-      act.account = N(f_tests)+count;
+      act.account = name(N(f_tests).to_uint64_t()+count);
       act.name = N();
-      act.authorization = vector<permission_level>{{N(f_tests)+count,config::active_name}};
+      act.authorization = vector<permission_level>{{name(N(f_tests).to_uint64_t()+count),config::active_name}};
       trx.actions.push_back(act);
 
       set_transaction_headers(trx);
-      trx.sign(get_private_key( N(f_tests)+count, "active" ), control->get_chain_id());
+      trx.sign(get_private_key( name(N(f_tests).to_uint64_t()+count), "active" ), control->get_chain_id());
 
       try {
          push_transaction(trx);
@@ -608,7 +608,7 @@ BOOST_FIXTURE_TEST_CASE( check_global_reset, TESTER ) try {
    {
    action act;
    act.account = N(globalreset);
-   act.name = 1ULL;
+   act.name = name(1ULL);
    act.authorization = vector<permission_level>{{N(globalreset),config::active_name}};
    trx.actions.push_back(act);
    }
@@ -1087,7 +1087,7 @@ BOOST_FIXTURE_TEST_CASE( check_table_maximum, TESTER ) try {
    {
    signed_transaction trx;
    action act;
-   act.name = 555ULL<<32 | 0ULL;       //top 32 is what we assert against, bottom 32 is indirect call index
+   act.name = name(555ULL<<32 | 0ULL);       //top 32 is what we assert against, bottom 32 is indirect call index
    act.account = N(tbl);
    act.authorization = vector<permission_level>{{N(tbl),config::active_name}};
    trx.actions.push_back(act);
@@ -1101,7 +1101,7 @@ BOOST_FIXTURE_TEST_CASE( check_table_maximum, TESTER ) try {
    {
    signed_transaction trx;
    action act;
-   act.name = 555ULL<<32 | 1022ULL;       //top 32 is what we assert against, bottom 32 is indirect call index
+   act.name = name(555ULL<<32 | 1022ULL);       //top 32 is what we assert against, bottom 32 is indirect call index
    act.account = N(tbl);
    act.authorization = vector<permission_level>{{N(tbl),config::active_name}};
    trx.actions.push_back(act);
@@ -1115,7 +1115,7 @@ BOOST_FIXTURE_TEST_CASE( check_table_maximum, TESTER ) try {
    {
    signed_transaction trx;
    action act;
-   act.name = 7777ULL<<32 | 1023ULL;       //top 32 is what we assert against, bottom 32 is indirect call index
+   act.name = name(7777ULL<<32 | 1023ULL);       //top 32 is what we assert against, bottom 32 is indirect call index
    act.account = N(tbl);
    act.authorization = vector<permission_level>{{N(tbl),config::active_name}};
    trx.actions.push_back(act);
@@ -1129,7 +1129,7 @@ BOOST_FIXTURE_TEST_CASE( check_table_maximum, TESTER ) try {
    {
    signed_transaction trx;
    action act;
-   act.name = 7778ULL<<32 | 1023ULL;       //top 32 is what we assert against, bottom 32 is indirect call index
+   act.name = name(7778ULL<<32 | 1023ULL);       //top 32 is what we assert against, bottom 32 is indirect call index
    act.account = N(tbl);
    act.authorization = vector<permission_level>{{N(tbl),config::active_name}};
    trx.actions.push_back(act);
@@ -1145,7 +1145,7 @@ BOOST_FIXTURE_TEST_CASE( check_table_maximum, TESTER ) try {
    {
    signed_transaction trx;
    action act;
-   act.name = 133ULL<<32 | 5ULL;       //top 32 is what we assert against, bottom 32 is indirect call index
+   act.name = name(133ULL<<32 | 5ULL);       //top 32 is what we assert against, bottom 32 is indirect call index
    act.account = N(tbl);
    act.authorization = vector<permission_level>{{N(tbl),config::active_name}};
    trx.actions.push_back(act);
@@ -1161,7 +1161,7 @@ BOOST_FIXTURE_TEST_CASE( check_table_maximum, TESTER ) try {
    {
    signed_transaction trx;
    action act;
-   act.name = eosio::chain::wasm_constraints::maximum_table_elements+54334;
+   act.name = name(eosio::chain::wasm_constraints::maximum_table_elements+54334);
    act.account = N(tbl);
    act.authorization = vector<permission_level>{{N(tbl),config::active_name}};
    trx.actions.push_back(act);
@@ -1181,7 +1181,7 @@ BOOST_FIXTURE_TEST_CASE( check_table_maximum, TESTER ) try {
    {
    signed_transaction trx;
    action act;
-   act.name = 555ULL<<32 | 1022ULL;       //top 32 is what we assert against, bottom 32 is indirect call index
+   act.name = name(555ULL<<32 | 1022ULL);       //top 32 is what we assert against, bottom 32 is indirect call index
    act.account = N(tbl);
    act.authorization = vector<permission_level>{{N(tbl),config::active_name}};
    trx.actions.push_back(act);
@@ -1194,7 +1194,7 @@ BOOST_FIXTURE_TEST_CASE( check_table_maximum, TESTER ) try {
    {
    signed_transaction trx;
    action act;
-   act.name = 7777ULL<<32 | 1023ULL;       //top 32 is what we assert against, bottom 32 is indirect call index
+   act.name = name(7777ULL<<32 | 1023ULL);       //top 32 is what we assert against, bottom 32 is indirect call index
    act.account = N(tbl);
    act.authorization = vector<permission_level>{{N(tbl),config::active_name}};
    trx.actions.push_back(act);
@@ -1208,7 +1208,7 @@ BOOST_FIXTURE_TEST_CASE( check_table_maximum, TESTER ) try {
    {
    signed_transaction trx;
    action act;
-   act.name = 888ULL;
+   act.name = name(888ULL);
    act.account = N(tbl);
    act.authorization = vector<permission_level>{{N(tbl),config::active_name}};
    trx.actions.push_back(act);

--- a/unittests/whitelist_blacklist_tests.cpp
+++ b/unittests/whitelist_blacklist_tests.cpp
@@ -452,7 +452,7 @@ BOOST_AUTO_TEST_CASE( actor_blacklist_inline_deferred ) { try {
    tester1.chain->set_abi( N(charlie),  contracts::deferred_test_abi().data() );
    tester1.chain->produce_blocks();
 
-   auto auth = authority(eosio::testing::base_tester::get_public_key("alice", "active"));
+   auto auth = authority(eosio::testing::base_tester::get_public_key(name("alice"), "active"));
    auth.accounts.push_back( permission_level_weight{{N(alice), config::eosio_code_name}, 1} );
 
    tester1.chain->push_action( N(eosio), N(updateauth), N(alice), mvo()
@@ -462,7 +462,7 @@ BOOST_AUTO_TEST_CASE( actor_blacklist_inline_deferred ) { try {
       ( "auth", auth )
    );
 
-   auth = authority(eosio::testing::base_tester::get_public_key("bob", "active"));
+   auth = authority(eosio::testing::base_tester::get_public_key(name("bob"), "active"));
    auth.accounts.push_back( permission_level_weight{{N(alice), config::eosio_code_name}, 1} );
    auth.accounts.push_back( permission_level_weight{{N(bob), config::eosio_code_name}, 1} );
 
@@ -473,7 +473,7 @@ BOOST_AUTO_TEST_CASE( actor_blacklist_inline_deferred ) { try {
       ( "auth", auth )
    );
 
-   auth = authority(eosio::testing::base_tester::get_public_key("charlie", "active"));
+   auth = authority(eosio::testing::base_tester::get_public_key(name("charlie"), "active"));
    auth.accounts.push_back( permission_level_weight{{N(charlie), config::eosio_code_name}, 1} );
 
    tester1.chain->push_action( N(eosio), N(updateauth), N(charlie), mvo()
@@ -596,7 +596,7 @@ BOOST_AUTO_TEST_CASE( blacklist_sender_bypass ) { try {
    tester1.chain->set_abi( N(charlie),  contracts::deferred_test_abi().data() );
    tester1.chain->produce_blocks();
 
-   auto auth = authority(eosio::testing::base_tester::get_public_key("alice", "active"));
+   auto auth = authority(eosio::testing::base_tester::get_public_key(name("alice"), "active"));
    auth.accounts.push_back( permission_level_weight{{N(alice), config::eosio_code_name}, 1} );
 
    tester1.chain->push_action( N(eosio), N(updateauth), N(alice), mvo()
@@ -606,7 +606,7 @@ BOOST_AUTO_TEST_CASE( blacklist_sender_bypass ) { try {
       ( "auth", auth )
    );
 
-   auth = authority(eosio::testing::base_tester::get_public_key("bob", "active"));
+   auth = authority(eosio::testing::base_tester::get_public_key(name("bob"), "active"));
    auth.accounts.push_back( permission_level_weight{{N(bob), config::eosio_code_name}, 1} );
 
    tester1.chain->push_action( N(eosio), N(updateauth), N(bob), mvo()
@@ -616,7 +616,7 @@ BOOST_AUTO_TEST_CASE( blacklist_sender_bypass ) { try {
       ( "auth", auth )
    );
 
-   auth = authority(eosio::testing::base_tester::get_public_key("charlie", "active"));
+   auth = authority(eosio::testing::base_tester::get_public_key(name("charlie"), "active"));
    auth.accounts.push_back( permission_level_weight{{N(charlie), config::eosio_code_name}, 1} );
 
    tester1.chain->push_action( N(eosio), N(updateauth), N(charlie), mvo()


### PR DESCRIPTION
## Change Description

- Make construction of `name` explicit
- Make conversion from `name` explicit
- Make `name` immutable except for "creation" from `fc::variant`
- Use `std::string_view` instead of `const char*` and `std::string` for construction

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
