### PR TITLE
Retain persisted trx until expired on speculative nodes

### DIFF
--- a/libraries/chain/include/eosio/chain/unapplied_transaction_queue.hpp
+++ b/libraries/chain/include/eosio/chain/unapplied_transaction_queue.hpp
@@ -125,7 +125,12 @@ public:
       for( const auto& receipt : bs->block->transactions ) {
          if( receipt.trx.contains<packed_transaction>() ) {
             const auto& pt = receipt.trx.get<packed_transaction>();
-            idx.erase( pt.id() );
+            auto itr = queue.get<by_trx_id>().find( pt.id() );
+            if( itr != queue.get<by_trx_id>().end() ) {
+               if( itr->trx_type != trx_enum_type::persisted ) {
+                  idx.erase( pt.id() );
+               }
+            }
          }
       }
    }


### PR DESCRIPTION
## Change Description

- Keep persisted trx until expired on speculative nodes. Retains 1.8.x behavior.

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
