### PR TITLE
properly add single quotes for parameter with spaces in logs output

### DIFF
--- a/tests/Cluster.py
+++ b/tests/Cluster.py
@@ -384,7 +384,7 @@ class Cluster(object):
 
         Cluster.__LauncherCmdArr = cmdArr.copy()
 
-        s=" ".join(cmdArr)
+        s=" ".join([("'{0}'".format(element) if (' ' in element) else element) for element in cmdArr.copy()])
         if Utils.Debug: Utils.Print("cmd: %s" % (s))
         if 0 != subprocess.call(cmdArr):
             Utils.Print("ERROR: Launcher failed to launch. failed cmd: %s" % (s))


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

properly add single quotes for the parameter with spaces. Useful for --nodeos parameter.

Example:

programs/eosio-launcher/eosio-launcher -p 4 -n 4 -d 1 -i 2019-06-13T13:14:13.031 -f --producers 84 --unstarted-nodes 0 --nodeos '--max-transaction-time -1 --abi-serializer-max-time-ms 990000 --filter-on "*" --p2p-max-nodes-per-host 4 --contracts-console --plugin eosio::producer_api_plugin' --max-block-cpu-usage 160000000 --max-transaction-cpu-usage 150000000 --shape mesh

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
