### PR TITLE
Fix intermittent crash on exit when port already in use - develop

### DIFF
--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -866,6 +866,7 @@ void producer_plugin::plugin_startup()
 { try {
    handle_sighup(); // Sets loggers
 
+   try {
    ilog("producer plugin:  plugin_startup() begin");
 
    chain::controller& chain = my->chain_plug->chain();
@@ -901,6 +902,11 @@ void producer_plugin::plugin_startup()
    my->schedule_production_loop();
 
    ilog("producer plugin:  plugin_startup() end");
+   } catch( ... ) {
+      // always call plugin_shutdown, even on exception
+      plugin_shutdown();
+      throw;
+   }
 } FC_CAPTURE_AND_RETHROW() }
 
 void producer_plugin::plugin_shutdown() {


### PR DESCRIPTION
## Change Description

- When exception is thrown because of port already in use in `net_plugin::plugin_startup`, the `plugin_shutdown` was not called which can lead to issues with destruction of the `net_plugin_impl`.
- Ensure `plugin_shutdown` is called even when `plugin_startup` doesn't complete in `net_plugin` and `producer_plugin`.
- Changed the `fc_elog` to `elog` of port in use so it will always be logged regardless of `net_plugin_impl` logging settings.
- Resolves #7909 

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
