### PR TITLE
Kill mongoDB Before Creating the build.tar.gz Artifact

### DIFF
--- a/.cicd/docker/amazonlinux-2.dockerfile
+++ b/.cicd/docker/amazonlinux-2.dockerfile
@@ -87,8 +87,9 @@ COPY ./docker/.logging-helpers /tmp/.helpers
 CMD bash -c ". /tmp/.helpers && $PRE_COMMANDS && \
     fold-execute ccache -s && \
     mkdir /workdir/build && cd /workdir/build && fold-execute cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true $CMAKE_EXTRAS /workdir && \
-    fold-execute make -j$JOBS && \
+    fold-execute make -j $JOBS && \
     if ${ENABLE_PARALLEL_TESTS:-true}; then fold-execute ctest -j$JOBS -LE _tests --output-on-failure -T Test; fi && \
     if ${ENABLE_SERIAL_TESTS:-true}; then mkdir -p ./mongodb && fold-execute mongod --dbpath ./mongodb --fork --logpath mongod.log && fold-execute ctest -L nonparallelizable_tests --output-on-failure -T Test; fi && \
     if ${ENABLE_LR_TESTS:-false}; then fold-execute ctest -L long_running_tests --output-on-failure -T Test; fi && \
-    if ! ${TRAVIS:-false}; then cd .. && tar -pczf build.tar.gz build && buildkite-agent artifact upload build.tar.gz --agent-access-token $BUILDKITE_AGENT_ACCESS_TOKEN; fi"
+    if ! ${TRAVIS:-false}; then cd .. && echo $(pkill mongod || :) && tar -pczf build.tar.gz build && buildkite-agent artifact upload build.tar.gz --agent-access-token $BUILDKITE_AGENT_ACCESS_TOKEN; fi && \
+    if ${ENABLE_INSTALL:-false}; then fold-execute make install; fi"

--- a/.cicd/docker/centos-7.6.dockerfile
+++ b/.cicd/docker/centos-7.6.dockerfile
@@ -102,8 +102,9 @@ COPY ./docker/.logging-helpers /tmp/.helpers
 CMD bash -c ". /tmp/.helpers && $PRE_COMMANDS && \
     fold-execute ccache -s && \
     mkdir /workdir/build && cd /workdir/build && fold-execute cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true $CMAKE_EXTRAS /workdir && \
-    fold-execute make -j$JOBS && \
+    fold-execute make -j $JOBS && \
     if ${ENABLE_PARALLEL_TESTS:-true}; then fold-execute ctest -j$JOBS -LE _tests --output-on-failure -T Test; fi && \
     if ${ENABLE_SERIAL_TESTS:-true}; then mkdir -p ./mongodb && fold-execute mongod --dbpath ./mongodb --fork --logpath mongod.log && fold-execute ctest -L nonparallelizable_tests --output-on-failure -T Test; fi && \
     if ${ENABLE_LR_TESTS:-false}; then fold-execute ctest -L long_running_tests --output-on-failure -T Test; fi && \
-    if ! ${TRAVIS:-false}; then cd .. && tar -pczf build.tar.gz build && buildkite-agent artifact upload build.tar.gz --agent-access-token $BUILDKITE_AGENT_ACCESS_TOKEN; fi"
+    if ! ${TRAVIS:-false}; then cd .. && echo $(pkill mongod || :) && tar -pczf build.tar.gz build && buildkite-agent artifact upload build.tar.gz --agent-access-token $BUILDKITE_AGENT_ACCESS_TOKEN; fi && \
+    if ${ENABLE_INSTALL:-false}; then fold-execute make install; fi"

--- a/.cicd/docker/ubuntu-16.04.dockerfile
+++ b/.cicd/docker/ubuntu-16.04.dockerfile
@@ -97,8 +97,9 @@ COPY ./docker/.logging-helpers /tmp/.helpers
 CMD bash -c ". /tmp/.helpers && $PRE_COMMANDS && \
     fold-execute ccache -s && \
     mkdir /workdir/build && cd /workdir/build && fold-execute cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true $CMAKE_EXTRAS /workdir && \
-    fold-execute make -j$JOBS && \
+    fold-execute make -j $JOBS && \
     if ${ENABLE_PARALLEL_TESTS:-true}; then fold-execute ctest -j$JOBS -LE _tests --output-on-failure -T Test; fi && \
     if ${ENABLE_SERIAL_TESTS:-true}; then mkdir -p ./mongodb && fold-execute mongod --dbpath ./mongodb --fork --logpath mongod.log && fold-execute ctest -L nonparallelizable_tests --output-on-failure -T Test; fi && \
     if ${ENABLE_LR_TESTS:-false}; then fold-execute ctest -L long_running_tests --output-on-failure -T Test; fi && \
-    if ! ${TRAVIS:-false}; then cd .. && tar -pczf build.tar.gz build && buildkite-agent artifact upload build.tar.gz --agent-access-token $BUILDKITE_AGENT_ACCESS_TOKEN; fi"
+    if ! ${TRAVIS:-false}; then cd .. && echo $(pkill mongod || :) && tar -pczf build.tar.gz build && buildkite-agent artifact upload build.tar.gz --agent-access-token $BUILDKITE_AGENT_ACCESS_TOKEN; fi && \
+    if ${ENABLE_INSTALL:-false}; then fold-execute make install; fi"

--- a/.cicd/docker/ubuntu-18.04.dockerfile
+++ b/.cicd/docker/ubuntu-18.04.dockerfile
@@ -78,5 +78,5 @@ CMD bash -c ". /tmp/.helpers && $PRE_COMMANDS && \
     if ${ENABLE_PARALLEL_TESTS:-true}; then fold-execute ctest -j$JOBS -LE _tests --output-on-failure -T Test; fi && \
     if ${ENABLE_SERIAL_TESTS:-true}; then mkdir -p ./mongodb && fold-execute mongod --dbpath ./mongodb --fork --logpath mongod.log && fold-execute ctest -L nonparallelizable_tests --output-on-failure -T Test; fi && \
     if ${ENABLE_LR_TESTS:-false}; then fold-execute ctest -L long_running_tests --output-on-failure -T Test; fi && \
-    if ! ${TRAVIS:-false}; then cd .. && tar -pczf build.tar.gz build && buildkite-agent artifact upload build.tar.gz --agent-access-token $BUILDKITE_AGENT_ACCESS_TOKEN; fi && \
+    if ! ${TRAVIS:-false}; then cd .. && echo $(pkill mongod || :) && tar -pczf build.tar.gz build && buildkite-agent artifact upload build.tar.gz --agent-access-token $BUILDKITE_AGENT_ACCESS_TOKEN; fi && \
     if ${ENABLE_INSTALL:-false}; then fold-execute make install; fi"

--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -73,7 +73,7 @@ steps:
       - "if ${ENABLE_PARALLEL_TESTS:-true}; then cd eos/build && ctest -j$(getconf _NPROCESSORS_ONLN) -LE _tests --output-on-failure -T Test; fi"
       - "if ${ENABLE_SERIAL_TESTS:-true}; then cd eos/build && mkdir -p ./mongodb && mongod --dbpath ./mongodb --fork --logpath mongod.log && ctest -L nonparallelizable_tests --output-on-failure -T Test; fi"
       - "if ${ENABLE_LR_TESTS:-false}; then cd eos/build && ctest -L long_running_tests --output-on-failure -T Test; fi"
-      - "cd eos && tar -pczf build.tar.gz build && buildkite-agent artifact upload build.tar.gz"
+      - "cd eos && echo $(pkill mongod || :) && tar -pczf build.tar.gz build && buildkite-agent artifact upload build.tar.gz"
     plugins:
       - chef/anka#v0.5.1:
           no-volume: true

--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -15,7 +15,7 @@ steps:
     plugins:
       - docker#v3.2.0:
           debug: $DEBUG
-          image: "eosio/producer:eosio-amazonlinux-2-2f50b90dc0587a1bb96f8001891fc54efc81b11e"
+          image: "eosio/producer:eosio-amazonlinux-2-d89cfcba2c5002f7c79e5f2ea07d9f514b960fcd"
           environment:
             - "BUILDKITE_AGENT_ACCESS_TOKEN" # Needed for buildkite-agent upload/download
             - "JOBS" # Number for -j make/ctest args.
@@ -30,7 +30,7 @@ steps:
     plugins:
       - docker#v3.2.0:
           debug: true
-          image: "eosio/producer:eosio-centos-7.6-3d1cc1fb9f1681a5d8dc0b2e6425407c37d8fff6"
+          image: "eosio/producer:eosio-centos-7.6-8837beff70f9bb04717630bdeb3a29ff984ae985"
           environment:
             # - "ENABLE_LR_TESTS=true"
             - "BUILDKITE_AGENT_ACCESS_TOKEN" # Needed for buildkite-agent upload/download
@@ -44,7 +44,7 @@ steps:
     plugins:
       - docker#v3.2.0:
           debug: $DEBUG
-          image: "eosio/producer:eosio-ubuntu-16.04-1837c2968d507ca2d73ab0ae8963c9dbb4275048"
+          image: "eosio/producer:eosio-ubuntu-16.04-a86f678994109fd09a13468f9b8f5ebf10b48a6b"
           environment:
             - "BUILDKITE_AGENT_ACCESS_TOKEN" # Needed for buildkite-agent upload/download
             - "JOBS" # Number for -j make/ctest args.
@@ -57,7 +57,7 @@ steps:
     plugins:
       - docker#v3.2.0:
           debug: $DEBUG
-          image: "eosio/producer:eosio-ubuntu-18.04-b6f49042288158f36dfa668ac15300f6ed9750fb"
+          image: "eosio/producer:eosio-ubuntu-18.04-d1248048f40158965ff9876c0c21ac728bb82da6"
           environment:
             - "BUILDKITE_AGENT_ACCESS_TOKEN" # Needed for buildkite-agent upload/download
             - "JOBS" # Number for -j make/ctest args.
@@ -122,7 +122,7 @@ steps:
     plugins:
       - docker#v3.2.0:
           debug: true
-          image: "eosio/producer:eosio-centos-7.6-3d1cc1fb9f1681a5d8dc0b2e6425407c37d8fff6"
+          image: "eosio/producer:eosio-centos-7.6-8837beff70f9bb04717630bdeb3a29ff984ae985"
           environment:
             - "BUILDKITE_AGENT_ACCESS_TOKEN" # Needed for buildkite-agent upload/download
           mount-buildkite-agent: false # Mounting bk-agent doesn't work, so disable it
@@ -138,7 +138,7 @@ steps:
     plugins:
       - docker#v3.2.0:
           debug: $DEBUG
-          image: "eosio/producer:eosio-ubuntu-16.04-1837c2968d507ca2d73ab0ae8963c9dbb4275048"
+          image: "eosio/producer:eosio-ubuntu-16.04-a86f678994109fd09a13468f9b8f5ebf10b48a6b"
           environment:
             - "BUILDKITE_AGENT_ACCESS_TOKEN" # Needed for buildkite-agent upload/download
           mount-buildkite-agent: false # Mounting bk-agent doesn't work, so disable it
@@ -154,7 +154,7 @@ steps:
     plugins:
       - docker#v3.2.0:
           debug: $DEBUG
-          image: "eosio/producer:eosio-ubuntu-18.04-ccb89fe03979636296d4999e09ce8a49a23e3059"
+          image: "eosio/producer:eosio-ubuntu-18.04-d1248048f40158965ff9876c0c21ac728bb82da6"
           environment:
             - "BUILDKITE_AGENT_ACCESS_TOKEN" # Needed for buildkite-agent upload/download
           mount-buildkite-agent: false # Mounting bk-agent doesn't work, so disable it


### PR DESCRIPTION
## Change Description
While pulling test metrics for [my work](https://github.com/EOSIO/eos/pull/7697) on the `db_modes_test`, I found two errors on eosio-beta [build 593](https://buildkite.com/EOSIO/eosio-beta/builds/563#d2441c03-beb4-4600-9545-82f26f35fcd5/1104-1139) and [build 598](https://buildkite.com/EOSIO/eosio-beta/builds/598#6a087cb3-32fb-406b-9802-1ea3212f96b2/1123-1158) which have the same error message:
```
100% tests passed, 0 tests failed out of 12

Label Time Summary:
nonparallelizable_tests    = 819.67 sec*proc (12 tests)

Total Test time (real) = 819.81 sec 
tar: build/mongodb/journal/WiredTigerLog.0000000001: file changed as we read it 
🚨 Error: The command exited with status 1
```

To fix this, we can kill mongoDB before creating the `build.tar.gz` artifact.   
  
### Tested
Images built and pushed locally.
- Base Images [build 779](https://buildkite.com/EOSIO/eosio-base-images-beta/builds/779) -- image already exists
- Buildkite [build 784](https://buildkite.com/EOSIO/eosio-beta/builds/784)
- Travis CI [build 4097](https://travis-ci.com/EOSIO/eos/builds/122338474)

## Consensus Changes
- [ ] Consensus Changes
None.

## API Changes
- [ ] API Changes
None.

## Documentation Additions
- [ ] Documentation Additions
None.