### PR TITLE
cleos get actions - 1.7

### DIFF
--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -2288,6 +2288,7 @@ int main( int argc, char** argv ) {
    setlocale(LC_ALL, "");
    bindtextdomain(locale_domain, locale_path);
    textdomain(locale_domain);
+   fc::logger::get(DEFAULT_LOGGER).set_log_level(fc::log_level::debug);
    context = eosio::client::http::create_http_context();
    wallet_url = default_wallet_url;
 


### PR DESCRIPTION
## Change Description

- Set `cleos` to use default log level of debug since it uses debug for some output; specifically `cleos get actions`
- Resolves #7867 

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
