### PR TITLE
Fix path error in cleos set code/abi

### DIFF
--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -2972,13 +2972,13 @@ int main( int argc, char** argv ) {
    bool suppress_duplicate_check = false;
    auto codeSubcommand = setSubcommand->add_subcommand("code", localized("Create or update the code on an account"));
    codeSubcommand->add_option("account", account, localized("The account to set code for"))->required();
-   codeSubcommand->add_option("code-file", wasmPath, localized("The fullpath containing the contract WASM"));//->required();
+   codeSubcommand->add_option("code-file", wasmPath, localized("The path containing the contract WASM"));//->required();
    codeSubcommand->add_flag( "-c,--clear", contract_clear, localized("Remove code on an account"));
    codeSubcommand->add_flag( "--suppress-duplicate-check", suppress_duplicate_check, localized("Don't check for duplicate"));
 
    auto abiSubcommand = setSubcommand->add_subcommand("abi", localized("Create or update the abi on an account"));
    abiSubcommand->add_option("account", account, localized("The account to set the ABI for"))->required();
-   abiSubcommand->add_option("abi-file", abiPath, localized("The fullpath containing the contract ABI"));//->required();
+   abiSubcommand->add_option("abi-file", abiPath, localized("The path containing the contract ABI"));//->required();
    abiSubcommand->add_flag( "-c,--clear", contract_clear, localized("Remove abi on an account"));
    abiSubcommand->add_flag( "--suppress-duplicate-check", suppress_duplicate_check, localized("Don't check for duplicate"));
 
@@ -3015,10 +3015,11 @@ int main( int argc, char** argv ) {
         std::string wasm;
         fc::path cpath = fc::canonical(fc::path(contractPath));
 
-        if( wasmPath.empty() )
+        if( wasmPath.empty() ) {
            wasmPath = (cpath / (cpath.filename().generic_string()+".wasm")).generic_string();
-        else
+        } else if ( boost::filesystem::path(wasmPath).is_relative() ) {
            wasmPath = (cpath / wasmPath).generic_string();
+        }
 
         std::cerr << localized(("Reading WASM from " + wasmPath + "...").c_str()) << std::endl;
         fc::read_file_contents(wasmPath, wasm);
@@ -3070,7 +3071,7 @@ int main( int argc, char** argv ) {
 
         if( abiPath.empty() ) {
            abiPath = (cpath / (cpath.filename().generic_string()+".abi")).generic_string();
-        } else {
+        } else if ( boost::filesystem::path(abiPath).is_relative() ) {
            abiPath = (cpath / abiPath).generic_string();
         }
 


### PR DESCRIPTION
## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

This fixes the path error described in issue #7659.

Previously, `cleos set code` and `cleos set abi` implicitly assume the wasm/abi file path is relative. However, the usage text contradictorily says the commands are expecting a `"fullpath"`. This is misleading, and can be problematic when an absolute file path is provided. 

In this pull request, the path is checked using `boost::filesystem` and can be either relative or absolute. Correspondingly, the `"fullpath"` in the usage text is changed to `"path"` to remove any ambiguity.

In one word, referring to the bug example in issue #7659, commands like

```
cleos set code eosio ~/contracts/eosio.contracts/eosio.token/eosio.token.wasm
```

which would cause a problem before, will work fine now.

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
