### PR TITLE
nodeos & keosd version reporting

### DIFF
--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1430,7 +1430,8 @@ read_only::get_info_results read_only::get_info(const read_only::get_info_params
       //__builtin_popcountll(db.get_dynamic_global_properties().recent_slots_filled) / 64.0,
       app().version_string(),
       db.fork_db_pending_head_block_num(),
-      db.fork_db_pending_head_block_id()
+      db.fork_db_pending_head_block_id(),
+      app().full_version_string()
    };
 }
 

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -113,6 +113,7 @@ public:
       optional<string>        server_version_string;
       optional<uint32_t>              fork_db_head_block_num;
       optional<chain::block_id_type>  fork_db_head_block_id;
+      optional<string>        server_full_version_string;
    };
    get_info_results get_info(const get_info_params&) const;
 
@@ -749,7 +750,10 @@ private:
 FC_REFLECT( eosio::chain_apis::permission, (perm_name)(parent)(required_auth) )
 FC_REFLECT(eosio::chain_apis::empty, )
 FC_REFLECT(eosio::chain_apis::read_only::get_info_results,
-(server_version)(chain_id)(head_block_num)(last_irreversible_block_num)(last_irreversible_block_id)(head_block_id)(head_block_time)(head_block_producer)(virtual_block_cpu_limit)(virtual_block_net_limit)(block_cpu_limit)(block_net_limit)(server_version_string)(fork_db_head_block_num)(fork_db_head_block_id) )
+           (server_version)(chain_id)(head_block_num)(last_irreversible_block_num)(last_irreversible_block_id)
+           (head_block_id)(head_block_time)(head_block_producer)
+           (virtual_block_cpu_limit)(virtual_block_net_limit)(block_cpu_limit)(block_net_limit)
+           (server_version_string)(fork_db_head_block_num)(fork_db_head_block_id)(server_full_version_string) )
 FC_REFLECT(eosio::chain_apis::read_only::get_activated_protocol_features_params, (lower_bound)(upper_bound)(limit)(search_by_block_num)(reverse) )
 FC_REFLECT(eosio::chain_apis::read_only::get_activated_protocol_features_results, (activated_protocol_features)(more) )
 FC_REFLECT(eosio::chain_apis::read_only::get_block_params, (block_num_or_id))

--- a/programs/keosd/CMakeLists.txt
+++ b/programs/keosd/CMakeLists.txt
@@ -12,7 +12,7 @@ endif()
 configure_file(config.hpp.in config.hpp ESCAPE_QUOTES)
 
 target_link_libraries( ${KEY_STORE_EXECUTABLE_NAME}
-        PRIVATE appbase
+        PRIVATE appbase version
         PRIVATE wallet_api_plugin wallet_plugin
         PRIVATE http_plugin
         PRIVATE eosio_chain fc ${CMAKE_DL_LIBS} ${PLATFORM_SPECIFIC_LIBS} )

--- a/programs/keosd/main.cpp
+++ b/programs/keosd/main.cpp
@@ -3,6 +3,7 @@
 #include <eosio/http_plugin/http_plugin.hpp>
 #include <eosio/wallet_plugin/wallet_plugin.hpp>
 #include <eosio/wallet_api_plugin/wallet_api_plugin.hpp>
+#include <eosio/version/version.hpp>
 
 #include <fc/log/logger_config.hpp>
 #include <fc/exception/exception.hpp>
@@ -33,6 +34,8 @@ bfs::path determine_home_directory()
 int main(int argc, char** argv)
 {
    try {
+      app().set_version_string(eosio::version::version_client());
+      app().set_full_version_string(eosio::version::version_full());
       bfs::path home = determine_home_directory();
       app().set_default_data_dir(home / "eosio-wallet");
       app().set_default_config_dir(home / "eosio-wallet");

--- a/programs/nodeos/CMakeLists.txt
+++ b/programs/nodeos/CMakeLists.txt
@@ -48,7 +48,7 @@ else()
 endif()
 
 target_link_libraries( ${NODE_EXECUTABLE_NAME}
-        PRIVATE appbase
+        PRIVATE appbase version
         PRIVATE -Wl,${whole_archive_flag} login_plugin               -Wl,${no_whole_archive_flag}
         PRIVATE -Wl,${whole_archive_flag} history_plugin             -Wl,${no_whole_archive_flag}
         PRIVATE -Wl,${whole_archive_flag} state_history_plugin       -Wl,${no_whole_archive_flag}

--- a/programs/nodeos/main.cpp
+++ b/programs/nodeos/main.cpp
@@ -4,6 +4,7 @@
 #include <eosio/http_plugin/http_plugin.hpp>
 #include <eosio/net_plugin/net_plugin.hpp>
 #include <eosio/producer_plugin/producer_plugin.hpp>
+#include <eosio/version/version.hpp>
 
 #include <fc/log/logger_config.hpp>
 #include <fc/log/appender.hpp>
@@ -82,6 +83,8 @@ int main(int argc, char** argv)
 {
    try {
       app().set_version(eosio::nodeos::config::version);
+      app().set_version_string(eosio::version::version_client());
+      app().set_full_version_string(eosio::version::version_full());
 
       auto root = fc::app_path();
       app().set_default_data_dir(root / "eosio" / nodeos::config::node_executable_name / "data" );
@@ -91,7 +94,7 @@ int main(int argc, char** argv)
          .default_http_port = 8888
       });
       if(!app().initialize<chain_plugin, net_plugin, producer_plugin>(argc, argv)) {
-         if(app().get_options().count("help") || app().get_options().count("version")) {
+         if(app().get_options().count("help") || app().get_options().count("version") || app().get_options().count("full-version")) {
             return SUCCESS;
          }
          return INITIALIZE_FAIL;


### PR DESCRIPTION
## Change Description

- Added new option `--full-version` to `nodeos` and `keosd` which uses the version library introduced in #7468. See #7468 for more information on version reported.
- `--version` now reports version setup in `CMakeLists.txt`
- `--full-version` reports full version including the cmake version and git hash.
- Added `server_full_version_string` to `/v1/chain/get_info` RPC
- Depends on https://github.com/EOSIO/appbase/pull/75
- Resolves #8059

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [x] Documentation Additions
