### PR TITLE
Net plugin sync - 1.7

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -1497,13 +1497,13 @@ namespace eosio {
          }
       }
       if( req.req_blocks.mode == catch_up ) {
-         c->fork_head = id;
-         c->fork_head_num = num;
          fc_ilog( logger, "got a catch_up notice while in ${s}, fork head num = ${fhn} target LIB = ${lib} next_expected = ${ne}",
                   ("s",stage_str(state))("fhn",num)("lib",sync_known_lib_num)("ne", sync_next_expected_num) );
          if (state == lib_catchup)
             return false;
          set_state(head_catchup);
+         c->fork_head = id;
+         c->fork_head_num = num;
       }
       else {
          c->fork_head = block_id_type();


### PR DESCRIPTION
## Change Description

- This PR contains a fix that brings stability to the nodeos startup catchup test `nodeos_startup_catchup_lr_test`.
- Moved the recording of `connection` `fork_head` & `fork_head_num` after we have determined we are not in `lib_catchup` as setting this when in lib catchup and returning sets up condition where subsequent calls would see the change and not send a catchup request.

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
