### PR TITLE
Add `cleos` version format changes

### DIFF
--- a/programs/cleos/CMakeLists.txt
+++ b/programs/cleos/CMakeLists.txt
@@ -16,9 +16,16 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/../../.git)
     execute_process(
       COMMAND ${GIT_EXECUTABLE} rev-parse --short=8 HEAD
       WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/../.."
-      OUTPUT_VARIABLE "cleos_BUILD_VERSION"
+      OUTPUT_VARIABLE "cleos_BUILD_HASH"
       ERROR_QUIET
       OUTPUT_STRIP_TRAILING_WHITESPACE)
+    execute_process(
+      COMMAND ${GIT_EXECUTABLE} describe --tags --dirty
+      WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/../.."
+      OUTPUT_VARIABLE "cleos_BUILD_DIRTY"
+      ERROR_QUIET
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+    string(REGEX MATCH "-dirty$" cleos_BUILD_DIRTY "${cleos_BUILD_DIRTY}")
     message(STATUS "Git commit revision: ${cleos_BUILD_VERSION}")
   else()
     set(cleos_BUILD_VERSION 0)

--- a/programs/cleos/config.hpp.in
+++ b/programs/cleos/config.hpp.in
@@ -6,6 +6,10 @@
 #pragma once
 
 namespace eosio { namespace client { namespace config {
+   constexpr char cleos_version_full[] = "${VERSION_FULL}";
+   constexpr char cleos_build_hash[]   = "${cleos_BUILD_HASH}";
+   constexpr char cleos_build_dirty[]  = "${cleos_BUILD_DIRTY}";
+         
    constexpr char version_str[] = "${cleos_BUILD_VERSION}";
    constexpr char locale_path[] = "${LOCALEDIR}";
    constexpr char locale_domain[] = "${LOCALEDOMAIN}";

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -2366,8 +2366,16 @@ int main( int argc, char** argv ) {
    auto version = app.add_subcommand("version", localized("Retrieve version information"), false);
    version->require_subcommand();
 
-   version->add_subcommand("client", localized("Retrieve version information of the client"))->set_callback([] {
-     std::cout << localized("Build version: ${ver}", ("ver", eosio::client::config::version_str)) << std::endl;
+   version->add_subcommand("client", localized("Retrieve basic version information of the client"))->set_callback([] {
+      std::string version_string{ localized("${str}", ("str", eosio::client::config::cleos_version_full)) };
+      std::cout << version_string << '\n';
+   });
+
+   version->add_subcommand("full", localized("Retrieve full version information of the client"))->set_callback([] {
+      std::string version_string{localized("${str}", ("str", eosio::client::config::cleos_version_full)) + "-" +
+                                 localized("${str}", ("str", eosio::client::config::cleos_build_hash))   +
+                                 localized("${str}", ("str", eosio::client::config::cleos_build_dirty))};
+      std::cout << version_string << '\n';
    });
 
    // Create subcommand

--- a/programs/nodeos/CMakeLists.txt
+++ b/programs/nodeos/CMakeLists.txt
@@ -27,7 +27,7 @@ else()
   set(nodeos_BUILD_VERSION 0)
 endif()
 
-configure_file(config.hpp.in config.hpp ESCAPE_QUOTES)
+configure_file(config.hpp.in ${CMAKE_CURRENT_BINARY_DIR}/config.hpp ESCAPE_QUOTES)
 
 target_include_directories(${NODE_EXECUTABLE_NAME} PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
 


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
In reference to [Issue #7396](https://github.com/EOSIO/eos/issues/7396), this PR alters the format of printing the `cleos` version in a more intuitive way; in addition, a new `cleos version` sub-command has been added as well.

Examples:
```
~/eos/build/bin $ ./cleos version client
1.9.0-develop
```

```
~/eos/build/bin $ ./cleos version full
1.9.0-develop-7de45825-dirty
```

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [x] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->
New `cleos version` sub-command: `cleos version full`.

## Documentation Additions
- [x] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
