### PR TITLE
Use debug level logging for --verbose - 1.6.x

### DIFF
--- a/unittests/main.cpp
+++ b/unittests/main.cpp
@@ -26,7 +26,11 @@ boost::unit_test::test_suite* init_unit_test_suite(int argc, char* argv[]) {
          break;
       }
    }
-   if(!is_verbose) fc::logger::get(DEFAULT_LOGGER).set_log_level(fc::log_level::off);
+   if(is_verbose) {
+      fc::logger::get(DEFAULT_LOGGER).set_log_level(fc::log_level::debug);
+   } else {
+      fc::logger::get(DEFAULT_LOGGER).set_log_level(fc::log_level::off);
+   }
 
    // Register fc::exception translator
    boost::unit_test::unit_test_monitor.register_exception_translator<fc::exception>(&translate_fc_exception);


### PR DESCRIPTION
## Change Description

- Use debug level logging when --verbose output requested for unittests

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
