### PR TITLE
Created "version-label" Integration Test

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/nodeos_voting_test.py ${CMAKE_CURRENT
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/consensus-validation-malicious-producers.py ${CMAKE_CURRENT_BINARY_DIR}/consensus-validation-malicious-producers.py COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/validate-dirty-db.py ${CMAKE_CURRENT_BINARY_DIR}/validate-dirty-db.py COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/launcher_test.py ${CMAKE_CURRENT_BINARY_DIR}/launcher_test.py COPYONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/version-label.sh ${CMAKE_CURRENT_BINARY_DIR}/version-label.sh COPYONLY)
 
 #To run plugin_test with all log from blockchain displayed, put --verbose after --, i.e. plugin_test -- --verbose
 add_test(NAME plugin_test COMMAND plugin_test --report_level=detailed --color_output)
@@ -78,6 +79,7 @@ add_test(NAME validate_dirty_db_test COMMAND tests/validate-dirty-db.py -v --cle
 set_property(TEST validate_dirty_db_test PROPERTY LABELS nonparallelizable_tests)
 add_test(NAME launcher_test COMMAND tests/launcher_test.py -v --clean-run --dump-error-detail WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 set_property(TEST launcher_test PROPERTY LABELS nonparallelizable_tests)
+add_test(NAME version-label-test COMMAND tests/version-label.sh WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 
 # Long running tests
 add_test(NAME nodeos_sanity_lr_test COMMAND tests/nodeos_run_test.py -v --sanity-test --clean-run --dump-error-detail WORKING_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/tests/version-label.sh
+++ b/tests/version-label.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# The purpose of this test is to ensure that the output of the "nodeos --version" command matches the 
+# The purpose of this test is to ensure that the output of the "nodeos --version" command matches the version string defined by our CMake files
 # If the environment variable BUILDKITE_TAG is empty or unset, this test will echo success
 echo '##### Nodeos Version Label Test #####'
 if [[ "$BUILDKITE_TAG" == '' || "$BUILDKITE" != 'true' ]]; then

--- a/tests/version-label.sh
+++ b/tests/version-label.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# The purpose of this test is to ensure that the output of the "nodeos --version" command matches the 
+# If the environment variable BUILDKITE_TAG is empty or unset, this test will echo success
+echo '##### Nodeos Version Label Test #####'
+if [[ "$BUILDKITE_TAG" == '' || "$BUILDKITE" != 'true' ]]; then
+    echo 'This test is only run in Buildkite against tagged builds.'
+    [[ "$BUILDKITE" != 'true' ]] && echo 'This is not Buildkite.'
+    [[ "$BUILDKITE_TAG" == '' ]] && echo 'This is not a tagged build.'
+    echo 'Exiting...'
+    exit 0
+fi
+echo 'Tagged build detected, running test.'
+# orient ourselves
+[[ "$EOSIO_ROOT" == '' ]] && EOSIO_ROOT=$(echo $(pwd)/ | grep -ioe '.*/eos/')
+[[ "$EOSIO_ROOT" == '' ]] && EOSIO_ROOT=$(echo $(pwd)/ | grep -ioe '.*/EOSIO/eosio/')
+[[ "$EOSIO_ROOT" == '' ]] && EOSIO_ROOT=$(echo $(pwd)/ | grep -ioe '.*/build/' | sed 's,/build/,,')
+echo "Using EOSIO_ROOT=\"$EOSIO_ROOT\"."
+# determine expected value
+CMAKE_CACHE="$EOSIO_ROOT/build/CMakeCache.txt"
+CMAKE_LISTS="$EOSIO_ROOT/CMakeLists.txt"
+if [[ -f "$CMAKE_CACHE" && $(cat "$CMAKE_CACHE" | grep -c 'DOXY_EOS_VERSION') > 0 ]]; then
+    echo "Parsing \"$CMAKE_CACHE\"..."
+    EXPECTED="v$(cat "$CMAKE_CACHE" | grep 'DOXY_EOS_VERSION' | cut -d '=' -f 2)"
+elif [[ -f "$CMAKE_LISTS" ]]; then
+    echo "Parsing \"$CMAKE_LISTS\"..."
+    export $(cat $CMAKE_LISTS | grep -ie 'set *( *VERSION_MAJOR' | cut -d '(' -f 2 | cut -d ')' -f 1 | awk '{print $1"="$2}')
+    export $(cat $CMAKE_LISTS | grep -ie 'set *( *VERSION_MINOR' | cut -d '(' -f 2 | cut -d ')' -f 1 | awk '{print $1"="$2}')
+    export $(cat $CMAKE_LISTS | grep -ie 'set *( *VERSION_PATCH' | cut -d '(' -f 2 | cut -d ')' -f 1 | awk '{print $1"="$2}')
+    if [[ $(cat $CMAKE_LISTS | grep -ice 'set *( *VERSION_SUFFIX') > 0 ]]; then
+        echo 'Using version suffix...'
+        export $(cat $CMAKE_LISTS | grep -ie 'set *( *VERSION_SUFFIX' | cut -d '(' -f 2 | cut -d ')' -f 1 | awk '{print $1"="$2}')
+        export $(echo "$(cat $CMAKE_LISTS | grep -ie 'set *( *VERSION_FULL.*VERSION_SUFFIX' | cut -d '(' -f 2 | cut -d ')' -f 1 | awk '{print $1"="$2}')" | sed "s/VERSION_MAJOR/$VERSION_MAJOR/" | sed "s/VERSION_MINOR/$VERSION_MINOR/" | sed "s/VERSION_PATCH/$VERSION_PATCH/" | sed "s/VERSION_SUFFIX/$VERSION_SUFFIX/" | tr -d '"{}$')
+    else
+        echo 'No version suffix found.'
+        export $(echo "$(cat $CMAKE_LISTS | grep -ie 'set *( *VERSION_FULL' | grep -ive 'VERSION_SUFFIX' | cut -d '(' -f 2 | cut -d ')' -f 1 | awk '{print $1"="$2}')" | sed "s/VERSION_MAJOR/$VERSION_MAJOR/" | sed "s/VERSION_MINOR/$VERSION_MINOR/" | sed "s/VERSION_PATCH/$VERSION_PATCH/" | tr -d '"{}$')
+    fi
+    EXPECTED="v$VERSION_FULL"
+fi
+# fail if no expected value was found
+if [[ "$EXPECTED" == '' ]]; then
+    echo 'ERROR: Could not determine expected value for version label!'
+    set +e
+    echo "EOSIO_ROOT=\"$EOSIO_ROOT\""
+    echo "CMAKE_CACHE=\"$CMAKE_CACHE\""
+    echo "CMAKE_LISTS=\"$CMAKE_LISTS\""
+    echo ''
+    echo "VERSION_MAJOR=\"$VERSION_MAJOR\""
+    echo "VERSION_MINOR=\"$VERSION_MINOR\""
+    echo "VERSION_PATCH=\"$VERSION_PATCH\""
+    echo "VERSION_SUFFIX=\"$VERSION_SUFFIX\""
+    echo "VERSION_FULL=\"$VERSION_FULL\""
+    echo ''
+    echo '$ cat "$CMAKE_CACHE" | grep "DOXY_EOS_VERSION"'
+    cat "$CMAKE_CACHE" | grep "DOXY_EOS_VERSION"
+    echo '$ pwd'
+    pwd
+    echo '$ ls -la "$EOSIO_ROOT"'
+    ls -la "$EOSIO_ROOT"
+    echo '$ ls -la "$EOSIO_ROOT/build"'
+    ls -la "$EOSIO_ROOT/build"
+    exit 1
+fi
+echo "Expecting \"$EXPECTED\"..."
+# get nodeos version
+ACTUAL=$($EOSIO_ROOT/build/bin/nodeos --version) || : # nodeos currently returns -1 for --version
+# test
+if [[ "$EXPECTED" == "$ACTUAL" ]]; then
+    echo 'Passed with \"$ACTUAL\".'
+    exit 0
+fi
+echo 'Failed!'
+echo "\"$EXPECTED\" != \"$ACTUAL\""
+exit 1


### PR DESCRIPTION
## Change Description
Last week, we had [an issue](https://github.com/EOSIO/eos/issues/7269) where the binaries attached to a 1.8 release contained a 1.7 version string.  
  
This pull request introduces the "version-label" integration test, which compares the output of `nodes --version` to our CMake files to determine that the version string is what we expect it to be. This test will only run in Buildkite against tagged builds. If this test is not running in Buildkite or the build does not have a GitHub tag, this test immediately returns `EXIT_SUCCESS`.  
  
### Tested
- [Build 12036](https://buildkite.com/EOSIO/eosio/builds/12036) tests a tagged build
- [Build 12037](https://buildkite.com/EOSIO/eosio/builds/12037) tests an untagged build

### See Also
- [Issue 7269](https://github.com/EOSIO/eos/issues/7269)
- [Pull Request 7341](https://github.com/EOSIO/eos/pull/7341)
- [Pull Request 7353](https://github.com/EOSIO/eos/pull/7353)
- [Pull Request 7354](https://github.com/EOSIO/eos/pull/7354)

## Consensus Changes
- [ ] Consensus Changes
None.

## API Changes
- [ ] API Changes
None.

## Documentation Additions
- [ ] Documentation Additions
None.