### PR TITLE
[develop] Fix Mac builds on Travis

### DIFF
--- a/.cicd/build.sh
+++ b/.cicd/build.sh
@@ -9,7 +9,6 @@ if [[ "$(uname)" == 'Darwin' ]]; then
         export PINNED=false
         ccache -s
         CMAKE_EXTRAS="$CMAKE_EXTRAS -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
-        ./$CICD_DIR/platforms/macos-10.14.sh
     else
         CMAKE_EXTRAS="$CMAKE_EXTRAS -DBUILD_MONGO_DB_PLUGIN=true"
     fi

--- a/.cicd/build.sh
+++ b/.cicd/build.sh
@@ -15,7 +15,9 @@ if [[ "$(uname)" == 'Darwin' ]]; then
     fi
     [[ ! "$PINNED" == 'false' || "$UNPINNED" == 'true' ]] && CMAKE_EXTRAS="$CMAKE_EXTRAS -DCMAKE_TOOLCHAIN_FILE=$HELPERS_DIR/clang.make"
     cd $BUILD_DIR
+    echo "cmake $CMAKE_EXTRAS"
     cmake $CMAKE_EXTRAS ..
+    echo "make -j$JOBS"
     make -j$JOBS
 else # Linux
     ARGS=${ARGS:-"--rm --init -v $(pwd):$MOUNTED_DIR"}

--- a/.cicd/build.sh
+++ b/.cicd/build.sh
@@ -15,7 +15,7 @@ if [[ "$(uname)" == 'Darwin' ]]; then
     fi
     [[ ! "$PINNED" == 'false' || "$UNPINNED" == 'true' ]] && CMAKE_EXTRAS="$CMAKE_EXTRAS -DCMAKE_TOOLCHAIN_FILE=$HELPERS_DIR/clang.make"
     cd $BUILD_DIR
-    echo "cmake $CMAKE_EXTRAS"
+    echo "cmake $CMAKE_EXTRAS .."
     cmake $CMAKE_EXTRAS ..
     echo "make -j$JOBS"
     make -j$JOBS

--- a/.cicd/build.sh
+++ b/.cicd/build.sh
@@ -2,7 +2,7 @@
 set -eo pipefail
 . ./.cicd/helpers/general.sh
 mkdir -p $BUILD_DIR
-CMAKE_EXTRAS="-DBUILD_MONGO_DB_PLUGIN=true -DCMAKE_BUILD_TYPE='Release'"
+CMAKE_EXTRAS="-DCMAKE_BUILD_TYPE='Release'"
 if [[ "$(uname)" == 'Darwin' ]]; then
     # You can't use chained commands in execute
     if [[ "$TRAVIS" == 'true' ]]; then
@@ -10,6 +10,8 @@ if [[ "$(uname)" == 'Darwin' ]]; then
         ccache -s
         CMAKE_EXTRAS="$CMAKE_EXTRAS -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
         ./$CICD_DIR/platforms/macos-10.14.sh
+    else
+        CMAKE_EXTRAS="$CMAKE_EXTRAS -DBUILD_MONGO_DB_PLUGIN=true"
     fi
     [[ ! "$PINNED" == 'false' || "$UNPINNED" == 'true' ]] && CMAKE_EXTRAS="$CMAKE_EXTRAS -DCMAKE_TOOLCHAIN_FILE=$HELPERS_DIR/clang.make"
     cd $BUILD_DIR
@@ -44,6 +46,7 @@ else # Linux
     if [[ "$BUILDKITE" == 'true' ]]; then
         # Generate Base Images
         $CICD_DIR/generate-base-images.sh
+        CMAKE_EXTRAS="$CMAKE_EXTRAS -DBUILD_MONGO_DB_PLUGIN=true"
         [[ "$ENABLE_INSTALL" == 'true' ]] && COMMANDS="cp -r $MOUNTED_DIR /root/eosio && cd /root/eosio/build &&"
         COMMANDS="$COMMANDS $BUILD_COMMANDS"
         [[ "$ENABLE_INSTALL" == 'true' ]] && COMMANDS="$COMMANDS && make install"

--- a/.cicd/build.sh
+++ b/.cicd/build.sh
@@ -9,6 +9,7 @@ if [[ "$(uname)" == 'Darwin' ]]; then
         export PINNED=false
         ccache -s
         CMAKE_EXTRAS="$CMAKE_EXTRAS -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
+        ./$CICD_DIR/platforms/macos-10.14.sh
     else
         CMAKE_EXTRAS="$CMAKE_EXTRAS -DBUILD_MONGO_DB_PLUGIN=true"
     fi

--- a/.cicd/build.sh
+++ b/.cicd/build.sh
@@ -20,6 +20,7 @@ if [[ "$(uname)" == 'Darwin' ]]; then
     echo "make -j$JOBS"
     make -j$JOBS
 else # Linux
+    CMAKE_EXTRAS="$CMAKE_EXTRAS -DBUILD_MONGO_DB_PLUGIN=true"
     ARGS=${ARGS:-"--rm --init -v $(pwd):$MOUNTED_DIR"}
     . $HELPERS_DIR/file-hash.sh $CICD_DIR/platforms/$IMAGE_TAG.dockerfile
     PRE_COMMANDS="cd $MOUNTED_DIR/build"
@@ -48,7 +49,6 @@ else # Linux
     if [[ "$BUILDKITE" == 'true' ]]; then
         # Generate Base Images
         $CICD_DIR/generate-base-images.sh
-        CMAKE_EXTRAS="$CMAKE_EXTRAS -DBUILD_MONGO_DB_PLUGIN=true"
         [[ "$ENABLE_INSTALL" == 'true' ]] && COMMANDS="cp -r $MOUNTED_DIR /root/eosio && cd /root/eosio/build &&"
         COMMANDS="$COMMANDS $BUILD_COMMANDS"
         [[ "$ENABLE_INSTALL" == 'true' ]] && COMMANDS="$COMMANDS && make install"

--- a/.cicd/build.sh
+++ b/.cicd/build.sh
@@ -4,6 +4,7 @@ set -eo pipefail
 mkdir -p $BUILD_DIR
 CMAKE_EXTRAS="-DCMAKE_BUILD_TYPE='Release'"
 if [[ "$(uname)" == 'Darwin' ]]; then
+    # You can't use chained commands in execute
     if [[ "$TRAVIS" == 'true' ]]; then
         export PINNED=false
         ccache -s
@@ -42,20 +43,20 @@ else # Linux
         PRE_COMMANDS="$PRE_COMMANDS && export PATH=/usr/lib/ccache:\\\$PATH"
         CMAKE_EXTRAS="$CMAKE_EXTRAS -DCMAKE_CXX_COMPILER='clang++' -DCMAKE_C_COMPILER='clang' -DLLVM_DIR='/usr/lib/llvm-7/lib/cmake/llvm'"
     fi
+    BUILD_COMMANDS="cmake $CMAKE_EXTRAS .. && make -j$JOBS"
     # Docker Commands
     if [[ "$BUILDKITE" == 'true' ]]; then
         # Generate Base Images
         $CICD_DIR/generate-base-images.sh
         CMAKE_EXTRAS="$CMAKE_EXTRAS -DBUILD_MONGO_DB_PLUGIN=true"
         [[ "$ENABLE_INSTALL" == 'true' ]] && COMMANDS="cp -r $MOUNTED_DIR /root/eosio && cd /root/eosio/build &&"
-        [[ "$ENABLE_INSTALL" == 'true' ]] && POST_COMMANDS="make install"
+        COMMANDS="$COMMANDS $BUILD_COMMANDS"
+        [[ "$ENABLE_INSTALL" == 'true' ]] && COMMANDS="$COMMANDS && make install"
     elif [[ "$TRAVIS" == 'true' ]]; then
         ARGS="$ARGS -v /usr/lib/ccache -v $HOME/.ccache:/opt/.ccache -e JOBS -e TRAVIS -e CCACHE_DIR=/opt/.ccache"
-        COMMANDS="ccache -s"
+        COMMANDS="ccache -s && $BUILD_COMMANDS"
     fi
-    BUILD_COMMANDS="cmake $CMAKE_EXTRAS .. && make -j$JOBS"
-    COMMANDS="$PRE_COMMANDS && $COMMANDS && $BUILD_COMMANDS && $POST_COMMANDS"
+    COMMANDS="$PRE_COMMANDS && $COMMANDS"
     echo "$ docker run $ARGS $(buildkite-intrinsics) $FULL_TAG bash -c \"$COMMANDS\""
-    exit
     eval docker run $ARGS $(buildkite-intrinsics) $FULL_TAG bash -c \"$COMMANDS\"
 fi

--- a/.cicd/platforms/macos-10.14.sh
+++ b/.cicd/platforms/macos-10.14.sh
@@ -61,34 +61,31 @@ else
     # install boost from brew
     brew install boost || true
 fi
-# mongo dependencies only needed in Buildkite.
-if [[ "$BUILDKITE" == 'true' ]]; then
-    # install mongoDB
-    cd ~
-    curl -OL https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-3.6.3.tgz
-    tar -xzf mongodb-osx-ssl-x86_64-3.6.3.tgz
-    rm -f mongodb-osx-ssl-x86_64-3.6.3.tgz
-    ln -s ~/mongodb-osx-x86_64-3.6.3 ~/mongodb
-    # install mongo-c-driver from source
-    cd /tmp
-    curl -LO https://github.com/mongodb/mongo-c-driver/releases/download/1.13.0/mongo-c-driver-1.13.0.tar.gz
-    tar -xzf mongo-c-driver-1.13.0.tar.gz
-    cd mongo-c-driver-1.13.0
-    mkdir -p cmake-build
-    cd cmake-build
-    cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX='/usr/local' -DENABLE_BSON=ON -DENABLE_SSL=DARWIN -DENABLE_AUTOMATIC_INIT_AND_CLEANUP=OFF -DENABLE_STATIC=ON -DENABLE_ICU=OFF -DENABLE_SASL=OFF -DENABLE_SNAPPY=OFF ..
-    make -j $(getconf _NPROCESSORS_ONLN)
-    sudo make install
-    cd ../..
-    rm mongo-c-driver-1.13.0.tar.gz
-    # install mongo-cxx-driver from source
-    cd /tmp
-    curl -L https://github.com/mongodb/mongo-cxx-driver/archive/r3.4.0.tar.gz -o mongo-cxx-driver-r3.4.0.tar.gz
-    tar -xzf mongo-cxx-driver-r3.4.0.tar.gz
-    cd mongo-cxx-driver-r3.4.0/build
-    cmake -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX='/usr/local' ..
-    make -j $(getconf _NPROCESSORS_ONLN) VERBOSE=1
-    sudo make install
-    cd ../..
-    rm -f mongo-cxx-driver-r3.4.0.tar.gz
-fi
+# install mongoDB
+cd ~
+curl -OL https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-3.6.3.tgz
+tar -xzf mongodb-osx-ssl-x86_64-3.6.3.tgz
+rm -f mongodb-osx-ssl-x86_64-3.6.3.tgz
+ln -s ~/mongodb-osx-x86_64-3.6.3 ~/mongodb
+# install mongo-c-driver from source
+cd /tmp
+curl -LO https://github.com/mongodb/mongo-c-driver/releases/download/1.13.0/mongo-c-driver-1.13.0.tar.gz
+tar -xzf mongo-c-driver-1.13.0.tar.gz
+cd mongo-c-driver-1.13.0
+mkdir -p cmake-build
+cd cmake-build
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX='/usr/local' -DENABLE_BSON=ON -DENABLE_SSL=DARWIN -DENABLE_AUTOMATIC_INIT_AND_CLEANUP=OFF -DENABLE_STATIC=ON -DENABLE_ICU=OFF -DENABLE_SASL=OFF -DENABLE_SNAPPY=OFF ..
+make -j $(getconf _NPROCESSORS_ONLN)
+sudo make install
+cd ../..
+rm mongo-c-driver-1.13.0.tar.gz
+# install mongo-cxx-driver from source
+cd /tmp
+curl -L https://github.com/mongodb/mongo-cxx-driver/archive/r3.4.0.tar.gz -o mongo-cxx-driver-r3.4.0.tar.gz
+tar -xzf mongo-cxx-driver-r3.4.0.tar.gz
+cd mongo-cxx-driver-r3.4.0/build
+cmake -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX='/usr/local' ..
+make -j $(getconf _NPROCESSORS_ONLN) VERBOSE=1
+sudo make install
+cd ../..
+rm -f mongo-cxx-driver-r3.4.0.tar.gz

--- a/.cicd/platforms/macos-10.14.sh
+++ b/.cicd/platforms/macos-10.14.sh
@@ -61,31 +61,34 @@ else
     # install boost from brew
     brew install boost || true
 fi
-# install mongoDB
-cd ~
-curl -OL https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-3.6.3.tgz
-tar -xzf mongodb-osx-ssl-x86_64-3.6.3.tgz
-rm -f mongodb-osx-ssl-x86_64-3.6.3.tgz
-ln -s ~/mongodb-osx-x86_64-3.6.3 ~/mongodb
-# install mongo-c-driver from source
-cd /tmp
-curl -LO https://github.com/mongodb/mongo-c-driver/releases/download/1.13.0/mongo-c-driver-1.13.0.tar.gz
-tar -xzf mongo-c-driver-1.13.0.tar.gz
-cd mongo-c-driver-1.13.0
-mkdir -p cmake-build
-cd cmake-build
-cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX='/usr/local' -DENABLE_BSON=ON -DENABLE_SSL=DARWIN -DENABLE_AUTOMATIC_INIT_AND_CLEANUP=OFF -DENABLE_STATIC=ON -DENABLE_ICU=OFF -DENABLE_SASL=OFF -DENABLE_SNAPPY=OFF ..
-make -j $(getconf _NPROCESSORS_ONLN)
-sudo make install
-cd ../..
-rm mongo-c-driver-1.13.0.tar.gz
-# install mongo-cxx-driver from source
-cd /tmp
-curl -L https://github.com/mongodb/mongo-cxx-driver/archive/r3.4.0.tar.gz -o mongo-cxx-driver-r3.4.0.tar.gz
-tar -xzf mongo-cxx-driver-r3.4.0.tar.gz
-cd mongo-cxx-driver-r3.4.0/build
-cmake -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX='/usr/local' ..
-make -j $(getconf _NPROCESSORS_ONLN) VERBOSE=1
-sudo make install
-cd ../..
-rm -f mongo-cxx-driver-r3.4.0.tar.gz
+# mongo dependencies only needed in Buildkite.
+if [[ "$BUILDKITE" == 'true' ]]; then
+    # install mongoDB
+    cd ~
+    curl -OL https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-3.6.3.tgz
+    tar -xzf mongodb-osx-ssl-x86_64-3.6.3.tgz
+    rm -f mongodb-osx-ssl-x86_64-3.6.3.tgz
+    ln -s ~/mongodb-osx-x86_64-3.6.3 ~/mongodb
+    # install mongo-c-driver from source
+    cd /tmp
+    curl -LO https://github.com/mongodb/mongo-c-driver/releases/download/1.13.0/mongo-c-driver-1.13.0.tar.gz
+    tar -xzf mongo-c-driver-1.13.0.tar.gz
+    cd mongo-c-driver-1.13.0
+    mkdir -p cmake-build
+    cd cmake-build
+    cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX='/usr/local' -DENABLE_BSON=ON -DENABLE_SSL=DARWIN -DENABLE_AUTOMATIC_INIT_AND_CLEANUP=OFF -DENABLE_STATIC=ON -DENABLE_ICU=OFF -DENABLE_SASL=OFF -DENABLE_SNAPPY=OFF ..
+    make -j $(getconf _NPROCESSORS_ONLN)
+    sudo make install
+    cd ../..
+    rm mongo-c-driver-1.13.0.tar.gz
+    # install mongo-cxx-driver from source
+    cd /tmp
+    curl -L https://github.com/mongodb/mongo-cxx-driver/archive/r3.4.0.tar.gz -o mongo-cxx-driver-r3.4.0.tar.gz
+    tar -xzf mongo-cxx-driver-r3.4.0.tar.gz
+    cd mongo-cxx-driver-r3.4.0/build
+    cmake -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX='/usr/local' ..
+    make -j $(getconf _NPROCESSORS_ONLN) VERBOSE=1
+    sudo make install
+    cd ../..
+    rm -f mongo-cxx-driver-r3.4.0.tar.gz
+fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,18 +34,20 @@ matrix:
         homebrew:
           update: true
           packages:
-            - graphviz
+            - ccache
+            - boost
+            - python@2
+            - python
             - libtool
+            - libusb
+            - graphviz
+            - automake
+            - wget
             - gmp
             - llvm@7
             - pkgconfig
-            - python
-            - python@2
             - doxygen
-            - libusb
             - openssl
-            - boost
-            - ccache
       env: 
         - PATH="/usr/local/opt/ccache/libexec:$PATH"
 script: "ccache --max-size=1G && ./.cicd/build.sh && ./.cicd/test.sh scripts/parallel-test.sh && ./.cicd/test.sh scripts/serial-test.sh && if [[ $(uname) != 'Darwin' ]]; then ./.cicd/submodule-regression-check.sh; fi"

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ matrix:
             - graphviz
             - libtool
             - gmp
-            - llvm@4
+            - llvm@7
             - pkgconfig
             - python
             - python@2

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ matrix:
             - doxygen
             - libusb
             - openssl
-            - boost@1.70
+            - boost
             - ccache
       env: 
         - PATH="/usr/local/opt/ccache/libexec:$PATH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ matrix:
           update: true
           packages:
             - ccache
+            - jq
             - boost
             - python@2
             - python


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
Added various improvements to Mac builds on TravisCI:
- Ensured that `-DBUILD_MONGO_DB_PLUGIN=true` is not set on Mac builds in TravisCI.
  - This resulted in every Mac build that occurred in Travis to fail due to timeouts in the mongo serial test.
- Updated brew packages for Mac builds on TravisCI.
  - Brew packages listed on `.travis.yml` were out of date compared to `.cicd/platforms/macos-10.14.sh`.
- Add echos for cmake and make commands executed on all Mac builds.
  - Linux builds had echo statements that displayed all steps executed within Docker. This will help to ensure what cmake and make commands were executed during debug situations.

See:
https://travis-ci.com/EOSIO/eos/jobs/237611319 | TravisCI Mac build.

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
