### PR TITLE
extended_symbol is different than in eosio.contract

### DIFF
--- a/libraries/chain/include/eosio/chain/symbol.hpp
+++ b/libraries/chain/include/eosio/chain/symbol.hpp
@@ -148,7 +148,7 @@ namespace eosio {
       }; // class symbol
 
       struct extended_symbol {
-         symbol       sym;
+         symbol       symbol;
          account_name contract;
       };
 
@@ -190,4 +190,4 @@ namespace fc {
 
 FC_REFLECT(eosio::chain::symbol_code, (value))
 FC_REFLECT(eosio::chain::symbol, (m_value))
-FC_REFLECT(eosio::chain::extended_symbol, (sym)(contract))
+FC_REFLECT(eosio::chain::extended_symbol, (symbol)(contract))


### PR DESCRIPTION
extended_symbol is different than in eosio.contract (can't use it for unit test)

https://github.com/EOSIO/eosio.cdt/blob/796ff8bee9a0fc864f665a0a4d018e0ff18ac383/libraries/eosiolib/core/eosio/symbol.hpp#L449

<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
