### PR TITLE
Producer incoming-transaction-queue-size-mb

### DIFF
--- a/libraries/chain/include/eosio/chain/exceptions.hpp
+++ b/libraries/chain/include/eosio/chain/exceptions.hpp
@@ -244,6 +244,8 @@ namespace eosio { namespace chain {
                                     3040016, "Transaction includes an ill-formed deferred transaction generation context extension" )
       FC_DECLARE_DERIVED_EXCEPTION( disallowed_transaction_extensions_bad_block_exception, transaction_exception,
                                     3250002, "Transaction includes disallowed extensions (invalid block)" )
+      FC_DECLARE_DERIVED_EXCEPTION( tx_resource_exhaustion, transaction_exception,
+                                    3040018, "Transaction exceeded transient resource limit" )
 
 
    FC_DECLARE_DERIVED_EXCEPTION( action_validate_exception, chain_exception,

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -604,6 +604,8 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
       void schedule_delayed_production_loop(const std::weak_ptr<producer_plugin_impl>& weak_this, const block_timestamp_type& current_block_time);
 };
 
+uint64_t producer_plugin_impl::_max_incoming_transaction_queue_size = 0;
+
 void new_chain_banner(const eosio::chain::controller& db)
 {
    std::cerr << "\n"

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -429,7 +429,7 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
          }
       }
 
-      class incoming_transactions {
+      class incoming_transaction_queue {
          uint64_t size_in_bytes = 0;
          std::deque<std::tuple<transaction_metadata_ptr, bool, next_function<transaction_trace_ptr>>> _incoming_transactions;
 
@@ -441,8 +441,7 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
       public:
          void add( const transaction_metadata_ptr& trx, bool persist_until_expired, next_function<transaction_trace_ptr> next ) {
             auto size = calc_size( trx );
-            EOS_ASSERT( size_in_bytes + size < _max_incoming_transaction_queue_size, tx_resource_exhaustion,
-                        "Transaction exceeded producer resource limit" );
+            EOS_ASSERT( size_in_bytes + size < _max_incoming_transaction_queue_size, tx_resource_exhaustion, "Transaction exceeded producer resource limit" );
             size_in_bytes += size;
             _incoming_transactions.emplace_back( trx, persist_until_expired, std::move( next ) );
          }
@@ -461,7 +460,7 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
 
       };
 
-      incoming_transactions _pending_incoming_transactions;
+      incoming_transaction_queue _pending_incoming_transactions;
 
       void on_incoming_transaction_async(const transaction_metadata_ptr& trx, bool persist_until_expired, next_function<transaction_trace_ptr> next) {
          chain::controller& chain = chain_plug->chain();

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -812,6 +812,8 @@ void producer_plugin::plugin_initialize(const boost::program_options::variables_
    my->_max_irreversible_block_age_us = fc::seconds(options.at("max-irreversible-block-age").as<int32_t>());
 
    my->_max_incoming_transaction_queue_size = options.at("incoming-transaction-queue-size-mb").as<uint16_t>() * 1024*1024;
+   EOS_ASSERT( my->_max_incoming_transaction_queue_size > 0, plugin_config_exception,
+               "incoming-transaction-queue-size-mb ${mb} must be greater than 0", ("mb", my->_max_incoming_transaction_queue_size) );
 
    my->_incoming_defer_ratio = options.at("incoming-defer-ratio").as<double>();
 

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -201,6 +201,7 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
 
       std::atomic<int32_t>                                      _max_transaction_time_ms; // modified by app thread, read by net_plugin thread pool
       fc::microseconds                                          _max_irreversible_block_age_us;
+      static uint64_t                                           _max_incoming_transaction_queue_size;
       int32_t                                                   _produce_time_offset_us = 0;
       int32_t                                                   _last_block_time_offset_us = 0;
       int32_t                                                   _max_scheduled_transaction_time_per_block_ms;
@@ -428,7 +429,39 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
          }
       }
 
-      std::deque<std::tuple<transaction_metadata_ptr, bool, next_function<transaction_trace_ptr>>> _pending_incoming_transactions;
+      class incoming_transactions {
+         uint64_t size_in_bytes = 0;
+         std::deque<std::tuple<transaction_metadata_ptr, bool, next_function<transaction_trace_ptr>>> _incoming_transactions;
+
+      private:
+         uint64_t calc_size( const transaction_metadata_ptr& trx ) {
+            return trx->packed_trx()->get_unprunable_size() + trx->packed_trx()->get_prunable_size() + sizeof( *trx );
+         }
+
+      public:
+         void add( const transaction_metadata_ptr& trx, bool persist_until_expired, next_function<transaction_trace_ptr> next ) {
+            auto size = calc_size( trx );
+            EOS_ASSERT( size_in_bytes + size < _max_incoming_transaction_queue_size, tx_resource_exhaustion,
+                        "Transaction exceeded producer resource limit" );
+            size_in_bytes += size;
+            _incoming_transactions.emplace_back( trx, persist_until_expired, std::move( next ) );
+         }
+
+         auto pop_front() {
+            EOS_ASSERT( !_incoming_transactions.empty(), producer_exception, "logic error, front() called on empty incoming_transactions" );
+            auto intrx = _incoming_transactions.front();
+            _incoming_transactions.pop_front();
+            const transaction_metadata_ptr& trx = std::get<0>( intrx );
+            size_in_bytes -= calc_size( trx );
+            return intrx;
+         }
+
+         bool empty()const { return _incoming_transactions.empty(); }
+         size_t size()const { return _incoming_transactions.size(); }
+
+      };
+
+      incoming_transactions _pending_incoming_transactions;
 
       void on_incoming_transaction_async(const transaction_metadata_ptr& trx, bool persist_until_expired, next_function<transaction_trace_ptr> next) {
          chain::controller& chain = chain_plug->chain();
@@ -448,12 +481,6 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
 
       void process_incoming_transaction_async(const transaction_metadata_ptr& trx, bool persist_until_expired, next_function<transaction_trace_ptr> next) {
          chain::controller& chain = chain_plug->chain();
-         if (!chain.is_building_block()) {
-            _pending_incoming_transactions.emplace_back(trx, persist_until_expired, next);
-            return;
-         }
-
-         auto block_time = chain.pending_block_time();
 
          auto send_response = [this, &trx, &chain, &next](const fc::static_variant<fc::exception_ptr, transaction_trace_ptr>& response) {
             next(response);
@@ -484,53 +511,62 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
             }
          };
 
-         const auto& id = trx->id();
-         if( fc::time_point(trx->packed_trx()->expiration()) < block_time ) {
-            send_response(std::static_pointer_cast<fc::exception>(
-                  std::make_shared<expired_tx_exception>(
-                        FC_LOG_MESSAGE(error, "expired transaction ${id}, expiration ${e}, block time ${bt}",
-                                       ("id", id)("e", trx->packed_trx()->expiration())("bt", block_time)) )));
-            return;
-         }
-
-         if( chain.is_known_unexpired_transaction(id) ) {
-            send_response(std::static_pointer_cast<fc::exception>(std::make_shared<tx_duplicate>(FC_LOG_MESSAGE(error, "duplicate transaction ${id}", ("id", id)) )));
-            return;
-         }
-
-         auto deadline = fc::time_point::now() + fc::milliseconds(_max_transaction_time_ms);
-         bool deadline_is_subjective = false;
-         const auto block_deadline = calculate_block_deadline(block_time);
-         if (_max_transaction_time_ms < 0 || (_pending_block_mode == pending_block_mode::producing && block_deadline < deadline) ) {
-            deadline_is_subjective = true;
-            deadline = block_deadline;
-         }
-
          try {
-            auto trace = chain.push_transaction(trx, deadline);
-            if (trace->except) {
-               if (failure_is_subjective(*trace->except, deadline_is_subjective)) {
-                  _pending_incoming_transactions.emplace_back(trx, persist_until_expired, next);
-                  if (_pending_block_mode == pending_block_mode::producing) {
-                     fc_dlog(_trx_trace_log, "[TRX_TRACE] Block ${block_num} for producer ${prod} COULD NOT FIT, tx: ${txid} RETRYING ",
-                             ("block_num", chain.head_block_num() + 1)
-                             ("prod", chain.pending_block_producer())
-                             ("txid", trx->id()));
+            if( !chain.is_building_block()) {
+               _pending_incoming_transactions.add( trx, persist_until_expired, next );
+               return;
+            }
+
+            auto block_time = chain.pending_block_time();
+
+            const auto& id = trx->id();
+            if( fc::time_point( trx->packed_trx()->expiration()) < block_time ) {
+               send_response( std::static_pointer_cast<fc::exception>(
+                     std::make_shared<expired_tx_exception>(
+                           FC_LOG_MESSAGE( error, "expired transaction ${id}, expiration ${e}, block time ${bt}",
+                                           ("id", id)("e", trx->packed_trx()->expiration())( "bt", block_time )))));
+               return;
+            }
+
+            if( chain.is_known_unexpired_transaction( id )) {
+               send_response( std::static_pointer_cast<fc::exception>( std::make_shared<tx_duplicate>(
+                     FC_LOG_MESSAGE( error, "duplicate transaction ${id}", ("id", id)))) );
+               return;
+            }
+
+            auto deadline = fc::time_point::now() + fc::milliseconds( _max_transaction_time_ms );
+            bool deadline_is_subjective = false;
+            const auto block_deadline = calculate_block_deadline( block_time );
+            if( _max_transaction_time_ms < 0 ||
+                (_pending_block_mode == pending_block_mode::producing && block_deadline < deadline)) {
+               deadline_is_subjective = true;
+               deadline = block_deadline;
+            }
+
+            auto trace = chain.push_transaction( trx, deadline );
+            if( trace->except ) {
+               if( failure_is_subjective( *trace->except, deadline_is_subjective )) {
+                  _pending_incoming_transactions.add( trx, persist_until_expired, next );
+                  if( _pending_block_mode == pending_block_mode::producing ) {
+                     fc_dlog( _trx_trace_log, "[TRX_TRACE] Block ${block_num} for producer ${prod} COULD NOT FIT, tx: ${txid} RETRYING ",
+                              ("block_num", chain.head_block_num() + 1)
+                              ("prod", chain.pending_block_producer())
+                              ("txid", trx->id()));
                   } else {
-                     fc_dlog(_trx_trace_log, "[TRX_TRACE] Speculative execution COULD NOT FIT tx: ${txid} RETRYING",
-                             ("txid", trx->id()));
+                     fc_dlog( _trx_trace_log, "[TRX_TRACE] Speculative execution COULD NOT FIT tx: ${txid} RETRYING",
+                              ("txid", trx->id()));
                   }
                } else {
                   auto e_ptr = trace->except->dynamic_copy_exception();
-                  send_response(e_ptr);
+                  send_response( e_ptr );
                }
             } else {
-               if (persist_until_expired) {
+               if( persist_until_expired ) {
                   // if this trx didnt fail/soft-fail and the persist flag is set, store its ID so that we can
                   // ensure its applied to all future speculative blocks as well.
-                  _persistent_transactions.insert(transaction_id_with_expiry{trx->id(), trx->packed_trx()->expiration()});
+                  _persistent_transactions.insert( transaction_id_with_expiry{trx->id(), trx->packed_trx()->expiration()} );
                }
-               send_response(trace);
+               send_response( trace );
             }
 
          } catch ( const guard_exception& e ) {
@@ -637,6 +673,8 @@ void producer_plugin::set_program_options(
           "Maximum wall-clock time, in milliseconds, spent retiring scheduled transactions in any block before returning to normal transaction processing.")
          ("incoming-defer-ratio", bpo::value<double>()->default_value(1.0),
           "ratio between incoming transations and deferred transactions when both are exhausted")
+         ("incoming-transaction-queue-size-mb", bpo::value<uint16_t>()->default_value( 1024 ),
+          "Maximum size (in MiB) of the incoming transaction queue. Exceeding this value will subjectively drop transaction with resource exhaustion.")
          ("producer-threads", bpo::value<uint16_t>()->default_value(config::default_controller_thread_pool_size),
           "Number of worker threads in producer thread pool")
          ("snapshots-dir", bpo::value<bfs::path>()->default_value("snapshots"),
@@ -770,6 +808,8 @@ void producer_plugin::plugin_initialize(const boost::program_options::variables_
    my->_max_transaction_time_ms = options.at("max-transaction-time").as<int32_t>();
 
    my->_max_irreversible_block_age_us = fc::seconds(options.at("max-irreversible-block-age").as<int32_t>());
+
+   my->_max_incoming_transaction_queue_size = options.at("incoming-transaction-queue-size-mb").as<uint16_t>() * 1024*1024;
 
    my->_incoming_defer_ratio = options.at("incoming-defer-ratio").as<double>();
 
@@ -1616,8 +1656,7 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block() {
                while (_incoming_trx_weight >= 1.0 && orig_pending_txn_size && _pending_incoming_transactions.size()) {
                   if (scheduled_trx_deadline <= fc::time_point::now()) break;
 
-                  auto e = _pending_incoming_transactions.front();
-                  _pending_incoming_transactions.pop_front();
+                  auto e = _pending_incoming_transactions.pop_front();
                   --orig_pending_txn_size;
                   _incoming_trx_weight -= 1.0;
                   process_incoming_transaction_async(std::get<0>(e), std::get<1>(e), std::get<2>(e));
@@ -1683,8 +1722,7 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block() {
                fc_dlog(_log, "Processing ${n} pending transactions", ("n", _pending_incoming_transactions.size()));
                while (orig_pending_txn_size && _pending_incoming_transactions.size()) {
                   if (preprocess_deadline <= fc::time_point::now()) return start_block_result::exhausted;
-                  auto e = _pending_incoming_transactions.front();
-                  _pending_incoming_transactions.pop_front();
+                  auto e = _pending_incoming_transactions.pop_front();
                   --orig_pending_txn_size;
                   process_incoming_transaction_async(std::get<0>(e), std::get<1>(e), std::get<2>(e));
                }


### PR DESCRIPTION
## Change Description

- Add `producer_plugin` `incoming-transaction-queue-size-mb` so that incoming transactions can be rejected with `tx_resource_exhaustion exception` when queue is full.
- This is useful for a new transaction only connection option that is in work for the net_plugin.

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
