### PR TITLE
net_plugin better error for unknown block

### DIFF
--- a/plugins/net_plugin/include/eosio/net_plugin/protocol.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/protocol.hpp
@@ -64,7 +64,7 @@ namespace eosio {
     case validation : return "invalid block";
     case authentication : return "authentication failure";
     case fatal_other : return "some other failure";
-    case benign_other : return "some other non-fatal condition";
+    case benign_other : return "some other non-fatal condition, possibly unknown block";
     default : return "some crazy reason";
     }
   }


### PR DESCRIPTION
## Change Description

- Since the snapshot feature was added `net_plugin` has been reporting "chain is forked" error for requested blocks not in local block log.
- Send `benign_other` now for unknown blocks so 1.8.x peers do not report "chain is forked" but instead will report "some other non-fatal condition".
- 2.0+ will report "some other non-fatal condition, possibly unknown block" and will attempt to reconnect in `connection-cleanup-period` seconds.

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
