### PR TITLE
[Master] dockerhub | eosio/producer -> eosio/ci

### DIFF
--- a/.cicd/helpers/file-hash.sh
+++ b/.cicd/helpers/file-hash.sh
@@ -5,4 +5,4 @@ FILE_NAME=$(basename $1 | awk '{split($0,a,/\.(d|s)/); print a[1] }')
 export DETERMINED_HASH=$(sha1sum $1 | awk '{ print $1 }')
 ( [[ $FILE_NAME =~ 'macos' ]] && [[ $PINNED == false || $UNPINNED == true ]] ) && FILE_NAME="${FILE_NAME}-unpinned"
 export HASHED_IMAGE_TAG="eos-${FILE_NAME}-${DETERMINED_HASH}"
-export FULL_TAG="eosio/producer:$HASHED_IMAGE_TAG"
+export FULL_TAG="eosio/ci:$HASHED_IMAGE_TAG"


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

Community members are asking Dev Relations about what eosio/producer is in dockerhub. I'm not sure why we're using it and we need to change it to use the eosio/ci instead.

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
