### PR TITLE
Remove redundant work from net plugin

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2823,21 +2823,6 @@ namespace eosio {
                fc_elog( logger, "bad packed_transaction : ${m}", ("m", trace->except->what()));
             }
          }
-/* this comes through the transaction_ack channel
-         boost::asio::post( my_impl->thread_pool->get_executor(), [accepted, weak{std::move(weak)}, trx{std::move(trx)}]() mutable {
-            if( accepted ) {
-               my_impl->dispatcher->bcast_transaction( *trx );
-            } else {
-               uint32_t head_blk_num = 0;
-               std::tie( std::ignore, head_blk_num, std::ignore, std::ignore, std::ignore, std::ignore ) = my_impl->get_chain_info();
-               my_impl->dispatcher->rejected_transaction( trx, head_blk_num );
-            }
-            connection_ptr conn = weak.lock();
-            if( conn ) {
-               conn->trx_in_progress_size -= calc_trx_size( trx );
-            }
-         });
-         */
         });
       });
    }

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2201,7 +2201,7 @@ namespace eosio {
                      return true;
                   } );
                   if( from_addr < max_nodes_per_host && (max_client_count == 0 || visitors < max_client_count)) {
-                     fc_dlog( logger, "Accepted new connection: " + paddr_str );
+                     fc_ilog( logger, "Accepted new connection: " + paddr_str );
                      if( new_connection->start_session()) {
                         std::lock_guard<std::shared_mutex> g_unique( connections_mtx );
                         connections.insert( new_connection );

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2809,19 +2809,19 @@ namespace eosio {
          my_impl->chain_plug->accept_transaction( trx,
             [weak, trx](const static_variant<fc::exception_ptr, transaction_trace_ptr>& result) mutable {
          // next (this lambda) called from application thread
-         bool accepted = false;
          if (result.contains<fc::exception_ptr>()) {
             fc_dlog( logger, "bad packed_transaction : ${m}", ("m", result.get<fc::exception_ptr>()->what()) );
          } else {
             const transaction_trace_ptr& trace = result.get<transaction_trace_ptr>();
-            if (!trace->except) {
+            if( !trace->except ) {
                fc_dlog( logger, "chain accepted transaction, bcast ${id}", ("id", trace->id) );
-               accepted = true;
-            }
-
-            if( !accepted ) {
+            } else {
                fc_elog( logger, "bad packed_transaction : ${m}", ("m", trace->except->what()));
             }
+         }
+         connection_ptr conn = weak.lock();
+         if( conn ) {
+            conn->trx_in_progress_size -= calc_trx_size( trx );
          }
         });
       });

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -179,7 +179,7 @@ namespace eosio {
       : strand( io_context ) {}
 
       void bcast_transaction(const packed_transaction& trx);
-      void rejected_transaction(const transaction_id_type& msg, uint32_t head_blk_num);
+      void rejected_transaction(const packed_transaction_ptr& trx, uint32_t head_blk_num);
       void bcast_block(const block_state_ptr& bs);
       void bcast_notice( const block_id_type& id );
       void rejected_block(const block_id_type& id);
@@ -2010,11 +2010,13 @@ namespace eosio {
       } );
    }
 
-   void dispatch_manager::rejected_transaction(const transaction_id_type& id, uint32_t head_blk_num) {
-      fc_dlog( logger, "not sending rejected transaction ${tid}", ("tid", id) );
+   void dispatch_manager::rejected_transaction(const packed_transaction_ptr& trx, uint32_t head_blk_num) {
+      fc_dlog( logger, "not sending rejected transaction ${tid}", ("tid", trx->id()) );
       // keep rejected transaction around for awhile so we don't broadcast it
       // update its block number so it will be purged when current block number is lib
-      update_txns_block_num( id, head_blk_num );
+      if( trx->expiration() > fc::time_point::now() ) { // no need to update blk_num if already expired
+         update_txns_block_num( trx->id(), head_blk_num );
+      }
    }
 
    // called from connection strand
@@ -2821,20 +2823,21 @@ namespace eosio {
                fc_elog( logger, "bad packed_transaction : ${m}", ("m", trace->except->what()));
             }
          }
-
+/* this comes through the transaction_ack channel
          boost::asio::post( my_impl->thread_pool->get_executor(), [accepted, weak{std::move(weak)}, trx{std::move(trx)}]() mutable {
             if( accepted ) {
                my_impl->dispatcher->bcast_transaction( *trx );
             } else {
                uint32_t head_blk_num = 0;
                std::tie( std::ignore, head_blk_num, std::ignore, std::ignore, std::ignore, std::ignore ) = my_impl->get_chain_info();
-               my_impl->dispatcher->rejected_transaction( trx->id(), head_blk_num );
+               my_impl->dispatcher->rejected_transaction( trx, head_blk_num );
             }
             connection_ptr conn = weak.lock();
             if( conn ) {
                conn->trx_in_progress_size -= calc_trx_size( trx );
             }
          });
+         */
         });
       });
    }
@@ -3067,7 +3070,7 @@ namespace eosio {
 
             uint32_t head_blk_num = 0;
             std::tie( std::ignore, head_blk_num, std::ignore, std::ignore, std::ignore, std::ignore ) = get_chain_info();
-            dispatcher->rejected_transaction(id, head_blk_num);
+            dispatcher->rejected_transaction(results.second->packed_trx(), head_blk_num);
          } else {
             fc_dlog( logger, "signaled ACK, trx-id = ${id}", ("id", id) );
             dispatcher->bcast_transaction(*results.second->packed_trx());

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2199,6 +2199,7 @@ namespace eosio {
                      return true;
                   } );
                   if( from_addr < max_nodes_per_host && (max_client_count == 0 || visitors < max_client_count)) {
+                     fc_dlog( logger, "Accepted new connection: " + paddr_str );
                      if( new_connection->start_session()) {
                         std::lock_guard<std::shared_mutex> g_unique( connections_mtx );
                         connections.insert( new_connection );
@@ -2630,7 +2631,7 @@ namespace eosio {
          node_id = msg.node_id;
       }
       flush_queues();
-      close();
+      close( false );
    }
 
    void connection::handle_message( const time_message& msg ) {


### PR DESCRIPTION
## Change Description

- No need to process transactions from `accept_transaction` `next` as the transactions are signaled via `transaction_ack` and processed there. See `net_plugin_impl::transaction_ack`.
- No need to update cached transactions `block_num` if they are expired as they will be purged from the local cache on next cache purge and we should not get them again from the network.
- Add log of accepted connections.
- When receiving a `go_away` message, do not attempt to reconnect immediately. This restores old net_plugin behavior for `go_away` messages.

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
