### PR TITLE
[develop] CMAKE version check before dependencies are installed

### DIFF
--- a/scripts/.build_vars
+++ b/scripts/.build_vars
@@ -7,7 +7,6 @@ export LIB_DIR=${EOSIO_INSTALL_DIR}/lib
 export DATA_DIR=${EOSIO_INSTALL_DIR}/data
 
 # CMAKE
-export CMAKE_REQUIRED_VERSION=$(cat $REPO_ROOT/CMakeLists.txt | grep -E "^[[:blank:]]*cmake_minimum_required[[:blank:]]*\([[:blank:]]*VERSION" | tail -1 | sed 's/.*VERSION //g' | sed 's/ //g' | sed 's/"//g' | cut -d\) -f1)
 export CMAKE_VERSION_MAJOR=3
 export CMAKE_VERSION_MINOR=13
 export CMAKE_VERSION_PATCH=2

--- a/scripts/.build_vars
+++ b/scripts/.build_vars
@@ -7,7 +7,7 @@ export LIB_DIR=${EOSIO_INSTALL_DIR}/lib
 export DATA_DIR=${EOSIO_INSTALL_DIR}/data
 
 # CMAKE
-export CMAKE_REQUIRED_VERSION=$(cat $REPO_ROOT/CMakeLists.txt | grep -E "cmake_minimum_required\([[:blank:]]*VERSION" | tail -1 | sed 's/.*VERSION //g' | cut -d\) -f1 | sed 's/ //g')
+export CMAKE_REQUIRED_VERSION=$(cat $REPO_ROOT/CMakeLists.txt | grep -E "^[[:blank:]]*cmake_minimum_required[[:blank:]]*\([[:blank:]]*VERSION" | tail -1 | sed 's/.*VERSION //g' | sed 's/ //g' | sed 's/"//g' | cut -d\) -f1)
 export CMAKE_VERSION_MAJOR=3
 export CMAKE_VERSION_MINOR=13
 export CMAKE_VERSION_PATCH=2

--- a/scripts/.build_vars
+++ b/scripts/.build_vars
@@ -7,6 +7,7 @@ export LIB_DIR=${EOSIO_INSTALL_DIR}/lib
 export DATA_DIR=${EOSIO_INSTALL_DIR}/data
 
 # CMAKE
+export CMAKE_REQUIRED_VERSION=$(cat $REPO_ROOT/CMakeLists.txt | grep -E "cmake_minimum_required\([[:blank:]]*VERSION" | tail -1 | sed 's/.*VERSION //g' | cut -d\) -f1 | sed 's/ //g')
 export CMAKE_VERSION_MAJOR=3
 export CMAKE_VERSION_MINOR=13
 export CMAKE_VERSION_PATCH=2

--- a/scripts/.environment
+++ b/scripts/.environment
@@ -13,6 +13,8 @@ else
     export EOSIO_VERSION_FULL="${EOSIO_VERSION_MAJOR}.${EOSIO_VERSION_MINOR}.${EOSIO_VERSION_PATCH}-${EOSIO_VERSION_SUFFIX}"
 fi
 
+export CMAKE_REQUIRED_VERSION=$(cat $REPO_ROOT/CMakeLists.txt | grep -E "^[[:blank:]]*cmake_minimum_required[[:blank:]]*\([[:blank:]]*VERSION" | tail -1 | sed 's/.*VERSION //g' | sed 's/ //g' | sed 's/"//g' | cut -d\) -f1)
+
 export EOSIO_INSTALL_DIR="${EOSIO_INSTALL_DIR:-${HOME}/eosio/${EOSIO_VERSION}}"
 export TEMP_DIR="${TEMP_DIR:-${HOME}/tmp}"
 

--- a/scripts/eosio_build.sh
+++ b/scripts/eosio_build.sh
@@ -144,7 +144,12 @@ execute cd $REPO_ROOT
 ensure-submodules-up-to-date
 
 # Check if cmake already exists
-( [[ -z "${CMAKE}" ]] && [[ ! -z $(command -v cmake 2>/dev/null) ]] ) && export CMAKE=$(command -v cmake 2>/dev/null)
+( [[ -z "${CMAKE}" ]] && [[ ! -z $(command -v cmake 2>/dev/null) ]] ) && export CMAKE=$(command -v cmake 2>/dev/null) && export CMAKE_CURRENT_VERSION=$($CMAKE --version | grep -E "cmake version[[:blank:]]*" | sed 's/.*cmake version //g')
+# If it exists, check that it's > required version
+if [[ ! -z $CMAKE_CURRENT_VERSION ]] && [[ $( echo $CURRENT_CMAKE_VERSION | awk -F. '{ printf("%03d%03d%03d\n", $1,$2,$3); }' ) < $( echo $CMAKE_REQUIRED_VERSION | awk -F. '{ printf("%03d%03d%03d\n", $1,$2,$3); }' ) ]]; then
+   echo "${COLOR_YELLOW}The currently installed cmake version ($CMAKE_CURRENT_VERSION) is less than the required version ($CMAKE_REQUIRED_VERSION). We will be installing $CMAKE_VERSION.${COLOR_NC}"
+   export CMAKE=
+fi
 
 # Use existing cmake on system (either global or specific to eosio)
 # Setup based on architecture

--- a/scripts/eosio_build.sh
+++ b/scripts/eosio_build.sh
@@ -146,7 +146,7 @@ ensure-submodules-up-to-date
 # Check if cmake already exists
 ( [[ -z "${CMAKE}" ]] && [[ ! -z $(command -v cmake 2>/dev/null) ]] ) && export CMAKE=$(command -v cmake 2>/dev/null) && export CMAKE_CURRENT_VERSION=$($CMAKE --version | grep -E "cmake version[[:blank:]]*" | sed 's/.*cmake version //g')
 # If it exists, check that it's > required version
-if [[ ! -z $CMAKE_CURRENT_VERSION ]] && [[ $( echo $CURRENT_CMAKE_VERSION | awk -F. '{ printf("%03d%03d%03d\n", $1,$2,$3); }' ) < $( echo $CMAKE_REQUIRED_VERSION | awk -F. '{ printf("%03d%03d%03d\n", $1,$2,$3); }' ) ]]; then
+if [[ ! -z $CMAKE_CURRENT_VERSION ]] && (( $( echo $CURRENT_CMAKE_VERSION | awk -F. '{ printf("%03d%03d%03d\n", $1,$2,$3); }' ) < $( echo $CMAKE_REQUIRED_VERSION | awk -F. '{ printf("%03d%03d%03d\n", $1,$2,$3); }' ) )); then
    export CMAKE=
    if [[ $ARCH == 'Darwin' ]]; then
       echo "${COLOR_RED}The currently installed cmake version ($CMAKE_CURRENT_VERSION) is less than the required version ($CMAKE_REQUIRED_VERSION). Cannot proceed."

--- a/scripts/eosio_build.sh
+++ b/scripts/eosio_build.sh
@@ -147,8 +147,13 @@ ensure-submodules-up-to-date
 ( [[ -z "${CMAKE}" ]] && [[ ! -z $(command -v cmake 2>/dev/null) ]] ) && export CMAKE=$(command -v cmake 2>/dev/null) && export CMAKE_CURRENT_VERSION=$($CMAKE --version | grep -E "cmake version[[:blank:]]*" | sed 's/.*cmake version //g')
 # If it exists, check that it's > required version
 if [[ ! -z $CMAKE_CURRENT_VERSION ]] && [[ $( echo $CURRENT_CMAKE_VERSION | awk -F. '{ printf("%03d%03d%03d\n", $1,$2,$3); }' ) < $( echo $CMAKE_REQUIRED_VERSION | awk -F. '{ printf("%03d%03d%03d\n", $1,$2,$3); }' ) ]]; then
-   echo "${COLOR_YELLOW}The currently installed cmake version ($CMAKE_CURRENT_VERSION) is less than the required version ($CMAKE_REQUIRED_VERSION). We will be installing $CMAKE_VERSION.${COLOR_NC}"
    export CMAKE=
+   if [[ $ARCH == 'Darwin' ]]; then
+      echo "${COLOR_RED}The currently installed cmake version ($CMAKE_CURRENT_VERSION) is less than the required version ($CMAKE_REQUIRED_VERSION). Cannot proceed."
+      exit
+   else
+      echo "${COLOR_YELLOW}The currently installed cmake version ($CMAKE_CURRENT_VERSION) is less than the required version ($CMAKE_REQUIRED_VERSION). We will be installing $CMAKE_VERSION.${COLOR_NC}"
+   fi
 fi
 
 # Use existing cmake on system (either global or specific to eosio)

--- a/scripts/eosio_build.sh
+++ b/scripts/eosio_build.sh
@@ -145,8 +145,8 @@ ensure-submodules-up-to-date
 
 # Check if cmake already exists
 ( [[ -z "${CMAKE}" ]] && [[ ! -z $(command -v cmake 2>/dev/null) ]] ) && export CMAKE=$(command -v cmake 2>/dev/null) && export CMAKE_CURRENT_VERSION=$($CMAKE --version | grep -E "cmake version[[:blank:]]*" | sed 's/.*cmake version //g')
-# If it exists, check that it's > required version
-if [[ ! -z $CMAKE_CURRENT_VERSION ]] && (( $( echo $CURRENT_CMAKE_VERSION | awk -F. '{ printf("%03d%03d%03d\n", $1,$2,$3); }' ) < $( echo $CMAKE_REQUIRED_VERSION | awk -F. '{ printf("%03d%03d%03d\n", $1,$2,$3); }' ) )); then
+# If it exists, check that it's > required version + 
+if [[ ! -z $CMAKE_CURRENT_VERSION ]] && [[ $((10#$( echo $CMAKE_CURRENT_VERSION | awk -F. '{ printf("%03d%03d%03d\n", $1,$2,$3); }' ))) -lt $((10#$( echo $CMAKE_REQUIRED_VERSION | awk -F. '{ printf("%03d%03d%03d\n", $1,$2,$3); }' ))) ]]; then
    export CMAKE=
    if [[ $ARCH == 'Darwin' ]]; then
       echo "${COLOR_RED}The currently installed cmake version ($CMAKE_CURRENT_VERSION) is less than the required version ($CMAKE_REQUIRED_VERSION). Cannot proceed."

--- a/scripts/eosio_build.sh
+++ b/scripts/eosio_build.sh
@@ -150,7 +150,7 @@ if [[ ! -z $CMAKE_CURRENT_VERSION ]] && [[ $( echo $CURRENT_CMAKE_VERSION | awk 
    export CMAKE=
    if [[ $ARCH == 'Darwin' ]]; then
       echo "${COLOR_RED}The currently installed cmake version ($CMAKE_CURRENT_VERSION) is less than the required version ($CMAKE_REQUIRED_VERSION). Cannot proceed."
-      exit
+      exit 1
    else
       echo "${COLOR_YELLOW}The currently installed cmake version ($CMAKE_CURRENT_VERSION) is less than the required version ($CMAKE_REQUIRED_VERSION). We will be installing $CMAKE_VERSION.${COLOR_NC}"
    fi

--- a/tests/bash-bats/eosio_build.sh
+++ b/tests/bash-bats/eosio_build.sh
@@ -24,7 +24,7 @@ TEST_LABEL="[eosio_build]"
             run bash -c "printf \"y\ny\ny\nn\nn\n\" | ./${SCRIPT_LOCATION}"
             [[ ! -z $(echo "${output}" | grep "Unable to find .* compiler") ]] || exit
         fi
-    fi 
+    fi
 
     cd ./scripts # Also test that we can run the script from a directory other than the root
     run bash -c "./eosio_build.sh -y -P"

--- a/tests/bash-bats/modules/cmake.sh
+++ b/tests/bash-bats/modules/cmake.sh
@@ -7,6 +7,9 @@ load ../helpers/functions
     touch $CMAKE
     run bash -c " ./$SCRIPT_LOCATION -y -P"
     [[ ! -z $(echo "${output}" | grep "Executing: bash -c ${HOME}/cmake") ]] || exit
+    export CMAKE_CURRENT_VERSION=3.7.1
+    run bash -c " ./$SCRIPT_LOCATION -y -P"
+    [[ ! -z $(echo "${output}" | grep "We will be installing $CMAKE_VERSION") ]] || exit
     # Testing for if cmake doesn't exist to be sure it's set properly
     export CMAKE=
     run bash -c "./$SCRIPT_LOCATION -y -P"

--- a/tests/bash-bats/modules/cmake.sh
+++ b/tests/bash-bats/modules/cmake.sh
@@ -9,7 +9,7 @@ load ../helpers/functions
     export CMAKE_CURRENT_VERSION=3.7.1
     run bash -c " ./$SCRIPT_LOCATION -y -P"
     if [[ $ARCH == "Darwin" ]]; then
-        [[ ! -z $(echo "${output}" | grep "($CMAKE_REQUIRED_VERSION). Cannot proceed") ]] || exit # Test the required version
+        [[ "${output##*$'\n'}" =~ "($CMAKE_REQUIRED_VERSION). Cannot proceed" ]] || exit # Test the required version
     else
         [[ ! -z $(echo "${output}" | grep "We will be installing $CMAKE_VERSION") ]] || exit # Test the required version
         [[ ! -z $(echo "${output}" | grep "Executing: bash -c ${BIN_DIR}/cmake") ]] || exit
@@ -26,7 +26,7 @@ load ../helpers/functions
     export CMAKE_CURRENT_VERSION=3.6
     run bash -c "./$SCRIPT_LOCATION -y -P"
     if [[ $ARCH == "Darwin" ]]; then
-        [[ ! -z $(echo "${output}" | grep "($CMAKE_REQUIRED_VERSION). Cannot proceed") ]] || exit # Test the required version
+        [[ "${output##*$'\n'}" =~ "($CMAKE_REQUIRED_VERSION). Cannot proceed" ]] || exit # Test the required version
     else
         [[ ! -z $(echo "${output}" | grep "We will be installing $CMAKE_VERSION") ]] || exit # Test the required version
         [[ ! -z $(echo "${output}" | grep "Executing: bash -c ${BIN_DIR}/cmake") ]] || exit

--- a/tests/bash-bats/modules/cmake.sh
+++ b/tests/bash-bats/modules/cmake.sh
@@ -2,6 +2,7 @@
 load ../helpers/functions
 
 @test "${TEST_LABEL} > Testing CMAKE" {
+
     # Testing for if CMAKE already exists
     export CMAKE=${HOME}/cmake
     touch $CMAKE
@@ -11,10 +12,18 @@ load ../helpers/functions
         [[ ! -z $(echo "${output}" | grep "($CMAKE_REQUIRED_VERSION). Cannot proceed") ]] || exit # Test the required version
     else
         [[ ! -z $(echo "${output}" | grep "We will be installing $CMAKE_VERSION") ]] || exit # Test the required version
-        [[ ! -z $(echo "${output}" | grep "Executing: bash -c ${HOME}/cmake") ]] || exit
+        [[ ! -z $(echo "${output}" | grep "Executing: bash -c ${BIN_DIR}/cmake") ]] || exit
     fi
+    export CMAKE_CURRENT_VERSION=
+    run bash -c " ./$SCRIPT_LOCATION -y -P"
+    [[ ! -z $(echo "${output}" | grep "Executing: bash -c ${HOME}/cmake") ]] || exit
+    if [[ $ARCH != "Darwin" ]]; then
+        [[ -z $(echo "${output}" | grep "CMAKE successfully installed") ]] || exit
+    fi
+
     # Testing for if cmake doesn't exist to be sure it's set properly
     export CMAKE=
+    export CMAKE_CURRENT_VERSION=3.6
     run bash -c "./$SCRIPT_LOCATION -y -P"
     if [[ $ARCH == "Darwin" ]]; then
         [[ ! -z $(echo "${output}" | grep "($CMAKE_REQUIRED_VERSION). Cannot proceed") ]] || exit # Test the required version

--- a/tests/bash-bats/modules/cmake.sh
+++ b/tests/bash-bats/modules/cmake.sh
@@ -5,13 +5,25 @@ load ../helpers/functions
     # Testing for if CMAKE already exists
     export CMAKE=${HOME}/cmake
     touch $CMAKE
-    run bash -c " ./$SCRIPT_LOCATION -y -P"
-    [[ ! -z $(echo "${output}" | grep "Executing: bash -c ${HOME}/cmake") ]] || exit
     export CMAKE_CURRENT_VERSION=3.7.1
     run bash -c " ./$SCRIPT_LOCATION -y -P"
-    [[ ! -z $(echo "${output}" | grep "We will be installing $CMAKE_VERSION") ]] || exit
+    if [[ $ARCH == "Darwin" ]]; then
+        [[ ! -z $(echo "${output}" | grep "($CMAKE_REQUIRED_VERSION). Cannot proceed") ]] || exit # Test the required version
+    else
+        [[ ! -z $(echo "${output}" | grep "We will be installing $CMAKE_VERSION") ]] || exit # Test the required version
+        [[ ! -z $(echo "${output}" | grep "Executing: bash -c ${HOME}/cmake") ]] || exit
+    fi
     # Testing for if cmake doesn't exist to be sure it's set properly
     export CMAKE=
+    run bash -c "./$SCRIPT_LOCATION -y -P"
+    if [[ $ARCH == "Darwin" ]]; then
+        [[ ! -z $(echo "${output}" | grep "($CMAKE_REQUIRED_VERSION). Cannot proceed") ]] || exit # Test the required version
+    else
+        [[ ! -z $(echo "${output}" | grep "We will be installing $CMAKE_VERSION") ]] || exit # Test the required version
+        [[ ! -z $(echo "${output}" | grep "Executing: bash -c ${BIN_DIR}/cmake") ]] || exit
+        [[ ! -z $(echo "${output}" | grep "CMAKE successfully installed") ]] || exit
+    fi
+    export CMAKE_CURRENT_VERSION=
     run bash -c "./$SCRIPT_LOCATION -y -P"
     if [[ $ARCH == "Darwin" ]]; then
         [[ ! -z $(echo "${output}" | grep "Executing: bash -c /usr/local/bin/cmake -DCMAKE_BUILD") ]] || exit


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
Problem: People with versions less than the required don't see the requirement failure until too late (after dependencies are installed). 

Solution: Add a check for the required version of CMAKE (using CMakeLists.txt) and compare it to the currently installed version.

Base Images pipeline tests & builds : https://buildkite.com/EOSIO/eosio-base-images/builds/339

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
