### PR TITLE
transaction deadline cleanup

### DIFF
--- a/libraries/chain/include/eosio/chain/exceptions.hpp
+++ b/libraries/chain/include/eosio/chain/exceptions.hpp
@@ -23,7 +23,11 @@
  * This macro will rethrow the exception as the specified "exception_type"
  */
 #define EOS_RETHROW_EXCEPTIONS(exception_type, FORMAT, ... ) \
-   catch (eosio::chain::chain_exception& e) { \
+   catch( const std::bad_alloc& ) {\
+      throw;\
+   } catch( const boost::interprocess::bad_alloc& ) {\
+      throw;\
+   } catch (eosio::chain::chain_exception& e) { \
       FC_RETHROW_EXCEPTION( e, warn, FORMAT, __VA_ARGS__ ); \
    } catch (fc::exception& e) { \
       exception_type new_exception(FC_LOG_MESSAGE( warn, FORMAT, __VA_ARGS__ )); \
@@ -46,7 +50,11 @@
  * This macro will rethrow the exception as the specified "exception_type"
  */
 #define EOS_CAPTURE_AND_RETHROW( exception_type, ... ) \
-   catch (eosio::chain::chain_exception& e) { \
+   catch( const std::bad_alloc& ) {\
+      throw;\
+   } catch( const boost::interprocess::bad_alloc& ) {\
+      throw;\
+   } catch (eosio::chain::chain_exception& e) { \
       FC_RETHROW_EXCEPTION( e, warn, "", FC_FORMAT_ARG_PARAMS(__VA_ARGS__) ); \
    } catch (fc::exception& e) { \
       exception_type new_exception(e.get_log()); \
@@ -61,6 +69,26 @@
       throw fc::unhandled_exception( \
                 FC_LOG_MESSAGE( warn, "",FC_FORMAT_ARG_PARAMS(__VA_ARGS__)), \
                 std::current_exception() ); \
+   }
+
+/**
+ * Capture all exceptions and pass to NEXT function
+ */
+#define CATCH_AND_CALL(NEXT)\
+   catch ( const fc::exception& err ) {\
+      NEXT(err.dynamic_copy_exception());\
+   } catch ( const std::exception& e ) {\
+      fc::exception fce( \
+         FC_LOG_MESSAGE( warn, "rethrow ${what}: ", ("what",e.what())),\
+         fc::std_exception_code,\
+         BOOST_CORE_TYPEID(e).name(),\
+         e.what() ) ;\
+      NEXT(fce.dynamic_copy_exception());\
+   } catch( ... ) {\
+      fc::unhandled_exception e(\
+         FC_LOG_MESSAGE(warn, "rethrow"),\
+         std::current_exception());\
+      NEXT(e.dynamic_copy_exception());\
    }
 
 #define EOS_RECODE_EXC( cause_type, effect_type ) \

--- a/libraries/chain/transaction.cpp
+++ b/libraries/chain/transaction.cpp
@@ -111,8 +111,8 @@ fc::microseconds transaction::get_signature_keys( const vector<signature_type>& 
    fc::microseconds sig_cpu_usage;
    for(const signature_type& sig : signatures) {
       auto now = fc::time_point::now();
-      EOS_ASSERT( now < deadline, tx_cpu_usage_exceeded, "transaction signature verification executed for too long",
-                  ("now", now)("deadline", deadline)("start", start) );
+      EOS_ASSERT( now < deadline, tx_cpu_usage_exceeded, "transaction signature verification executed for too long ${time}us",
+                  ("time", now - start)("now", now)("deadline", deadline)("start", start) );
       public_key_type recov;
       const auto& tid = id();
       lock.lock();

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -471,28 +471,29 @@ namespace bacc = boost::accumulators;
       if( BOOST_UNLIKELY( now > _deadline ) ) {
          // edump((now-start)(now-pseudo_start));
          if( explicit_billed_cpu_time || deadline_exception_code == deadline_exception::code_value ) {
-            EOS_THROW( deadline_exception, "deadline exceeded", ("now", now)("deadline", _deadline)("start", start) );
+            EOS_THROW( deadline_exception, "deadline exceeded ${billing_timer}us",
+                       ("billing_timer", now - pseudo_start)("now", now)("deadline", _deadline)("start", start) );
          } else if( deadline_exception_code == block_cpu_usage_exceeded::code_value ) {
             EOS_THROW( block_cpu_usage_exceeded,
-                        "not enough time left in block to complete executing transaction",
+                        "not enough time left in block to complete executing transaction ${billing_timer}us",
                         ("now", now)("deadline", _deadline)("start", start)("billing_timer", now - pseudo_start) );
          } else if( deadline_exception_code == tx_cpu_usage_exceeded::code_value ) {
             if (cpu_limit_due_to_greylist) {
                EOS_THROW( greylist_cpu_usage_exceeded,
-                        "greylisted transaction was executing for too long",
+                        "greylisted transaction was executing for too long ${billing_timer}us",
                         ("now", now)("deadline", _deadline)("start", start)("billing_timer", now - pseudo_start) );
             } else {
                EOS_THROW( tx_cpu_usage_exceeded,
-                        "transaction was executing for too long",
+                        "transaction was executing for too long ${billing_timer}us",
                         ("now", now)("deadline", _deadline)("start", start)("billing_timer", now - pseudo_start) );
             }
          } else if( deadline_exception_code == leeway_deadline_exception::code_value ) {
             EOS_THROW( leeway_deadline_exception,
                         "the transaction was unable to complete by deadline, "
-                        "but it is possible it could have succeeded if it were allowed to run to completion",
+                        "but it is possible it could have succeeded if it were allowed to run to completion ${billing_timer}",
                         ("now", now)("deadline", _deadline)("start", start)("billing_timer", now - pseudo_start) );
          }
-         EOS_ASSERT( false,  transaction_exception, "unexpected deadline exception code" );
+         EOS_ASSERT( false,  transaction_exception, "unexpected deadline exception code ${code}", ("code", deadline_exception_code) );
       }
    }
 

--- a/libraries/chain/transaction_metadata.cpp
+++ b/libraries/chain/transaction_metadata.cpp
@@ -16,6 +16,7 @@ recovery_keys_type transaction_metadata::recover_keys( const chain_id_type& chai
 
    g.unlock();
    // shared_keys_future not created or different chain_id
+   wlog( "recovering keys in recover_keys" );
    auto recovered_pub_keys = std::make_shared<flat_set<public_key_type>>();
    const signed_transaction& trn = _packed_trx->get_signed_transaction();
    fc::microseconds cpu_usage = trn.get_signature_keys( chain_id, fc::time_point::maximum(), *recovered_pub_keys );
@@ -39,15 +40,22 @@ void transaction_metadata::start_recover_keys( const transaction_metadata_ptr& m
    if( mtrx->_signing_keys_future.valid() && std::get<0>( mtrx->_signing_keys_future.get() ) == chain_id ) { // already created
       g.unlock();
       if( next ) next();
+      return;
    }
 
    mtrx->_signing_keys_future = async_thread_pool( thread_pool, [time_limit, chain_id, mtrx, next{std::move(next)}]() {
-      fc::time_point deadline = time_limit == fc::microseconds::maximum() ?
-                                fc::time_point::maximum() : fc::time_point::now() + time_limit;
-
       auto recovered_pub_keys = std::make_shared<flat_set<public_key_type>>();
-      const signed_transaction& trn = mtrx->_packed_trx->get_signed_transaction();
-      fc::microseconds cpu_usage = trn.get_signature_keys( chain_id, deadline, *recovered_pub_keys );
+      fc::microseconds cpu_usage;
+      try {
+         fc::time_point deadline = time_limit == fc::microseconds::maximum() ?
+                                   fc::time_point::maximum() : fc::time_point::now() + time_limit;
+
+         const signed_transaction& trn = mtrx->_packed_trx->get_signed_transaction();
+         cpu_usage = trn.get_signature_keys( chain_id, deadline, *recovered_pub_keys );
+      } catch( ... ) {
+         if( next ) next();
+         throw;
+      }
       if( next ) next();
       return std::make_tuple( chain_id, cpu_usage, std::move( recovered_pub_keys ));
    } );

--- a/libraries/chain/transaction_metadata.cpp
+++ b/libraries/chain/transaction_metadata.cpp
@@ -16,7 +16,7 @@ recovery_keys_type transaction_metadata::recover_keys( const chain_id_type& chai
 
    g.unlock();
    // shared_keys_future not created or different chain_id
-   wlog( "recovering keys in recover_keys" );
+   dlog( "recovering keys in recover_keys" );
    auto recovered_pub_keys = std::make_shared<flat_set<public_key_type>>();
    const signed_transaction& trn = _packed_trx->get_signed_transaction();
    fc::microseconds cpu_usage = trn.get_signature_keys( chain_id, fc::time_point::maximum(), *recovered_pub_keys );

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -117,26 +117,6 @@ using fc::flat_map;
 
 using boost::signals2::scoped_connection;
 
-//using txn_msg_rate_limits = controller::txn_msg_rate_limits;
-
-#define CATCH_AND_CALL(NEXT)\
-   catch ( const fc::exception& err ) {\
-      NEXT(err.dynamic_copy_exception());\
-   } catch ( const std::exception& e ) {\
-      fc::exception fce( \
-         FC_LOG_MESSAGE( warn, "rethrow ${what}: ", ("what",e.what())),\
-         fc::std_exception_code,\
-         BOOST_CORE_TYPEID(e).name(),\
-         e.what() ) ;\
-      NEXT(fce.dynamic_copy_exception());\
-   } catch( ... ) {\
-      fc::unhandled_exception e(\
-         FC_LOG_MESSAGE(warn, "rethrow"),\
-         std::current_exception());\
-      NEXT(e.dynamic_copy_exception());\
-   }
-
-
 class chain_plugin_impl {
 public:
    chain_plugin_impl()

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -155,22 +155,6 @@ enum class pending_block_mode {
    producing,
    speculating
 };
-#define CATCH_AND_CALL(NEXT)\
-   catch ( const fc::exception& err ) {\
-      NEXT(err.dynamic_copy_exception());\
-   } catch ( const std::exception& e ) {\
-      fc::exception fce( \
-         FC_LOG_MESSAGE( warn, "rethrow ${what}: ", ("what",e.what())),\
-         fc::std_exception_code,\
-         BOOST_CORE_TYPEID(e).name(),\
-         e.what() ) ;\
-      NEXT(fce.dynamic_copy_exception());\
-   } catch( ... ) {\
-      fc::unhandled_exception e(\
-         FC_LOG_MESSAGE(warn, "rethrow"),\
-         std::current_exception());\
-      NEXT(e.dynamic_copy_exception());\
-   }
 
 class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin_impl> {
    public:


### PR DESCRIPTION
## Change Description

- Fixed issue in `transaction_metadata` `start_key_recovery` where exceptions when `next()` provided didn't call `next()` causing silent dropping of exceptions. This produced a confusing unable to connect error to `cleos` instead of a deadline exception error. 
- Added elapsed time to transaction deadline exception strings so users can see how long the transaction executed. 
-  Moved `CATCH_AND_CALL` macro to `exceptions.hpp` and handle `bad_alloc` in `EOS_RETHROW_EXCEPTIONS` and `EOS_CAPTURE_AND_RETHROW`.

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
