### PR TITLE
Fix #7436 SIGSEGV - 1.6.x

### DIFF
--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1208,7 +1208,7 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block() {
 
                   if( preprocess_deadline <= fc::time_point::now() ) exhausted = true;
                   if( exhausted ) break;
-                  const auto& trx = itr->second;
+                  const transaction_metadata_ptr trx = itr->second;
                   auto category = calculate_transaction_category(trx);
                   if (category == tx_category::EXPIRED ||
                      (category == tx_category::UNEXPIRED_UNPERSISTED && _producers.empty()))


### PR DESCRIPTION
## Change Description

- Resolves #7436 
- Fix lifetime issue with `transaction_metadata_ptr` to avoid SIGSEGV.

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
