### PR TITLE
Create Release Build Test

### DIFF
--- a/.cicd/platforms/amazon_linux-2-unpinned.dockerfile
+++ b/.cicd/platforms/amazon_linux-2-unpinned.dockerfile
@@ -5,7 +5,7 @@ RUN yum update -y && \
     yum install -y which git sudo procps-ng util-linux autoconf automake \
     libtool make bzip2 bzip2-devel openssl-devel gmp-devel libstdc++ libcurl-devel \
     libusbx-devel python3 python3-devel python-devel libedit-devel doxygen \
-    graphviz clang patch
+    graphviz clang patch vim-common
 # build cmake.
 RUN curl -LO https://cmake.org/files/v3.13/cmake-3.13.2.tar.gz && \
     tar -xzf cmake-3.13.2.tar.gz && \

--- a/.cicd/platforms/amazon_linux-2.dockerfile
+++ b/.cicd/platforms/amazon_linux-2.dockerfile
@@ -5,7 +5,7 @@ RUN yum update -y && \
     yum install -y which git sudo procps-ng util-linux autoconf automake \
     libtool make bzip2 bzip2-devel openssl-devel gmp-devel libstdc++ libcurl-devel \
     libusbx-devel python3 python3-devel python-devel libedit-devel doxygen \
-    graphviz patch gcc gcc-c++
+    graphviz patch gcc gcc-c++ vim-common
 # build cmake.
 RUN curl -LO https://cmake.org/files/v3.13/cmake-3.13.2.tar.gz && \
     tar -xzf cmake-3.13.2.tar.gz && \

--- a/.cicd/platforms/centos-7.6-unpinned.dockerfile
+++ b/.cicd/platforms/centos-7.6-unpinned.dockerfile
@@ -7,7 +7,7 @@ RUN yum update -y && \
     yum --enablerepo=extras install -y which git autoconf automake libtool make bzip2 doxygen \
     graphviz bzip2-devel openssl-devel gmp-devel ocaml libicu-devel \
     python python-devel rh-python36 gettext-devel file libusbx-devel \
-    libcurl-devel patch
+    libcurl-devel patch vim-common
 # build cmake.
 RUN curl -LO https://cmake.org/files/v3.13/cmake-3.13.2.tar.gz && \
     source /opt/rh/devtoolset-8/enable && \

--- a/.cicd/platforms/centos-7.6.dockerfile
+++ b/.cicd/platforms/centos-7.6.dockerfile
@@ -7,7 +7,7 @@ RUN yum update -y && \
     yum --enablerepo=extras install -y which git autoconf automake libtool make bzip2 doxygen \
     graphviz bzip2-devel openssl-devel gmp-devel ocaml libicu-devel \
     python python-devel rh-python36 gettext-devel file libusbx-devel \
-    libcurl-devel patch
+    libcurl-devel patch vim-common
 # build cmake.
 RUN curl -LO https://cmake.org/files/v3.13/cmake-3.13.2.tar.gz && \
     source /opt/rh/devtoolset-8/enable && \

--- a/.cicd/platforms/ubuntu-16.04.dockerfile
+++ b/.cicd/platforms/ubuntu-16.04.dockerfile
@@ -1,7 +1,8 @@
 FROM ubuntu:16.04
 ENV VERSION 1
 # install dependencies.
-RUN apt-get update && apt-get upgrade -y && \
+RUN apt-get update && \
+    apt-get upgrade -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential git automake \
     libbz2-dev libssl-dev doxygen graphviz libgmp3-dev autotools-dev libicu-dev \
     python2.7 python2.7-dev python3 python3-dev autoconf libtool curl zlib1g-dev \

--- a/.cicd/platforms/ubuntu-16.04.dockerfile
+++ b/.cicd/platforms/ubuntu-16.04.dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential git automake \
     libbz2-dev libssl-dev doxygen graphviz libgmp3-dev autotools-dev libicu-dev \
     python2.7 python2.7-dev python3 python3-dev autoconf libtool curl zlib1g-dev \
-    sudo ruby libusb-1.0-0-dev libcurl4-gnutls-dev pkg-config apt-transport-https
+    sudo ruby libusb-1.0-0-dev libcurl4-gnutls-dev pkg-config apt-transport-https vim-common
 # build cmake.
 RUN curl -LO https://cmake.org/files/v3.13/cmake-3.13.2.tar.gz && \
     tar -xzf cmake-3.13.2.tar.gz && \

--- a/.cicd/platforms/ubuntu-18.04-unpinned.dockerfile
+++ b/.cicd/platforms/ubuntu-18.04-unpinned.dockerfile
@@ -1,7 +1,8 @@
 FROM ubuntu:18.04
 ENV VERSION 1
 # install dependencies.
-RUN apt-get update && apt-get upgrade -y && \
+RUN apt-get update && \
+    apt-get upgrade -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y git make \
     bzip2 automake libbz2-dev libssl-dev doxygen graphviz libgmp3-dev \
     autotools-dev libicu-dev python2.7 python2.7-dev python3 python3-dev \

--- a/.cicd/platforms/ubuntu-18.04-unpinned.dockerfile
+++ b/.cicd/platforms/ubuntu-18.04-unpinned.dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && \
     bzip2 automake libbz2-dev libssl-dev doxygen graphviz libgmp3-dev \
     autotools-dev libicu-dev python2.7 python2.7-dev python3 python3-dev \
     autoconf libtool g++ gcc curl zlib1g-dev sudo ruby libusb-1.0-0-dev \
-    libcurl4-gnutls-dev pkg-config patch llvm-4.0 clang ccache
+    libcurl4-gnutls-dev pkg-config patch llvm-4.0 clang ccache vim-common
 # build cmake.
 RUN curl -LO https://cmake.org/files/v3.13/cmake-3.13.2.tar.gz && \
     tar -xzf cmake-3.13.2.tar.gz && \

--- a/.cicd/platforms/ubuntu-18.04.dockerfile
+++ b/.cicd/platforms/ubuntu-18.04.dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && \
     bzip2 automake libbz2-dev libssl-dev doxygen graphviz libgmp3-dev \
     autotools-dev libicu-dev python2.7 python2.7-dev python3 python3-dev \
     autoconf libtool g++ gcc curl zlib1g-dev sudo ruby libusb-1.0-0-dev \
-    libcurl4-gnutls-dev pkg-config patch ccache
+    libcurl4-gnutls-dev pkg-config patch ccache vim-common
 # build cmake.
 RUN curl -LO https://cmake.org/files/v3.13/cmake-3.13.2.tar.gz && \
     tar -xzf cmake-3.13.2.tar.gz && \

--- a/.cicd/platforms/ubuntu-18.04.dockerfile
+++ b/.cicd/platforms/ubuntu-18.04.dockerfile
@@ -1,7 +1,8 @@
 FROM ubuntu:18.04
 ENV VERSION 1
 # install dependencies.
-RUN apt-get update && apt-get upgrade -y && \
+RUN apt-get update && \
+    apt-get upgrade -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y git make \
     bzip2 automake libbz2-dev libssl-dev doxygen graphviz libgmp3-dev \
     autotools-dev libicu-dev python2.7 python2.7-dev python3 python3-dev \

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -48,6 +48,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/validate-dirty-db.py ${CMAKE_CURRENT_
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/launcher_test.py ${CMAKE_CURRENT_BINARY_DIR}/launcher_test.py COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/db_modes_test.sh ${CMAKE_CURRENT_BINARY_DIR}/db_modes_test.sh COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/prod_preactivation_test.py ${CMAKE_CURRENT_BINARY_DIR}/prod_preactivation_test.py COPYONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/release-build.sh ${CMAKE_CURRENT_BINARY_DIR}/release-build.sh COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/version-label.sh ${CMAKE_CURRENT_BINARY_DIR}/version-label.sh COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/nodeos_producer_watermark_test.py ${CMAKE_CURRENT_BINARY_DIR}/nodeos_producer_watermark_test.py COPYONLY)
 
@@ -86,6 +87,8 @@ add_test(NAME launcher_test COMMAND tests/launcher_test.py -v --clean-run --dump
 set_property(TEST launcher_test PROPERTY LABELS nonparallelizable_tests)
 add_test(NAME db_modes_test COMMAND tests/db_modes_test.sh WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 set_tests_properties(db_modes_test PROPERTIES COST 6000)
+add_test(NAME release-build-test COMMAND tests/release-build.sh WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+set_property(TEST release-build-test PROPERTY LABELS nonparallelizable_tests)
 add_test(NAME version-label-test COMMAND tests/version-label.sh WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 
 # Long running tests

--- a/tests/release-build.sh
+++ b/tests/release-build.sh
@@ -34,6 +34,7 @@ if [[ ! -f data/state/shared_memory.bin ]]; then
     echo "$ ls -la \"$(pwd)/data/state\""
     ls -la "$(pwd)/data/state"
     echo 'Release build test not run.'
+    rm -rf config data
     exit 2
 fi
 # test state files for debug flag
@@ -48,4 +49,5 @@ echo "Debug Byte = 0x$DEBUG_BYTE"
 echo 'First kilobyte of shared_memory.bin:'
 echo '$ xxd -l 1024 shared_memory.bin'
 xxd -l 1024 data/state/shared_memory.bin
+rm -rf config data
 exit 3

--- a/tests/release-build.sh
+++ b/tests/release-build.sh
@@ -10,7 +10,7 @@ echo 'performance-critical applications like nodeos. Anyone intending to build a
 echo 'install nodeos from source should perform a "release build," which excludes'
 echo 'debugging symbols to generate faster and lighter binaries.'
 echo ''
-# environment
+# find nodeos
 [[ -z "$EOSIO_ROOT" && $(git --version) ]] && export EOSIO_ROOT="$(git rev-parse --show-toplevel)"
 [[ -z "$EOSIO_ROOT" ]] && export EOSIO_ROOT="$(echo $(pwd)/ | grep -ioe '.*/eos/' -e '.*/eosio/' -e '.*/build/' | sed 's,/build/,/,')"
 if [[ ! -f "$EOSIO_ROOT/build/bin/nodeos" && ! -f "$EOSIO_ROOT/build/programs/nodeos/nodeos" ]]; then
@@ -24,8 +24,8 @@ if [[ ! -f "$EOSIO_ROOT/build/bin/nodeos" && ! -f "$EOSIO_ROOT/build/programs/no
     exit 1
 fi
 [[ -f "$EOSIO_ROOT/build/bin/nodeos" ]] && cd "$EOSIO_ROOT/build/bin" || cd "$EOSIO_ROOT/build/programs/nodeos"
-# setup
-./nodeos --config-dir "$(pwd)/config" --data-dir "$(pwd)/data" & # run nodeos in background
+# run nodeos to generate state files
+./nodeos --config-dir "$(pwd)/config" --data-dir "$(pwd)/data" &
 sleep 10
 kill $! # kill nodeos gracefully, by PID
 if [[ ! -f data/state/shared_memory.bin ]]; then
@@ -36,7 +36,7 @@ if [[ ! -f data/state/shared_memory.bin ]]; then
     echo 'Release build test not run.'
     exit 2
 fi
-# test
+# test state files for debug flag
 export DEBUG_BYTE="$(xxd -seek 9 -l 1 data/state/shared_memory.bin | awk '{print $2}')"
 if [[ "$DEBUG_BYTE" == '00' ]]; then
     echo 'PASS: Debug byte not set.'

--- a/tests/release-build.sh
+++ b/tests/release-build.sh
@@ -25,7 +25,7 @@ if [[ ! -f "$EOSIO_ROOT/build/bin/nodeos" && ! -f "$EOSIO_ROOT/build/programs/no
 fi
 [[ -f "$EOSIO_ROOT/build/bin/nodeos" ]] && cd "$EOSIO_ROOT/build/bin" || cd "$EOSIO_ROOT/build/programs/nodeos"
 # run nodeos to generate state files
-./nodeos --config-dir "$(pwd)/config" --data-dir "$(pwd)/data" &
+./nodeos --config-dir "$(pwd)/config" --data-dir "$(pwd)/data" 1>/dev/null 2>/dev/null &
 sleep 10
 kill $! # kill nodeos gracefully, by PID
 if [[ ! -f data/state/shared_memory.bin ]]; then

--- a/tests/release-build.sh
+++ b/tests/release-build.sh
@@ -17,23 +17,23 @@ echo ''
 if [[ ! -f "$EOSIO_ROOT/build/bin/nodeos" && ! -f "$EOSIO_ROOT/build/programs/nodeos/nodeos" ]]; then
     echo 'ERROR: nodeos binary not found!'
     echo 'Looked in the following places:'
-    echo "$ ls -la $EOSIO_ROOT/build/bin"
-    ls -la $EOSIO_ROOT/build/bin
-    echo "$ ls -la $EOSIO_ROOT/build/programs/nodeos"
-    ls -la $EOSIO_ROOT/build/programs/nodeos
+    echo "$ ls -la \"$EOSIO_ROOT/build/bin\""
+    ls -la "$EOSIO_ROOT/build/bin"
+    echo "$ ls -la \"$EOSIO_ROOT/build/programs/nodeos\""
+    ls -la "$EOSIO_ROOT/build/programs/nodeos"
     echo "Release Build Test not run because test conditions were not met."
     exit 1
 fi
 [[ -f "$EOSIO_ROOT/build/bin/nodeos" ]] && cd "$EOSIO_ROOT/build/bin" || cd "$EOSIO_ROOT/build/programs/nodeos"
 # setup
-./nodeos --config-dir $(pwd)/config --data-dir $(pwd)/data & # run nodeos in background
+./nodeos --config-dir "$(pwd)/config" --data-dir "$(pwd)/data" & # run nodeos in background
 sleep 10
 kill $! # kill nodeos gracefully, by PID
 if [[ ! -f data/state/shared_memory.bin ]]; then
     echo 'ERROR: nodeos state not found!'
     echo 'Looked for shared_memory.bin in the following places:'
-    echo "$ ls -la $(pwd)/data/state"
-    ls -la $(pwd)/data/state
+    echo "$ ls -la \"$(pwd)/data/state\""
+    ls -la "$(pwd)/data/state"
     echo "Release Build Test not run because test setup failed."
     exit 2
 fi

--- a/tests/release-build.sh
+++ b/tests/release-build.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -e
 # test name and purpose
 echo ''
 echo '                        ##### Release Build Test #####'

--- a/tests/release-build.sh
+++ b/tests/release-build.sh
@@ -15,6 +15,7 @@ echo ''
 [[ -z "$EOSIO_ROOT" ]] && export EOSIO_ROOT="$(echo $(pwd)/ | grep -ioe '.*/eos/' -e '.*/eosio/' -e '.*/build/' | sed 's,/build/,/,')"
 if [[ ! -f "$EOSIO_ROOT/build/bin/nodeos" && ! -f "$EOSIO_ROOT/build/programs/nodeos/nodeos" ]]; then
     echo 'ERROR: nodeos binary not found!'
+    echo ''
     echo 'Looked in the following places:'
     echo "$ ls -la \"$EOSIO_ROOT/build/bin\""
     ls -la "$EOSIO_ROOT/build/bin"
@@ -30,6 +31,7 @@ sleep 10
 kill $! # kill nodeos gracefully, by PID
 if [[ ! -f data/state/shared_memory.bin ]]; then
     echo 'ERROR: nodeos state not found!'
+    echo ''
     echo 'Looked for shared_memory.bin in the following places:'
     echo "$ ls -la \"$(pwd)/data/state\""
     ls -la "$(pwd)/data/state"
@@ -41,11 +43,13 @@ fi
 export DEBUG_BYTE="$(xxd -seek 9 -l 1 data/state/shared_memory.bin | awk '{print $2}')"
 if [[ "$DEBUG_BYTE" == '00' ]]; then
     echo 'PASS: Debug byte not set.'
+    echo ''
     rm -rf config data
     exit 0
 fi
 echo 'FAIL: Debug byte is set!'
 echo "Debug Byte = 0x$DEBUG_BYTE"
+echo ''
 echo 'First kilobyte of shared_memory.bin:'
 echo '$ xxd -l 1024 shared_memory.bin'
 xxd -l 1024 data/state/shared_memory.bin

--- a/tests/release-build.sh
+++ b/tests/release-build.sh
@@ -1,8 +1,15 @@
 #!/bin/bash
 set -e
-# test name
+# test name and purpose
 echo ''
-echo '                         ##### Release Build Test #####'
+echo '                        ##### Release Build Test #####'
+echo ''
+echo 'The purpose of this test is to ensure that nodeos was built without debugging'
+echo 'symbols. Debugging symbols enable software engineers to inspect and control a'
+echo 'running program with a debugging tool, but they significantly slow down'
+echo 'performance-critical applications like nodeos. Anyone intending to build and'
+echo 'install nodeos from source should perform a "release build," which excludes'
+echo 'debugging symbols to generate faster and lighter binaries.'
 echo ''
 # environment
 [[ -z "$EOSIO_ROOT" && $(git --version) ]] && export EOSIO_ROOT="$(git rev-parse --show-toplevel)"

--- a/tests/release-build.sh
+++ b/tests/release-build.sh
@@ -29,6 +29,14 @@ fi
 ./nodeos --config-dir $(pwd)/config --data-dir $(pwd)/data & # run nodeos in background
 sleep 10
 kill $! # kill nodeos gracefully, by PID
+if [[ ! -f data/state/shared_memory.bin ]]; then
+    echo 'ERROR: nodeos state not found!'
+    echo 'Looked for shared_memory.bin in the following places:'
+    echo "$ ls -la $(pwd)/data/state"
+    ls -la $(pwd)/data/state
+    echo "Release Build Test not run because test setup failed."
+    exit 2
+fi
 # test
 export DEBUG_BYTE="$(xxd -seek 9 -l 1 data/state/shared_memory.bin | awk '{print $2}')"
 if [[ "$DEBUG_BYTE" == '00' ]]; then
@@ -40,4 +48,4 @@ echo "Debug Byte = 0x$DEBUG_BYTE"
 echo 'First kilobyte of shared_memory.bin:'
 echo '$ xxd -l 1024 shared_memory.bin'
 xxd -l 1024 data/state/shared_memory.bin
-exit 2
+exit 3

--- a/tests/release-build.sh
+++ b/tests/release-build.sh
@@ -25,10 +25,11 @@ if [[ ! -f "$EOSIO_ROOT/build/bin/nodeos" && ! -f "$EOSIO_ROOT/build/programs/no
     exit 1
 fi
 [[ -f "$EOSIO_ROOT/build/bin/nodeos" ]] && cd "$EOSIO_ROOT/build/bin" || cd "$EOSIO_ROOT/build/programs/nodeos"
-# test
+# setup
 ./nodeos --config-dir $(pwd)/config --data-dir $(pwd)/data & # run nodeos in background
 sleep 10
 kill $! # kill nodeos gracefully, by PID
+# test
 export DEBUG_BYTE="$(xxd -seek 9 -l 1 data/state/shared_memory.bin | awk '{print $2}')"
 if [[ "$DEBUG_BYTE" == '00' ]]; then
     echo 'PASS: Debug byte not set.'

--- a/tests/release-build.sh
+++ b/tests/release-build.sh
@@ -40,6 +40,7 @@ fi
 export DEBUG_BYTE="$(xxd -seek 9 -l 1 data/state/shared_memory.bin | awk '{print $2}')"
 if [[ "$DEBUG_BYTE" == '00' ]]; then
     echo 'PASS: Debug byte not set.'
+    rm -rf config data
     exit 0
 fi
 echo 'FAIL: Debug byte is set!'

--- a/tests/release-build.sh
+++ b/tests/release-build.sh
@@ -19,9 +19,11 @@ echo ''
 ./nodeos --config-dir $(pwd)/config --data-dir $(pwd)/data & # run nodeos in background
 sleep 10
 kill $! # kill nodeos gracefully, by PID
-if [[ "$(xxd -seek 9 -l 1 data/state/shared_memory.bin | awk '{print $2}')" == '00' ]]; then
+export DEBUG_BYTE="$(xxd -seek 9 -l 1 data/state/shared_memory.bin | awk '{print $2}')"
+if [[ "$DEBUG_BYTE" == '00' ]]; then
     echo 'PASS: Debug byte not set.'
     exit 0
 fi
 echo 'FAIL: Debug byte is set!'
+echo "Debug Byte = 0x$DEBUG_BYTE"
 exit 1

--- a/tests/release-build.sh
+++ b/tests/release-build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+# test name
+echo ''
+echo '                         ##### Release Build Test #####'
+echo ''
+# environment
+[[ -z "$EOSIO_ROOT" && $(git --version) ]] && export EOSIO_ROOT="$(git rev-parse --show-toplevel)"
+[[ -z "$EOSIO_ROOT" ]] && export EOSIO_ROOT="$(echo $(pwd)/ | grep -ioe '.*/eos/' -e '.*/eosio/' -e '.*/build/' | sed 's,/build/,/,')"
+[[ -f "$EOSIO_ROOT/build/bin/nodeos" ]] && cd "$EOSIO_ROOT/build/bin" || cd "$EOSIO_ROOT/build/programs/nodeos"
+# test
+./nodeos --config-dir $(pwd)/config --data-dir $(pwd)/data & # run nodeos in background
+sleep 10
+kill $! # kill nodeos gracefully, by PID
+if [[ "$(xxd -seek 9 -l 1 data/state/shared_memory.bin | awk '{print $2}')" == '00' ]]; then
+    echo 'pass'
+    exit 0
+fi
+echo 'FAIL'
+exit 1

--- a/tests/release-build.sh
+++ b/tests/release-build.sh
@@ -20,8 +20,8 @@ echo ''
 sleep 10
 kill $! # kill nodeos gracefully, by PID
 if [[ "$(xxd -seek 9 -l 1 data/state/shared_memory.bin | awk '{print $2}')" == '00' ]]; then
-    echo 'pass'
+    echo 'PASS: Debug byte not set.'
     exit 0
 fi
-echo 'FAIL'
+echo 'FAIL: Debug byte is set!'
 exit 1

--- a/tests/release-build.sh
+++ b/tests/release-build.sh
@@ -14,6 +14,16 @@ echo ''
 # environment
 [[ -z "$EOSIO_ROOT" && $(git --version) ]] && export EOSIO_ROOT="$(git rev-parse --show-toplevel)"
 [[ -z "$EOSIO_ROOT" ]] && export EOSIO_ROOT="$(echo $(pwd)/ | grep -ioe '.*/eos/' -e '.*/eosio/' -e '.*/build/' | sed 's,/build/,/,')"
+if [[ ! -f "$EOSIO_ROOT/build/bin/nodeos" && ! -f "$EOSIO_ROOT/build/programs/nodeos/nodeos" ]]; then
+    echo 'ERROR: nodeos binary not found!'
+    echo 'Looked in the following places:'
+    echo "$ ls -la $EOSIO_ROOT/build/bin"
+    ls -la $EOSIO_ROOT/build/bin
+    echo "$ ls -la $EOSIO_ROOT/build/programs/nodeos"
+    ls -la $EOSIO_ROOT/build/programs/nodeos
+    echo "Release Build Test not run because test conditions were not met."
+    exit 1
+fi
 [[ -f "$EOSIO_ROOT/build/bin/nodeos" ]] && cd "$EOSIO_ROOT/build/bin" || cd "$EOSIO_ROOT/build/programs/nodeos"
 # test
 ./nodeos --config-dir $(pwd)/config --data-dir $(pwd)/data & # run nodeos in background
@@ -29,4 +39,4 @@ echo "Debug Byte = 0x$DEBUG_BYTE"
 echo 'First kilobyte of shared_memory.bin:'
 echo '$ xxd -l 1024 shared_memory.bin'
 xxd -l 1024 data/state/shared_memory.bin
-exit 1
+exit 2

--- a/tests/release-build.sh
+++ b/tests/release-build.sh
@@ -21,7 +21,7 @@ if [[ ! -f "$EOSIO_ROOT/build/bin/nodeos" && ! -f "$EOSIO_ROOT/build/programs/no
     ls -la "$EOSIO_ROOT/build/bin"
     echo "$ ls -la \"$EOSIO_ROOT/build/programs/nodeos\""
     ls -la "$EOSIO_ROOT/build/programs/nodeos"
-    echo "Release Build Test not run because test conditions were not met."
+    echo 'Release build test not run.'
     exit 1
 fi
 [[ -f "$EOSIO_ROOT/build/bin/nodeos" ]] && cd "$EOSIO_ROOT/build/bin" || cd "$EOSIO_ROOT/build/programs/nodeos"
@@ -34,7 +34,7 @@ if [[ ! -f data/state/shared_memory.bin ]]; then
     echo 'Looked for shared_memory.bin in the following places:'
     echo "$ ls -la \"$(pwd)/data/state\""
     ls -la "$(pwd)/data/state"
-    echo "Release Build Test not run because test setup failed."
+    echo 'Release build test not run.'
     exit 2
 fi
 # test

--- a/tests/release-build.sh
+++ b/tests/release-build.sh
@@ -10,6 +10,13 @@ echo 'performance-critical applications like nodeos. Anyone intending to build a
 echo 'install nodeos from source should perform a "release build," which excludes'
 echo 'debugging symbols to generate faster and lighter binaries.'
 echo ''
+# check for xxd
+if ! $(xxd --version 2>/dev/null); then
+    echo 'ERROR: Test requires xxd, but xxd was not found in your PATH!'
+    echo ''
+    echo 'The xxd hex dump tool can be installed as part of the vim-common package on most operating systems.'
+    exit 1
+fi
 # find nodeos
 [[ -z "$EOSIO_ROOT" && $(git --version) ]] && export EOSIO_ROOT="$(git rev-parse --show-toplevel)"
 [[ -z "$EOSIO_ROOT" ]] && export EOSIO_ROOT="$(echo $(pwd)/ | grep -ioe '.*/eos/' -e '.*/eosio/' -e '.*/build/' | sed 's,/build/,/,')"
@@ -22,7 +29,7 @@ if [[ ! -f "$EOSIO_ROOT/build/bin/nodeos" && ! -f "$EOSIO_ROOT/build/programs/no
     echo "$ ls -la \"$EOSIO_ROOT/build/programs/nodeos\""
     ls -la "$EOSIO_ROOT/build/programs/nodeos"
     echo 'Release build test not run.'
-    exit 1
+    exit 2
 fi
 [[ -f "$EOSIO_ROOT/build/bin/nodeos" ]] && cd "$EOSIO_ROOT/build/bin" || cd "$EOSIO_ROOT/build/programs/nodeos"
 # run nodeos to generate state files
@@ -37,7 +44,7 @@ if [[ ! -f data/state/shared_memory.bin ]]; then
     ls -la "$(pwd)/data/state"
     echo 'Release build test not run.'
     rm -rf config data
-    exit 2
+    exit 3
 fi
 # test state files for debug flag
 export DEBUG_BYTE="$(xxd -seek 9 -l 1 data/state/shared_memory.bin | awk '{print $2}')"
@@ -54,4 +61,4 @@ echo 'First kilobyte of shared_memory.bin:'
 echo '$ xxd -l 1024 shared_memory.bin'
 xxd -l 1024 data/state/shared_memory.bin
 rm -rf config data
-exit 3
+exit 4

--- a/tests/release-build.sh
+++ b/tests/release-build.sh
@@ -26,4 +26,7 @@ if [[ "$DEBUG_BYTE" == '00' ]]; then
 fi
 echo 'FAIL: Debug byte is set!'
 echo "Debug Byte = 0x$DEBUG_BYTE"
+echo 'First kilobyte of shared_memory.bin:'
+echo '$ xxd -l 1024 shared_memory.bin'
+xxd -l 1024 data/state/shared_memory.bin
 exit 1


### PR DESCRIPTION
## Change Description
One problem we identified on Friday is that we have no good way of knowing whether a binary was built with debugging symbols or not. Debugging symbols enable software engineers to inspect and control a running program with a debugging tool, but they significantly slow down
performance-critical applications like `nodeos`. I created an integration test which fails when EOSIO is built with debugging symbols.  
  
Though I can write the test to only fail in a CI environment like Buildkite, it currently fails for local debugging builds as well. I know a lot of members of our community build and install EOSIO for production systems from source, and I wanted this test to be able to catch build-type errors for those users despite any inconvenience to our own developers. This test behavior is open to persuasion from any stakeholders.  
  
The test provides useful error messages when test prerequisites are not met, and when the test fails.
   
## Consensus Changes
- [ ] Consensus Changes
None.

## API Changes
- [ ] API Changes
None.

## Documentation Additions
- [ ] Documentation Additions
None.