### PR TITLE
on supported platforms build with system clang by default

### DIFF
--- a/scripts/eosio_build_amazonlinux.sh
+++ b/scripts/eosio_build_amazonlinux.sh
@@ -14,11 +14,11 @@ fi
 [[ $MEM_GIG -lt 7 ]] && echo "Your system must have 7 or more Gigabytes of physical memory installed." && exit 1
 [[ "${DISK_AVAIL}" -lt "${DISK_MIN}" ]] && echo " - You must have at least ${DISK_MIN}GB of available storage to install EOSIO." && exit 1
 
-# Handle clang/compiler
-ensure-compiler
 # Ensure packages exist
 ($PIN_COMPILER && $BUILD_CLANG) && EXTRA_DEPS=(gcc-c++,rpm\ -qa)
 ensure-yum-packages $DEPS_FILE $(echo ${EXTRA_DEPS[@]})
+# Handle clang/compiler
+ensure-compiler
 # CMAKE Installation
 ensure-cmake
 # CLANG Installation

--- a/scripts/eosio_build_amazonlinux2_deps
+++ b/scripts/eosio_build_amazonlinux2_deps
@@ -19,3 +19,4 @@ python-devel,rpm -qa
 libedit-devel,rpm -qa
 doxygen,rpm -qa
 graphviz,rpm -qa
+clang,rpm -qa

--- a/scripts/eosio_build_centos.sh
+++ b/scripts/eosio_build_centos.sh
@@ -12,14 +12,14 @@ echo "Disk space available: ${DISK_AVAIL}G"
 
 echo ""
 
-# Repo necessary for rh-python3 and devtoolset-7
+# Repo necessary for rh-python3 and devtoolset-8
 ensure-scl
 # GCC7 for Centos / Needed for CMAKE install even if we're pinning
 ensure-devtoolset
-if [[ -d /opt/rh/devtoolset-7 ]]; then
-	echo "${COLOR_CYAN}[Enabling Centos devtoolset-7 (so we can use GCC 7)]${COLOR_NC}"
-	execute-always source /opt/rh/devtoolset-7/enable
-	echo " - ${COLOR_GREEN}Centos devtoolset-7 successfully enabled!${COLOR_NC}"
+if [[ -d /opt/rh/devtoolset-8 ]]; then
+	echo "${COLOR_CYAN}[Enabling Centos devtoolset-8 (for newer GCC)]${COLOR_NC}"
+	execute-always source /opt/rh/devtoolset-8/enable
+	echo " - ${COLOR_GREEN}Centos devtoolset-8 successfully enabled!${COLOR_NC}"
 fi
 # Handle clang/compiler
 ensure-compiler

--- a/scripts/eosio_build_ubuntu.sh
+++ b/scripts/eosio_build_ubuntu.sh
@@ -10,15 +10,15 @@ echo "Disk space available: ${DISK_AVAIL}G"
 [[ $MEM_GIG -lt 7 ]] && echo "Your system must have 7 or more Gigabytes of physical memory installed." && exit 1
 [[ "${DISK_AVAIL}" -lt "${DISK_MIN}" ]] && echo " - You must have at least ${DISK_MIN}GB of available storage to install EOSIO." && exit 1
 
-# C++7 for Ubuntu 18 (16 build-essential has cpp5)
-( [[ $PIN_COMPILER == false ]] && [[ "$(echo ${VERSION_ID})" == "18.04" ]] ) && ensure-build-essential
-# Handle clang/compiler
-ensure-compiler
+# system clang and build essential for Ubuntu 18 (16 too old)
+( [[ $PIN_COMPILER == false ]] && [[ "$(echo ${VERSION_ID})" == "18.04" ]] ) && ensure-build-essential && EXTRA_DEPS=(clang,dpkg\ -s)
 # Ensure packages exist
-([[ $PIN_COMPILER == false ]] && [[ $BUILD_CLANG == false ]]) && EXTRA_DEPS=(llvm-4.0,dpkg\ -s libclang-4.0-dev,dpkg\ -s)
+([[ $PIN_COMPILER == false ]] && [[ $BUILD_CLANG == false ]]) && EXTRA_DEPS+=(llvm-4.0,dpkg\ -s)
 $ENABLE_COVERAGE_TESTING && EXTRA_DEPS+=(lcov,dpkg\ -s)
 ensure-apt-packages "${REPO_ROOT}/scripts/eosio_build_ubuntu_deps" $(echo ${EXTRA_DEPS[@]})
 echo ""
+# Handle clang/compiler
+ensure-compiler
 # CMAKE Installation
 ensure-cmake
 # CLANG Installation

--- a/scripts/helpers/eosio.sh
+++ b/scripts/helpers/eosio.sh
@@ -121,8 +121,14 @@ function prompt-mongo-install() {
 }
 
 function ensure-compiler() {
-    export CXX=${CXX:-c++}
-    export CC=${CC:-cc}
+    DEFAULT_CXX=clang++
+    DEFAULT_CC=clang
+    if [[ $NAME == "CentOS Linux" ]]; then
+        DEFAULT_CXX=g++
+        DEFAULT_CC=gcc
+    fi
+    export CXX=${CXX:-$DEFAULT_CXX}
+    export CC=${CC:-$DEFAULT_CC}
     if $PIN_COMPILER || [[ -f $CLANG_ROOT/bin/clang++ ]]; then
         export PIN_COMPILER=true
         export BUILD_CLANG=true
@@ -141,9 +147,9 @@ function ensure-compiler() {
                 [[ $( $(which $CXX) --version | cut -d ' ' -f 4 | cut -d '.' -f 1 | head -n 1 ) -lt 10 ]] && export NO_CPP17=true
             else
                 if [[ $( $(which $CXX) --version | cut -d ' ' -f 3 | head -n 1 | cut -d '.' -f1) =~ ^[0-9]+$ ]]; then # Check if the version message cut returns an integer
-                    [[ $( $(which $CXX) --version | cut -d ' ' -f 3 | head -n 1 | cut -d '.' -f1) < 5 ]] && export NO_CPP17=true
+                    [[ $( $(which $CXX) --version | cut -d ' ' -f 3 | head -n 1 | cut -d '.' -f1) < 6 ]] && export NO_CPP17=true
                 elif [[ $(clang --version | cut -d ' ' -f 4 | head -n 1 | cut -d '.' -f1) =~ ^[0-9]+$ ]]; then # Check if the version message cut returns an integer
-                    [[ $( $(which $CXX) --version | cut -d ' ' -f 4 | cut -d '.' -f 1 | head -n 1 ) < 5 ]] && export NO_CPP17=true
+                    [[ $( $(which $CXX) --version | cut -d ' ' -f 4 | cut -d '.' -f 1 | head -n 1 ) < 6 ]] && export NO_CPP17=true
                 fi
             fi
         else

--- a/scripts/helpers/general.sh
+++ b/scripts/helpers/general.sh
@@ -150,16 +150,16 @@ function ensure-scl() {
 }
 
 function ensure-devtoolset() {
-    echo "${COLOR_CYAN}[Ensuring installation of devtoolset-7 with C++7]${COLOR_NC}"
-    DEVTOOLSET=$( rpm -qa | grep -E 'devtoolset-7-[0-9].*' || true )
+    echo "${COLOR_CYAN}[Ensuring installation of devtoolset-8]${COLOR_NC}"
+    DEVTOOLSET=$( rpm -qa | grep -E 'devtoolset-8-[0-9].*' || true )
     if [[ -z "${DEVTOOLSET}" ]]; then
         while true; do
             [[ $NONINTERACTIVE == false ]] && printf "${COLOR_YELLOW}Not Found: Do you wish to install it? (y/n)?${COLOR_NC}" && read -p " " PROCEED
             echo ""
             case $PROCEED in
                 "" ) echo "What would you like to do?";;
-                0 | true | [Yy]* ) install-package devtoolset-7; break;;
-                1 | false | [Nn]* ) echo " - User aborted installation of devtoolset-7."; break;;
+                0 | true | [Yy]* ) install-package devtoolset-8; break;;
+                1 | false | [Nn]* ) echo " - User aborted installation of devtoolset-8."; break;;
                 * ) echo "Please type 'y' for yes or 'n' for no.";;
             esac
         done

--- a/tests/bash-bats/eosio_build_centos.sh
+++ b/tests/bash-bats/eosio_build_centos.sh
@@ -25,12 +25,12 @@ export TEST_LABEL="[eosio_build_centos]"
     set_system_vars # Obtain current machine's resources and set the necessary variables (like JOBS, etc)
 
     execute-always yum -y --enablerepo=extras install centos-release-scl &>/dev/null
-    install-package devtoolset-7 WETRUN &>/dev/null
-    # Ensure SCL and devtoolset-7 for c++ binary installation
+    install-package devtoolset-8 WETRUN &>/dev/null
+    # Ensure SCL and devtoolset-8 for c++ binary installation
     run bash -c "printf \"y\n%.0s\" {1..100}| ./${SCRIPT_LOCATION}"
     [[ ! -z $(echo "${output}" | grep "centos-release-scl-2-3.el7.centos.noarch found") ]] || exit
-    [[ ! -z $(echo "${output}" | grep "devtoolset-7-7.1-4.el7.x86_64 found") ]] || exit
-    [[ ! -z $(echo "${output}" | grep "Executing: source /opt/rh/devtoolset-7/enable") ]] || exit
+    [[ ! -z $(echo "${output}" | grep "devtoolset-8-8.0-2.el7.0.1.x86_64 found") ]] || exit
+    [[ ! -z $(echo "${output}" | grep "Executing: source /opt/rh/devtoolset-8/enable") ]] || exit
     [[ ! -z $(echo "${output}" | grep "Executing: make -j${JOBS}") ]] || exit
     [[ ! -z $(echo "${output}" | grep "Starting EOSIO Dependency Install") ]] || exit
     [[ ! -z $(echo "${output}" | grep "Executing: eval /usr/bin/yum -y update") ]] || exit
@@ -42,7 +42,7 @@ export TEST_LABEL="[eosio_build_centos]"
     [[ ! -z $(echo "${output}" | grep "Starting EOSIO Build") ]] || exit
     [[ ! -z $(echo "${output}" | grep "make -j${CPU_CORES}") ]] || exit
     [[ ! -z $(echo "${output}" | grep "EOSIO has been successfully built") ]] || exit
-    uninstall-package devtoolset-7* WETRUN &>/dev/null
+    uninstall-package devtoolset-8* WETRUN &>/dev/null
     uninstall-package centos-release-scl WETRUN &>/dev/null
 
 }

--- a/tests/bash-bats/helpers/functions.sh
+++ b/tests/bash-bats/helpers/functions.sh
@@ -17,10 +17,9 @@ setup-bats-dirs
 
 function teardown() { # teardown is run once after each test, even if it fails
   [[ -d "$HOME" ]] && rm -rf "$HOME"
-  [[ -d /opt/rh/devtoolset-7 ]] && rm -rf /opt/rh/devtoolset-7
   uninstall-package which WETRUN
   uninstall-package sudo WETRUN
-  uninstall-package devtoolset-7* WETRUN
+  uninstall-package devtoolset-8* WETRUN
   uninstall-package centos-release-scl
   uninstall-package gcc-c++ WETRUN
   uninstall-package build-essential WETRUN


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
compared to clang, building with gcc has shown significant performance degradation particularly for wabt execution. See #7402. Ubuntu 18 & amz2 will now use a system provided clang to build. Compilers used for various platforms:

<table>
  <heae>
    <th>Platform</th>
    <th>pre 1.8</th>
    <th>1.8 rc2</th>
    <th>this PR</th>
  </tr>
  <tr>
    <td>Ubuntu 16.04</td>
    <td>clang 4</td>
    <td colspan="2">clang 8 (via pin)</td>
  </tr>
  <tr>
    <td>Ubuntu 18.04</td>
    <td>clang 4</td>
    <td>gcc 7</td>
    <td>clang 6</td>
  </tr>
  <tr>
    <td>Amazon Linux 2</td>
    <td>gcc 7</td>
    <td>gcc 7</td>
    <td>clang 7</td>
  </tr>
  <tr>
    <td>Centos 7</td>
    <td>gcc 7</td>
    <td>gcc 7</td>
    <td>gcc 8</td>
  </tr>
  <tr>
    <td>macOS</td>
    <td colspan="3">clang as provided by Xcode</td>
  </tr>
</table>

Centos7 will not be upgraded to clang at this time due to the following reasons:
* While the clang 5 provided by centos' SCL compiles eosio today, it won't compile various c++17 tests. Therefore it isn't considered safe to invest in.
* clang 6 is not available in centos' SCL. It is available in Springdale Linux repos (another RHEL clone) but this wasn't considered reasonable to migrate to at the moment
* clang 7 has been released by RH but no one provides built RPMs yet. (in theory it would be great for us to shepherd this in to centos' SCL)
* centos7 never used clang for eosio, so it's not _technically_ a performance regression to keep using it in to 1.8 and later
* EOSVM doesn't suffer from gcc vs clang nearly as badly, so the performance deviation in the future won't be as bad
* Users can still either
  * install llvm-toolset-6.0 or llvm-toolset-7.0 themselves and use it via setting CC and CXX for the build script
  * Use pinned build getting you a clang 8

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
