### PR TITLE
net_plugin correctly handle unknown_block_exception - 1.7

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -1476,7 +1476,11 @@ namespace eosio {
             c->enqueue( note );
          }
          c->syncing = true;
-         if( cc.get_block_id_for_num( msg.head_num ) != msg.head_id ) {
+         bool on_fork = true;
+         try {
+            on_fork = cc.get_block_id_for_num( msg.head_num ) != msg.head_id;
+         } catch( ... ) {}
+         if( on_fork ) {
             request_message req;
             req.req_blocks.mode = catch_up;
             req.req_trx.mode = none;


### PR DESCRIPTION
## Change Description

- net_plugin call of `get_block_id_for_num` was not catching `unknown_block_exception` causing nodeos to shutdown when block not found.

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
