### PR TITLE
add softfloat only injection mode

### DIFF
--- a/libraries/chain/include/eosio/chain/wasm_eosio_injection.hpp
+++ b/libraries/chain/include/eosio/chain/wasm_eosio_injection.hpp
@@ -677,9 +677,6 @@ namespace eosio { namespace chain { namespace wasm_injections {
    };
 
    struct pre_op_injectors : wasm_ops::op_types<pass_injector> {
-      using call_t            = wasm_ops::call                    <call_depth_check_and_insert_checktime>;
-      using call_indirect_t   = wasm_ops::call_indirect           <call_depth_check_and_insert_checktime>;
-      
       // float binops 
       using f32_add_t         = wasm_ops::f32_add                 <f32_binop_injector<wasm_ops::f32_add_code>>;
       using f32_sub_t         = wasm_ops::f32_sub                 <f32_binop_injector<wasm_ops::f32_sub_code>>;
@@ -752,10 +749,17 @@ namespace eosio { namespace chain { namespace wasm_injections {
       using f64_convert_u_i64 = wasm_ops::f64_convert_u_i64       <i64_convert_f64_injector<wasm_ops::f64_convert_u_i64_code>>;
    }; // pre_op_injectors
 
+   struct pre_op_full_injectors : pre_op_injectors {
+      using call_t            = wasm_ops::call                    <call_depth_check_and_insert_checktime>;
+      using call_indirect_t   = wasm_ops::call_indirect           <call_depth_check_and_insert_checktime>;
+   };
 
    struct post_op_injectors : wasm_ops::op_types<pass_injector> {
-      using loop_t   = wasm_ops::loop        <checktime_injection>;
       using call_t   = wasm_ops::call        <fix_call_index>;
+   };
+
+   struct post_op_full_injectors : post_op_injectors {
+      using loop_t   = wasm_ops::loop        <checktime_injection>;
    };
 
    template <typename ... Visitors>
@@ -773,7 +777,9 @@ namespace eosio { namespace chain { namespace wasm_injections {
       }
    };
  
-   // inherit from this class and define your own injectors 
+   // "full injection" gives checktime & depth counting along with softfloat injection.
+   // Otherwise you'll just get softfloat injection
+   template<bool full_injection>
    class wasm_binary_injection {
       using standard_module_injectors = module_injectors< max_memory_injection_visitor >;
 
@@ -789,10 +795,11 @@ namespace eosio { namespace chain { namespace wasm_injections {
          void inject() {
             _module_injectors.inject( *_module );
             // inject checktime first
-            injector_utils::add_import<ResultType::none>( *_module, u8"checktime", checktime_injection::chktm_idx );
+            if constexpr (full_injection)
+               injector_utils::add_import<ResultType::none>( *_module, u8"checktime", checktime_injection::chktm_idx );
 
             for ( auto& fd : _module->functions.defs ) {
-               wasm_ops::EOSIO_OperatorDecoderStream<pre_op_injectors> pre_decoder(fd.code);
+               wasm_ops::EOSIO_OperatorDecoderStream<typename std::conditional<full_injection, pre_op_full_injectors, pre_op_injectors>::type> pre_decoder(fd.code);
                wasm_ops::instruction_stream pre_code(fd.code.size()*2);
 
                while ( pre_decoder ) {
@@ -810,12 +817,14 @@ namespace eosio { namespace chain { namespace wasm_injections {
                fd.code = pre_code.get();
             }
             for ( auto& fd : _module->functions.defs ) {
-               wasm_ops::EOSIO_OperatorDecoderStream<post_op_injectors> post_decoder(fd.code);
+               wasm_ops::EOSIO_OperatorDecoderStream<typename std::conditional<full_injection, post_op_full_injectors, post_op_injectors>::type> post_decoder(fd.code);
                wasm_ops::instruction_stream post_code(fd.code.size()*2);
 
-               wasm_ops::op_types<>::call_t chktm; 
-               chktm.field = injector_utils::injected_index_mapping.find(checktime_injection::chktm_idx)->second;
-               chktm.pack(&post_code);
+               if constexpr (full_injection) {
+                  wasm_ops::op_types<>::call_t chktm;
+                  chktm.field = injector_utils::injected_index_mapping.find(checktime_injection::chktm_idx)->second;
+                  chktm.pack(&post_code);
+               }
 
                while ( post_decoder ) {
                   auto op = post_decoder.decodeOp();
@@ -834,8 +843,7 @@ namespace eosio { namespace chain { namespace wasm_injections {
          }
       private:
          IR::Module* _module;
-         static std::string op_string;
-         static standard_module_injectors _module_injectors;
+         standard_module_injectors _module_injectors;
    };
 
 }}} // namespace wasm_constraints, chain, eosio

--- a/libraries/chain/include/eosio/chain/wasm_eosio_injection.hpp
+++ b/libraries/chain/include/eosio/chain/wasm_eosio_injection.hpp
@@ -799,7 +799,7 @@ namespace eosio { namespace chain { namespace wasm_injections {
                injector_utils::add_import<ResultType::none>( *_module, u8"checktime", checktime_injection::chktm_idx );
 
             for ( auto& fd : _module->functions.defs ) {
-               wasm_ops::EOSIO_OperatorDecoderStream<typename std::conditional<full_injection, pre_op_full_injectors, pre_op_injectors>::type> pre_decoder(fd.code);
+               wasm_ops::EOSIO_OperatorDecoderStream<std::conditional_t<full_injection, pre_op_full_injectors, pre_op_injectors>> pre_decoder(fd.code);
                wasm_ops::instruction_stream pre_code(fd.code.size()*2);
 
                while ( pre_decoder ) {
@@ -817,7 +817,7 @@ namespace eosio { namespace chain { namespace wasm_injections {
                fd.code = pre_code.get();
             }
             for ( auto& fd : _module->functions.defs ) {
-               wasm_ops::EOSIO_OperatorDecoderStream<typename std::conditional<full_injection, post_op_full_injectors, post_op_injectors>::type> post_decoder(fd.code);
+               wasm_ops::EOSIO_OperatorDecoderStream<std::conditional_t<full_injection, post_op_full_injectors, post_op_injectors>> post_decoder(fd.code);
                wasm_ops::instruction_stream post_code(fd.code.size()*2);
 
                if constexpr (full_injection) {

--- a/libraries/chain/include/eosio/chain/wasm_interface_private.hpp
+++ b/libraries/chain/include/eosio/chain/wasm_interface_private.hpp
@@ -123,7 +123,7 @@ namespace eosio { namespace chain {
                EOS_ASSERT(false, wasm_serialization_error, e.message.c_str());
             }
 
-            wasm_injections::wasm_binary_injection injector(module);
+            wasm_injections::wasm_binary_injection<true> injector(module);
             injector.inject();
 
             std::vector<U8> bytes;


### PR DESCRIPTION


<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
refactor the injection code to offer a softfloat only injection mode along with its classical "full" injection that includes checktime & depth checking. This new softfloat only injection is useful for potential new wasm runtimes that don't need checktime/depth validation


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
