### PR TITLE
ship: uncompress when sending to clients

### DIFF
--- a/plugins/state_history_plugin/include/eosio/state_history_plugin/state_history_serialization.hpp
+++ b/plugins/state_history_plugin/include/eosio/state_history_plugin/state_history_serialization.hpp
@@ -90,9 +90,18 @@ datastream<ST>& operator<<(datastream<ST>& ds, const history_serial_big_vector_w
 }
 
 template <typename ST>
+inline void history_pack_varuint64(datastream<ST>& ds, uint64_t val) {
+   do {
+      uint8_t b = uint8_t(val) & 0x7f;
+      val >>= 7;
+      b |= ((val > 0) << 7);
+      ds.write((char*)&b, 1);
+   } while (val);
+}
+
+template <typename ST>
 void history_pack_big_bytes(datastream<ST>& ds, const eosio::chain::bytes& v) {
-   FC_ASSERT(v.size() <= 1024 * 1024 * 1024);
-   fc::raw::pack(ds, unsigned_int((uint32_t)v.size()));
+   history_pack_varuint64(ds, v.size());
    if (v.size())
       ds.write(&v.front(), (uint32_t)v.size());
 }

--- a/plugins/state_history_plugin/state_history_plugin.cpp
+++ b/plugins/state_history_plugin/state_history_plugin.cpp
@@ -53,6 +53,16 @@ static bytes zlib_compress_bytes(bytes in) {
    return out;
 }
 
+static bytes zlib_decompress(const bytes& in) {
+   bytes                  out;
+   bio::filtering_ostream decomp;
+   decomp.push(bio::zlib_decompressor());
+   decomp.push(bio::back_inserter(out));
+   bio::write(decomp, in.data(), in.size());
+   bio::close(decomp);
+   return out;
+}
+
 template <typename T>
 bool include_delta(const T& old, const T& curr) {
    return true;
@@ -126,10 +136,10 @@ struct state_history_plugin_impl : std::enable_shared_from_this<state_history_pl
       auto&                    stream = log.get_entry(block_num, header);
       uint32_t                 s;
       stream.read((char*)&s, sizeof(s));
-      result.emplace();
-      result->resize(s);
+      bytes compressed(s);
       if (s)
-         stream.read(result->data(), s);
+         stream.read(compressed.data(), s);
+      result = zlib_decompress(compressed);
    }
 
    void get_block(uint32_t block_num, fc::optional<bytes>& result) {


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

This change separates on-disk compression from on-socket compression. This helps to support the following in the future:
* User-configured on-disk compression policy (e.g. none, gzip, lz4, ...)
* Websocket compression extensions

This change causes the first delta to bump past the exising 1GB limit in the on-socket protocol on partial history nodes. This is close to varuint32's 4GB limit. This PR upgrades the size prefix from a varuint32 to a varuint64 and removes the limit.

Related: #7381 

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->

`get_blocks_result_v0` `traces` and `deltas` fields:
* Are no longer compressed
* Now have a varuint64 length prefix. varuint32 and varuint64 length prefixes have the same binary format as long as the payload doesn't hit 4GB.

## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
