### PR TITLE
wasm unit test with an imported function as start function

### DIFF
--- a/unittests/contracts/test_wasts.hpp
+++ b/unittests/contracts/test_wasts.hpp
@@ -179,6 +179,16 @@ static const char entry_wast_2[] = R"=====(
 )
 )=====";
 
+static const char entry_import_wast[] = R"=====(
+(module
+ (import "env" "abort" (func $abort))
+ (import "env" "eosio_assert" (func $eosio_assert (param i32 i32)))
+ (export "apply" (func $apply))
+ (start $abort)
+ (func $apply (param $0 i64) (param $1 i64) (param $2 i64))
+)
+)=====";
+
 static const char simple_no_memory_wast[] = R"=====(
 (module
  (import "env" "require_auth" (func $require_auth (param i64)))

--- a/unittests/contracts/test_wasts.hpp
+++ b/unittests/contracts/test_wasts.hpp
@@ -182,7 +182,6 @@ static const char entry_wast_2[] = R"=====(
 static const char entry_import_wast[] = R"=====(
 (module
  (import "env" "abort" (func $abort))
- (import "env" "eosio_assert" (func $eosio_assert (param i32 i32)))
  (export "apply" (func $apply))
  (start $abort)
  (func $apply (param $0 i64) (param $1 i64) (param $2 i64))

--- a/unittests/wasm_tests.cpp
+++ b/unittests/wasm_tests.cpp
@@ -561,6 +561,23 @@ BOOST_FIXTURE_TEST_CASE( check_entry_behavior_2, TESTER ) try {
    BOOST_CHECK_EQUAL(transaction_receipt::executed, receipt.status);
 } FC_LOG_AND_RETHROW()
 
+BOOST_FIXTURE_TEST_CASE( entry_import, TESTER ) try {
+   create_accounts( {N(enterimport)} );
+   produce_block();
+
+   set_code(N(enterimport), entry_import_wast);
+
+   signed_transaction trx;
+   action act;
+   act.account = N(enterimport);
+   act.name = N();
+   act.authorization = vector<permission_level>{{N(enterimport),config::active_name}};
+   trx.actions.push_back(act);
+
+   set_transaction_headers(trx);
+   trx.sign(get_private_key( N(enterimport), "active" ), control->get_chain_id());
+   BOOST_CHECK_THROW(push_transaction(trx), abort_called);
+} FC_LOG_AND_RETHROW()
 
 /**
  * Ensure we can load a wasm w/o memory


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
I have no idea why you'd ever do this, but it's an interesting edge case that would break any future assumption that the start function must be declared in the given wasm

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
