### PR TITLE
fix block serialization order in fork_database::close - v1.8.x

### DIFF
--- a/libraries/chain/fork_database.cpp
+++ b/libraries/chain/fork_database.cpp
@@ -200,7 +200,7 @@ namespace eosio { namespace chain {
          auto itr = (validated_remaining ? validated_itr : unvalidated_itr);
 
          if( unvalidated_remaining && validated_remaining ) {
-            if( first_preferred( **unvalidated_itr, **validated_itr ) ) {
+            if( first_preferred( **validated_itr, **unvalidated_itr ) ) {
                itr = unvalidated_itr;
                ++unvalidated_itr;
             } else {


### PR DESCRIPTION
## Change Description

This PR fixes a bug in `fork_database::close` which serialized blocks to disk in the wrong order thus causing unlinkable block errors when attempting to open the fork_db.dat file in `fork_database::open`. 

Also, a new unit test, `forked_tests/reopen_forkdb`, has been added to test a scenario that lead to the unlinkable block errors described above when the `fork_database::close` was not fixed.

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions

