### PR TITLE
Add output of build info on nodeos startup

### DIFF
--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -14,6 +14,8 @@
 
 #include <eosio/chain/eosio_contract.hpp>
 
+#include <chainbase/environment.hpp>
+
 #include <boost/signals2/connection.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
@@ -22,6 +24,13 @@
 #include <fc/variant.hpp>
 #include <signal.h>
 #include <cstdlib>
+
+// reflect chainbase::environment for --print-build-info option
+FC_REFLECT_ENUM( chainbase::environment::os_t,
+                 (OS_LINUX)(OS_MACOS)(OS_WINDOWS)(OS_OTHER) )
+FC_REFLECT_ENUM( chainbase::environment::arch_t,
+                 (ARCH_X86_64)(ARCH_ARM)(ARCH_RISCV)(ARCH_OTHER) )
+FC_REFLECT(chainbase::environment, (debug)(os)(arch)(boost_version)(compiler) )
 
 namespace eosio {
 
@@ -263,6 +272,8 @@ void chain_plugin::set_program_options(options_description& cli, options_descrip
           "extract genesis_state from blocks.log as JSON, print to console, and exit")
          ("extract-genesis-json", bpo::value<bfs::path>(),
           "extract genesis_state from blocks.log as JSON, write into specified file, and exit")
+         ("print-build-info", bpo::bool_switch()->default_value(false),
+          "print build environment information to console as JSON and exit")
          ("fix-reversible-blocks", bpo::bool_switch()->default_value(false),
           "recovers reversible block database if that database is in a bad state")
          ("force-all-checks", bpo::bool_switch()->default_value(false),
@@ -566,6 +577,11 @@ void chain_plugin::plugin_initialize(const variables_map& options) {
       }
 
       my->chain_config = controller::config();
+
+      if( options.at( "print-build-info" ).as<bool>() ) {
+         ilog( "Build environment JSON:\n${e}", ("e", json::to_pretty_string( chainbase::environment() )) );
+         EOS_THROW( node_management_success, "reported build environment information" );
+      }
 
       LOAD_VALUE_SET( options, "sender-bypass-whiteblacklist", my->chain_config->sender_bypass_whiteblacklist );
       LOAD_VALUE_SET( options, "actor-whitelist", my->chain_config->actor_whitelist );

--- a/programs/nodeos/main.cpp
+++ b/programs/nodeos/main.cpp
@@ -5,8 +5,6 @@
 #include <eosio/net_plugin/net_plugin.hpp>
 #include <eosio/producer_plugin/producer_plugin.hpp>
 
-#include <chainbase/environment.hpp>
-
 #include <fc/log/logger_config.hpp>
 #include <fc/log/appender.hpp>
 #include <fc/exception/exception.hpp>
@@ -84,8 +82,6 @@ int main(int argc, char** argv)
 {
    try {
       app().set_version(eosio::nodeos::config::version);
-      std::stringstream ss_env;
-      ss_env << chainbase::environment();
 
       auto root = fc::app_path();
       app().set_default_data_dir(root / "eosio" / nodeos::config::node_executable_name / "data" );
@@ -104,7 +100,6 @@ int main(int argc, char** argv)
       ilog("${name} version ${ver}", ("name", nodeos::config::node_executable_name)("ver", app().version_string()));
       ilog("${name} using configuration file ${c}", ("name", nodeos::config::node_executable_name)("c", app().full_config_file_path().string()));
       ilog("${name} data directory is ${d}", ("name", nodeos::config::node_executable_name)("d", app().data_dir().string()));
-      ilog("${name} build:\n${e}", ("name", nodeos::config::node_executable_name)("e", ss_env.str()));
       app().startup();
       app().set_thread_priority_max();
       app().exec();

--- a/programs/nodeos/main.cpp
+++ b/programs/nodeos/main.cpp
@@ -5,6 +5,8 @@
 #include <eosio/net_plugin/net_plugin.hpp>
 #include <eosio/producer_plugin/producer_plugin.hpp>
 
+#include <chainbase/environment.hpp>
+
 #include <fc/log/logger_config.hpp>
 #include <fc/log/appender.hpp>
 #include <fc/exception/exception.hpp>
@@ -82,6 +84,8 @@ int main(int argc, char** argv)
 {
    try {
       app().set_version(eosio::nodeos::config::version);
+      std::stringstream ss_env;
+      ss_env << chainbase::environment();
 
       auto root = fc::app_path();
       app().set_default_data_dir(root / "eosio" / nodeos::config::node_executable_name / "data" );
@@ -100,6 +104,7 @@ int main(int argc, char** argv)
       ilog("${name} version ${ver}", ("name", nodeos::config::node_executable_name)("ver", app().version_string()));
       ilog("${name} using configuration file ${c}", ("name", nodeos::config::node_executable_name)("c", app().full_config_file_path().string()));
       ilog("${name} data directory is ${d}", ("name", nodeos::config::node_executable_name)("d", app().data_dir().string()));
+      ilog("${name} build:\n${e}", ("name", nodeos::config::node_executable_name)("e", ss_env.str()));
       app().startup();
       app().set_thread_priority_max();
       app().exec();


### PR DESCRIPTION
## Change Description

- Add output of build info of `nodeos` via `--print-build-info` & `--extract-build-info`
- Example:
```
10:28:58@heifnerk:~/ext/eosio/programs/nodeos$ ./nodeos --print-build-info
info  2019-09-09T15:29:17.655 nodeos    chain_plugin.cpp:568          plugin_initialize    ] initializing chain plugin
info  2019-09-09T15:29:17.655 nodeos    chain_plugin.cpp:582          plugin_initialize    ] Build environment JSON:
{
  "debug": false,
  "os": "OS_LINUX",
  "arch": "ARCH_X86_64",
  "boost_version": 107000,
  "compiler": "4.2.1 Compatible Clang 7.0.0 (tags/RELEASE_700/final)"
}
warn  2019-09-09T15:29:17.655 nodeos    chain_plugin.cpp:960          plugin_initialize    ] 3100009 node_management_success: Node management operation successfully executed
reported build environment information
    {}
    nodeos  chain_plugin.cpp:583 plugin_initialize
Failed to initialize
```

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [x] Documentation Additions

- Add documentation for new `--print-build-info` & `--extract-build-info`

```
  --print-build-info                    print build environment information to 
                                        console as JSON and exit
  --extract-build-info arg              extract build environment information 
                                        as JSON, write into specified file, and
                                        exit
```