### PR TITLE
[TRAVIS POC] 1.7 Support passing in JOBS for docker/kube multi-tenancy

### DIFF
--- a/scripts/eosio_build_amazon.sh
+++ b/scripts/eosio_build_amazon.sh
@@ -100,7 +100,7 @@ MEM_MEG=$( free -m | sed -n 2p | tr -s ' ' | cut -d\  -f2 )
 CPU_SPEED=$( lscpu | grep "MHz" | tr -s ' ' | cut -d\  -f3 | cut -d'.' -f1 )
 CPU_CORE=$( nproc )
 MEM_GIG=$(( ((MEM_MEG / 1000) / 2) ))
-export JOBS=$(( MEM_GIG > CPU_CORE ? CPU_CORE : MEM_GIG ))
+export JOBS=${JOBS:-$(( MEM_GIG > CPU_CORE ? CPU_CORE : MEM_GIG ))}
 
 printf "\\nOS name: %s\\n" "${OS_NAME}"
 printf "OS Version: %s\\n" "${OS_VER}"

--- a/scripts/eosio_build_centos.sh
+++ b/scripts/eosio_build_centos.sh
@@ -7,7 +7,7 @@ MEM_MEG=$( free -m | sed -n 2p | tr -s ' ' | cut -d\  -f2 )
 CPU_SPEED=$( lscpu | grep "MHz" | tr -s ' ' | cut -d\  -f3 | cut -d'.' -f1 )
 CPU_CORE=$( nproc )
 MEM_GIG=$(( ((MEM_MEG / 1000) / 2) ))
-export JOBS=$(( MEM_GIG > CPU_CORE ? CPU_CORE : MEM_GIG ))
+export JOBS=${JOBS:-$(( MEM_GIG > CPU_CORE ? CPU_CORE : MEM_GIG ))}
 
 DISK_INSTALL=$( df -h . | tail -1 | tr -s ' ' | cut -d\  -f1 )
 DISK_TOTAL_KB=$( df . | tail -1 | awk '{print $2}' )

--- a/scripts/eosio_build_darwin.sh
+++ b/scripts/eosio_build_darwin.sh
@@ -7,7 +7,7 @@ OS_PATCH=$(echo "${OS_VER}" | cut -d'.' -f3)
 MEM_GIG=$(bc <<< "($(sysctl -in hw.memsize) / 1024000000)")
 CPU_SPEED=$(bc <<< "scale=2; ($(sysctl -in hw.cpufrequency) / 10^8) / 10")
 CPU_CORE=$( sysctl -in machdep.cpu.core_count )
-export JOBS=$(( MEM_GIG > CPU_CORE ? CPU_CORE : MEM_GIG ))
+export JOBS=${JOBS:-$(( MEM_GIG > CPU_CORE ? CPU_CORE : MEM_GIG ))}
 
 DISK_INSTALL=$(df -h . | tail -1 | tr -s ' ' | cut -d\  -f1 || cut -d' ' -f1)
 blksize=$(df . | head -1 | awk '{print $2}' | cut -d- -f1)
@@ -174,7 +174,7 @@ if [ "${BOOSTVERSION}" != "${BOOST_VERSION_MAJOR}0${BOOST_VERSION_MINOR}0${BOOST
 	&& tar -xjf boost_$BOOST_VERSION.tar.bz2 \
 	&& cd $BOOST_ROOT \
 	&& ./bootstrap.sh --prefix=$BOOST_ROOT \
-	&& ./b2 -q -j$(sysctl -in machdep.cpu.core_count) --with-iostreams --with-date_time --with-filesystem \
+	&& ./b2 -q -j"${JOBS}" --with-iostreams --with-date_time --with-filesystem \
 	                                                  --with-system --with-program_options --with-chrono --with-test install \
 	&& cd .. \
 	&& rm -f boost_$BOOST_VERSION.tar.bz2 \

--- a/scripts/eosio_build_fedora.sh
+++ b/scripts/eosio_build_fedora.sh
@@ -19,7 +19,7 @@ if [ "${MEM_MEG}" -lt 7000 ]; then
 	exit 1;
 fi
 MEM_GIG=$(( ((MEM_MEG / 1000) / 2) ))
-export JOBS=$(( MEM_GIG > CPU_CORE ? CPU_CORE : MEM_GIG ))
+export JOBS=${JOBS:-$(( MEM_GIG > CPU_CORE ? CPU_CORE : MEM_GIG ))}
 
 DISK_INSTALL=$( df -h . | tail -1 | tr -s ' ' | cut -d\\ -f1 )
 DISK_TOTAL_KB=$( df . | tail -1 | awk '{print $2}' )

--- a/scripts/eosio_build_ubuntu.sh
+++ b/scripts/eosio_build_ubuntu.sh
@@ -8,7 +8,7 @@ MEM_MEG=$( free -m | sed -n 2p | tr -s ' ' | cut -d\  -f2 || cut -d' ' -f2 )
 CPU_SPEED=$( lscpu | grep -m1 "MHz" | tr -s ' ' | cut -d\  -f3 || cut -d' ' -f3 | cut -d'.' -f1 )
 CPU_CORE=$( nproc )
 MEM_GIG=$(( ((MEM_MEG / 1000) / 2) ))
-export JOBS=$(( MEM_GIG > CPU_CORE ? CPU_CORE : MEM_GIG ))
+export JOBS=${JOBS:-$(( MEM_GIG > CPU_CORE ? CPU_CORE : MEM_GIG ))}
 
 DISK_INSTALL=$(df -h . | tail -1 | tr -s ' ' | cut -d\  -f1 || cut -d' ' -f1)
 DISK_TOTAL_KB=$(df . | tail -1 | awk '{print $2}')


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
Problem: We run multiple docker instances in a single node and they have no way to prevent a single docker instance from using all CPUs and the others failing with agent lost.

Solution: Allow the scripts to use the JOBS env already on the host, which will then be passed in with `docker run --env JOBS`. Build scripts need to support this.

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
