### PR TITLE
Reuse producer threads

### DIFF
--- a/plugins/producer_plugin/include/eosio/producer_plugin/producer_plugin.hpp
+++ b/plugins/producer_plugin/include/eosio/producer_plugin/producer_plugin.hpp
@@ -115,8 +115,23 @@ public:
    get_account_ram_corrections_result  get_account_ram_corrections( const get_account_ram_corrections_params& params ) const;
 
    signal<void(const chain::producer_confirmation&)> confirmed_block;
+
+   boost::asio::io_service& get_io_service() { return *io_serv; }
+
+   template <typename Func>
+   auto post( int priority, Func&& func ) {
+      return boost::asio::post(*io_serv, pri_queue.wrap(priority, std::forward<Func>(func)));
+   }
+
+   auto& get_priority_queue() {
+      return pri_queue;
+   }
 private:
    std::shared_ptr<class producer_plugin_impl> my;
+
+   std::shared_ptr<boost::asio::io_service>  io_serv;
+   std::shared_ptr<boost::asio::io_service::work> work_ptr;
+   execution_priority_queue pri_queue;
 };
 
 } //eosio


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
**Description**
- Producer threads perform core operations in producer_plugin, such as `push_transaction`, `push_block`, and `produce_block`. 
- The purpose of this PR is to observe the impact of separating these operations from the application thread. 
- Note that this code works well, but not concrete.


**Motivation and Work Notes**
- Application thread is still overhead despite the help of chain-threads, net-threads, and http-threads.
- Our first intuition was to separate `push_transaction` from the application thread.
- However, `push_transaction` is tightly coupled with `push_block` and `produce_block`, therefore we needed to separate them all.
- The producer threads were idle since #6845 (https://github.com/EOSIO/eos/pull/6845/commits/eceaa9bb5cd551e3d38b15ddeeb5404421fdc786) and were suitable for performing separated operations.
- We limit the number of producer threads to 1, because currently sequential processing must be guaranteed.
- We carefully changed the processing of `push_transaction`, `push_block`, `produce_block` from application thread to producer threads.

**Experiment Environment**
- Nodes: 8 nodes
- HW: Each Intel(R) Xeon(R) CPU E5-2699 v4 @ 2.20GHz (44 cores), 128GB
- Options: 2 chain-threads, 2 net-threads, 2 http-threads, 2 txn_test_gen-threads, 1 producer-thread, wavm
- Benchmark: txn_test_gen - generate 200 transactions every 170 ms on each 8 node (intended 9,400 TPS) for 30 seconds

**Results**
- Before: 7,832 TPS, 99% CPU usage (application thread)
- After: 8,512 TPS, 7.1% CPU usage (application thread), 99% CPU usage (producer thread)

**Discussion**
- Producer threads increases TPS by 9% and reduces application thread CPU usage by 99% to 7%.
- We can observe that the core operations in producer_plugin accounted for a large portion of the application thread previously.
- If we evenly distribute the core operations in producer_plugin to producer threads and application thread, we can achieve higher throughput.
- If we can increase the number of producer threads (e.g., the parallel processing of push transaction is supported), we can easily achieve much higher throughput. Because the CPU usage of the application thread is low currently.
- We hope that this PR will help design multithreading techniques.


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
