### PR TITLE
Fix under min avail ram test

### DIFF
--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1254,6 +1254,7 @@ void chain_plugin::log_guard_exception(const chain::guard_exception&e ) const {
 void chain_plugin::handle_guard_exception(const chain::guard_exception& e) const {
    log_guard_exception(e);
 
+   elog("database chain::guard_exception, quiting..."); // log string searched for in: tests/nodeos_under_min_avail_ram.py
    // quit the app
    app().quit();
 }

--- a/tests/nodeos_under_min_avail_ram.py
+++ b/tests/nodeos_under_min_avail_ram.py
@@ -205,8 +205,8 @@ try:
     for i in range(numNodes):
         f = open(Utils.getNodeDataDir(i) + "/stderr.txt")
         contents = f.read()
-        if contents.find("3060101 database_guard_exception") == -1:
-            errorExit("Node%d is expected to exit because of database_guard_exception, but was not." % (i))
+        if contents.find("database chain::guard_exception") == -1:
+            errorExit("Node%d is expected to exit because of database guard_exception, but was not." % (i))
 
     Print("all nodes exited with expected reason database_guard_exception")
 


### PR DESCRIPTION
## Change Description

- Fix the `tests/nodeos_under_min_avail_ram.py` test to look for a specific error level log output since the default logging was changed from `debug` to `info`.

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
