### PR TITLE
Add JOBS env support to Travis/Buildkite builds for trav-poc

### DIFF
--- a/.cicd/amazonlinux-2.dockerfile
+++ b/.cicd/amazonlinux-2.dockerfile
@@ -78,5 +78,6 @@ ENV PRE_COMMANDS="export PATH=/usr/lib64/ccache:$PATH &&"
 ENV CMAKE_EXTRAS="-DCMAKE_CXX_COMPILER='clang++' -DCMAKE_C_COMPILER='clang'"
 
 CMD bash -c "$PRE_COMMANDS ccache -s && \
-    mkdir /workdir/build && cd /workdir/build && cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true $CMAKE_EXTRAS /workdir && make -j $(getconf _NPROCESSORS_ONLN) && \
-    ctest -j$(getconf _NPROCESSORS_ONLN) -LE _tests --output-on-failure -T Test"
+    echo Building with -j$JOBS && \
+    mkdir /workdir/build && cd /workdir/build && cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true $CMAKE_EXTRAS /workdir && make -j$JOBS && \
+    ctest -j$JOBS -LE _tests --output-on-failure -T Test"

--- a/.cicd/base-images.yml
+++ b/.cicd/base-images.yml
@@ -15,7 +15,7 @@ steps:
 
   - label: ":centos: CentOS 7.6 - Build"
     command:
-      - ".cicd/generate-base-images.sh centos-7"
+      - ".cicd/generate-base-images.sh centos-7.6"
     agents:
       queue: "automation-eos-dockerhub-image-builder-fleet"
     timeout: $BUILD_TIMEOUT

--- a/.cicd/centos-7.6.dockerfile
+++ b/.cicd/centos-7.6.dockerfile
@@ -1,4 +1,4 @@
-FROM centos:7
+FROM centos:7.6.1810
 
 # YUM dependencies.
 RUN yum update -y \
@@ -93,5 +93,6 @@ ENV CCACHE_PATH="/opt/rh/devtoolset-8/root/usr/bin"
 ENV PRE_COMMANDS="source /opt/rh/devtoolset-8/enable && source /opt/rh/rh-python36/enable && export PATH=/usr/lib64/ccache:$PATH &&"
 
 CMD bash -c "$PRE_COMMANDS ccache -s && \
-    mkdir /workdir/build && cd /workdir/build && cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true $CMAKE_EXTRAS /workdir && make -j $(getconf _NPROCESSORS_ONLN) && \
-    ctest -j$(getconf _NPROCESSORS_ONLN) -LE _tests --output-on-failure -T Test"
+    echo Building with -j$JOBS && \
+    mkdir /workdir/build && cd /workdir/build && cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true $CMAKE_EXTRAS /workdir && make -j $JOBS && \
+    ctest -j$JOBS -LE _tests --output-on-failure -T Test"

--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -39,7 +39,7 @@ steps:
     plugins:
       - docker#v3.2.0:
           debug: $DEBUG
-          image: "eosio/producer:eosio-centos-7-d45789dfb1a5b830a62381afd205b34d3d7c2d63"
+          image: "eosio/producer:eosio-centos-7.6-d45789dfb1a5b830a62381afd205b34d3d7c2d63"
     timeout: $BUILD_TIMEOUT
     skip: $SKIP_CENTOS_7
 

--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -25,7 +25,7 @@ steps:
     agents:
       queue: "automation-eos-builder-fleet"
     plugins:
-      - docker#v3.2.0:
+      - docker#v3.3.0:
           debug: $DEBUG
           image: "eosio/producer:eosio-amazonlinux-2-5e20c60cfce1471deb7d970bd55a35240c583252"
     timeout: $BUILD_TIMEOUT
@@ -37,7 +37,7 @@ steps:
     agents:
       queue: "automation-eos-builder-fleet"
     plugins:
-      - docker#v3.2.0:
+      - docker#v3.3.0:
           debug: $DEBUG
           image: "eosio/producer:eosio-centos-7.6-6d1d8821e92fc3e6ebfb61a40d6778b8934d008e"
     timeout: $BUILD_TIMEOUT
@@ -47,7 +47,7 @@ steps:
     agents:
       queue: "automation-eos-builder-fleet"
     plugins:
-      - docker#v3.2.0:
+      - docker#v3.3.0:
           debug: $DEBUG
           image: "eosio/producer:eosio-ubuntu-16.04-b59dcc9c547a0e17ea1dfcc5ba2bbfc74ed5df11"
     timeout: $BUILD_TIMEOUT
@@ -57,7 +57,7 @@ steps:
     agents:
       queue: "automation-eos-builder-fleet"
     plugins:
-      - docker#v3.2.0:
+      - docker#v3.3.0:
           debug: $DEBUG
           image: "eosio/producer:eosio-ubuntu-18.04-a269bf2e944de92084f25b95a2309bce3828a9f9"
     timeout: $BUILD_TIMEOUT

--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -27,7 +27,7 @@ steps:
     plugins:
       - docker#v3.2.0:
           debug: $DEBUG
-          image: "eosio/producer:eosio-amazonlinux-2-1c266e25276ad1f1147a4df5c12921968079c49b"
+          image: "eosio/producer:eosio-amazonlinux-2-5e20c60cfce1471deb7d970bd55a35240c583252"
     timeout: $BUILD_TIMEOUT
     skip: $SKIP_AMAZON_LINUX_2
 
@@ -39,7 +39,7 @@ steps:
     plugins:
       - docker#v3.2.0:
           debug: $DEBUG
-          image: "eosio/producer:eosio-centos-7.6-d45789dfb1a5b830a62381afd205b34d3d7c2d63"
+          image: "eosio/producer:eosio-centos-7.6-6d1d8821e92fc3e6ebfb61a40d6778b8934d008e"
     timeout: $BUILD_TIMEOUT
     skip: $SKIP_CENTOS_7
 
@@ -49,7 +49,7 @@ steps:
     plugins:
       - docker#v3.2.0:
           debug: $DEBUG
-          image: "eosio/producer:eosio-ubuntu-16.04-4f430ef21e359ef2581c25255c99e5411adfaed9"
+          image: "eosio/producer:eosio-ubuntu-16.04-b59dcc9c547a0e17ea1dfcc5ba2bbfc74ed5df11"
     timeout: $BUILD_TIMEOUT
     skip: $SKIP_UBUNTU_16
 
@@ -59,7 +59,7 @@ steps:
     plugins:
       - docker#v3.2.0:
           debug: $DEBUG
-          image: "eosio/producer:eosio-ubuntu-18.04-14091ac0e5618b0ea5ce026cd75b648efbde4be7"
+          image: "eosio/producer:eosio-ubuntu-18.04-a269bf2e944de92084f25b95a2309bce3828a9f9"
     timeout: $BUILD_TIMEOUT
     skip: $SKIP_UBUNTU_18
 

--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -28,6 +28,8 @@ steps:
       - docker#v3.3.0:
           debug: $DEBUG
           image: "eosio/producer:eosio-amazonlinux-2-5e20c60cfce1471deb7d970bd55a35240c583252"
+          environment:
+            - "JOBS"
     timeout: $BUILD_TIMEOUT
     skip: $SKIP_AMAZON_LINUX_2
 
@@ -40,6 +42,8 @@ steps:
       - docker#v3.3.0:
           debug: $DEBUG
           image: "eosio/producer:eosio-centos-7.6-6d1d8821e92fc3e6ebfb61a40d6778b8934d008e"
+          environment:
+            - "JOBS"
     timeout: $BUILD_TIMEOUT
     skip: $SKIP_CENTOS_7
 
@@ -50,6 +54,8 @@ steps:
       - docker#v3.3.0:
           debug: $DEBUG
           image: "eosio/producer:eosio-ubuntu-16.04-b59dcc9c547a0e17ea1dfcc5ba2bbfc74ed5df11"
+          environment:
+            - "JOBS"
     timeout: $BUILD_TIMEOUT
     skip: $SKIP_UBUNTU_16
 
@@ -60,6 +66,8 @@ steps:
       - docker#v3.3.0:
           debug: $DEBUG
           image: "eosio/producer:eosio-ubuntu-18.04-a269bf2e944de92084f25b95a2309bce3828a9f9"
+          environment:
+            - "JOBS"
     timeout: $BUILD_TIMEOUT
     skip: $SKIP_UBUNTU_18
 

--- a/.cicd/travis-build.sh
+++ b/.cicd/travis-build.sh
@@ -13,11 +13,11 @@ if [[ "$(uname)" == Darwin ]]; then
     ccache -s
     echo '$ cmake ..'
     cmake ..
-    echo "$ make -j $CPU_CORES"
-    make -j $CPU_CORES
+    echo "$ make -j$JOBS"
+    make -j$JOBS
     echo 'Running unit tests.'
-    echo "$ ctest -j $CPU_CORES -LE _tests --output-on-failure -T Test"
-    ctest -j $CPU_CORES -LE _tests --output-on-failure -T Test # run unit tests
+    echo "$ ctest -j$JOBS -LE _tests --output-on-failure -T Test"
+    ctest -j$JOBS -LE _tests --output-on-failure -T Test # run unit tests
 else # linux
-    execute docker run --rm -v $(pwd):/workdir -v /usr/lib/ccache -v $HOME/.ccache:/opt/.ccache -e CCACHE_DIR=/opt/.ccache $FULL_TAG
+    execute docker run --rm -v $(pwd):/workdir -v /usr/lib/ccache -v $HOME/.ccache:/opt/.ccache -e JOBS -e CCACHE_DIR=/opt/.ccache $FULL_TAG
 fi

--- a/.cicd/ubuntu-16.04.dockerfile
+++ b/.cicd/ubuntu-16.04.dockerfile
@@ -18,8 +18,17 @@ RUN curl -LO https://cmake.org/files/v3.13/cmake-3.13.2.tar.gz \
   && rm -f cmake-3.13.2.tar.gz
 
 # Build appropriate version of Clang.
-RUN mkdir -p /root/tmp && cd /root/tmp && git clone --single-branch --branch release_80 https://git.llvm.org/git/llvm.git clang8             && cd clang8 && git checkout 18e41dc             && cd tools             && git clone --single-branch --branch release_80 https://git.llvm.org/git/lld.git             && cd lld && git checkout d60a035 && cd ../             && git clone --single-branch --branch release_80 https://git.llvm.org/git/polly.git             && cd polly && git checkout 1bc06e5 && cd ../             && git clone --single-branch --branch release_80 https://git.llvm.org/git/clang.git clang && cd clang             && git checkout a03da8b             && cd tools && mkdir extra && cd extra             && git clone --single-branch --branch release_80 https://git.llvm.org/git/clang-tools-extra.git             && cd clang-tools-extra && git checkout 6b34834 && cd ..             && cd ../../../../projects             && git clone --single-branch --branch release_80 https://git.llvm.org/git/libcxx.git             && cd libcxx && git checkout 1853712 && cd ../             && git clone --single-branch --branch release_80 https://git.llvm.org/git/libcxxabi.git             && cd libcxxabi && git checkout d7338a4 && cd ../             && git clone --single-branch --branch release_80 https://git.llvm.org/git/libunwind.git             && cd libunwind && git checkout 57f6739 && cd ../             && git clone --single-branch --branch release_80 https://git.llvm.org/git/compiler-rt.git             && cd compiler-rt && git checkout 5bc7979 && cd ../             && cd /root/tmp/clang8             && mkdir build && cd build             && cmake -G 'Unix Makefiles' -DCMAKE_INSTALL_PREFIX='/usr/local' -DLLVM_BUILD_EXTERNAL_COMPILER_RT=ON -DLLVM_BUILD_LLVM_DYLIB=ON -DLLVM_ENABLE_LIBCXX=ON -DLLVM_ENABLE_RTTI=ON -DLLVM_INCLUDE_DOCS=OFF -DLLVM_OPTIMIZED_TABLEGEN=ON -DLLVM_TARGETS_TO_BUILD=all -DCMAKE_BUILD_TYPE=Release ..             && make -j$(nproc)             && make install \
-  && cd / && rm -rf /root/tmp/clang8
+RUN mkdir -p /root/tmp && cd /root/tmp && git clone --single-branch --branch release_80 https://git.llvm.org/git/llvm.git clang8 \
+  && cd clang8 && git checkout 18e41dc && cd tools && git clone --single-branch --branch release_80 https://git.llvm.org/git/lld.git \
+  && cd lld && git checkout d60a035 && cd ../ && git clone --single-branch --branch release_80 https://git.llvm.org/git/polly.git \
+  && cd polly && git checkout 1bc06e5 && cd ../ && git clone --single-branch --branch release_80 https://git.llvm.org/git/clang.git clang \
+  && cd clang && git checkout a03da8b && cd tools && mkdir extra && cd extra && git clone --single-branch --branch release_80 https://git.llvm.org/git/clang-tools-extra.git \
+  && cd clang-tools-extra && git checkout 6b34834 && cd .. && cd ../../../../projects && git clone --single-branch --branch release_80 https://git.llvm.org/git/libcxx.git \
+  && cd libcxx && git checkout 1853712 && cd ../ && git clone --single-branch --branch release_80 https://git.llvm.org/git/libcxxabi.git && cd libcxxabi \
+  && git checkout d7338a4 && cd ../ && git clone --single-branch --branch release_80 https://git.llvm.org/git/libunwind.git && cd libunwind && git checkout 57f6739 \
+  && cd ../ && git clone --single-branch --branch release_80 https://git.llvm.org/git/compiler-rt.git && cd compiler-rt && git checkout 5bc7979 && cd ../ && cd /root/tmp/clang8 \
+  && mkdir build && cd build && cmake -G 'Unix Makefiles' -DCMAKE_INSTALL_PREFIX='/usr/local' -DLLVM_BUILD_EXTERNAL_COMPILER_RT=ON -DLLVM_BUILD_LLVM_DYLIB=ON -DLLVM_ENABLE_LIBCXX=ON -DLLVM_ENABLE_RTTI=ON -DLLVM_INCLUDE_DOCS=OFF -DLLVM_OPTIMIZED_TABLEGEN=ON -DLLVM_TARGETS_TO_BUILD=all -DCMAKE_BUILD_TYPE=Release .. \
+  && make -j$(nproc) && make install && cd / && rm -rf /root/tmp/clang8
 
 COPY ./pinned_toolchain.cmake /tmp/pinned_toolchain.cmake
 
@@ -89,5 +98,6 @@ ENV PRE_COMMANDS="export PATH=/usr/lib/ccache:$PATH &&"
 ENV CMAKE_EXTRAS="$CMAKE_EXTRAS -DCMAKE_TOOLCHAIN_FILE='/tmp/pinned_toolchain.cmake' -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
 
 CMD bash -c "$PRE_COMMANDS ccache -s && \
-    mkdir /workdir/build && cd /workdir/build && cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true $CMAKE_EXTRAS /workdir && make -j $(getconf _NPROCESSORS_ONLN) && \
-    ctest -j$(getconf _NPROCESSORS_ONLN) -LE _tests --output-on-failure -T Test"
+    echo Building with -j$JOBS && \
+    mkdir /workdir/build && cd /workdir/build && cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true $CMAKE_EXTRAS /workdir && make -j$JOBS && \
+    ctest -j$JOBS -LE _tests --output-on-failure -T Test"

--- a/.cicd/ubuntu-18.04.dockerfile
+++ b/.cicd/ubuntu-18.04.dockerfile
@@ -65,5 +65,6 @@ ENV PRE_COMMANDS="export PATH=/usr/lib/ccache:$PATH &&"
 ENV CMAKE_EXTRAS="-DCMAKE_CXX_COMPILER='clang++' -DCMAKE_C_COMPILER='clang'"
 
 CMD bash -c "$PRE_COMMANDS ccache -s && \
-    mkdir /workdir/build && cd /workdir/build && cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true $CMAKE_EXTRAS /workdir && make -j $(getconf _NPROCESSORS_ONLN) && \
-    ctest -j$(getconf _NPROCESSORS_ONLN) -LE _tests --output-on-failure -T Test"
+    echo Building with -j$JOBS && \
+    mkdir /workdir/build && cd /workdir/build && cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true $CMAKE_EXTRAS /workdir && make -j$JOBS && \
+    ctest -j$JOBS -LE _tests --output-on-failure -T Test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ cache:
   ccache: true
   directories:
     - $HOME/Library/Caches/Homebrew
+env:
+  global:
+    - JOBS='2'
 matrix:
   include:
     - os: linux
@@ -26,7 +29,7 @@ matrix:
       dist: xenial
       services: docker
       env: 
-        - IMAGE_TAG='centos-7'
+        - IMAGE_TAG='centos-7.6'
     - os: osx
       osx_image: xcode10.2
       addons:


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
* Changed all Dockerfiles and Travis files to use the JOBS environment variable in ```make``` and ```ctest``` commands.

* Updated naming convention of CentOS Dockerfile and image

* Updated docker plugin version for Buildkite.

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
