### PR TITLE
[1.8.x] Change submodule script to see stderr for git commands

### DIFF
--- a/.cicd/submodule-regression-check.sh
+++ b/.cicd/submodule-regression-check.sh
@@ -20,8 +20,8 @@ while read -r a b; do
 done < <(git submodule --quiet foreach --recursive 'echo $path `git log -1 --format=%ct`')
 
 echo "getting submodule info for $BASE_BRANCH"
-git checkout $BASE_BRANCH &> /dev/null
-git submodule update --init &> /dev/null
+git checkout $BASE_BRANCH 1> /dev/null
+git submodule update --init 1> /dev/null
 while read -r a b; do
     BASE_MAP[$a]=$b
 done < <(git submodule --quiet foreach --recursive 'echo $path `git log -1 --format=%ct`')
@@ -29,13 +29,13 @@ done < <(git submodule --quiet foreach --recursive 'echo $path `git log -1 --for
 # We need to switch back to the PR ref/head so we can git log properly
 if [[ $TRAVIS == true && ! -z $TRAVIS_PULL_REQUEST_SLUG ]]; then
     echo "git fetch origin +refs/pull/$TRAVIS_PULL_REQUEST/merge:"
-    git fetch origin +refs/pull/$TRAVIS_PULL_REQUEST/merge: &> /dev/null
+    git fetch origin +refs/pull/$TRAVIS_PULL_REQUEST/merge: 1> /dev/null
     echo "switching back to $TRAVIS_COMMIT"
     echo 'git checkout -qf FETCH_HEAD'
-    git checkout -qf FETCH_HEAD &> /dev/null
+    git checkout -qf FETCH_HEAD 1> /dev/null
 elif [[ $BUILDKITE == true ]]; then
     echo "switching back to $CURRENT_BRANCH"
-    git checkout -f $CURRENT_BRANCH &> /dev/null
+    git checkout -f $CURRENT_BRANCH 1> /dev/null
 fi
 
 for k in "${!BASE_MAP[@]}"; do


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

@arhag  noticed https://buildkite.com/EOSIO/eosio-build-unpinned/builds/672#5d95d3d3-5a60-4180-864a-8316b1840036 was failing, but it didn't say why. It's understandably confusing since it looks like agent lost or other agent/infra failures. 

While I can't see the reason for the original failure, I can see that we hide STDERR with &> /dev/null. That's not good, so I'm going to change it to 1> /dev/null instead.

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
