### PR TITLE
Conan poc v2 mongo

### DIFF
--- a/.cicd/build.sh
+++ b/.cicd/build.sh
@@ -5,7 +5,14 @@ mkdir -p $BUILD_DIR
 CMAKE_EXTRAS="-DCMAKE_BUILD_TYPE='Release' -DCORE_SYMBOL_NAME='SYS'"
 if [[ $(uname) == 'Darwin' ]]; then
     # You can't use chained commands in execute
-    [[ $TRAVIS == true ]] && export PINNED=false && ccache -s && CMAKE_EXTRAS="$CMAKE_EXTRAS -DCMAKE_CXX_COMPILER_LAUNCHER=ccache" && ./$CICD_DIR/platforms/unpinned/$IMAGE_TAG.sh
+    if [[ $TRAVIS == true ]]; then
+        export PINNED=false
+        ccache -s
+        CMAKE_EXTRAS="$CMAKE_EXTRAS -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
+        ./$CICD_DIR/platforms/unpinned/$IMAGE_TAG.sh
+    else
+        CMAKE_EXTRAS="$CMAKE_EXTRAS -DBUILD_MONGO_DB_PLUGIN=true"
+    fi
     ( [[ ! $PINNED == false || $UNPINNED == true ]] ) && CMAKE_EXTRAS="$CMAKE_EXTRAS -DCMAKE_TOOLCHAIN_FILE=$SCRIPTS_DIR/pinned_toolchain.cmake"
     if [[ "$USE_CONAN" == 'true' ]]; then
         sed -n '/## Build Steps/,/make -j/p' $CONAN_DIR/$IMAGE_TAG.md | grep -v -e '```' -e '^$' -e 'git' -e 'cd eos' >> $CONAN_DIR/conan-build.sh
@@ -16,6 +23,7 @@ if [[ $(uname) == 'Darwin' ]]; then
         make -j$JOBS
     fi
 else # Linux
+    CMAKE_EXTRAS="$CMAKE_EXTRAS -DBUILD_MONGO_DB_PLUGIN=true"
     ARGS=${ARGS:-"--rm --init -v $(pwd):$MOUNTED_DIR -e UNPINNED -e PINNED -e IMAGE_TAG"}
     PRE_COMMANDS="cd $MOUNTED_DIR/build"
     # PRE_COMMANDS: Executed pre-cmake

--- a/.cicd/generate-pipeline.sh
+++ b/.cicd/generate-pipeline.sh
@@ -22,6 +22,7 @@ if [[ $PINNED == false || $UNPINNED == true ]]; then
     export PLATFORM_TYPE="unpinned"
 elif [[ $USE_CONAN == true ]]; then
     export PLATFORM_TYPE="conan"
+    sed -i.bak '/nodeos_run_test-mongodb/s/^/#/' ./tests/CMakeLists.txt
 else
     export PLATFORM_TYPE="pinned"
 fi

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -63,6 +63,10 @@ set_property(TEST block_log_util_test PROPERTY LABELS nonparallelizable_tests)
 
 add_test(NAME p2p_dawn515_test COMMAND tests/p2p_tests/dawn_515/test.sh WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 set_property(TEST p2p_dawn515_test PROPERTY LABELS nonparallelizable_tests)
+if(BUILD_MONGO_DB_PLUGIN)
+  add_test(NAME nodeos_run_test-mongodb COMMAND tests/nodeos_run_test.py --mongodb -v --clean-run --dump-error-detail WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+  set_property(TEST nodeos_run_test-mongodb PROPERTY LABELS nonparallelizable_tests)
+endif()
 
 add_test(NAME producer-preactivate-feature-test COMMAND tests/prod_preactivation_test.py --clean-run --dump-error-detail WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 set_property(TEST producer-preactivate-feature-test PROPERTY LABELS nonparallelizable_tests)


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
Added MongoDB back.
- Enabled Mongo on all Linux builds in Travis and Buildkite.
- Enabled Mongo on Mac builds in Buildkite. Mongo is disabled on Mac in Travis due to timeouts.
- Add comments to Mongo steps in tests/CMakeLists.txt if USE_CONAN is set.
  - This allows pinned/unpinned builds to still build and test the Mongo plugin but avoids adding the Mongo test for builds with Conan as it is not installed in the Conan Docker images.

See:
[Build #341](https://buildkite.com/EOSIO/eosio-conan/builds/341) | Conan managed build that does not execute the Mongo test.
[Build #18089](https://buildkite.com/EOSIO/eosio/builds/18089) | Pinned build that executes the Mongo test.
[Build #710](https://buildkite.com/EOSIO/eosio-build-unpinned/builds/710) | Unpinned build that executes the Mongo test.

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
