### PR TITLE
Net plugin trx progress - 1.7

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -810,7 +810,6 @@ namespace eosio {
       }
       reset();
       sent_handshake_count = 0;
-      trx_in_progress_size = 0;
       node_id = fc::sha256();
       last_handshake_recv = handshake_message();
       last_handshake_sent = handshake_message();


### PR DESCRIPTION
## Change Description

- Do not clear `trx_in_progress` on close since low priority main application thread lambda callbacks can still be in progress.

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes


## Documentation Additions
- [ ] Documentation Additions
