### PR TITLE
Add Version Check for Package Builder

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,6 +6,7 @@ env:
   WORKDIR: "/data/job"
 
 steps:
+  - wait
 
   - label: ":darwin: Ensure Mojave Anka Template Dependency Tag/Layer Exists"
     command:
@@ -22,17 +23,18 @@ steps:
       TAG_COMMANDS: "git clone ${BUILDKITE_PULL_REQUEST_REPO:-$BUILDKITE_REPO} && cd eos && git checkout ${BUILDKITE_COMMIT} && git submodule update --init --recursive && ./scripts/eosio_build.sh -y -P -f -m && cd .. && rm -rf eos" # CLONED_REPO_DIR IS REQUIRED and is where the repo is always cloned into
       PROJECT_TAG: "${MAC_TAG}"
     timeout: 320
-
+    skip: $SKIP_MOJAVE
 
   - wait
 
-  ############################
-  # BUILDING #################
-  ############################
-
   - label: ":darwin: [Darwin] Mojave Build"
-    command:
-      - "git clone ${BUILDKITE_PULL_REQUEST_REPO:-$BUILDKITE_REPO} && cd eos && git checkout ${BUILDKITE_COMMIT} && git submodule update --init --recursive && ./scripts/eosio_build.sh -y -P -m && tar -pczf build.tar.gz build && buildkite-agent artifact upload build.tar.gz"
+    command: |
+      git clone ${BUILDKITE_PULL_REQUEST_REPO:-$BUILDKITE_REPO} .
+      git checkout ${BUILDKITE_COMMIT}
+      git submodule update --init --recursive
+      ./scripts/eosio_build.sh -y -P -m
+      tar -pczf build.tar.gz build
+      [[ -f build.tar.gz ]] && buildkite-agent artifact upload build.tar.gz || (echo '+++ :no_entry: ERROR: No build.tar.gz artifact found, or artifact upload failed!'; echo '$$ ls -la'; ls -la; exit 1)
     plugins:
       chef/anka#v0.4.4:
         no-volume: true
@@ -48,14 +50,13 @@ steps:
     agents:
       - "queue=mac-anka-large-node-fleet"
     timeout: 120
+    skip: $SKIP_MOJAVE
 
-  - command: | # Amazon Linux 2 Build
-        echo "+++ :hammer: Building"
-        ./scripts/eosio_build.sh -y -P -m
-        echo "--- :compression: Compressing build directory"
-        tar -pczf build.tar.gz build
-        if [[ ! -f build.tar.gz ]]; then echo 'ERROR: No build.tar.gz artifact found!' && exit 1; fi
-    label: ":aws: Amazon Linux 2 Build"
+  - label: ":aws: Amazon Linux 2 Build"
+    command: |
+      ./scripts/eosio_build.sh -y -P -m
+      tar -pczf build.tar.gz build
+      [[ ! -f build.tar.gz ]] && (echo '+++ :no_entry: ERROR: No build.tar.gz artifact found!'; echo '$$ ls -la'; ls -la; exit 1) || :
     agents:
       queue: "automation-large-builder-fleet"
     artifact_paths: "build.tar.gz"
@@ -65,20 +66,19 @@ steps:
         account_ids: "436617320021"
         no-include-email: true
         region: "us-west-2"
-      docker#v2.1.0:
+      docker#v3.1.0:
+        shell: ["/bin/bash", "-i", "-e", "-c"]
         debug: true
         image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:amazonlinux2_1-8-0-rc1"
         propagate-environment: true
         workdir: /data/job
     timeout: 120
 
-  - command: | # CentOS 7 Build
-        echo "+++ :hammer: Building"
-        ./scripts/eosio_build.sh -y -P -m
-        echo "--- :compression: Compressing build directory"
-        tar -pczf build.tar.gz build
-        if [[ ! -f build.tar.gz ]]; then echo 'ERROR: No build.tar.gz artifact found!' && exit 1; fi
-    label: ":centos: CentOS 7 Build"
+  - label: ":centos: CentOS 7 Build"
+    command: |
+      ./scripts/eosio_build.sh -y -P -m
+      tar -pczf build.tar.gz build
+      [[ ! -f build.tar.gz ]] && (echo '+++ :no_entry: ERROR: No build.tar.gz artifact found!'; echo '$$ ls -la'; ls -la; exit 1) || :
     agents:
       queue: "automation-large-builder-fleet"
     artifact_paths: "build.tar.gz"
@@ -88,19 +88,19 @@ steps:
         account_ids: "436617320021"
         no-include-email: true
         region: "us-west-2"
-      docker#v2.1.0:
+      docker#v3.2.0:
+        shell: ["/bin/bash", "-i", "-e", "-c"]
         debug: true
         image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:centos7_1-8-0-rc1"
         propagate-environment: true
         workdir: /data/job
     timeout: 120
 
-  - command: | # Ubuntu 16.04 Build
-        echo "+++ :hammer: Building"
-        ./scripts/eosio_build.sh -y -P -m
-        echo "--- :compression: Compressing build directory"
-        tar -pczf build.tar.gz build
-        if [[ ! -f build.tar.gz ]]; then echo 'ERROR: No build.tar.gz artifact found!' && exit 1; fi
+  - label: ":ubuntu: Ubuntu 16.04 Build"
+    command: |
+      ./scripts/eosio_build.sh -y -P -m
+      tar -pczf build.tar.gz build
+      [[ ! -f build.tar.gz ]] && (echo '+++ :no_entry: ERROR: No build.tar.gz artifact found!'; echo '$$ ls -la'; ls -la; exit 1) || :
     label: ":ubuntu: Ubuntu 16.04 Build"
     agents:
       queue: "automation-large-builder-fleet"
@@ -111,20 +111,19 @@ steps:
         account_ids: "436617320021"
         no-include-email: true
         region: "us-west-2"
-      docker#v2.1.0:
+      docker#v3.2.0:
+        shell: ["/bin/bash", "-i", "-e", "-c"]
         debug: true
         image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu16_1-8-0-rc1"
         propagate-environment: true
         workdir: /data/job
     timeout: 120
 
-  - command: | # Ubuntu 18.04 Build
-        echo "+++ :hammer: Building"
-        ./scripts/eosio_build.sh -y -P -m
-        echo "--- :compression: Compressing build directory"
-        tar -pczf build.tar.gz build
-        if [[ ! -f build.tar.gz ]]; then echo 'ERROR: No build.tar.gz artifact found!' && exit 1; fi
-    label: ":ubuntu: Ubuntu 18.04 Build"
+  - label: ":ubuntu: Ubuntu 18.04 Build"
+    command: |
+      ./scripts/eosio_build.sh -y -P -m
+      tar -pczf build.tar.gz build
+      [[ ! -f build.tar.gz ]] && (echo '+++ :no_entry: ERROR: No build.tar.gz artifact found!'; echo '$$ ls -la'; ls -la; exit 1) || :
     agents:
       queue: "automation-large-builder-fleet"
     artifact_paths: "build.tar.gz"
@@ -134,7 +133,8 @@ steps:
         account_ids: "436617320021"
         no-include-email: true
         region: "us-west-2"
-      docker#v2.1.0:
+      docker#v3.2.0:
+        shell: ["/bin/bash", "-i", "-e", "-c"]
         debug: true
         image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu18_1-8-0-rc1"
         propagate-environment: true
@@ -143,16 +143,13 @@ steps:
 
   - wait
 
-
-  ################################
-  # TESTS ########################
-  ################################
-
-  # MOJAVE #
+  # MacOS Mojave
   - label: ":darwin: [Darwin] Mojave Tests"
-    command:
-      - "git clone ${BUILDKITE_PULL_REQUEST_REPO:-$BUILDKITE_REPO} && cd eos && git checkout ${BUILDKITE_COMMIT} && buildkite-agent artifact download \"build.tar.gz\" . --step \":darwin: [Darwin] Mojave Build\""
-      - "cd eos && ./scripts/parallel-test.sh"
+    command: |
+      git clone ${BUILDKITE_PULL_REQUEST_REPO:-$BUILDKITE_REPO} .
+      git checkout ${BUILDKITE_COMMIT}
+      buildkite-agent artifact download build.tar.gz . --step ":darwin: [Darwin] Mojave Build"
+      ./scripts/parallel-test.sh
     agents:
       - "queue=mac-anka-node-fleet"
     plugins:
@@ -167,11 +164,14 @@ steps:
         debug: true
         wait-network: true
     timeout: 120
+    skip: $SKIP_MOJAVE$SKIP_TESTS
 
   - label: ":darwin: [Darwin] Mojave NP Tests"
-    command:
-      - "git clone ${BUILDKITE_PULL_REQUEST_REPO:-$BUILDKITE_REPO} && cd eos && git checkout ${BUILDKITE_COMMIT} && buildkite-agent artifact download \"build.tar.gz\" . --step \":darwin: [Darwin] Mojave Build\""
-      - "cd eos && ./scripts/serial-test.sh"
+    command: |
+      git clone ${BUILDKITE_PULL_REQUEST_REPO:-$BUILDKITE_REPO} .
+      git checkout ${BUILDKITE_COMMIT}
+      buildkite-agent artifact download build.tar.gz . --step ":darwin: [Darwin] Mojave Build"
+      ./scripts/serial-test.sh
     agents:
       - "queue=mac-anka-node-fleet"
     plugins:
@@ -186,14 +186,14 @@ steps:
         debug: true
         wait-network: true
     timeout: 120
+    skip: $SKIP_MOJAVE
 
-  # Amazon Linux 2 Tests
-  - command: |
-        echo "--- :arrow_down: Downloading Build Directory"
-        buildkite-agent artifact download "build.tar.gz" . --step ":aws: Amazon Linux 2 Build"
-        echo "+++ :microscope: Running Tests"
-        ./scripts/parallel-test.sh
-    label: ":aws: Amazon Linux 2 Tests"
+  # Amazon Linux 2
+  - label: ":aws: Amazon Linux 2 Tests"
+    command: |
+      echo "--- :arrow_down: Downloading Build Directory"
+      buildkite-agent artifact download build.tar.gz . --step ":aws: Amazon Linux 2 Build"
+      ./scripts/parallel-test.sh
     agents:
       queue: "automation-large-builder-fleet"
     plugins:
@@ -202,18 +202,20 @@ steps:
         account_ids: "436617320021"
         no-include-email: true
         region: "us-west-2"
-      docker#v2.1.0:
+      docker#v3.2.0:
+        shell: ["/bin/bash", "-i", "-e", "-c"]
         debug: true
         image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:amazonlinux2_1-8-0-rc1"
         propagate-environment: true
         workdir: /data/job
     timeout: 60
+    skip: $SKIP_TESTS
 
-  - command: |
-        echo "--- :arrow_down: Downloading Build Directory"
-        buildkite-agent artifact download "build.tar.gz" . --step ":aws: Amazon Linux 2 Build"
-        echo "+++ :microscope: Running Tests"
-        ./scripts/serial-test.sh
+  - label: ":aws: Amazon Linux 2 NP Tests"
+    command: |
+      echo "--- :arrow_down: Downloading Build Directory"
+      buildkite-agent artifact download build.tar.gz . --step ":aws: Amazon Linux 2 Build"
+      ./scripts/serial-test.sh
     label: ":aws: Amazon Linux 2 NP Tests"
     agents:
       queue: "automation-large-builder-fleet"
@@ -223,20 +225,20 @@ steps:
         account_ids: "436617320021"
         no-include-email: true
         region: "us-west-2"
-      docker#v2.1.0:
+      docker#v3.2.0:
+        shell: ["/bin/bash", "-i", "-e", "-c"]
         debug: true
         image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:amazonlinux2_1-8-0-rc1"
         propagate-environment: true
         workdir: /data/job
     timeout: 60
 
-  # centOS 7 Tests
-  - command: |
-        echo "--- :arrow_down: Downloading Build Directory"
-        buildkite-agent artifact download "build.tar.gz" . --step ":centos: CentOS 7 Build"
-        echo "+++ :microscope: Running Tests"
-        ./scripts/parallel-test.sh
-    label: ":centos: CentOS 7 Tests"
+  # CentOS
+  - label: ":centos: CentOS 7 Tests"
+    command: |
+      echo "--- :arrow_down: Downloading Build Directory"
+      buildkite-agent artifact download build.tar.gz . --step ":centos: CentOS 7 Build"
+      ./scripts/parallel-test.sh
     agents:
       queue: "automation-large-builder-fleet"
     plugins:
@@ -245,19 +247,42 @@ steps:
         account_ids: "436617320021"
         no-include-email: true
         region: "us-west-2"
-      docker#v2.1.0:
+      docker#v3.2.0:
+        shell: ["/bin/bash", "-i", "-e", "-c"]
+        debug: true
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:centos7_1-8-0-rc1"
+        propagate-environment: true
+        workdir: /data/job
+    timeout: 60
+    skip: $SKIP_TESTS
+
+  - label: ":centos: CentOS 7 NP Tests"
+    command: |
+      echo "--- :arrow_down: Downloading Build Directory"
+      buildkite-agent artifact download build.tar.gz . --step ":centos: CentOS 7 Build"
+      ./scripts/serial-test.sh
+    agents:
+      queue: "automation-large-builder-fleet"
+    plugins:
+      ecr#v1.1.4:
+        login: true
+        account_ids: "436617320021"
+        no-include-email: true
+        region: "us-west-2"
+      docker#v3.2.0:
+        shell: ["/bin/bash", "-i", "-e", "-c"]
         debug: true
         image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:centos7_1-8-0-rc1"
         propagate-environment: true
         workdir: /data/job
     timeout: 60
 
-  - command: |
-        echo "--- :arrow_down: Downloading Build Directory"
-        buildkite-agent artifact download "build.tar.gz" . --step ":centos: CentOS 7 Build"
-        echo "+++ :microscope: Running Tests"
-        ./scripts/serial-test.sh
-    label: ":centos: CentOS 7 NP Tests"
+  # Ubuntu 16.04
+  - label: ":ubuntu: Ubuntu 16.04 Tests"
+    command: |
+      echo "--- :arrow_down: Downloading Build Directory"
+      buildkite-agent artifact download build.tar.gz . --step ":ubuntu: Ubuntu 16.04 Build"
+      ./scripts/parallel-test.sh
     agents:
       queue: "automation-large-builder-fleet"
     plugins:
@@ -266,20 +291,20 @@ steps:
         account_ids: "436617320021"
         no-include-email: true
         region: "us-west-2"
-      docker#v2.1.0:
+      docker#v3.2.0:
+        shell: ["/bin/bash", "-i", "-e", "-c"]
         debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:centos7_1-8-0-rc1"
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu16_1-8-0-rc1"
         propagate-environment: true
         workdir: /data/job
     timeout: 60
+    skip: $SKIP_TESTS
 
-  # Ubuntu 16.04 Tests
-  - command: |
-        echo "--- :arrow_down: Downloading Build Directory"
-        buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: Ubuntu 16.04 Build"
-        echo "+++ :microscope: Running Tests"
-        ./scripts/parallel-test.sh
-    label: ":ubuntu: Ubuntu 16.04 Tests"
+  - label: ":ubuntu: Ubuntu 16.04 NP Tests"
+    command: |
+      echo "--- :arrow_down: Downloading Build Directory"
+      buildkite-agent artifact download build.tar.gz . --step ":ubuntu: Ubuntu 16.04 Build"
+      ./scripts/serial-test.sh
     agents:
       queue: "automation-large-builder-fleet"
     plugins:
@@ -288,19 +313,20 @@ steps:
         account_ids: "436617320021"
         no-include-email: true
         region: "us-west-2"
-      docker#v2.1.0:
+      docker#v3.2.0:
+        shell: ["/bin/bash", "-i", "-e", "-c"]
         debug: true
         image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu16_1-8-0-rc1"
         propagate-environment: true
         workdir: /data/job
     timeout: 60
 
-  - command: |
-        echo "--- :arrow_down: Downloading Build Directory"
-        buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: Ubuntu 16.04 Build"
-        echo "+++ :microscope: Running Tests"
-        ./scripts/serial-test.sh
-    label: ":ubuntu: Ubuntu 16.04 NP Tests"
+  # Ubuntu 18.04
+  - label: ":ubuntu: Ubuntu 18.04 Tests"
+    command: |
+      echo "--- :arrow_down: Downloading Build Directory"
+      buildkite-agent artifact download build.tar.gz . --step ":ubuntu: Ubuntu 18.04 Build"
+      ./scripts/parallel-test.sh
     agents:
       queue: "automation-large-builder-fleet"
     plugins:
@@ -309,20 +335,20 @@ steps:
         account_ids: "436617320021"
         no-include-email: true
         region: "us-west-2"
-      docker#v2.1.0:
+      docker#v3.2.0:
+        shell: ["/bin/bash", "-i", "-e", "-c"]
         debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu16_1-8-0-rc1"
+        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu18_1-8-0-rc1"
         propagate-environment: true
         workdir: /data/job
     timeout: 60
+    skip: $SKIP_TESTS
 
-  # Ubuntu 18.04 Tests
-  - command: |
-        echo "--- :arrow_down: Downloading Build Directory"
-        buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: Ubuntu 18.04 Build"
-        echo "+++ :microscope: Running Tests"
-        ./scripts/parallel-test.sh
-    label: ":ubuntu: Ubuntu 18.04 Tests"
+  - label: ":ubuntu: Ubuntu 18.04 NP Tests"
+    command: |
+      echo "--- :arrow_down: Downloading Build Directory"
+      buildkite-agent artifact download build.tar.gz . --step ":ubuntu: Ubuntu 18.04 Build"
+      ./scripts/serial-test.sh
     agents:
       queue: "automation-large-builder-fleet"
     plugins:
@@ -331,35 +357,15 @@ steps:
         account_ids: "436617320021"
         no-include-email: true
         region: "us-west-2"
-      docker#v2.1.0:
+      docker#v3.2.0:
+        shell: ["/bin/bash", "-i", "-e", "-c"]
         debug: true
         image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu18_1-8-0-rc1"
         propagate-environment: true
         workdir: /data/job
     timeout: 60
 
-  - command: |
-        echo "--- :arrow_down: Downloading Build Directory"
-        buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: Ubuntu 18.04 Build"
-        echo "+++ :microscope: Running Tests"
-        ./scripts/serial-test.sh
-    label: ":ubuntu: Ubuntu 18.04 NP Tests"
-    agents:
-      queue: "automation-large-builder-fleet"
-    plugins:
-      ecr#v1.1.4:
-        login: true
-        account_ids: "436617320021"
-        no-include-email: true
-        region: "us-west-2"
-      docker#v2.1.0:
-        debug: true
-        image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu18_1-8-0-rc1"
-        propagate-environment: true
-        workdir: /data/job
-    timeout: 60
-
-  - wait:
+  - wait: # Test Metrics
     continue_on_failure: true
 
   - command: |
@@ -373,32 +379,19 @@ steps:
 
   - wait
 
-  - command: | # CentOS 7 Package Builder
-        echo "--- :arrow_down: Downloading build directory"
-        buildkite-agent artifact download "build.tar.gz" . --step ":centos: CentOS 7 Build"
-        tar -zxf build.tar.gz
-        echo "+++ :microscope: Starting package build"
-        yum install -y rpm-build
-        mkdir -p /root/rpmbuild/BUILD
-        mkdir -p /root/rpmbuild/BUILDROOT
-        mkdir -p /root/rpmbuild/RPMS
-        mkdir -p /root/rpmbuild/SOURCES
-        mkdir -p /root/rpmbuild/SPECS
-        mkdir -p /root/rpmbuild/SRPMS
-        cd /data/job/build/packages
-        bash generate_package.sh rpm
-    label: ":centos: CentOS 7 Package Builder"
+  - label: ":centos: CentOS 7 Package Builder"
+    command: |
+      ./scripts/package-builder.sh ':centos: CentOS 7 Build'
     agents:
       queue: "automation-large-builder-fleet"
-    artifact_paths:
-      - "build/packages/*.rpm"
     plugins:
       ecr#v1.1.4:
         login: true
         account_ids: "436617320021"
         no-include-email: true
         region: "us-west-2"
-      docker#v2.1.0:
+      docker#v3.2.0:
+        shell: ["/bin/bash", "-i", "-e", "-c"]
         debug: true
         image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:centos7_1-8-0-rc1"
         propagate-environment: true
@@ -409,24 +402,18 @@ steps:
     timeout: 60
 
   - command: | # Ubuntu 16.04 Package Builder
-        echo "--- :arrow_down: Downloading build directory"
-        buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: Ubuntu 16.04 Build"
-        tar -zxf build.tar.gz
-        echo "+++ :microscope: Starting package build"
-        cd /data/job/build/packages
-        bash generate_package.sh deb
+      ./scripts/package-builder.sh ':ubuntu: Ubuntu 16.04 Build'
     label: ":ubuntu: Ubuntu 16.04 Package Builder"
     agents:
       queue: "automation-large-builder-fleet"
-    artifact_paths:
-      - "build/packages/*.deb"
     plugins:
       ecr#v1.1.4:
         login: true
         account_ids: "436617320021"
         no-include-email: true
         region: "us-west-2"
-      docker#v2.1.0:
+      docker#v3.2.0:
+        shell: ["/bin/bash", "-i", "-e", "-c"]
         debug: true
         image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu16_1-8-0-rc1"
         propagate-environment: true
@@ -437,24 +424,18 @@ steps:
     timeout: 60
 
   - command: | # Ubuntu 18.04 Package Builder
-        echo "--- :arrow_down: Downloading build directory"
-        buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: Ubuntu 18.04 Build"
-        tar -zxf build.tar.gz
-        echo "+++ :microscope: Starting package build"
-        cd /data/job/build/packages
-        bash generate_package.sh deb
+      ./scripts/package-builder.sh ':ubuntu: Ubuntu 18.04 Build'
     label: ":ubuntu: Ubuntu 18.04 Package Builder"
     agents:
       queue: "automation-large-builder-fleet"
-    artifact_paths:
-      - "build/packages/*.deb"
     plugins:
       ecr#v1.1.4:
         login: true
         account_ids: "436617320021"
         no-include-email: true
         region: "us-west-2"
-      docker#v2.1.0:
+      docker#v3.2.0:
+        shell: ["/bin/bash", "-i", "-e", "-c"]
         debug: true
         image: "436617320021.dkr.ecr.us-west-2.amazonaws.com/ci:ubuntu18_1-8-0-rc1"
         propagate-environment: true
@@ -465,11 +446,10 @@ steps:
     timeout: 60
 
   - label: ":darwin: Mojave Package Builder"
-    command:
-      - "git clone ${BUILDKITE_PULL_REQUEST_REPO:-$BUILDKITE_REPO} && cd eos && git checkout ${BUILDKITE_COMMIT} && buildkite-agent artifact download \"build.tar.gz\" . --step \":darwin: [Darwin] Mojave Build\" && tar -xzf build.tar.gz"
-      - "cd eos/build/packages && bash generate_package.sh brew"
-      - "cd eos && buildkite-agent artifact upload build/packages/*.tar.gz"
-      - "cd eos && buildkite-agent artifact upload build/packages/*.rb"
+    command: |
+      git clone ${BUILDKITE_PULL_REQUEST_REPO:-$BUILDKITE_REPO} .
+      git checkout ${BUILDKITE_COMMIT}
+      ./scripts/package-builder.sh ':darwin: [Darwin] Mojave Build'
     agents:
       - "queue=mac-anka-node-fleet"
     plugins:
@@ -483,22 +463,24 @@ steps:
         always-pull: true
         debug: true
         wait-network: true
-    timeout: 120
+    timeout: 60
+    skip: $SKIP_MOJAVE
 
   - wait
 
   - command: | # Brew Updater
-        echo "--- :arrow_down: Downloading brew files"
-        buildkite-agent artifact download "build/packages/eosio.rb" . --step ":darwin: Mojave Package Builder"
+        echo "+++ :arrow_down: Downloading brew files"
+        buildkite-agent artifact download "eosio.rb" . --step ":darwin: Mojave Package Builder"
     label: ":darwin: Brew Updater"
     agents:
       queue: "automation-large-builder-fleet"
     artifact_paths:
-      - "build/packages/eosio.rb"
+      - "eosio.rb"
     timeout: 5
+    skip: $SKIP_MOJAVE
 
   - command: | # Git Submodule Regression Check
-        echo "+++ :microscope: Running git submodule regression check" && \
+        echo "+++ :git: Running Git Submodule Regression Check"
         ./scripts/submodule_check.sh
     label: "Git Submodule Regression Check"
     agents:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -149,7 +149,6 @@ steps:
       git clone ${BUILDKITE_PULL_REQUEST_REPO:-$BUILDKITE_REPO} .
       git checkout ${BUILDKITE_COMMIT}
       buildkite-agent artifact download build.tar.gz . --step ":darwin: [Darwin] Mojave Build"
-      export BUILDKITE_TAG='not-empty'
       ./scripts/parallel-test.sh
     agents:
       - "queue=mac-anka-node-fleet"
@@ -194,7 +193,6 @@ steps:
     command: |
       echo "--- :arrow_down: Downloading Build Directory"
       buildkite-agent artifact download build.tar.gz . --step ":aws: Amazon Linux 2 Build"
-      export BUILDKITE_TAG='not-empty'
       ./scripts/parallel-test.sh
     agents:
       queue: "automation-large-builder-fleet"
@@ -240,7 +238,6 @@ steps:
     command: |
       echo "--- :arrow_down: Downloading Build Directory"
       buildkite-agent artifact download build.tar.gz . --step ":centos: CentOS 7 Build"
-      export BUILDKITE_TAG='not-empty'
       ./scripts/parallel-test.sh
     agents:
       queue: "automation-large-builder-fleet"
@@ -285,7 +282,6 @@ steps:
     command: |
       echo "--- :arrow_down: Downloading Build Directory"
       buildkite-agent artifact download build.tar.gz . --step ":ubuntu: Ubuntu 16.04 Build"
-      export BUILDKITE_TAG='not-empty'
       ./scripts/parallel-test.sh
     agents:
       queue: "automation-large-builder-fleet"
@@ -330,7 +326,6 @@ steps:
     command: |
       echo "--- :arrow_down: Downloading Build Directory"
       buildkite-agent artifact download build.tar.gz . --step ":ubuntu: Ubuntu 18.04 Build"
-      export BUILDKITE_TAG='not-empty'
       ./scripts/parallel-test.sh
     agents:
       queue: "automation-large-builder-fleet"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -149,6 +149,7 @@ steps:
       git clone ${BUILDKITE_PULL_REQUEST_REPO:-$BUILDKITE_REPO} .
       git checkout ${BUILDKITE_COMMIT}
       buildkite-agent artifact download build.tar.gz . --step ":darwin: [Darwin] Mojave Build"
+      export BUILDKITE_TAG='not-empty'
       ./scripts/parallel-test.sh
     agents:
       - "queue=mac-anka-node-fleet"
@@ -193,6 +194,7 @@ steps:
     command: |
       echo "--- :arrow_down: Downloading Build Directory"
       buildkite-agent artifact download build.tar.gz . --step ":aws: Amazon Linux 2 Build"
+      export BUILDKITE_TAG='not-empty'
       ./scripts/parallel-test.sh
     agents:
       queue: "automation-large-builder-fleet"
@@ -238,6 +240,7 @@ steps:
     command: |
       echo "--- :arrow_down: Downloading Build Directory"
       buildkite-agent artifact download build.tar.gz . --step ":centos: CentOS 7 Build"
+      export BUILDKITE_TAG='not-empty'
       ./scripts/parallel-test.sh
     agents:
       queue: "automation-large-builder-fleet"
@@ -282,6 +285,7 @@ steps:
     command: |
       echo "--- :arrow_down: Downloading Build Directory"
       buildkite-agent artifact download build.tar.gz . --step ":ubuntu: Ubuntu 16.04 Build"
+      export BUILDKITE_TAG='not-empty'
       ./scripts/parallel-test.sh
     agents:
       queue: "automation-large-builder-fleet"
@@ -326,6 +330,7 @@ steps:
     command: |
       echo "--- :arrow_down: Downloading Build Directory"
       buildkite-agent artifact download build.tar.gz . --step ":ubuntu: Ubuntu 18.04 Build"
+      export BUILDKITE_TAG='not-empty'
       ./scripts/parallel-test.sh
     agents:
       queue: "automation-large-builder-fleet"

--- a/scripts/package-builder.sh
+++ b/scripts/package-builder.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+set -e # exit on failure of any "simple" command (excludes &&, ||, or | chains)
+echo '+++ :evergreen_tree: Configuring Environment'
+[[ "$BUILD_STEP" == '' ]] && BUILD_STEP="$1"
+[[ "$BUILD_STEP" == '' ]] && (echo '+++ :no_entry: ERROR: Build step name must be given as BUILD_STEP or argument 1!' && exit 1)
+if [[ "$(uname)" == 'Darwin' ]]; then
+    echo 'Darwin family detected, building for brew.'
+    [[ "$ARTIFACT" == '' ]] && ARTIFACT='*.rb;*.tar.gz'
+    PACKAGE_TYPE='brew'
+else
+    . /etc/os-release
+    if [[ "$ID_LIKE" == 'rhel fedora' ]]; then
+        echo 'Fedora family detected, building for RPM.'
+        [[ "$ARTIFACT" == '' ]] && ARTIFACT='*.rpm'
+        PACKAGE_TYPE='rpm'
+        mkdir -p /root/rpmbuild/BUILD
+        mkdir -p /root/rpmbuild/BUILDROOT
+        mkdir -p /root/rpmbuild/RPMS
+        mkdir -p /root/rpmbuild/SOURCES
+        mkdir -p /root/rpmbuild/SPECS
+        mkdir -p /root/rpmbuild/SRPMS
+        yum install -y rpm-build
+    elif [[ "$ID_LIKE" == 'debian' ]]; then
+        echo 'Debian family detected, building for dpkg.'
+        [[ "$ARTIFACT" == '' ]] && ARTIFACT='*.deb'
+        PACKAGE_TYPE='deb'
+    else
+        echo '+++ :no_entry: ERROR: Could not determine which operating system this script is running on!'
+        echo '$ uname'
+        uname
+        echo "ID_LIKE=\"$ID_LIKE\""
+        echo '$ cat /etc/os-release'
+        cat /etc/os-release
+        echo 'Exiting...'
+        exit 1
+    fi
+fi
+echo "+++ :arrow_down: Downloading Build Directory"
+buildkite-agent artifact download build.tar.gz . --step "$BUILD_STEP"
+echo "+++ :compression: Extracting Build Directory"
+[[ -d build ]] && rm -rf build
+tar -zxf build.tar.gz
+echo "+++ :package: Starting Package Build"
+BASE_COMMIT=$(cat build/programs/nodeos/config.hpp | grep 'version' | awk '{print $5}' | tr -d ';')
+BASE_COMMIT="${BASE_COMMIT:2:42}"
+echo "Found build against $BASE_COMMIT."
+cd build/packages
+chmod 755 ./*.sh
+./generate_package.sh "$PACKAGE_TYPE"
+echo '+++ :arrow_up: Uploading Artifacts'
+buildkite-agent artifact upload "./$ARTIFACT"
+for A in $(echo $ARTIFACT | tr ';' ' '); do
+    if [[ $(ls $A | grep -c '') == 0 ]]; then
+        echo "+++ :no_entry: ERROR: Expected artifact \"$A\" not found!"
+        echo '$ pwd'
+        pwd
+        echo '$ ls -la'
+        ls -la
+        exit 1
+    fi
+done
+echo "+++ :white_check_mark: Done."

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -47,6 +47,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/validate-dirty-db.py ${CMAKE_CURRENT_
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/launcher_test.py ${CMAKE_CURRENT_BINARY_DIR}/launcher_test.py COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/db_modes_test.sh ${CMAKE_CURRENT_BINARY_DIR}/db_modes_test.sh COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/prod_preactivation_test.py ${CMAKE_CURRENT_BINARY_DIR}/prod_preactivation_test.py COPYONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/version-label.sh ${CMAKE_CURRENT_BINARY_DIR}/version-label.sh COPYONLY)
 
 #To run plugin_test with all log from blockchain displayed, put --verbose after --, i.e. plugin_test -- --verbose
 add_test(NAME plugin_test COMMAND plugin_test --report_level=detailed --color_output)
@@ -82,6 +83,7 @@ set_property(TEST validate_dirty_db_test PROPERTY LABELS nonparallelizable_tests
 add_test(NAME launcher_test COMMAND tests/launcher_test.py -v --clean-run --dump-error-detail WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 set_property(TEST launcher_test PROPERTY LABELS nonparallelizable_tests)
 add_test(NAME db_modes_test COMMAND tests/db_modes_test.sh WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+add_test(NAME version-label-test COMMAND tests/version-label.sh WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 
 # Long running tests
 add_test(NAME nodeos_sanity_lr_test COMMAND tests/nodeos_run_test.py -v --sanity-test --clean-run --dump-error-detail WORKING_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/tests/version-label.sh
+++ b/tests/version-label.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# The purpose of this test is to ensure that the output of the "nodeos --version" command matches the 
+# The purpose of this test is to ensure that the output of the "nodeos --version" command matches the version string defined by our CMake files
 # If the environment variable BUILDKITE_TAG is empty or unset, this test will echo success
 echo '##### Nodeos Version Label Test #####'
 if [[ "$BUILDKITE_TAG" == '' || "$BUILDKITE" != 'true' ]]; then

--- a/tests/version-label.sh
+++ b/tests/version-label.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# The purpose of this test is to ensure that the output of the "nodeos --version" command matches the 
+# If the environment variable BUILDKITE_TAG is empty or unset, this test will echo success
+echo '##### Nodeos Version Label Test #####'
+if [[ "$BUILDKITE_TAG" == '' || "$BUILDKITE" != 'true' ]]; then
+    echo 'This test is only run in Buildkite against tagged builds.'
+    [[ "$BUILDKITE" != 'true' ]] && echo 'This is not Buildkite.'
+    [[ "$BUILDKITE_TAG" == '' ]] && echo 'This is not a tagged build.'
+    echo 'Exiting...'
+    exit 0
+fi
+echo 'Tagged build detected, running test.'
+# orient ourselves
+[[ "$EOSIO_ROOT" == '' ]] && EOSIO_ROOT=$(echo $(pwd)/ | grep -ioe '.*/eos/')
+[[ "$EOSIO_ROOT" == '' ]] && EOSIO_ROOT=$(echo $(pwd)/ | grep -ioe '.*/EOSIO/eosio/')
+[[ "$EOSIO_ROOT" == '' ]] && EOSIO_ROOT=$(echo $(pwd)/ | grep -ioe '.*/build/' | sed 's,/build/,,')
+echo "Using EOSIO_ROOT=\"$EOSIO_ROOT\"."
+# determine expected value
+CMAKE_CACHE="$EOSIO_ROOT/build/CMakeCache.txt"
+CMAKE_LISTS="$EOSIO_ROOT/CMakeLists.txt"
+if [[ -f "$CMAKE_CACHE" && $(cat "$CMAKE_CACHE" | grep -c 'DOXY_EOS_VERSION') > 0 ]]; then
+    echo "Parsing \"$CMAKE_CACHE\"..."
+    EXPECTED="v$(cat "$CMAKE_CACHE" | grep 'DOXY_EOS_VERSION' | cut -d '=' -f 2)"
+elif [[ -f "$CMAKE_LISTS" ]]; then
+    echo "Parsing \"$CMAKE_LISTS\"..."
+    export $(cat $CMAKE_LISTS | grep -ie 'set *( *VERSION_MAJOR' | cut -d '(' -f 2 | cut -d ')' -f 1 | awk '{print $1"="$2}')
+    export $(cat $CMAKE_LISTS | grep -ie 'set *( *VERSION_MINOR' | cut -d '(' -f 2 | cut -d ')' -f 1 | awk '{print $1"="$2}')
+    export $(cat $CMAKE_LISTS | grep -ie 'set *( *VERSION_PATCH' | cut -d '(' -f 2 | cut -d ')' -f 1 | awk '{print $1"="$2}')
+    if [[ $(cat $CMAKE_LISTS | grep -ice 'set *( *VERSION_SUFFIX') > 0 ]]; then
+        echo 'Using version suffix...'
+        export $(cat $CMAKE_LISTS | grep -ie 'set *( *VERSION_SUFFIX' | cut -d '(' -f 2 | cut -d ')' -f 1 | awk '{print $1"="$2}')
+        export $(echo "$(cat $CMAKE_LISTS | grep -ie 'set *( *VERSION_FULL.*VERSION_SUFFIX' | cut -d '(' -f 2 | cut -d ')' -f 1 | awk '{print $1"="$2}')" | sed "s/VERSION_MAJOR/$VERSION_MAJOR/" | sed "s/VERSION_MINOR/$VERSION_MINOR/" | sed "s/VERSION_PATCH/$VERSION_PATCH/" | sed "s/VERSION_SUFFIX/$VERSION_SUFFIX/" | tr -d '"{}$')
+    else
+        echo 'No version suffix found.'
+        export $(echo "$(cat $CMAKE_LISTS | grep -ie 'set *( *VERSION_FULL' | grep -ive 'VERSION_SUFFIX' | cut -d '(' -f 2 | cut -d ')' -f 1 | awk '{print $1"="$2}')" | sed "s/VERSION_MAJOR/$VERSION_MAJOR/" | sed "s/VERSION_MINOR/$VERSION_MINOR/" | sed "s/VERSION_PATCH/$VERSION_PATCH/" | tr -d '"{}$')
+    fi
+    EXPECTED="v$VERSION_FULL"
+fi
+# fail if no expected value was found
+if [[ "$EXPECTED" == '' ]]; then
+    echo 'ERROR: Could not determine expected value for version label!'
+    set +e
+    echo "EOSIO_ROOT=\"$EOSIO_ROOT\""
+    echo "CMAKE_CACHE=\"$CMAKE_CACHE\""
+    echo "CMAKE_LISTS=\"$CMAKE_LISTS\""
+    echo ''
+    echo "VERSION_MAJOR=\"$VERSION_MAJOR\""
+    echo "VERSION_MINOR=\"$VERSION_MINOR\""
+    echo "VERSION_PATCH=\"$VERSION_PATCH\""
+    echo "VERSION_SUFFIX=\"$VERSION_SUFFIX\""
+    echo "VERSION_FULL=\"$VERSION_FULL\""
+    echo ''
+    echo '$ cat "$CMAKE_CACHE" | grep "DOXY_EOS_VERSION"'
+    cat "$CMAKE_CACHE" | grep "DOXY_EOS_VERSION"
+    echo '$ pwd'
+    pwd
+    echo '$ ls -la "$EOSIO_ROOT"'
+    ls -la "$EOSIO_ROOT"
+    echo '$ ls -la "$EOSIO_ROOT/build"'
+    ls -la "$EOSIO_ROOT/build"
+    exit 1
+fi
+echo "Expecting \"$EXPECTED\"..."
+# get nodeos version
+ACTUAL=$($EOSIO_ROOT/build/bin/nodeos --version) || : # nodeos currently returns -1 for --version
+# test
+if [[ "$EXPECTED" == "$ACTUAL" ]]; then
+    echo 'Passed with \"$ACTUAL\".'
+    exit 0
+fi
+echo 'Failed!'
+echo "\"$EXPECTED\" != \"$ACTUAL\""
+exit 1


### PR DESCRIPTION
## Change Description
Last week, we had [an issue](https://github.com/EOSIO/eos/issues/7269) where the binaries attached to a 1.8 release contained a 1.7 version string.  
  
### Version Label Integration Test
This pull request introduces the "version-label" integration test, which compares the output of `nodes --version` to our CMake files to determine that the version string is what we expect it to be. This test will only run in Buildkite against tagged builds. If this test is not running in Buildkite or the build does not have a GitHub tag, this test immediately returns `EXIT_SUCCESS`.  
  
### Package Builder Improvements
Because this check was initially going to be in the package builder step, I have also made changes there:
- Moved commands into script
- Step now fails if there are no packages produced
- Prints commit hash of build directory being used
- Detects host operating system and runs correct package builder instructions for you

### Tested
- [Build 12036](https://buildkite.com/EOSIO/eosio/builds/12036) tests a tagged build
- [Build 12037](https://buildkite.com/EOSIO/eosio/builds/12037) tests an untagged build

### See Also
- [Issue 7269](https://github.com/EOSIO/eos/issues/7269)
- [Pull Request 7341](https://github.com/EOSIO/eos/pull/7341)
- [Pull Request 7354](https://github.com/EOSIO/eos/pull/7354)
- [Pull Request 7355](https://github.com/EOSIO/eos/pull/7355)

## Consensus Changes
- [ ] Consensus Changes
None.

## API Changes
- [ ] API Changes
None.

## Documentation Additions
- [ ] Documentation Additions
None.