### PR TITLE
net_plugin correctly handle unknown_block_exception - develop

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -1611,8 +1611,12 @@ namespace eosio {
          c->syncing = true;
          app().post( priority::medium, [chain_plug = my_impl->chain_plug, c,
                                         msg_head_num = msg.head_num, msg_head_id = msg.head_id]() {
-            controller& cc = chain_plug->chain();
-            if( cc.get_block_id_for_num( msg_head_num ) != msg_head_id ) {
+            bool on_fork = true;
+            try {
+               controller& cc = chain_plug->chain();
+               on_fork = cc.get_block_id_for_num( msg_head_num ) != msg_head_id;
+            } catch( ... ) {}
+            if( on_fork ) {
                c->strand.post( [c]() {
                   request_message req;
                   req.req_blocks.mode = catch_up;


### PR DESCRIPTION
## Change Description

- net_plugin call of `get_block_id_for_num` was not catching `unknown_block_exception` causing nodeos to shutdown when block not found.

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
