### PR TITLE
Fix tests bootstrap - 1.8

### DIFF
--- a/tests/Cluster.py
+++ b/tests/Cluster.py
@@ -1289,10 +1289,14 @@ class Cluster(object):
         if not biosNode.waitForTransInBlock(transId):
             Utils.Print("ERROR: Failed to validate transaction %s got rolled into a block on server port %d." % (transId, biosNode.port))
             return None
-        action="init"
-        data="{\"version\":0,\"core\":\"4,%s\"}" % (CORE_SYMBOL)
-        opts="--permission %s@active" % (eosioAccount.name)
-        trans=biosNode.pushMessage(eosioAccount.name, action, data, opts)
+
+        # Only call init if the system contract is loaded
+        if loadSystemContract:
+            action="init"
+            data="{\"version\":0,\"core\":\"4,%s\"}" % (CORE_SYMBOL)
+            opts="--permission %s@active" % (eosioAccount.name)
+            trans=biosNode.pushMessage(eosioAccount.name, action, data, opts)
+
         Utils.Print("Cluster bootstrap done.")
 
         return biosNode


### PR DESCRIPTION
## Change Description

- The python bootstrap tests launch was calling `init` even when `eosio.system` contract not loaded.
- This was already fixed in `develop` branch (#7321).

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
