### PR TITLE
restore usage of devtoolset-8 on centos7

### DIFF
--- a/scripts/clang-devtoolset8-support.patch
+++ b/scripts/clang-devtoolset8-support.patch
@@ -1,0 +1,55 @@
+From 32b65345c5760295d04c95e0abb3653fe20ffd16 Mon Sep 17 00:00:00 2001
+From: Tom Stellard <tstellar@redhat.com>
+Date: Tue, 9 Apr 2019 13:26:10 +0000
+Subject: [PATCH] Add support for detection of devtoolset-8
+
+Summary:
+The current llvm/clang et al. project can be built with the latest developer toolset (devtoolset-8) on RHEL, which provides GCC 8.2.1.
+However, the result compiler will not identify this toolset itself when compiling programs, which is of course not desirable.
+
+After the patch - which simply adds the name of the developer toolset to the existing list - it gets identified and selected, as shown below:
+
+[bamboo@bamboo llvm-project]$ clang -v
+clang version 9.0.0 (https://github.com/llvm/llvm-project.git e5ac385fb1ffa4bd3875ea6a4d24efdbd7814572)
+Target: x86_64-unknown-linux-gnu
+Thread model: posix
+InstalledDir: /home/bamboo/llvm/bin
+Found candidate GCC installation: /opt/rh/devtoolset-4/root/usr/lib/gcc/x86_64-redhat-linux/5.2.1
+Found candidate GCC installation: /opt/rh/devtoolset-7/root/usr/lib/gcc/x86_64-redhat-linux/7
+Found candidate GCC installation: /opt/rh/devtoolset-8/root/usr/lib/gcc/x86_64-redhat-linux/8
+Found candidate GCC installation: /usr/lib/gcc/x86_64-redhat-linux/4.8.2
+Found candidate GCC installation: /usr/lib/gcc/x86_64-redhat-linux/4.8.5
+Selected GCC installation: /opt/rh/devtoolset-8/root/usr/lib/gcc/x86_64-redhat-linux/8
+Candidate multilib: .;@m64
+Candidate multilib: 32;@m32
+Selected multilib: .;@m64
+
+Patch By: Radu-Adrian Popescu
+
+Reviewers: tstellar, fedor.sergeev
+
+Reviewed By: tstellar
+
+Subscribers: jdoerfert, cfe-commits
+
+Tags: #clang
+
+Differential Revision: https://reviews.llvm.org/D59987
+
+llvm-svn: 358002
+---
+ clang/lib/Driver/ToolChains/Gnu.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/clang/lib/Driver/ToolChains/Gnu.cpp b/clang/lib/Driver/ToolChains/Gnu.cpp
+index 2a58f0f7142..8915e3f948f 100644
+--- a/clang/lib/Driver/ToolChains/Gnu.cpp
++++ b/clang/lib/Driver/ToolChains/Gnu.cpp
+@@ -1875,6 +1875,7 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
+   // Non-Solaris is much simpler - most systems just go with "/usr".
+   if (SysRoot.empty() && TargetTriple.getOS() == llvm::Triple::Linux) {
+     // Yet, still look for RHEL devtoolsets.
++    Prefixes.push_back("/opt/rh/devtoolset-8/root/usr");
+     Prefixes.push_back("/opt/rh/devtoolset-7/root/usr");
+     Prefixes.push_back("/opt/rh/devtoolset-6/root/usr");
+     Prefixes.push_back("/opt/rh/devtoolset-4/root/usr");

--- a/scripts/eosio_build_amazonlinux2_deps
+++ b/scripts/eosio_build_amazonlinux2_deps
@@ -20,3 +20,4 @@ libedit-devel,rpm -qa
 doxygen,rpm -qa
 graphviz,rpm -qa
 clang,rpm -qa
+patch,rpm -qa

--- a/scripts/eosio_build_centos.sh
+++ b/scripts/eosio_build_centos.sh
@@ -12,14 +12,14 @@ echo "Disk space available: ${DISK_AVAIL}G"
 
 echo ""
 
-# Repo necessary for rh-python3 and devtoolset-7
+# Repo necessary for rh-python3 and devtoolset-8
 ensure-scl
-# GCC7 for Centos / Needed for CMAKE install even if we're pinning
+# GCC8 for Centos / Needed for CMAKE install even if we're pinning
 ensure-devtoolset
-if [[ -d /opt/rh/devtoolset-7 ]]; then
-	echo "${COLOR_CYAN}[Enabling Centos devtoolset-7 (so we can use GCC 7)]${COLOR_NC}"
-	execute-always source /opt/rh/devtoolset-7/enable
-	echo " - ${COLOR_GREEN}Centos devtoolset-7 successfully enabled!${COLOR_NC}"
+if [[ -d /opt/rh/devtoolset-8 ]]; then
+	echo "${COLOR_CYAN}[Enabling Centos devtoolset-8 (so we can use GCC 8)]${COLOR_NC}"
+	execute-always source /opt/rh/devtoolset-8/enable
+	echo " - ${COLOR_GREEN}Centos devtoolset-8 successfully enabled!${COLOR_NC}"
 fi
 # Ensure packages exist
 ensure-yum-packages "${REPO_ROOT}/scripts/eosio_build_centos7_deps"

--- a/scripts/eosio_build_centos7_deps
+++ b/scripts/eosio_build_centos7_deps
@@ -18,3 +18,4 @@ gettext-devel,rpm -qa
 file,rpm -qa
 libusbx-devel,rpm -qa
 libcurl-devel,rpm -qa
+patch,rpm -qa

--- a/scripts/eosio_build_ubuntu_deps
+++ b/scripts/eosio_build_ubuntu_deps
@@ -22,3 +22,4 @@ ruby,dpkg -s
 libusb-1.0-0-dev,dpkg -s
 libcurl4-gnutls-dev,dpkg -s
 pkg-config,dpkg -s
+patch,dpkg -s

--- a/scripts/helpers/eosio.sh
+++ b/scripts/helpers/eosio.sh
@@ -311,9 +311,10 @@ function build-clang() {
             && cd lld && git checkout $PINNED_COMPILER_LLD_COMMIT && cd ../ \
             && git clone --single-branch --branch $PINNED_COMPILER_BRANCH https://git.llvm.org/git/polly.git \
             && cd polly && git checkout $PINNED_COMPILER_POLLY_COMMIT && cd ../ \
-            && git clone --single-branch --branch $PINNED_COMPILER_BRANCH https://git.llvm.org/git/clang.git clang && cd clang/tools \
+            && git clone --single-branch --branch $PINNED_COMPILER_BRANCH https://git.llvm.org/git/clang.git clang && cd clang \
             && git checkout $PINNED_COMPILER_CLANG_COMMIT \
-            && mkdir extra && cd extra \
+            && patch -p2 < \"$REPO_ROOT/scripts/clang-devtoolset8-support.patch\" \
+            && cd tools && mkdir extra && cd extra \
             && git clone --single-branch --branch $PINNED_COMPILER_BRANCH https://git.llvm.org/git/clang-tools-extra.git \
             && cd clang-tools-extra && git checkout $PINNED_COMPILER_CLANG_TOOLS_EXTRA_COMMIT && cd .. \
             && cd ../../../../projects \

--- a/scripts/helpers/general.sh
+++ b/scripts/helpers/general.sh
@@ -152,16 +152,16 @@ function ensure-scl() {
 }
 
 function ensure-devtoolset() {
-    echo "${COLOR_CYAN}[Ensuring installation of devtoolset-7]${COLOR_NC}"
-    DEVTOOLSET=$( rpm -qa | grep -E 'devtoolset-7-[0-9].*' || true )
+    echo "${COLOR_CYAN}[Ensuring installation of devtoolset-8]${COLOR_NC}"
+    DEVTOOLSET=$( rpm -qa | grep -E 'devtoolset-8-[0-9].*' || true )
     if [[ -z "${DEVTOOLSET}" ]]; then
         while true; do
             [[ $NONINTERACTIVE == false ]] && printf "${COLOR_YELLOW}Not Found: Do you wish to install it? (y/n)?${COLOR_NC}" && read -p " " PROCEED
             echo ""
             case $PROCEED in
                 "" ) echo "What would you like to do?";;
-                0 | true | [Yy]* ) install-package devtoolset-7; break;;
-                1 | false | [Nn]* ) echo " - User aborted installation of devtoolset-7."; break;;
+                0 | true | [Yy]* ) install-package devtoolset-8; break;;
+                1 | false | [Nn]* ) echo " - User aborted installation of devtoolset-8."; break;;
                 * ) echo "Please type 'y' for yes or 'n' for no.";;
             esac
         done

--- a/tests/bash-bats/eosio_build_centos.sh
+++ b/tests/bash-bats/eosio_build_centos.sh
@@ -25,12 +25,12 @@ export TEST_LABEL="[eosio_build_centos]"
     set_system_vars # Obtain current machine's resources and set the necessary variables (like JOBS, etc)
 
     execute-always yum -y --enablerepo=extras install centos-release-scl &>/dev/null
-    install-package devtoolset-7 WETRUN &>/dev/null
-    # Ensure SCL and devtoolset-7 for c++ binary installation
+    install-package devtoolset-8 WETRUN &>/dev/null
+    # Ensure SCL and devtoolset-8 for c++ binary installation
     run bash -c "printf \"y\n%.0s\" {1..100}| ./${SCRIPT_LOCATION} -i /NEWPATH"
     [[ ! -z $(echo "${output}" | grep "centos-release-scl-2-3.el7.centos.noarch found") ]] || exit
-    [[ ! -z $(echo "${output}" | grep "devtoolset-7.* found") ]] || exit
-    [[ ! -z $(echo "${output}" | grep "Executing: source /opt/rh/devtoolset-7/enable") ]] || exit
+    [[ ! -z $(echo "${output}" | grep "devtoolset-8.* found") ]] || exit
+    [[ ! -z $(echo "${output}" | grep "Executing: source /opt/rh/devtoolset-8/enable") ]] || exit
     [[ ! -z $(echo "${output}" | grep "Executing: make -j${JOBS}") ]] || exit
     [[ ! -z $(echo "${output}" | grep "Starting EOSIO Dependency Install") ]] || exit
     [[ ! -z $(echo "${output}" | grep "Executing: eval /usr/bin/yum -y update") ]] || exit
@@ -41,6 +41,6 @@ export TEST_LABEL="[eosio_build_centos]"
     [[ ! -z $(echo "${output}" | grep "Starting EOSIO Build") ]] || exit
     [[ ! -z $(echo "${output}" | grep "make -j${CPU_CORES}") ]] || exit
     [[ ! -z $(echo "${output}" | grep "EOSIO has been successfully built") ]] || exit
-    uninstall-package devtoolset-7* WETRUN &>/dev/null
+    uninstall-package devtoolset-8* WETRUN &>/dev/null
     uninstall-package centos-release-scl WETRUN &>/dev/null
 }

--- a/tests/bash-bats/helpers/functions.sh
+++ b/tests/bash-bats/helpers/functions.sh
@@ -21,7 +21,7 @@ function teardown() { # teardown is run once after each test, even if it fails
     uninstall-package which WETRUN
     export SUDO_FORCE_REMOVE=yes
     uninstall-package sudo WETRUN
-    uninstall-package devtoolset-7* WETRUN
+    uninstall-package devtoolset-8* WETRUN
     uninstall-package centos-release-scl
     uninstall-package gcc-c++ WETRUN
     if [[ $NAME == 'Ubuntu' ]]; then


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
This restores behavior of #7516 where centos7 builds are with devtoolset-8 (gcc8) 


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
