### PR TITLE
Net plugin trx progress - develop

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -940,7 +940,6 @@ namespace eosio {
       self->connecting = false;
       self->syncing = false;
       self->consecutive_rejected_blocks = 0;
-      self->trx_in_progress_size = 0;
       ++self->consecutive_immediate_connection_close;
       bool has_last_req = false;
       {


### PR DESCRIPTION
## Change Description

- Do not clear `trx_in_progress` on close since low priority main application thread lambda callbacks can still be in progress.

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes


## Documentation Additions
- [ ] Documentation Additions
