### PR TITLE
eosio-beta: Build and Install EOSIO in the Ubuntu 18.04 Container, then Push to Docker Hub

### DIFF
--- a/.cicd/build-then-push.sh
+++ b/.cicd/build-then-push.sh
@@ -2,7 +2,7 @@
 set -e
 . ./.cicd/.helpers
 # build
-execute docker build -f ./.cicd/ubuntu-18.04-build.dockerfile -t eosio/ci-contracts-builder:base-ubuntu-18.04-$(git log | head -n 1 | awk '{print $2}') .
+execute docker build -f ./.cicd/docker/ubuntu-18.04-build.dockerfile -t eosio/ci-contracts-builder:base-ubuntu-18.04-$(git log | head -n 1 | awk '{print $2}') .
 # push
 echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 execute docker push eosio/ci-contracts-builder:base-ubuntu-18.04-$(git log | head -n 1 | awk '{print $2}')

--- a/.cicd/build-then-push.sh
+++ b/.cicd/build-then-push.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+. ./.helpers
+# build
+execute docker build -f ./.cicd/ubuntu-18.04-build.dockerfile -t eosio/ci-contracts-builder:base-ubuntu-18.04-$(git log | head -n 1 | awk '{print $2}') .
+# push
+echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+execute docker push eosio/ci-contracts-builder:base-ubuntu-18.04-$(git log | head -n 1 | awk '{print $2}')

--- a/.cicd/build-then-push.sh
+++ b/.cicd/build-then-push.sh
@@ -6,7 +6,8 @@ export COMMIT="$(git log | head -n 1 | awk '{print $2}')"
 export SANITIZED_BRANCH="$(git branch --show-current | tr '/' '_')" # '/' messes with URLs
 [[ "$BUILDKITE" != 'true' ]] && export SANITIZED_TAG="$(echo $BUILDKITE_TAG | tr '/' '_')"
 # build
-execute docker build -f ./.cicd/docker/ubuntu-18.04-build.dockerfile -t eosio/ci-contracts-builder:base-ubuntu-18.04-latest .
+cat ./.cicd/docker/ubuntu-18.04-build.dockerfile | envsubst > ubuntu-18.04-build.dockerfile
+execute docker build -f ubuntu-18.04-build.dockerfile -t eosio/ci-contracts-builder:base-ubuntu-18.04-latest .
 # tag
 execute docker tag eosio/ci-contracts-builder:base-ubuntu-18.04-latest eosio/ci-contracts-builder:base-ubuntu-18.04-$COMMIT
 execute docker tag eosio/ci-contracts-builder:base-ubuntu-18.04-latest eosio/ci-contracts-builder:base-ubuntu-18.04-$SANITIZED_BRANCH

--- a/.cicd/build-then-push.sh
+++ b/.cicd/build-then-push.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-. ./.helpers
+. ./.cicd/.helpers
 # build
 execute docker build -f ./.cicd/ubuntu-18.04-build.dockerfile -t eosio/ci-contracts-builder:base-ubuntu-18.04-$(git log | head -n 1 | awk '{print $2}') .
 # push

--- a/.cicd/build-then-push.sh
+++ b/.cicd/build-then-push.sh
@@ -1,12 +1,23 @@
 #!/bin/bash
 set -e
 . ./.cicd/.helpers
+# variables
+export COMMIT="$(git log | head -n 1 | awk '{print $2}')"
+export SANITIZED_BRANCH="$(git branch --show-current | tr '/' '_')" # '/' messes with URLs
+[[ "$BUILDKITE" != 'true' ]] && export SANITIZED_TAG="$(echo $BUILDKITE_TAG | tr '/' '_')"
 # build
-execute docker build -f ./.cicd/docker/ubuntu-18.04-build.dockerfile -t eosio/ci-contracts-builder:base-ubuntu-18.04-$(git log | head -n 1 | awk '{print $2}') .
+execute docker build -f ./.cicd/docker/ubuntu-18.04-build.dockerfile -t eosio/ci-contracts-builder:base-ubuntu-18.04-latest .
+# tag
+execute docker tag eosio/ci-contracts-builder:base-ubuntu-18.04-latest eosio/ci-contracts-builder:base-ubuntu-18.04-$COMMIT
+execute docker tag eosio/ci-contracts-builder:base-ubuntu-18.04-latest eosio/ci-contracts-builder:base-ubuntu-18.04-$SANITIZED_BRANCH
+[[ "$BUILDKITE" != 'true' && ! -z "$SANITIZED_TAG" ]] && execute docker tag eosio/ci-contracts-builder:base-ubuntu-18.04-latest eosio/ci-contracts-builder:base-ubuntu-18.04-$SANITIZED_TAG
 # push
 if [[ "$TRAVIS" != 'true' ]]; then
     [[ "$BUILDKITE" != 'true' ]] && docker login || echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-    execute docker push eosio/ci-contracts-builder:base-ubuntu-18.04-$(git log | head -n 1 | awk '{print $2}')
+    execute docker push eosio/ci-contracts-builder:base-ubuntu-18.04-latest
+    execute docker push eosio/ci-contracts-builder:base-ubuntu-18.04-$COMMIT
+    execute docker push eosio/ci-contracts-builder:base-ubuntu-18.04-$SANITIZED_BRANCH
+    [[ "$BUILDKITE" != 'true' && ! -z "$SANITIZED_TAG" ]] && execute docker push eosio/ci-contracts-builder:base-ubuntu-18.04-$SANITIZED_TAG
     # attach build.tar.gz artifact
     [[ "$BUILDKITE" == 'true' ]] && buildkite-agent artifact upload build.tar.gz
 fi

--- a/.cicd/build-then-push.sh
+++ b/.cicd/build-then-push.sh
@@ -6,3 +6,5 @@ execute docker build -f ./.cicd/docker/ubuntu-18.04-build.dockerfile -t eosio/ci
 # push
 echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 execute docker push eosio/ci-contracts-builder:base-ubuntu-18.04-$(git log | head -n 1 | awk '{print $2}')
+# attach build.tar.gz artifact
+[[ "$BUILDKITE" == 'true' ]] && buildkite-agent artifact upload build.tar.gz

--- a/.cicd/build-then-push.sh
+++ b/.cicd/build-then-push.sh
@@ -4,7 +4,9 @@ set -e
 # build
 execute docker build -f ./.cicd/docker/ubuntu-18.04-build.dockerfile -t eosio/ci-contracts-builder:base-ubuntu-18.04-$(git log | head -n 1 | awk '{print $2}') .
 # push
-echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-execute docker push eosio/ci-contracts-builder:base-ubuntu-18.04-$(git log | head -n 1 | awk '{print $2}')
-# attach build.tar.gz artifact
-[[ "$BUILDKITE" == 'true' ]] && buildkite-agent artifact upload build.tar.gz
+if [[ "$TRAVIS" != 'true' ]]; then
+    [[ "$BUILDKITE" != 'true' ]] && docker login || echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+    execute docker push eosio/ci-contracts-builder:base-ubuntu-18.04-$(git log | head -n 1 | awk '{print $2}')
+    # attach build.tar.gz artifact
+    [[ "$BUILDKITE" == 'true' ]] && buildkite-agent artifact upload build.tar.gz
+fi

--- a/.cicd/docker/ubuntu-18.04-build.dockerfile
+++ b/.cicd/docker/ubuntu-18.04-build.dockerfile
@@ -13,4 +13,4 @@ RUN bash -c 'cd /eos/build && \
     make install'
 RUN bash -c 'cd /eos && \
     tar -pczf build.tar.gz build && \
-    buildkite-agent artifact upload build.tar.gz'
+    buildkite-agent artifact upload build.tar.gz --agent-access-token $BUILDKITE_AGENT_ACCESS_TOKEN'

--- a/.cicd/docker/ubuntu-18.04-build.dockerfile
+++ b/.cicd/docker/ubuntu-18.04-build.dockerfile
@@ -5,7 +5,6 @@ ENV CMAKE_FRAMEWORK_PATH='/usr/local'
 ENV ENABLE_PARALLEL_TESTS=false
 ENV ENABLE_SERIAL_TESTS=false
 ENV ENABLE_INSTALL=true
-ENV TRAVIS=false
 RUN bash -c "[[ -d /eos/build ]] || mkdir /eos/build ; \
     cd /eos/build && \
     cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true .. && \

--- a/.cicd/docker/ubuntu-18.04-build.dockerfile
+++ b/.cicd/docker/ubuntu-18.04-build.dockerfile
@@ -5,11 +5,12 @@ ENV CMAKE_FRAMEWORK_PATH='/usr/local'
 ENV ENABLE_PARALLEL_TESTS=false
 ENV ENABLE_SERIAL_TESTS=false
 ENV ENABLE_INSTALL=true
+ENV BUILDKITE_AGENT_ACCESS_TOKEN=$BUILDKITE_AGENT_ACCESS_TOKEN
 RUN bash -c '[[ -d /eos/build ]] || mkdir /eos/build'
 RUN bash -c 'cd /eos/build && \
     cmake -DCMAKE_BUILD_TYPE=Release -DCORE_SYMBOL_NAME=SYS -DOPENSSL_ROOT_DIR=/usr/include/openssl -DBUILD_MONGO_DB_PLUGIN=true .. && \
     make -j $(nproc) && \
     make install'
 RUN bash -c 'cd /eos && \
-    tar -pczf build.tar.gz build'
-COPY /eos/build.tar.gz .
+    tar -pczf build.tar.gz build && \
+    ls -la'

--- a/.cicd/docker/ubuntu-18.04-build.dockerfile
+++ b/.cicd/docker/ubuntu-18.04-build.dockerfile
@@ -5,12 +5,12 @@ ENV CMAKE_FRAMEWORK_PATH='/usr/local'
 ENV ENABLE_PARALLEL_TESTS=false
 ENV ENABLE_SERIAL_TESTS=false
 ENV ENABLE_INSTALL=true
-RUN bash -c "[[ -d /eos/build ]] || mkdir /eos/build ; \
+RUN bash -c '[[ -d /eos/build ]] || mkdir /eos/build ; \
     cd /eos/build && \
-    cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true .. && \
+    cmake -DCMAKE_BUILD_TYPE=Release -DCORE_SYMBOL_NAME=SYS -DOPENSSL_ROOT_DIR=/usr/include/openssl -DBUILD_MONGO_DB_PLUGIN=true .. && \
     make -j $(nproc) && \
     make install && \
     cd .. && \
     echo $(pkill mongod || :) && \
-    tar -pczf build.tar.gz build"
+    tar -pczf build.tar.gz build'
 COPY /eos/build.tar.gz .

--- a/.cicd/docker/ubuntu-18.04-build.dockerfile
+++ b/.cicd/docker/ubuntu-18.04-build.dockerfile
@@ -1,7 +1,7 @@
 FROM eosio/producer:eosio-ubuntu-18.04-d1248048f40158965ff9876c0c21ac728bb82da6
 COPY . /eos
 ENV CCACHE_DIR=/opt/.ccache
-ENV EOSIO_ROOT='/eos'
+ENV EOSIO_ROOT='/usr/local'
 ENV ENABLE_PARALLEL_TESTS=false
 ENV ENABLE_SERIAL_TESTS=false
 ENV ENABLE_INSTALL=true

--- a/.cicd/docker/ubuntu-18.04-build.dockerfile
+++ b/.cicd/docker/ubuntu-18.04-build.dockerfile
@@ -5,12 +5,11 @@ ENV CMAKE_FRAMEWORK_PATH='/usr/local'
 ENV ENABLE_PARALLEL_TESTS=false
 ENV ENABLE_SERIAL_TESTS=false
 ENV ENABLE_INSTALL=true
-RUN bash -c '[[ -d /eos/build ]] || mkdir /eos/build ; \
-    cd /eos/build && \
+RUN bash -c '[[ -d /eos/build ]] || mkdir /eos/build'
+RUN bash -c 'cd /eos/build && \
     cmake -DCMAKE_BUILD_TYPE=Release -DCORE_SYMBOL_NAME=SYS -DOPENSSL_ROOT_DIR=/usr/include/openssl -DBUILD_MONGO_DB_PLUGIN=true .. && \
     make -j $(nproc) && \
-    make install && \
-    cd .. && \
-    echo $(pkill mongod || :) && \
+    make install'
+RUN bash -c 'cd /eos && \
     tar -pczf build.tar.gz build'
 COPY /eos/build.tar.gz .

--- a/.cicd/docker/ubuntu-18.04-build.dockerfile
+++ b/.cicd/docker/ubuntu-18.04-build.dockerfile
@@ -13,4 +13,4 @@ RUN bash -c 'cd /eos/build && \
     make install'
 RUN bash -c 'cd /eos && \
     tar -pczf build.tar.gz build && \
-    ls -la'
+    buildkite-agent artifact upload build.tar.gz'

--- a/.cicd/docker/ubuntu-18.04-build.dockerfile
+++ b/.cicd/docker/ubuntu-18.04-build.dockerfile
@@ -10,4 +10,8 @@ RUN bash -c "[[ -d /eos/build ]] || mkdir /eos/build ; \
     cd /eos/build && \
     cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true .. && \
     make -j $(nproc) && \
-    make install"
+    make install && \
+    cd .. && \
+    echo $(pkill mongod || :) && \
+    tar -pczf build.tar.gz build"
+COPY /eos/build.tar.gz .

--- a/.cicd/docker/ubuntu-18.04-build.dockerfile
+++ b/.cicd/docker/ubuntu-18.04-build.dockerfile
@@ -1,7 +1,7 @@
 FROM eosio/producer:eosio-ubuntu-18.04-d1248048f40158965ff9876c0c21ac728bb82da6
 COPY . /eos
 ENV CCACHE_DIR=/opt/.ccache
-ENV EOSIO_ROOT='/usr/local'
+ENV CMAKE_FRAMEWORK_PATH='/usr/local'
 ENV ENABLE_PARALLEL_TESTS=false
 ENV ENABLE_SERIAL_TESTS=false
 ENV ENABLE_INSTALL=true

--- a/.cicd/docker/ubuntu-18.04-build.dockerfile
+++ b/.cicd/docker/ubuntu-18.04-build.dockerfile
@@ -1,4 +1,4 @@
-FROM eosio/producer:eosio-ubuntu-18.04-d1248048f40158965ff9876c0c21ac728bb82da6
+FROM eosio/producer:eosio-ubuntu-18.04-2049ab48a02aee3a7c8964291408259eed4bbc8b
 COPY . /eos
 ENV CCACHE_DIR=/opt/.ccache
 ENV CMAKE_FRAMEWORK_PATH='/usr/local'

--- a/.cicd/docker/ubuntu-18.04-build.dockerfile
+++ b/.cicd/docker/ubuntu-18.04-build.dockerfile
@@ -1,0 +1,13 @@
+FROM eosio/producer:eosio-ubuntu-18.04-d1248048f40158965ff9876c0c21ac728bb82da6
+COPY . /eos
+ENV CCACHE_DIR=/opt/.ccache
+ENV EOSIO_ROOT='/eos'
+ENV ENABLE_PARALLEL_TESTS=false
+ENV ENABLE_SERIAL_TESTS=false
+ENV ENABLE_INSTALL=true
+ENV TRAVIS=false
+RUN bash -c "[[ -d /eos/build ]] || mkdir /eos/build ; \
+    cd /eos/build && \
+    cmake -DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS' -DOPENSSL_ROOT_DIR='/usr/include/openssl' -DBUILD_MONGO_DB_PLUGIN=true .. && \
+    make -j $(nproc) && \
+    make install"

--- a/.cicd/docker/ubuntu-18.04.dockerfile
+++ b/.cicd/docker/ubuntu-18.04.dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get upgrade -y \
   bzip2 automake libbz2-dev libssl-dev doxygen graphviz libgmp3-dev \
   autotools-dev libicu-dev python2.7 python2.7-dev python3 python3-dev \
   autoconf libtool g++ gcc curl zlib1g-dev sudo ruby libusb-1.0-0-dev \
-  libcurl4-gnutls-dev pkg-config patch llvm-4.0 clang ccache
+  libcurl4-gnutls-dev pkg-config patch llvm-4.0 clang ccache jq
 
 # Build appropriate version of CMake.
 RUN curl -LO https://cmake.org/files/v3.13/cmake-3.13.2.tar.gz \

--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -101,15 +101,11 @@ steps:
     timeout: 10
     soft_fail: true
 
-  - wait
-  
-  - trigger: "eosio-installation-images"
-    label: ":docker: Start EOS Installation Pipeline"
+  - trigger: "eosio-dot-contracts-base-images-beta"
+    label: ":docker: Create eosio.contracts Base Images Pipeline"
     build:
       commit: "${BUILDKITE_COMMIT}"
       branch: "${BUILDKITE_BRANCH}"
-      env:
-        FORCE_BINARIES_BUILD: "${FORCE_BINARIES_BUILD}"
     async: true
 
   - wait

--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -93,7 +93,7 @@ steps:
     soft_fail: true
 
   - trigger: "eosio-dot-contracts-base-images-beta"
-    label: ":docker: Create eosio.contracts Base Images Pipeline"
+    label: ":docker: Create eosio.contracts Base Image"
     build:
       commit: "${BUILDKITE_COMMIT}"
       branch: "${BUILDKITE_BRANCH}"

--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -50,6 +50,7 @@ steps:
           propagate-environment: true # Need for buildkite-agent upload/download (JOB_ID, etc)
 
   - label: ":ubuntu: Ubuntu 18.04 - Build & Test"
+    command: ". .cicd/build-then-push.sh"
     agents:
       queue: "automation-eos-builder-fleet"
     plugins:

--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -23,8 +23,6 @@ steps:
           propagate-environment: true # Need for buildkite-agent upload/download (JOB_ID, etc)
 
   - label: ":centos: CentOS 7.6 - Build & Test"
-    command:
-      - ""
     agents:
       queue: "automation-eos-builder-fleet"
     plugins:

--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -50,7 +50,7 @@ steps:
           propagate-environment: true # Need for buildkite-agent upload/download (JOB_ID, etc)
 
   - label: ":ubuntu: Ubuntu 18.04 - Build & Test"
-    command: ". .cicd/build-then-push.sh"
+    command: ".cicd/build-then-push.sh"
     agents:
       queue: "automation-eos-builder-fleet"
     plugins:

--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -92,13 +92,6 @@ steps:
     timeout: 10
     soft_fail: true
 
-  - trigger: "eosio-dot-contracts-base-images-beta"
-    label: ":docker: Create eosio.contracts Base Image"
-    build:
-      commit: "${BUILDKITE_COMMIT}"
-      branch: "${BUILDKITE_BRANCH}"
-    async: true
-
   - wait
 
   - label: ":centos: Centos 7.6 - Package Builder"

--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -53,15 +53,6 @@ steps:
     command: ".cicd/build-then-push.sh"
     agents:
       queue: "automation-eos-builder-fleet"
-    plugins:
-      - docker#v3.2.0:
-          debug: $DEBUG
-          image: "eosio/producer:eosio-ubuntu-18.04-d1248048f40158965ff9876c0c21ac728bb82da6"
-          environment:
-            - "BUILDKITE_AGENT_ACCESS_TOKEN" # Needed for buildkite-agent upload/download
-            - "JOBS" # Number for -j make/ctest args.
-          mount-buildkite-agent: false # Mounting bk-agent doesn't work, so disable it
-          propagate-environment: true # Need for buildkite-agent upload/download (JOB_ID, etc)
 
   - label: ":darwin: macOS 10.14 - Build & Test"
     command:


### PR DESCRIPTION
## Change Description
The base image the [eosio.contracts beta pipelines](https://github.com/EOSIO/eosio.contracts/pull/306) are using is still built from the eosio/builder image on GCR, but we want these beta pipelines to be independent of our existing infrastructure.  

To accomplish this, we build and install EOSIO inside the Docker container, then push it to [Docker Hub](https://hub.docker.com/r/eosio/ci-contracts-builder/tags) as a part of the [EOSIO beta pipeline](https://buildkite.com/EOSIO/eosio-beta). The [eosio.contracts base image pipeline](https://buildkite.com/EOSIO/eosio-dot-contracts-base-image-beta) then pulls these images which already have EOSIO, installs CDT, and pushes the image back to [Docker Hub](https://hub.docker.com/r/eosio/ci-contracts-builder/tags) for consumption by the contracts pipelines. This only needs to be done for Ubuntu 18.04, as eosio.contracts is testing WASM and the host operating system is arbitrary.

The current rapid-prototyped solution invokes `/.cicd/docker/ubuntu-18.04-build.dockerfile` to perform the build and installation, exports the `build.tar.gz` for testing, and then pushes. I think this solution is a bit sloppy because the other operating systems do not use a Dockerfile. I would prefer to use a `docker run` command, commit the image, then `docker push` so that the only difference between operating systems is the `docker login` and `docker push`. The Build Bros have decided to deploy this prototype solution for now because we will invest time in reworking the eosio-beta pipeline in a future sprint.

### Tested
- Buildkite [build 851](https://buildkite.com/EOSIO/eosio-beta/builds/851)
- Travis CI [build 4101](https://travis-ci.com/EOSIO/eos/builds/122608299)

## Consensus Changes
- [ ] Consensus Changes
None.

## API Changes
- [ ] API Changes
None.

## Documentation Additions
- [ ] Documentation Additions
None.