### PR TITLE
Fix bug to make sed -i work properly on Mac

### DIFF
--- a/plugins/eosio-make_new_plugin.sh
+++ b/plugins/eosio-make_new_plugin.sh
@@ -9,13 +9,13 @@ fi
 pluginName=$1
 
 echo Copying template...
-cp -r template_plugin $pluginName
+cp -R template_plugin $pluginName
 
 echo Renaming files/directories...
 mv $pluginName/include/eosio/template_plugin $pluginName/include/eosio/$pluginName
 for file in `find $pluginName -type f -name '*template_plugin*'`; do mv $file `sed s/template_plugin/$pluginName/g <<< $file`; done;
 
 echo Renaming in files...
-find $pluginName -type f -exec sed -i "s/template_plugin/$pluginName/g" {} \;
+for file in `find $pluginName -type f`; do sed -i.bak -e "s/template_plugin/$pluginName/g" "$file" && rm "$file.bak"; done
 
 echo "Done! $pluginName is ready. Don't forget to add it to CMakeLists.txt!"


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

This fixes the bug described in issue #7711 where `sed -i` in the script does not work properly on Mac. 

The previous script works fine on Linux (GNU) but not on Mac (BSD). The current one works well both on Mac and Linux. Tested locally on Mac Mojave 10.14.6, and remotely on Ubuntu 18.04 LTS.

Only two places are changed. One is to fix this particular bug. The other one, which changes command `cp -r` to `cp -R`, is also related to portability, as the BSD version on Mac strongly discourages the use of `cp -r`, as described in its `man` page.

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
