### PR TITLE
Kill mongoDB Before Creating the build.tar.gz Artifact

### DIFF
--- a/.cicd/docker/amazonlinux-2.dockerfile
+++ b/.cicd/docker/amazonlinux-2.dockerfile
@@ -1,9 +1,7 @@
 FROM amazonlinux:2.0.20190508
-
 # YUM dependencies.
 RUN yum update -y && \
     yum install -y which git sudo procps-ng util-linux autoconf automake libtool make bzip2 bzip2-devel openssl-devel gmp-devel libstdc++ libcurl-devel libusbx-devel python3 python3-devel python-devel libedit-devel doxygen graphviz clang patch
-
 # Build appropriate version of CMake.
 RUN curl -LO https://cmake.org/files/v3.13/cmake-3.13.2.tar.gz && \
     tar -xzf cmake-3.13.2.tar.gz && \
@@ -13,7 +11,6 @@ RUN curl -LO https://cmake.org/files/v3.13/cmake-3.13.2.tar.gz && \
     make install && \
     cd .. && \
     rm -f cmake-3.13.2.tar.gz
-
 # Build appropriate version of LLVM.
 RUN git clone --depth 1 --single-branch --branch release_40 https://github.com/llvm-mirror/llvm.git llvm && \
     cd llvm && \
@@ -23,7 +20,6 @@ RUN git clone --depth 1 --single-branch --branch release_40 https://github.com/l
     make -j$(nproc) && \
     make install && \
     cd /
-
 # Build appropriate version of Boost.
 RUN curl -LO https://dl.bintray.com/boostorg/release/1.70.0/source/boost_1_70_0.tar.bz2 && \
     tar -xjf boost_1_70_0.tar.bz2 && \
@@ -32,12 +28,10 @@ RUN curl -LO https://dl.bintray.com/boostorg/release/1.70.0/source/boost_1_70_0.
     ./b2 --with-iostreams --with-date_time --with-filesystem --with-system --with-program_options --with-chrono --with-test -q -j$(nproc) install && \
     cd .. && \
     rm -f boost_1_70_0.tar.bz2    
-
 # Build appropriate version of MongoDB.
 RUN curl -LO https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-amazon-3.6.3.tgz && \
     tar -xzf mongodb-linux-x86_64-amazon-3.6.3.tgz && \
     rm -f mongodb-linux-x86_64-amazon-3.6.3.tgz
-
 # Build appropriate version of MongoDB C Driver. 
 RUN curl -LO https://github.com/mongodb/mongo-c-driver/releases/download/1.13.0/mongo-c-driver-1.13.0.tar.gz && \
     tar -xzf mongo-c-driver-1.13.0.tar.gz && \
@@ -49,7 +43,6 @@ RUN curl -LO https://github.com/mongodb/mongo-c-driver/releases/download/1.13.0/
     make install && \
     cd / && \
     rm -rf mongo-c-driver-1.13.0.tar.gz
-
 # Build appropriate version of MongoDB C++ driver.
 RUN curl -L https://github.com/mongodb/mongo-cxx-driver/archive/r3.4.0.tar.gz -o mongo-cxx-driver-r3.4.0.tar.gz && \
     tar -xzf mongo-cxx-driver-r3.4.0.tar.gz && \
@@ -62,23 +55,17 @@ RUN curl -L https://github.com/mongodb/mongo-cxx-driver/archive/r3.4.0.tar.gz -o
     make install && \
     cd / && \
     rm -f mongo-cxx-driver-r3.4.0.tar.gz
-
 ENV PATH=${PATH}:/mongodb-linux-x86_64-amazon-3.6.3/bin
-
 # CCACHE
 RUN curl -LO http://download-ib01.fedoraproject.org/pub/epel/7/x86_64/Packages/c/ccache-3.3.4-1.el7.x86_64.rpm && \
     yum install -y ccache-3.3.4-1.el7.x86_64.rpm
-
 # Install Buildkite Agent
 RUN echo -e "[buildkite-agent]\nname = Buildkite Pty Ltd\nbaseurl = https://yum.buildkite.com/buildkite-agent/stable/x86_64/\nenabled=1\ngpgcheck=0\npriority=1" > /etc/yum.repos.d/buildkite-agent.repo && \
     yum -y install buildkite-agent
-
 # PRE_COMMANDS: Executed pre-cmake
 # CMAKE_EXTRAS: Executed right before the cmake path (on the end)
 ENV PRE_COMMANDS="export PATH=/usr/lib64/ccache:\$PATH"
 ENV CMAKE_EXTRAS="-DCMAKE_CXX_COMPILER='clang++' -DCMAKE_C_COMPILER='clang'"
-
 # Bring in helpers that provides execute function so we can get better logging in BK and TRAV
 COPY ./docker/.logging-helpers /tmp/.helpers
-
 CMD /workdir/.cicd/docker/entrypoint.sh

--- a/.cicd/docker/amazonlinux-2.dockerfile
+++ b/.cicd/docker/amazonlinux-2.dockerfile
@@ -1,80 +1,77 @@
 FROM amazonlinux:2.0.20190508
 
 # YUM dependencies.
-RUN yum update -y \
-  && yum install -y which git sudo procps-ng util-linux autoconf automake \
-  libtool make bzip2 bzip2-devel openssl-devel gmp-devel libstdc++ libcurl-devel \
-  libusbx-devel python3 python3-devel python-devel libedit-devel doxygen \
-  graphviz clang patch
+RUN yum update -y && \
+    yum install -y which git sudo procps-ng util-linux autoconf automake libtool make bzip2 bzip2-devel openssl-devel gmp-devel libstdc++ libcurl-devel libusbx-devel python3 python3-devel python-devel libedit-devel doxygen graphviz clang patch
 
 # Build appropriate version of CMake.
-RUN curl -LO https://cmake.org/files/v3.13/cmake-3.13.2.tar.gz \
-  && tar -xzf cmake-3.13.2.tar.gz \
-  && cd cmake-3.13.2 \
-  && ./bootstrap --prefix=/usr/local \
-  && make -j$(nproc) \
-  && make install \
-  && cd .. \
-  && rm -f cmake-3.13.2.tar.gz
+RUN curl -LO https://cmake.org/files/v3.13/cmake-3.13.2.tar.gz && \
+    tar -xzf cmake-3.13.2.tar.gz && \
+    cd cmake-3.13.2 && \
+    ./bootstrap --prefix=/usr/local && \
+    make -j$(nproc) && \
+    make install && \
+    cd .. && \
+    rm -f cmake-3.13.2.tar.gz
 
 # Build appropriate version of LLVM.
-RUN git clone --depth 1 --single-branch --branch release_40 https://github.com/llvm-mirror/llvm.git llvm \
-  && cd llvm \
-  && mkdir build \
-  && cd build \
-  && cmake -G 'Unix Makefiles' -DLLVM_TARGETS_TO_BUILD=host -DLLVM_BUILD_TOOLS=false -DLLVM_ENABLE_RTTI=1 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local .. \
-  && make -j$(nproc) \
-  && make install \
-  && cd /
+RUN git clone --depth 1 --single-branch --branch release_40 https://github.com/llvm-mirror/llvm.git llvm && \
+    cd llvm && \
+    mkdir build && \
+    cd build && \
+    cmake -G 'Unix Makefiles' -DLLVM_TARGETS_TO_BUILD=host -DLLVM_BUILD_TOOLS=false -DLLVM_ENABLE_RTTI=1 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local .. && \
+    make -j$(nproc) && \
+    make install && \
+    cd /
 
 # Build appropriate version of Boost.
-RUN curl -LO https://dl.bintray.com/boostorg/release/1.70.0/source/boost_1_70_0.tar.bz2 \
-  && tar -xjf boost_1_70_0.tar.bz2 \
-  && cd boost_1_70_0 \
-  && ./bootstrap.sh --prefix=/usr/local \
-  && ./b2 --with-iostreams --with-date_time --with-filesystem --with-system --with-program_options --with-chrono --with-test -q -j$(nproc) install \
-  && cd .. \
-  && rm -f boost_1_70_0.tar.bz2    
+RUN curl -LO https://dl.bintray.com/boostorg/release/1.70.0/source/boost_1_70_0.tar.bz2 && \
+    tar -xjf boost_1_70_0.tar.bz2 && \
+    cd boost_1_70_0 && \
+    ./bootstrap.sh --prefix=/usr/local && \
+    ./b2 --with-iostreams --with-date_time --with-filesystem --with-system --with-program_options --with-chrono --with-test -q -j$(nproc) install && \
+    cd .. && \
+    rm -f boost_1_70_0.tar.bz2    
 
 # Build appropriate version of MongoDB.
-RUN curl -LO https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-amazon-3.6.3.tgz \
-  && tar -xzf mongodb-linux-x86_64-amazon-3.6.3.tgz \
-  && rm -f mongodb-linux-x86_64-amazon-3.6.3.tgz
+RUN curl -LO https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-amazon-3.6.3.tgz && \
+    tar -xzf mongodb-linux-x86_64-amazon-3.6.3.tgz && \
+    rm -f mongodb-linux-x86_64-amazon-3.6.3.tgz
 
 # Build appropriate version of MongoDB C Driver. 
-RUN curl -LO https://github.com/mongodb/mongo-c-driver/releases/download/1.13.0/mongo-c-driver-1.13.0.tar.gz \
-  && tar -xzf mongo-c-driver-1.13.0.tar.gz \
-  && cd mongo-c-driver-1.13.0 \
-  && mkdir -p build \
-  && cd build \
-  && cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local -DENABLE_BSON=ON -DENABLE_SSL=OPENSSL -DENABLE_AUTOMATIC_INIT_AND_CLEANUP=OFF -DENABLE_STATIC=ON -DENABLE_ICU=OFF -DENABLE_SNAPPY=OFF .. \
-  && make -j$(nproc) \
-  && make install \
-  && cd / \
-  && rm -rf mongo-c-driver-1.13.0.tar.gz
+RUN curl -LO https://github.com/mongodb/mongo-c-driver/releases/download/1.13.0/mongo-c-driver-1.13.0.tar.gz && \
+    tar -xzf mongo-c-driver-1.13.0.tar.gz && \
+    cd mongo-c-driver-1.13.0 && \
+    mkdir -p build && \
+    cd build && \
+    cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local -DENABLE_BSON=ON -DENABLE_SSL=OPENSSL -DENABLE_AUTOMATIC_INIT_AND_CLEANUP=OFF -DENABLE_STATIC=ON -DENABLE_ICU=OFF -DENABLE_SNAPPY=OFF .. && \
+    make -j$(nproc) && \
+    make install && \
+    cd / && \
+    rm -rf mongo-c-driver-1.13.0.tar.gz
 
 # Build appropriate version of MongoDB C++ driver.
-RUN curl -L https://github.com/mongodb/mongo-cxx-driver/archive/r3.4.0.tar.gz -o mongo-cxx-driver-r3.4.0.tar.gz \
-  && tar -xzf mongo-cxx-driver-r3.4.0.tar.gz \
-  && cd mongo-cxx-driver-r3.4.0 \
-  && sed -i 's/\"maxAwaitTimeMS\", count/\"maxAwaitTimeMS\", static_cast<int64_t>(count)/' src/mongocxx/options/change_stream.cpp \
-  && sed -i 's/add_subdirectory(test)//' src/mongocxx/CMakeLists.txt src/bsoncxx/CMakeLists.txt \
-  && cd build \
-  && cmake -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local .. \
-  && make -j$(nproc) \
-  && make install \
-  && cd / \
-  && rm -f mongo-cxx-driver-r3.4.0.tar.gz
+RUN curl -L https://github.com/mongodb/mongo-cxx-driver/archive/r3.4.0.tar.gz -o mongo-cxx-driver-r3.4.0.tar.gz && \
+    tar -xzf mongo-cxx-driver-r3.4.0.tar.gz && \
+    cd mongo-cxx-driver-r3.4.0 && \
+    sed -i 's/\"maxAwaitTimeMS\", count/\"maxAwaitTimeMS\", static_cast<int64_t>(count)/' src/mongocxx/options/change_stream.cpp && \
+    sed -i 's/add_subdirectory(test)//' src/mongocxx/CMakeLists.txt src/bsoncxx/CMakeLists.txt && \
+    cd build && \
+    cmake -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local .. && \
+    make -j$(nproc) && \
+    make install && \
+    cd / && \
+    rm -f mongo-cxx-driver-r3.4.0.tar.gz
 
 ENV PATH=${PATH}:/mongodb-linux-x86_64-amazon-3.6.3/bin
 
 # CCACHE
-RUN curl -LO http://download-ib01.fedoraproject.org/pub/epel/7/x86_64/Packages/c/ccache-3.3.4-1.el7.x86_64.rpm \
-  && yum install -y ccache-3.3.4-1.el7.x86_64.rpm
+RUN curl -LO http://download-ib01.fedoraproject.org/pub/epel/7/x86_64/Packages/c/ccache-3.3.4-1.el7.x86_64.rpm && \
+    yum install -y ccache-3.3.4-1.el7.x86_64.rpm
 
 # Install Buildkite Agent
 RUN echo -e "[buildkite-agent]\nname = Buildkite Pty Ltd\nbaseurl = https://yum.buildkite.com/buildkite-agent/stable/x86_64/\nenabled=1\ngpgcheck=0\npriority=1" > /etc/yum.repos.d/buildkite-agent.repo && \
-  yum -y install buildkite-agent
+    yum -y install buildkite-agent
 
 # PRE_COMMANDS: Executed pre-cmake
 # CMAKE_EXTRAS: Executed right before the cmake path (on the end)

--- a/.cicd/docker/amazonlinux-2.dockerfile
+++ b/.cicd/docker/amazonlinux-2.dockerfile
@@ -1,8 +1,8 @@
 FROM amazonlinux:2.0.20190508
-# YUM dependencies.
+# install dependencies
 RUN yum update -y && \
     yum install -y which git sudo procps-ng util-linux autoconf automake libtool make bzip2 bzip2-devel openssl-devel gmp-devel libstdc++ libcurl-devel libusbx-devel python3 python3-devel python-devel libedit-devel doxygen graphviz clang patch
-# Build appropriate version of CMake.
+# build cmake
 RUN curl -LO https://cmake.org/files/v3.13/cmake-3.13.2.tar.gz && \
     tar -xzf cmake-3.13.2.tar.gz && \
     cd cmake-3.13.2 && \
@@ -11,7 +11,7 @@ RUN curl -LO https://cmake.org/files/v3.13/cmake-3.13.2.tar.gz && \
     make install && \
     cd .. && \
     rm -f cmake-3.13.2.tar.gz
-# Build appropriate version of LLVM.
+# build llvm
 RUN git clone --depth 1 --single-branch --branch release_40 https://github.com/llvm-mirror/llvm.git llvm && \
     cd llvm && \
     mkdir build && \
@@ -20,7 +20,7 @@ RUN git clone --depth 1 --single-branch --branch release_40 https://github.com/l
     make -j$(nproc) && \
     make install && \
     cd /
-# Build appropriate version of Boost.
+# build boost
 RUN curl -LO https://dl.bintray.com/boostorg/release/1.70.0/source/boost_1_70_0.tar.bz2 && \
     tar -xjf boost_1_70_0.tar.bz2 && \
     cd boost_1_70_0 && \
@@ -28,11 +28,11 @@ RUN curl -LO https://dl.bintray.com/boostorg/release/1.70.0/source/boost_1_70_0.
     ./b2 --with-iostreams --with-date_time --with-filesystem --with-system --with-program_options --with-chrono --with-test -q -j$(nproc) install && \
     cd .. && \
     rm -f boost_1_70_0.tar.bz2    
-# Build appropriate version of MongoDB.
+# build mongodb
 RUN curl -LO https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-amazon-3.6.3.tgz && \
     tar -xzf mongodb-linux-x86_64-amazon-3.6.3.tgz && \
     rm -f mongodb-linux-x86_64-amazon-3.6.3.tgz
-# Build appropriate version of MongoDB C Driver. 
+# build mongo c driver
 RUN curl -LO https://github.com/mongodb/mongo-c-driver/releases/download/1.13.0/mongo-c-driver-1.13.0.tar.gz && \
     tar -xzf mongo-c-driver-1.13.0.tar.gz && \
     cd mongo-c-driver-1.13.0 && \
@@ -43,7 +43,7 @@ RUN curl -LO https://github.com/mongodb/mongo-c-driver/releases/download/1.13.0/
     make install && \
     cd / && \
     rm -rf mongo-c-driver-1.13.0.tar.gz
-# Build appropriate version of MongoDB C++ driver.
+# build mongo c++ driver
 RUN curl -L https://github.com/mongodb/mongo-cxx-driver/archive/r3.4.0.tar.gz -o mongo-cxx-driver-r3.4.0.tar.gz && \
     tar -xzf mongo-cxx-driver-r3.4.0.tar.gz && \
     cd mongo-cxx-driver-r3.4.0 && \
@@ -55,17 +55,19 @@ RUN curl -L https://github.com/mongodb/mongo-cxx-driver/archive/r3.4.0.tar.gz -o
     make install && \
     cd / && \
     rm -f mongo-cxx-driver-r3.4.0.tar.gz
+# add mongodb to path
 ENV PATH=${PATH}:/mongodb-linux-x86_64-amazon-3.6.3/bin
-# CCACHE
+# install ccache
 RUN curl -LO http://download-ib01.fedoraproject.org/pub/epel/7/x86_64/Packages/c/ccache-3.3.4-1.el7.x86_64.rpm && \
     yum install -y ccache-3.3.4-1.el7.x86_64.rpm
-# Install Buildkite Agent
+# install buildkite-agent
 RUN echo -e "[buildkite-agent]\nname = Buildkite Pty Ltd\nbaseurl = https://yum.buildkite.com/buildkite-agent/stable/x86_64/\nenabled=1\ngpgcheck=0\npriority=1" > /etc/yum.repos.d/buildkite-agent.repo && \
     yum -y install buildkite-agent
-# PRE_COMMANDS: Executed pre-cmake
-# CMAKE_EXTRAS: Executed right before the cmake path (on the end)
+# PRE_COMMANDS is executed before cmake
 ENV PRE_COMMANDS="export PATH=/usr/lib64/ccache:\$PATH"
+# CMAKE_EXTRAS is inserted at the end of the cmake command right before the ..
 ENV CMAKE_EXTRAS="-DCMAKE_CXX_COMPILER='clang++' -DCMAKE_C_COMPILER='clang'"
-# Bring in helpers that provides execute function so we can get better logging in BK and TRAV
+# import logging libraries
 COPY ./docker/.logging-helpers /tmp/.helpers
+# runtime instructions
 CMD /workdir/.cicd/docker/entrypoint.sh

--- a/.cicd/docker/amazonlinux-2.dockerfile
+++ b/.cicd/docker/amazonlinux-2.dockerfile
@@ -91,4 +91,4 @@ CMD bash -c ". /tmp/.helpers && $PRE_COMMANDS && \
     if ${ENABLE_PARALLEL_TESTS:-true}; then fold-execute ctest -j$JOBS -LE _tests --output-on-failure -T Test; fi && \
     if ${ENABLE_SERIAL_TESTS:-true}; then mkdir -p ./mongodb && fold-execute mongod --dbpath ./mongodb --fork --logpath mongod.log && fold-execute ctest -L nonparallelizable_tests --output-on-failure -T Test; fi && \
     if ${ENABLE_LR_TESTS:-false}; then fold-execute ctest -L long_running_tests --output-on-failure -T Test; fi && \
-    if ! ${TRAVIS:-false}; then cd .. && ($(pgrep mongod | xargs kill -9) || :) && tar -pczf build.tar.gz build && buildkite-agent artifact upload build.tar.gz --agent-access-token $BUILDKITE_AGENT_ACCESS_TOKEN; fi"
+    if ! ${TRAVIS:-false}; then cd .. && if [[ $(pgrep mongod) ]]; then pgrep mongod | xargs kill -9; fi && tar -pczf build.tar.gz build && buildkite-agent artifact upload build.tar.gz --agent-access-token $BUILDKITE_AGENT_ACCESS_TOKEN; fi"

--- a/.cicd/docker/amazonlinux-2.dockerfile
+++ b/.cicd/docker/amazonlinux-2.dockerfile
@@ -84,11 +84,4 @@ ENV CMAKE_EXTRAS="-DCMAKE_CXX_COMPILER='clang++' -DCMAKE_C_COMPILER='clang'"
 # Bring in helpers that provides execute function so we can get better logging in BK and TRAV
 COPY ./docker/.logging-helpers /tmp/.helpers
 
-CMD bash -c ". /tmp/.helpers && $PRE_COMMANDS && \
-    fold-execute ccache -s && \
-    mkdir /workdir/build && cd /workdir/build && fold-execute cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true $CMAKE_EXTRAS /workdir && \
-    fold-execute make -j$JOBS && \
-    if ${ENABLE_PARALLEL_TESTS:-true}; then fold-execute ctest -j$JOBS -LE _tests --output-on-failure -T Test; fi && \
-    if ${ENABLE_SERIAL_TESTS:-true}; then mkdir -p ./mongodb && fold-execute mongod --dbpath ./mongodb --fork --logpath mongod.log && fold-execute ctest -L nonparallelizable_tests --output-on-failure -T Test; fi && \
-    if ${ENABLE_LR_TESTS:-false}; then fold-execute ctest -L long_running_tests --output-on-failure -T Test; fi && \
-    if ! ${TRAVIS:-false}; then cd .. && if [[ $(pgrep mongod) ]]; then pgrep mongod | xargs kill -9; fi && tar -pczf build.tar.gz build && buildkite-agent artifact upload build.tar.gz --agent-access-token $BUILDKITE_AGENT_ACCESS_TOKEN; fi"
+CMD /workdir/.cicd/docker/entrypoint.sh

--- a/.cicd/docker/amazonlinux-2.dockerfile
+++ b/.cicd/docker/amazonlinux-2.dockerfile
@@ -91,4 +91,4 @@ CMD bash -c ". /tmp/.helpers && $PRE_COMMANDS && \
     if ${ENABLE_PARALLEL_TESTS:-true}; then fold-execute ctest -j$JOBS -LE _tests --output-on-failure -T Test; fi && \
     if ${ENABLE_SERIAL_TESTS:-true}; then mkdir -p ./mongodb && fold-execute mongod --dbpath ./mongodb --fork --logpath mongod.log && fold-execute ctest -L nonparallelizable_tests --output-on-failure -T Test; fi && \
     if ${ENABLE_LR_TESTS:-false}; then fold-execute ctest -L long_running_tests --output-on-failure -T Test; fi && \
-    if ! ${TRAVIS:-false}; then cd .. && tar -pczf build.tar.gz build && buildkite-agent artifact upload build.tar.gz --agent-access-token $BUILDKITE_AGENT_ACCESS_TOKEN; fi"
+    if ! ${TRAVIS:-false}; then cd .. && ($(pgrep mongod | xargs kill -9) || :) && tar -pczf build.tar.gz build && buildkite-agent artifact upload build.tar.gz --agent-access-token $BUILDKITE_AGENT_ACCESS_TOKEN; fi"

--- a/.cicd/docker/centos-7.6.dockerfile
+++ b/.cicd/docker/centos-7.6.dockerfile
@@ -1,10 +1,10 @@
 FROM centos:7.6.1810
-# YUM dependencies.
+# install dependencies
 RUN yum update -y && \
     yum --enablerepo=extras install -y centos-release-scl && \
     yum --enablerepo=extras install -y devtoolset-8 && \
     yum --enablerepo=extras install -y which git autoconf automake libtool make bzip2 doxygen graphviz bzip2-devel openssl-devel gmp-devel ocaml libicu-devel python python-devel rh-python36 gettext-devel file libusbx-devel libcurl-devel patch
-# Build appropriate version of CMake.
+# build cmake
 RUN curl -LO https://cmake.org/files/v3.13/cmake-3.13.2.tar.gz && \
     source /opt/rh/devtoolset-8/enable && \
     source /opt/rh/rh-python36/enable && \
@@ -15,7 +15,7 @@ RUN curl -LO https://cmake.org/files/v3.13/cmake-3.13.2.tar.gz && \
     make install && \
     cd .. && \
     rm -f cmake-3.13.2.tar.gz
-# Build appropriate version of LLVM.
+# build llvm
 RUN git clone --depth 1 --single-branch --branch release_40 https://github.com/llvm-mirror/llvm.git llvm && \
     source /opt/rh/devtoolset-8/enable && \
     source /opt/rh/rh-python36/enable && \
@@ -26,7 +26,7 @@ RUN git clone --depth 1 --single-branch --branch release_40 https://github.com/l
     make -j$(nproc) && \
     make install && \
     cd /
-# Build appropriate version of Boost.
+# build boost
 RUN curl -LO https://dl.bintray.com/boostorg/release/1.70.0/source/boost_1_70_0.tar.bz2 && \
     source /opt/rh/devtoolset-8/enable && \
     source /opt/rh/rh-python36/enable && \
@@ -36,11 +36,11 @@ RUN curl -LO https://dl.bintray.com/boostorg/release/1.70.0/source/boost_1_70_0.
     ./b2 --with-iostreams --with-date_time --with-filesystem --with-system --with-program_options --with-chrono --with-test -q -j$(nproc) install && \
     cd .. && \
     rm -f boost_1_70_0.tar.bz2    
-# Build appropriate version of MongoDB.
+# build mongodb
 RUN curl -LO https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-amazon-3.6.3.tgz && \
     tar -xzf mongodb-linux-x86_64-amazon-3.6.3.tgz && \
     rm -f mongodb-linux-x86_64-amazon-3.6.3.tgz
-# Build appropriate version of MongoDB C Driver. 
+# build mongo c driver
 RUN curl -LO https://github.com/mongodb/mongo-c-driver/releases/download/1.13.0/mongo-c-driver-1.13.0.tar.gz && \
     source /opt/rh/devtoolset-8/enable && \
     source /opt/rh/rh-python36/enable && \
@@ -53,7 +53,7 @@ RUN curl -LO https://github.com/mongodb/mongo-c-driver/releases/download/1.13.0/
     make install && \
     cd / && \
     rm -rf mongo-c-driver-1.13.0.tar.gz
-# Build appropriate version of MongoDB C++ driver.
+# build mongo c++ driver
 RUN curl -L https://github.com/mongodb/mongo-cxx-driver/archive/r3.4.0.tar.gz -o mongo-cxx-driver-r3.4.0.tar.gz && \
     source /opt/rh/devtoolset-8/enable && \
     source /opt/rh/rh-python36/enable && \
@@ -67,22 +67,23 @@ RUN curl -L https://github.com/mongodb/mongo-cxx-driver/archive/r3.4.0.tar.gz -o
     make install && \
     cd / && \
     rm -f mongo-cxx-driver-r3.4.0.tar.gz
+# add mongodb to path
 ENV PATH=${PATH}:/mongodb-linux-x86_64-amazon-3.6.3/bin
-# CCACHE
+# install ccache
 RUN curl -LO http://download-ib01.fedoraproject.org/pub/epel/7/x86_64/Packages/c/ccache-3.3.4-1.el7.x86_64.rpm && \
     yum install -y ccache-3.3.4-1.el7.x86_64.rpm
-## Needed as devtoolset uses c++ and it's not in ccache by default
+# add c++ support to ccache
 RUN cd /usr/lib64/ccache && ln -s ../../bin/ccache c++
-## We need to tell ccache to actually use devtoolset-8 instead of the default system one (ccache resets anything set in PATH when it launches)
+# configure ccache to use devtoolset
 ENV CCACHE_PATH="/opt/rh/devtoolset-8/root/usr/bin"
-# Install Buildkite Agent
+# install buildkite-agent
 RUN echo -e "[buildkite-agent]\nname = Buildkite Pty Ltd\nbaseurl = https://yum.buildkite.com/buildkite-agent/stable/x86_64/\nenabled=1\ngpgcheck=0\npriority=1" > /etc/yum.repos.d/buildkite-agent.repo && \
     yum -y install buildkite-agent
-# PRE_COMMANDS: Executed pre-cmake
-# CMAKE_EXTRAS: Executed right before the cmake path (on the end)
+# PRE_COMMANDS is executed before cmake
 ENV PRE_COMMANDS="source /opt/rh/devtoolset-8/enable && \
     source /opt/rh/rh-python36/enable && \
-	export PATH=/usr/lib64/ccache:\$PATH"
-# Bring in helpers that provides execute function so we can get better logging in BK and TRAV
+    export PATH=/usr/lib64/ccache:\$PATH"
+# import logging libraries
 COPY ./docker/.logging-helpers /tmp/.helpers
+# runtime instructions
 CMD /workdir/.cicd/docker/entrypoint.sh

--- a/.cicd/docker/centos-7.6.dockerfile
+++ b/.cicd/docker/centos-7.6.dockerfile
@@ -99,11 +99,4 @@ ENV PRE_COMMANDS="source /opt/rh/devtoolset-8/enable && source /opt/rh/rh-python
 # Bring in helpers that provides execute function so we can get better logging in BK and TRAV
 COPY ./docker/.logging-helpers /tmp/.helpers
 
-CMD bash -c ". /tmp/.helpers && $PRE_COMMANDS && \
-    fold-execute ccache -s && \
-    mkdir /workdir/build && cd /workdir/build && fold-execute cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true $CMAKE_EXTRAS /workdir && \
-    fold-execute make -j$JOBS && \
-    if ${ENABLE_PARALLEL_TESTS:-true}; then fold-execute ctest -j$JOBS -LE _tests --output-on-failure -T Test; fi && \
-    if ${ENABLE_SERIAL_TESTS:-true}; then mkdir -p ./mongodb && fold-execute mongod --dbpath ./mongodb --fork --logpath mongod.log && fold-execute ctest -L nonparallelizable_tests --output-on-failure -T Test; fi && \
-    if ${ENABLE_LR_TESTS:-false}; then fold-execute ctest -L long_running_tests --output-on-failure -T Test; fi && \
-    if ! ${TRAVIS:-false}; then cd .. && if [[ $(pgrep mongod) ]]; then pgrep mongod | xargs kill -9; fi && tar -pczf build.tar.gz build && buildkite-agent artifact upload build.tar.gz --agent-access-token $BUILDKITE_AGENT_ACCESS_TOKEN; fi"
+CMD /workdir/.cicd/docker/entrypoint.sh

--- a/.cicd/docker/centos-7.6.dockerfile
+++ b/.cicd/docker/centos-7.6.dockerfile
@@ -1,88 +1,85 @@
 FROM centos:7.6.1810
 
 # YUM dependencies.
-RUN yum update -y \
-  && yum --enablerepo=extras install -y centos-release-scl \
-  && yum --enablerepo=extras install -y devtoolset-8 \
-  && yum --enablerepo=extras install -y which git autoconf automake libtool make bzip2 doxygen \
-  graphviz bzip2-devel openssl-devel gmp-devel ocaml libicu-devel \
-  python python-devel rh-python36 gettext-devel file libusbx-devel \
-  libcurl-devel patch
+RUN yum update -y && \
+    yum --enablerepo=extras install -y centos-release-scl && \
+    yum --enablerepo=extras install -y devtoolset-8 && \
+    yum --enablerepo=extras install -y which git autoconf automake libtool make bzip2 doxygen graphviz bzip2-devel openssl-devel gmp-devel ocaml libicu-devel python python-devel rh-python36 gettext-devel file libusbx-devel libcurl-devel patch
 
 # Build appropriate version of CMake.
-RUN curl -LO https://cmake.org/files/v3.13/cmake-3.13.2.tar.gz \
-  && source /opt/rh/devtoolset-8/enable \
-  && source /opt/rh/rh-python36/enable \
-  && tar -xzf cmake-3.13.2.tar.gz \
-  && cd cmake-3.13.2 \
-  && ./bootstrap --prefix=/usr/local \
-  && make -j$(nproc) \
-  && make install \
-  && cd .. \
-  && rm -f cmake-3.13.2.tar.gz
+RUN curl -LO https://cmake.org/files/v3.13/cmake-3.13.2.tar.gz && \
+    source /opt/rh/devtoolset-8/enable && \
+    source /opt/rh/rh-python36/enable && \
+    tar -xzf cmake-3.13.2.tar.gz && \
+    cd cmake-3.13.2 && \
+    ./bootstrap --prefix=/usr/local && \
+    make -j$(nproc) && \
+    make install && \
+    cd .. && \
+    rm -f cmake-3.13.2.tar.gz
 
 # Build appropriate version of LLVM.
-RUN git clone --depth 1 --single-branch --branch release_40 https://github.com/llvm-mirror/llvm.git llvm \
-  && source /opt/rh/devtoolset-8/enable \
-  && source /opt/rh/rh-python36/enable \
-  && cd llvm \
-  && mkdir build \
-  && cd build \
-  && cmake -G 'Unix Makefiles' -DLLVM_TARGETS_TO_BUILD=host -DLLVM_BUILD_TOOLS=false -DLLVM_ENABLE_RTTI=1 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local .. \
-  && make -j$(nproc) \
-  && make install \
-  && cd /
+RUN git clone --depth 1 --single-branch --branch release_40 https://github.com/llvm-mirror/llvm.git llvm && \
+    source /opt/rh/devtoolset-8/enable && \
+    source /opt/rh/rh-python36/enable && \
+    cd llvm && \
+    mkdir build && \
+    cd build && \
+    cmake -G 'Unix Makefiles' -DLLVM_TARGETS_TO_BUILD=host -DLLVM_BUILD_TOOLS=false -DLLVM_ENABLE_RTTI=1 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local .. && \
+    make -j$(nproc) && \
+    make install && \
+    cd /
 
 # Build appropriate version of Boost.
-RUN curl -LO https://dl.bintray.com/boostorg/release/1.70.0/source/boost_1_70_0.tar.bz2 \
-  && source /opt/rh/devtoolset-8/enable \
-  && source /opt/rh/rh-python36/enable \
-  && tar -xjf boost_1_70_0.tar.bz2 \
-  && cd boost_1_70_0 \
-  && ./bootstrap.sh --prefix=/usr/local \
-  && ./b2 --with-iostreams --with-date_time --with-filesystem --with-system --with-program_options --with-chrono --with-test -q -j$(nproc) install \
-  && cd .. \
-  && rm -f boost_1_70_0.tar.bz2    
+RUN curl -LO https://dl.bintray.com/boostorg/release/1.70.0/source/boost_1_70_0.tar.bz2 && \
+    source /opt/rh/devtoolset-8/enable && \
+    source /opt/rh/rh-python36/enable && \
+    tar -xjf boost_1_70_0.tar.bz2 && \
+    cd boost_1_70_0 && \
+    ./bootstrap.sh --prefix=/usr/local && \
+    ./b2 --with-iostreams --with-date_time --with-filesystem --with-system --with-program_options --with-chrono --with-test -q -j$(nproc) install && \
+    cd .. && \
+    rm -f boost_1_70_0.tar.bz2    
 
 # Build appropriate version of MongoDB.
-RUN curl -LO https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-amazon-3.6.3.tgz \
-  && tar -xzf mongodb-linux-x86_64-amazon-3.6.3.tgz \
-  && rm -f mongodb-linux-x86_64-amazon-3.6.3.tgz
+RUN curl -LO https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-amazon-3.6.3.tgz && \
+    tar -xzf mongodb-linux-x86_64-amazon-3.6.3.tgz && \
+    rm -f mongodb-linux-x86_64-amazon-3.6.3.tgz
 
 # Build appropriate version of MongoDB C Driver. 
-RUN curl -LO https://github.com/mongodb/mongo-c-driver/releases/download/1.13.0/mongo-c-driver-1.13.0.tar.gz \
-  && source /opt/rh/devtoolset-8/enable \
-  && source /opt/rh/rh-python36/enable \
-  && tar -xzf mongo-c-driver-1.13.0.tar.gz \
-  && cd mongo-c-driver-1.13.0 \
-  && mkdir -p build \
-  && cd build \
-  && cmake --DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local -DENABLE_BSON=ON -DENABLE_SSL=OPENSSL -DENABLE_AUTOMATIC_INIT_AND_CLEANUP=OFF -DENABLE_STATIC=ON -DENABLE_ICU=OFF -DENABLE_SNAPPY=OFF .. \
-  && make -j$(nproc) \
-  && make install \
-  && cd / \
-  && rm -rf mongo-c-driver-1.13.0.tar.gz
+RUN curl -LO https://github.com/mongodb/mongo-c-driver/releases/download/1.13.0/mongo-c-driver-1.13.0.tar.gz && \
+    source /opt/rh/devtoolset-8/enable && \
+    source /opt/rh/rh-python36/enable && \
+    tar -xzf mongo-c-driver-1.13.0.tar.gz && \
+    cd mongo-c-driver-1.13.0 && \
+    mkdir -p build && \
+    cd build && \
+    cmake --DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local -DENABLE_BSON=ON -DENABLE_SSL=OPENSSL -DENABLE_AUTOMATIC_INIT_AND_CLEANUP=OFF -DENABLE_STATIC=ON -DENABLE_ICU=OFF -DENABLE_SNAPPY=OFF .. && \
+    make -j$(nproc) && \
+    make install && \
+    cd / && \
+    rm -rf mongo-c-driver-1.13.0.tar.gz
 
 # Build appropriate version of MongoDB C++ driver.
-RUN curl -L https://github.com/mongodb/mongo-cxx-driver/archive/r3.4.0.tar.gz -o mongo-cxx-driver-r3.4.0.tar.gz \
-  && source /opt/rh/devtoolset-8/enable \
-  && source /opt/rh/rh-python36/enable \
-  && tar -xzf mongo-cxx-driver-r3.4.0.tar.gz \
-  && cd mongo-cxx-driver-r3.4.0 \
-  && sed -i 's/\"maxAwaitTimeMS\", count/\"maxAwaitTimeMS\", static_cast<int64_t>(count)/' src/mongocxx/options/change_stream.cpp \
-  && sed -i 's/add_subdirectory(test)//' src/mongocxx/CMakeLists.txt src/bsoncxx/CMakeLists.txt \
-  && cd build \
-  && cmake -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local .. \
-  && make -j$(nproc) \
-  && make install \
-  && cd / \
-  && rm -f mongo-cxx-driver-r3.4.0.tar.gz
+RUN curl -L https://github.com/mongodb/mongo-cxx-driver/archive/r3.4.0.tar.gz -o mongo-cxx-driver-r3.4.0.tar.gz && \
+    source /opt/rh/devtoolset-8/enable && \
+    source /opt/rh/rh-python36/enable && \
+    tar -xzf mongo-cxx-driver-r3.4.0.tar.gz && \
+    cd mongo-cxx-driver-r3.4.0 && \
+    sed -i 's/\"maxAwaitTimeMS\", count/\"maxAwaitTimeMS\", static_cast<int64_t>(count)/' src/mongocxx/options/change_stream.cpp && \
+    sed -i 's/add_subdirectory(test)//' src/mongocxx/CMakeLists.txt src/bsoncxx/CMakeLists.txt && \
+    cd build && \
+    cmake -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local .. && \
+    make -j$(nproc) && \
+    make install && \
+    cd / && \
+    rm -f mongo-cxx-driver-r3.4.0.tar.gz
 
 ENV PATH=${PATH}:/mongodb-linux-x86_64-amazon-3.6.3/bin
 
 # CCACHE
-RUN curl -LO http://download-ib01.fedoraproject.org/pub/epel/7/x86_64/Packages/c/ccache-3.3.4-1.el7.x86_64.rpm \
-  && yum install -y ccache-3.3.4-1.el7.x86_64.rpm
+RUN curl -LO http://download-ib01.fedoraproject.org/pub/epel/7/x86_64/Packages/c/ccache-3.3.4-1.el7.x86_64.rpm && \
+    yum install -y ccache-3.3.4-1.el7.x86_64.rpm
 ## Needed as devtoolset uses c++ and it's not in ccache by default
 RUN cd /usr/lib64/ccache && ln -s ../../bin/ccache c++
 ## We need to tell ccache to actually use devtoolset-8 instead of the default system one (ccache resets anything set in PATH when it launches)
@@ -90,11 +87,13 @@ ENV CCACHE_PATH="/opt/rh/devtoolset-8/root/usr/bin"
 
 # Install Buildkite Agent
 RUN echo -e "[buildkite-agent]\nname = Buildkite Pty Ltd\nbaseurl = https://yum.buildkite.com/buildkite-agent/stable/x86_64/\nenabled=1\ngpgcheck=0\npriority=1" > /etc/yum.repos.d/buildkite-agent.repo && \
-  yum -y install buildkite-agent
+    yum -y install buildkite-agent
 
 # PRE_COMMANDS: Executed pre-cmake
 # CMAKE_EXTRAS: Executed right before the cmake path (on the end)
-ENV PRE_COMMANDS="source /opt/rh/devtoolset-8/enable && source /opt/rh/rh-python36/enable && export PATH=/usr/lib64/ccache:\$PATH"
+ENV PRE_COMMANDS="source /opt/rh/devtoolset-8/enable && \
+    source /opt/rh/rh-python36/enable && \
+	export PATH=/usr/lib64/ccache:\$PATH"
 
 # Bring in helpers that provides execute function so we can get better logging in BK and TRAV
 COPY ./docker/.logging-helpers /tmp/.helpers

--- a/.cicd/docker/centos-7.6.dockerfile
+++ b/.cicd/docker/centos-7.6.dockerfile
@@ -1,11 +1,9 @@
 FROM centos:7.6.1810
-
 # YUM dependencies.
 RUN yum update -y && \
     yum --enablerepo=extras install -y centos-release-scl && \
     yum --enablerepo=extras install -y devtoolset-8 && \
     yum --enablerepo=extras install -y which git autoconf automake libtool make bzip2 doxygen graphviz bzip2-devel openssl-devel gmp-devel ocaml libicu-devel python python-devel rh-python36 gettext-devel file libusbx-devel libcurl-devel patch
-
 # Build appropriate version of CMake.
 RUN curl -LO https://cmake.org/files/v3.13/cmake-3.13.2.tar.gz && \
     source /opt/rh/devtoolset-8/enable && \
@@ -17,7 +15,6 @@ RUN curl -LO https://cmake.org/files/v3.13/cmake-3.13.2.tar.gz && \
     make install && \
     cd .. && \
     rm -f cmake-3.13.2.tar.gz
-
 # Build appropriate version of LLVM.
 RUN git clone --depth 1 --single-branch --branch release_40 https://github.com/llvm-mirror/llvm.git llvm && \
     source /opt/rh/devtoolset-8/enable && \
@@ -29,7 +26,6 @@ RUN git clone --depth 1 --single-branch --branch release_40 https://github.com/l
     make -j$(nproc) && \
     make install && \
     cd /
-
 # Build appropriate version of Boost.
 RUN curl -LO https://dl.bintray.com/boostorg/release/1.70.0/source/boost_1_70_0.tar.bz2 && \
     source /opt/rh/devtoolset-8/enable && \
@@ -40,12 +36,10 @@ RUN curl -LO https://dl.bintray.com/boostorg/release/1.70.0/source/boost_1_70_0.
     ./b2 --with-iostreams --with-date_time --with-filesystem --with-system --with-program_options --with-chrono --with-test -q -j$(nproc) install && \
     cd .. && \
     rm -f boost_1_70_0.tar.bz2    
-
 # Build appropriate version of MongoDB.
 RUN curl -LO https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-amazon-3.6.3.tgz && \
     tar -xzf mongodb-linux-x86_64-amazon-3.6.3.tgz && \
     rm -f mongodb-linux-x86_64-amazon-3.6.3.tgz
-
 # Build appropriate version of MongoDB C Driver. 
 RUN curl -LO https://github.com/mongodb/mongo-c-driver/releases/download/1.13.0/mongo-c-driver-1.13.0.tar.gz && \
     source /opt/rh/devtoolset-8/enable && \
@@ -59,7 +53,6 @@ RUN curl -LO https://github.com/mongodb/mongo-c-driver/releases/download/1.13.0/
     make install && \
     cd / && \
     rm -rf mongo-c-driver-1.13.0.tar.gz
-
 # Build appropriate version of MongoDB C++ driver.
 RUN curl -L https://github.com/mongodb/mongo-cxx-driver/archive/r3.4.0.tar.gz -o mongo-cxx-driver-r3.4.0.tar.gz && \
     source /opt/rh/devtoolset-8/enable && \
@@ -74,9 +67,7 @@ RUN curl -L https://github.com/mongodb/mongo-cxx-driver/archive/r3.4.0.tar.gz -o
     make install && \
     cd / && \
     rm -f mongo-cxx-driver-r3.4.0.tar.gz
-
 ENV PATH=${PATH}:/mongodb-linux-x86_64-amazon-3.6.3/bin
-
 # CCACHE
 RUN curl -LO http://download-ib01.fedoraproject.org/pub/epel/7/x86_64/Packages/c/ccache-3.3.4-1.el7.x86_64.rpm && \
     yum install -y ccache-3.3.4-1.el7.x86_64.rpm
@@ -84,18 +75,14 @@ RUN curl -LO http://download-ib01.fedoraproject.org/pub/epel/7/x86_64/Packages/c
 RUN cd /usr/lib64/ccache && ln -s ../../bin/ccache c++
 ## We need to tell ccache to actually use devtoolset-8 instead of the default system one (ccache resets anything set in PATH when it launches)
 ENV CCACHE_PATH="/opt/rh/devtoolset-8/root/usr/bin"
-
 # Install Buildkite Agent
 RUN echo -e "[buildkite-agent]\nname = Buildkite Pty Ltd\nbaseurl = https://yum.buildkite.com/buildkite-agent/stable/x86_64/\nenabled=1\ngpgcheck=0\npriority=1" > /etc/yum.repos.d/buildkite-agent.repo && \
     yum -y install buildkite-agent
-
 # PRE_COMMANDS: Executed pre-cmake
 # CMAKE_EXTRAS: Executed right before the cmake path (on the end)
 ENV PRE_COMMANDS="source /opt/rh/devtoolset-8/enable && \
     source /opt/rh/rh-python36/enable && \
 	export PATH=/usr/lib64/ccache:\$PATH"
-
 # Bring in helpers that provides execute function so we can get better logging in BK and TRAV
 COPY ./docker/.logging-helpers /tmp/.helpers
-
 CMD /workdir/.cicd/docker/entrypoint.sh

--- a/.cicd/docker/centos-7.6.dockerfile
+++ b/.cicd/docker/centos-7.6.dockerfile
@@ -106,4 +106,4 @@ CMD bash -c ". /tmp/.helpers && $PRE_COMMANDS && \
     if ${ENABLE_PARALLEL_TESTS:-true}; then fold-execute ctest -j$JOBS -LE _tests --output-on-failure -T Test; fi && \
     if ${ENABLE_SERIAL_TESTS:-true}; then mkdir -p ./mongodb && fold-execute mongod --dbpath ./mongodb --fork --logpath mongod.log && fold-execute ctest -L nonparallelizable_tests --output-on-failure -T Test; fi && \
     if ${ENABLE_LR_TESTS:-false}; then fold-execute ctest -L long_running_tests --output-on-failure -T Test; fi && \
-    if ! ${TRAVIS:-false}; then cd .. && ($(pgrep mongod | xargs kill -9) || :) && tar -pczf build.tar.gz build && buildkite-agent artifact upload build.tar.gz --agent-access-token $BUILDKITE_AGENT_ACCESS_TOKEN; fi"
+    if ! ${TRAVIS:-false}; then cd .. && if [[ $(pgrep mongod) ]]; then pgrep mongod | xargs kill -9; fi && tar -pczf build.tar.gz build && buildkite-agent artifact upload build.tar.gz --agent-access-token $BUILDKITE_AGENT_ACCESS_TOKEN; fi"

--- a/.cicd/docker/centos-7.6.dockerfile
+++ b/.cicd/docker/centos-7.6.dockerfile
@@ -106,4 +106,4 @@ CMD bash -c ". /tmp/.helpers && $PRE_COMMANDS && \
     if ${ENABLE_PARALLEL_TESTS:-true}; then fold-execute ctest -j$JOBS -LE _tests --output-on-failure -T Test; fi && \
     if ${ENABLE_SERIAL_TESTS:-true}; then mkdir -p ./mongodb && fold-execute mongod --dbpath ./mongodb --fork --logpath mongod.log && fold-execute ctest -L nonparallelizable_tests --output-on-failure -T Test; fi && \
     if ${ENABLE_LR_TESTS:-false}; then fold-execute ctest -L long_running_tests --output-on-failure -T Test; fi && \
-    if ! ${TRAVIS:-false}; then cd .. && tar -pczf build.tar.gz build && buildkite-agent artifact upload build.tar.gz --agent-access-token $BUILDKITE_AGENT_ACCESS_TOKEN; fi"
+    if ! ${TRAVIS:-false}; then cd .. && ($(pgrep mongod | xargs kill -9) || :) && tar -pczf build.tar.gz build && buildkite-agent artifact upload build.tar.gz --agent-access-token $BUILDKITE_AGENT_ACCESS_TOKEN; fi"

--- a/.cicd/docker/entrypoint.sh
+++ b/.cicd/docker/entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+. /tmp/.helpers
+$PRE_COMMANDS
+fold-execute ccache -s
+mkdir /workdir/build
+cd /workdir/build
+fold-execute cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true $CMAKE_EXTRAS /workdir
+fold-execute make -j$JOBS
+[[ "${ENABLE_PARALLEL_TESTS:-true}" != 'false' ]] && fold-execute ctest -j $JOBS -LE _tests --output-on-failure -T Test
+if ${ENABLE_SERIAL_TESTS:-true}; then
+    mkdir mongodb
+    fold-execute mongod --dbpath ./mongodb --fork --logpath mongod.log
+    fold-execute ctest -L nonparallelizable_tests --output-on-failure -T Test
+fi
+[[ "${ENABLE_LR_TESTS:-false}" != 'false' ]] && fold-execute ctest -L long_running_tests --output-on-failure -T Test
+if ! ${TRAVIS:-false}; then
+    cd ..
+    [[ $(pgrep mongod) ]] && pgrep mongod | xargs kill -9
+    tar -pczf build.tar.gz build
+    buildkite-agent artifact upload build.tar.gz --agent-access-token $BUILDKITE_AGENT_ACCESS_TOKEN
+fi

--- a/.cicd/docker/ubuntu-16.04.dockerfile
+++ b/.cicd/docker/ubuntu-16.04.dockerfile
@@ -27,15 +27,6 @@ RUN git clone --single-branch --branch release_80 https://git.llvm.org/git/llvm.
     make install && \
     rm -rf /clang8
 COPY ./docker/pinned_toolchain.cmake /tmp/pinned_toolchain.cmake
-# Build appropriate version of LLVM.
-RUN git clone --depth 1 --single-branch --branch release_40 https://github.com/llvm-mirror/llvm.git llvm && \
-    cd llvm && \
-    mkdir build && \
-    cd build && \
-    cmake -DLLVM_TARGETS_TO_BUILD=host -DLLVM_BUILD_TOOLS=false -DLLVM_ENABLE_RTTI=1 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local -DCMAKE_TOOLCHAIN_FILE='/tmp/pinned_toolchain.cmake' .. && \
-    make -j$(nproc) && \
-    make install && \
-    cd /
 # Build appropriate version of Boost.
 RUN curl -LO https://dl.bintray.com/boostorg/release/1.70.0/source/boost_1_70_0.tar.bz2 && \
     tar -xjf boost_1_70_0.tar.bz2 && \

--- a/.cicd/docker/ubuntu-16.04.dockerfile
+++ b/.cicd/docker/ubuntu-16.04.dockerfile
@@ -101,4 +101,4 @@ CMD bash -c ". /tmp/.helpers && $PRE_COMMANDS && \
     if ${ENABLE_PARALLEL_TESTS:-true}; then fold-execute ctest -j$JOBS -LE _tests --output-on-failure -T Test; fi && \
     if ${ENABLE_SERIAL_TESTS:-true}; then mkdir -p ./mongodb && fold-execute mongod --dbpath ./mongodb --fork --logpath mongod.log && fold-execute ctest -L nonparallelizable_tests --output-on-failure -T Test; fi && \
     if ${ENABLE_LR_TESTS:-false}; then fold-execute ctest -L long_running_tests --output-on-failure -T Test; fi && \
-    if ! ${TRAVIS:-false}; then cd .. && ($(pgrep mongod | xargs kill -9) || :) && tar -pczf build.tar.gz build && buildkite-agent artifact upload build.tar.gz --agent-access-token $BUILDKITE_AGENT_ACCESS_TOKEN; fi"
+    if ! ${TRAVIS:-false}; then cd .. && if [[ $(pgrep mongod) ]]; then pgrep mongod | xargs kill -9; fi && tar -pczf build.tar.gz build && buildkite-agent artifact upload build.tar.gz --agent-access-token $BUILDKITE_AGENT_ACCESS_TOKEN; fi"

--- a/.cicd/docker/ubuntu-16.04.dockerfile
+++ b/.cicd/docker/ubuntu-16.04.dockerfile
@@ -94,11 +94,4 @@ ENV CMAKE_EXTRAS="$CMAKE_EXTRAS -DCMAKE_TOOLCHAIN_FILE='/tmp/pinned_toolchain.cm
 # Bring in helpers that provides execute function so we can get better logging in BK and TRAV
 COPY ./docker/.logging-helpers /tmp/.helpers
 
-CMD bash -c ". /tmp/.helpers && $PRE_COMMANDS && \
-    fold-execute ccache -s && \
-    mkdir /workdir/build && cd /workdir/build && fold-execute cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true $CMAKE_EXTRAS /workdir && \
-    fold-execute make -j$JOBS && \
-    if ${ENABLE_PARALLEL_TESTS:-true}; then fold-execute ctest -j$JOBS -LE _tests --output-on-failure -T Test; fi && \
-    if ${ENABLE_SERIAL_TESTS:-true}; then mkdir -p ./mongodb && fold-execute mongod --dbpath ./mongodb --fork --logpath mongod.log && fold-execute ctest -L nonparallelizable_tests --output-on-failure -T Test; fi && \
-    if ${ENABLE_LR_TESTS:-false}; then fold-execute ctest -L long_running_tests --output-on-failure -T Test; fi && \
-    if ! ${TRAVIS:-false}; then cd .. && if [[ $(pgrep mongod) ]]; then pgrep mongod | xargs kill -9; fi && tar -pczf build.tar.gz build && buildkite-agent artifact upload build.tar.gz --agent-access-token $BUILDKITE_AGENT_ACCESS_TOKEN; fi"
+CMD /workdir/.cicd/docker/entrypoint.sh

--- a/.cicd/docker/ubuntu-16.04.dockerfile
+++ b/.cicd/docker/ubuntu-16.04.dockerfile
@@ -101,4 +101,4 @@ CMD bash -c ". /tmp/.helpers && $PRE_COMMANDS && \
     if ${ENABLE_PARALLEL_TESTS:-true}; then fold-execute ctest -j$JOBS -LE _tests --output-on-failure -T Test; fi && \
     if ${ENABLE_SERIAL_TESTS:-true}; then mkdir -p ./mongodb && fold-execute mongod --dbpath ./mongodb --fork --logpath mongod.log && fold-execute ctest -L nonparallelizable_tests --output-on-failure -T Test; fi && \
     if ${ENABLE_LR_TESTS:-false}; then fold-execute ctest -L long_running_tests --output-on-failure -T Test; fi && \
-    if ! ${TRAVIS:-false}; then cd .. && tar -pczf build.tar.gz build && buildkite-agent artifact upload build.tar.gz --agent-access-token $BUILDKITE_AGENT_ACCESS_TOKEN; fi"
+    if ! ${TRAVIS:-false}; then cd .. && ($(pgrep mongod | xargs kill -9) || :) && tar -pczf build.tar.gz build && buildkite-agent artifact upload build.tar.gz --agent-access-token $BUILDKITE_AGENT_ACCESS_TOKEN; fi"

--- a/.cicd/docker/ubuntu-16.04.dockerfile
+++ b/.cicd/docker/ubuntu-16.04.dockerfile
@@ -1,90 +1,100 @@
 FROM ubuntu:16.04
 
 # APT-GET dependencies.
-RUN apt-get update && apt-get upgrade -y \
-  && DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential git automake \
-  libbz2-dev libssl-dev doxygen graphviz libgmp3-dev autotools-dev libicu-dev \
-  python2.7 python2.7-dev python3 python3-dev autoconf libtool curl zlib1g-dev \
-  sudo ruby libusb-1.0-0-dev libcurl4-gnutls-dev pkg-config apt-transport-https
+RUN apt-get update && apt-get upgrade -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential git automake libbz2-dev libssl-dev doxygen graphviz libgmp3-dev autotools-dev libicu-dev python2.7 python2.7-dev python3 python3-dev autoconf libtool curl zlib1g-dev sudo ruby libusb-1.0-0-dev libcurl4-gnutls-dev pkg-config apt-transport-https
 
 # Build appropriate version of CMake.
-RUN curl -LO https://cmake.org/files/v3.13/cmake-3.13.2.tar.gz \
-  && tar -xzf cmake-3.13.2.tar.gz \
-  && cd cmake-3.13.2 \
-  && ./bootstrap --prefix=/usr/local \
-  && make -j$(nproc) \
-  && make install \
-  && cd .. \
-  && rm -f cmake-3.13.2.tar.gz
+RUN curl -LO https://cmake.org/files/v3.13/cmake-3.13.2.tar.gz && \
+    tar -xzf cmake-3.13.2.tar.gz && \
+    cd cmake-3.13.2 && \
+    ./bootstrap --prefix=/usr/local && \
+    make -j$(nproc) && \
+    make install && \
+    cd .. && \
+    rm -f cmake-3.13.2.tar.gz
 
 # Build appropriate version of Clang.
-RUN mkdir -p /root/tmp && cd /root/tmp && git clone --single-branch --branch release_80 https://git.llvm.org/git/llvm.git clang8             && cd clang8 && git checkout 18e41dc             && cd tools             && git clone --single-branch --branch release_80 https://git.llvm.org/git/lld.git             && cd lld && git checkout d60a035 && cd ../             && git clone --single-branch --branch release_80 https://git.llvm.org/git/polly.git             && cd polly && git checkout 1bc06e5 && cd ../             && git clone --single-branch --branch release_80 https://git.llvm.org/git/clang.git clang && cd clang             && git checkout a03da8b             && cd tools && mkdir extra && cd extra             && git clone --single-branch --branch release_80 https://git.llvm.org/git/clang-tools-extra.git             && cd clang-tools-extra && git checkout 6b34834 && cd ..             && cd ../../../../projects             && git clone --single-branch --branch release_80 https://git.llvm.org/git/libcxx.git             && cd libcxx && git checkout 1853712 && cd ../             && git clone --single-branch --branch release_80 https://git.llvm.org/git/libcxxabi.git             && cd libcxxabi && git checkout d7338a4 && cd ../             && git clone --single-branch --branch release_80 https://git.llvm.org/git/libunwind.git             && cd libunwind && git checkout 57f6739 && cd ../             && git clone --single-branch --branch release_80 https://git.llvm.org/git/compiler-rt.git             && cd compiler-rt && git checkout 5bc7979 && cd ../             && cd /root/tmp/clang8             && mkdir build && cd build             && cmake -G 'Unix Makefiles' -DCMAKE_INSTALL_PREFIX='/usr/local' -DLLVM_BUILD_EXTERNAL_COMPILER_RT=ON -DLLVM_BUILD_LLVM_DYLIB=ON -DLLVM_ENABLE_LIBCXX=ON -DLLVM_ENABLE_RTTI=ON -DLLVM_INCLUDE_DOCS=OFF -DLLVM_OPTIMIZED_TABLEGEN=ON -DLLVM_TARGETS_TO_BUILD=all -DCMAKE_BUILD_TYPE=Release ..             && make -j$(nproc)             && make install \
-  && cd / && rm -rf /root/tmp/clang8
+RUN git clone --single-branch --branch release_80 https://git.llvm.org/git/llvm.git clang8 && cd clang8 && git checkout 18e41dc && \
+    cd tools && git clone --single-branch --branch release_80 https://git.llvm.org/git/lld.git && cd lld && git checkout d60a035 && \
+    cd ../ && git clone --single-branch --branch release_80 https://git.llvm.org/git/polly.git && cd polly && git checkout 1bc06e5 && \
+    cd ../ && git clone --single-branch --branch release_80 https://git.llvm.org/git/clang.git clang && cd clang && git checkout a03da8b && \
+    cd tools && mkdir extra && cd extra && git clone --single-branch --branch release_80 https://git.llvm.org/git/clang-tools-extra.git && cd clang-tools-extra && git checkout 6b34834 && \
+    cd /clang8/projects && git clone --single-branch --branch release_80 https://git.llvm.org/git/libcxx.git && cd libcxx && git checkout 1853712 && \
+    cd ../ && git clone --single-branch --branch release_80 https://git.llvm.org/git/libcxxabi.git && cd libcxxabi && git checkout d7338a4 && \
+    cd ../ && git clone --single-branch --branch release_80 https://git.llvm.org/git/libunwind.git && cd libunwind && git checkout 57f6739 && \
+    cd ../ && git clone --single-branch --branch release_80 https://git.llvm.org/git/compiler-rt.git && cd compiler-rt && git checkout 5bc7979 && \
+    mkdir /clang8/build && cd /clang8/build && \
+    cmake -G 'Unix Makefiles' -DCMAKE_INSTALL_PREFIX='/usr/local' -DLLVM_BUILD_EXTERNAL_COMPILER_RT=ON -DLLVM_BUILD_LLVM_DYLIB=ON -DLLVM_ENABLE_LIBCXX=ON -DLLVM_ENABLE_RTTI=ON -DLLVM_INCLUDE_DOCS=OFF -DLLVM_OPTIMIZED_TABLEGEN=ON -DLLVM_TARGETS_TO_BUILD=X86 -DCMAKE_BUILD_TYPE=Release .. && \
+    make -j $(nproc) && \
+    make install && \
+    rm -rf /clang8
+
 COPY ./docker/pinned_toolchain.cmake /tmp/pinned_toolchain.cmake
 
 # Build appropriate version of LLVM.
-RUN git clone --depth 1 --single-branch --branch release_40 https://github.com/llvm-mirror/llvm.git llvm \
-  && cd llvm \
-  && mkdir build \
-  && cd build \
-  && cmake -DLLVM_TARGETS_TO_BUILD=host -DLLVM_BUILD_TOOLS=false -DLLVM_ENABLE_RTTI=1 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local -DCMAKE_TOOLCHAIN_FILE='/tmp/pinned_toolchain.cmake' .. \
-  && make -j$(nproc) \
-  && make install \
-  && cd /
+RUN git clone --depth 1 --single-branch --branch release_40 https://github.com/llvm-mirror/llvm.git llvm && \
+    cd llvm && \
+    mkdir build && \
+    cd build && \
+    cmake -DLLVM_TARGETS_TO_BUILD=host -DLLVM_BUILD_TOOLS=false -DLLVM_ENABLE_RTTI=1 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local -DCMAKE_TOOLCHAIN_FILE='/tmp/pinned_toolchain.cmake' .. && \
+    make -j$(nproc) && \
+    make install && \
+    cd /
 
 # Build appropriate version of Boost.
-RUN curl -LO https://dl.bintray.com/boostorg/release/1.70.0/source/boost_1_70_0.tar.bz2 \
-  && tar -xjf boost_1_70_0.tar.bz2 \
-  && cd boost_1_70_0 \
-  && ./bootstrap.sh --with-toolset=clang --prefix=/usr/local \
-  && ./b2 toolset=clang cxxflags='-stdlib=libc++ -D__STRICT_ANSI__ -nostdinc++ -I/usr/local/include/c++/v1' linkflags='-stdlib=libc++' link=static threading=multi --with-iostreams --with-date_time --with-filesystem --with-system --with-program_options --with-chrono --with-test -q -j$(nproc) install \
-  && cd .. \
-  && rm -f boost_1_70_0.tar.bz2    
+RUN curl -LO https://dl.bintray.com/boostorg/release/1.70.0/source/boost_1_70_0.tar.bz2 && \
+    tar -xjf boost_1_70_0.tar.bz2 && \
+    cd boost_1_70_0 && \
+    ./bootstrap.sh --with-toolset=clang --prefix=/usr/local && \
+    ./b2 toolset=clang cxxflags='-stdlib=libc++ -D__STRICT_ANSI__ -nostdinc++ -I/usr/local/include/c++/v1' linkflags='-stdlib=libc++' link=static threading=multi --with-iostreams --with-date_time --with-filesystem --with-system --with-program_options --with-chrono --with-test -q -j$(nproc) install && \
+    cd .. && \
+    rm -f boost_1_70_0.tar.bz2    
 
 # Build appropriate version of MongoDB.
-RUN curl -LO http://downloads.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1604-3.6.3.tgz \
-  && tar -xzf mongodb-linux-x86_64-ubuntu1604-3.6.3.tgz \
-  && rm -f mongodb-linux-x86_64-ubuntu1604-3.6.3.tgz
+RUN curl -LO http://downloads.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1604-3.6.3.tgz && \
+    tar -xzf mongodb-linux-x86_64-ubuntu1604-3.6.3.tgz && \
+    rm -f mongodb-linux-x86_64-ubuntu1604-3.6.3.tgz
 
 # Build appropriate version of MongoDB C Driver. 
-RUN curl -LO https://github.com/mongodb/mongo-c-driver/releases/download/1.13.0/mongo-c-driver-1.13.0.tar.gz \
-  && tar -xzf mongo-c-driver-1.13.0.tar.gz \
-  && cd mongo-c-driver-1.13.0 \
-  && mkdir -p build \
-  && cd build \
-  && cmake --DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local -DENABLE_BSON=ON -DENABLE_SSL=OPENSSL -DENABLE_AUTOMATIC_INIT_AND_CLEANUP=OFF -DENABLE_STATIC=ON -DCMAKE_TOOLCHAIN_FILE='/tmp/pinned_toolchain.cmake' .. \
-  && make -j$(nproc) \
-  && make install \
-  && cd / \
-  && rm -rf mongo-c-driver-1.13.0.tar.gz
+RUN curl -LO https://github.com/mongodb/mongo-c-driver/releases/download/1.13.0/mongo-c-driver-1.13.0.tar.gz && \
+    tar -xzf mongo-c-driver-1.13.0.tar.gz && \
+    cd mongo-c-driver-1.13.0 && \
+    mkdir -p build && \
+    cd build && \
+    cmake --DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local -DENABLE_BSON=ON -DENABLE_SSL=OPENSSL -DENABLE_AUTOMATIC_INIT_AND_CLEANUP=OFF -DENABLE_STATIC=ON -DCMAKE_TOOLCHAIN_FILE='/tmp/pinned_toolchain.cmake' .. && \
+    make -j$(nproc) && \
+    make install && \
+    cd / && \
+    rm -rf mongo-c-driver-1.13.0.tar.gz
 
 # Build appropriate version of MongoDB C++ driver.
-RUN curl -L https://github.com/mongodb/mongo-cxx-driver/archive/r3.4.0.tar.gz -o mongo-cxx-driver-r3.4.0.tar.gz \
-  && tar -xzf mongo-cxx-driver-r3.4.0.tar.gz \
-  && cd mongo-cxx-driver-r3.4.0 \
-  && sed -i 's/\"maxAwaitTimeMS\", count/\"maxAwaitTimeMS\", static_cast<int64_t>(count)/' src/mongocxx/options/change_stream.cpp \
-  && sed -i 's/add_subdirectory(test)//' src/mongocxx/CMakeLists.txt src/bsoncxx/CMakeLists.txt \
-  && cd build \
-  && cmake -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local -DCMAKE_TOOLCHAIN_FILE='/tmp/pinned_toolchain.cmake' .. \
-  && make -j$(nproc) \
-  && make install \
-  && cd / \
-  && rm -f mongo-cxx-driver-r3.4.0.tar.gz
+RUN curl -L https://github.com/mongodb/mongo-cxx-driver/archive/r3.4.0.tar.gz -o mongo-cxx-driver-r3.4.0.tar.gz && \
+    tar -xzf mongo-cxx-driver-r3.4.0.tar.gz && \
+    cd mongo-cxx-driver-r3.4.0 && \
+    sed -i 's/\"maxAwaitTimeMS\", count/\"maxAwaitTimeMS\", static_cast<int64_t>(count)/' src/mongocxx/options/change_stream.cpp && \
+    sed -i 's/add_subdirectory(test)//' src/mongocxx/CMakeLists.txt src/bsoncxx/CMakeLists.txt && \
+    cd build && \
+    cmake -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local -DCMAKE_TOOLCHAIN_FILE='/tmp/pinned_toolchain.cmake' .. && \
+    make -j$(nproc) && \
+    make install && \
+    cd / && \
+    rm -f mongo-cxx-driver-r3.4.0.tar.gz
 
 ENV PATH=${PATH}:/mongodb-linux-x86_64-ubuntu1604-3.6.3/bin
 
 # Build appropriate version of ccache.
-RUN curl -LO https://github.com/ccache/ccache/releases/download/v3.4.1/ccache-3.4.1.tar.gz \
-  && tar -xzf ccache-3.4.1.tar.gz \
-  && cd ccache-3.4.1 \
-  && ./configure \
-  && make \
-  && make install \
-  && cd / && rm -rf ccache-3.4.1/
+RUN curl -LO https://github.com/ccache/ccache/releases/download/v3.4.1/ccache-3.4.1.tar.gz && \
+    tar -xzf ccache-3.4.1.tar.gz && \
+    cd ccache-3.4.1 && \
+    ./configure && \
+    make && \
+    make install && \
+    cd / && rm -rf ccache-3.4.1/
 
-RUN echo "deb https://apt.buildkite.com/buildkite-agent stable main" > /etc/apt/sources.list.d/buildkite-agent.list \
-    && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198 \
-    && apt-get update && apt-get install -y buildkite-agent
+RUN echo "deb https://apt.buildkite.com/buildkite-agent stable main" > /etc/apt/sources.list.d/buildkite-agent.list && \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198 && \
+    apt-get update && apt-get install -y buildkite-agent
 
 # PRE_COMMANDS: Executed pre-cmake
 # CMAKE_EXTRAS: Executed right before the cmake path (on the end)

--- a/.cicd/docker/ubuntu-16.04.dockerfile
+++ b/.cicd/docker/ubuntu-16.04.dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu:16.04
-# APT-GET dependencies.
+# install dependencies
 RUN apt-get update && apt-get upgrade -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential git automake libbz2-dev libssl-dev doxygen graphviz libgmp3-dev autotools-dev libicu-dev python2.7 python2.7-dev python3 python3-dev autoconf libtool curl zlib1g-dev sudo ruby libusb-1.0-0-dev libcurl4-gnutls-dev pkg-config apt-transport-https
-# Build appropriate version of CMake.
+# build cmake
 RUN curl -LO https://cmake.org/files/v3.13/cmake-3.13.2.tar.gz && \
     tar -xzf cmake-3.13.2.tar.gz && \
     cd cmake-3.13.2 && \
@@ -11,7 +11,7 @@ RUN curl -LO https://cmake.org/files/v3.13/cmake-3.13.2.tar.gz && \
     make install && \
     cd .. && \
     rm -f cmake-3.13.2.tar.gz
-# Build appropriate version of Clang.
+# build clang
 RUN git clone --single-branch --branch release_80 https://git.llvm.org/git/llvm.git clang8 && cd clang8 && git checkout 18e41dc && \
     cd tools && git clone --single-branch --branch release_80 https://git.llvm.org/git/lld.git && cd lld && git checkout d60a035 && \
     cd ../ && git clone --single-branch --branch release_80 https://git.llvm.org/git/polly.git && cd polly && git checkout 1bc06e5 && \
@@ -26,8 +26,9 @@ RUN git clone --single-branch --branch release_80 https://git.llvm.org/git/llvm.
     make -j $(nproc) && \
     make install && \
     rm -rf /clang8
+# configure toolchain
 COPY ./docker/pinned_toolchain.cmake /tmp/pinned_toolchain.cmake
-# Build appropriate version of Boost.
+# build boost
 RUN curl -LO https://dl.bintray.com/boostorg/release/1.70.0/source/boost_1_70_0.tar.bz2 && \
     tar -xjf boost_1_70_0.tar.bz2 && \
     cd boost_1_70_0 && \
@@ -35,11 +36,11 @@ RUN curl -LO https://dl.bintray.com/boostorg/release/1.70.0/source/boost_1_70_0.
     ./b2 toolset=clang cxxflags='-stdlib=libc++ -D__STRICT_ANSI__ -nostdinc++ -I/usr/local/include/c++/v1' linkflags='-stdlib=libc++' link=static threading=multi --with-iostreams --with-date_time --with-filesystem --with-system --with-program_options --with-chrono --with-test -q -j$(nproc) install && \
     cd .. && \
     rm -f boost_1_70_0.tar.bz2    
-# Build appropriate version of MongoDB.
+# build mongodb
 RUN curl -LO http://downloads.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1604-3.6.3.tgz && \
     tar -xzf mongodb-linux-x86_64-ubuntu1604-3.6.3.tgz && \
     rm -f mongodb-linux-x86_64-ubuntu1604-3.6.3.tgz
-# Build appropriate version of MongoDB C Driver. 
+# build mongo c driver
 RUN curl -LO https://github.com/mongodb/mongo-c-driver/releases/download/1.13.0/mongo-c-driver-1.13.0.tar.gz && \
     tar -xzf mongo-c-driver-1.13.0.tar.gz && \
     cd mongo-c-driver-1.13.0 && \
@@ -50,7 +51,7 @@ RUN curl -LO https://github.com/mongodb/mongo-c-driver/releases/download/1.13.0/
     make install && \
     cd / && \
     rm -rf mongo-c-driver-1.13.0.tar.gz
-# Build appropriate version of MongoDB C++ driver.
+# build mongo c++ driver
 RUN curl -L https://github.com/mongodb/mongo-cxx-driver/archive/r3.4.0.tar.gz -o mongo-cxx-driver-r3.4.0.tar.gz && \
     tar -xzf mongo-cxx-driver-r3.4.0.tar.gz && \
     cd mongo-cxx-driver-r3.4.0 && \
@@ -62,8 +63,9 @@ RUN curl -L https://github.com/mongodb/mongo-cxx-driver/archive/r3.4.0.tar.gz -o
     make install && \
     cd / && \
     rm -f mongo-cxx-driver-r3.4.0.tar.gz
+# add mongodb to path
 ENV PATH=${PATH}:/mongodb-linux-x86_64-ubuntu1604-3.6.3/bin
-# Build appropriate version of ccache.
+# build ccache
 RUN curl -LO https://github.com/ccache/ccache/releases/download/v3.4.1/ccache-3.4.1.tar.gz && \
     tar -xzf ccache-3.4.1.tar.gz && \
     cd ccache-3.4.1 && \
@@ -71,13 +73,16 @@ RUN curl -LO https://github.com/ccache/ccache/releases/download/v3.4.1/ccache-3.
     make && \
     make install && \
     cd / && rm -rf ccache-3.4.1/
+# install buildkite-agent
 RUN echo "deb https://apt.buildkite.com/buildkite-agent stable main" > /etc/apt/sources.list.d/buildkite-agent.list && \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198 && \
-    apt-get update && apt-get install -y buildkite-agent
-# PRE_COMMANDS: Executed pre-cmake
-# CMAKE_EXTRAS: Executed right before the cmake path (on the end)
+    apt-get update && \
+    apt-get install -y buildkite-agent
+# PRE_COMMANDS is executed before cmake
 ENV PRE_COMMANDS="export PATH=/usr/lib/ccache:\$PATH"
+# CMAKE_EXTRAS is inserted at the end of the cmake command right before the ..
 ENV CMAKE_EXTRAS="$CMAKE_EXTRAS -DCMAKE_TOOLCHAIN_FILE='/tmp/pinned_toolchain.cmake' -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
-# Bring in helpers that provides execute function so we can get better logging in BK and TRAV
+# import logging libraries
 COPY ./docker/.logging-helpers /tmp/.helpers
+# runtime instructions
 CMD /workdir/.cicd/docker/entrypoint.sh

--- a/.cicd/docker/ubuntu-18.04.dockerfile
+++ b/.cicd/docker/ubuntu-18.04.dockerfile
@@ -78,4 +78,4 @@ CMD bash -c ". /tmp/.helpers && $PRE_COMMANDS && \
     if ${ENABLE_PARALLEL_TESTS:-true}; then fold-execute ctest -j$JOBS -LE _tests --output-on-failure -T Test; fi && \
     if ${ENABLE_SERIAL_TESTS:-true}; then mkdir -p ./mongodb && fold-execute mongod --dbpath ./mongodb --fork --logpath mongod.log && fold-execute ctest -L nonparallelizable_tests --output-on-failure -T Test; fi && \
     if ${ENABLE_LR_TESTS:-false}; then fold-execute ctest -L long_running_tests --output-on-failure -T Test; fi && \
-    if ! ${TRAVIS:-false}; then cd .. && ($(pgrep mongod | xargs kill -9) || :) && tar -pczf build.tar.gz build && buildkite-agent artifact upload build.tar.gz --agent-access-token $BUILDKITE_AGENT_ACCESS_TOKEN; fi"
+    if ! ${TRAVIS:-false}; then cd .. && if [[ $(pgrep mongod) ]]; then pgrep mongod | xargs kill -9; fi && tar -pczf build.tar.gz build && buildkite-agent artifact upload build.tar.gz --agent-access-token $BUILDKITE_AGENT_ACCESS_TOKEN; fi"

--- a/.cicd/docker/ubuntu-18.04.dockerfile
+++ b/.cicd/docker/ubuntu-18.04.dockerfile
@@ -78,4 +78,4 @@ CMD bash -c ". /tmp/.helpers && $PRE_COMMANDS && \
     if ${ENABLE_PARALLEL_TESTS:-true}; then fold-execute ctest -j$JOBS -LE _tests --output-on-failure -T Test; fi && \
     if ${ENABLE_SERIAL_TESTS:-true}; then mkdir -p ./mongodb && fold-execute mongod --dbpath ./mongodb --fork --logpath mongod.log && fold-execute ctest -L nonparallelizable_tests --output-on-failure -T Test; fi && \
     if ${ENABLE_LR_TESTS:-false}; then fold-execute ctest -L long_running_tests --output-on-failure -T Test; fi && \
-    if ! ${TRAVIS:-false}; then cd .. && tar -pczf build.tar.gz build && buildkite-agent artifact upload build.tar.gz --agent-access-token $BUILDKITE_AGENT_ACCESS_TOKEN; fi"
+    if ! ${TRAVIS:-false}; then cd .. && ($(pgrep mongod | xargs kill -9) || :) && tar -pczf build.tar.gz build && buildkite-agent artifact upload build.tar.gz --agent-access-token $BUILDKITE_AGENT_ACCESS_TOKEN; fi"

--- a/.cicd/docker/ubuntu-18.04.dockerfile
+++ b/.cicd/docker/ubuntu-18.04.dockerfile
@@ -1,10 +1,8 @@
 FROM ubuntu:18.04
-
 # APT-GET dependencies.
 RUN apt-get update && \
     apt-get upgrade -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y git make bzip2 automake libbz2-dev libssl-dev doxygen graphviz libgmp3-dev autotools-dev libicu-dev python2.7 python2.7-dev python3 python3-dev autoconf libtool g++ gcc curl zlib1g-dev sudo ruby libusb-1.0-0-dev libcurl4-gnutls-dev pkg-config patch llvm-4.0 clang ccache
-
 # Build appropriate version of CMake.
 RUN curl -LO https://cmake.org/files/v3.13/cmake-3.13.2.tar.gz && \
     tar -xzf cmake-3.13.2.tar.gz && \
@@ -14,7 +12,6 @@ RUN curl -LO https://cmake.org/files/v3.13/cmake-3.13.2.tar.gz && \
     make install && \
     cd .. && \
     rm -f cmake-3.13.2.tar.gz
-
 # Build appropriate version of Boost.
 RUN curl -LO https://dl.bintray.com/boostorg/release/1.70.0/source/boost_1_70_0.tar.bz2 && \
     tar -xjf boost_1_70_0.tar.bz2 && \
@@ -23,12 +20,10 @@ RUN curl -LO https://dl.bintray.com/boostorg/release/1.70.0/source/boost_1_70_0.
     ./b2 --with-iostreams --with-date_time --with-filesystem --with-system --with-program_options --with-chrono --with-test -j$(nproc) install && \
     cd .. && \
     rm -f boost_1_70_0.tar.bz2     
-
 # Build appropriate version of MongoDB.
 RUN curl -LO http://downloads.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1804-4.1.1.tgz && \
     tar -xzf mongodb-linux-x86_64-ubuntu1804-4.1.1.tgz && \
     rm -f mongodb-linux-x86_64-ubuntu1804-4.1.1.tgz
-
 # Build appropriate version of MongoDB C Driver. 
 RUN curl -LO https://github.com/mongodb/mongo-c-driver/releases/download/1.13.0/mongo-c-driver-1.13.0.tar.gz && \
     tar -xzf mongo-c-driver-1.13.0.tar.gz && \
@@ -40,7 +35,6 @@ RUN curl -LO https://github.com/mongodb/mongo-c-driver/releases/download/1.13.0/
     make install && \
     cd / && \
     rm -rf mongo-c-driver-1.13.0.tar.gz
-
 # Build appropriate version of MongoDB C++ driver.
 RUN curl -L https://github.com/mongodb/mongo-cxx-driver/archive/r3.4.0.tar.gz -o mongo-cxx-driver-r3.4.0.tar.gz && \
     tar -xzf mongo-cxx-driver-r3.4.0.tar.gz && \
@@ -53,21 +47,16 @@ RUN curl -L https://github.com/mongodb/mongo-cxx-driver/archive/r3.4.0.tar.gz -o
     make install && \
     cd / && \
     rm -f mongo-cxx-driver-r3.4.0.tar.gz
-
 ENV PATH=${PATH}:/mongodb-linux-x86_64-ubuntu1804-4.1.1/bin
-
 RUN echo "deb https://apt.buildkite.com/buildkite-agent stable main" > /etc/apt/sources.list.d/buildkite-agent.list && \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198 && \
     apt-get update && \
 	apt-get install -y apt-transport-https && \
 	apt-get install -y buildkite-agent
-
 # PRE_COMMANDS: Executed pre-cmake
 # CMAKE_EXTRAS: Executed right before the cmake path (on the end)
 ENV PRE_COMMANDS="export PATH=/usr/lib/ccache:\$PATH"
 ENV CMAKE_EXTRAS="-DCMAKE_CXX_COMPILER='clang++' -DCMAKE_C_COMPILER='clang'"
-
 # Bring in helpers that provides execute function so we can get better logging in BK and TRAV
 COPY ./docker/.logging-helpers /tmp/.helpers
-
 CMD /workdir/.cicd/docker/entrypoint.sh

--- a/.cicd/docker/ubuntu-18.04.dockerfile
+++ b/.cicd/docker/ubuntu-18.04.dockerfile
@@ -71,11 +71,4 @@ ENV CMAKE_EXTRAS="-DCMAKE_CXX_COMPILER='clang++' -DCMAKE_C_COMPILER='clang'"
 # Bring in helpers that provides execute function so we can get better logging in BK and TRAV
 COPY ./docker/.logging-helpers /tmp/.helpers
 
-CMD bash -c ". /tmp/.helpers && $PRE_COMMANDS && \
-    fold-execute ccache -s && \
-    mkdir /workdir/build && cd /workdir/build && fold-execute cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true $CMAKE_EXTRAS /workdir && \
-    fold-execute make -j $JOBS && \
-    if ${ENABLE_PARALLEL_TESTS:-true}; then fold-execute ctest -j$JOBS -LE _tests --output-on-failure -T Test; fi && \
-    if ${ENABLE_SERIAL_TESTS:-true}; then mkdir -p ./mongodb && fold-execute mongod --dbpath ./mongodb --fork --logpath mongod.log && fold-execute ctest -L nonparallelizable_tests --output-on-failure -T Test; fi && \
-    if ${ENABLE_LR_TESTS:-false}; then fold-execute ctest -L long_running_tests --output-on-failure -T Test; fi && \
-    if ! ${TRAVIS:-false}; then cd .. && if [[ $(pgrep mongod) ]]; then pgrep mongod | xargs kill -9; fi && tar -pczf build.tar.gz build && buildkite-agent artifact upload build.tar.gz --agent-access-token $BUILDKITE_AGENT_ACCESS_TOKEN; fi"
+CMD /workdir/.cicd/docker/entrypoint.sh

--- a/.cicd/docker/ubuntu-18.04.dockerfile
+++ b/.cicd/docker/ubuntu-18.04.dockerfile
@@ -1,9 +1,9 @@
 FROM ubuntu:18.04
-# APT-GET dependencies.
+# install dependencies
 RUN apt-get update && \
     apt-get upgrade -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y git make bzip2 automake libbz2-dev libssl-dev doxygen graphviz libgmp3-dev autotools-dev libicu-dev python2.7 python2.7-dev python3 python3-dev autoconf libtool g++ gcc curl zlib1g-dev sudo ruby libusb-1.0-0-dev libcurl4-gnutls-dev pkg-config patch llvm-4.0 clang ccache
-# Build appropriate version of CMake.
+# build cmake
 RUN curl -LO https://cmake.org/files/v3.13/cmake-3.13.2.tar.gz && \
     tar -xzf cmake-3.13.2.tar.gz && \
     cd cmake-3.13.2 && \
@@ -12,7 +12,7 @@ RUN curl -LO https://cmake.org/files/v3.13/cmake-3.13.2.tar.gz && \
     make install && \
     cd .. && \
     rm -f cmake-3.13.2.tar.gz
-# Build appropriate version of Boost.
+# build boost
 RUN curl -LO https://dl.bintray.com/boostorg/release/1.70.0/source/boost_1_70_0.tar.bz2 && \
     tar -xjf boost_1_70_0.tar.bz2 && \
     cd boost_1_70_0 && \
@@ -20,11 +20,11 @@ RUN curl -LO https://dl.bintray.com/boostorg/release/1.70.0/source/boost_1_70_0.
     ./b2 --with-iostreams --with-date_time --with-filesystem --with-system --with-program_options --with-chrono --with-test -j$(nproc) install && \
     cd .. && \
     rm -f boost_1_70_0.tar.bz2     
-# Build appropriate version of MongoDB.
+# build mongodb
 RUN curl -LO http://downloads.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1804-4.1.1.tgz && \
     tar -xzf mongodb-linux-x86_64-ubuntu1804-4.1.1.tgz && \
     rm -f mongodb-linux-x86_64-ubuntu1804-4.1.1.tgz
-# Build appropriate version of MongoDB C Driver. 
+# build mongo c driver
 RUN curl -LO https://github.com/mongodb/mongo-c-driver/releases/download/1.13.0/mongo-c-driver-1.13.0.tar.gz && \
     tar -xzf mongo-c-driver-1.13.0.tar.gz && \
     cd mongo-c-driver-1.13.0 && \
@@ -35,7 +35,7 @@ RUN curl -LO https://github.com/mongodb/mongo-c-driver/releases/download/1.13.0/
     make install && \
     cd / && \
     rm -rf mongo-c-driver-1.13.0.tar.gz
-# Build appropriate version of MongoDB C++ driver.
+# build mongo c++ driver
 RUN curl -L https://github.com/mongodb/mongo-cxx-driver/archive/r3.4.0.tar.gz -o mongo-cxx-driver-r3.4.0.tar.gz && \
     tar -xzf mongo-cxx-driver-r3.4.0.tar.gz && \
     cd mongo-cxx-driver-r3.4.0 && \
@@ -47,16 +47,19 @@ RUN curl -L https://github.com/mongodb/mongo-cxx-driver/archive/r3.4.0.tar.gz -o
     make install && \
     cd / && \
     rm -f mongo-cxx-driver-r3.4.0.tar.gz
+# add mongodb to path
 ENV PATH=${PATH}:/mongodb-linux-x86_64-ubuntu1804-4.1.1/bin
+# install buildkite-agent
 RUN echo "deb https://apt.buildkite.com/buildkite-agent stable main" > /etc/apt/sources.list.d/buildkite-agent.list && \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198 && \
     apt-get update && \
-	apt-get install -y apt-transport-https && \
-	apt-get install -y buildkite-agent
-# PRE_COMMANDS: Executed pre-cmake
-# CMAKE_EXTRAS: Executed right before the cmake path (on the end)
+	  apt-get install -y apt-transport-https && \
+	  apt-get install -y buildkite-agent
+# PRE_COMMANDS is executed before cmake
 ENV PRE_COMMANDS="export PATH=/usr/lib/ccache:\$PATH"
+# CMAKE_EXTRAS is inserted at the end of the cmake command right before the ..
 ENV CMAKE_EXTRAS="-DCMAKE_CXX_COMPILER='clang++' -DCMAKE_C_COMPILER='clang'"
-# Bring in helpers that provides execute function so we can get better logging in BK and TRAV
+# import logging libraries
 COPY ./docker/.logging-helpers /tmp/.helpers
+# runtime instructions
 CMD /workdir/.cicd/docker/entrypoint.sh

--- a/.cicd/docker/ubuntu-18.04.dockerfile
+++ b/.cicd/docker/ubuntu-18.04.dockerfile
@@ -1,67 +1,66 @@
 FROM ubuntu:18.04
 
 # APT-GET dependencies.
-RUN apt-get update && apt-get upgrade -y \
-  && DEBIAN_FRONTEND=noninteractive apt-get install -y git make \
-  bzip2 automake libbz2-dev libssl-dev doxygen graphviz libgmp3-dev \
-  autotools-dev libicu-dev python2.7 python2.7-dev python3 python3-dev \
-  autoconf libtool g++ gcc curl zlib1g-dev sudo ruby libusb-1.0-0-dev \
-  libcurl4-gnutls-dev pkg-config patch llvm-4.0 clang ccache
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y git make bzip2 automake libbz2-dev libssl-dev doxygen graphviz libgmp3-dev autotools-dev libicu-dev python2.7 python2.7-dev python3 python3-dev autoconf libtool g++ gcc curl zlib1g-dev sudo ruby libusb-1.0-0-dev libcurl4-gnutls-dev pkg-config patch llvm-4.0 clang ccache
 
 # Build appropriate version of CMake.
-RUN curl -LO https://cmake.org/files/v3.13/cmake-3.13.2.tar.gz \
-  && tar -xzf cmake-3.13.2.tar.gz \
-  && cd cmake-3.13.2 \
-  && ./bootstrap --prefix=/usr/local \
-  && make -j$(nproc) \
-  && make install \
-  && cd .. \
-  && rm -f cmake-3.13.2.tar.gz
+RUN curl -LO https://cmake.org/files/v3.13/cmake-3.13.2.tar.gz && \
+    tar -xzf cmake-3.13.2.tar.gz && \
+    cd cmake-3.13.2 && \
+    ./bootstrap --prefix=/usr/local && \
+    make -j$(nproc) && \
+    make install && \
+    cd .. && \
+    rm -f cmake-3.13.2.tar.gz
 
 # Build appropriate version of Boost.
-RUN curl -LO https://dl.bintray.com/boostorg/release/1.70.0/source/boost_1_70_0.tar.bz2 \
-  && tar -xjf boost_1_70_0.tar.bz2 \
-  && cd boost_1_70_0 \
-  && ./bootstrap.sh --prefix=/usr/local \
-  && ./b2 --with-iostreams --with-date_time --with-filesystem --with-system --with-program_options --with-chrono --with-test -j$(nproc) install \
-  && cd .. \
-  && rm -f boost_1_70_0.tar.bz2     
+RUN curl -LO https://dl.bintray.com/boostorg/release/1.70.0/source/boost_1_70_0.tar.bz2 && \
+    tar -xjf boost_1_70_0.tar.bz2 && \
+    cd boost_1_70_0 && \
+    ./bootstrap.sh --prefix=/usr/local && \
+    ./b2 --with-iostreams --with-date_time --with-filesystem --with-system --with-program_options --with-chrono --with-test -j$(nproc) install && \
+    cd .. && \
+    rm -f boost_1_70_0.tar.bz2     
 
 # Build appropriate version of MongoDB.
-RUN curl -LO http://downloads.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1804-4.1.1.tgz \
-  && tar -xzf mongodb-linux-x86_64-ubuntu1804-4.1.1.tgz \
-  && rm -f mongodb-linux-x86_64-ubuntu1804-4.1.1.tgz
+RUN curl -LO http://downloads.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1804-4.1.1.tgz && \
+    tar -xzf mongodb-linux-x86_64-ubuntu1804-4.1.1.tgz && \
+    rm -f mongodb-linux-x86_64-ubuntu1804-4.1.1.tgz
 
 # Build appropriate version of MongoDB C Driver. 
-RUN curl -LO https://github.com/mongodb/mongo-c-driver/releases/download/1.13.0/mongo-c-driver-1.13.0.tar.gz \
-  && tar -xzf mongo-c-driver-1.13.0.tar.gz \
-  && cd mongo-c-driver-1.13.0 \
-  && mkdir -p build \
-  && cd build \
-  && cmake --DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local -DENABLE_BSON=ON -DENABLE_SSL=OPENSSL -DENABLE_AUTOMATIC_INIT_AND_CLEANUP=OFF -DENABLE_STATIC=ON .. \
-  && make -j$(nproc) \
-  && make install \
-  && cd / \
-  && rm -rf mongo-c-driver-1.13.0.tar.gz
+RUN curl -LO https://github.com/mongodb/mongo-c-driver/releases/download/1.13.0/mongo-c-driver-1.13.0.tar.gz && \
+    tar -xzf mongo-c-driver-1.13.0.tar.gz && \
+    cd mongo-c-driver-1.13.0 && \
+    mkdir -p build && \
+    cd build && \
+    cmake --DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local -DENABLE_BSON=ON -DENABLE_SSL=OPENSSL -DENABLE_AUTOMATIC_INIT_AND_CLEANUP=OFF -DENABLE_STATIC=ON .. && \
+    make -j$(nproc) && \
+    make install && \
+    cd / && \
+    rm -rf mongo-c-driver-1.13.0.tar.gz
 
 # Build appropriate version of MongoDB C++ driver.
-RUN curl -L https://github.com/mongodb/mongo-cxx-driver/archive/r3.4.0.tar.gz -o mongo-cxx-driver-r3.4.0.tar.gz \
-  && tar -xzf mongo-cxx-driver-r3.4.0.tar.gz \
-  && cd mongo-cxx-driver-r3.4.0 \
-  && sed -i 's/\"maxAwaitTimeMS\", count/\"maxAwaitTimeMS\", static_cast<int64_t>(count)/' src/mongocxx/options/change_stream.cpp \
-  && sed -i 's/add_subdirectory(test)//' src/mongocxx/CMakeLists.txt src/bsoncxx/CMakeLists.txt \
-  && cd build \
-  && cmake -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local .. \
-  && make -j$(nproc) \
-  && make install \
-  && cd / \
-  && rm -f mongo-cxx-driver-r3.4.0.tar.gz
+RUN curl -L https://github.com/mongodb/mongo-cxx-driver/archive/r3.4.0.tar.gz -o mongo-cxx-driver-r3.4.0.tar.gz && \
+    tar -xzf mongo-cxx-driver-r3.4.0.tar.gz && \
+    cd mongo-cxx-driver-r3.4.0 && \
+    sed -i 's/\"maxAwaitTimeMS\", count/\"maxAwaitTimeMS\", static_cast<int64_t>(count)/' src/mongocxx/options/change_stream.cpp && \
+    sed -i 's/add_subdirectory(test)//' src/mongocxx/CMakeLists.txt src/bsoncxx/CMakeLists.txt && \
+    cd build && \
+    cmake -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local .. && \
+    make -j$(nproc) && \
+    make install && \
+    cd / && \
+    rm -f mongo-cxx-driver-r3.4.0.tar.gz
 
 ENV PATH=${PATH}:/mongodb-linux-x86_64-ubuntu1804-4.1.1/bin
 
-RUN echo "deb https://apt.buildkite.com/buildkite-agent stable main" > /etc/apt/sources.list.d/buildkite-agent.list \
-    && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198 \
-    && apt-get update && apt-get install -y apt-transport-https && apt-get install -y buildkite-agent
+RUN echo "deb https://apt.buildkite.com/buildkite-agent stable main" > /etc/apt/sources.list.d/buildkite-agent.list && \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198 && \
+    apt-get update && \
+	apt-get install -y apt-transport-https && \
+	apt-get install -y buildkite-agent
 
 # PRE_COMMANDS: Executed pre-cmake
 # CMAKE_EXTRAS: Executed right before the cmake path (on the end)

--- a/.cicd/travis/travis-build.sh
+++ b/.cicd/travis/travis-build.sh
@@ -15,5 +15,5 @@ if [[ "$(uname)" == Darwin ]]; then
     if ${ENABLE_LR_TESTS:-false}; then fold-execute ctest -L long_running_tests --output-on-failure -T Test; fi
 else # linux
     DOCKER_RUN_EXTRAS="-e ENABLE_PACKAGE_BUILDER=false" # Travis doesn't need to test or push packages
-    execute eval docker run --rm -v $(pwd):/workdir -v /usr/lib/ccache -v $HOME/.ccache:/opt/.ccache -e JOBS -e CCACHE_DIR=/opt/.ccache -e TRAVIS $DOCKER_RUN_EXTRAS $FULL_TAG
+    execute eval docker run --rm -v $(pwd):/workdir -v $HOME/.ccache:/opt/.ccache -e JOBS -e CCACHE_DIR=/opt/.ccache -e TRAVIS $DOCKER_RUN_EXTRAS $FULL_TAG
 fi

--- a/.cicd/travis/travis-build.sh
+++ b/.cicd/travis/travis-build.sh
@@ -15,5 +15,5 @@ if [[ "$(uname)" == Darwin ]]; then
     if ${ENABLE_LR_TESTS:-false}; then fold-execute ctest -L long_running_tests --output-on-failure -T Test; fi
 else # linux
     DOCKER_RUN_EXTRAS="-e ENABLE_PACKAGE_BUILDER=false" # Travis doesn't need to test or push packages
-    execute eval docker run --rm -v $(pwd):/workdir -v $HOME/.ccache:/opt/.ccache -e JOBS -e CCACHE_DIR=/opt/.ccache -e TRAVIS $DOCKER_RUN_EXTRAS $FULL_TAG
+    execute eval docker run --rm -v $(pwd):/workdir -v /usr/lib/ccache -v $HOME/.ccache:/opt/.ccache -e JOBS -e CCACHE_DIR=/opt/.ccache -e TRAVIS $DOCKER_RUN_EXTRAS $FULL_TAG
 fi


### PR DESCRIPTION
## Change Description
While pulling test metrics for [my work](https://github.com/EOSIO/eos/pull/7697) on the `db_modes_test`, I found two errors on eosio-beta [build 593](https://buildkite.com/EOSIO/eosio-beta/builds/563#d2441c03-beb4-4600-9545-82f26f35fcd5/1104-1139) and [build 598](https://buildkite.com/EOSIO/eosio-beta/builds/598#6a087cb3-32fb-406b-9802-1ea3212f96b2/1123-1158) which have the same error message:
```
100% tests passed, 0 tests failed out of 12

Label Time Summary:
nonparallelizable_tests    = 819.67 sec*proc (12 tests)

Total Test time (real) = 819.81 sec 
tar: build/mongodb/journal/WiredTigerLog.0000000001: file changed as we read it 
🚨 Error: The command exited with status 1
```

To fix this, I kill mongoDB before creating the `build.tar.gz` artifact.   
   
### Update
I kept getting obtuse failures in Travis CI, like [this](https://travis-ci.com/EOSIO/eos/jobs/222602651#L239), where the same code [ran just fine in Buildkite](https://buildkite.com/EOSIO/eosio-beta/builds/706#1bacd83a-0efb-43cf-96fa-039c059e5305). To side-step these issues, I moved all of the run code into an `entrypoint.sh` like in eos-vm. While doing this, I also spent a little time cleaning up the Dockerfiles, which were a mess.

### Tested
Note that tests are also failing on `eos:trav-poc` for [Travis CI](https://travis-ci.com/EOSIO/eos/builds/122174763) but [not Buildkite](https://buildkite.com/EOSIO/eosio-beta/builds/744). I recommend that we merge this pull request and consider the "Travis Beta: mongodb tar" service item done, and open a new service item to fix ccache.  
  
Buildkite [build 735](https://buildkite.com/EOSIO/eosio-beta/builds/735) and Travis CI [build 4087](https://travis-ci.com/EOSIO/eos/builds/122148054).

## Consensus Changes
- [ ] Consensus Changes
None.

## API Changes
- [ ] API Changes
None.

## Documentation Additions
- [ ] Documentation Additions
None.