### PR TITLE
Fix exit crash - 1.8

### DIFF
--- a/plugins/net_plugin/include/eosio/net_plugin/net_plugin.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/net_plugin.hpp
@@ -40,7 +40,7 @@ namespace eosio {
 
         size_t num_peers() const;
       private:
-        std::unique_ptr<class net_plugin_impl> my;
+        std::shared_ptr<class net_plugin_impl> my;
    };
 
 }

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -3124,6 +3124,9 @@ namespace eosio {
          if( my->thread_pool ) {
             my->thread_pool->stop();
          }
+
+         app().post( 0, [me = my](){} ); // keep my pointer alive until queue is drained
+
          fc_ilog( logger, "exit shutdown" );
       }
       FC_CAPTURE_AND_RETHROW()

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -852,9 +852,8 @@ void producer_plugin::plugin_shutdown() {
    if( my->_thread_pool ) {
       my->_thread_pool->stop();
    }
-   my->_accepted_block_connection.reset();
-   my->_accepted_block_header_connection.reset();
-   my->_irreversible_block_connection.reset();
+
+   app().post( 0, [me = my](){} ); // keep my pointer alive until queue is drained
 }
 
 void producer_plugin::handle_sighup() {


### PR DESCRIPTION
## Change Description

- `nodeos` has been core dumping on exit intermittently for our `nodeos_startup_catchup_lr_test`
- core file indicated processing of `publish` of transaction result during destruction of `io_context`
- Add application post of low priority item to application queue with capture of `shared_ptr` of impls of `producer_plugin_impl` and `net_plugin_impl` to keep them alive. The `net_plugin` change was already part of `develop` branch.
- 40+ runs of  `nodeos_startup_catchup_lr_test` all passed with this fix.

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
