### PR TITLE
callback support for checktime timer expiry

### DIFF
--- a/libraries/chain/include/eosio/chain/platform_timer.hpp
+++ b/libraries/chain/include/eosio/chain/platform_timer.hpp
@@ -4,6 +4,8 @@
 
 #include <eosio/chain/exceptions.hpp>
 
+#include <atomic>
+
 #include <signal.h>
 
 namespace eosio { namespace chain {
@@ -18,11 +20,22 @@ struct platform_timer {
    /* Sets a callback for when timer expires. Be aware this could might fire from a signal handling context and/or
       on any particular thread. Only a single callback can be registered at once; trying to register more will
       result in an exception. Setting to nullptr disables any current set callback */
-   void set_expiry_callback(void(*func)(void*), void* user) {
-      EOS_ASSERT(!(func && __atomic_load_n(&_callback_enabled, __ATOMIC_CONSUME)), misc_exception, "Setting a platform_timer callback when one already exists");
+   void set_expiration_callback(void(*func)(void*), void* user) {
+      callback_state current_state;
+      while((current_state = _callback_state.load(std::memory_order_acquire)) == READING) {} //wait for call_expiration_callback() to be done with it
+      if(func)
+         EOS_ASSERT(current_state == UNSET, misc_exception, "Setting a platform_timer callback when one already exists");
+      if(!func && current_state == UNSET)
+         return;
+
+      //prepare for loading in new values by moving from UNSET->WRITING
+      while(!atomic_compare_exchange_strong(&_callback_state, &current_state, WRITING))
+         current_state = UNSET;
       _expiration_callback = func;
       _expiration_callback_data = user;
-      __atomic_store_n(&_callback_enabled, !!_expiration_callback, __ATOMIC_RELEASE);
+
+      //finally go WRITING->SET
+      _callback_state.store(func ? SET : UNSET, std::memory_order_release);
    }
 
    volatile sig_atomic_t expired = 1;
@@ -32,17 +45,24 @@ private:
    constexpr static size_t fwd_size = 8;
    fc::fwd<impl,fwd_size> my;
 
+   enum callback_state {
+      UNSET,
+      READING,
+      WRITING,
+      SET
+   };
+
    void call_expiration_callback() {
-      if(__atomic_load_n(&_callback_enabled, __ATOMIC_CONSUME)) {
+      callback_state state_is_SET = SET;
+      if(atomic_compare_exchange_strong(&_callback_state, &state_is_SET, READING)) {
          void(*cb)(void*) = _expiration_callback;
          void* cb_data = _expiration_callback_data;
-         if(__atomic_load_n(&_callback_enabled, __ATOMIC_CONSUME))
-            cb(cb_data);
+         _callback_state.store(SET, std::memory_order_release);
+         cb(cb_data);
       }
    }
 
-   bool _callback_enabled = false;
-   static_assert(__atomic_always_lock_free(sizeof(_callback_enabled), 0), "eosio requires an always lock free bool type");
+   std::atomic<callback_state> _callback_state = UNSET;
    void(*_expiration_callback)(void*);
    void* _expiration_callback_data;
 };

--- a/libraries/chain/include/eosio/chain/platform_timer.hpp
+++ b/libraries/chain/include/eosio/chain/platform_timer.hpp
@@ -2,6 +2,8 @@
 #include <fc/time.hpp>
 #include <fc/fwd.hpp>
 
+#include <eosio/chain/exceptions.hpp>
+
 #include <signal.h>
 
 namespace eosio { namespace chain {
@@ -13,12 +15,29 @@ struct platform_timer {
    void start(fc::time_point tp);
    void stop();
 
+   /* Sets a callback for when timer expires. Be aware this could might fire from a signal handling context and/or
+      on any particular thread. Only a single callback can be registered at once; trying to register more will
+      result in an exception. Setting to nullptr is allowed as a "no callback" hint */
+   void set_expiry_callback(void(*func)(void*), void* user) {
+      EOS_ASSERT(!(func && _expiration_callback), misc_exception, "Setting a platform_timer callback when one already exists");
+      _expiration_callback = func;
+      _expiration_callback_data = user;
+   }
+
    volatile sig_atomic_t expired = 1;
 
 private:
    struct impl;
    constexpr static size_t fwd_size = 8;
    fc::fwd<impl,fwd_size> my;
+
+   void call_expiration_callback() {
+      if(_expiration_callback)
+         _expiration_callback(_expiration_callback_data);
+   }
+
+   void(*_expiration_callback)(void*) = nullptr;
+   void* _expiration_callback_data;
 };
 
 }}

--- a/libraries/chain/include/eosio/chain/transaction_context.hpp
+++ b/libraries/chain/include/eosio/chain/transaction_context.hpp
@@ -18,8 +18,8 @@ namespace eosio { namespace chain {
 
          /* Sets a callback for when timer expires. Be aware this could might fire from a signal handling context and/or
             on any particular thread. Only a single callback can be registered at once; trying to register more will
-            result in an exception. */
-         void set_expiry_callback(void(*func)(void*), void* user);
+            result in an exception. Use nullptr to disable a previously set callback. */
+         void set_expiration_callback(void(*func)(void*), void* user);
 
          volatile sig_atomic_t& expired;
       private:

--- a/libraries/chain/include/eosio/chain/transaction_context.hpp
+++ b/libraries/chain/include/eosio/chain/transaction_context.hpp
@@ -16,6 +16,11 @@ namespace eosio { namespace chain {
          void start(fc::time_point tp);
          void stop();
 
+         /* Sets a callback for when timer expires. Be aware this could might fire from a signal handling context and/or
+            on any particular thread. Only a single callback can be registered at once; trying to register more will
+            result in an exception. */
+         void set_expiry_callback(void(*func)(void*), void* user);
+
          volatile sig_atomic_t& expired;
       private:
          platform_timer& _timer;
@@ -125,6 +130,8 @@ namespace eosio { namespace chain {
          int64_t                       billed_cpu_time_us = 0;
          bool                          explicit_billed_cpu_time = false;
 
+         transaction_checktime_timer   transaction_timer;
+
       private:
          bool                          is_initialized = false;
 
@@ -145,8 +152,6 @@ namespace eosio { namespace chain {
          fc::time_point                pseudo_start;
          fc::microseconds              billed_time;
          fc::microseconds              billing_timer_duration_limit;
-
-         transaction_checktime_timer   transaction_timer;
    };
 
 } }

--- a/libraries/chain/platform_timer_asio_fallback.cpp
+++ b/libraries/chain/platform_timer_asio_fallback.cpp
@@ -76,6 +76,7 @@ void platform_timer::start(fc::time_point tp) {
          if(ec)
             return;
          expired = 1;
+         call_expiration_callback();
       });
    }
 }

--- a/libraries/chain/platform_timer_posix.cpp
+++ b/libraries/chain/platform_timer_posix.cpp
@@ -16,7 +16,9 @@ struct platform_timer::impl {
    timer_t timerid;
 
    static void sig_handler(int, siginfo_t* si, void*) {
-      *(sig_atomic_t*)(si->si_value.sival_ptr) = 1;
+      platform_timer* self = (platform_timer*)si->si_value.sival_ptr;
+      self->expired = 1;
+      self->call_expiration_callback();
    }
 };
 
@@ -38,7 +40,7 @@ platform_timer::platform_timer() {
    struct sigevent se;
    se.sigev_notify = SIGEV_SIGNAL;
    se.sigev_signo = SIGRTMIN;
-   se.sigev_value.sival_ptr = (void*)&expired;
+   se.sigev_value.sival_ptr = (void*)this;
 
    FC_ASSERT(timer_create(CLOCK_REALTIME, &se, &my->timerid) == 0, "failed to create timer");
 

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -34,13 +34,13 @@ namespace eosio { namespace chain {
       _timer.stop();
    }
 
-   void transaction_checktime_timer::set_expiry_callback(void(*func)(void*), void* user) {
-      _timer.set_expiry_callback(func, user);
+   void transaction_checktime_timer::set_expiration_callback(void(*func)(void*), void* user) {
+      _timer.set_expiration_callback(func, user);
    }
 
    transaction_checktime_timer::~transaction_checktime_timer() {
       stop();
-      _timer.set_expiry_callback(nullptr, nullptr);
+      _timer.set_expiration_callback(nullptr, nullptr);
    }
 
    transaction_context::transaction_context( controller& c,

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -34,8 +34,13 @@ namespace eosio { namespace chain {
       _timer.stop();
    }
 
+   void transaction_checktime_timer::set_expiry_callback(void(*func)(void*), void* user) {
+      _timer.set_expiry_callback(func, user);
+   }
+
    transaction_checktime_timer::~transaction_checktime_timer() {
       stop();
+      _timer.set_expiry_callback(nullptr, nullptr);
    }
 
    transaction_context::transaction_context( controller& c,
@@ -49,9 +54,9 @@ namespace eosio { namespace chain {
    ,undo_session()
    ,trace(std::make_shared<transaction_trace>())
    ,start(s)
+   ,transaction_timer(std::move(tmr))
    ,net_usage(trace->net_usage)
    ,pseudo_start(s)
-   ,transaction_timer(std::move(tmr))
    {
       if (!c.skip_db_sessions()) {
          undo_session = c.mutable_db().start_undo_session(true);


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
When a transaction's checktimer timer expires, call a user specified function. This can allow potential future wasm runtimes to be notified of expiry in a very low overhead manner (they don't need to poll expiry).

This PR tries to KISS and just adds support for a single callback by storing two `void*`s in the platform_timer. Since the callback could be called within a signal handling context I didn't want to complicate manners with `std::function`s or anything that required resizing to support more than one.

Usage could be something like this:
```c++
super_fast_wasm_runtime::execute_action(apply_context& context, ...) {
   context.trx_context.transaction_timer.set_expiry_callback([](void* user) {
      //this code could be called from signal handling context!
      super_fast_wasm_runtime* self = (super_fast_wasm_runtime*)user;
      self->stop_wasm_execution();
   }, this);
   context.trx_context.checktime(); //catch any expiration that might have occurred before setting up callback

   //when wasm code is done, disable callback
   auto reset_expiry_cb = fc::make_scoped_exit([&tt=context.trx_context.transaction_timer](){tt.set_expiry_callback(nullptr, nullptr);});

   run_wasm();
}
```

You will notice what technically amounts to a very slight race condition here. If the timer expires at the very same time that the callback is attempting to be disabled (by calling `set_expiry_callback(nullptr, nullptr)`) it's conceivable that the callback will still be called even though it has been disabled at that point.

It's not clear what the best way is to solve that problem. The expiry code being run from a signal handling context ties my hands on many typical solutions. Any thoughts on this are welcome.

However, this issue isn't a problem for potential new wasm runtime given the current state of single threaded execution -- slight late execution of the callback even after disabling it doesn't cause a problem (as long it isn't so late that it is called after the next transaction's wasm starts executing, which would be absurd in practice). In fact, the only reason potential new wasm runtime needs to disable the callback at all is just to make platform_timer's assert() happy that no one is trying to pile up more than one callback.

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
