### PR TITLE
Correct cpu_usage calculation when more than one signature

### DIFF
--- a/libraries/chain/transaction.cpp
+++ b/libraries/chain/transaction.cpp
@@ -116,7 +116,7 @@ fc::microseconds transaction::get_signature_keys( const vector<signature_type>& 
       if( it == recovery_cache.get<by_sig>().end() || it->trx_id != tid ) {
          lock.unlock();
          recov = public_key_type( sig, digest );
-         fc::microseconds cpu_usage = fc::time_point::now() - start;
+         fc::microseconds cpu_usage = fc::time_point::now() - start - sig_cpu_usage;
          lock.lock();
          recovery_cache.emplace_back( cached_pub_key{tid, recov, sig, cpu_usage} ); //could fail on dup signatures; not a problem
          sig_cpu_usage += cpu_usage;

--- a/libraries/chain/transaction.cpp
+++ b/libraries/chain/transaction.cpp
@@ -105,10 +105,11 @@ fc::microseconds transaction::get_signature_keys( const vector<signature_type>& 
 
    std::unique_lock<std::mutex> lock(cache_mtx, std::defer_lock);
    fc::microseconds sig_cpu_usage;
+   const auto digest_time = fc::time_point::now() - start;
    for(const signature_type& sig : signatures) {
-      auto now = fc::time_point::now();
-      EOS_ASSERT( now < deadline, tx_cpu_usage_exceeded, "transaction signature verification executed for too long ${time}us",
-                  ("time", now - start)("now", now)("deadline", deadline)("start", start) );
+      auto sig_start = fc::time_point::now();
+      EOS_ASSERT( sig_start < deadline, tx_cpu_usage_exceeded, "transaction signature verification executed for too long ${time}us",
+                  ("time", sig_start - start)("now", sig_start)("deadline", deadline)("start", start) );
       public_key_type recov;
       const auto& tid = id();
       lock.lock();
@@ -116,7 +117,7 @@ fc::microseconds transaction::get_signature_keys( const vector<signature_type>& 
       if( it == recovery_cache.get<by_sig>().end() || it->trx_id != tid ) {
          lock.unlock();
          recov = public_key_type( sig, digest );
-         fc::microseconds cpu_usage = fc::time_point::now() - start - sig_cpu_usage;
+         fc::microseconds cpu_usage = fc::time_point::now() - sig_start;
          lock.lock();
          recovery_cache.emplace_back( cached_pub_key{tid, recov, sig, cpu_usage} ); //could fail on dup signatures; not a problem
          sig_cpu_usage += cpu_usage;
@@ -137,7 +138,7 @@ fc::microseconds transaction::get_signature_keys( const vector<signature_type>& 
       recovery_cache.erase( recovery_cache.begin());
    lock.unlock();
 
-   return sig_cpu_usage;
+   return sig_cpu_usage + digest_time;
 } FC_CAPTURE_AND_RETHROW() }
 
 flat_multimap<uint16_t, transaction_extension> transaction::validate_and_extract_extensions()const {

--- a/unittests/misc_tests.cpp
+++ b/unittests/misc_tests.cpp
@@ -712,10 +712,6 @@ BOOST_AUTO_TEST_CASE(transaction_test) { try {
    BOOST_CHECK(cpu_time1 > fc::microseconds(0));
    BOOST_CHECK(cpu_time2 > fc::microseconds(0));
 
-   // verify that hitting cache still indicates same billable time
-   // if we remove cache so that the second is a real time calculation then remove this check
-   BOOST_CHECK(cpu_time1 == cpu_time2);
-
    // pack
    uint32_t pack_size = fc::raw::pack_size( pkt );
    vector<char> buf(pack_size);


### PR DESCRIPTION
## Change Description

- CPU usage of signature recovery was not being calculated correctly for multiple signatures. Correct calculation so that multiple signature recovery time is not overly calculated.

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
