### PR TITLE
Remove unused code

### DIFF
--- a/libraries/chain/wasm_interface.cpp
+++ b/libraries/chain/wasm_interface.cpp
@@ -293,7 +293,6 @@ class softfloat_api : public context_aware_api {
       float _eosio_f32_copysign( float af, float bf ) {
          float32_t a = to_softfloat32(af);
          float32_t b = to_softfloat32(bf);
-         uint32_t sign_of_a = a.v >> 31;
          uint32_t sign_of_b = b.v >> 31;
          a.v &= ~(1 << 31);             // clear the sign bit
          a.v = a.v | (sign_of_b << 31); // add the sign of b
@@ -456,7 +455,6 @@ class softfloat_api : public context_aware_api {
       double _eosio_f64_copysign( double af, double bf ) {
          float64_t a = to_softfloat64(af);
          float64_t b = to_softfloat64(bf);
-         uint64_t sign_of_a = a.v >> 63;
          uint64_t sign_of_b = b.v >> 63;
          a.v &= ~(uint64_t(1) << 63);             // clear the sign bit
          a.v = a.v | (sign_of_b << 63); // add the sign of b


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
Remove unused variable `uint32_t sign_of_a = a.v >> 31;` in `float _eosio_f32_copysign( float af, float bf )` function and `uint64_t sign_of_a = a.v >> 63;` in `double _eosio_f64_copysign( double af, double bf )` function.

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
