### PR TITLE
bios-boot-tutorial.py: bugfix, SYS hardcoded instead of using command…

### DIFF
--- a/tutorials/bios-boot-tutorial/bios-boot-tutorial.py
+++ b/tutorials/bios-boot-tutorial/bios-boot-tutorial.py
@@ -297,7 +297,7 @@ def stepSetSystemContract():
     sleep(1)
     run(args.cleos + 'push action eosio setpriv' + jsonArg(['eosio.msig', 1]) + '-p eosio@active')
 def stepInitSystemContract():
-    run(args.cleos + 'push action eosio init' + jsonArg(['0', '4,SYS']) + '-p eosio@active')
+    run(args.cleos + 'push action eosio init' + jsonArg(['0', '4,' + args.symbol]) + '-p eosio@active')
     sleep(1)
 def stepCreateStakedAccounts():
     createStakedAccounts(0, len(accounts))


### PR DESCRIPTION
## Change Description

Minor bugfix in testnet spin-up script. In one place, it uses hardcoded SYS instead of symbol used in --symbol command-line argument

## Consensus Changes

none

## API Changes

none

## Documentation Additions

none