### PR TITLE
missing block log chain id unit tests

### DIFF
--- a/.cicd/generate-pipeline.sh
+++ b/.cicd/generate-pipeline.sh
@@ -182,7 +182,7 @@ for ROUND in $(seq 1 $ROUNDS); do
       BUILDKITE_AGENT_ACCESS_TOKEN:
     agents:
       queue: "$BUILDKITE_AGENT_QUEUE"
-    timeout: ${TIMEOUT:-20}
+    timeout: ${TIMEOUT:-30}
     skip: \${SKIP_$(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_UPCASE)_$(echo "$PLATFORM_JSON" | jq -r .VERSION_MAJOR)$(echo "$PLATFORM_JSON" | jq -r .VERSION_MINOR)}${SKIP_UNIT_TESTS}
 
 EOF

--- a/.cicd/generate-pipeline.sh
+++ b/.cicd/generate-pipeline.sh
@@ -182,7 +182,7 @@ for ROUND in $(seq 1 $ROUNDS); do
       BUILDKITE_AGENT_ACCESS_TOKEN:
     agents:
       queue: "$BUILDKITE_AGENT_QUEUE"
-    timeout: ${TIMEOUT:-15}
+    timeout: ${TIMEOUT:-20}
     skip: \${SKIP_$(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_UPCASE)_$(echo "$PLATFORM_JSON" | jq -r .VERSION_MAJOR)$(echo "$PLATFORM_JSON" | jq -r .VERSION_MINOR)}${SKIP_UNIT_TESTS}
 
 EOF

--- a/unittests/restart_chain_tests.cpp
+++ b/unittests/restart_chain_tests.cpp
@@ -1,0 +1,59 @@
+#include <sstream>
+
+#include <eosio/chain/block_log.hpp>
+#include <eosio/chain/global_property_object.hpp>
+#include <eosio/chain/snapshot.hpp>
+#include <eosio/testing/tester.hpp>
+
+#include <boost/mpl/list.hpp>
+#include <boost/test/unit_test.hpp>
+
+#include <contracts.hpp>
+#include <snapshots.hpp>
+
+using namespace eosio;
+using namespace testing;
+using namespace chain;
+
+void remove_existing_blocks(controller::config& config) {
+   auto block_log_path = config.blocks_dir / "blocks.log";
+   remove(block_log_path);
+   auto block_index_path = config.blocks_dir / "blocks.index";
+   remove(block_index_path);
+}
+
+BOOST_AUTO_TEST_SUITE(restart_chain_tests)
+
+BOOST_AUTO_TEST_CASE(test_existing_state_without_block_log)
+{
+   tester chain;
+
+   chain.create_account(N(snapshot));
+   std::vector<signed_block_ptr> blocks;
+   blocks.push_back(chain.produce_block());
+   blocks.push_back(chain.produce_block());
+   blocks.push_back(chain.produce_block());
+
+   tester other;
+   for (auto new_block : blocks) {
+      other.push_block(new_block);
+   }
+   blocks.clear();
+
+   other.close();
+   auto cfg = other.get_config();
+   remove_existing_blocks(cfg);
+   // restarting chain with no block log and no genesis
+   other.init(cfg);
+
+   blocks.push_back(chain.produce_block());
+   blocks.push_back(chain.produce_block());
+   blocks.push_back(chain.produce_block());
+   chain.control->abort_block();
+
+   for (auto new_block : blocks) {
+      other.push_block(new_block);
+   }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/unittests/restart_chain_tests.cpp
+++ b/unittests/restart_chain_tests.cpp
@@ -77,7 +77,7 @@ BOOST_AUTO_TEST_CASE(test_restart_with_different_chain_id)
    genesis.initial_timestamp = fc::time_point::from_iso_string("2020-01-01T00:00:00.999");
    genesis.initial_key = eosio::testing::base_tester::get_public_key( config::system_account_name, "active" );
    fc::optional<chain_id_type> chain_id = genesis.compute_chain_id();
-   BOOST_REQUIRE_EXCEPTION(other.open(chain_id), block_log_exception, fc_exception_message_starts_with("Controller configured with: "));
+   BOOST_REQUIRE_EXCEPTION(other.open(chain_id), chain_id_type_exception, fc_exception_message_starts_with("chain ID in state "));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/unittests/restart_chain_tests.cpp
+++ b/unittests/restart_chain_tests.cpp
@@ -44,7 +44,8 @@ BOOST_AUTO_TEST_CASE(test_existing_state_without_block_log)
    auto cfg = other.get_config();
    remove_existing_blocks(cfg);
    // restarting chain with no block log and no genesis
-   other.init(cfg);
+   auto chain_id = controller::extract_chain_id_from_db( cfg.state_dir );
+   other.open(chain_id);
 
    blocks.push_back(chain.produce_block());
    blocks.push_back(chain.produce_block());

--- a/unittests/restart_chain_tests.cpp
+++ b/unittests/restart_chain_tests.cpp
@@ -28,7 +28,6 @@ BOOST_AUTO_TEST_CASE(test_existing_state_without_block_log)
 {
    tester chain;
 
-   chain.create_account(N(snapshot));
    std::vector<signed_block_ptr> blocks;
    blocks.push_back(chain.produce_block());
    blocks.push_back(chain.produce_block());
@@ -60,7 +59,6 @@ BOOST_AUTO_TEST_CASE(test_restart_with_different_chain_id)
 {
    tester chain;
 
-   chain.create_account(N(snapshot));
    std::vector<signed_block_ptr> blocks;
    blocks.push_back(chain.produce_block());
    blocks.push_back(chain.produce_block());
@@ -74,7 +72,7 @@ BOOST_AUTO_TEST_CASE(test_restart_with_different_chain_id)
 
    other.close();
    genesis_state genesis;
-   genesis.initial_timestamp = fc::time_point::from_iso_string("2020-01-01T00:00:00.999");
+   genesis.initial_timestamp = fc::time_point::from_iso_string("2020-01-01T00:00:01.000");
    genesis.initial_key = eosio::testing::base_tester::get_public_key( config::system_account_name, "active" );
    fc::optional<chain_id_type> chain_id = genesis.compute_chain_id();
    BOOST_REQUIRE_EXCEPTION(other.open(chain_id), chain_id_type_exception, fc_exception_message_starts_with("chain ID in state "));

--- a/unittests/restart_chain_tests.cpp
+++ b/unittests/restart_chain_tests.cpp
@@ -44,8 +44,7 @@ BOOST_AUTO_TEST_CASE(test_existing_state_without_block_log)
    auto cfg = other.get_config();
    remove_existing_blocks(cfg);
    // restarting chain with no block log and no genesis
-   auto chain_id = controller::extract_chain_id_from_db( cfg.state_dir );
-   other.open(chain_id);
+   other.open();
 
    blocks.push_back(chain.produce_block());
    blocks.push_back(chain.produce_block());

--- a/unittests/restart_chain_tests.cpp
+++ b/unittests/restart_chain_tests.cpp
@@ -57,4 +57,28 @@ BOOST_AUTO_TEST_CASE(test_existing_state_without_block_log)
    }
 }
 
+BOOST_AUTO_TEST_CASE(test_restart_with_different_chain_id)
+{
+   tester chain;
+
+   chain.create_account(N(snapshot));
+   std::vector<signed_block_ptr> blocks;
+   blocks.push_back(chain.produce_block());
+   blocks.push_back(chain.produce_block());
+   blocks.push_back(chain.produce_block());
+
+   tester other;
+   for (auto new_block : blocks) {
+      other.push_block(new_block);
+   }
+   blocks.clear();
+
+   other.close();
+   genesis_state genesis;
+   genesis.initial_timestamp = fc::time_point::from_iso_string("2020-01-01T00:00:00.999");
+   genesis.initial_key = eosio::testing::base_tester::get_public_key( config::system_account_name, "active" );
+   fc::optional<chain_id_type> chain_id = genesis.compute_chain_id();
+   BOOST_REQUIRE_EXCEPTION(other.open(chain_id), block_log_exception, fc_exception_message_starts_with("Controller configured with: "));
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/unittests/snapshot_tests.cpp
+++ b/unittests/snapshot_tests.cpp
@@ -568,7 +568,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_restart_with_existing_state_and_truncated_blo
    snap_chain.close();
    auto cfg = snap_chain.get_config();
    // restart chain with truncated block log and existing state, but no genesis state (chain_id)
-   snap_chain.init(cfg);
+   auto chain_id = block_log::extract_chain_id( cfg.blocks_dir );
+   snap_chain.open(chain_id);
 
    auto block = chain.produce_block();
    chain.control->abort_block();

--- a/unittests/snapshot_tests.cpp
+++ b/unittests/snapshot_tests.cpp
@@ -564,14 +564,18 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_restart_with_existing_state_and_truncated_blo
    int ordinal = 1;
    snapshotted_tester snap_chain(chain.get_config(), SNAPSHOT_SUITE::get_reader(snapshot), ordinal++);
    verify_integrity_hash<SNAPSHOT_SUITE>(*chain.control, *snap_chain.control);
+   auto block = chain.produce_block();
+   chain.control->abort_block();
+   snap_chain.push_block(block);
+   verify_integrity_hash<SNAPSHOT_SUITE>(*chain.control, *snap_chain.control);
 
    snap_chain.close();
    auto cfg = snap_chain.get_config();
    // restart chain with truncated block log and existing state, but no genesis state (chain_id)
-   auto chain_id = block_log::extract_chain_id( cfg.blocks_dir );
-   snap_chain.open(chain_id);
+   snap_chain.open();
+   verify_integrity_hash<SNAPSHOT_SUITE>(*chain.control, *snap_chain.control);
 
-   auto block = chain.produce_block();
+   block = chain.produce_block();
    chain.control->abort_block();
    snap_chain.push_block(block);
    verify_integrity_hash<SNAPSHOT_SUITE>(*chain.control, *snap_chain.control);


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
#7988 
Added test cases for restarting chain with existing state but with and without an existing block_log

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
