### PR TITLE
[1.8.x] Install location fix

### DIFF
--- a/scripts/.build_vars
+++ b/scripts/.build_vars
@@ -1,10 +1,11 @@
-export SRC_DIR=${SRC_DIR:-${EOSIO_INSTALL_DIR}/src}
-export OPT_DIR=${OPT_DIR:-${EOSIO_INSTALL_DIR}/opt}
-export VAR_DIR=${VAR_DIR:-${EOSIO_INSTALL_DIR}/var}
-export ETC_DIR=${ETC_DIR:-${EOSIO_INSTALL_DIR}/etc}
-export BIN_DIR=${BIN_DIR:-${EOSIO_INSTALL_DIR}/bin}
-export LIB_DIR=${LIB_DIR:-${EOSIO_INSTALL_DIR}/lib}
-export DATA_DIR=${DATA_DIR:-${EOSIO_INSTALL_DIR}/data}
+# See install-directory-prompt for logic that sets EOSIO_INSTALL_DIR
+export SRC_DIR=${EOSIO_INSTALL_DIR}/src
+export OPT_DIR=${EOSIO_INSTALL_DIR}/opt
+export VAR_DIR=${EOSIO_INSTALL_DIR}/var
+export ETC_DIR=${EOSIO_INSTALL_DIR}/etc
+export BIN_DIR=${EOSIO_INSTALL_DIR}/bin
+export LIB_DIR=${EOSIO_INSTALL_DIR}/lib
+export DATA_DIR=${EOSIO_INSTALL_DIR}/data
 
 # CMAKE
 export CMAKE_VERSION_MAJOR=3

--- a/scripts/.environment
+++ b/scripts/.environment
@@ -15,7 +15,7 @@ fi
 
 export CMAKE_REQUIRED_VERSION=$(cat $REPO_ROOT/CMakeLists.txt | grep -E "^[[:blank:]]*cmake_minimum_required[[:blank:]]*\([[:blank:]]*VERSION" | tail -1 | sed 's/.*VERSION //g' | sed 's/ //g' | sed 's/"//g' | cut -d\) -f1)
 
-export EOSIO_INSTALL_DIR="${EOSIO_INSTALL_DIR:-${HOME}/eosio/${EOSIO_VERSION}}"
+export EOSIO_INSTALL_DIR="${HOME}/eosio/${EOSIO_VERSION}"
 export TEMP_DIR="${TEMP_DIR:-${HOME}/tmp}"
 
 [[ -f ${BUILD_DIR}/CMakeCache.txt ]] && export CACHED_INSTALL_PATH=$(grep "CMAKE_INSTALL_PREFIX:PATH" ${BUILD_DIR}/CMakeCache.txt | cut -d= -f2)

--- a/scripts/eosio_build.sh
+++ b/scripts/eosio_build.sh
@@ -119,9 +119,6 @@ cd $( dirname "${BASH_SOURCE[0]}" )/..
 # Load eosio specific helper functions
 . ./scripts/helpers/eosio.sh
 
-# Support relative paths : https://github.com/EOSIO/eos/issues/7560
-( [[ ! -z $INSTALL_LOCATION ]] && [[ ! $INSTALL_LOCATION =~ ^\/ ]] ) && export INSTALL_LOCATION="${CURRENT_WORKING_DIR}/$INSTALL_LOCATION"
-
 $VERBOSE && echo "Build Script Version: ${SCRIPT_VERSION}"
 echo "EOSIO Version: ${EOSIO_VERSION_FULL}"
 echo "$( date -u )"

--- a/scripts/helpers/eosio.sh
+++ b/scripts/helpers/eosio.sh
@@ -76,28 +76,30 @@ function ensure-which() {
 
 # Prompt user for installation directory.
 function install-directory-prompt() {
-  if [[ -z $INSTALL_LOCATION ]]; then
-    echo "No installation location was specified. Please provide the location where EOSIO is installed."
-    while true; do
-      [[ $NONINTERACTIVE == false ]] && printf "${COLOR_YELLOW}Do you wish to use the default location? ${EOSIO_INSTALL_DIR}? (y/n)${COLOR_NC}" && read -p " " PROCEED
-      echo ""
-      case $PROCEED in
-        "" )
-          echo "What would you like to do?";;
-        0 | true | [Yy]* )
-          break;;
-        1 | false | [Nn]* )
-          printf "Enter the desired installation location." && read -p " " EOSIO_INSTALL_DIR;
-          export EOSIO_INSTALL_DIR;
-          break;;
-        * ) echo "Please type 'y' for yes or 'n' for no.";;
-      esac
-    done
-  else
-    export EOSIO_INSTALL_DIR=${INSTALL_LOCATION}
-  fi
-  . ./scripts/.build_vars
-  echo "EOSIO will be installed to: ${EOSIO_INSTALL_DIR}"
+    if [[ -z $INSTALL_LOCATION ]]; then
+        echo "No installation location was specified. Please provide the location where EOSIO is installed."
+        while true; do
+            [[ $NONINTERACTIVE == false ]] && printf "${COLOR_YELLOW}Do you wish to use the default location? ${EOSIO_INSTALL_DIR}? (y/n)${COLOR_NC}" && read -p " " PROCEED
+            echo ""
+            case $PROCEED in
+                "" )
+                echo "What would you like to do?";;
+                0 | true | [Yy]* )
+                break;;
+                1 | false | [Nn]* )
+                printf "Enter the desired installation location." && read -p " " EOSIO_INSTALL_DIR;
+                export EOSIO_INSTALL_DIR;
+                break;;
+                * ) echo "Please type 'y' for yes or 'n' for no.";;
+            esac
+        done
+    else
+        # Support relative paths : https://github.com/EOSIO/eos/issues/7560
+        [[ ! $INSTALL_LOCATION =~ ^\/ ]] && export INSTALL_LOCATION="${CURRENT_WORKING_DIR}/$INSTALL_LOCATION"
+        export EOSIO_INSTALL_DIR="$INSTALL_LOCATION"
+    fi
+    . ./scripts/.build_vars
+    echo "EOSIO will be installed to: ${EOSIO_INSTALL_DIR}"
 }
 
 function previous-install-prompt() {

--- a/tests/bash-bats/eosio_build_darwin.sh
+++ b/tests/bash-bats/eosio_build_darwin.sh
@@ -29,7 +29,7 @@ export TEST_LABEL="[eosio_build_darwin]"
     ### Make sure deps are loaded properly
     [[ ! -z $(echo "${output}" | grep "Starting EOSIO Dependency Install") ]] || exit
     [[ ! -z $(echo "${output}" | grep "Executing: /usr/bin/xcode-select --install") ]] || exit
-    [[ -z $(echo "${output}" | grep "-   NOT found") ]] || exit
+    [[ -z $(echo "${output}" | grep " -   NOT found") ]] || exit
     rm -f $CMAKE
     [[ ! -z $(echo "${output}" | grep "[Updating HomeBrew]") ]] || exit
     [[ ! -z $(echo "${output}" | grep "brew tap eosio/eosio") ]] || exit


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

Problem: Several changes are not compatible with each other. EOSIO_INSTALL_DIR was not being set properly. Backing up the changes to the _BIN vars as they are loaded twice and won't get the INSTALL_LOCATION.

Also, I've moved the relative INSTALL_LOCATION fix into the install-directory-prompt function to make it easier to maintain.

Base Images: https://buildkite.com/EOSIO/eosio-base-images/builds/373

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
