### PR TITLE
return error when attempting to remove key from YubiHSM wallet

### DIFF
--- a/plugins/wallet_plugin/yubihsm_wallet.cpp
+++ b/plugins/wallet_plugin/yubihsm_wallet.cpp
@@ -257,6 +257,7 @@ string yubihsm_wallet::create_key(string key_type) {
 
 bool yubihsm_wallet::remove_key(string key) {
    FC_ASSERT(!is_locked());
+   FC_THROW_EXCEPTION(chain::wallet_exception, "YubiHSM wallet does not currently support removal of keys");
    return true;
 }
 


### PR DESCRIPTION


<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
The YubiHSM keosd wallet doesn't support removing keys from the YubiHSM. This is mostly because the interaction with the YubiHSM for removing a key is tricky given our desire to validate the wallet password before performing that action. Implementing this would mean opening up a second simultaneous session with the YubiHSM just to verify the wallet password. While this may be a valid enhancement in the future, it's too much effort for now.

That said, the current implementation was silently dropping removal requests. Fix it to return an error so it's not deceptive.

Fixes #7904

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
