### PR TITLE
Fix `-b` flag for `cleos get table` subcommand

### DIFF
--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -2617,7 +2617,6 @@ int main( int argc, char** argv ) {
    getTable->add_option( "account", code, localized("The account who owns the table") )->required();
    getTable->add_option( "scope", scope, localized("The scope within the contract in which the table is found") )->required();
    getTable->add_option( "table", table, localized("The name of the table as specified by the contract abi") )->required();
-   getTable->add_option( "-b,--binary", binary, localized("Return the value as BINARY rather than using abi to interpret as JSON") );
    getTable->add_option( "-l,--limit", limit, localized("The maximum number of rows to return") );
    getTable->add_option( "-k,--key", table_key, localized("Deprecated") );
    getTable->add_option( "-L,--lower", lower, localized("JSON representation of lower bound value of key, defaults to first") );
@@ -2631,6 +2630,7 @@ int main( int argc, char** argv ) {
    getTable->add_option( "--encode-type", encode_type,
                          localized("The encoding type of key_type (i64 , i128 , float64, float128) only support decimal encoding e.g. 'dec'"
                                     "i256 - supports both 'dec' and 'hex', ripemd160 and sha256 is 'hex' only"));
+   getTable->add_flag("-b,--binary", binary, localized("Return the value as BINARY rather than using abi to interpret as JSON"));
    getTable->add_flag("-r,--reverse", reverse, localized("Iterate in reverse order"));
    getTable->add_flag("--show-payer", show_payer, localized("show RAM payer"));
 


### PR DESCRIPTION
In reference to issue [#7362](https://github.com/EOSIO/eos/issues/7362) passing the `-b` flag is sufficient for retrieving the table row in binary format.

<hr>

**Before**
```
cleos get table eosio.token eosio accounts -b
```

```
{
  "rows": [{
      "balance": "0.0000 SYS"
    }
  ],
  "more": false
}
```

<hr>

**After**
```
cleos get table eosio.token eosio accounts -b
```

```
{
  "rows": [
    "00000000000000000453595300000000"
  ],
  "more": false
}
```