### PR TITLE
[1.8.x] Mac Builder Boost Fix

### DIFF
--- a/.cicd/generate-pipeline.sh
+++ b/.cicd/generate-pipeline.sh
@@ -360,7 +360,7 @@ cat <<EOF
     agents:
       queue: "automation-basic-builder-fleet"
     timeout: "${TIMEOUT:-5}"
-    skip: ${SKIP_MOJAVE}${SKIP_PACKAGE_BUILDER}${SKIP_MAC}
+    skip: ${SKIP_PACKAGE_BUILDER}${SKIP_MAC}${SKIP_MACOS_10_14}
 
 EOF
 IFS=$oIFS

--- a/.cicd/platforms/macos-10.14.sh
+++ b/.cicd/platforms/macos-10.14.sh
@@ -56,7 +56,7 @@ if [[ ! $PINNED == false || $UNPINNED == true ]]; then
     ./bootstrap.sh --with-toolset=clang --prefix=/usr/local
     sudo ./b2 toolset=clang cxxflags='-stdlib=libc++ -D__STRICT_ANSI__ -nostdinc++ -I/usr/local/include/c++/v1' linkflags='-stdlib=libc++' link=static threading=multi --with-iostreams --with-date_time --with-filesystem --with-system --with-program_options --with-chrono --with-test -q -j$(getconf _NPROCESSORS_ONLN) install
     cd ..
-    rm -rf boost_1_70_0.tar.bz2 /boost_1_70_0  
+    sudo rm -rf boost_1_70_0.tar.bz2 boost_1_70_0  
 else
     # install boost from brew
     brew install boost || true

--- a/.cicd/platforms/macos-10.14.sh
+++ b/.cicd/platforms/macos-10.14.sh
@@ -54,7 +54,7 @@ if [[ ! $PINNED == false || $UNPINNED == true ]]; then
     tar -xjf boost_1_70_0.tar.bz2
     cd boost_1_70_0
     ./bootstrap.sh --with-toolset=clang --prefix=/usr/local
-    ./b2 toolset=clang cxxflags='-stdlib=libc++ -D__STRICT_ANSI__ -nostdinc++ -I/usr/local/include/c++/v1' linkflags='-stdlib=libc++' link=static threading=multi --with-iostreams --with-date_time --with-filesystem --with-system --with-program_options --with-chrono --with-test -q -j$(getconf _NPROCESSORS_ONLN) install
+    sudo ./b2 toolset=clang cxxflags='-stdlib=libc++ -D__STRICT_ANSI__ -nostdinc++ -I/usr/local/include/c++/v1' linkflags='-stdlib=libc++' link=static threading=multi --with-iostreams --with-date_time --with-filesystem --with-system --with-program_options --with-chrono --with-test -q -j$(getconf _NPROCESSORS_ONLN) install
     cd ..
     rm -rf boost_1_70_0.tar.bz2 /boost_1_70_0  
 else

--- a/.cicd/platforms/macos-10.14.sh
+++ b/.cicd/platforms/macos-10.14.sh
@@ -53,8 +53,8 @@ if [[ ! $PINNED == false || $UNPINNED == true ]]; then
     curl -LO https://dl.bintray.com/boostorg/release/1.70.0/source/boost_1_70_0.tar.bz2
     tar -xjf boost_1_70_0.tar.bz2
     cd boost_1_70_0
-    ./bootstrap.sh --with-toolset=clang --prefix=/usr/local
-    sudo ./b2 toolset=clang cxxflags='-stdlib=libc++ -D__STRICT_ANSI__ -nostdinc++ -I/usr/local/include/c++/v1' linkflags='-stdlib=libc++' link=static threading=multi --with-iostreams --with-date_time --with-filesystem --with-system --with-program_options --with-chrono --with-test -q -j$(getconf _NPROCESSORS_ONLN) install
+    ./bootstrap.sh --prefix=/usr/local
+    sudo ./b2 --with-iostreams --with-date_time --with-filesystem --with-system --with-program_options --with-chrono --with-test -q -j$(getconf _NPROCESSORS_ONLN) install
     cd ..
     sudo rm -rf boost_1_70_0.tar.bz2 boost_1_70_0  
 else

--- a/.cicd/platforms/macos-10.14.sh
+++ b/.cicd/platforms/macos-10.14.sh
@@ -2,9 +2,9 @@
 set -eo pipefail
 VERSION=1
 brew update
-brew install git boost@1.70 cmake python@2 python libtool libusb graphviz automake wget gmp llvm@4 pkgconfig doxygen openssl || true
-# install clang from source
+brew install git cmake python@2 python libtool libusb graphviz automake wget gmp llvm@4 pkgconfig doxygen openssl || true
 if [[ ! $PINNED == false || $UNPINNED == true ]]; then
+    # install clang from source
     git clone --single-branch --branch release_80 https://git.llvm.org/git/llvm.git clang8
     cd clang8
     git checkout 18e41dc
@@ -49,6 +49,17 @@ if [[ ! $PINNED == false || $UNPINNED == true ]]; then
     sudo make install
     cd ../..
     rm -rf clang8
+    # install boost from source
+    curl -LO https://dl.bintray.com/boostorg/release/1.70.0/source/boost_1_70_0.tar.bz2
+    tar -xjf boost_1_70_0.tar.bz2
+    cd boost_1_70_0
+    ./bootstrap.sh --with-toolset=clang --prefix=/usr/local
+    ./b2 toolset=clang cxxflags='-stdlib=libc++ -D__STRICT_ANSI__ -nostdinc++ -I/usr/local/include/c++/v1' linkflags='-stdlib=libc++' link=static threading=multi --with-iostreams --with-date_time --with-filesystem --with-system --with-program_options --with-chrono --with-test -q -j$(getconf _NPROCESSORS_ONLN) install
+    cd ..
+    rm -rf boost_1_70_0.tar.bz2 /boost_1_70_0  
+else
+    # install boost from brew
+    brew install boost || true
 fi
 # install mongoDB
 cd ~


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
Added fixes for the following CICD issues:
* Removed leftover SKIP_MOJAVE flag and replaced with flag used in build and test steps: SKIP_MACOS_10_14.
* Fixed issue where Mac pinned builders were not source installing Boost 1.70.
** All pinned Mac builders now install Boost 1.70 from source.
** All unpinned Mac builders now install Boost via Brew.

See:
https://buildkite.com/EOSIO/eosio/builds/17139 | Pinned
https://buildkite.com/EOSIO/eosio-build-unpinned/builds/516 | Unpinned
## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
