### PR TITLE
Fix Release Build Type for macOS on Travis CI

### DIFF
--- a/.cicd/build.sh
+++ b/.cicd/build.sh
@@ -5,7 +5,7 @@ mkdir -p $BUILD_DIR
 CMAKE_EXTRAS="-DBUILD_MONGO_DB_PLUGIN=true -DCMAKE_BUILD_TYPE='Release'"
 if [[ $(uname) == 'Darwin' ]]; then
     # You can't use chained commands in execute
-    [[ $TRAVIS == true ]] && export PINNED=false && ccache -s && CMAKE_EXTRAS="-DCMAKE_CXX_COMPILER_LAUNCHER=ccache" && ./$CICD_DIR/platforms/macos-10.14.sh
+    [[ $TRAVIS == true ]] && export PINNED=false && ccache -s && CMAKE_EXTRAS="$CMAKE_EXTRAS -DCMAKE_CXX_COMPILER_LAUNCHER=ccache" && ./$CICD_DIR/platforms/macos-10.14.sh
     ( [[ ! $PINNED == false || $UNPINNED == true ]] ) && CMAKE_EXTRAS="$CMAKE_EXTRAS -DCMAKE_TOOLCHAIN_FILE=$HELPERS_DIR/clang.make"
     cd $BUILD_DIR
     cmake $CMAKE_EXTRAS ..

--- a/.cicd/build.sh
+++ b/.cicd/build.sh
@@ -5,8 +5,13 @@ mkdir -p $BUILD_DIR
 CMAKE_EXTRAS="-DBUILD_MONGO_DB_PLUGIN=true -DCMAKE_BUILD_TYPE='Release'"
 if [[ $(uname) == 'Darwin' ]]; then
     # You can't use chained commands in execute
-    [[ $TRAVIS == true ]] && export PINNED=false && ccache -s && CMAKE_EXTRAS="$CMAKE_EXTRAS -DCMAKE_CXX_COMPILER_LAUNCHER=ccache" && ./$CICD_DIR/platforms/macos-10.14.sh
-    ( [[ ! $PINNED == false || $UNPINNED == true ]] ) && CMAKE_EXTRAS="$CMAKE_EXTRAS -DCMAKE_TOOLCHAIN_FILE=$HELPERS_DIR/clang.make"
+    if [[ $TRAVIS == true ]]; then
+        export PINNED=false
+        ccache -s
+        CMAKE_EXTRAS="$CMAKE_EXTRAS -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
+        ./$CICD_DIR/platforms/macos-10.14.sh
+    fi
+    [[ ! $PINNED == false || $UNPINNED == true ]] && CMAKE_EXTRAS="$CMAKE_EXTRAS -DCMAKE_TOOLCHAIN_FILE=$HELPERS_DIR/clang.make"
     cd $BUILD_DIR
     cmake $CMAKE_EXTRAS ..
     make -j$JOBS

--- a/.cicd/build.sh
+++ b/.cicd/build.sh
@@ -3,15 +3,15 @@ set -eo pipefail
 . ./.cicd/helpers/general.sh
 mkdir -p $BUILD_DIR
 CMAKE_EXTRAS="-DBUILD_MONGO_DB_PLUGIN=true -DCMAKE_BUILD_TYPE='Release'"
-if [[ $(uname) == 'Darwin' ]]; then
+if [[ "$(uname)" == 'Darwin' ]]; then
     # You can't use chained commands in execute
-    if [[ $TRAVIS == true ]]; then
+    if [[ "$TRAVIS" == 'true' ]]; then
         export PINNED=false
         ccache -s
         CMAKE_EXTRAS="$CMAKE_EXTRAS -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
         ./$CICD_DIR/platforms/macos-10.14.sh
     fi
-    [[ ! $PINNED == false || $UNPINNED == true ]] && CMAKE_EXTRAS="$CMAKE_EXTRAS -DCMAKE_TOOLCHAIN_FILE=$HELPERS_DIR/clang.make"
+    [[ ! "$PINNED" == 'false' || "$UNPINNED" == 'true' ]] && CMAKE_EXTRAS="$CMAKE_EXTRAS -DCMAKE_TOOLCHAIN_FILE=$HELPERS_DIR/clang.make"
     cd $BUILD_DIR
     cmake $CMAKE_EXTRAS ..
     make -j$JOBS
@@ -21,33 +21,33 @@ else # Linux
     PRE_COMMANDS="cd $MOUNTED_DIR/build"
     # PRE_COMMANDS: Executed pre-cmake
     # CMAKE_EXTRAS: Executed within and right before the cmake path (cmake CMAKE_EXTRAS ..)
-    [[ ! $IMAGE_TAG =~ 'unpinned' ]] && CMAKE_EXTRAS="$CMAKE_EXTRAS -DCMAKE_TOOLCHAIN_FILE=$MOUNTED_DIR/.cicd/helpers/clang.make -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
-    if [[ $IMAGE_TAG == 'amazon_linux-2' ]]; then
+    [[ ! "$IMAGE_TAG" =~ 'unpinned' ]] && CMAKE_EXTRAS="$CMAKE_EXTRAS -DCMAKE_TOOLCHAIN_FILE=$MOUNTED_DIR/.cicd/helpers/clang.make -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
+    if [[ "$IMAGE_TAG" == 'amazon_linux-2' ]]; then
         PRE_COMMANDS="$PRE_COMMANDS && export PATH=/usr/lib64/ccache:\\\$PATH"
-    elif [[ $IMAGE_TAG == 'centos-7.6' ]]; then
+    elif [[ "$IMAGE_TAG" == 'centos-7.6' ]]; then
         PRE_COMMANDS="$PRE_COMMANDS && export PATH=/usr/lib64/ccache:\\\$PATH"
-    elif [[ $IMAGE_TAG == 'ubuntu-16.04' ]]; then
+    elif [[ "$IMAGE_TAG" == 'ubuntu-16.04' ]]; then
         PRE_COMMANDS="$PRE_COMMANDS && export PATH=/usr/lib/ccache:\\\$PATH"
-    elif [[ $IMAGE_TAG == 'ubuntu-18.04' ]]; then
+    elif [[ "$IMAGE_TAG" == 'ubuntu-18.04' ]]; then
         PRE_COMMANDS="$PRE_COMMANDS && export PATH=/usr/lib/ccache:\\\$PATH"
-    elif [[ $IMAGE_TAG == 'amazon_linux-2-unpinned' ]]; then
+    elif [[ "$IMAGE_TAG" == 'amazon_linux-2-unpinned' ]]; then
         PRE_COMMANDS="$PRE_COMMANDS && export PATH=/usr/lib64/ccache:\\\$PATH"
         CMAKE_EXTRAS="$CMAKE_EXTRAS -DCMAKE_CXX_COMPILER='clang++' -DCMAKE_C_COMPILER='clang'"
-    elif [[ $IMAGE_TAG == 'centos-7.6-unpinned' ]]; then
+    elif [[ "$IMAGE_TAG" == 'centos-7.6-unpinned' ]]; then
         PRE_COMMANDS="$PRE_COMMANDS && source /opt/rh/devtoolset-8/enable && source /opt/rh/rh-python36/enable && export PATH=/usr/lib64/ccache:\\\$PATH"
-    elif [[ $IMAGE_TAG == 'ubuntu-18.04-unpinned' ]]; then
+    elif [[ "$IMAGE_TAG" == 'ubuntu-18.04-unpinned' ]]; then
         PRE_COMMANDS="$PRE_COMMANDS && export PATH=/usr/lib/ccache:\\\$PATH"
         CMAKE_EXTRAS="$CMAKE_EXTRAS -DCMAKE_CXX_COMPILER='clang++' -DCMAKE_C_COMPILER='clang' -DLLVM_DIR='/usr/lib/llvm-7/lib/cmake/llvm'"
     fi
     BUILD_COMMANDS="cmake $CMAKE_EXTRAS .. && make -j$JOBS"
     # Docker Commands
-    if [[ $BUILDKITE == true ]]; then
+    if [[ "$BUILDKITE" == 'true' ]]; then
         # Generate Base Images
         $CICD_DIR/generate-base-images.sh
-        [[ $ENABLE_INSTALL == true ]] && COMMANDS="cp -r $MOUNTED_DIR /root/eosio && cd /root/eosio/build &&"
+        [[ "$ENABLE_INSTALL" == 'true' ]] && COMMANDS="cp -r $MOUNTED_DIR /root/eosio && cd /root/eosio/build &&"
         COMMANDS="$COMMANDS $BUILD_COMMANDS"
-        [[ $ENABLE_INSTALL == true ]] && COMMANDS="$COMMANDS && make install"
-    elif [[ $TRAVIS == true ]]; then
+        [[ "$ENABLE_INSTALL" == 'true' ]] && COMMANDS="$COMMANDS && make install"
+    elif [[ "$TRAVIS" == 'true' ]]; then
         ARGS="$ARGS -v /usr/lib/ccache -v $HOME/.ccache:/opt/.ccache -e JOBS -e TRAVIS -e CCACHE_DIR=/opt/.ccache"
         COMMANDS="ccache -s && $BUILD_COMMANDS"
     fi


### PR DESCRIPTION
## Change Description
This pull request fixes a missing variable which was preventing Travis CI from performing a `Release` build type on macOS, as seen [here](https://travis-ci.com/EOSIO/eos/jobs/235960655#L3947).

I have also cleaned up some `if` statements and quoted some strings, as requested, for clarity.

### See Also
- [Pull request 7928](https://github.com/EOSIO/eos/pull/7928) -- `release/1.8.x`

## Consensus Changes
- [ ] Consensus Changes
None.

## API Changes
- [ ] API Changes
None.

## Documentation Additions
- [ ] Documentation Additions
None.