### PR TITLE
Fix Incorrectly Resolved and Untested Merge Conflicts in Pipeline Configuration File

### DIFF
--- a/pipeline.jsonc
+++ b/pipeline.jsonc
@@ -7,13 +7,8 @@
             "IMAGE_TAG": "1.9.0-develop"
         }
     },
-    "eosio-build-unpinned":
-    {
-        "pipeline-branch": "master"
-    },
     "eosio-lrt":
     {
-        "pipeline-branch": "master",
         "environment":
         {
             "BUILD_FLAGS": "-y -P -m",

--- a/pipeline.jsonc
+++ b/pipeline.jsonc
@@ -7,11 +7,18 @@
             "IMAGE_TAG": "1.9.0-develop"
         }
     },
-    "eosio-build-unpinned": {
-        "pipeline-branch": "protocol-features-sync-nodes"
+    "eosio-build-unpinned":
+    {
+        "pipeline-branch": "master"
     },
-    "eosio-lrt": {
-        "pipeline-branch": "protocol-features-sync-nodes"
+    "eosio-lrt":
+    {
+        "pipeline-branch": "master",
+        "environment":
+        {
+            "BUILD_FLAGS": "-y -P -m",
+            "IMAGE_TAG": "_1-8-0-rc2"
+        }
     },
     "eos-multiversion-tests":
     {

--- a/pipeline.jsonc
+++ b/pipeline.jsonc
@@ -1,8 +1,10 @@
 {
-    "eosio": {
-        "environment": {
-            "IMAGE_TAG": "1.9.0-develop",
-            "HELPER_ENABLED": true
+    "eosio":
+    {
+        "environment":
+        {
+            "HELPER_ENABLED": true,
+            "IMAGE_TAG": "1.9.0-develop"
         }
     },
     "eosio-build-unpinned": {


### PR DESCRIPTION
## Change Description
I removed the `auto-buildkite-pipelines:protocol-features-sync-nodes` branch in [pull request 7467](https://github.com/EOSIO/eos/pull/7467) but then, in [commit 2bcddd7fca4162f49db350ece8e27b49cd8e5080](https://github.com/EOSIO/eos/commit/2bcddd7fca4162f49db350ece8e27b49cd8e5080), someone incorrectly resolved merge conflicts and pointed the `eosio-lrt` and `eosio-build-unpinned` pipelines at this deleted branch without testing their changes.
I have restored these pipelines to their state in [pull request 7467](https://github.com/EOSIO/eos/pull/7467).  
   
### Tested
- [`eosio-build-unpinned` build 241](https://buildkite.com/EOSIO/eosio-build-unpinned/builds/241)   
  - This build is expected to fail on Amazon Linux 2 NP Tests and Ubuntu 18.04 NP Tests as seen in [build 221](https://buildkite.com/EOSIO/eosio-build-unpinned/builds/221). DevOps has an open story to address that failure.
- [`eosio-lrt` build 549](https://buildkite.com/EOSIO/eosio-lrt/builds/549)

## Consensus Changes
- [ ] Consensus Changes
None.

## API Changes
- [ ] API Changes
None.

## Documentation Additions
- [ ] Documentation Additions
None.