### PR TITLE
[TRAVIS POC] 1.8 Support passing in JOBS for docker/kube multi-tenancy

### DIFF
--- a/scripts/helpers/general.sh
+++ b/scripts/helpers/general.sh
@@ -79,7 +79,7 @@ function set_system_vars() {
         export DISK_TOTAL=$(( DISK_TOTAL_KB / 1048576 ))
         export DISK_AVAIL=$(( DISK_AVAIL_KB / 1048576 ))
     fi
-    export JOBS=$(( MEM_GIG > CPU_CORES ? CPU_CORES : MEM_GIG ))
+    export JOBS=${JOBS:-$(( MEM_GIG > CPU_CORES ? CPU_CORES : MEM_GIG ))}
 }
 
 function install-package() {


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description

Problem: We run multiple docker instances in a single node and they have no way to prevent a single docker instance from using all CPUs and the others failing with agent lost.

Solution: Allow the scripts to use the JOBS env already on the host, which will then be passed in with `docker run --env JOBS`. Build scripts need to support this.

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
