### PR TITLE
support unix socket HTTP server for nodeos

### DIFF
--- a/plugins/http_plugin/http_plugin.cpp
+++ b/plugins/http_plugin/http_plugin.cpp
@@ -392,6 +392,10 @@ namespace eosio {
          cfg.add_options()
             ("unix-socket-path", bpo::value<string>()->default_value(current_http_plugin_defaults.default_unix_socket_path),
              "The filename (relative to data-dir) to create a unix socket for HTTP RPC; set blank to disable.");
+      else
+         cfg.add_options()
+            ("unix-socket-path", bpo::value<string>(),
+             "The filename (relative to data-dir) to create a unix socket for HTTP RPC; set blank to disable.");   
 #endif
 
       if(current_http_plugin_defaults.default_http_port)


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
When unix socket support for the http plugin was initially added it was implicitly disabled for nodeos because it was only available to configure if the program activating http plugin had a default unix socket path set. (keosd had a default, nodeos doesn't)

Some users have requested the ability to use unix socket for nodeos because they have something in front of nodeos (like haproxy) and desire the, at least on paper, lower overhead of a unix socket.

This PR removes the check thus allowing any application using http plugin (like nodeos) to enable the unix socket by configuring it appropriately. It still is off by default for nodeos.

Enabling it for nodeos is as simple as a `unix-socket-path = nodeos.sock` for example. And to test you can `curl --unix-socket $EOSIO_DATA_DIR/nodeos.sock http://x/v1/chain/get_info`


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
