### PR TITLE
[1.8.x] Fix Mac builds on Travis

### DIFF
--- a/.cicd/build.sh
+++ b/.cicd/build.sh
@@ -2,18 +2,21 @@
 set -eo pipefail
 . ./.cicd/helpers/general.sh
 mkdir -p $BUILD_DIR
-CMAKE_EXTRAS="-DBUILD_MONGO_DB_PLUGIN=true -DCMAKE_BUILD_TYPE='Release'"
+CMAKE_EXTRAS="-DCMAKE_BUILD_TYPE='Release'"
 if [[ "$(uname)" == 'Darwin' ]]; then
     # You can't use chained commands in execute
     if [[ "$TRAVIS" == 'true' ]]; then
         export PINNED=false
         ccache -s
         CMAKE_EXTRAS="$CMAKE_EXTRAS -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
-        ./$CICD_DIR/platforms/macos-10.14.sh
+    else
+        CMAKE_EXTRAS="$CMAKE_EXTRAS -DBUILD_MONGO_DB_PLUGIN=true"
     fi
     [[ ! "$PINNED" == 'false' || "$UNPINNED" == 'true' ]] && CMAKE_EXTRAS="$CMAKE_EXTRAS -DCMAKE_TOOLCHAIN_FILE=$HELPERS_DIR/clang.make"
     cd $BUILD_DIR
+    echo "cmake $CMAKE_EXTRAS .."
     cmake $CMAKE_EXTRAS ..
+    echo "make -j$JOBS"
     make -j$JOBS
 else # Linux
     ARGS=${ARGS:-"--rm --init -v $(pwd):$MOUNTED_DIR"}

--- a/.cicd/build.sh
+++ b/.cicd/build.sh
@@ -9,6 +9,7 @@ if [[ "$(uname)" == 'Darwin' ]]; then
         export PINNED=false
         ccache -s
         CMAKE_EXTRAS="$CMAKE_EXTRAS -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
+        ./$CICD_DIR/platforms/macos-10.14.sh
     else
         CMAKE_EXTRAS="$CMAKE_EXTRAS -DBUILD_MONGO_DB_PLUGIN=true"
     fi

--- a/.cicd/build.sh
+++ b/.cicd/build.sh
@@ -19,6 +19,7 @@ if [[ "$(uname)" == 'Darwin' ]]; then
     echo "make -j$JOBS"
     make -j$JOBS
 else # Linux
+    CMAKE_EXTRAS="$CMAKE_EXTRAS -DBUILD_MONGO_DB_PLUGIN=true"
     ARGS=${ARGS:-"--rm --init -v $(pwd):$MOUNTED_DIR"}
     . $HELPERS_DIR/file-hash.sh $CICD_DIR/platforms/$IMAGE_TAG.dockerfile
     PRE_COMMANDS="cd $MOUNTED_DIR/build"

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,18 +34,19 @@ matrix:
         homebrew:
           update: true
           packages:
-            - graphviz
+            - boost
+            - python@2
+            - python
             - libtool
+            - libusb
+            - graphviz
+            - automake
+            - wget
             - gmp
             - llvm@4
             - pkgconfig
-            - python
-            - python@2
             - doxygen
-            - libusb
-            - openssl
-            - boost@1.70
-            - ccache
+            - openssl            
       env: 
         - PATH="/usr/local/opt/ccache/libexec:$PATH"
 script: "ccache --max-size=1G && ./.cicd/build.sh && ./.cicd/test.sh scripts/parallel-test.sh && ./.cicd/test.sh scripts/serial-test.sh && if [[ $(uname) != 'Darwin' ]]; then ./.cicd/submodule-regression-check.sh; fi"

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,8 @@ matrix:
         homebrew:
           update: true
           packages:
+            - ccache
+            - jq
             - boost
             - python@2
             - python
@@ -46,7 +48,7 @@ matrix:
             - llvm@4
             - pkgconfig
             - doxygen
-            - openssl            
+            - openssl
       env: 
         - PATH="/usr/local/opt/ccache/libexec:$PATH"
 script: "ccache --max-size=1G && ./.cicd/build.sh && ./.cicd/test.sh scripts/parallel-test.sh && ./.cicd/test.sh scripts/serial-test.sh && if [[ $(uname) != 'Darwin' ]]; then ./.cicd/submodule-regression-check.sh; fi"


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
Added various improvements to Mac builds on TravisCI:
- Ensured that `-DBUILD_MONGO_DB_PLUGIN=true` is not set on Mac builds in TravisCI.
  - This resulted in every Mac build that occurred in Travis to fail due to timeouts in the mongo serial test.
- Updated brew packages for Mac builds on TravisCI.
  - Brew packages listed on `.travis.yml` were out of date compared to `.cicd/platforms/macos-10.14.sh`.
- Add echos for cmake and make commands executed on all Mac builds.
  - Linux builds had echo statements that displayed all steps executed within Docker. This will help to ensure what cmake and make commands were executed during debug situations.

See:
https://travis-ci.com/EOSIO/eos/jobs/237611457 | TravisCI Mac build.

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
