### PR TITLE
[1.7.x] Increase Contracts Builder Timeout + Fix $SKIP_MAC + Fix hard-coded build command

### DIFF
--- a/.cicd/build.sh
+++ b/.cicd/build.sh
@@ -44,8 +44,6 @@ else # linux
         COMMANDS="ccache -s && $BUILD_COMMANDS"
     fi
     COMMANDS="$PRE_COMMANDS && $COMMANDS"
-    # install eosio for contracts CICD release
-    COMMANDS="cd $MOUNTED_DIR && ./scripts/eosio_build.sh -y && ./scripts/eosio_install.sh"
     echo "docker run $ARGS $(buildkite-intrinsics) $FULL_TAG bash -c \"$COMMANDS\""
     eval docker run $ARGS $(buildkite-intrinsics) $FULL_TAG bash -c \"$COMMANDS\"
 fi

--- a/.cicd/generate-pipeline.sh
+++ b/.cicd/generate-pipeline.sh
@@ -395,7 +395,7 @@ cat <<EOF
     agents:
       queue: "automation-basic-builder-fleet"
     timeout: "${TIMEOUT:-5}"
-    skip: ${SKIP_HIGH_SIERRA}${SKIP_MOJAVE}${SKIP_PACKAGE_BUILDER}
+    skip: ${SKIP_HIGH_SIERRA}${SKIP_MOJAVE}${SKIP_PACKAGE_BUILDER}${SKIP_MAC}
 
 EOF
 IFS=$oIFS

--- a/.cicd/generate-pipeline.sh
+++ b/.cicd/generate-pipeline.sh
@@ -370,7 +370,7 @@ cat <<EOF
       BUILDKITE_AGENT_ACCESS_TOKEN:
     agents:
       queue: "automation-eos-builder-fleet"
-    timeout: ${TIMEOUT:-10}
+    timeout: ${TIMEOUT:-30}
     skip: ${SKIP_CONTRACT_BUILDER}${SKIP_LINUX}
 
   - wait


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
This pull request fixes two problems we found in [Buildkite pipeline 3.0](https://github.com/EOSIO/eos/pull/7700). The first is a missing `SKIP_MAC` variable on the Brew Updater step, causing that step to fail any builds started with `SKIP_MAC='true'`. The second problem was that the Contracts Builder step had a timeout of 10 minutes, but took about 10 minutes to run. The default timeout for that step has been increased to 30 minutes.

1.7 has an additional fix impacting `.cicd/build.sh`. Linux builds previously had a hard-coded COMMANDS variable. This worked appropriately when only performing a build, but was incorrect for the Contract Builder step. This script now runs cmake, make, and make install with the appropriately determined CMAKE_FLAGS.

### Tested
- [Buildkite build 16694](https://buildkite.com/EOSIO/eosio/builds/16694)
- [Buildkite beta build 1829](https://buildkite.com/EOSIO/eosio-beta/builds/1829)

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
