### PR TITLE
Increase db_modes_test Timeout

### DIFF
--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -12,6 +12,7 @@ steps:
       . ./.cicd/trigger-travis.sh
     agents:
       queue: "automation-eos-builder-fleet"
+    skip: $SKIP_TRAVIS_TRIGGER
 
   - trigger: "eosio-base-images-beta"
     label: ":docker: Ensure base images exist"

--- a/tests/db_modes_test.sh
+++ b/tests/db_modes_test.sh
@@ -45,7 +45,7 @@ run_nodeos() {
 run_expect_success() {
    run_nodeos "$@"
    local NODEOS_PID=$!
-   sleep 5
+   sleep 10
    kill $NODEOS_PID
    wait $NODEOS_PID
 }
@@ -53,7 +53,7 @@ run_expect_success() {
 run_and_kill() {
    run_nodeos "$@"
    local NODEOS_PID=$!
-   sleep 5
+   sleep 10
    kill -KILL $NODEOS_PID
    ! wait $NODEOS_PID
 }
@@ -62,9 +62,9 @@ run_expect_failure() {
    run_nodeos "$@"
    local NODEOS_PID=$!
    MYPID=$$
-   (sleep 10; kill -ALRM $MYPID) & local TIMER_PID=$!
+   (sleep 20; kill -ALRM $MYPID) & local TIMER_PID=$!
    trap "kill $NODEOS_PID; wait $NODEOS_PID; exit 1" ALRM
-   sleep 5
+   sleep 10
    if wait $NODEOS_PID; then exit 1; fi
    kill $TIMER_PID
    trap ALRM


### PR DESCRIPTION
## Change Description
During our [Travis CI beta testing](https://github.com/EOSIO/eos/pull/7696), we experienced a higher-than-average failure rate of `db_modes_test` on the Travis CI macOS agents. We believe the failures are because their mac agents are [underpowered](https://docs.travis-ci.com/user/reference/overview/#virtualisation-environment-vs-operating-system) compared to our own hardware, and the timeouts are insufficient.  
  
I have doubled the timeouts in `db_modes_test` and set up scheduled builds against this branch, expecting to see less failures on macOS.

## Consensus Changes
- [ ] Consensus Changes
None.

## API Changes
- [ ] API Changes
None.

## Documentation Additions
- [ ] Documentation Additions
None.