### PR TITLE
Test Unpinned Build Trigger Rules

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -439,6 +439,9 @@ steps:
         echo "+++ :microscope: Running Tests"
         ln -s "$(pwd)" /data/job
         ./scripts/parallel-test.sh
+        cd ..
+        tar -pczf build.tar.gz build
+        buildkite-agent artifact upload build.tar.gz
     label: ":darwin: High Sierra Tests"
     agents:
       - "role=tester-v2-1"
@@ -451,6 +454,9 @@ steps:
         echo "+++ :microscope: Running Tests"
         ln -s "$(pwd)" /data/job
         ./scripts/serial-test.sh
+        cd ..
+        tar -pczf build.tar.gz build
+        buildkite-agent artifact upload build.tar.gz
     label: ":darwin: High Sierra NP Tests"
     agents:
       - "role=tester-v2-1"
@@ -464,6 +470,9 @@ steps:
         echo "+++ :microscope: Running Tests"
         ln -s "$(pwd)" /data/job
         ./scripts/parallel-test.sh
+        cd ..
+        tar -pczf build.tar.gz build
+        buildkite-agent artifact upload build.tar.gz
     label: ":darwin: Mojave Tests"
     agents:
       - "role=tester-v2-1"
@@ -476,6 +485,9 @@ steps:
         echo "+++ :microscope: Running Tests"
         ln -s "$(pwd)" /data/job
         ./scripts/serial-test.sh
+        cd ..
+        tar -pczf build.tar.gz build
+        buildkite-agent artifact upload build.tar.gz
     label: ":darwin: Mojave NP Tests"
     agents:
       - "role=tester-v2-1"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -439,9 +439,6 @@ steps:
         echo "+++ :microscope: Running Tests"
         ln -s "$(pwd)" /data/job
         ./scripts/parallel-test.sh
-        cd ..
-        tar -pczf build.tar.gz build
-        buildkite-agent artifact upload build.tar.gz
     label: ":darwin: High Sierra Tests"
     agents:
       - "role=tester-v2-1"
@@ -454,9 +451,6 @@ steps:
         echo "+++ :microscope: Running Tests"
         ln -s "$(pwd)" /data/job
         ./scripts/serial-test.sh
-        cd ..
-        tar -pczf build.tar.gz build
-        buildkite-agent artifact upload build.tar.gz
     label: ":darwin: High Sierra NP Tests"
     agents:
       - "role=tester-v2-1"
@@ -470,9 +464,6 @@ steps:
         echo "+++ :microscope: Running Tests"
         ln -s "$(pwd)" /data/job
         ./scripts/parallel-test.sh
-        cd ..
-        tar -pczf build.tar.gz build
-        buildkite-agent artifact upload build.tar.gz
     label: ":darwin: Mojave Tests"
     agents:
       - "role=tester-v2-1"
@@ -485,9 +476,6 @@ steps:
         echo "+++ :microscope: Running Tests"
         ln -s "$(pwd)" /data/job
         ./scripts/serial-test.sh
-        cd ..
-        tar -pczf build.tar.gz build
-        buildkite-agent artifact upload build.tar.gz
     label: ":darwin: Mojave NP Tests"
     agents:
       - "role=tester-v2-1"

--- a/scripts/parallel-test.sh
+++ b/scripts/parallel-test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e # exit on failure of any "simple" command (excludes &&, ||, or | chains)
+# set -e # exit on failure of any "simple" command (excludes &&, ||, or | chains)
 # prepare environment
 PATH=$PATH:~/opt/mongodb/bin
 echo "Extracting build directory..."
@@ -17,7 +17,7 @@ set +e # defer ctest error handling to end
 echo "$ ctest -j $CPU_CORES -LE _tests --output-on-failure -T Test"
 ctest -j $CPU_CORES -LE _tests --output-on-failure -T Test
 EXIT_STATUS=$?
-[[ "$EXIT_STATUS" == 0 ]] && set -e
+# [[ "$EXIT_STATUS" == 0 ]] && set -e
 echo "Done running parallelizable tests."
 # upload artifacts
 echo "Uploading artifacts..."
@@ -26,6 +26,8 @@ mv $(pwd)/Testing/$(ls $(pwd)/Testing/ | grep '20' | tail -n 1)/Test.xml $XML_FI
 buildkite-agent artifact upload config.ini
 buildkite-agent artifact upload genesis.json
 cd ..
+tar -pczf build.tar.gz build
+buildkite-agent artifact upload build.tar.gz
 buildkite-agent artifact upload mongod.log
 cd build
 buildkite-agent artifact upload $XML_FILENAME

--- a/scripts/serial-test.sh
+++ b/scripts/serial-test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e # exit on failure of any "simple" command (excludes &&, ||, or | chains)
+# set -e # exit on failure of any "simple" command (excludes &&, ||, or | chains)
 # prepare environment
 PATH=$PATH:~/opt/mongodb/bin
 echo "Extracting build directory..."
@@ -15,7 +15,7 @@ set +e # defer ctest error handling to end
 echo "$ ctest -L nonparallelizable_tests --output-on-failure -T Test"
 ctest -L nonparallelizable_tests --output-on-failure -T Test
 EXIT_STATUS=$?
-[[ "$EXIT_STATUS" == 0 ]] && set -e
+# [[ "$EXIT_STATUS" == 0 ]] && set -e
 echo "Done running non-parallelizable tests."
 # upload artifacts
 echo "Uploading artifacts..."
@@ -24,6 +24,8 @@ mv $(pwd)/Testing/$(ls $(pwd)/Testing/ | grep '20' | tail -n 1)/Test.xml $XML_FI
 buildkite-agent artifact upload config.ini
 buildkite-agent artifact upload genesis.json
 cd ..
+tar -pczf build.tar.gz build
+buildkite-agent artifact upload build.tar.gz
 buildkite-agent artifact upload mongod.log
 cd build
 buildkite-agent artifact upload $XML_FILENAME


### PR DESCRIPTION
## Change Description
The purpose of this pull request is to test that opening a new PR against release/1.7.x does not create an `eosio-build-unpinned` build. Do not merge this pull request.

## Consensus Changes
- [ ] Consensus Changes
None.

## API Changes
- [ ] API Changes
None.

## Documentation Additions
- [ ] Documentation Additions
None.