### PR TITLE
use the LLVM 7 library provided by SCL on CentOS7

### DIFF
--- a/.cicd/build.sh
+++ b/.cicd/build.sh
@@ -40,6 +40,7 @@ else # Linux
         CMAKE_EXTRAS="$CMAKE_EXTRAS -DCMAKE_CXX_COMPILER='clang++' -DCMAKE_C_COMPILER='clang'"
     elif [[ "$IMAGE_TAG" == 'centos-7.6-unpinned' ]]; then
         PRE_COMMANDS="$PRE_COMMANDS && source /opt/rh/devtoolset-8/enable && source /opt/rh/rh-python36/enable && export PATH=/usr/lib64/ccache:\\\$PATH"
+        CMAKE_EXTRAS="$CMAKE_EXTRAS -DLLVM_DIR='/opt/rh/llvm-toolset-7.0/root/usr/lib64/cmake/llvm'"
     elif [[ "$IMAGE_TAG" == 'ubuntu-18.04-unpinned' ]]; then
         PRE_COMMANDS="$PRE_COMMANDS && export PATH=/usr/lib/ccache:\\\$PATH"
         CMAKE_EXTRAS="$CMAKE_EXTRAS -DCMAKE_CXX_COMPILER='clang++' -DCMAKE_C_COMPILER='clang' -DLLVM_DIR='/usr/lib/llvm-7/lib/cmake/llvm'"

--- a/.cicd/platforms/centos-7.6-unpinned.dockerfile
+++ b/.cicd/platforms/centos-7.6-unpinned.dockerfile
@@ -8,7 +8,7 @@ RUN yum update -y && \
     yum --enablerepo=extras install -y which git autoconf automake libtool make bzip2 doxygen \
     graphviz bzip2-devel openssl-devel gmp-devel ocaml libicu-devel \
     python python-devel rh-python36 gettext-devel file libusbx-devel \
-    libcurl-devel patch vim-common jq
+    libcurl-devel patch vim-common jq llvm-toolset-7.0-llvm-devel llvm-toolset-7.0-llvm-static
 # build cmake.
 RUN curl -LO https://cmake.org/files/v3.13/cmake-3.13.2.tar.gz && \
     source /opt/rh/devtoolset-8/enable && \
@@ -20,18 +20,6 @@ RUN curl -LO https://cmake.org/files/v3.13/cmake-3.13.2.tar.gz && \
     make install && \
     cd / && \
     rm -rf cmake-3.13.2.tar.gz /cmake-3.13.2
-# build llvm8
-RUN git clone --depth 1 --single-branch --branch release_80 https://github.com/llvm-mirror/llvm.git llvm && \
-    source /opt/rh/devtoolset-8/enable && \
-    source /opt/rh/rh-python36/enable && \
-    cd llvm && \
-    mkdir build && \
-    cd build && \
-    cmake -G 'Unix Makefiles' -DLLVM_TARGETS_TO_BUILD=host -DLLVM_BUILD_TOOLS=false -DLLVM_ENABLE_RTTI=1 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local .. && \
-    make -j$(nproc) && \
-    make install && \
-    cd / && \
-    rm -rf /llvm
 # build boost
 RUN curl -LO https://dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.tar.bz2 && \
     source /opt/rh/devtoolset-8/enable && \

--- a/scripts/eosio_build_centos.sh
+++ b/scripts/eosio_build_centos.sh
@@ -12,7 +12,7 @@ echo "Disk space available: ${DISK_AVAIL}G"
 
 echo ""
 
-# Repo necessary for rh-python3 and devtoolset-8
+# Repo necessary for rh-python3, devtoolset-8 and llvm-toolset-7.0
 ensure-scl
 # GCC8 for Centos / Needed for CMAKE install even if we're pinning
 ensure-devtoolset

--- a/scripts/eosio_build_centos7_deps
+++ b/scripts/eosio_build_centos7_deps
@@ -19,3 +19,5 @@ file,rpm -qa
 libusbx-devel,rpm -qa
 libcurl-devel,rpm -qa
 patch,rpm -qa
+llvm-toolset-7.0-llvm-devel,rpm -qa
+llvm-toolset-7.0-llvm-static,rpm -qa

--- a/scripts/helpers/eosio.sh
+++ b/scripts/helpers/eosio.sh
@@ -269,7 +269,7 @@ function ensure-boost() {
 }
 
 function ensure-llvm() {
-    if $PIN_COMPILER || $BUILD_CLANG || [[ $NAME == "CentOS Linux" ]]; then
+    if $PIN_COMPILER || $BUILD_CLANG; then
         LLVM_TEMP_DIR=$(mktemp -d)
         if $PIN_COMPILER || $BUILD_CLANG; then
             local LLVM_PINNED_CMAKE_ARGS="-DCMAKE_TOOLCHAIN_FILE='${BUILD_DIR}/pinned_toolchain.cmake' -DCMAKE_EXE_LINKER_FLAGS=-pthread -DCMAKE_SHARED_LINKER_FLAGS=-pthread"
@@ -287,6 +287,8 @@ function ensure-llvm() {
         execute ln -sf /usr/lib/llvm-7 $LLVM_ROOT
     elif [[ $NAME == "Amazon Linux" ]]; then
         execute unlink $LLVM_ROOT || true
+    elif [[ $NAME == "CentOS Linux" ]]; then
+        execute ln -sf /opt/rh/llvm-toolset-7.0/root $LLVM_ROOT
     fi
 }
 


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
SCL is now providing llvm-toolset-7.0 for centos7. We can use this package for LLVM on Centos7 instead of building from source. It's a significant time saver for unpinned centos7 builds and means that on all supported platforms that don't require a pinned build there is no need to build llvm.

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
