### PR TITLE
Fix memory leak

### DIFF
--- a/libraries/chain/transaction_metadata.cpp
+++ b/libraries/chain/transaction_metadata.cpp
@@ -43,16 +43,19 @@ void transaction_metadata::start_recover_keys( const transaction_metadata_ptr& m
       return;
    }
 
-   mtrx->_signing_keys_future = async_thread_pool( thread_pool, [time_limit, chain_id, mtrx_ptr=mtrx, next{std::move(next)}]() mutable {
+   std::weak_ptr<transaction_metadata> mtrx_wp = mtrx;
+   mtrx->_signing_keys_future = async_thread_pool( thread_pool, [time_limit, chain_id, mtrx_wp, next{std::move(next)}]() mutable {
       auto recovered_pub_keys = std::make_shared<flat_set<public_key_type>>();
       fc::microseconds cpu_usage;
       try {
          fc::time_point deadline = time_limit == fc::microseconds::maximum() ?
                                    fc::time_point::maximum() : fc::time_point::now() + time_limit;
 
-         const signed_transaction& trn = mtrx_ptr->_packed_trx->get_signed_transaction();
-         cpu_usage = trn.get_signature_keys( chain_id, deadline, *recovered_pub_keys );
-         mtrx_ptr.reset();
+         transaction_metadata_ptr mtrx = mtrx_wp.lock(); // if mtrx no longer exists then no signing_keys_future to get results
+         if( mtrx ) {
+            const signed_transaction& trn = mtrx->_packed_trx->get_signed_transaction();
+            cpu_usage = trn.get_signature_keys( chain_id, deadline, *recovered_pub_keys );
+         }
       } catch( ... ) {
          if( next ) next();
          throw;

--- a/libraries/chain/transaction_metadata.cpp
+++ b/libraries/chain/transaction_metadata.cpp
@@ -43,15 +43,16 @@ void transaction_metadata::start_recover_keys( const transaction_metadata_ptr& m
       return;
    }
 
-   mtrx->_signing_keys_future = async_thread_pool( thread_pool, [time_limit, chain_id, mtrx, next{std::move(next)}]() {
+   mtrx->_signing_keys_future = async_thread_pool( thread_pool, [time_limit, chain_id, mtrx_ptr=mtrx, next{std::move(next)}]() mutable {
       auto recovered_pub_keys = std::make_shared<flat_set<public_key_type>>();
       fc::microseconds cpu_usage;
       try {
          fc::time_point deadline = time_limit == fc::microseconds::maximum() ?
                                    fc::time_point::maximum() : fc::time_point::now() + time_limit;
 
-         const signed_transaction& trn = mtrx->_packed_trx->get_signed_transaction();
+         const signed_transaction& trn = mtrx_ptr->_packed_trx->get_signed_transaction();
          cpu_usage = trn.get_signature_keys( chain_id, deadline, *recovered_pub_keys );
+         mtrx_ptr.reset();
       } catch( ... ) {
          if( next ) next();
          throw;


### PR DESCRIPTION
## Change Description

- `transaction_metadata::start_recover_keys` captured a `transaction_metadata` `shared_ptr` of itself in a lambda to `async_thread_pool`. This capture created a cycle in reference counts of `shared_ptr` for the `transaction_metadata` causing a memory leak.
- `reset()` the `shared_ptr` after use to prevent captured `shared_ptr<transaction_metadata>` from keeping the `transaction_metadata` alive.

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
