### PR TITLE
Add option for cleos sign subcommand to ask keosd for signing

### DIFF
--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -3300,20 +3300,21 @@ int main( int argc, char** argv ) {
    string str_private_key;
    string str_chain_id;
    string str_private_key_file;
-   string str_keosd_pub_key;
+   string str_public_key;
    bool push_trx = false;
 
    auto sign = app.add_subcommand("sign", localized("Sign a transaction"), false);
    sign->add_option("transaction", trx_json_to_sign,
                                  localized("The JSON string or filename defining the transaction to sign"), true)->required();
    sign->add_option("-k,--private-key", str_private_key, localized("The private key that will be used to sign the transaction"));
-   sign->add_option("-w,--wallet", str_keosd_pub_key, localized("Ask keosd to sign with the given public key"));
+   sign->add_option("--public-key", str_public_key, localized(string("Ask ") + string(key_store_executable_name +
+                                                                 "to sign with the corresponding private key of the given public key"));
    sign->add_option("-c,--chain-id", str_chain_id, localized("The chain id that will be used to sign the transaction"));
-   sign->add_flag( "-p,--push-transaction", push_trx, localized("Push transaction after signing"));
+   sign->add_flag("-p,--push-transaction", push_trx, localized("Push transaction after signing"));
 
    sign->set_callback([&] {
 
-      EOSC_ASSERT( str_private_key.empty() || str_keosd_pub_key.empty(), "ERROR: Either -k/--private-key or -w/--wallet or none of them can be set" );
+      EOSC_ASSERT( str_private_key.empty() || str_public_key.empty(), "ERROR: Either -k/--private-key or --public-key or none of them can be set" );
 
       signed_transaction trx = json_from_file_or_string(trx_json_to_sign).as<signed_transaction>();
 
@@ -3327,11 +3328,11 @@ int main( int argc, char** argv ) {
          chain_id = chain_id_type(str_chain_id);
       }
 
-      if( str_keosd_pub_key.size() > 0 ) {
+      if( str_public_key.size() > 0 ) {
          public_key_type pub_key;
          try {
-            pub_key = public_key_type(str_keosd_pub_key);
-         } EOS_RETHROW_EXCEPTIONS(public_key_type_exception, "Invalid public key: ${public_key}", ("public_key", str_keosd_pub_key))
+            pub_key = public_key_type(str_public_key);
+         } EOS_RETHROW_EXCEPTIONS(public_key_type_exception, "Invalid public key: ${public_key}", ("public_key", str_public_key))
          fc::variant keys_var(flat_set<public_key_type>{ pub_key });
          sign_transaction(trx, keys_var, *chain_id);
       } else {

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -3219,7 +3219,7 @@ int main( int argc, char** argv ) {
       try {
          wallet_key = private_key_type( wallet_key_str );
       } catch (...) {
-         EOS_THROW(private_key_type_exception, "Invalid private key: ${private_key}", ("private_key", wallet_key_str))
+         EOS_THROW(private_key_type_exception, "Invalid private key")
       }
       public_key_type pubkey = wallet_key.get_public_key();
 
@@ -3345,7 +3345,7 @@ int main( int argc, char** argv ) {
          private_key_type priv_key;
          try {
             priv_key = private_key_type(str_private_key);
-         } EOS_RETHROW_EXCEPTIONS(private_key_type_exception, "Invalid private key: ${private_key}", ("private_key", str_private_key))
+         } EOS_RETHROW_EXCEPTIONS(private_key_type_exception, "Invalid private key")
          trx.sign(priv_key, *chain_id);
       }
 

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -3327,13 +3327,7 @@ int main( int argc, char** argv ) {
          chain_id = chain_id_type(str_chain_id);
       }
 
-      if( str_private_key.size() > 0 ) {
-         private_key_type priv_key;
-         try {
-            priv_key = private_key_type(str_private_key);
-         } EOS_RETHROW_EXCEPTIONS(private_key_type_exception, "Invalid private key: ${private_key}", ("private_key", str_private_key))
-         trx.sign(priv_key, *chain_id);
-      } else if( str_keosd_pub_key.size() > 0 ) {
+      if( str_keosd_pub_key.size() > 0 ) {
          public_key_type pub_key;
          try {
             pub_key = public_key_type(str_keosd_pub_key);
@@ -3341,10 +3335,17 @@ int main( int argc, char** argv ) {
          fc::variant keys_var(flat_set<public_key_type>{ pub_key });
          sign_transaction(trx, keys_var, *chain_id);
       } else {
-         std::cerr << localized("private key: ");
-         fc::set_console_echo(false);
-         std::getline( std::cin, str_private_key, '\n' );
-         fc::set_console_echo(true);
+         if( str_private_key.size() == 0 ) {
+            std::cerr << localized("private key: ");
+            fc::set_console_echo(false);
+            std::getline( std::cin, str_private_key, '\n' );
+            fc::set_console_echo(true);
+         }
+         private_key_type priv_key;
+         try {
+            priv_key = private_key_type(str_private_key);
+         } EOS_RETHROW_EXCEPTIONS(private_key_type_exception, "Invalid private key: ${private_key}", ("private_key", str_private_key))
+         trx.sign(priv_key, *chain_id);
       }
 
       if(push_trx) {

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -3307,8 +3307,7 @@ int main( int argc, char** argv ) {
    sign->add_option("transaction", trx_json_to_sign,
                                  localized("The JSON string or filename defining the transaction to sign"), true)->required();
    sign->add_option("-k,--private-key", str_private_key, localized("The private key that will be used to sign the transaction"));
-   sign->add_option("--public-key", str_public_key, localized(string("Ask ") + string(key_store_executable_name +
-                                                                 "to sign with the corresponding private key of the given public key"));
+   sign->add_option("--public-key", str_public_key, localized("Ask ${exec} to sign with the corresponding private key of the given public key", ("exec", key_store_executable_name)));
    sign->add_option("-c,--chain-id", str_chain_id, localized("The chain id that will be used to sign the transaction"));
    sign->add_flag("-p,--push-transaction", push_trx, localized("Push transaction after signing"));
 


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

Related to https://github.com/EOSIO/eos/issues/7407
Currently "cleos sign" subcommand doesn't allow the user to sign using the private key which is stored in keosd. This PR will enable this capability for cleos.

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
