### PR TITLE
[1.7.x] Support all BK cases in Submodule Regression Script

### DIFF
--- a/.cicd/submodule-regression-check.sh
+++ b/.cicd/submodule-regression-check.sh
@@ -1,18 +1,18 @@
-
 #!/bin/bash
 set -eo pipefail
 declare -A PR_MAP
 declare -A BASE_MAP
 # Support Travis and BK
 if ${TRAVIS:-false}; then
+    [[ -z $TRAVIS_PULL_REQUEST_BRANCH ]] && echo "Unable to find TRAVIS_PULL_REQUEST_BRANCH ENV. Skipping submodule regression check." && exit 0
     BASE_BRANCH=$TRAVIS_BRANCH
-    CURRENT_BRANCH=${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH} # We default to TRAVIS_BRANCH if it's not a PR so it passes on non PR runs
-    [[ ! -z $TRAVIS_PULL_REQUEST_SLUG ]] && CURRENT_BRANCH=$TRAVIS_COMMIT # Support git log & echo output
+    CURRENT_BRANCH=$TRAVIS_PULL_REQUEST_BRANCH
+    [[ ! -z $TRAVIS_PULL_REQUEST_SLUG ]] && CURRENT_BRANCH=$TRAVIS_COMMIT # When we're not running from a PR, the slug is not set. When we are, we need to use the TRAVIS_COMMIT to be sure we're supporting the Forked PR's merge/code that's in the EOS repo. This is needed for the git log below.
 else
-    BASE_BRANCH=${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-$BUILDKITE_BRANCH}
+    [[ -z $BUILDKITE_PULL_REQUEST_BASE_BRANCH ]] && echo "Unable to find BUILDKITE_PULL_REQUEST_BASE_BRANCH ENV. Skipping submodule regression check." && exit 0
+    BASE_BRANCH=$BUILDKITE_PULL_REQUEST_BASE_BRANCH
     CURRENT_BRANCH=$BUILDKITE_BRANCH
 fi
-[[ $BASE_BRANCH == $CURRENT_BRANCH ]] && echo 'BASE_BRANCH and CURRENT_BRANCH are the same' && exit 0
 
 echo "getting submodule info for $CURRENT_BRANCH"
 while read -r a b; do
@@ -26,6 +26,18 @@ while read -r a b; do
     BASE_MAP[$a]=$b
 done < <(git submodule --quiet foreach --recursive 'echo $path `git log -1 --format=%ct`')
 
+# We need to switch back to the PR ref/head so we can git log properly
+if [[ $TRAVIS == true && ! -z $TRAVIS_PULL_REQUEST_SLUG ]]; then
+    echo "git fetch origin +refs/pull/$TRAVIS_PULL_REQUEST/merge:"
+    git fetch origin +refs/pull/$TRAVIS_PULL_REQUEST/merge: &> /dev/null
+    echo "switching back to $TRAVIS_COMMIT"
+    echo 'git checkout -qf FETCH_HEAD'
+    git checkout -qf FETCH_HEAD &> /dev/null
+elif [[ $BUILDKITE == true ]]; then
+    echo "switching back to $CURRENT_BRANCH"
+    git checkout -f $CURRENT_BRANCH &> /dev/null
+fi
+
 for k in "${!BASE_MAP[@]}"; do
     base_ts=${BASE_MAP[$k]}
     pr_ts=${PR_MAP[$k]}
@@ -33,17 +45,7 @@ for k in "${!BASE_MAP[@]}"; do
     echo "  timestamp on $CURRENT_BRANCH: $pr_ts"
     echo "  timestamp on $BASE_BRANCH: $base_ts"
     if (( $pr_ts < $base_ts)); then
-        echo "$k is older on $CURRENT_BRANCH than $BASE_BRANCH; investigating..."
-        if [[ $TRAVIS == true && ! -z $TRAVIS_PULL_REQUEST_SLUG ]]; then # IF it's a forked PR, we need to switch back to the PR ref/head so we can git log properly
-            echo "git fetch origin +refs/pull/$TRAVIS_PULL_REQUEST/merge:"
-            git fetch origin +refs/pull/$TRAVIS_PULL_REQUEST/merge: &> /dev/null
-            echo "switching back to $TRAVIS_PULL_REQUEST_SLUG:$TRAVIS_PULL_REQUEST_BRANCH ($TRAVIS_COMMIT)"
-            echo 'git checkout -qf FETCH_HEAD'
-            git checkout -qf FETCH_HEAD &> /dev/null
-        elif [[ $BUILDKITE == true ]]; then
-            echo "switching back to $CURRENT_BRANCH"
-            git checkout -f $CURRENT_BRANCH &> /dev/null
-        fi
+        echo "$k is older on $CURRENT_BRANCH than $BASE_BRANCH; investigating the difference between $CURRENT_BRANCH and $BASE_BRANCH to look for $k changing..."
         if [[ ! -z $(for c in $(git --no-pager log $CURRENT_BRANCH ^$BASE_BRANCH --pretty=format:"%H"); do git show --pretty="" --name-only $c; done | grep "^$k$") ]]; then
             echo "ERROR: $k has regressed"
             exit 1

--- a/.cicd/submodule-regression-check.sh
+++ b/.cicd/submodule-regression-check.sh
@@ -1,34 +1,50 @@
+
 #!/bin/bash
 set -eo pipefail
 declare -A PR_MAP
 declare -A BASE_MAP
-# support travis and buildkite
+# Support Travis and BK
 if ${TRAVIS:-false}; then
     BASE_BRANCH=$TRAVIS_BRANCH
     CURRENT_BRANCH=${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH} # We default to TRAVIS_BRANCH if it's not a PR so it passes on non PR runs
+    [[ ! -z $TRAVIS_PULL_REQUEST_SLUG ]] && CURRENT_BRANCH=$TRAVIS_COMMIT # Support git log & echo output
 else
     BASE_BRANCH=${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-$BUILDKITE_BRANCH}
     CURRENT_BRANCH=$BUILDKITE_BRANCH
 fi
+[[ $BASE_BRANCH == $CURRENT_BRANCH ]] && echo 'BASE_BRANCH and CURRENT_BRANCH are the same' && exit 0
+
 echo "getting submodule info for $CURRENT_BRANCH"
 while read -r a b; do
     PR_MAP[$a]=$b
 done < <(git submodule --quiet foreach --recursive 'echo $path `git log -1 --format=%ct`')
+
 echo "getting submodule info for $BASE_BRANCH"
 git checkout $BASE_BRANCH &> /dev/null
 git submodule update --init &> /dev/null
 while read -r a b; do
     BASE_MAP[$a]=$b
 done < <(git submodule --quiet foreach --recursive 'echo $path `git log -1 --format=%ct`')
+
 for k in "${!BASE_MAP[@]}"; do
     base_ts=${BASE_MAP[$k]}
     pr_ts=${PR_MAP[$k]}
     echo "submodule $k"
-    echo "    timestamp on $CURRENT_BRANCH: $pr_ts"
-    echo "    timestamp on $BASE_BRANCH: $base_ts"
+    echo "  timestamp on $CURRENT_BRANCH: $pr_ts"
+    echo "  timestamp on $BASE_BRANCH: $base_ts"
     if (( $pr_ts < $base_ts)); then
         echo "$k is older on $CURRENT_BRANCH than $BASE_BRANCH; investigating..."
-        if for c in `git log $CURRENT_BRANCH ^$BASE_BRANCH --pretty=format:"%H"`; do git show --pretty="" --name-only $c; done | grep -q "^$k$"; then
+        if [[ $TRAVIS == true && ! -z $TRAVIS_PULL_REQUEST_SLUG ]]; then # IF it's a forked PR, we need to switch back to the PR ref/head so we can git log properly
+            echo "git fetch origin +refs/pull/$TRAVIS_PULL_REQUEST/merge:"
+            git fetch origin +refs/pull/$TRAVIS_PULL_REQUEST/merge: &> /dev/null
+            echo "switching back to $TRAVIS_PULL_REQUEST_SLUG:$TRAVIS_PULL_REQUEST_BRANCH ($TRAVIS_COMMIT)"
+            echo 'git checkout -qf FETCH_HEAD'
+            git checkout -qf FETCH_HEAD &> /dev/null
+        elif [[ $BUILDKITE == true ]]; then
+            echo "switching back to $CURRENT_BRANCH"
+            git checkout -f $CURRENT_BRANCH &> /dev/null
+        fi
+        if [[ ! -z $(for c in $(git --no-pager log $CURRENT_BRANCH ^$BASE_BRANCH --pretty=format:"%H"); do git show --pretty="" --name-only $c; done | grep "^$k$") ]]; then
             echo "ERROR: $k has regressed"
             exit 1
         else


### PR DESCRIPTION
Problems: 

1. When manually running a forked PR using `pull/7924/head:develop-submodule-regression-fix`, the script will fail to use the merged commit for that forked PR. 
2. git log logic wasn't working and throwing exit 1

Solutions:
1. Support if the PR slug exists (it's a forked PR) by doing git fetch/checkout of the ghost/merged commit.
2. Added no-pager and changed the logic to wrap in test

### Buildkite
- Manual branch (no PR): 
  - Same branches: https://buildkite.com/EOSIO/eosio/builds/17592#554e460e-0dd1-4ef7-9301-ec9fa5e0e48c
- PR branch: https://github.com/EOSIO/eos/pull/7932: 
  - PASS: https://buildkite.com/EOSIO/eosio/builds/17620#0ac3f53f-ec8d-407c-a99e-b489c315d0d5
  - FAIL: https://buildkite.com/EOSIO/eosio/builds/17623#a4055444-b080-4148-81fd-7dee8f61b4bc
- Manual PR branch https://github.com/EOSIO/eos/pull/7932: 
  - Skip: https://buildkite.com/EOSIO/eosio/builds/17626#ac14ed47-6b98-4e28-8531-f6f674bee882
- Forked PR branch https://github.com/EOSIO/eos/pull/7924: 
  - Doesn't run...
- Manual Forked PR branch https://github.com/EOSIO/eos/pull/7924:
  - Skip: https://buildkite.com/EOSIO/eosio/builds/17625#58677818-5cfd-498a-975e-6923293d4df0


