### PR TITLE
fix fc::temp_directory usage in tester

### DIFF
--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -370,8 +370,7 @@ namespace eosio { namespace testing {
       }
       controller::config vcfg;
 
-      static controller::config default_config() {
-         fc::temp_directory tempdir;
+      static controller::config default_config(fc::temp_directory& tempdir) {
          controller::config vcfg;
          vcfg.blocks_dir      = tempdir.path() / std::string("v_").append(config::default_blocks_dir_name);
          vcfg.state_dir  = tempdir.path() /  std::string("v_").append(config::default_state_dir_name);
@@ -394,7 +393,7 @@ namespace eosio { namespace testing {
       }
 
       validating_tester(const flat_set<account_name>& trusted_producers = flat_set<account_name>()) {
-         vcfg = default_config();
+         vcfg = default_config(tempdir);
 
          vcfg.trusted_producers = trusted_producers;
 

--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -591,7 +591,8 @@ BOOST_FIXTURE_TEST_CASE(require_notice_tests, TESTER) { try {
    } FC_LOG_AND_RETHROW() }
 
 BOOST_AUTO_TEST_CASE(ram_billing_in_notify_tests) { try {
-   validating_tester chain( validating_tester::default_config() );
+   fc::temp_directory tempdir;
+   validating_tester chain( validating_tester::default_config(tempdir) );
    chain.execute_setup_policy( setup_policy::preactivate_feature_and_new_bios );
 
    chain.produce_blocks(2);
@@ -1319,7 +1320,8 @@ BOOST_FIXTURE_TEST_CASE(deferred_transaction_tests, TESTER) { try {
 } FC_LOG_AND_RETHROW() }
 
 BOOST_AUTO_TEST_CASE(more_deferred_transaction_tests) { try {
-   auto cfg = validating_tester::default_config();
+   fc::temp_directory tempdir;
+   auto cfg = validating_tester::default_config(tempdir);
    cfg.contracts_console = true;
    validating_tester chain( cfg );
    chain.execute_setup_policy( setup_policy::preactivate_feature_and_new_bios );

--- a/unittests/auth_tests.cpp
+++ b/unittests/auth_tests.cpp
@@ -371,7 +371,8 @@ BOOST_AUTO_TEST_CASE( any_auth ) { try {
 
 BOOST_AUTO_TEST_CASE(no_double_billing) {
 try {
-   validating_tester chain( validating_tester::default_config() );
+   fc::temp_directory tempdir;
+   validating_tester chain( validating_tester::default_config(tempdir) );
    chain.execute_setup_policy( setup_policy::preactivate_feature_and_new_bios );
 
    chain.produce_block();

--- a/unittests/producer_schedule_tests.cpp
+++ b/unittests/producer_schedule_tests.cpp
@@ -328,7 +328,8 @@ BOOST_FIXTURE_TEST_CASE( producer_schedule_reduction, tester ) try {
 } FC_LOG_AND_RETHROW()
 
 BOOST_AUTO_TEST_CASE( empty_producer_schedule_has_no_effect ) try {
-   validating_tester c( validating_tester::default_config() );
+   fc::temp_directory tempdir;
+   validating_tester c( validating_tester::default_config(tempdir) );
    c.execute_setup_policy( setup_policy::preactivate_feature_and_new_bios );
 
    c.create_accounts( {N(alice),N(bob),N(carol)} );


### PR DESCRIPTION


<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
Can't have fc::temp_directory scoped to default_config() because that means once defualt_config() returns the only attempt at trying to clean up the tempdir is at that time -- way before any files are actually created. Make default_config() use an fc::temp_directory which tester already has anyways. So, once tester is destroyed that's when the fc::temp_directory falls out of scope and it can properly clean up at that point. A run through unit_test doesn't leave behind all its data files any longer.

Fixes #6800

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
