### PR TITLE
Restore default logging if logging.json is removed when SIGHUP.

### DIFF
--- a/programs/nodeos/main.cpp
+++ b/programs/nodeos/main.cpp
@@ -23,7 +23,11 @@ void configure_logging(const bfs::path& config_path)
 {
    try {
       try {
-         fc::configure_logging(config_path);
+         if( fc::exists( config_path ) ) {
+            fc::configure_logging( config_path );
+         } else {
+            fc::configure_logging( fc::logging_config::default_config() );
+         }
       } catch (...) {
          elog("Error reloading logging.json");
          throw;
@@ -44,9 +48,12 @@ void configure_logging(const bfs::path& config_path)
 void logging_conf_handler()
 {
    auto config_path = app().get_logging_conf();
-   ilog("Received HUP.  Reloading logging configuration from ${p}.", ("p", config_path.string()));
-   if(fc::exists(config_path))
-      ::detail::configure_logging(config_path);
+   if( fc::exists( config_path ) ) {
+      ilog( "Received HUP.  Reloading logging configuration from ${p}.", ("p", config_path.string()) );
+   } else {
+      ilog( "Received HUP.  No log config found at ${p}, setting to default.", ("p", config_path.string()) );
+   }
+   ::detail::configure_logging( config_path );
    fc::log_config::initialize_appenders( app().get_io_service() );
 }
 


### PR DESCRIPTION
## Change Description

- Restore default logging if `logging.json` is removed when SIGHUP. Before if no `logging.json` was found during a SIGHUP, then no modifications were made to logging.

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ x ] Documentation Additions

Update docs to reflect that default logging can be restored by removing the `logging.json` and sending a SIGHUP to the process.
