### PR TITLE
Avoid validating keys within block signing authorities in proposed schedule

### DIFF
--- a/libraries/chain/wasm_interface.cpp
+++ b/libraries/chain/wasm_interface.cpp
@@ -199,7 +199,7 @@ class privileged_api : public context_aware_api {
          context.control.get_resource_limits_manager().get_account_limits( account, ram_bytes, net_weight, cpu_weight);
       }
 
-      int64_t set_proposed_producers_common( vector<producer_authority> && producers ) {
+      int64_t set_proposed_producers_common( vector<producer_authority> && producers, bool validate_keys ) {
          EOS_ASSERT(producers.size() <= config::max_producers, wasm_execution_error, "Producer schedule exceeds the maximum producer count for this chain");
          EOS_ASSERT( producers.size() > 0
                      || !context.control.is_builtin_activated( builtin_protocol_feature_t::disallow_empty_producer_schedule ),
@@ -214,14 +214,16 @@ class privileged_api : public context_aware_api {
          for (const auto& p: producers) {
             EOS_ASSERT( context.is_account(p.producer_name), wasm_execution_error, "producer schedule includes a nonexisting account" );
 
-            p.authority.visit([&p, num_supported_key_types](const auto& a) {
+            p.authority.visit([&p, num_supported_key_types, validate_keys](const auto& a) {
                uint32_t sum_weights = 0;
                std::set<public_key_type> unique_keys;
                for (const auto& kw: a.keys ) {
                   EOS_ASSERT( kw.key.which() < num_supported_key_types, unactivated_key_type,
                               "Unactivated key type used in proposed producer schedule");
 
-                  EOS_ASSERT( kw.key.valid(), wasm_execution_error, "producer schedule includes an invalid key" );
+                  if( validate_keys ) {
+                     EOS_ASSERT( kw.key.valid(), wasm_execution_error, "producer schedule includes an invalid key" );
+                  }
 
                   if (std::numeric_limits<uint32_t>::max() - sum_weights <= kw.weight) {
                      sum_weights = std::numeric_limits<uint32_t>::max();
@@ -245,7 +247,7 @@ class privileged_api : public context_aware_api {
          return context.control.set_proposed_producers( std::move(producers) );
       }
 
-      int64_t set_proposed_producers( array_ptr<char> packed_producer_schedule, uint32_t datalen) {
+      int64_t set_proposed_producers( array_ptr<char> packed_producer_schedule, uint32_t datalen ) {
          datastream<const char*> ds( packed_producer_schedule, datalen );
          vector<producer_authority> producers;
 
@@ -259,10 +261,10 @@ class privileged_api : public context_aware_api {
             producers.emplace_back(producer_authority{ p.producer_name, block_signing_authority_v0{ 1, {{p.block_signing_key, 1}} } } );
          }
 
-         return set_proposed_producers_common(std::move(producers));
+         return set_proposed_producers_common(std::move(producers), true);
       }
 
-      int64_t set_proposed_producers_ex( uint64_t packed_producer_format, array_ptr<char> packed_producer_schedule, uint32_t datalen) {
+      int64_t set_proposed_producers_ex( uint64_t packed_producer_format, array_ptr<char> packed_producer_schedule, uint32_t datalen ) {
          if (packed_producer_format == 0) {
             return set_proposed_producers(packed_producer_schedule, datalen);
          } else if (packed_producer_format == 1) {
@@ -270,7 +272,7 @@ class privileged_api : public context_aware_api {
             vector<producer_authority> producers;
 
             fc::raw::unpack(ds, producers);
-            return set_proposed_producers_common(std::move(producers));
+            return set_proposed_producers_common(std::move(producers), false);
          } else {
             EOS_THROW(wasm_execution_error, "Producer schedule is in an unknown format!");
          }


### PR DESCRIPTION
## Change Description

The `set_proposed_producers` intrinsic validated that all of the keys in the proposed schedule are valid (according to the `valid()` member function) and aborted if one of them was not valid. This PR still maintains that behavior to avoid introducing an unintended consensus change.

The protocol feature introduced in #7404 added a new intrinsic `set_proposed_producers_ex` which allows for a proposed producer schedule to include the new `block_signing_authority` rather than merely single producer keys. 

The `set_proposed_producers_ex` also provides a mode that unpacks the provided schedule data according to the old format of `set_proposed_producers` (this requires provided a `packed_producer_format` value of 0). In the case of using that legacy mode, the system will again validate that the keys in the schedule (just one key per producer) are valid according to the `valid()` member function.

The original behavior of `set_proposed_producers_ex` under the new mode that allows for `block_signing_authority` (when `packed_producer_format` has a value of 1) was to also validate all of the keys. This PR changes that behavior to avoid validating the keys. All the other validation checks on the `block_signing_authority` are still in place.

The reason for this change is to allow contracts to call `set_proposed_producers_ex` in a manner that gives the contract confidence that the intrinsic will not abort the transaction. Doing this requires validating the inputs to avoid triggering any of the assertions in the native side implementation of `set_proposed_producers_ex`. The validation of the public keys causes a huge burden on the contract because there is no easy way to pre-validate whether, for example, a given R1 public key is valid without bringing in a lot of cryptography code into the contract. Furthermore, passing in invalid keys does no harm to the system (assuming a supermajority of producers do not all simultaneously make all their block signing keys invalid). It may only harm the producer who chooses the invalid keys because it can prevent them from signing blocks; and, there are already many ways of generating public keys that are considered valid points on the elliptic curve and yet have a corresponding private key that no one knows (short of breaking the cryptography).

## Consensus Changes
- [x] Consensus Changes

While this is technically a consensus change, it merely modifies the behavior of the currently unreleased consensus changes introduced in #7404.

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
