### PR TITLE
Add Support for eosio-test-stability Pipeline

### DIFF
--- a/.cicd/generate-pipeline.sh
+++ b/.cicd/generate-pipeline.sh
@@ -76,11 +76,11 @@ echo $PLATFORMS_JSON_ARRAY | jq -cr '.[]' | while read -r PLATFORM_JSON; do
     timeout: ${TIMEOUT:-320}
     skip: \${SKIP_$(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_UPCASE)_$(echo "$PLATFORM_JSON" | jq -r .VERSION_MAJOR)$(echo "$PLATFORM_JSON" | jq -r .VERSION_MINOR)}\${SKIP_ENSURE_$(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_UPCASE)_$(echo "$PLATFORM_JSON" | jq -r .VERSION_MAJOR)$(echo "$PLATFORM_JSON" | jq -r .VERSION_MINOR)}
 
-  - wait
-
 EOF
     fi
 done
+echo '  - wait'
+echo ''
 # build steps
 echo '    # builds'
 echo $PLATFORMS_JSON_ARRAY | jq -cr '.[]' | while read -r PLATFORM_JSON; do


### PR DESCRIPTION
## Change Description
There has been a lot of speculation surrounding our integration and long-running tests. Some engineers think they are flakey, others believe they are stable. Automation only cares about one thing: numbers. This pull request enables us to run the same tests on the same commit hash any number of times, given by the `ROUNDS` environment variable. To save resources, the build stops after the first failing round of tests.   
   
In conjunction with these changes, I have introduced the [`eosio-test-stability`](https://buildkite.com/EOSIO/eosio-test-stability) pipeline in [this pull request](https://github.com/EOSIO/eos-buildkite-pipelines/pull/47) which has `ROUNDS='1000'` set by default.

### Example
- [Build 10](https://buildkite.com/EOSIO/eosio-test-stability/builds/10) set with `ROUNDS='2'`

## Consensus Changes
- [ ] Consensus Changes
None.

## API Changes
- [ ] API Changes
None.

## Documentation Additions
- [ ] Documentation Additions
None.