### PR TITLE
Travis CI Equivalent Buildkite Pipeline

### DIFF
--- a/.cicd/base-images.yml
+++ b/.cicd/base-images.yml
@@ -2,83 +2,37 @@ env:
   BUILD_TIMEOUT: 120
   TEST_TIMEOUT: 60
   TIMEOUT: 120
-  VERBOSE: true
 
 steps:
 
   - label: ":aws: [Amazon] 2 Ensure Docker Image"
     command:
-      - "/workdir/.cicd/generate-base-images.sh"
+      - ".cicd/generate-base-images.sh amazonlinux-2"
     agents:
-      queue: "automation-large-builder-fleet"
-    plugins:
-      - docker#v3.2.0:
-          shell: ["/bin/bash", "-i", "-e", "-c"]
-          debug: $DEBUG
-          image: "eosio/producer:ci-amazonlinux-2"
+      queue: "automation-eos-builder-fleet"
     timeout: $BUILD_TIMEOUT
     skip: $SKIP_AMAZON_LINUX_2
 
-  # - label: ":centos: [CentOS] 7 Build"
-  #   command:
-  #     - "mkdir /workdir/build && cd /workdir/build && source /opt/rh/devtoolset-8/enable && source /opt/rh/rh-python36/enable && cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true /workdir && make -j $(getconf _NPROCESSORS_ONLN)"
-  #     - "cd /workdir/build && ctest -j$(getconf _NPROCESSORS_ONLN) -LE _tests --output-on-failure -T Test"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   plugins:
-  #     - docker#v3.2.0:
-  #         shell: ["/bin/bash", "-i", "-e", "-c"]
-  #         debug: $DEBUG
-  #         image: "eosio/producer:ci-centos-7"
-  #   timeout: $BUILD_TIMEOUT
-  #   skip: $SKIP_CENTOS_7
+  - label: ":centos: [CentOS] 7 Build"
+    command:
+      - ".cicd/generate-base-images.sh centos-7"
+    agents:
+      queue: "automation-eos-builder-fleet"
+    timeout: $BUILD_TIMEOUT
+    skip: $SKIP_CENTOS_7
 
-  # - label: ":ubuntu: [Ubuntu] 16.04 Build"
-  #   command:
-  #     - "mkdir /workdir/build && cd /workdir/build && cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true -DCMAKE_TOOLCHAIN_FILE='/tmp/pinned_toolchain.cmake' /workdir && make -j $(getconf _NPROCESSORS_ONLN)"
-  #     - "cd /workdir/build && ctest -j$(getconf _NPROCESSORS_ONLN) -LE _tests --output-on-failure -T Test"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   plugins:
-  #     - docker#v3.2.0:
-  #         shell: ["/bin/bash", "-i", "-e", "-c"]
-  #         debug: $DEBUG
-  #         image: "eosio/producer:ci-ubuntu-16.04"
-  #   timeout: $BUILD_TIMEOUT
-  #   skip: $SKIP_UBUNTU_16
+  - label: ":ubuntu: [Ubuntu] 16.04 Build"
+    command:
+      - ".cicd/generate-base-images.sh ubuntu-16.04"
+    agents:
+      queue: "automation-eos-builder-fleet"
+    timeout: $BUILD_TIMEOUT
+    skip: $SKIP_UBUNTU_16
 
-  # - label: ":ubuntu: [Ubuntu] 18.04 Build"
-  #   command:
-  #     - "mkdir /workdir/build && cd /workdir/build && cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true /workdir && make -j $(getconf _NPROCESSORS_ONLN)"
-  #     - "cd /workdir/build && ctest -j$(getconf _NPROCESSORS_ONLN) -LE _tests --output-on-failure -T Test"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   plugins:
-  #     - docker#v3.2.0:
-  #         shell: ["/bin/bash", "-i", "-e", "-c"]
-  #         debug: $DEBUG
-  #         image: "eosio/producer:ci-ubuntu-18.04"
-  #   timeout: $BUILD_TIMEOUT
-  #   skip: $SKIP_UBUNTU_18
-
-  # - label: ":darwin: [Darwin] 10.14 Build"
-  #   command:
-  #     - "brew install git graphviz libtool gmp llvm@4 pkgconfig python python@2 doxygen libusb openssl boost@1.70 cmake"
-  #     - "git clone $BUILDKITE_REPO eos && cd eos && git checkout $BUILDKITE_COMMIT && git submodule update --init --recursive"
-  #     - "cd eos && mkdir build && cd build && cmake .. && make -j$(getconf _NPROCESSORS_ONLN)"
-  #     - "cd eos/build && ctest -j$(getconf _NPROCESSORS_ONLN) -LE _tests --output-on-failure -T Test"
-  #   plugins:
-  #     - chef/anka#v0.5.1:
-  #         no-volume: true
-  #         inherit-environment-vars: true
-  #         vm-name: 10.14.4_6C_14G_40G
-  #         vm-registry-tag: "clean::cicd::git-ssh::nas::brew"
-  #         modify-cpu: 12
-  #         modify-ram: 24
-  #         always-pull: true
-  #         debug: true
-  #         wait-network: true
-  #   agents:
-  #     - "queue=mac-anka-large-node-fleet"
-  #   timeout: $BUILD_TIMEOUT
-  #   skip: $SKIP_MOJAVE
+  - label: ":ubuntu: [Ubuntu] 18.04 Build"
+    command:
+      - ".cicd/generate-base-images.sh ubuntu-18.04"
+    agents:
+      queue: "automation-eos-builder-fleet"
+    timeout: $BUILD_TIMEOUT
+    skip: $SKIP_UBUNTU_18

--- a/.cicd/base-images.yml
+++ b/.cicd/base-images.yml
@@ -6,10 +6,9 @@ env:
 
 steps:
 
-  - label: ":aws: [Amazon] 2 Build"
+  - label: ":aws: [Amazon] 2 Ensure Docker Image"
     command:
-      - "mkdir /workdir/build && cd /workdir/build && cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true -DCMAKE_CXX_COMPILER='clang++' -DCMAKE_C_COMPILER='clang' /workdir && make -j $(getconf _NPROCESSORS_ONLN)"
-      - "cd /workdir/build && ctest -j$(getconf _NPROCESSORS_ONLN) -LE _tests --output-on-failure -T Test"
+      - "pwd"
     agents:
       queue: "automation-large-builder-fleet"
     plugins:
@@ -20,66 +19,66 @@ steps:
     timeout: $BUILD_TIMEOUT
     skip: $SKIP_AMAZON_LINUX_2
 
-  - label: ":centos: [CentOS] 7 Build"
-    command:
-      - "mkdir /workdir/build && cd /workdir/build && source /opt/rh/devtoolset-8/enable && source /opt/rh/rh-python36/enable && cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true /workdir && make -j $(getconf _NPROCESSORS_ONLN)"
-      - "cd /workdir/build && ctest -j$(getconf _NPROCESSORS_ONLN) -LE _tests --output-on-failure -T Test"
-    agents:
-      queue: "automation-large-builder-fleet"
-    plugins:
-      - docker#v3.2.0:
-          shell: ["/bin/bash", "-i", "-e", "-c"]
-          debug: $DEBUG
-          image: "eosio/producer:ci-centos-7"
-    timeout: $BUILD_TIMEOUT
-    skip: $SKIP_CENTOS_7
+  # - label: ":centos: [CentOS] 7 Build"
+  #   command:
+  #     - "mkdir /workdir/build && cd /workdir/build && source /opt/rh/devtoolset-8/enable && source /opt/rh/rh-python36/enable && cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true /workdir && make -j $(getconf _NPROCESSORS_ONLN)"
+  #     - "cd /workdir/build && ctest -j$(getconf _NPROCESSORS_ONLN) -LE _tests --output-on-failure -T Test"
+  #   agents:
+  #     queue: "automation-large-builder-fleet"
+  #   plugins:
+  #     - docker#v3.2.0:
+  #         shell: ["/bin/bash", "-i", "-e", "-c"]
+  #         debug: $DEBUG
+  #         image: "eosio/producer:ci-centos-7"
+  #   timeout: $BUILD_TIMEOUT
+  #   skip: $SKIP_CENTOS_7
 
-  - label: ":ubuntu: [Ubuntu] 16.04 Build"
-    command:
-      - "mkdir /workdir/build && cd /workdir/build && cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true -DCMAKE_TOOLCHAIN_FILE='/tmp/pinned_toolchain.cmake' /workdir && make -j $(getconf _NPROCESSORS_ONLN)"
-      - "cd /workdir/build && ctest -j$(getconf _NPROCESSORS_ONLN) -LE _tests --output-on-failure -T Test"
-    agents:
-      queue: "automation-large-builder-fleet"
-    plugins:
-      - docker#v3.2.0:
-          shell: ["/bin/bash", "-i", "-e", "-c"]
-          debug: $DEBUG
-          image: "eosio/producer:ci-ubuntu-16.04"
-    timeout: $BUILD_TIMEOUT
-    skip: $SKIP_UBUNTU_16
+  # - label: ":ubuntu: [Ubuntu] 16.04 Build"
+  #   command:
+  #     - "mkdir /workdir/build && cd /workdir/build && cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true -DCMAKE_TOOLCHAIN_FILE='/tmp/pinned_toolchain.cmake' /workdir && make -j $(getconf _NPROCESSORS_ONLN)"
+  #     - "cd /workdir/build && ctest -j$(getconf _NPROCESSORS_ONLN) -LE _tests --output-on-failure -T Test"
+  #   agents:
+  #     queue: "automation-large-builder-fleet"
+  #   plugins:
+  #     - docker#v3.2.0:
+  #         shell: ["/bin/bash", "-i", "-e", "-c"]
+  #         debug: $DEBUG
+  #         image: "eosio/producer:ci-ubuntu-16.04"
+  #   timeout: $BUILD_TIMEOUT
+  #   skip: $SKIP_UBUNTU_16
 
-  - label: ":ubuntu: [Ubuntu] 18.04 Build"
-    command:
-      - "mkdir /workdir/build && cd /workdir/build && cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true /workdir && make -j $(getconf _NPROCESSORS_ONLN)"
-      - "cd /workdir/build && ctest -j$(getconf _NPROCESSORS_ONLN) -LE _tests --output-on-failure -T Test"
-    agents:
-      queue: "automation-large-builder-fleet"
-    plugins:
-      - docker#v3.2.0:
-          shell: ["/bin/bash", "-i", "-e", "-c"]
-          debug: $DEBUG
-          image: "eosio/producer:ci-ubuntu-18.04"
-    timeout: $BUILD_TIMEOUT
-    skip: $SKIP_UBUNTU_18
+  # - label: ":ubuntu: [Ubuntu] 18.04 Build"
+  #   command:
+  #     - "mkdir /workdir/build && cd /workdir/build && cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true /workdir && make -j $(getconf _NPROCESSORS_ONLN)"
+  #     - "cd /workdir/build && ctest -j$(getconf _NPROCESSORS_ONLN) -LE _tests --output-on-failure -T Test"
+  #   agents:
+  #     queue: "automation-large-builder-fleet"
+  #   plugins:
+  #     - docker#v3.2.0:
+  #         shell: ["/bin/bash", "-i", "-e", "-c"]
+  #         debug: $DEBUG
+  #         image: "eosio/producer:ci-ubuntu-18.04"
+  #   timeout: $BUILD_TIMEOUT
+  #   skip: $SKIP_UBUNTU_18
 
-  - label: ":darwin: [Darwin] 10.14 Build"
-    command:
-      - "brew install git graphviz libtool gmp llvm@4 pkgconfig python python@2 doxygen libusb openssl boost@1.70 cmake"
-      - "git clone $BUILDKITE_REPO eos && cd eos && git checkout $BUILDKITE_COMMIT && git submodule update --init --recursive"
-      - "cd eos && mkdir build && cd build && cmake .. && make -j$(getconf _NPROCESSORS_ONLN)"
-      - "cd eos/build && ctest -j$(getconf _NPROCESSORS_ONLN) -LE _tests --output-on-failure -T Test"
-    plugins:
-      - chef/anka#v0.5.1:
-          no-volume: true
-          inherit-environment-vars: true
-          vm-name: 10.14.4_6C_14G_40G
-          vm-registry-tag: "clean::cicd::git-ssh::nas::brew"
-          modify-cpu: 12
-          modify-ram: 24
-          always-pull: true
-          debug: true
-          wait-network: true
-    agents:
-      - "queue=mac-anka-large-node-fleet"
-    timeout: $BUILD_TIMEOUT
-    skip: $SKIP_MOJAVE
+  # - label: ":darwin: [Darwin] 10.14 Build"
+  #   command:
+  #     - "brew install git graphviz libtool gmp llvm@4 pkgconfig python python@2 doxygen libusb openssl boost@1.70 cmake"
+  #     - "git clone $BUILDKITE_REPO eos && cd eos && git checkout $BUILDKITE_COMMIT && git submodule update --init --recursive"
+  #     - "cd eos && mkdir build && cd build && cmake .. && make -j$(getconf _NPROCESSORS_ONLN)"
+  #     - "cd eos/build && ctest -j$(getconf _NPROCESSORS_ONLN) -LE _tests --output-on-failure -T Test"
+  #   plugins:
+  #     - chef/anka#v0.5.1:
+  #         no-volume: true
+  #         inherit-environment-vars: true
+  #         vm-name: 10.14.4_6C_14G_40G
+  #         vm-registry-tag: "clean::cicd::git-ssh::nas::brew"
+  #         modify-cpu: 12
+  #         modify-ram: 24
+  #         always-pull: true
+  #         debug: true
+  #         wait-network: true
+  #   agents:
+  #     - "queue=mac-anka-large-node-fleet"
+  #   timeout: $BUILD_TIMEOUT
+  #   skip: $SKIP_MOJAVE

--- a/.cicd/base-images.yml
+++ b/.cicd/base-images.yml
@@ -1,0 +1,85 @@
+env:
+  BUILD_TIMEOUT: 120
+  TEST_TIMEOUT: 60
+  TIMEOUT: 120
+  VERBOSE: true
+
+steps:
+
+  - label: ":aws: [Amazon] 2 Build"
+    command:
+      - "mkdir /workdir/build && cd /workdir/build && cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true -DCMAKE_CXX_COMPILER='clang++' -DCMAKE_C_COMPILER='clang' /workdir && make -j $(getconf _NPROCESSORS_ONLN)"
+      - "cd /workdir/build && ctest -j$(getconf _NPROCESSORS_ONLN) -LE _tests --output-on-failure -T Test"
+    agents:
+      queue: "automation-large-builder-fleet"
+    plugins:
+      - docker#v3.2.0:
+          shell: ["/bin/bash", "-i", "-e", "-c"]
+          debug: $DEBUG
+          image: "eosio/producer:ci-amazonlinux-2"
+    timeout: $BUILD_TIMEOUT
+    skip: $SKIP_AMAZON_LINUX_2
+
+  - label: ":centos: [CentOS] 7 Build"
+    command:
+      - "mkdir /workdir/build && cd /workdir/build && source /opt/rh/devtoolset-8/enable && source /opt/rh/rh-python36/enable && cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true /workdir && make -j $(getconf _NPROCESSORS_ONLN)"
+      - "cd /workdir/build && ctest -j$(getconf _NPROCESSORS_ONLN) -LE _tests --output-on-failure -T Test"
+    agents:
+      queue: "automation-large-builder-fleet"
+    plugins:
+      - docker#v3.2.0:
+          shell: ["/bin/bash", "-i", "-e", "-c"]
+          debug: $DEBUG
+          image: "eosio/producer:ci-centos-7"
+    timeout: $BUILD_TIMEOUT
+    skip: $SKIP_CENTOS_7
+
+  - label: ":ubuntu: [Ubuntu] 16.04 Build"
+    command:
+      - "mkdir /workdir/build && cd /workdir/build && cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true -DCMAKE_TOOLCHAIN_FILE='/tmp/pinned_toolchain.cmake' /workdir && make -j $(getconf _NPROCESSORS_ONLN)"
+      - "cd /workdir/build && ctest -j$(getconf _NPROCESSORS_ONLN) -LE _tests --output-on-failure -T Test"
+    agents:
+      queue: "automation-large-builder-fleet"
+    plugins:
+      - docker#v3.2.0:
+          shell: ["/bin/bash", "-i", "-e", "-c"]
+          debug: $DEBUG
+          image: "eosio/producer:ci-ubuntu-16.04"
+    timeout: $BUILD_TIMEOUT
+    skip: $SKIP_UBUNTU_16
+
+  - label: ":ubuntu: [Ubuntu] 18.04 Build"
+    command:
+      - "mkdir /workdir/build && cd /workdir/build && cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true /workdir && make -j $(getconf _NPROCESSORS_ONLN)"
+      - "cd /workdir/build && ctest -j$(getconf _NPROCESSORS_ONLN) -LE _tests --output-on-failure -T Test"
+    agents:
+      queue: "automation-large-builder-fleet"
+    plugins:
+      - docker#v3.2.0:
+          shell: ["/bin/bash", "-i", "-e", "-c"]
+          debug: $DEBUG
+          image: "eosio/producer:ci-ubuntu-18.04"
+    timeout: $BUILD_TIMEOUT
+    skip: $SKIP_UBUNTU_18
+
+  - label: ":darwin: [Darwin] 10.14 Build"
+    command:
+      - "brew install git graphviz libtool gmp llvm@4 pkgconfig python python@2 doxygen libusb openssl boost@1.70 cmake"
+      - "git clone $BUILDKITE_REPO eos && cd eos && git checkout $BUILDKITE_COMMIT && git submodule update --init --recursive"
+      - "cd eos && mkdir build && cd build && cmake .. && make -j$(getconf _NPROCESSORS_ONLN)"
+      - "cd eos/build && ctest -j$(getconf _NPROCESSORS_ONLN) -LE _tests --output-on-failure -T Test"
+    plugins:
+      - chef/anka#v0.5.1:
+          no-volume: true
+          inherit-environment-vars: true
+          vm-name: 10.14.4_6C_14G_40G
+          vm-registry-tag: "clean::cicd::git-ssh::nas::brew"
+          modify-cpu: 12
+          modify-ram: 24
+          always-pull: true
+          debug: true
+          wait-network: true
+    agents:
+      - "queue=mac-anka-large-node-fleet"
+    timeout: $BUILD_TIMEOUT
+    skip: $SKIP_MOJAVE

--- a/.cicd/base-images.yml
+++ b/.cicd/base-images.yml
@@ -8,7 +8,7 @@ steps:
 
   - label: ":aws: [Amazon] 2 Ensure Docker Image"
     command:
-      - "pwd"
+      - "/workdir/.cicd/generate-base-images.sh"
     agents:
       queue: "automation-large-builder-fleet"
     plugins:

--- a/.cicd/base-images.yml
+++ b/.cicd/base-images.yml
@@ -9,7 +9,7 @@ steps:
     command:
       - ".cicd/generate-base-images.sh amazonlinux-2"
     agents:
-      queue: "automation-eos-builder-fleet"
+      queue: "automation-eos-dockerhub-image-builder-fleet"
     timeout: $BUILD_TIMEOUT
     skip: $SKIP_AMAZON_LINUX_2
 
@@ -17,7 +17,7 @@ steps:
     command:
       - ".cicd/generate-base-images.sh centos-7"
     agents:
-      queue: "automation-eos-builder-fleet"
+      queue: "automation-eos-dockerhub-image-builder-fleet"
     timeout: $BUILD_TIMEOUT
     skip: $SKIP_CENTOS_7
 
@@ -25,7 +25,7 @@ steps:
     command:
       - ".cicd/generate-base-images.sh ubuntu-16.04"
     agents:
-      queue: "automation-eos-builder-fleet"
+      queue: "automation-eos-dockerhub-image-builder-fleet"
     timeout: $BUILD_TIMEOUT
     skip: $SKIP_UBUNTU_16
 
@@ -33,6 +33,6 @@ steps:
     command:
       - ".cicd/generate-base-images.sh ubuntu-18.04"
     agents:
-      queue: "automation-eos-builder-fleet"
+      queue: "automation-eos-dockerhub-image-builder-fleet"
     timeout: $BUILD_TIMEOUT
     skip: $SKIP_UBUNTU_18

--- a/.cicd/generate-base-images.sh
+++ b/.cicd/generate-base-images.sh
@@ -21,6 +21,7 @@ function determine-hash() {
 
 function generate_docker_image() {
     # If we cannot pull the image, we build and push it first.
+    echo "PASSWORD: $DOCKER_PASSWORD"
     docker login -u "$DOCKER_USERNAME" -p $DOCKER_PASSWORD
     cd ./.cicd
     docker build -t eosio/producer:ci-${HASHED_IMAGE_TAG} -f ./${IMAGE_TAG}.dockerfile .

--- a/.cicd/generate-base-images.sh
+++ b/.cicd/generate-base-images.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-[[ -z $1 ]] && echo "Must provide the distro IMAGE_TAG name (example: ubuntu-18.04" && exit 1
+[[ -z $1 ]] && echo "Must provide the distro IMAGE_TAG name (example: ubuntu-18.04) OR provide 'trigger' if this is the first step in a pipeline" && exit 1
 export IMAGE_TAG=$1
 
 function determine-hash() {

--- a/.cicd/generate-base-images.sh
+++ b/.cicd/generate-base-images.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-[[ -z $1 ]] && echo "Must provide the distro IMAGE_TAG name (example: ubuntu-18.04) OR provide 'trigger' if this is the first step in a pipeline" && exit 1
+[[ -z $1 ]] && echo "Must provide the distro IMAGE_TAG name (example: ubuntu-18.04)" && exit 1
 export IMAGE_TAG=$1
 
 function determine-hash() {

--- a/.cicd/generate-base-images.sh
+++ b/.cicd/generate-base-images.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
+[[ -z $1 ]] && echo "Must provide the distro IMAGE_TAG name (example: ubuntu-18.04" && exit 1
+export IMAGE_TAG=$1
+
 function determine-hash() {
     # Determine the sha1 hash of all dockerfiles in the .cicd directory.
     [[ -z $1 ]] && echo "Please provide the files to be hashed (wildcards supported)" && exit 1
@@ -18,7 +21,7 @@ function determine-hash() {
 
 function generate_docker_image() {
     # If we cannot pull the image, we build and push it first.
-    echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+    # echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
     cd ./.cicd
     docker build -t eosio/producer:ci-${HASHED_IMAGE_TAG} -f ./${IMAGE_TAG}.dockerfile .
     docker push eosio/producer:ci-${HASHED_IMAGE_TAG}

--- a/.cicd/generate-base-images.sh
+++ b/.cicd/generate-base-images.sh
@@ -21,7 +21,7 @@ function determine-hash() {
 
 function generate_docker_image() {
     # If we cannot pull the image, we build and push it first.
-    # echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+    docker login -u "$DOCKER_USERNAME" -p $DOCKER_PASSWORD
     cd ./.cicd
     docker build -t eosio/producer:ci-${HASHED_IMAGE_TAG} -f ./${IMAGE_TAG}.dockerfile .
     docker push eosio/producer:ci-${HASHED_IMAGE_TAG}

--- a/.cicd/generate-base-images.sh
+++ b/.cicd/generate-base-images.sh
@@ -21,8 +21,7 @@ function determine-hash() {
 
 function generate_docker_image() {
     # If we cannot pull the image, we build and push it first.
-    echo "PASSWORD: $DOCKER_PASSWORD"
-    docker login -u "$DOCKER_USERNAME" -p $DOCKER_PASSWORD
+    docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
     cd ./.cicd
     docker build -t eosio/producer:ci-${HASHED_IMAGE_TAG} -f ./${IMAGE_TAG}.dockerfile .
     docker push eosio/producer:ci-${HASHED_IMAGE_TAG}

--- a/.cicd/generate-base-images.sh
+++ b/.cicd/generate-base-images.sh
@@ -16,19 +16,6 @@ function determine-hash() {
     export HASHED_IMAGE_TAG="${IMAGE_TAG}-${DETERMINED_HASH}"
 }
 
-function build() {
-    # Per distro additions to docker command
-    [[ $IMAGE_TAG  == centos-7 ]] && PRE_COMMANDS="source /opt/rh/devtoolset-8/enable && source /opt/rh/rh-python36/enable &&"
-    [[ $IMAGE_TAG == amazonlinux-2 ]] && CMAKE_EXTRAS="-DCMAKE_CXX_COMPILER='clang++' -DCMAKE_C_COMPILER='clang'" # explicitly set to clang as gcc is default
-    [[ $IMAGE_TAG == ubuntu-16.04 ]] && CMAKE_EXTRAS="$CMAKE_EXTRAS -DCMAKE_TOOLCHAIN_FILE='/tmp/pinned_toolchain.cmake' -DCMAKE_CXX_COMPILER_LAUNCHER=ccache" # pinned only
-    [[ $IMAGE_TAG == amazonlinux-2 || $IMAGE_TAG == centos-7 ]] && EXPORTS="export PATH=/usr/lib64/ccache:$PATH &&" || EXPORTS="$EXPORTS export PATH=/usr/lib/ccache:$PATH &&" # ccache needs to come first in the list (devtoolset-8 overrides that if we include this in the Dockerfile)
-    # DOCKER
-    docker run --rm -v $(pwd):/eos -v /usr/lib/ccache -v $HOME/.ccache:/opt/.ccache -e CCACHE_DIR=/opt/.ccache eosio/producer:ci-${HASHED_IMAGE_TAG} bash -c " \
-        $PRE_COMMANDS ccache -s && \
-        mkdir /eos/build && cd /eos/build && $EXPORTS cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true $CMAKE_EXTRAS /eos && make -j $(getconf _NPROCESSORS_ONLN) 
-        ctest -j$(getconf _NPROCESSORS_ONLN) -LE _tests --output-on-failure -T Test"
-}
-
 function generate_docker_image() {
     # If we cannot pull the image, we build and push it first.
     echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin

--- a/.cicd/generate-base-images.sh
+++ b/.cicd/generate-base-images.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+function determine-hash() {
+    # Determine the sha1 hash of all dockerfiles in the .cicd directory.
+    [[ -z $1 ]] && echo "Please provide the files to be hashed (wildcards supported)" && exit 1
+    echo "Obtaining Hash of files from $1..."
+    # Collect all files, hash them, then hash those.
+    HASHES=()
+    for FILE in $(find $1 -type f); do
+        HASH=$(sha1sum $FILE | sha1sum | awk '{ print $1 }')
+        HASHES=($HASH "${HASHES[*]}")
+        echo "$FILE - $HASH"
+    done
+    export DETERMINED_HASH=$(echo ${HASHES[*]} | sha1sum | awk '{ print $1 }')
+    export HASHED_IMAGE_TAG="${IMAGE_TAG}-${DETERMINED_HASH}"
+}
+
+function build() {
+    # Per distro additions to docker command
+    [[ $IMAGE_TAG  == centos-7 ]] && PRE_COMMANDS="source /opt/rh/devtoolset-8/enable && source /opt/rh/rh-python36/enable &&"
+    [[ $IMAGE_TAG == amazonlinux-2 ]] && CMAKE_EXTRAS="-DCMAKE_CXX_COMPILER='clang++' -DCMAKE_C_COMPILER='clang'" # explicitly set to clang as gcc is default
+    [[ $IMAGE_TAG == ubuntu-16.04 ]] && CMAKE_EXTRAS="$CMAKE_EXTRAS -DCMAKE_TOOLCHAIN_FILE='/tmp/pinned_toolchain.cmake' -DCMAKE_CXX_COMPILER_LAUNCHER=ccache" # pinned only
+    [[ $IMAGE_TAG == amazonlinux-2 || $IMAGE_TAG == centos-7 ]] && EXPORTS="export PATH=/usr/lib64/ccache:$PATH &&" || EXPORTS="$EXPORTS export PATH=/usr/lib/ccache:$PATH &&" # ccache needs to come first in the list (devtoolset-8 overrides that if we include this in the Dockerfile)
+    # DOCKER
+    docker run --rm -v $(pwd):/eos -v /usr/lib/ccache -v $HOME/.ccache:/opt/.ccache -e CCACHE_DIR=/opt/.ccache eosio/producer:ci-${HASHED_IMAGE_TAG} bash -c " \
+        $PRE_COMMANDS ccache -s && \
+        mkdir /eos/build && cd /eos/build && $EXPORTS cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true $CMAKE_EXTRAS /eos && make -j $(getconf _NPROCESSORS_ONLN) 
+        ctest -j$(getconf _NPROCESSORS_ONLN) -LE _tests --output-on-failure -T Test"
+}
+
+function generate_docker_image() {
+    # If we cannot pull the image, we build and push it first.
+    echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+    cd ./.cicd
+    docker build -t eosio/producer:ci-${HASHED_IMAGE_TAG} -f ./${IMAGE_TAG}.dockerfile .
+    docker push eosio/producer:ci-${HASHED_IMAGE_TAG}
+    cd -
+}
+
+determine-hash ".cicd/${IMAGE_TAG}.dockerfile"
+[[ -z $DETERMINED_HASH ]] && echo "DETERMINED_HASH empty! (check determine-hash function)" && exit 1
+echo "Looking for $IMAGE_TAG-$DETERMINED_HASH"
+if docker pull eosio/producer:ci-${HASHED_IMAGE_TAG}; then
+    echo "eosio/producer:ci-${HASHED_IMAGE_TAG} already exists"
+else
+    generate_docker_image
+fi

--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -1,0 +1,86 @@
+env:
+  BUILD_TIMEOUT: 120
+  TEST_TIMEOUT: 60
+  TIMEOUT: 120
+  VERBOSE: true
+
+  - label: ":aws: [Amazon] 2 Build"
+    command:
+      - "mkdir /eos/build && cd /eos/build && cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true -DCMAKE_CXX_COMPILER='clang++' -DCMAKE_C_COMPILER='clang' /eos && make -j $(getconf _NPROCESSORS_ONLN)"
+      - "ctest -j$(getconf _NPROCESSORS_ONLN) -LE _tests --output-on-failure -T Test"
+    agents:
+      queue: "automation-large-builder-fleet"
+    plugins:
+      - docker#v3.2.0:
+          shell: ["/bin/bash", "-i", "-e", "-c"]
+          debug: $DEBUG
+          mount-checkout: false
+          image: "eosio/producer:ci-amazonlinux-2"
+    timeout: $BUILD_TIMEOUT
+    skip: $SKIP_AMAZON_LINUX_2
+
+  - label: ":centos: [CentOS] 7 Build"
+    command:
+      - "mkdir /eos/build && cd /eos/build && source /opt/rh/devtoolset-8/enable && source /opt/rh/rh-python36/enable && cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true /eos && make -j $(getconf _NPROCESSORS_ONLN)"
+      - "ctest -j$(getconf _NPROCESSORS_ONLN) -LE _tests --output-on-failure -T Test"
+    agents:
+      queue: "automation-large-builder-fleet"
+    plugins:
+      - docker#v3.2.0:
+          shell: ["/bin/bash", "-i", "-e", "-c"]
+          debug: $DEBUG
+          mount-checkout: false
+          image: "eosio/producer:ci-centos-7"
+    timeout: $BUILD_TIMEOUT
+    skip: $SKIP_CENTOS_7
+
+  - label: ":ubuntu: [Ubuntu] 16.04 Build"
+    command:
+      - "mkdir /eos/build && cd /eos/build && cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true -DCMAKE_TOOLCHAIN_FILE='/tmp/pinned_toolchain.cmake' /eos && make -j $(getconf _NPROCESSORS_ONLN)"
+      - "ctest -j$(getconf _NPROCESSORS_ONLN) -LE _tests --output-on-failure -T Test"
+    agents:
+      queue: "automation-large-builder-fleet"
+    plugins:
+      - docker#v3.2.0:
+          shell: ["/bin/bash", "-i", "-e", "-c"]
+          debug: $DEBUG
+          mount-checkout: false
+          image: "eosio/producer:ci-ubuntu-16.04"
+    timeout: $BUILD_TIMEOUT
+    skip: $SKIP_UBUNTU_16
+
+  - label: ":ubuntu: [Ubuntu] 18.04 Build"
+    command:
+      - "mkdir /eos/build && cd /eos/build && cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true /eos && make -j $(getconf _NPROCESSORS_ONLN)"
+      - "ctest -j$(getconf _NPROCESSORS_ONLN) -LE _tests --output-on-failure -T Test"
+    agents:
+      queue: "automation-large-builder-fleet"
+    plugins:
+      - docker#v3.2.0:
+          shell: ["/bin/bash", "-i", "-e", "-c"]
+          debug: $DEBUG
+          mount-checkout: false
+          image: "eosio/producer:ci-ubuntu-18.04"
+    timeout: $BUILD_TIMEOUT
+    skip: $SKIP_UBUNTU_18
+
+  - label: ":darwin: [Darwin] 10.14 Build"
+    command:
+      - "git clone $BUILDKITE_HTTPS_REPO_URL eos && cd eos && git checkout $BUILDKITE_COMMIT && git submodule update --init --recursive"
+      - "cd eos && mkdir build && cd build && cmake .. && make -j$(getconf _NPROCESSORS_ONLN)"
+      - "cd eos/build && ctest -j$(getconf _NPROCESSORS_ONLN) -LE _tests --output-on-failure -T Test"
+    plugins:
+      - chef/anka#v0.5.1:
+          no-volume: true
+          inherit-environment-vars: true
+          vm-name: 10.14.4_6C_14G_40G
+          vm-registry-tag: "clean::cicd::git-ssh::nas::xcode-10.2"
+          modify-cpu: 12
+          modify-ram: 24
+          always-pull: true
+          debug: true
+          wait-network: true
+    agents:
+      - "queue=mac-anka-large-node-fleet"
+    timeout: $BUILD_TIMEOUT
+    skip: $SKIP_MOJAVE

--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -8,7 +8,7 @@ steps:
 
   - label: ":aws: [Amazon] 2 Build"
     command:
-      - "mkdir /eos/build && cd /eos/build && cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true -DCMAKE_CXX_COMPILER='clang++' -DCMAKE_C_COMPILER='clang' /eos && make -j $(getconf _NPROCESSORS_ONLN)"
+      - "mkdir /workdir/build && cd /workdir/build && cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true -DCMAKE_CXX_COMPILER='clang++' -DCMAKE_C_COMPILER='clang' /eos && make -j $(getconf _NPROCESSORS_ONLN)"
       - "ctest -j$(getconf _NPROCESSORS_ONLN) -LE _tests --output-on-failure -T Test"
     agents:
       queue: "automation-large-builder-fleet"
@@ -23,7 +23,7 @@ steps:
 
   - label: ":centos: [CentOS] 7 Build"
     command:
-      - "mkdir /eos/build && cd /eos/build && source /opt/rh/devtoolset-8/enable && source /opt/rh/rh-python36/enable && cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true /eos && make -j $(getconf _NPROCESSORS_ONLN)"
+      - "mkdir /workdir/build && cd /workdir/build && source /opt/rh/devtoolset-8/enable && source /opt/rh/rh-python36/enable && cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true /eos && make -j $(getconf _NPROCESSORS_ONLN)"
       - "ctest -j$(getconf _NPROCESSORS_ONLN) -LE _tests --output-on-failure -T Test"
     agents:
       queue: "automation-large-builder-fleet"
@@ -38,7 +38,7 @@ steps:
 
   - label: ":ubuntu: [Ubuntu] 16.04 Build"
     command:
-      - "mkdir /eos/build && cd /eos/build && cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true -DCMAKE_TOOLCHAIN_FILE='/tmp/pinned_toolchain.cmake' /eos && make -j $(getconf _NPROCESSORS_ONLN)"
+      - "mkdir /workdir/build && cd /workdir/build && cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true -DCMAKE_TOOLCHAIN_FILE='/tmp/pinned_toolchain.cmake' /eos && make -j $(getconf _NPROCESSORS_ONLN)"
       - "ctest -j$(getconf _NPROCESSORS_ONLN) -LE _tests --output-on-failure -T Test"
     agents:
       queue: "automation-large-builder-fleet"
@@ -53,7 +53,7 @@ steps:
 
   - label: ":ubuntu: [Ubuntu] 18.04 Build"
     command:
-      - "mkdir /eos/build && cd /eos/build && cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true /eos && make -j $(getconf _NPROCESSORS_ONLN)"
+      - "mkdir /workdir/build && cd /workdir/build && cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true /eos && make -j $(getconf _NPROCESSORS_ONLN)"
       - "ctest -j$(getconf _NPROCESSORS_ONLN) -LE _tests --output-on-failure -T Test"
     agents:
       queue: "automation-large-builder-fleet"
@@ -68,6 +68,7 @@ steps:
 
   - label: ":darwin: [Darwin] 10.14 Build"
     command:
+      - "brew install graphviz libtool gmp llvm@4 pkgconfig python python@2 doxygen libusb openssl boost@1.70"
       - "git clone $BUILDKITE_HTTPS_REPO_URL eos && cd eos && git checkout $BUILDKITE_COMMIT && git submodule update --init --recursive"
       - "cd eos && mkdir build && cd build && cmake .. && make -j$(getconf _NPROCESSORS_ONLN)"
       - "cd eos/build && ctest -j$(getconf _NPROCESSORS_ONLN) -LE _tests --output-on-failure -T Test"

--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -65,7 +65,7 @@ steps:
   - label: ":darwin: [Darwin] 10.14 Build"
     command:
       - "brew install git graphviz libtool gmp llvm@4 pkgconfig python python@2 doxygen libusb openssl boost@1.70"
-      - "git clone $BUILDKITE_HTTPS_REPO_URL eos && cd eos && git checkout $BUILDKITE_COMMIT && git submodule update --init --recursive"
+      - "git clone $BUILDKITE_REPO eos && cd eos && git checkout $BUILDKITE_COMMIT && git submodule update --init --recursive"
       - "cd eos && mkdir build && cd build && cmake .. && make -j$(getconf _NPROCESSORS_ONLN)"
       - "cd eos/build && cd /workdir/build && ctest -j$(getconf _NPROCESSORS_ONLN) -LE _tests --output-on-failure -T Test"
     plugins:

--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -4,6 +4,8 @@ env:
   TIMEOUT: 120
   VERBOSE: true
 
+steps:
+
   - label: ":aws: [Amazon] 2 Build"
     command:
       - "mkdir /eos/build && cd /eos/build && cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true -DCMAKE_CXX_COMPILER='clang++' -DCMAKE_C_COMPILER='clang' /eos && make -j $(getconf _NPROCESSORS_ONLN)"

--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -11,7 +11,7 @@ steps:
       - "mkdir /workdir/build && cd /workdir/build && cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true -DCMAKE_CXX_COMPILER='clang++' -DCMAKE_C_COMPILER='clang' /workdir && make -j $(getconf _NPROCESSORS_ONLN)"
       - "cd /workdir/build && ctest -j$(getconf _NPROCESSORS_ONLN) -LE _tests --output-on-failure -T Test"
     agents:
-      queue: "automation-large-builder-fleet"
+      queue: "automation-eos-builder-fleet"
     plugins:
       - docker#v3.2.0:
           shell: ["/bin/bash", "-i", "-e", "-c"]
@@ -25,7 +25,7 @@ steps:
       - "mkdir /workdir/build && cd /workdir/build && source /opt/rh/devtoolset-8/enable && source /opt/rh/rh-python36/enable && cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true /workdir && make -j $(getconf _NPROCESSORS_ONLN)"
       - "cd /workdir/build && ctest -j$(getconf _NPROCESSORS_ONLN) -LE _tests --output-on-failure -T Test"
     agents:
-      queue: "automation-large-builder-fleet"
+      queue: "automation-eos-builder-fleet"
     plugins:
       - docker#v3.2.0:
           shell: ["/bin/bash", "-i", "-e", "-c"]
@@ -39,7 +39,7 @@ steps:
       - "mkdir /workdir/build && cd /workdir/build && cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true -DCMAKE_TOOLCHAIN_FILE='/tmp/pinned_toolchain.cmake' /workdir && make -j $(getconf _NPROCESSORS_ONLN)"
       - "cd /workdir/build && ctest -j$(getconf _NPROCESSORS_ONLN) -LE _tests --output-on-failure -T Test"
     agents:
-      queue: "automation-large-builder-fleet"
+      queue: "automation-eos-builder-fleet"
     plugins:
       - docker#v3.2.0:
           shell: ["/bin/bash", "-i", "-e", "-c"]
@@ -53,7 +53,7 @@ steps:
       - "mkdir /workdir/build && cd /workdir/build && cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true /workdir && make -j $(getconf _NPROCESSORS_ONLN)"
       - "cd /workdir/build && ctest -j$(getconf _NPROCESSORS_ONLN) -LE _tests --output-on-failure -T Test"
     agents:
-      queue: "automation-large-builder-fleet"
+      queue: "automation-eos-builder-fleet"
     plugins:
       - docker#v3.2.0:
           shell: ["/bin/bash", "-i", "-e", "-c"]

--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -11,7 +11,7 @@ steps:
     build:
       commit: "${BUILDKITE_COMMIT}"
       branch: "${BUILDKITE_BRANCH}"
-      
+
   - wait
 
   - label: ":aws: [Amazon] 2 Build"
@@ -24,7 +24,7 @@ steps:
       - docker#v3.2.0:
           shell: ["/bin/bash", "-i", "-e", "-c"]
           debug: $DEBUG
-          image: "eosio/producer:ci-amazonlinux-2"
+          image: "eosio/producer:ci-amazonlinux-2-266a1fe17771b1c1e9aeb3087516dbe8570e0e25"
     timeout: $BUILD_TIMEOUT
     skip: $SKIP_AMAZON_LINUX_2
 
@@ -38,7 +38,7 @@ steps:
       - docker#v3.2.0:
           shell: ["/bin/bash", "-i", "-e", "-c"]
           debug: $DEBUG
-          image: "eosio/producer:ci-centos-7"
+          image: "eosio/producer:ci-centos-7-9b1b0f1e15eba74234860434ebd82b93b23dd1de"
     timeout: $BUILD_TIMEOUT
     skip: $SKIP_CENTOS_7
 
@@ -52,7 +52,7 @@ steps:
       - docker#v3.2.0:
           shell: ["/bin/bash", "-i", "-e", "-c"]
           debug: $DEBUG
-          image: "eosio/producer:ci-ubuntu-16.04"
+          image: "eosio/producer:ci-ubuntu-16.04-0b3d8a452a4dd471d073d12d7e5971e2416d0536"
     timeout: $BUILD_TIMEOUT
     skip: $SKIP_UBUNTU_16
 
@@ -66,7 +66,7 @@ steps:
       - docker#v3.2.0:
           shell: ["/bin/bash", "-i", "-e", "-c"]
           debug: $DEBUG
-          image: "eosio/producer:ci-ubuntu-18.04"
+          image: "eosio/producer:ci-ubuntu-18.04-254c25845ae6f00c8c4c63a90a5f49e7e61b5662"
     timeout: $BUILD_TIMEOUT
     skip: $SKIP_UBUNTU_18
 

--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -16,7 +16,6 @@ steps:
       - docker#v3.2.0:
           shell: ["/bin/bash", "-i", "-e", "-c"]
           debug: $DEBUG
-          mount-checkout: false
           image: "eosio/producer:ci-amazonlinux-2"
     timeout: $BUILD_TIMEOUT
     skip: $SKIP_AMAZON_LINUX_2
@@ -31,7 +30,6 @@ steps:
       - docker#v3.2.0:
           shell: ["/bin/bash", "-i", "-e", "-c"]
           debug: $DEBUG
-          mount-checkout: false
           image: "eosio/producer:ci-centos-7"
     timeout: $BUILD_TIMEOUT
     skip: $SKIP_CENTOS_7
@@ -46,7 +44,6 @@ steps:
       - docker#v3.2.0:
           shell: ["/bin/bash", "-i", "-e", "-c"]
           debug: $DEBUG
-          mount-checkout: false
           image: "eosio/producer:ci-ubuntu-16.04"
     timeout: $BUILD_TIMEOUT
     skip: $SKIP_UBUNTU_16
@@ -61,7 +58,6 @@ steps:
       - docker#v3.2.0:
           shell: ["/bin/bash", "-i", "-e", "-c"]
           debug: $DEBUG
-          mount-checkout: false
           image: "eosio/producer:ci-ubuntu-18.04"
     timeout: $BUILD_TIMEOUT
     skip: $SKIP_UBUNTU_18

--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -9,6 +9,8 @@ steps:
   - trigger: "eosio-base-images-beta"
     label: ":docker: Ensure base images exist"
 
+  - wait
+  
   - label: ":aws: [Amazon] 2 Build"
     command:
       - "mkdir /workdir/build && cd /workdir/build && cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true -DCMAKE_CXX_COMPILER='clang++' -DCMAKE_C_COMPILER='clang' /workdir && make -j $(getconf _NPROCESSORS_ONLN)"

--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -8,9 +8,12 @@ steps:
 
   - trigger: "eosio-base-images-beta"
     label: ":docker: Ensure base images exist"
-
+    build:
+      commit: "${BUILDKITE_COMMIT}"
+      branch: "${BUILDKITE_BRANCH}"
+      
   - wait
-  
+
   - label: ":aws: [Amazon] 2 Build"
     command:
       - "mkdir /workdir/build && cd /workdir/build && cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true -DCMAKE_CXX_COMPILER='clang++' -DCMAKE_C_COMPILER='clang' /workdir && make -j $(getconf _NPROCESSORS_ONLN)"

--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -64,7 +64,7 @@ steps:
 
   - label: ":darwin: [Darwin] 10.14 Build"
     command:
-      - "brew install git graphviz libtool gmp llvm@4 pkgconfig python python@2 doxygen libusb openssl boost@1.70"
+      - "brew install git graphviz libtool gmp llvm@4 pkgconfig python python@2 doxygen libusb openssl boost@1.70 cmake"
       - "git clone $BUILDKITE_REPO eos && cd eos && git checkout $BUILDKITE_COMMIT && git submodule update --init --recursive"
       - "cd eos && mkdir build && cd build && cmake .. && make -j$(getconf _NPROCESSORS_ONLN)"
       - "cd eos/build && cd /workdir/build && ctest -j$(getconf _NPROCESSORS_ONLN) -LE _tests --output-on-failure -T Test"

--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -64,7 +64,7 @@ steps:
 
   - label: ":darwin: [Darwin] 10.14 Build"
     command:
-      - "brew install graphviz libtool gmp llvm@4 pkgconfig python python@2 doxygen libusb openssl boost@1.70"
+      - "brew install git graphviz libtool gmp llvm@4 pkgconfig python python@2 doxygen libusb openssl boost@1.70"
       - "git clone $BUILDKITE_HTTPS_REPO_URL eos && cd eos && git checkout $BUILDKITE_COMMIT && git submodule update --init --recursive"
       - "cd eos && mkdir build && cd build && cmake .. && make -j$(getconf _NPROCESSORS_ONLN)"
       - "cd eos/build && ctest -j$(getconf _NPROCESSORS_ONLN) -LE _tests --output-on-failure -T Test"
@@ -73,7 +73,7 @@ steps:
           no-volume: true
           inherit-environment-vars: true
           vm-name: 10.14.4_6C_14G_40G
-          vm-registry-tag: "clean::cicd::git-ssh::nas::xcode-10.2"
+          vm-registry-tag: "clean::cicd::git-ssh::nas::brew"
           modify-cpu: 12
           modify-ram: 24
           always-pull: true

--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -6,6 +6,9 @@ env:
 
 steps:
 
+  - trigger: "eosio-base-images-beta"
+    label: ":docker: Ensure base images exist"
+
   - label: ":aws: [Amazon] 2 Build"
     command:
       - "mkdir /workdir/build && cd /workdir/build && cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true -DCMAKE_CXX_COMPILER='clang++' -DCMAKE_C_COMPILER='clang' /workdir && make -j $(getconf _NPROCESSORS_ONLN)"

--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -67,7 +67,7 @@ steps:
       - "brew install git graphviz libtool gmp llvm@4 pkgconfig python python@2 doxygen libusb openssl boost@1.70 cmake"
       - "git clone $BUILDKITE_REPO eos && cd eos && git checkout $BUILDKITE_COMMIT && git submodule update --init --recursive"
       - "cd eos && mkdir build && cd build && cmake .. && make -j$(getconf _NPROCESSORS_ONLN)"
-      - "cd eos/build && cd /workdir/build && ctest -j$(getconf _NPROCESSORS_ONLN) -LE _tests --output-on-failure -T Test"
+      - "cd eos/build && ctest -j$(getconf _NPROCESSORS_ONLN) -LE _tests --output-on-failure -T Test"
     plugins:
       - chef/anka#v0.5.1:
           no-volume: true

--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -8,8 +8,8 @@ steps:
 
   - label: ":aws: [Amazon] 2 Build"
     command:
-      - "mkdir /workdir/build && cd /workdir/build && cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true -DCMAKE_CXX_COMPILER='clang++' -DCMAKE_C_COMPILER='clang' /eos && make -j $(getconf _NPROCESSORS_ONLN)"
-      - "ctest -j$(getconf _NPROCESSORS_ONLN) -LE _tests --output-on-failure -T Test"
+      - "mkdir /workdir/build && cd /workdir/build && cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true -DCMAKE_CXX_COMPILER='clang++' -DCMAKE_C_COMPILER='clang' /workdir && make -j $(getconf _NPROCESSORS_ONLN)"
+      - "cd /workdir/build && ctest -j$(getconf _NPROCESSORS_ONLN) -LE _tests --output-on-failure -T Test"
     agents:
       queue: "automation-large-builder-fleet"
     plugins:
@@ -22,8 +22,8 @@ steps:
 
   - label: ":centos: [CentOS] 7 Build"
     command:
-      - "mkdir /workdir/build && cd /workdir/build && source /opt/rh/devtoolset-8/enable && source /opt/rh/rh-python36/enable && cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true /eos && make -j $(getconf _NPROCESSORS_ONLN)"
-      - "ctest -j$(getconf _NPROCESSORS_ONLN) -LE _tests --output-on-failure -T Test"
+      - "mkdir /workdir/build && cd /workdir/build && source /opt/rh/devtoolset-8/enable && source /opt/rh/rh-python36/enable && cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true /workdir && make -j $(getconf _NPROCESSORS_ONLN)"
+      - "cd /workdir/build && ctest -j$(getconf _NPROCESSORS_ONLN) -LE _tests --output-on-failure -T Test"
     agents:
       queue: "automation-large-builder-fleet"
     plugins:
@@ -36,8 +36,8 @@ steps:
 
   - label: ":ubuntu: [Ubuntu] 16.04 Build"
     command:
-      - "mkdir /workdir/build && cd /workdir/build && cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true -DCMAKE_TOOLCHAIN_FILE='/tmp/pinned_toolchain.cmake' /eos && make -j $(getconf _NPROCESSORS_ONLN)"
-      - "ctest -j$(getconf _NPROCESSORS_ONLN) -LE _tests --output-on-failure -T Test"
+      - "mkdir /workdir/build && cd /workdir/build && cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true -DCMAKE_TOOLCHAIN_FILE='/tmp/pinned_toolchain.cmake' /workdir && make -j $(getconf _NPROCESSORS_ONLN)"
+      - "cd /workdir/build && ctest -j$(getconf _NPROCESSORS_ONLN) -LE _tests --output-on-failure -T Test"
     agents:
       queue: "automation-large-builder-fleet"
     plugins:
@@ -50,8 +50,8 @@ steps:
 
   - label: ":ubuntu: [Ubuntu] 18.04 Build"
     command:
-      - "mkdir /workdir/build && cd /workdir/build && cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true /eos && make -j $(getconf _NPROCESSORS_ONLN)"
-      - "ctest -j$(getconf _NPROCESSORS_ONLN) -LE _tests --output-on-failure -T Test"
+      - "mkdir /workdir/build && cd /workdir/build && cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true /workdir && make -j $(getconf _NPROCESSORS_ONLN)"
+      - "cd /workdir/build && ctest -j$(getconf _NPROCESSORS_ONLN) -LE _tests --output-on-failure -T Test"
     agents:
       queue: "automation-large-builder-fleet"
     plugins:
@@ -67,7 +67,7 @@ steps:
       - "brew install git graphviz libtool gmp llvm@4 pkgconfig python python@2 doxygen libusb openssl boost@1.70"
       - "git clone $BUILDKITE_HTTPS_REPO_URL eos && cd eos && git checkout $BUILDKITE_COMMIT && git submodule update --init --recursive"
       - "cd eos && mkdir build && cd build && cmake .. && make -j$(getconf _NPROCESSORS_ONLN)"
-      - "cd eos/build && ctest -j$(getconf _NPROCESSORS_ONLN) -LE _tests --output-on-failure -T Test"
+      - "cd eos/build && cd /workdir/build && ctest -j$(getconf _NPROCESSORS_ONLN) -LE _tests --output-on-failure -T Test"
     plugins:
       - chef/anka#v0.5.1:
           no-volume: true


### PR DESCRIPTION
## Change Description
This is a part of the ongoing Travis CI alpha testing described in [pull request 7622](https://github.com/EOSIO/eos/pull/7622).   
   
This branch contains two Buildkite pipelines:  
- [`eosio-base-images-beta`](https://buildkite.com/EOSIO/eosio-base-images-beta) -- builds the Docker images being used for Travis CI in exactly the same way [we had implemented previously](https://github.com/EOSIO/eos/tree/e0a401fe63052a2dd3d63ffce03c3c6af28add47/.cicd), but for every OS  
- [`eosio-beta`](https://buildkite.com/EOSIO/eosio-beta) -- a clone of the [Travis CI eos pipeline](https://travis-ci.org/EOSIO/eos/builds) implemented the [exact same way as Travis](https://github.com/EOSIO/eos/tree/14e57086c3f037d35f0aea118fc3131772349b06), but in Buildkite for benchmarking comparison

## Consensus Changes
- [ ] Consensus Changes
None.

## API Changes
- [ ] API Changes
None.

## Documentation Additions
- [ ] Documentation Additions
None.
