### PR TITLE
Anka 1.8.x fixes

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,7 +10,7 @@ steps:
   - label: ":darwin: Ensure Mojave Anka Template Dependency Tag/Layer Exists"
     command:
       - "git clone git@github.com:EOSIO/mac-anka-fleet.git"
-      - "cd mac-anka-fleet && . ./ensure_tag.bash -u 12 -r 25G -a \"-n\""
+      - "cd mac-anka-fleet && ./ensure_tag.bash -u 12 -r 25G -a \"-n\""
     agents:
       - "queue=mac-anka-templater-fleet"
     env:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -32,7 +32,7 @@ steps:
 
   - label: ":darwin: [Darwin] Mojave Build"
     command:
-      - "git clone ${BUILDKITE_PULL_REQUEST_REPO:-$BUILDKITE_REPO} && cd eos && git checkout ${BUILDKITE_COMMIT} && git submodule update --init --recursive && ./scripts/eosio_build.sh -y -P -m && tar -pczf build.tar.gz build"
+      - "git clone ${BUILDKITE_PULL_REQUEST_REPO:-$BUILDKITE_REPO} && cd eos && git checkout ${BUILDKITE_COMMIT} && git submodule update --init --recursive && ./scripts/eosio_build.sh -y -P -m && tar -pczf build.tar.gz build && mv build.tar.gz ../"
     artifact_paths: "build.tar.gz"
     plugins:
       chef/anka#v0.4.4:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -32,8 +32,7 @@ steps:
 
   - label: ":darwin: [Darwin] Mojave Build"
     command:
-      - "git clone ${BUILDKITE_PULL_REQUEST_REPO:-$BUILDKITE_REPO} && cd eos && git checkout ${BUILDKITE_COMMIT} && git submodule update --init --recursive && ./scripts/eosio_build.sh -y -P -m && tar -pczf build.tar.gz build && mv build.tar.gz ../"
-    artifact_paths: "build.tar.gz"
+      - "git clone ${BUILDKITE_PULL_REQUEST_REPO:-$BUILDKITE_REPO} && cd eos && git checkout ${BUILDKITE_COMMIT} && git submodule update --init --recursive && ./scripts/eosio_build.sh -y -P -m && tar -pczf build.tar.gz build && buildkite-agent artifact upload build.tar.gz"
     plugins:
       chef/anka#v0.4.4:
         no-volume: true

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,7 +10,7 @@ steps:
   - label: ":darwin: Ensure Mojave Anka Template Dependency Tag/Layer Exists"
     command:
       - "git clone git@github.com:EOSIO/mac-anka-fleet.git"
-      - "cd mac-anka-fleet && . ./ensure_tag.bash -a \"-n\""
+      - "cd mac-anka-fleet && . ./ensure_tag.bash -u 12 -r 25G -a \"-n\""
     agents:
       - "queue=mac-anka-templater-fleet"
     env:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,7 +10,7 @@ steps:
   - label: ":darwin: Ensure Mojave Anka Template Dependency Tag/Layer Exists"
     command:
       - "git clone git@github.com:EOSIO/mac-anka-fleet.git"
-      - "cd mac-anka-fleet && ./ensure_tag.bash -u 12 -r 25G -a \"-n\""
+      - "cd mac-anka-fleet && . ./ensure_tag.bash -u 12 -r 25G -a \"-n\""
     agents:
       - "queue=mac-anka-templater-fleet"
     env:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -32,8 +32,7 @@ steps:
 
   - label: ":darwin: [Darwin] Mojave Build"
     command:
-      - "git clone ${BUILDKITE_PULL_REQUEST_REPO:-$BUILDKITE_REPO} && cd eos && git checkout ${BUILDKITE_COMMIT} && git submodule update --init --recursive && ./scripts/eosio_build.sh -y -P -m"
-      - "tar -pczf build.tar.gz build"
+      - "git clone ${BUILDKITE_PULL_REQUEST_REPO:-$BUILDKITE_REPO} && cd eos && git checkout ${BUILDKITE_COMMIT} && git submodule update --init --recursive && ./scripts/eosio_build.sh -y -P -m && tar -pczf build.tar.gz build"
     artifact_paths: "build.tar.gz"
     plugins:
       chef/anka#v0.4.4:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -33,7 +33,8 @@ steps:
   - label: ":darwin: [Darwin] Mojave Build"
     command:
       - "git clone ${BUILDKITE_PULL_REQUEST_REPO:-$BUILDKITE_REPO} && cd eos && git checkout ${BUILDKITE_COMMIT} && git submodule update --init --recursive && ./scripts/eosio_build.sh -y -P -m"
-      - "tar -pczf /Network/NAS/MAC_FLEET/BUILDKITE/artifacts/${ANKA_MOJAVE_TEMPLATE}-${BUILDKITE_PIPELINE_SLUG}-${BUILDKITE_BUILD_ID}.tar.gz eos"
+      - "tar -pczf build.tar.gz build"
+    artifact_paths: "build.tar.gz"
     plugins:
       chef/anka#v0.4.4:
         no-volume: true
@@ -152,8 +153,9 @@ steps:
   # MOJAVE #
   - label: ":darwin: [Darwin] Mojave Tests"
     command:
-      - "tar -xzf /Network/NAS/MAC_FLEET/BUILDKITE/artifacts/${ANKA_MOJAVE_TEMPLATE}-${BUILDKITE_PIPELINE_SLUG}-${BUILDKITE_BUILD_ID}.tar.gz"
-      - "cd eos && ./scripts/parallel-test.sh"
+      - "git clone ${BUILDKITE_PULL_REQUEST_REPO:-$BUILDKITE_REPO} && cd eos && git checkout ${BUILDKITE_COMMIT}"
+      - "buildkite-agent artifact download \"build.tar.gz\" . --step \":darwin: [Darwin] Mojave Build\""
+      - "./scripts/parallel-test.sh"
     agents:
       - "queue=mac-anka-node-fleet"
     plugins:
@@ -171,8 +173,9 @@ steps:
 
   - label: ":darwin: [Darwin] Mojave NP Tests"
     command:
-      - "tar -xzf /Network/NAS/MAC_FLEET/BUILDKITE/artifacts/${ANKA_MOJAVE_TEMPLATE}-${BUILDKITE_PIPELINE_SLUG}-${BUILDKITE_BUILD_ID}.tar.gz"
-      - "cd eos && ./scripts/serial-test.sh"
+      - "git clone ${BUILDKITE_PULL_REQUEST_REPO:-$BUILDKITE_REPO} && cd eos && git checkout ${BUILDKITE_COMMIT}"
+      - "buildkite-agent artifact download \"build.tar.gz\" . --step \":darwin: [Darwin] Mojave Build\""
+      - "./scripts/serial-test.sh"
     agents:
       - "queue=mac-anka-node-fleet"
     plugins:
@@ -467,7 +470,7 @@ steps:
 
   - label: ":darwin: Mojave Package Builder"
     command:
-      - "tar -xzf /Network/NAS/MAC_FLEET/BUILDKITE/artifacts/${ANKA_MOJAVE_TEMPLATE}-${BUILDKITE_PIPELINE_SLUG}-${BUILDKITE_BUILD_ID}.tar.gz"
+      - "git clone ${BUILDKITE_PULL_REQUEST_REPO:-$BUILDKITE_REPO} && cd eos && git checkout ${BUILDKITE_COMMIT} && buildkite-agent artifact download \"build.tar.gz\" . --step \":darwin: [Darwin] Mojave Build\" && tar -xzf build.tar.gz"
       - "cd eos/build/packages && bash generate_package.sh brew"
       - "cd eos && buildkite-agent artifact upload build/packages/*.tar.gz"
       - "cd eos && buildkite-agent artifact upload build/packages/*.rb"
@@ -476,6 +479,7 @@ steps:
     plugins:
       chef/anka#v0.4.4:
         no-volume: true
+        workdir: $WORKDIR
         inherit-environment-vars: true
         bash-interactive: true
         vm-name: $ANKA_MOJAVE_TEMPLATE

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -152,9 +152,8 @@ steps:
   # MOJAVE #
   - label: ":darwin: [Darwin] Mojave Tests"
     command:
-      - "git clone ${BUILDKITE_PULL_REQUEST_REPO:-$BUILDKITE_REPO} && cd eos && git checkout ${BUILDKITE_COMMIT}"
-      - "buildkite-agent artifact download \"build.tar.gz\" . --step \":darwin: [Darwin] Mojave Build\""
-      - "./scripts/parallel-test.sh"
+      - "git clone ${BUILDKITE_PULL_REQUEST_REPO:-$BUILDKITE_REPO} && cd eos && git checkout ${BUILDKITE_COMMIT} && buildkite-agent artifact download \"build.tar.gz\" . --step \":darwin: [Darwin] Mojave Build\""
+      - "cd eos && ./scripts/parallel-test.sh"
     agents:
       - "queue=mac-anka-node-fleet"
     plugins:
@@ -172,9 +171,8 @@ steps:
 
   - label: ":darwin: [Darwin] Mojave NP Tests"
     command:
-      - "git clone ${BUILDKITE_PULL_REQUEST_REPO:-$BUILDKITE_REPO} && cd eos && git checkout ${BUILDKITE_COMMIT}"
-      - "buildkite-agent artifact download \"build.tar.gz\" . --step \":darwin: [Darwin] Mojave Build\""
-      - "./scripts/serial-test.sh"
+      - "git clone ${BUILDKITE_PULL_REQUEST_REPO:-$BUILDKITE_REPO} && cd eos && git checkout ${BUILDKITE_COMMIT} && buildkite-agent artifact download \"build.tar.gz\" . --step \":darwin: [Darwin] Mojave Build\""
+      - "cd eos && ./scripts/serial-test.sh"
     agents:
       - "queue=mac-anka-node-fleet"
     plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,7 +10,7 @@ steps:
   - label: ":darwin: Ensure Mojave Anka Template Dependency Tag/Layer Exists"
     command:
       - "git clone git@github.com:EOSIO/mac-anka-fleet.git"
-      - "cd mac-anka-fleet && . ./ensure_tag.bash -u '12' -r '25G' -a \"-n\""
+      - "cd mac-anka-fleet && . ./ensure_tag.bash -u 12 -r 25G -a '-n'"
     agents:
       - "queue=mac-anka-templater-fleet"
     env:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,7 +10,7 @@ steps:
   - label: ":darwin: Ensure Mojave Anka Template Dependency Tag/Layer Exists"
     command:
       - "git clone git@github.com:EOSIO/mac-anka-fleet.git"
-      - "cd mac-anka-fleet && . ./ensure_tag.bash -u 12 -r 25G -a \"-n\""
+      - "cd mac-anka-fleet && . ./ensure_tag.bash -u '12' -r '25G' -a \"-n\""
     agents:
       - "queue=mac-anka-templater-fleet"
     env:


### PR DESCRIPTION
These fixes move us back to buildkite's artifact storage since the NAS is not as stable as I had hoped. Also added the ability to use 12 CPUs for creating the tag/vm layers.