### PR TITLE
fix hash<>::result_type deprecation spam

### DIFF
--- a/libraries/chain/include/eosio/chain/name.hpp
+++ b/libraries/chain/include/eosio/chain/name.hpp
@@ -93,8 +93,7 @@ namespace eosio::chain {
 namespace std {
    template<> struct hash<eosio::chain::name> : private hash<uint64_t> {
       typedef eosio::chain::name argument_type;
-      typedef typename hash<uint64_t>::result_type result_type;
-      result_type operator()(const argument_type& name) const noexcept
+      size_t operator()(const argument_type& name) const noexcept
       {
          return hash<uint64_t>::operator()(name.to_uint64_t());
       }


### PR DESCRIPTION


<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
the hash<> return value is specified to be size_t and as of c++17 result_type is deprecated. as is this is causing warning spam for compilers that have deprecation warnings on, so just change it to be size_t

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
