### PR TITLE
Fix exit crash - develop

### DIFF
--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -913,9 +913,8 @@ void producer_plugin::plugin_shutdown() {
    if( my->_thread_pool ) {
       my->_thread_pool->stop();
    }
-   my->_accepted_block_connection.reset();
-   my->_accepted_block_header_connection.reset();
-   my->_irreversible_block_connection.reset();
+
+   app().post( 0, [me = my](){} ); // keep my pointer alive until queue is drained
 }
 
 void producer_plugin::handle_sighup() {


### PR DESCRIPTION
## Change Description

- `nodeos` has been core dumping on exit intermittently for our 1.8.x `nodeos_startup_catchup_lr_test`
- core file indicated processing of `publish` of transaction result during destruction of `io_context`
- Add application post of low priority item to application queue with capture of `shared_ptr` of impls of `producer_plugin_impl` to keep it alive. The `net_plugin` already had this shutdown behavior.
- 40+ runs of  `nodeos_startup_catchup_lr_test` of 1.8.x all passed with this fix.
- Ported this from 1.8.x to develop even though `develop` tests were not failing since it seems like it could at least in theory be an issue on `develop` branch.


## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
