### PR TITLE
Update cleos to support new producer schedule - develop

### DIFF
--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -1322,10 +1322,21 @@ struct get_schedule_subcommand {
          return;
       }
       printf("%s schedule version %s\n", name, schedule["version"].as_string().c_str());
-      printf("    %-13s %s\n", "Producer", "Producer key");
+      printf("    %-13s %s\n", "Producer", "Producer Authority");
       printf("    %-13s %s\n", "=============", "==================");
-      for (auto& row: schedule["producers"].get_array())
-         printf("    %-13s %s\n", row["producer_name"].as_string().c_str(), row["block_signing_key"].as_string().c_str());
+      for( auto& row: schedule["producers"].get_array() ) {
+         if( row.get_object().contains("block_signing_key") ) {
+            // pre 2.0
+            printf( "    %-13s %s\n", row["producer_name"].as_string().c_str(), row["block_signing_key"].as_string().c_str() );
+         } else {
+            printf( "    %-13s ", row["producer_name"].as_string().c_str() );
+            auto a = row["authority"].as<block_signing_authority>();
+            static_assert( std::is_same<decltype(a), static_variant<block_signing_authority_v0>>::value,
+                           "Updates maybe needed if block_signing_authority changes" );
+            block_signing_authority_v0 auth = a.get<block_signing_authority_v0>();
+            printf( "%s\n", fc::json::to_string( auth ).c_str() );
+         }
+      }
       printf("\n");
    }
 


### PR DESCRIPTION
## Change Description

- Resolves #8045 
- Starting with 2.0, #7404 added Weighted-Threshold-Multi-Signature (WTMsig) Block Production. This changed the block signing authority from a simple signing key to a full authority. However, `cleos` was not updated to present this new authority. This PR updates `cleos` to show the full authority when communicating with a 2.0 `nodeos`. `cleos` will continue to display only the block signing key when communicating with a pre-2.0 `nodeos`.

In the image below, the first output is from a 1.8.4 `nodeos`, the second is from a 2.0.0-rc1 `nodeos`:

![image](https://user-images.githubusercontent.com/3933649/66488353-63527e00-ea73-11e9-964b-ec081b3e3904.png)

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [x] Documentation Additions

- `cleos get schedule` output has been modified as described above.
- `chain_api_plugin`  `/v1/chain/get_producer_schedule` JSON output changed with #7404
