### PR TITLE
two useful chainbase backports for 1.8

### DIFF
--- a/programs/eosio-blocklog/main.cpp
+++ b/programs/eosio-blocklog/main.cpp
@@ -60,7 +60,7 @@ void blocklog::read_log() {
          reversible_blocks.reset();
       }
    } catch( const std::runtime_error& e ) {
-      if( std::string(e.what()) == "database dirty flag set" ) {
+      if( std::string(e.what()).find("database dirty flag set") != std::string::npos ) {
          elog( "database dirty flag set (likely due to unclean shutdown): only block_log blocks are available" );
       } else if( std::string(e.what()) == "database metadata dirty flag set" ) {
          elog( "database metadata dirty flag set (likely due to unclean shutdown): only block_log blocks are available" );

--- a/programs/nodeos/main.cpp
+++ b/programs/nodeos/main.cpp
@@ -120,7 +120,7 @@ int main(int argc, char** argv)
       elog("${e}", ("e",boost::diagnostic_information(e)));
       return OTHER_FAIL;
    } catch( const std::runtime_error& e ) {
-      if( std::string(e.what()) == "database dirty flag set" ) {
+      if( std::string(e.what()).find("database dirty flag set") != std::string::npos ) {
          elog( "database dirty flag set (likely due to unclean shutdown): replay required" );
          return DATABASE_DIRTY;
       } else if( std::string(e.what()) == "database metadata dirty flag set" ) {


### PR DESCRIPTION

<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
This backports EOSIO/chainbase#50 (the fix for boost 1.71) and EOSIO/chainbase#49 (printing which DB causes typical startup failures). These are small and useful for 1.8 users.
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
