### PR TITLE
adds support for builder priority queues

### DIFF
--- a/.cicd/build.sh
+++ b/.cicd/build.sh
@@ -32,7 +32,7 @@ else # Linux
         PRE_COMMANDS="$PRE_COMMANDS && source /opt/rh/devtoolset-8/enable && source /opt/rh/rh-python36/enable && export PATH=/usr/lib64/ccache:\\\$PATH"
     elif [[ $IMAGE_TAG == 'ubuntu-18.04-unpinned' ]]; then
         PRE_COMMANDS="$PRE_COMMANDS && export PATH=/usr/lib/ccache:\\\$PATH"
-        CMAKE_EXTRAS="$CMAKE_EXTRAS -DCMAKE_CXX_COMPILER='clang++' -DCMAKE_C_COMPILER='clang' -DLLVM_DIR='/usr/lib/llvm-7'"
+        CMAKE_EXTRAS="$CMAKE_EXTRAS -DCMAKE_CXX_COMPILER='clang++' -DCMAKE_C_COMPILER='clang' -DLLVM_DIR='/usr/lib/llvm-7/lib/cmake/llvm'"
     fi
     BUILD_COMMANDS="cmake $CMAKE_EXTRAS .. && make -j$JOBS"
     # Docker Commands

--- a/.cicd/build.sh
+++ b/.cicd/build.sh
@@ -32,7 +32,7 @@ else # Linux
         PRE_COMMANDS="$PRE_COMMANDS && source /opt/rh/devtoolset-8/enable && source /opt/rh/rh-python36/enable && export PATH=/usr/lib64/ccache:\\\$PATH"
     elif [[ $IMAGE_TAG == 'ubuntu-18.04-unpinned' ]]; then
         PRE_COMMANDS="$PRE_COMMANDS && export PATH=/usr/lib/ccache:\\\$PATH"
-        CMAKE_EXTRAS="$CMAKE_EXTRAS -DCMAKE_CXX_COMPILER='clang++' -DCMAKE_C_COMPILER='clang'"
+        CMAKE_EXTRAS="$CMAKE_EXTRAS -DCMAKE_CXX_COMPILER='clang++' -DCMAKE_C_COMPILER='clang' -DLLVM_DIR='/usr/lib/llvm-7'"
     fi
     BUILD_COMMANDS="cmake $CMAKE_EXTRAS .. && make -j$JOBS"
     # Docker Commands

--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -1,8 +1,11 @@
 steps:
   - wait
 
-  - label: ":pipeline: Generate Pipeline Steps"  
-    command: "./.cicd/generate-pipeline.sh | buildkite-agent pipeline upload"
+  - label: ":pipeline: Generate Pipeline Steps"
+    command:
+      - "./.cicd/generate-pipeline.sh > generated-pipeline.yml"
+      - "buildkite-agent pipeline upload < generated-pipeline.yml"
+      - "buildkite-agent artifact upload generated-pipeline.yml"
     agents:
       queue: "automation-basic-builder-fleet"
     timeout: ${TIMEOUT:-10}

--- a/.cicd/platforms/ubuntu-18.04-unpinned.dockerfile
+++ b/.cicd/platforms/ubuntu-18.04-unpinned.dockerfile
@@ -8,6 +8,9 @@ RUN apt-get update && \
     autotools-dev libicu-dev python2.7 python2.7-dev python3 python3-dev \
     autoconf libtool g++ gcc curl zlib1g-dev sudo ruby libusb-1.0-0-dev \
     libcurl4-gnutls-dev pkg-config patch llvm-7-dev clang ccache vim-common jq
+# remove llvm-6
+RUN apt purge libllvm6* && \
+    apt purge llvm-6*
 # build cmake.
 RUN curl -LO https://cmake.org/files/v3.13/cmake-3.13.2.tar.gz && \
     tar -xzf cmake-3.13.2.tar.gz && \

--- a/.cicd/platforms/ubuntu-18.04-unpinned.dockerfile
+++ b/.cicd/platforms/ubuntu-18.04-unpinned.dockerfile
@@ -8,9 +8,6 @@ RUN apt-get update && \
     autotools-dev libicu-dev python2.7 python2.7-dev python3 python3-dev \
     autoconf libtool g++ gcc curl zlib1g-dev sudo ruby libusb-1.0-0-dev \
     libcurl4-gnutls-dev pkg-config patch llvm-7-dev clang ccache vim-common jq
-# remove llvm-6
-RUN apt purge libllvm6* && \
-    apt purge llvm-6*
 # build cmake.
 RUN curl -LO https://cmake.org/files/v3.13/cmake-3.13.2.tar.gz && \
     tar -xzf cmake-3.13.2.tar.gz && \


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
On every commit, we run a large number of tests across many instances simultaneously.  This allows us to parallelize the previously non parallelized tests that competed for resources on the same builder/instance.  The primary effect is a much faster build than we've typically known.  One side effect is that, in the case of many scheduled builds running concurrently, build steps queue up and waits occur for some builds (regardless of whether the builds consuming all the instances are scheduled). 

This change does two things:

1. Moves scheduled builds to a separate queue that's throttled aggressively (8 instances max for linux and 2 instances max for mac)
2. Introduces a new builder queue that scales to 4x the current number of builders in the fleet




## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
