### PR TITLE
Pipeline Configuration File Update

### DIFF
--- a/pipeline.jsonc
+++ b/pipeline.jsonc
@@ -1,23 +1,10 @@
 {
-    "eosio":
-    {
-        "pipeline-branch": "master",
-        "environment":
-        {
-            "IMAGE_TAG": "_2-5"
-        }
-    },
     "eosio-base-images":
     {
         "pipeline-branch": "develop"
     },
-    "eosio-build-unpinned":
-    {
-        "pipeline-branch": "master"
-    },
     "eosio-lrt":
     {
-        "pipeline-branch": "master",
         "environment":
         {
             "BUILD_FLAGS": "-y -P -m",
@@ -26,7 +13,6 @@
     },
     "eos-multiversion-tests":
     {
-        "pipeline-branch": "master",
         "environment":
         {
             "IMAGE_TAG": "_1-8-0-rc2"

--- a/pipeline.jsonc
+++ b/pipeline.jsonc
@@ -4,7 +4,7 @@
         "pipeline-branch": "master",
         "environment":
         {
-            "IMAGE_TAG": "_develop"
+            "IMAGE_TAG": "_2-5"
         }
     },
     "eosio-base-images":

--- a/pipeline.jsonc
+++ b/pipeline.jsonc
@@ -1,9 +1,10 @@
 {
-    "eosio": {
-        "pipeline-branch": "develop",
-        "environment": {
-            "IMAGE_TAG": "develop",
-            "DEBUG": true
+    "eosio":
+    {
+        "pipeline-branch": "master",
+        "environment":
+        {
+            "IMAGE_TAG": "_develop"
         }
     },
     "eosio-base-images":

--- a/pipeline.jsonc
+++ b/pipeline.jsonc
@@ -6,34 +6,54 @@
             "DEBUG": true
         }
     },
-    "eosio-base-images": {
+    "eosio-base-images":
+    {
         "pipeline-branch": "develop"
     },
-    "eosio-build-unpinned": {
-        "pipeline-branch": "protocol-features-sync-nodes"
+    "eosio-build-unpinned":
+    {
+        "pipeline-branch": "master"
     },
-    "eosio-lrt": {
-        "pipeline-branch": "protocol-features-sync-nodes"
+    "eosio-lrt":
+    {
+        "pipeline-branch": "master",
+        "environment":
+        {
+            "BUILD_FLAGS": "-y -P -m",
+            "IMAGE_TAG": "_1-8-0-rc2"
+        }
     },
-    "eos-multiversion-tests": {
-        "pipeline-branch": "protocol-features-sync-nodes",
-        "configuration": [
+    "eos-multiversion-tests":
+    {
+        "pipeline-branch": "master",
+        "environment":
+        {
+            "IMAGE_TAG": "_1-8-0-rc2"
+        },
+        "configuration":
+        [
             "170=v1.7.0"
         ]
     },
-    "eosio-docker-builds": {
-        "environment": {
+    "eosio-docker-builds":
+    {
+        "environment":
+        {
             "BUILDER_TAG": "v1.8.0"
         }
     },
-    "eosio-sync-tests": {
-        "environment": {
+    "eosio-sync-tests":
+    {
+        "environment":
+        {
             "SKIP_PRE_V180": "true",
             "SKIP_V180": "false"
         }
     },
-    "eosio-replay-tests": {
-        "environment": {
+    "eosio-replay-tests":
+    {
+        "environment":
+        {
             "SKIP_PRE_V180": "true",
             "SKIP_V180": "false"
         }


### PR DESCRIPTION
## Change Description
This pull request is a step towards our overall goal of reducing the number of branches on `auto-buildkite-pipelines` and simplifying the CI/CD pipelines.
- Added `IMAGE_TAG` and `BUILD_FLAGS` to the `eosio-lrt` pipeline for backwards-compatibility with `eos:release/1.7.x` and `eos:release/1.6.x`
- Added `IMAGE_TAG` to the `eos-multiversion` for backwards-compatibility with `eos:release/1.7.x` and `eos:release/1.6.x`
- Removed `pipeline-branch` references to any branches besides `auto-buildkite-pipelines:master`

Currently, several pipelines are running code from `auto-buildkite-pipelines:protocol-features-sync-nodes`. This branch was created with EOSIO 1.8 RC 1 to handle fundamental test and build differences between 1.8 and earlier versions. These test and build differences are now handled programmatically.

## Consensus Changes
- [ ] Consensus Changes
None.

## API Changes
- [ ] API Changes
None.

## Documentation Additions
- [ ] Documentation Additions
None.