### PR TITLE
Increase Contracts Builder Timeout + Fix $SKIP_MAC

### DIFF
--- a/.cicd/generate-pipeline.sh
+++ b/.cicd/generate-pipeline.sh
@@ -360,7 +360,7 @@ cat <<EOF
     agents:
       queue: "automation-basic-builder-fleet"
     timeout: "${TIMEOUT:-5}"
-    skip: ${SKIP_MOJAVE}${SKIP_PACKAGE_BUILDER}
+    skip: ${SKIP_MOJAVE}${SKIP_PACKAGE_BUILDER}${SKIP_MAC}
 
 EOF
 IFS=$oIFS

--- a/.cicd/generate-pipeline.sh
+++ b/.cicd/generate-pipeline.sh
@@ -342,7 +342,7 @@ cat <<EOF
       BUILDKITE_AGENT_ACCESS_TOKEN:
     agents:
       queue: "automation-eos-builder-fleet"
-    timeout: ${TIMEOUT:-10}
+    timeout: ${TIMEOUT:-30}
     skip: ${SKIP_CONTRACT_BUILDER}${SKIP_LINUX}
 
   - wait

--- a/.cicd/generate-pipeline.sh
+++ b/.cicd/generate-pipeline.sh
@@ -338,7 +338,7 @@ cat <<EOF
   - label: ":ubuntu: Ubuntu 18.04 - Contract Builder"
     command: "./.cicd/installation-build.sh"
     env:
-      IMAGE_TAG: "ubuntu-18.04"
+      IMAGE_TAG: "ubuntu-18.04-unpinned"
       BUILDKITE_AGENT_ACCESS_TOKEN:
     agents:
       queue: "automation-eos-builder-fleet"


### PR DESCRIPTION
## Change Description
This pull request fixes three problems we found in [Buildkite pipeline 3.0](https://github.com/EOSIO/eos/pull/7700). The first is a missing `SKIP_MAC` variable on the Brew Updater step, causing that step to fail any builds started with `SKIP_MAC='true'`. The second problem was that the Contracts Builder step had a timeout of 10 minutes, but took about 10 minutes to run. The default timeout for that step has been increased to 30 minutes. The third is that Contract Builders were incorrectly using the pinned U18 dockerfile. This is changed to the unpinned U18 dockerfile to match the current Contracts pipeline.

### Tested
- [Buildkite build 16702](https://buildkite.com/EOSIO/eosio/builds/16702)
- [Buildkite beta build 1839](https://buildkite.com/EOSIO/eosio-beta/builds/1839)

## Consensus Changes
- [ ] Consensus Changes
None.

## API Changes
- [ ] API Changes
None.

## Documentation Additions
- [ ] Documentation Additions
None.