### PR TITLE
Pipeline Configuration File Update

### DIFF
--- a/pipeline.jsonc
+++ b/pipeline.jsonc
@@ -3,13 +3,8 @@
     {
         "pipeline-branch": "release/1.8.x"
     },
-    "eosio-build-unpinned":
-    {
-        "pipeline-branch": "master"
-    },
     "eosio-lrt":
     {
-        "pipeline-branch": "master",
         "environment":
         {
             "BUILD_FLAGS": "-y -P -m",
@@ -18,7 +13,6 @@
     },
     "eos-multiversion-tests":
     {
-        "pipeline-branch": "master",
         "environment":
         {
             "IMAGE_TAG": "_1-8-0-rc2"

--- a/pipeline.jsonc
+++ b/pipeline.jsonc
@@ -1,19 +1,28 @@
 {
-    "eosio-build-unpinned":
-    {
-        "pipeline-branch": "protocol-features-sync-nodes"
-    },
-    "eosio-lrt":
-    {
-        "pipeline-branch": "protocol-features-sync-nodes"
-    },
     "eosio-base-images":
     {
         "pipeline-branch": "release/1.8.x"
     },
+    "eosio-build-unpinned":
+    {
+        "pipeline-branch": "master"
+    },
+    "eosio-lrt":
+    {
+        "pipeline-branch": "master",
+        "environment":
+        {
+            "BUILD_FLAGS": "-y -P -m",
+            "IMAGE_TAG": "_1-8-0-rc2"
+        }
+    },
     "eos-multiversion-tests":
     {
-        "pipeline-branch": "protocol-features-sync-nodes",
+        "pipeline-branch": "master",
+        "environment":
+        {
+            "IMAGE_TAG": "_1-8-0-rc2"
+        },
         "configuration":
         [
             "170=v1.7.0"


### PR DESCRIPTION
## Change Description
This pull request is a step towards our overall goal of reducing the number of branches on `auto-buildkite-pipelines` and simplifying the CI/CD pipelines.
- Added `IMAGE_TAG` and `BUILD_FLAGS` to the `eosio-lrt` pipeline for backwards-compatibility with `eos:release/1.7.x` and `eos:release/1.6.x`
- Added `IMAGE_TAG` to the `eos-multiversion` for backwards-compatibility with `eos:release/1.7.x` and `eos:release/1.6.x`
- Removed `pipeline-branch` references to any branches besides `auto-buildkite-pipelines:master`

Currently, several pipelines are running code from `auto-buildkite-pipelines:protocol-features-sync-nodes`. This branch was created with EOSIO 1.8 RC 1 to handle fundamental test and build differences between 1.8 and earlier versions. These test and build differences are now handled programmatically.

## Consensus Changes
- [ ] Consensus Changes
None.

## API Changes
- [ ] API Changes
None.

## Documentation Additions
- [ ] Documentation Additions
None.