### PR TITLE
throw error if trying to create non R1 key on SE or YubiHSM wallet

### DIFF
--- a/plugins/wallet_plugin/se_wallet.cpp
+++ b/plugins/wallet_plugin/se_wallet.cpp
@@ -362,6 +362,7 @@ bool se_wallet::import_key(string wif_key) {
 }
 
 string se_wallet::create_key(string key_type) {
+   EOS_ASSERT(key_type.empty() || key_type == "R1", chain::unsupported_key_type_exception, "Secure Enclave wallet only supports R1 keys");
    return (string)my->create();
 }
 

--- a/plugins/wallet_plugin/yubihsm_wallet.cpp
+++ b/plugins/wallet_plugin/yubihsm_wallet.cpp
@@ -257,6 +257,7 @@ bool yubihsm_wallet::import_key(string wif_key) {
 }
 
 string yubihsm_wallet::create_key(string key_type) {
+   EOS_ASSERT(key_type.empty() || key_type == "R1", chain::unsupported_key_type_exception, "YubiHSM wallet only supports R1 keys");
    return (string)my->create();
 }
 


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
Secure Enclave & YubiHSM wallets only support R1 keys. The enforcement of this was somehow missing causing the confusion in #7374. Add the assert that the user is either explicitly requesting an R1 key, or they didn't request any type of key (and should get wallet default in that case)

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
