### PR TITLE
[1.7.x] Ensure Artfacts Upload on Failed Tests

### DIFF
--- a/.cicd/test.sh
+++ b/.cicd/test.sh
@@ -5,11 +5,13 @@ set -eo pipefail
 # tests
 if [[ $(uname) == 'Darwin' ]]; then # macOS
     export PATH=$PATH:~/mongodb/bin
+    set +e # defer error handling to end
     ./"$@"
     EXIT_STATUS=$?
 else # Linux
     . $HELPERS_DIR/file-hash.sh $CICD_DIR/platforms/$IMAGE_TAG.dockerfile
     echo "$ docker run --rm --init -v $(pwd):$MOUNTED_DIR $(buildkite-intrinsics) $FULL_TAG bash -c \"$MOUNTED_DIR/$@\""
+    set +e # defer error handling to end
     eval docker run --rm --init -v $(pwd):$MOUNTED_DIR $(buildkite-intrinsics) $FULL_TAG bash -c \"$MOUNTED_DIR/$@\"
     EXIT_STATUS=$?
 fi


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
Fixed issue where artifacts from tests would not upload to Buildkite when the test would fail.

See:
[Build #17169](https://buildkite.com/EOSIO/eosio/builds/17169#ae7389c1-9983-4f9e-80f1-4513240678b9) | Issue originally reported.
[Build #17249](https://buildkite.com/EOSIO/eosio/builds/17249#275be10e-85bb-470d-8891-d7d4f531365b) | Test artifact uploading working as expected.
## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
