### PR TITLE
Enable extended_asset to be encoded from array

### DIFF
--- a/libraries/chain/include/eosio/chain/asset.hpp
+++ b/libraries/chain/include/eosio/chain/asset.hpp
@@ -114,5 +114,19 @@ inline void from_variant(const fc::variant& var, eosio::chain::asset& vo) {
 }
 }
 
+namespace fc {
+inline void from_variant(const fc::variant& var, eosio::chain::extended_asset& vo) {
+   if( var.is_array() ) {
+      const auto& va = var.get_array();
+      from_variant(va.at(0), vo.quantity);
+      from_variant(va.at(1), vo.contract);
+   } else {
+      const auto& vars = var.get_object();
+      from_variant(vars["quantity"], vo.quantity);
+      from_variant(vars["contract"], vo.contract);
+   }
+}
+}
+
 FC_REFLECT(eosio::chain::asset, (amount)(sym))
 FC_REFLECT(eosio::chain::extended_asset, (quantity)(contract) )


### PR DESCRIPTION
## Change Description
`eosio::extended_asset` uses generated `fc::from_variant()` to encode, so it should be passed by object.
```
$ cleos push action xxx xxx '[{"quantity": "1.0000 EOS", "contract": "eosio.token"}]' -p eosio
```
However, non-built_in type like `eosio::extended_symbol` uses `_variant_to_binary` of abi_serializer and encoding from array is supported.
```
$ cleos push action xxx xxx '[["4,EOS", "eosio.token"]]' -p eosio
```

This PR adds overloaded `fc::from_variant` for `extended_asset` to support encoding from both object and array.
```
$ cleos push action xxx xxx '[["1.0000 EOS", "eosio.token"]]' -p eosio
$ cleos push action xxx xxx '[{"quantity": "1.0000 EOS", "contract": "eosio.token"}]' -p eosio
```

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
