### PR TITLE
on supported platforms build with system clang by default

### DIFF
--- a/scripts/eosio_build_amazonlinux.sh
+++ b/scripts/eosio_build_amazonlinux.sh
@@ -14,11 +14,11 @@ fi
 [[ $MEM_GIG -lt 7 ]] && echo "Your system must have 7 or more Gigabytes of physical memory installed." && exit 1
 [[ "${DISK_AVAIL}" -lt "${DISK_MIN}" ]] && echo " - You must have at least ${DISK_MIN}GB of available storage to install EOSIO." && exit 1
 
-# Handle clang/compiler
-ensure-compiler
 # Ensure packages exist
 ($PIN_COMPILER && $BUILD_CLANG) && EXTRA_DEPS=(gcc-c++,rpm\ -qa)
 ensure-yum-packages $DEPS_FILE $(echo ${EXTRA_DEPS[@]})
+# Handle clang/compiler
+ensure-compiler
 # CMAKE Installation
 ensure-cmake
 # CLANG Installation

--- a/scripts/eosio_build_amazonlinux2_deps
+++ b/scripts/eosio_build_amazonlinux2_deps
@@ -19,3 +19,4 @@ python-devel,rpm -qa
 libedit-devel,rpm -qa
 doxygen,rpm -qa
 graphviz,rpm -qa
+clang,rpm -qa

--- a/scripts/eosio_build_ubuntu.sh
+++ b/scripts/eosio_build_ubuntu.sh
@@ -10,15 +10,15 @@ echo "Disk space available: ${DISK_AVAIL}G"
 [[ $MEM_GIG -lt 7 ]] && echo "Your system must have 7 or more Gigabytes of physical memory installed." && exit 1
 [[ "${DISK_AVAIL}" -lt "${DISK_MIN}" ]] && echo " - You must have at least ${DISK_MIN}GB of available storage to install EOSIO." && exit 1
 
-# C++7 for Ubuntu 18 (16 build-essential has cpp5)
-( [[ $PIN_COMPILER == false ]] && [[ "$(echo ${VERSION_ID})" == "18.04" ]] ) && ensure-build-essential
-# Handle clang/compiler
-ensure-compiler
+# system clang and build essential for Ubuntu 18 (16 too old)
+( [[ $PIN_COMPILER == false ]] && [[ "$(echo ${VERSION_ID})" == "18.04" ]] ) && ensure-build-essential && EXTRA_DEPS=(clang,dpkg\ -s)
 # Ensure packages exist
-([[ $PIN_COMPILER == false ]] && [[ $BUILD_CLANG == false ]]) && EXTRA_DEPS=(llvm-4.0,dpkg\ -s libclang-4.0-dev,dpkg\ -s)
+([[ $PIN_COMPILER == false ]] && [[ $BUILD_CLANG == false ]]) && EXTRA_DEPS+=(llvm-4.0,dpkg\ -s)
 $ENABLE_COVERAGE_TESTING && EXTRA_DEPS+=(lcov,dpkg\ -s)
 ensure-apt-packages "${REPO_ROOT}/scripts/eosio_build_ubuntu_deps" $(echo ${EXTRA_DEPS[@]})
 echo ""
+# Handle clang/compiler
+ensure-compiler
 # CMAKE Installation
 ensure-cmake
 # CLANG Installation

--- a/scripts/helpers/eosio.sh
+++ b/scripts/helpers/eosio.sh
@@ -139,7 +139,7 @@ function ensure-scl() {
 }
 
 function ensure-devtoolset() {
-    echo "${COLOR_CYAN}[Ensuring installation of devtoolset-7 with C++7]${COLOR_NC}"
+    echo "${COLOR_CYAN}[Ensuring installation of devtoolset-7]${COLOR_NC}"
     DEVTOOLSET=$( rpm -qa | grep -E 'devtoolset-7-[0-9].*' || true )
     if [[ -z "${DEVTOOLSET}" ]]; then
         while true; do
@@ -184,8 +184,8 @@ function ensure-build-essential() {
 }
 
 function ensure-compiler() {
-    export CXX=${CXX:-c++}
-    export CC=${CC:-cc}
+    export CXX=${CXX:-clang++}
+    export CC=${CC:-clang}
     if $PIN_COMPILER || [[ -f $CLANG_ROOT/bin/clang++ ]]; then
         export PIN_COMPILER=true
         export BUILD_CLANG=true
@@ -204,9 +204,9 @@ function ensure-compiler() {
                 [[ $( $(which $CXX) --version | cut -d ' ' -f 4 | cut -d '.' -f 1 | head -n 1 ) -lt 10 ]] && export NO_CPP17=true
             else
                 if [[ $( $(which $CXX) --version | cut -d ' ' -f 3 | head -n 1 | cut -d '.' -f1) =~ ^[0-9]+$ ]]; then # Check if the version message cut returns an integer
-                    [[ $( $(which $CXX) --version | cut -d ' ' -f 3 | head -n 1 | cut -d '.' -f1) < 5 ]] && export NO_CPP17=true
+                    [[ $( $(which $CXX) --version | cut -d ' ' -f 3 | head -n 1 | cut -d '.' -f1) < 6 ]] && export NO_CPP17=true
                 elif [[ $(clang --version | cut -d ' ' -f 4 | head -n 1 | cut -d '.' -f1) =~ ^[0-9]+$ ]]; then # Check if the version message cut returns an integer
-                    [[ $( $(which $CXX) --version | cut -d ' ' -f 4 | cut -d '.' -f 1 | head -n 1 ) < 5 ]] && export NO_CPP17=true
+                    [[ $( $(which $CXX) --version | cut -d ' ' -f 4 | cut -d '.' -f 1 | head -n 1 ) < 6 ]] && export NO_CPP17=true
                 fi
             fi
         else


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
compared to clang, building with gcc has shown significant performance degradation particularly for wabt execution. See #7402. Change the build scripts to use a system provided clang for platforms that provide it. For supported platforms we will now end up building with:

platform | compiler
------------ | -------------
Ubuntu 16.04 | clang 8 (via forced -P option)
Ubuntu 18.04 | clang 6
Centos 7 | clang 5
Amazon Linux 2 | clang 7
macOS | clang provided by Xcode

🚨🚨🚨I don't believe the clang5 in centos7 is completely c++17 compliant. It didn't seem able to use the c++17 variant properly. So maybe this isn't a good idea?

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
