### PR TITLE
Enable Test Stability Testing

### DIFF
--- a/.cicd/generate-pipeline.sh
+++ b/.cicd/generate-pipeline.sh
@@ -10,7 +10,7 @@ export PLATFORMS_JSON_ARRAY='[]'
 for FILE in $(ls $CICD_DIR/platforms); do
     # skip mac or linux by not even creating the json block
     ( [[ $SKIP_MAC == true ]] && [[ $FILE =~ 'macos' ]] ) && continue
-    ( [[ $SKIP_LINUX == true ]] &&    [[ ! $FILE =~ 'macos' ]] ) && continue
+    ( [[ $SKIP_LINUX == true ]] && [[ ! $FILE =~ 'macos' ]] ) && continue
     # use pinned or unpinned, not both sets of platform files
     if [[ $PINNED == false || $UNPINNED == true ]] && [[ ! $FILE =~ 'macos' ]]; then
         export SKIP_CONTRACT_BUILDER=${SKIP_CONTRACT_BUILDER:-true}

--- a/.cicd/generate-pipeline.sh
+++ b/.cicd/generate-pipeline.sh
@@ -255,6 +255,10 @@ EOF
         done
         IFS=$nIFS
     done
+    if [[ "$RUN" != "$RUNS" ]]; then
+        echo '  - wait'
+        echo ''
+    fi
 done
 # pipeline tail
 cat <<EOF


### PR DESCRIPTION
## Change Description
There has been a lot of speculation surrounding our integration and long-running tests. Some engineers think they are flakey, others believe they are stable. Automation only cares about one thing, which are numbers. This pull request enables us to run the same tests on the same commit hash any number of times, given by the `RUNS` variable. To save resources, the build fails after the first failing round of tests.   
   
In conjunction with these changes, I will introduce the `eosio-test-stability` pipeline which will have `RUNS=1000` set by default.

## Consensus Changes
- [ ] Consensus Changes
None.

## API Changes
- [ ] API Changes
None.

## Documentation Additions
- [ ] Documentation Additions
None.