### PR TITLE
unit test ensuring that OOB table init allowed on set code; fails on action

### DIFF
--- a/unittests/contracts/test_wasts.hpp
+++ b/unittests/contracts/test_wasts.hpp
@@ -439,6 +439,38 @@ static const char table_checker_small_wast[] = R"=====(
 )
 )=====";
 
+static const char table_init_oob_wast[] = R"=====(
+(module
+ (type $mahsig (func (param i64) (param i64) (param i64)))
+ (table 1024 anyfunc)
+ (export "apply" (func $apply))
+ (func $apply (param $0 i64) (param $1 i64) (param $2 i64)
+ )
+ (elem (i32.const 1024) $apply)
+)
+)=====";
+
+static const char table_init_oob_smaller_wast[] = R"=====(
+(module
+ (type $mahsig (func (param i64) (param i64) (param i64)))
+ (table 620 anyfunc)
+ (export "apply" (func $apply))
+ (func $apply (param $0 i64) (param $1 i64) (param $2 i64)
+ )
+ (elem (i32.const 700) $apply)
+)
+)=====";
+
+static const char table_init_oob_no_table_wast[] = R"=====(
+(module
+ (type $mahsig (func (param i64) (param i64) (param i64)))
+ (export "apply" (func $apply))
+ (func $apply (param $0 i64) (param $1 i64) (param $2 i64)
+ )
+ (elem (i32.const 0) $apply)
+)
+)=====";
+
 static const char global_protection_none_get_wast[] = R"=====(
 (module
  (export "apply" (func $apply))

--- a/unittests/wasm_tests.cpp
+++ b/unittests/wasm_tests.cpp
@@ -702,9 +702,7 @@ BOOST_FIXTURE_TEST_CASE( table_init_oob, TESTER ) try {
       
       //the unspecified_exception_code comes from WAVM, which manages to throw a WAVM specific exception
       // up to where exec_one captures it and doesn't understand it
-      BOOST_CHECK_EXCEPTION(push_transaction(trx), fc::exception, [](auto& e) {
-         return e.code() == unspecified_exception_code || e.code() == wasm_execution_error::code_value;
-      });
+      BOOST_CHECK_THROW(push_transaction(trx), eosio::chain::wasm_execution_error);
    };
 
    set_code(N(tableinitoob), table_init_oob_wast);

--- a/unittests/wasm_tests.cpp
+++ b/unittests/wasm_tests.cpp
@@ -686,6 +686,44 @@ BOOST_FIXTURE_TEST_CASE( table_init_tests, TESTER ) try {
 
 } FC_LOG_AND_RETHROW()
 
+BOOST_FIXTURE_TEST_CASE( table_init_oob, TESTER ) try {
+   create_accounts( {N(tableinitoob)} );
+   produce_block();
+
+   signed_transaction trx;
+   trx.actions.emplace_back(vector<permission_level>{{N(tableinitoob),config::active_name}}, N(tableinitoob), N(), bytes{});
+   trx.actions[0].authorization = vector<permission_level>{{N(tableinitoob),config::active_name}};
+
+    auto pushit_and_expect_fail = [&]() {
+      produce_block();
+      trx.signatures.clear();
+      set_transaction_headers(trx);
+      trx.sign(get_private_key(N(tableinitoob), "active"), control->get_chain_id());
+      
+      //the unspecified_exception_code comes from WAVM, which manages to throw a WAVM specific exception
+      // up to where exec_one captures it and doesn't understand it
+      BOOST_CHECK_EXCEPTION(push_transaction(trx), fc::exception, [](auto& e) {
+         return e.code() == unspecified_exception_code || e.code() == wasm_execution_error::code_value;
+      });
+   };
+
+   set_code(N(tableinitoob), table_init_oob_wast);
+   produce_block();
+
+   pushit_and_expect_fail();
+   //make sure doing it again didn't lodge something funky in to a cache
+   pushit_and_expect_fail();
+
+   set_code(N(tableinitoob), table_init_oob_smaller_wast);
+   produce_block();
+   pushit_and_expect_fail();
+   pushit_and_expect_fail();
+
+   //an elem w/o a table is a setcode fail though
+   BOOST_CHECK_THROW(set_code(N(tableinitoob), table_init_oob_no_table_wast), eosio::chain::wasm_exception);
+
+} FC_LOG_AND_RETHROW()
+
 BOOST_FIXTURE_TEST_CASE( memory_init_border, TESTER ) try {
    produce_blocks(2);
 


### PR DESCRIPTION


<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
Out of bound table elements are accepted during setcode but then fail later when the wasm module is actually instantiated when an action is executed. This is arguably the correct behavior when viewed from the standpoint of the wasm spec. However, it's probably not what we intended -- OOB memory init _is_ caught during setcode.

Regardless, this goof isn't really a problem. But, this goof is now consensus. So add a unit test for this goofy behavior.

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
