### PR TITLE
set initial costs for expensive parallel unit tests

### DIFF
--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -70,6 +70,12 @@ foreach(TEST_SUITE ${UNIT_TESTS}) # create an independent target for each test s
 endforeach(TEST_SUITE)
 set(ctest_tests "'${ctest_tests}' -j8") # surround test list string in apostrophies
 
+# The following tests are known to take the longest, bump up their cost (priority) so that they'll run first
+# even on fresh first time test runs before ctest auto-detects costs
+set_tests_properties(api_unit_test_wavm api_unit_test_wabt PROPERTIES COST 5000)
+set_tests_properties(wasm_unit_test_wavm wasm_unit_test_wabt PROPERTIES COST 4000)
+set_tests_properties(delay_unit_test_wavm delay_unit_test_wabt PROPERTIES COST 3000)
+
 ### COVERAGE TESTING ###
 if(ENABLE_COVERAGE_TESTING)
   set(Coverage_NAME ${PROJECT_NAME}_ut_coverage)


### PR DESCRIPTION


<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
When running multiple tests in parallel it is most optimal to run the longest ones first. Add some initial costs to the known pigs so that they run first.

This improved performance of running the parallel tests via `-j8` by ~15% for me.

Astute users will notice that if they run ctest a second time the tests do not run in the same order as the first time. ctest actually records the costs for each test in Testing/Temporary/CTestCostData.txt so that subsequent runs are more optimal. This auto-cost generation doesn't help the CI builds since they are always fresh.

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
