### PR TITLE
Ensure block signing authority does not have a threshold of 0

### DIFF
--- a/libraries/chain/wasm_interface.cpp
+++ b/libraries/chain/wasm_interface.cpp
@@ -214,6 +214,7 @@ class privileged_api : public context_aware_api {
                }
 
                EOS_ASSERT( a.keys.size() == unique_keys.size(), wasm_execution_error, "producer schedule includes a duplicated key for ${account}", ("account", p.producer_name));
+               EOS_ASSERT( a.threshold > 0, wasm_execution_error, "producer schedule includes an authority with a threshold of 0 for ${account}", ("account", p.producer_name));
                EOS_ASSERT( sum_weights >= a.threshold, wasm_execution_error, "producer schedule includes an unsatisfiable authority for ${account}", ("account", p.producer_name));
             });
 


### PR DESCRIPTION
## Change Description

Reject proposed producer schedules that have a block signing authority with a threshold of 0.

## Consensus Changes
- [X] Consensus Changes

While this is technically a consensus change, it merely adds on top of the currently unreleased consensus changes introduced in #7404.

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
