### PR TITLE
[1.8.x] CMAKE version check before dependencies are installed

### DIFF
--- a/scripts/.environment
+++ b/scripts/.environment
@@ -15,7 +15,6 @@ fi
 
 export CMAKE_REQUIRED_VERSION=$(cat $REPO_ROOT/CMakeLists.txt | grep -E "^[[:blank:]]*cmake_minimum_required[[:blank:]]*\([[:blank:]]*VERSION" | tail -1 | sed 's/.*VERSION //g' | sed 's/ //g' | sed 's/"//g' | cut -d\) -f1)
 
-
 export EOSIO_INSTALL_DIR="${EOSIO_INSTALL_DIR:-${HOME}/eosio/${EOSIO_VERSION}}"
 export TEMP_DIR="${TEMP_DIR:-${HOME}/tmp}"
 

--- a/scripts/.environment
+++ b/scripts/.environment
@@ -13,6 +13,9 @@ else
     export EOSIO_VERSION_FULL="${EOSIO_VERSION_MAJOR}.${EOSIO_VERSION_MINOR}.${EOSIO_VERSION_PATCH}-${EOSIO_VERSION_SUFFIX}"
 fi
 
+export CMAKE_REQUIRED_VERSION=$(cat $REPO_ROOT/CMakeLists.txt | grep -E "^[[:blank:]]*cmake_minimum_required[[:blank:]]*\([[:blank:]]*VERSION" | tail -1 | sed 's/.*VERSION //g' | sed 's/ //g' | sed 's/"//g' | cut -d\) -f1)
+
+
 export EOSIO_INSTALL_DIR="${EOSIO_INSTALL_DIR:-${HOME}/eosio/${EOSIO_VERSION}}"
 export TEMP_DIR="${TEMP_DIR:-${HOME}/tmp}"
 

--- a/scripts/eosio_build.sh
+++ b/scripts/eosio_build.sh
@@ -147,7 +147,17 @@ execute cd $REPO_ROOT
 ensure-submodules-up-to-date
 
 # Check if cmake already exists
-( [[ -z "${CMAKE}" ]] && [[ ! -z $(command -v cmake 2>/dev/null) ]] ) && export CMAKE=$(command -v cmake 2>/dev/null)
+( [[ -z "${CMAKE}" ]] && [[ ! -z $(command -v cmake 2>/dev/null) ]] ) && export CMAKE=$(command -v cmake 2>/dev/null) && export CMAKE_CURRENT_VERSION=$($CMAKE --version | grep -E "cmake version[[:blank:]]*" | sed 's/.*cmake version //g')
+# If it exists, check that it's > required version
+if [[ ! -z $CMAKE_CURRENT_VERSION ]] && [[ $( echo $CURRENT_CMAKE_VERSION | awk -F. '{ printf("%03d%03d%03d\n", $1,$2,$3); }' ) < $( echo $CMAKE_REQUIRED_VERSION | awk -F. '{ printf("%03d%03d%03d\n", $1,$2,$3); }' ) ]]; then
+   export CMAKE=
+   if [[ $ARCH == 'Darwin' ]]; then
+      echo "${COLOR_RED}The currently installed cmake version ($CMAKE_CURRENT_VERSION) is less than the required version ($CMAKE_REQUIRED_VERSION). Cannot proceed."
+      exit
+   else
+      echo "${COLOR_YELLOW}The currently installed cmake version ($CMAKE_CURRENT_VERSION) is less than the required version ($CMAKE_REQUIRED_VERSION). We will be installing $CMAKE_VERSION.${COLOR_NC}"
+   fi
+fi
 
 # Use existing cmake on system (either global or specific to eosio)
 # Setup based on architecture

--- a/scripts/eosio_build.sh
+++ b/scripts/eosio_build.sh
@@ -149,7 +149,7 @@ ensure-submodules-up-to-date
 # Check if cmake already exists
 ( [[ -z "${CMAKE}" ]] && [[ ! -z $(command -v cmake 2>/dev/null) ]] ) && export CMAKE=$(command -v cmake 2>/dev/null) && export CMAKE_CURRENT_VERSION=$($CMAKE --version | grep -E "cmake version[[:blank:]]*" | sed 's/.*cmake version //g')
 # If it exists, check that it's > required version
-if [[ ! -z $CMAKE_CURRENT_VERSION ]] && [[ $( echo $CURRENT_CMAKE_VERSION | awk -F. '{ printf("%03d%03d%03d\n", $1,$2,$3); }' ) < $( echo $CMAKE_REQUIRED_VERSION | awk -F. '{ printf("%03d%03d%03d\n", $1,$2,$3); }' ) ]]; then
+if [[ ! -z $CMAKE_CURRENT_VERSION ]] && (( $( echo $CURRENT_CMAKE_VERSION | awk -F. '{ printf("%03d%03d%03d\n", $1,$2,$3); }' ) < $( echo $CMAKE_REQUIRED_VERSION | awk -F. '{ printf("%03d%03d%03d\n", $1,$2,$3); }' ) )); then
    export CMAKE=
    if [[ $ARCH == 'Darwin' ]]; then
       echo "${COLOR_RED}The currently installed cmake version ($CMAKE_CURRENT_VERSION) is less than the required version ($CMAKE_REQUIRED_VERSION). Cannot proceed."

--- a/scripts/eosio_build.sh
+++ b/scripts/eosio_build.sh
@@ -148,12 +148,12 @@ ensure-submodules-up-to-date
 
 # Check if cmake already exists
 ( [[ -z "${CMAKE}" ]] && [[ ! -z $(command -v cmake 2>/dev/null) ]] ) && export CMAKE=$(command -v cmake 2>/dev/null) && export CMAKE_CURRENT_VERSION=$($CMAKE --version | grep -E "cmake version[[:blank:]]*" | sed 's/.*cmake version //g')
-# If it exists, check that it's > required version
-if [[ ! -z $CMAKE_CURRENT_VERSION ]] && (( $( echo $CURRENT_CMAKE_VERSION | awk -F. '{ printf("%03d%03d%03d\n", $1,$2,$3); }' ) < $( echo $CMAKE_REQUIRED_VERSION | awk -F. '{ printf("%03d%03d%03d\n", $1,$2,$3); }' ) )); then
+# If it exists, check that it's > required version + 
+if [[ ! -z $CMAKE_CURRENT_VERSION ]] && [[ $((10#$( echo $CMAKE_CURRENT_VERSION | awk -F. '{ printf("%03d%03d%03d\n", $1,$2,$3); }' ))) -lt $((10#$( echo $CMAKE_REQUIRED_VERSION | awk -F. '{ printf("%03d%03d%03d\n", $1,$2,$3); }' ))) ]]; then
    export CMAKE=
    if [[ $ARCH == 'Darwin' ]]; then
       echo "${COLOR_RED}The currently installed cmake version ($CMAKE_CURRENT_VERSION) is less than the required version ($CMAKE_REQUIRED_VERSION). Cannot proceed."
-      exit
+      exit 1
    else
       echo "${COLOR_YELLOW}The currently installed cmake version ($CMAKE_CURRENT_VERSION) is less than the required version ($CMAKE_REQUIRED_VERSION). We will be installing $CMAKE_VERSION.${COLOR_NC}"
    fi

--- a/tests/bash-bats/modules/cmake.sh
+++ b/tests/bash-bats/modules/cmake.sh
@@ -9,7 +9,7 @@ load ../helpers/functions
     export CMAKE_CURRENT_VERSION=3.7.1
     run bash -c " ./$SCRIPT_LOCATION -y -P"
     if [[ $ARCH == "Darwin" ]]; then
-        [[ ! -z $(echo "${output}" | grep "($CMAKE_REQUIRED_VERSION). Cannot proceed") ]] || exit # Test the required version
+        [[ "${output##*$'\n'}" =~ "($CMAKE_REQUIRED_VERSION). Cannot proceed" ]] || exit # Test the required version
     else
         [[ ! -z $(echo "${output}" | grep "We will be installing $CMAKE_VERSION") ]] || exit # Test the required version
         [[ ! -z $(echo "${output}" | grep "Executing: bash -c ${BIN_DIR}/cmake") ]] || exit
@@ -26,7 +26,7 @@ load ../helpers/functions
     export CMAKE_CURRENT_VERSION=3.6
     run bash -c "./$SCRIPT_LOCATION -y -P"
     if [[ $ARCH == "Darwin" ]]; then
-        [[ ! -z $(echo "${output}" | grep "($CMAKE_REQUIRED_VERSION). Cannot proceed") ]] || exit # Test the required version
+        [[ "${output##*$'\n'}" =~ "($CMAKE_REQUIRED_VERSION). Cannot proceed" ]] || exit # Test the required version
     else
         [[ ! -z $(echo "${output}" | grep "We will be installing $CMAKE_VERSION") ]] || exit # Test the required version
         [[ ! -z $(echo "${output}" | grep "Executing: bash -c ${BIN_DIR}/cmake") ]] || exit

--- a/tests/bash-bats/modules/cmake.sh
+++ b/tests/bash-bats/modules/cmake.sh
@@ -2,13 +2,37 @@
 load ../helpers/functions
 
 @test "${TEST_LABEL} > Testing CMAKE" {
+
     # Testing for if CMAKE already exists
     export CMAKE=${HOME}/cmake
     touch $CMAKE
+    export CMAKE_CURRENT_VERSION=3.7.1
+    run bash -c " ./$SCRIPT_LOCATION -y -P"
+    if [[ $ARCH == "Darwin" ]]; then
+        [[ ! -z $(echo "${output}" | grep "($CMAKE_REQUIRED_VERSION). Cannot proceed") ]] || exit # Test the required version
+    else
+        [[ ! -z $(echo "${output}" | grep "We will be installing $CMAKE_VERSION") ]] || exit # Test the required version
+        [[ ! -z $(echo "${output}" | grep "Executing: bash -c ${BIN_DIR}/cmake") ]] || exit
+    fi
+    export CMAKE_CURRENT_VERSION=
     run bash -c " ./$SCRIPT_LOCATION -y -P"
     [[ ! -z $(echo "${output}" | grep "Executing: bash -c ${HOME}/cmake") ]] || exit
+    if [[ $ARCH != "Darwin" ]]; then
+        [[ -z $(echo "${output}" | grep "CMAKE successfully installed") ]] || exit
+    fi
+
     # Testing for if cmake doesn't exist to be sure it's set properly
     export CMAKE=
+    export CMAKE_CURRENT_VERSION=3.6
+    run bash -c "./$SCRIPT_LOCATION -y -P"
+    if [[ $ARCH == "Darwin" ]]; then
+        [[ ! -z $(echo "${output}" | grep "($CMAKE_REQUIRED_VERSION). Cannot proceed") ]] || exit # Test the required version
+    else
+        [[ ! -z $(echo "${output}" | grep "We will be installing $CMAKE_VERSION") ]] || exit # Test the required version
+        [[ ! -z $(echo "${output}" | grep "Executing: bash -c ${BIN_DIR}/cmake") ]] || exit
+        [[ ! -z $(echo "${output}" | grep "CMAKE successfully installed") ]] || exit
+    fi
+    export CMAKE_CURRENT_VERSION=
     run bash -c "./$SCRIPT_LOCATION -y -P"
     if [[ $ARCH == "Darwin" ]]; then
         [[ ! -z $(echo "${output}" | grep "Executing: bash -c /usr/local/bin/cmake -DCMAKE_BUILD") ]] || exit


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description

Problem: People with versions less than the required don't see the requirement failure until too late (after dependencies are installed).

Solution: Add a check for the required version of CMAKE (using CMakeLists.txt) and compare it to the currently installed version.

Base Images (clean) builds: https://buildkite.com/EOSIO/eosio-base-images/builds/340

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
