### PR TITLE
Readlink bats fix r1.8

### DIFF
--- a/scripts/helpers/eosio.sh
+++ b/scripts/helpers/eosio.sh
@@ -165,9 +165,8 @@ function ensure-compiler() {
         which $CXX &>/dev/null || ( echo "${COLOR_RED}Unable to find compiler: Pass in the -P option if you wish for us to install it or install a C++17 compiler and set \$CXX and \$CC to the proper binary locations. ${COLOR_NC}"; exit 1 )
         # readlink on mac differs from linux readlink (mac doesn't have -f)
         [[ $ARCH == "Linux" ]] && READLINK_COMMAND="readlink -f" || READLINK_COMMAND="readlink"
-        COMPILER_TYPE=$( eval $READLINK_COMMAND $(which $CXX) )
-        [[ -z "${COMPILER_TYPE}" ]] && echo "${COLOR_RED}COMPILER_TYPE not set!${COLOR_NC}" && exit 1
-        if [[ $COMPILER_TYPE =~ "clang" ]]; then
+        COMPILER_TYPE=$( eval $READLINK_COMMAND $(which $CXX) || true )
+        if [[ $CXX =~ "clang" ]] || [[ $COMPILER_TYPE =~ "clang" ]]; then
             if [[ $ARCH == "Darwin" ]]; then
                 ### Check for apple clang version 10 or higher
                 [[ $( $(which $CXX) --version | cut -d ' ' -f 4 | cut -d '.' -f 1 | head -n 1 ) -lt 10 ]] && export NO_CPP17=true

--- a/tests/bash-bats/eosio_build.sh
+++ b/tests/bash-bats/eosio_build.sh
@@ -14,37 +14,34 @@ TEST_LABEL="[eosio_build]"
     if [[ $NAME =~ "Amazon Linux" ]] || [[ $NAME == "CentOS Linux" ]]; then
         # which package isn't installed
         uninstall-package which WETRUN &>/dev/null
-        run bash -c "printf \"y\nn\nn\n\" | ./scripts/eosio_build.sh"
+        run bash -c "printf \"y\ny\nn\nn\n\" | ./scripts/eosio_build.sh"
         [[ ! -z $(echo "${output}" | grep "EOSIO compiler checks require the 'which'") ]] || exit
-        [[ ! -z $(echo "${output}" | grep "Please install the 'which'") ]] || exit
     fi
 
     if [[ $ARCH == "Linux" ]]; then
         if [[ $NAME == "CentOS Linux" ]]; then # Centos has the SCL prompt before checking for the compiler
             # No c++!
-            run bash -c "printf \"y\ny\nn\n\" | ./${SCRIPT_LOCATION}"
+            run bash -c "printf \"y\ny\ny\nn\n\" | ./${SCRIPT_LOCATION}"
         else
             # No c++!
-            run bash -c "printf \"y\nn\nn\n\" | ./${SCRIPT_LOCATION}"
+            run bash -c "printf \"y\ny\ny\nn\nn\n\" | ./${SCRIPT_LOCATION}"
         fi
         [[ ! -z $(echo "${output}" | grep "Unable to find compiler") ]] || exit
     fi 
 
-    # -P with -y
-    cd .. # Also test that we can run the script from a directory other than the root
-    run bash -c "./eos/$SCRIPT_LOCATION -y -P"
+    cd ./scripts # Also test that we can run the script from a directory other than the root
+    run bash -c "./eosio_build.sh -y -P"
     [[ ! -z $(echo "${output}" | grep "PIN_COMPILER: true") ]] || exit
     [[ "${output}" =~ -DCMAKE_TOOLCHAIN_FILE=\'.*/scripts/../build/pinned_toolchain.cmake\' ]] || exit
     [[ "${output}" =~ "Clang 8 successfully installed" ]] || exit
-    cd eos
     # -P with prompts
+    cd ..
     run bash -c "printf \"y\nn\nn\nn\n\" | ./$SCRIPT_LOCATION -P"
     [[ "${output}" =~ .*User.aborted.* ]] || exit
     # lack of -m
     [[ ! -z $(echo "${output}" | grep "ENABLE_MONGO: false") ]] || exit
     [[ ! -z $(echo "${output}" | grep "INSTALL_MONGO: false") ]] || exit
     # lack of -i
-    # [[ ! -z $(echo "${output}" | grep "INSTALL_LOCATION: ${HOME}") ]] || exit
     [[ ! -z $(echo "${output}" | grep "EOSIO_INSTALL_DIR: ${HOME}/eosio/${EOSIO_VERSION}") ]] || exit
     ## -o
     run bash -c "printf \"y\ny\nn\nn\n\" | ./$SCRIPT_LOCATION -o Debug -P"

--- a/tests/bash-bats/eosio_build.sh
+++ b/tests/bash-bats/eosio_build.sh
@@ -14,7 +14,7 @@ TEST_LABEL="[eosio_build]"
     if [[ $NAME =~ "Amazon Linux" ]] || [[ $NAME == "CentOS Linux" ]]; then
         # which package isn't installed
         uninstall-package which WETRUN &>/dev/null
-        run bash -c "printf \"n\nn\n\" | ./scripts/eosio_build.sh"
+        run bash -c "printf \"y\nn\nn\n\" | ./scripts/eosio_build.sh"
         [[ ! -z $(echo "${output}" | grep "EOSIO compiler checks require the 'which'") ]] || exit
         [[ ! -z $(echo "${output}" | grep "Please install the 'which'") ]] || exit
     fi
@@ -38,35 +38,35 @@ TEST_LABEL="[eosio_build]"
     [[ "${output}" =~ "Clang 8 successfully installed" ]] || exit
     cd eos
     # -P with prompts
-    run bash -c "printf \"n\nn\nn\n\" | ./$SCRIPT_LOCATION -P"
+    run bash -c "printf \"y\nn\nn\nn\n\" | ./$SCRIPT_LOCATION -P"
     [[ "${output}" =~ .*User.aborted.* ]] || exit
     # lack of -m
     [[ ! -z $(echo "${output}" | grep "ENABLE_MONGO: false") ]] || exit
     [[ ! -z $(echo "${output}" | grep "INSTALL_MONGO: false") ]] || exit
     # lack of -i
-    [[ ! -z $(echo "${output}" | grep "INSTALL_LOCATION: ${HOME}") ]] || exit
+    # [[ ! -z $(echo "${output}" | grep "INSTALL_LOCATION: ${HOME}") ]] || exit
     [[ ! -z $(echo "${output}" | grep "EOSIO_INSTALL_DIR: ${HOME}/eosio/${EOSIO_VERSION}") ]] || exit
     ## -o
-    run bash -c "printf \"y\nn\nn\n\" | ./$SCRIPT_LOCATION -o Debug -P"
+    run bash -c "printf \"y\ny\nn\nn\n\" | ./$SCRIPT_LOCATION -o Debug -P"
     [[ ! -z $(echo "${output}" | grep "CMAKE_BUILD_TYPE: Debug") ]] || exit
     ## -s
-    run bash -c "printf \"y\nn\nn\n\" | ./$SCRIPT_LOCATION -s EOS2 -P"
+    run bash -c "printf \"y\ny\nn\nn\n\" | ./$SCRIPT_LOCATION -s EOS2 -P"
     [[ ! -z $(echo "${output}" | grep "CORE_SYMBOL_NAME: EOS2") ]] || exit
     ## -b
-    run bash -c "printf \"y\nn\nn\n\" | ./$SCRIPT_LOCATION -b /test -P"
+    run bash -c "printf \"y\ny\nn\nn\n\" | ./$SCRIPT_LOCATION -b /test -P"
     [[ ! -z $(echo "${output}" | grep "BOOST_LOCATION: /test") ]] || exit
     ## -i
-    run bash -c "printf \"y\nn\nn\n\"| ./$SCRIPT_LOCATION -i /NEWPATH -P"
-    [[ ! -z $(echo "${output}" | grep "INSTALL_LOCATION: /NEWPATH") ]] || exit
-    [[ ! -z $(echo "${output}" | grep "TEMP_DIR: /NEWPATH/tmp") ]] || exit
+    run bash -c "printf \"y\ny\nn\nn\n\"| ./$SCRIPT_LOCATION -i /NEWPATH -P"
+    [[ ! -z $(echo "${output}" | grep "EOSIO_INSTALL_DIR: /NEWPATH") ]] || exit
+    [[ ! -z $(echo "${output}" | grep "TEMP_DIR: ${HOME}/tmp") ]] || exit
     ## -c
-    run bash -c "printf \"y\nn\nn\n\"| ./$SCRIPT_LOCATION -c -P"
+    run bash -c "printf \"y\ny\nn\nn\n\"| ./$SCRIPT_LOCATION -c -P"
     [[ ! -z $(echo "${output}" | grep "ENABLE_COVERAGE_TESTING: true") ]] || exit
     ## -d
-    run bash -c "printf \"y\nn\nn\n\" | ./$SCRIPT_LOCATION -d -P"
+    run bash -c "printf \"y\ny\nn\nn\n\" | ./$SCRIPT_LOCATION -d -P"
     [[ ! -z $(echo "${output}" | grep "ENABLE_DOXYGEN: true") ]] || exit
     ## -m
-    run bash -c "printf \"y\nn\nn\n\" | ./$SCRIPT_LOCATION -m -y -P"
+    run bash -c "printf \"y\ny\nn\nn\n\" | ./$SCRIPT_LOCATION -m -y -P"
     [[ ! -z $(echo "${output}" | grep "ENABLE_MONGO: true") ]] || exit
     [[ ! -z $(echo "${output}" | grep "INSTALL_MONGO: true") ]] || exit
     ## -h / -anythingwedon'tsupport

--- a/tests/bash-bats/eosio_build_amazonlinux.sh
+++ b/tests/bash-bats/eosio_build_amazonlinux.sh
@@ -26,7 +26,7 @@ export TEST_LABEL="[eosio_build_amazonlinux]"
     run bash -c "printf \"y\n%.0s\" {1..100} | ./$SCRIPT_LOCATION -P  -i /NEWPATH"
     [[ ! -z $(echo "${output}" | grep "Executing: make -j${JOBS}") ]] || exit
     ### Make sure deps are loaded properly
-    [[ ! -z $(echo "${output}" | grep "Executing: cd ${SRC_DIR}") ]] || exit
+    [[ ! -z $(echo "${output}" | grep "Executing: cd /NEWPATH/src") ]] || exit
     [[ ! -z $(echo "${output}" | grep "Starting EOSIO Dependency Install") ]] || exit
     [[ ! -z $(echo "${output}" | grep "Executing: eval /usr/bin/yum -y update") ]] || exit
     if [[ $NAME == "Amazon Linux" ]]; then
@@ -42,8 +42,10 @@ export TEST_LABEL="[eosio_build_amazonlinux]"
     [[ -z $(echo "${output}" | grep "MongoDB C++ driver successfully installed") ]] || exit # Mongo is off
     # Ensure PIN_COMPILER=false uses proper flags for the various installs
     install-package gcc-c++ WETRUN
+    install-package clang WETRUN
     run bash -c "./$SCRIPT_LOCATION -y"
     [[ ! -z $(echo "${output}" | grep " -G 'Unix Makefiles'") ]] || exit # CMAKE
     [[ ! -z $(echo "${output}" | grep " --with-iostreams --with-date_time") ]] || exit # BOOST
     uninstall-package gcc-c++ WETRUN
+    uninstall-package clang WETRUN
 }

--- a/tests/bash-bats/eosio_build_amazonlinux.sh
+++ b/tests/bash-bats/eosio_build_amazonlinux.sh
@@ -23,7 +23,7 @@ export TEST_LABEL="[eosio_build_amazonlinux]"
 @test "${TEST_LABEL} > General" {
     set_system_vars # Obtain current machine's resources and set the necessary variables (like JOBS, etc)
 
-    run bash -c "printf \"y\n%.0s\" {1..100} | ./$SCRIPT_LOCATION -P"
+    run bash -c "printf \"y\n%.0s\" {1..100} | ./$SCRIPT_LOCATION -P  -i /NEWPATH"
     [[ ! -z $(echo "${output}" | grep "Executing: make -j${JOBS}") ]] || exit
     ### Make sure deps are loaded properly
     [[ ! -z $(echo "${output}" | grep "Executing: cd ${SRC_DIR}") ]] || exit
@@ -36,7 +36,7 @@ export TEST_LABEL="[eosio_build_amazonlinux]"
     fi
     [[ ! -z $(echo "${output}" | grep "sudo.*NOT.*found.") ]] || exit
     [[ -z $(echo "${output}" | grep "-   NOT found.") ]] || exit
-    [[ ! -z $(echo "${output}" | grep ${HOME}.*/src/boost) ]] || exit
+    [[ ! -z $(echo "${output}" | grep /NEWPATH*/src/boost) ]] || exit
     [[ ! -z $(echo "${output}" | grep "Starting EOSIO Build") ]] || exit
     [[ ! -z $(echo "${output}" | grep "make -j${CPU_CORES}") ]] || exit
     [[ -z $(echo "${output}" | grep "MongoDB C++ driver successfully installed") ]] || exit # Mongo is off

--- a/tests/bash-bats/eosio_build_centos.sh
+++ b/tests/bash-bats/eosio_build_centos.sh
@@ -29,7 +29,7 @@ export TEST_LABEL="[eosio_build_centos]"
     # Ensure SCL and devtoolset-8 for c++ binary installation
     run bash -c "printf \"y\n%.0s\" {1..100}| ./${SCRIPT_LOCATION} -i /NEWPATH"
     [[ ! -z $(echo "${output}" | grep "centos-release-scl-2-3.el7.centos.noarch found") ]] || exit
-    [[ ! -z $(echo "${output}" | grep "devtoolset-8-8.0-2.el7.0.1.x86_64 found") ]] || exit
+    [[ ! -z $(echo "${output}" | grep "devtoolset-8-8.0-2.el7.x86_64 found") ]] || exit
     [[ ! -z $(echo "${output}" | grep "Executing: source /opt/rh/devtoolset-8/enable") ]] || exit
     [[ ! -z $(echo "${output}" | grep "Executing: make -j${JOBS}") ]] || exit
     [[ ! -z $(echo "${output}" | grep "Starting EOSIO Dependency Install") ]] || exit
@@ -44,5 +44,4 @@ export TEST_LABEL="[eosio_build_centos]"
     [[ ! -z $(echo "${output}" | grep "EOSIO has been successfully built") ]] || exit
     uninstall-package devtoolset-8* WETRUN &>/dev/null
     uninstall-package centos-release-scl WETRUN &>/dev/null
-
 }

--- a/tests/bash-bats/eosio_build_centos.sh
+++ b/tests/bash-bats/eosio_build_centos.sh
@@ -27,7 +27,7 @@ export TEST_LABEL="[eosio_build_centos]"
     execute-always yum -y --enablerepo=extras install centos-release-scl &>/dev/null
     install-package devtoolset-8 WETRUN &>/dev/null
     # Ensure SCL and devtoolset-8 for c++ binary installation
-    run bash -c "printf \"y\n%.0s\" {1..100}| ./${SCRIPT_LOCATION}"
+    run bash -c "printf \"y\n%.0s\" {1..100}| ./${SCRIPT_LOCATION} -i /NEWPATH"
     [[ ! -z $(echo "${output}" | grep "centos-release-scl-2-3.el7.centos.noarch found") ]] || exit
     [[ ! -z $(echo "${output}" | grep "devtoolset-8-8.0-2.el7.0.1.x86_64 found") ]] || exit
     [[ ! -z $(echo "${output}" | grep "Executing: source /opt/rh/devtoolset-8/enable") ]] || exit
@@ -38,7 +38,7 @@ export TEST_LABEL="[eosio_build_centos]"
     [[ ! -z $(echo "${output}" | grep "python.*found!") ]] || exit
     [[ -z $(echo "${output}" | grep "-   NOT found.") ]] || exit
     [[ ! -z $(echo "${output}" | grep "Ensuring CMAKE") ]] || exit
-    [[ ! -z $(echo "${output}" | grep ${HOME}.*/src/boost) ]] || exit
+    [[ ! -z $(echo "${output}" | grep /NEWPATH.*/src/boost) ]] || exit
     [[ ! -z $(echo "${output}" | grep "Starting EOSIO Build") ]] || exit
     [[ ! -z $(echo "${output}" | grep "make -j${CPU_CORES}") ]] || exit
     [[ ! -z $(echo "${output}" | grep "EOSIO has been successfully built") ]] || exit

--- a/tests/bash-bats/eosio_build_darwin.sh
+++ b/tests/bash-bats/eosio_build_darwin.sh
@@ -29,7 +29,6 @@ export TEST_LABEL="[eosio_build_darwin]"
     ### Make sure deps are loaded properly
     [[ ! -z $(echo "${output}" | grep "Starting EOSIO Dependency Install") ]] || exit
     [[ ! -z $(echo "${output}" | grep "Executing: /usr/bin/xcode-select --install") ]] || exit
-    # [[ ! -z $(echo "${output}" | grep "automake.*NOT.*found") ]] || exit
     [[ -z $(echo "${output}" | grep "-   NOT found.") ]] || exit
     rm -f $CMAKE
     [[ ! -z $(echo "${output}" | grep "[Updating HomeBrew]") ]] || exit

--- a/tests/bash-bats/eosio_build_darwin.sh
+++ b/tests/bash-bats/eosio_build_darwin.sh
@@ -24,19 +24,19 @@ export TEST_LABEL="[eosio_build_darwin]"
 @test "${TEST_LABEL} > General" {
     set_system_vars # Obtain current machine's resources and set the necessary variables (like JOBS, etc)
 
-    run bash -c "printf \"y\n%.0s\" {1..100} | ./$SCRIPT_LOCATION"
+    run bash -c "printf \"y\n%.0s\" {1..100} | ./$SCRIPT_LOCATION -i /NEWPATH"
     [[ ! -z $(echo "${output}" | grep "Executing: make -j${JOBS}") ]] || exit
     ### Make sure deps are loaded properly
     [[ ! -z $(echo "${output}" | grep "Starting EOSIO Dependency Install") ]] || exit
     [[ ! -z $(echo "${output}" | grep "Executing: /usr/bin/xcode-select --install") ]] || exit
-    [[ ! -z $(echo "${output}" | grep "automake.*NOT.*found") ]] || exit
+    # [[ ! -z $(echo "${output}" | grep "automake.*NOT.*found") ]] || exit
     [[ -z $(echo "${output}" | grep "-   NOT found.") ]] || exit
     rm -f $CMAKE
     [[ ! -z $(echo "${output}" | grep "[Updating HomeBrew]") ]] || exit
     [[ ! -z $(echo "${output}" | grep "brew tap eosio/eosio") ]] || exit
     [[ ! -z $(echo "${output}" | grep "brew install.*llvm@4.*") ]] || exit
     [[ ! -z $(echo "${output}" | grep "LLVM successfully linked from /usr/local/opt/llvm@4") ]] || exit
-    [[ ! -z $(echo "${output}" | grep ${HOME}.*/src/boost) ]] || exit
+    [[ ! -z $(echo "${output}" | grep /NEWPATH.*/src/boost) ]] || exit
     [[ ! -z $(echo "${output}" | grep "Starting EOSIO Build") ]] || exit
     [[ ! -z $(echo "${output}" | grep " --with-iostreams --with-date_time") ]] || exit # BOOST
     [[ ! -z $(echo "${output}" | grep "EOSIO has been successfully built") ]] || exit

--- a/tests/bash-bats/eosio_build_ubuntu.sh
+++ b/tests/bash-bats/eosio_build_ubuntu.sh
@@ -26,7 +26,7 @@ export TEST_LABEL="[eosio_build_ubuntu]"
     set_system_vars # Obtain current machine's resources and set the necessary variables (like JOBS, etc)
 
     # Testing clang already existing (no pinning of clang8)
-    [[ "$(echo ${VERSION_ID})" == "16.04" ]] && install-package clang WETRUN &>/dev/null || install-package build-essential WETRUN
+    install-package clang WETRUN &>/dev/null 
     run bash -c "printf \"y\n%.0s\" {1..100} | ./$SCRIPT_LOCATION -i /NEWPATH"
     
     [[ ! -z $(echo "${output}" | grep "Executing: make -j${JOBS}") ]] || exit

--- a/tests/bash-bats/eosio_build_ubuntu.sh
+++ b/tests/bash-bats/eosio_build_ubuntu.sh
@@ -27,13 +27,13 @@ export TEST_LABEL="[eosio_build_ubuntu]"
 
     # Testing clang already existing (no pinning of clang8)
     [[ "$(echo ${VERSION_ID})" == "16.04" ]] && install-package clang WETRUN &>/dev/null || install-package build-essential WETRUN
-    run bash -c "printf \"y\n%.0s\" {1..100} | ./$SCRIPT_LOCATION"
+    run bash -c "printf \"y\n%.0s\" {1..100} | ./$SCRIPT_LOCATION -i /NEWPATH"
     
     [[ ! -z $(echo "${output}" | grep "Executing: make -j${JOBS}") ]] || exit
     [[ ! -z $(echo "${output}" | grep "Starting EOSIO Dependency Install") ]] || exit
     [[ ! -z $(echo "${output}" | grep python.*found) ]] || exit
     [[ ! -z $(echo "${output}" | grep make.*NOT.*found) ]] || exit
-    [[ ! -z $(echo "${output}" | grep ${HOME}.*/src/boost) ]] || exit
+    [[ ! -z $(echo "${output}" | grep /NEWPATH.*/src/boost) ]] || exit
     [[ ! -z $(echo "${output}" | grep "make -j${CPU_CORES}") ]] || exit
     [[ ! -z $(echo "${output}" | grep " --with-iostreams --with-date_time") ]] || exit # BOOST
     if [[ "$(echo ${VERSION_ID})" == "18.04" ]]; then

--- a/tests/bash-bats/modules/clang.sh
+++ b/tests/bash-bats/modules/clang.sh
@@ -4,21 +4,21 @@ load ../helpers/functions
 @test "${TEST_LABEL} > Testing CLANG" {
 
     if [[ $NAME == "Darwin" ]]; then
-        run bash -c "printf \"y\n%.0s\" {1..100} | ./$SCRIPT_LOCATION"
+        run bash -c "printf \"y\n%.0s\" {1..100} | ./$SCRIPT_LOCATION -i /NEWPATH"
         ## CLANG already exists (c++/default)
         [[ ! -z $(echo "${output}" | grep "PIN_COMPILER: true") ]] || exit
         [[ ! -z $(echo "${output}" | grep "DCMAKE_CXX_COMPILER='c++'") ]] || exit
         [[ ! -z $(echo "${output}" | grep "DCMAKE_C_COMPILER='cc'") ]] || exit
     elif [[ $NAME == "Ubuntu" ]]; then
         install-package build-essential WETRUN 1>/dev/null # ubuntu 18 build-essential will be high enough, 16 won't and has a version < 7
-        run bash -c "printf \"y\n%.0s\" {1..100} | ./$SCRIPT_LOCATION"
+        run bash -c "printf \"y\n%.0s\" {1..100} | ./$SCRIPT_LOCATION -i /NEWPATH"
         ## CLANG already exists (c++/default) (Ubuntu doesn't have clang>7, so we need to make sure it installs Clang 8)
         [[ ! -z $(echo "${output}" | grep "PIN_COMPILER: false") ]] || exit
-        if [[ $VERSION_ID == "16.04" ]]; then
-            [[ ! -z $(echo "${output}" | grep "Unable to find C++17 support") ]] || exit
-            [[ ! -z $(echo "${output}" | grep "Clang 8 successfully installed") ]] || exit
-            [[ ! -z $(echo "${output}" | grep "$CLANG_ROOT") ]] || exit
-        fi
+        # if [[ $VERSION_ID == "16.04" ]]; then
+        #     [[ ! -z $(echo "${output}" | grep "Unable to find compiler") ]] || exit
+        #     [[ ! -z $(echo "${output}" | grep "Clang 8 successfully installed") ]] || exit
+        #     [[ ! -z $(echo "${output}" | grep "$CLANG_ROOT") ]] || exit
+        # fi
         ## CLANG
         uninstall-package build-essential WETRUN 1>/dev/null
         run bash -c "./$SCRIPT_LOCATION -y -P"

--- a/tests/bash-bats/modules/dep_script_options.sh
+++ b/tests/bash-bats/modules/dep_script_options.sh
@@ -4,7 +4,8 @@ load ../helpers/functions
 @test "${TEST_LABEL} > Testing Options" {
     mkdir -p $HOME/test/tmp
     run bash -c "./$SCRIPT_LOCATION -y -P -i $HOME/test -b /boost_tmp -m"
-    [[ ! -z $(echo "${output}" | grep "CMAKE_INSTALL_PREFIX='${HOME}/test/eosio/${EOSIO_VERSION}") ]] || exit
+    # echo $output >&3
+    [[ ! -z $(echo "${output}" | grep "CMAKE_INSTALL_PREFIX='${HOME}/test") ]] || exit
     [[ ! -z $(echo "${output}" | grep "@ /boost_tmp") ]] || exit
     [[ ! -z $(echo "${output}" | grep "Ensuring MongoDB installation") ]] || exit
     [[ ! -z $(echo "${output}" | grep "MongoDB C driver successfully installed") ]] || exit

--- a/tests/bash-bats/modules/mongodb.sh
+++ b/tests/bash-bats/modules/mongodb.sh
@@ -4,14 +4,14 @@ load ../helpers/functions
 @test "${TEST_LABEL} > MongoDB" {
     # Existing MongoDB
     if [[ $NAME == "CentOS Linux" ]] || [[ $NAME == "Amazon Linux" ]]; then
-        run bash -c "printf \"y\yn\nn\ny\ny\ny\n\" | ./$SCRIPT_LOCATION -m -P" # which prompt requires first y
+        run bash -c "printf \"y\ny\nn\ny\ny\ny\n\" | ./$SCRIPT_LOCATION -m -P" # which prompt requires first y
     else
         run bash -c "printf \"y\nn\nn\ny\ny\n\" | ./$SCRIPT_LOCATION -m -P"
     fi
     [[ ! -z $(echo "${output}" | grep "Existing MongoDB will be used") ]] || exit
     [[ -z $(echo "${output}" | grep "Ensuring MongoDB installation") ]] || exit
     # Installing ours
-    run bash -c "printf \"y\ny\ny\ny\ny\n\" | ./$SCRIPT_LOCATION -m -P"
+    run bash -c "printf \"y\ny\ny\ny\ny\ny\n\" | ./$SCRIPT_LOCATION -m -P"
     [[ -z $(echo "${output}" | grep "Existing MongoDB will be used") ]] || exit
     [[ ! -z $(echo "${output}" | grep "Ensuring MongoDB installation") ]] || exit
 }

--- a/tests/bash-bats/modules/mongodb.sh
+++ b/tests/bash-bats/modules/mongodb.sh
@@ -4,9 +4,9 @@ load ../helpers/functions
 @test "${TEST_LABEL} > MongoDB" {
     # Existing MongoDB
     if [[ $NAME == "CentOS Linux" ]] || [[ $NAME == "Amazon Linux" ]]; then
-        run bash -c "printf \"y\nn\ny\ny\ny\n\" | ./$SCRIPT_LOCATION -m -P" # which prompt requires first y
+        run bash -c "printf \"y\yn\nn\ny\ny\ny\n\" | ./$SCRIPT_LOCATION -m -P" # which prompt requires first y
     else
-        run bash -c "printf \"n\nn\ny\ny\n\" | ./$SCRIPT_LOCATION -m -P"
+        run bash -c "printf \"y\nn\nn\ny\ny\n\" | ./$SCRIPT_LOCATION -m -P"
     fi
     [[ ! -z $(echo "${output}" | grep "Existing MongoDB will be used") ]] || exit
     [[ -z $(echo "${output}" | grep "Ensuring MongoDB installation") ]] || exit

--- a/tests/bash-bats/modules/root-user.sh
+++ b/tests/bash-bats/modules/root-user.sh
@@ -2,20 +2,20 @@
 load ../helpers/functions
 
 @test "${TEST_LABEL} > Testing root user run" {
-    run bash -c "printf \"y\n%.0s\" {1..100} | ./$SCRIPT_LOCATION -P"
+    run bash -c "printf \"y\n%.0s\" {1..100} | ./$SCRIPT_LOCATION -P -i /NEWPATH"
     [[ ! -z $(echo "${output}" | grep "User: $(whoami)") ]] || exit
     if [[ $ARCH == "Linux" ]]; then
         [[ -z $(echo "${output}" | grep "$SUDO_LOCATION -E") ]] || exit
     fi
     export CURRENT_USER=test
-    run bash -c "printf \"n\n\" | ./$SCRIPT_LOCATION -P"
+    run bash -c "printf \"y\nn\n\" | ./$SCRIPT_LOCATION -P"
     [[ ! -z $(echo "${output}" | grep "User: test") ]] || exit
     if [[ $ARCH == "Linux" ]]; then
         [[ ! -z $(echo "${output}" | grep "Please install the 'sudo' command before proceeding") ]] || exit
     fi
     install-package sudo WETRUN
     export SUDO_LOCATION=$( command -v sudo )
-    run bash -c "printf \"y\n%.0s\" {1..100} | ./$SCRIPT_LOCATION -P"
+    run bash -c "printf \"y\n%.0s\" {1..100} | ./$SCRIPT_LOCATION -P -i /NEWPATH"
     [[ ! -z $(echo "${output}" | grep "User: test") ]] || exit
     if [[ $ARCH == "Linux" ]]; then
         [[ ! -z $(echo "${output}" | grep "$SUDO_LOCATION -E .* install -y .*") ]] || exit


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
The readlink tool throws a return code of 1 if the path is not a symlink. It used to be a symlink /usr/bin/c++ -> /usr/bin/clang++ but since #7516, we need to return true regardless of readlink failing and check if CXX =~ clang already.

In addition, this also includes fixes and adjustments for the BATS tests to support both the new installation path prompt and changes to the ensure-compiler helper function. I am continuing to refine the BATS tests while we investigate issues with builds on clean containers to ensure we check for the correct dependencies.

**NOTE:** This is a backport of #7525 for release 1.8.x.