### PR TITLE
[develop] Add Trigger for LRTs and Multiversion Tests on PR

### DIFF
--- a/.cicd/generate-pipeline.sh
+++ b/.cicd/generate-pipeline.sh
@@ -260,8 +260,8 @@ EOF
     done
     IFS=$nIFS
 done
-##################
-# TRIGGERS ON PR #
+#############
+# LRT ON PR #
 if [[ -z $BUILDKITE_TRIGGERED_FROM_BUILD_ID && $BUILDKITE_PULL_REQUEST != "false" ]]; then
     cat <<EOF
   - label: ":pipeline: Trigger LRTs"
@@ -278,6 +278,13 @@ if [[ -z $BUILDKITE_TRIGGERED_FROM_BUILD_ID && $BUILDKITE_PULL_REQUEST != "false
         PINNED: "${PINNED}"
         UNPINNED: "${UNPINNED}"
 
+EOF
+fi
+######################
+# MULTIVERSION ON PR #
+if [[ -z $BUILDKITE_TRIGGERED_FROM_BUILD_ID && $BUILDKITE_PULL_REQUEST != "false" ]]; then
+    if ( [[ ! $PINNED == false || $UNPINNED == true ]] ); then
+    cat <<EOF
   - label: ":pipeline: Trigger Multiversion"
     trigger: "eos-multiversion-tests"
     build:
@@ -290,6 +297,7 @@ if [[ -z $BUILDKITE_TRIGGERED_FROM_BUILD_ID && $BUILDKITE_PULL_REQUEST != "false
         BUILDKITE_PULL_REQUEST_REPO: "${BUILDKITE_PULL_REQUEST_REPO}"
 
 EOF
+    fi
 fi
 cat <<EOF
   - wait:


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
Added functionality to `.cicd/generate-pipeline.sh`:
- New trigger for LRTs.
  - Builds that run attached to a PR now have a step that triggers a new pipeline: `eosio-lrt`.
  - Functionality remains unchanged for non-PR builds. You may still specify LRTs to run via `SKIP_LONG_RUNNING_TESTS=false` when creating a new build that does not have a PR open.
  - This change ensures LRTs are executed for branches ready for PR.
  - This change will run LRTs against both pinned and unpinned builds.
  - This pipeline reuses artifacts from the `eosio` or `eosio-build-unpinned` job that triggered it. Resources are not wasted to rebuild the same branch/commit on triggered builds.
  - The `eosio-lrt` pipeline can be used on its own. It knows to run a build if it was not triggered.


- New trigger for Multiversion tests.
  - Builds that run attached to a PR now have a step that triggers the `eosio-multiversion-test` pipeline.
  - This change ensures Multiversion tests are executed for branches ready for PR.
  - This change does not impact the functionality of the Multiversion test. It just triggers the pipeline to build/test the branch/commit specified.


See:
[Build 17409](https://buildkite.com/EOSIO/eosio/builds/17409) | This PR's build that triggers the LRT and Multiversion pipelines.
[Build 544](https://buildkite.com/EOSIO/eosio-build-unpinned/builds/544) | This PR's unpinned build that triggers the LRT and Multiversion pipelines.
[Build 30](https://buildkite.com/EOSIO/eosio-lrt/builds/30) | Manual build on `eosio-lrt` that would build EOS since it was not triggered.
[Build 32](https://buildkite.com/EOSIO/eosio-lrt/builds/) | Triggered build on `eosio-lrt` that reuses the build artifacts from Build 17409.
[Build 31](https://buildkite.com/EOSIO/eosio-lrt/builds/) | Triggered build on `eosio-lrt` that reuses the build artifacts from Build 544.

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
