### PR TITLE
port consolidated security fixes for 1.8.4 to develop; add unit tests associated with consolidated security fixes for 1.8.1

### DIFF
--- a/libraries/chain/include/eosio/chain/wasm_eosio_injection.hpp
+++ b/libraries/chain/include/eosio/chain/wasm_eosio_injection.hpp
@@ -759,7 +759,8 @@ namespace eosio { namespace chain { namespace wasm_injections {
    };
 
    struct post_op_full_injectors : post_op_injectors {
-      using loop_t   = wasm_ops::loop        <checktime_injection>;
+      using loop_t        = wasm_ops::loop        <checktime_injection>;
+      using grow_memory_t = wasm_ops::grow_memory <checktime_injection>;
    };
 
    template <typename ... Visitors>

--- a/unittests/producer_schedule_tests.cpp
+++ b/unittests/producer_schedule_tests.cpp
@@ -471,7 +471,29 @@ BOOST_AUTO_TEST_CASE( producer_watermark_test ) try {
    BOOST_CHECK_EQUAL( true, compare_schedules( sch1, *c.control->proposed_producers() ) );
 
    produce_until_transition( c, N(bob), N(alice) );
+
+   auto bob_last_produced_block_num = c.control->head_block_num();
+   wdump((bob_last_produced_block_num));
+
    produce_until_transition( c, N(alice), N(bob) );
+
+   auto alice_last_produced_block_num = c.control->head_block_num();
+   wdump((alice_last_produced_block_num));
+
+   {
+      wdump((c.control->head_block_state()->producer_to_last_produced));
+      const auto& last_produced = c.control->head_block_state()->producer_to_last_produced;
+      auto alice_itr = last_produced.find( N(alice) );
+      BOOST_REQUIRE( alice_itr != last_produced.end() );
+      BOOST_CHECK_EQUAL( alice_itr->second, alice_last_produced_block_num );
+      auto bob_itr = last_produced.find( N(bob) );
+      BOOST_REQUIRE( bob_itr != last_produced.end() );
+      BOOST_CHECK_EQUAL( bob_itr->second, bob_last_produced_block_num );
+      auto carol_itr = last_produced.find( N(carol) );
+      BOOST_REQUIRE( carol_itr != last_produced.end() );
+      BOOST_CHECK_EQUAL( carol_itr->second, carol_last_produced_block_num );
+   }
+
    BOOST_CHECK_EQUAL( c.control->pending_producers().version, 3u );
    BOOST_REQUIRE_EQUAL( c.control->active_producers().version, 2u );
 


### PR DESCRIPTION
## Change Description

### Port consolidated security fixes for 1.8.4 to develop

Consolidated Security Fixes ported from 1.8.4 to develop

- WebAssembly checktime fixes

Co-Authored-By: Matt Witherspoon 32485495+spoonincode@users.noreply.github.com

### Add unit tests associated with consolidated security fixes for 1.8.1

The consolidated security fixes for 1.8.1 (https://github.com/EOSIO/eos/pull/7619) fixed a consensus protocol regression bug introduced in v1.8.0-rc1 (transitioning from v1.7.x to v1.8.1 avoids this unintended consensus change). The `producer_to_last_produced` map within `block_header_state` was incorrectly setting a block number within the map that was one less than the intended block number during the normal case when a pending schedule was not promoted to active.

This PR now brings in an augmentation to an existing unit test to check for the expected values in the `producer_to_last_produced` map.

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions

