### PR TITLE
Introduce get_transaction_merkle_proof RPC

### DIFF
--- a/libraries/chain/include/eosio/chain/merkle.hpp
+++ b/libraries/chain/include/eosio/chain/merkle.hpp
@@ -19,4 +19,14 @@ namespace eosio { namespace chain {
     */
    digest_type merkle( vector<digest_type> ids );
 
+   /**
+    * Generates a merkle proof, a set of digests from leaf to root
+    */
+   vector<digest_type> generate_merkle_proof( digest_type id, vector<digest_type> ids );
+
+   /**
+    * Verifies a merkle proof
+    */
+   bool verify_merkle_proof( vector<digest_type> proof );
+
 } } /// eosio::chain

--- a/libraries/chain/include/eosio/chain/merkle.hpp
+++ b/libraries/chain/include/eosio/chain/merkle.hpp
@@ -22,11 +22,11 @@ namespace eosio { namespace chain {
    /**
     * Generates a merkle proof, a set of digests from leaf to root
     */
-   vector<digest_type> generate_merkle_proof( digest_type id, vector<digest_type> ids );
+   vector<digest_type> generate_merkle_proof( const digest_type& id, const vector<digest_type>& ids );
 
    /**
     * Verifies a merkle proof
     */
-   bool verify_merkle_proof( vector<digest_type> proof );
+   bool verify_merkle_proof( const vector<digest_type>& proof );
 
 } } /// eosio::chain

--- a/libraries/chain/merkle.cpp
+++ b/libraries/chain/merkle.cpp
@@ -74,13 +74,13 @@ vector<digest_type> generate_merkle_proof(size_t index, vector<digest_type> ids)
    return proof;
 }
 
-vector<digest_type> generate_merkle_proof(digest_type id, vector<digest_type> ids) {
+vector<digest_type> generate_merkle_proof(const digest_type& id, const vector<digest_type>& ids) {
    auto it = std::find(ids.begin(), ids.end(), id);
    FC_ASSERT(it != ids.end(), "id is not found in merkle tree");
    return generate_merkle_proof(std::distance(ids.begin(), it), ids);
 }
 
-bool verify_merkle_proof(vector<digest_type> proof) {
+bool verify_merkle_proof(const vector<digest_type>& proof) {
    auto node = proof.front();
    for (auto i = 1; i < proof.size() - 1; i++) {
       if( proof[i]._hash[0] & 0x80ULL ) {

--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -100,6 +100,7 @@ void chain_api_plugin::plugin_startup() {
       CHAIN_RO_CALL(abi_bin_to_json, 200),
       CHAIN_RO_CALL(get_required_keys, 200),
       CHAIN_RO_CALL(get_transaction_id, 200),
+      CHAIN_RO_CALL(get_transaction_merkle_proof, 200),
       CHAIN_RW_CALL_ASYNC(push_block, chain_apis::read_write::push_block_results, 202),
       CHAIN_RW_CALL_ASYNC(push_transaction, chain_apis::read_write::push_transaction_results, 202),
       CHAIN_RW_CALL_ASYNC(push_transactions, chain_apis::read_write::push_transactions_results, 202),

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -379,6 +379,13 @@ public:
 
    get_scheduled_transactions_result get_scheduled_transactions( const get_scheduled_transactions_params& params ) const;
 
+   struct get_transaction_merkle_proof_params {
+      chain::transaction_id_type  transaction_id;
+      string                      block_num_or_id;
+   };
+
+   vector<chain::digest_type> get_transaction_merkle_proof( const get_transaction_merkle_proof_params& params ) const;
+
    static void copy_inline_row(const chain::key_value_object& obj, vector<char>& data) {
       data.resize( obj.value.size() );
       memcpy( data.data(), obj.value.data(), obj.value.size() );
@@ -778,3 +785,4 @@ FC_REFLECT( eosio::chain_apis::read_only::abi_bin_to_json_params, (code)(action)
 FC_REFLECT( eosio::chain_apis::read_only::abi_bin_to_json_result, (args) )
 FC_REFLECT( eosio::chain_apis::read_only::get_required_keys_params, (transaction)(available_keys) )
 FC_REFLECT( eosio::chain_apis::read_only::get_required_keys_result, (required_keys) )
+FC_REFLECT( eosio::chain_apis::read_only::get_transaction_merkle_proof_params, (transaction_id)(block_num_or_id) )

--- a/programs/cleos/httpc.hpp
+++ b/programs/cleos/httpc.hpp
@@ -99,6 +99,7 @@ namespace eosio { namespace client { namespace http {
    const string get_producers_func = chain_func_base + "/get_producers";
    const string get_schedule_func = chain_func_base + "/get_producer_schedule";
    const string get_required_keys = chain_func_base + "/get_required_keys";
+   const string get_proof_func = chain_func_base + "/get_transaction_merkle_proof";
 
    const string history_func_base = "/v1/history";
    const string get_actions_func = history_func_base + "/get_actions";

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -2796,6 +2796,16 @@ int main( int argc, char** argv ) {
       std::cout << fc::json::to_pretty_string(call(get_transaction_func, arg)) << std::endl;
    });
 
+   // get transaction merkle proof
+   string block_num_or_id;
+   auto getProof = get->add_subcommand("proof", localized("Retrieve merkle proof of a given transaction"), false);
+   getProof->add_option("id", transaction_id_str, localized("ID of the transaction to generate merkle proof"))->required();
+   getProof->add_option("block", block_num_or_id, localized("The number or ID of the block which contains the transaction"))->required();
+   getProof->set_callback([&] {
+      auto arg = fc::mutable_variant_object("transaction_id", transaction_id_str)("block_num_or_id", block_num_or_id);
+      std::cout << fc::json::to_pretty_string(call(get_proof_func, arg)) << std::endl;
+   });
+
    // get actions
    string account_name;
    string skip_seq_str;

--- a/unittests/misc_tests.cpp
+++ b/unittests/misc_tests.cpp
@@ -4,6 +4,7 @@
 #include <eosio/chain/chain_config.hpp>
 #include <eosio/chain/types.hpp>
 #include <eosio/chain/thread_utils.hpp>
+#include <eosio/chain/merkle.hpp>
 #include <eosio/testing/tester.hpp>
 
 #include <fc/io/json.hpp>
@@ -1108,6 +1109,30 @@ BOOST_AUTO_TEST_CASE(stable_priority_queue_test) {
      }
 
   } FC_LOG_AND_RETHROW()
+}
+
+BOOST_AUTO_TEST_CASE(merkle_proof_test) {
+   try {
+      auto tx_digest = digest_type("42285b74bf7dbf5f2f98c06c8dfb73a4cb0f5bc3ecf869ebf45975728720cdb7");
+
+      vector<digest_type> ids;
+      ids.emplace_back("1389f82e38b40d73cd2f055aef2802b259e44622bf7f6689cb766d867ac542ea");
+      ids.push_back(tx_digest);
+      ids.emplace_back("c10aaf3ff64068a55ddddc277ff054879d63834161cc0dfebbb4b682915e8c48");
+
+      vector<digest_type> proof;
+      proof.push_back(tx_digest);
+      proof.emplace_back("1389f82e38b40d73cd2f055aef2802b259e44622bf7f6689cb766d867ac542ea");
+      proof.emplace_back("81b59aca8c63a42976a782bfe45e3e0d7aff28785aad25dd68643c835ce8925b");
+      proof.emplace_back("3737f95d45171a1830637a3878594b9bd52b9b6316149ee0773a3487add0a166");
+
+      auto gen_proof = generate_merkle_proof(tx_digest, ids);
+
+      BOOST_CHECK(std::equal(gen_proof.begin(), gen_proof.end(), proof.begin(), proof.end()));
+
+      BOOST_CHECK(verify_merkle_proof(gen_proof));
+
+   } FC_LOG_AND_RETHROW()
 }
 
 

--- a/unittests/misc_tests.cpp
+++ b/unittests/misc_tests.cpp
@@ -1128,7 +1128,7 @@ BOOST_AUTO_TEST_CASE(merkle_proof_test) {
 
       auto gen_proof = generate_merkle_proof(tx_digest, ids);
 
-      BOOST_CHECK(std::equal(gen_proof.begin(), gen_proof.end(), proof.begin(), proof.end()));
+      BOOST_TEST(gen_proof == proof);
 
       BOOST_CHECK(verify_merkle_proof(gen_proof));
 


### PR DESCRIPTION
## Change Description

Merkle proof is very basic feature used in inter-blockchain communication. It can be done in application level, but it would be helpful provided by RPC API.

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [x] API Changes

`/v1/chain/get_transaction_merkle_proof` is added.

## Documentation Additions
- [x] Documentation Additions

API needs to be documented.