### PR TITLE
Travis CI Alpha Testing - Get Working Macintosh Build

### DIFF
--- a/.cicd/travis-before.sh
+++ b/.cicd/travis-before.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+# print information about host resources
+echo '===== RESOURCES ====='
+echo "$(getconf _NPROCESSORS_ONLN) CPU cores found."
+if [[ "$(uname)" == Darwin ]]; then top -l 1 -s 0 | grep PhysMem; else vmstat -sSM | grep -i 'memory'; fi
+df -h
+echo '====================='

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,22 @@ git:
 cache: ccache
 os: osx
 osx_image: xcode10.2
+addons:
+  homebrew:
+    packages:
+      # - cmake
+      - graphviz
+      - libtool
+      # - automake
+      # - wget
+      - gmp
+      - llvm@4
+      - pkgconfig
+      - python
+      - python@2
+      - doxygen
+      - libusb
+      - openssl
 before_install: |
   ./.cicd/travis-before.sh
 # DOCKER

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ os: osx
 osx_image: xcode10.2
 addons:
   homebrew:
+    update: true
     packages:
       # - cmake
       - graphviz

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ addons:
       - doxygen
       - libusb
       - openssl
+      - boost
 before_install: |
   ./.cicd/travis-before.sh
 # DOCKER

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,35 +2,20 @@ language: cpp
 git:
   depth: false # prevent git describe failure when executing the appbase version.cmake.in
 cache: ccache
-matrix:
-  include:
-    - os: linux
-      dist: xenial
-      services: docker
-      env: IMAGE_TAG='ubuntu-18.04'
-    # - os: osx
-    #   osx_image: xcode10.2
-
+os: osx
+osx_image: xcode10.2
 before_install: |
-  echo '##### CHECKPOINT 1'
-  echo '===== RESOURCES ====='
-  echo "$(getconf _NPROCESSORS_ONLN) CPU cores found."
-  if [[ "$(uname)" == Darwin ]]; then top -l 1 -s 0 | grep PhysMem; else vmstat -sSM | grep -i 'memory'; fi
-  df -h
-  echo '====================='
+  ./.cicd/travis-before.sh
 # DOCKER
 # script:
-# - echo '##### CHECKPOINT 2'
 # # - docker build -t eosio/ci:ubuntu-18.04 -f ./.cicd/ubuntu-18.04.dockerfile .
 # - docker build -t eosio/producer:ci-ubuntu-18.04 -f ./.cicd/ubuntu-18.04.dockerfile .
 # after_success:
-# - echo '##### CHECKPOINT 3'
 # - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 # # - docker push eosio/ci:ubuntu-18.04
 # - docker push eosio/producer:ci-ubuntu-18.04
 # EOSIO
 script: |
-  echo '##### CHECKPOINT 2'
   ./.cicd/travis-build.sh
 after_success:
 - echo '##### CHECKPOINT 3'

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ addons:
       - doxygen
       - libusb
       - openssl
-      - boost
+      - boost@1.70
 before_install: |
   ./.cicd/travis-before.sh
 # DOCKER

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,8 @@ addons:
   homebrew:
     update: true
     packages:
-      # - cmake
       - graphviz
       - libtool
-      # - automake
-      # - wget
       - gmp
       - llvm@4
       - pkgconfig


### PR DESCRIPTION
## Change Description
This is a part of the ongoing Travis CI alpha testing described in [pull request 7622](https://github.com/EOSIO/eos/pull/7622).   
   
We are able to use Docker containers to perform the Linux build and testing on Travis CI, but the macOS builds must be performed natively on the available Travis CI agents because Apple licensing is not compatible with containerization

This branch is a fork of [`eos:trav_poc_r1.8`](https://github.com/EOSIO/eos/tree/trav_poc_r1.8) where linux builds have been disabled and I can work on configuration of the Travis macOS virtual machine exclusively.

## Consensus Changes
- [ ] Consensus Changes
None.

## API Changes
- [ ] API Changes
None.

## Documentation Additions
- [ ] Documentation Additions
None.