### PR TITLE
Optimize block log usage

### DIFF
--- a/libraries/chain/block_log.cpp
+++ b/libraries/chain/block_log.cpp
@@ -342,13 +342,12 @@ namespace eosio { namespace chain {
 
    block_id_type block_log::read_block_id_by_num(uint32_t block_num)const {
       try {
-         signed_block_ptr b;
          uint64_t pos = get_block_pos(block_num);
          if (pos != npos) {
             block_header bh;
             read_block_header(bh, pos);
-            EOS_ASSERT(b->block_num() == block_num, reversible_blocks_exception,
-                       "Wrong block header was read from block log.", ("returned", b->block_num())("expected", block_num));
+            EOS_ASSERT(bh.block_num() == block_num, reversible_blocks_exception,
+                       "Wrong block header was read from block log.", ("returned", bh.block_num())("expected", block_num));
             return bh.id();
          }
          return {};

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -377,7 +377,7 @@ struct controller_impl {
       auto root_id = fork_db.root()->id;
 
       if( log_head ) {
-         EOS_ASSERT( root_id == log_head->id(), fork_database_exception, "fork database root does not match block log head" );
+         EOS_ASSERT( root_id == blog.head_id(), fork_database_exception, "fork database root does not match block log head" );
       } else {
          EOS_ASSERT( fork_db.root()->block_num == lib_num, fork_database_exception,
                      "empty block log expects the first appended block to build off a block that is not the fork database root" );
@@ -2697,12 +2697,12 @@ block_id_type controller::last_irreversible_block_id() const {
    if( block_header::num_from_id(tapos_block_summary.block_id) == lib_num )
       return tapos_block_summary.block_id;
 
-   auto signed_blk = my->blog.read_block_by_num( lib_num );
+   auto id = my->blog.read_block_id_by_num( lib_num );
 
-   EOS_ASSERT( BOOST_LIKELY( signed_blk != nullptr ), unknown_block_exception,
+   EOS_ASSERT( BOOST_LIKELY( id != block_id_type() ), unknown_block_exception,
                "Could not find block: ${block}", ("block", lib_num) );
 
-   return signed_blk->id();
+   return id;
 }
 
 const dynamic_global_property_object& controller::get_dynamic_global_properties()const {
@@ -2768,12 +2768,12 @@ block_id_type controller::get_block_id_for_num( uint32_t block_num )const { try 
       }
    }
 
-   auto signed_blk = my->blog.read_block_by_num(block_num);
+   auto id = my->blog.read_block_id_by_num(block_num);
 
-   EOS_ASSERT( BOOST_LIKELY( signed_blk != nullptr ), unknown_block_exception,
+   EOS_ASSERT( BOOST_LIKELY( id != block_id_type() ), unknown_block_exception,
                "Could not find block: ${block}", ("block", block_num) );
 
-   return signed_blk->id();
+   return id;
 } FC_CAPTURE_AND_RETHROW( (block_num) ) }
 
 sha256 controller::calculate_integrity_hash()const { try {

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1654,11 +1654,11 @@ struct controller_impl {
             });
          }
 
+         emit( self.accepted_block, bsp );
+
          if( add_to_fork_db ) {
             log_irreversible();
          }
-
-         emit( self.accepted_block, bsp );
       } catch (...) {
          // dont bother resetting pending, instead abort the block
          reset_pending_on_exit.cancel();

--- a/libraries/chain/include/eosio/chain/block_log.hpp
+++ b/libraries/chain/include/eosio/chain/block_log.hpp
@@ -43,7 +43,9 @@ namespace eosio { namespace chain {
          void reset( const genesis_state& gs, const signed_block_ptr& genesis_block, uint32_t first_block_num = 1 );
 
          signed_block_ptr read_block(uint64_t file_pos)const;
+         void             read_block_header(block_header& bh, uint64_t file_pos)const;
          signed_block_ptr read_block_by_num(uint32_t block_num)const;
+         block_id_type    read_block_id_by_num(uint32_t block_num)const;
          signed_block_ptr read_block_by_id(const block_id_type& id)const {
             return read_block_by_num(block_header::num_from_id(id));
          }
@@ -54,6 +56,7 @@ namespace eosio { namespace chain {
          uint64_t get_block_pos(uint32_t block_num) const;
          signed_block_ptr        read_head()const;
          const signed_block_ptr& head()const;
+         const block_id_type&    head_id()const;
          uint32_t                first_block_num() const;
 
          static const uint64_t npos = std::numeric_limits<uint64_t>::max();


### PR DESCRIPTION
## Change Description

- Emit accepted block signal before updating block log since accepted block does not depend on lib. This allows the `net_plugin` to start sending out the block sooner.
- Optimize getting `block_id` via `block_num` out of block log by reading only the `block_header` instead of the entire block.
- Provide access to `head_id` of block log instead of calculating it from the `head` block.

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
