### PR TITLE
additional wasm unittests around max depth

### DIFF
--- a/unittests/contracts/test_wasts.hpp
+++ b/unittests/contracts/test_wasts.hpp
@@ -647,3 +647,81 @@ static const char large_maligned_host_ptr[] = R"=====(
  )
 )
 )=====";
+
+static const char depth_assert_wasm[] = R"=====(
+(module
+ (export "apply" (func $$apply))
+ (func $$apply (param $$0 i64) (param $$1 i64) (param $$2 i64)
+  (if (i64.eq (get_global $$depth) (i64.const 0)) (then
+    (return)
+  ))
+  (set_global $$depth
+   (i64.sub
+    (get_global $$depth)
+    (i64.const 1)
+   )
+  )
+  (call $$apply
+   (get_local $$0)
+   (get_local $$1)
+   (get_local $$2)
+  )
+ )
+ (global $$depth (mut i64) (i64.const ${MAX_DEPTH}))
+)
+)=====";
+
+static const char depth_assert_intrinsic[] = R"=====(
+(module
+ (import "env" "current_time" (func $$current_time (result i64)))
+ (export "apply" (func $$apply))
+ (func $$apply (param $$0 i64) (param $$1 i64) (param $$2 i64)
+  (if (i64.eq (get_global $$depth) (i64.const 1)) (then
+    (drop (call $$current_time))
+    (return)
+  ))
+  (set_global $$depth
+   (i64.sub
+    (get_global $$depth)
+    (i64.const 1)
+   )
+  )
+  (call $$apply
+   (get_local $$0)
+   (get_local $$1)
+   (get_local $$2)
+  )
+ )
+ (global $$depth (mut i64) (i64.const ${MAX_DEPTH}))
+)
+)=====";
+
+static const char depth_assert_wasm_float[] = R"=====(
+(module
+ (export "apply" (func $$apply))
+ (func $$apply (param $$0 i64) (param $$1 i64) (param $$2 i64)
+  (set_global $$mcfloaty
+   (f64.mul
+    (get_global $$mcfloaty)
+    (f64.const 3.1415)
+   )
+  )
+  (if (i64.eq (get_global $$depth) (i64.const 0)) (then
+    (return)
+  ))
+  (set_global $$depth
+   (i64.sub
+    (get_global $$depth)
+    (i64.const 1)
+   )
+  )
+  (call $$apply
+   (get_local $$0)
+   (get_local $$1)
+   (get_local $$2)
+  )
+ )
+ (global $$depth (mut i64) (i64.const ${MAX_DEPTH}))
+ (global $$mcfloaty (mut f64) (f64.const 3.14))
+)
+)=====";

--- a/unittests/wasm_tests.cpp
+++ b/unittests/wasm_tests.cpp
@@ -1742,6 +1742,58 @@ BOOST_FIXTURE_TEST_CASE( big_maligned_host_ptr, TESTER ) try {
    produce_blocks(1);
 } FC_LOG_AND_RETHROW()
 
+BOOST_FIXTURE_TEST_CASE( depth_tests, TESTER ) try {
+   produce_block();
+   create_accounts( {N(depth)} );
+   produce_block();
+
+   signed_transaction trx;
+   trx.actions.emplace_back(vector<permission_level>{{N(depth),config::active_name}}, N(depth), N(), bytes{});
+   trx.actions[0].authorization = vector<permission_level>{{N(depth),config::active_name}};
+
+    auto pushit = [&]() {
+      produce_block();
+      trx.signatures.clear();
+      set_transaction_headers(trx);
+      trx.sign(get_private_key(N(depth), "active"), control->get_chain_id());
+      push_transaction(trx);
+   };
+
+   //strictly wasm recursion to maximum_call_depth & maximum_call_depth+1
+   string wasm_depth_okay = fc::format_string(depth_assert_wasm, fc::mutable_variant_object()
+                                              ("MAX_DEPTH", eosio::chain::wasm_constraints::maximum_call_depth));
+   set_code(N(depth), wasm_depth_okay.c_str());
+   pushit();
+
+   string wasm_depth_one_over = fc::format_string(depth_assert_wasm, fc::mutable_variant_object()
+                                              ("MAX_DEPTH", eosio::chain::wasm_constraints::maximum_call_depth+1));
+   set_code(N(depth), wasm_depth_one_over.c_str());
+   BOOST_CHECK_THROW(pushit(), wasm_execution_error);
+
+   //wasm recursion but call an intrinsic as the last function instead
+   string intrinsic_depth_okay = fc::format_string(depth_assert_intrinsic, fc::mutable_variant_object()
+                                              ("MAX_DEPTH", eosio::chain::wasm_constraints::maximum_call_depth));
+   set_code(N(depth), intrinsic_depth_okay.c_str());
+   pushit();
+
+   string intrinsic_depth_one_over = fc::format_string(depth_assert_intrinsic, fc::mutable_variant_object()
+                                              ("MAX_DEPTH", eosio::chain::wasm_constraints::maximum_call_depth+1));
+   set_code(N(depth), intrinsic_depth_one_over.c_str());
+   BOOST_CHECK_THROW(pushit(), wasm_execution_error);
+
+   //add a float operation in the mix to ensure any injected softfloat call doesn't count against limit
+   string wasm_float_depth_okay = fc::format_string(depth_assert_wasm_float, fc::mutable_variant_object()
+                                              ("MAX_DEPTH", eosio::chain::wasm_constraints::maximum_call_depth));
+   set_code(N(depth), wasm_float_depth_okay.c_str());
+   pushit();
+
+   string wasm_float_depth_one_over = fc::format_string(depth_assert_wasm_float, fc::mutable_variant_object()
+                                              ("MAX_DEPTH", eosio::chain::wasm_constraints::maximum_call_depth+1));
+   set_code(N(depth), wasm_float_depth_one_over.c_str());
+   BOOST_CHECK_THROW(pushit(), wasm_execution_error);
+
+} FC_LOG_AND_RETHROW()
+
 // TODO: restore net_usage_tests
 #if 0
 BOOST_FIXTURE_TEST_CASE(net_usage_tests, tester ) try {


### PR DESCRIPTION

<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
Add some additional unittests around the wasm max depth. Of particular interest is a check that ensures intrinsics are counted against the depth -- in the current injected architecture depth checks happen before calls, so an intrinsic call can still cause depth check to fail. A non-injected runtime needs to ensure it follows this behavior still.


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
