### PR TITLE
[1.8.x] Ensure we're in repo root

### DIFF
--- a/scripts/eosio_build.sh
+++ b/scripts/eosio_build.sh
@@ -111,7 +111,7 @@ if [ $# -ne 0 ]; then
    done
 fi
 
-[[ ! -d scripts ]] && echo "You must run this script from the eos root!" && exit 1
+[[ ! -d scripts ]] && echo "You must run this script from the eos root." && exit 1
 
 # Load eosio specific helper functions
 . ./scripts/helpers/eosio.sh

--- a/scripts/eosio_build.sh
+++ b/scripts/eosio_build.sh
@@ -111,6 +111,8 @@ if [ $# -ne 0 ]; then
    done
 fi
 
+[[ ! -d scripts ]] && echo "You must run this script from the eos root!" && exit 1
+
 # Load eosio specific helper functions
 . ./scripts/helpers/eosio.sh
 

--- a/scripts/eosio_build.sh
+++ b/scripts/eosio_build.sh
@@ -111,7 +111,8 @@ if [ $# -ne 0 ]; then
    done
 fi
 
-[[ ! -d scripts ]] && echo "You must run this script from the eos root." && exit 1
+# Ensure we're in the repo root
+cd $( dirname "${BASH_SOURCE[0]}" )/..
 
 # Load eosio specific helper functions
 . ./scripts/helpers/eosio.sh

--- a/scripts/eosio_build.sh
+++ b/scripts/eosio_build.sh
@@ -112,9 +112,7 @@ if [ $# -ne 0 ]; then
 fi
 
 # Ensure we're in the repo root
-pwd
 cd $( dirname "${BASH_SOURCE[0]}" )/..
-pwd
 
 # Load eosio specific helper functions
 . ./scripts/helpers/eosio.sh

--- a/scripts/eosio_build.sh
+++ b/scripts/eosio_build.sh
@@ -112,7 +112,9 @@ if [ $# -ne 0 ]; then
 fi
 
 # Ensure we're in the repo root
+pwd
 cd $( dirname "${BASH_SOURCE[0]}" )/..
+pwd
 
 # Load eosio specific helper functions
 . ./scripts/helpers/eosio.sh

--- a/tests/bash-bats/eosio_build.sh
+++ b/tests/bash-bats/eosio_build.sh
@@ -31,10 +31,12 @@ TEST_LABEL="[eosio_build]"
     fi 
 
     # -P with -y
-    run bash -c "./$SCRIPT_LOCATION -y -P"
+    cd .. # Also test that we can run the script from a directory other than the root
+    run bash -c "./eos/$SCRIPT_LOCATION -y -P"
     [[ ! -z $(echo "${output}" | grep "PIN_COMPILER: true") ]] || exit
     [[ "${output}" =~ -DCMAKE_TOOLCHAIN_FILE=\'.*/scripts/../build/pinned_toolchain.cmake\' ]] || exit
     [[ "${output}" =~ "Clang 8 successfully installed" ]] || exit
+    cd eos
     # -P with prompts
     run bash -c "printf \"n\nn\nn\n\" | ./$SCRIPT_LOCATION -P"
     [[ "${output}" =~ .*User.aborted.* ]] || exit


### PR DESCRIPTION
Need a way to ensure we're in the repo root. This allows people to ./eos/scripts/eosio_build.sh or even run from the scripts directory.