### PR TITLE
Handle cases where version_* not specified in CMakeLists.txt - 2.0

### DIFF
--- a/libraries/version/src/version_impl.cpp.in
+++ b/libraries/version/src/version_impl.cpp.in
@@ -14,28 +14,27 @@ namespace eosio { namespace version {
    const bool        version_dirty { @_VERSION_DIRTY_@  };
 
    std::string _version_client() {
-      if (version_major == "unknown") {
-         std::string version{"unknown"};
-         return version;
-      }
-      else {
-         std::string version{'v' + version_major + '.' + version_minor + '.' + version_patch + '-' + version_suffix};
+      if( version_major == "unknown" || version_major.empty() ) {
+         return "unknown";
+      } else {
+         std::string version{'v' + version_major };
+         if( !version_minor.empty() )  version += '.' + version_minor;
+         if( !version_patch.empty() )  version += '.' + version_patch;
+         if( !version_suffix.empty() ) version += '-' + version_suffix;
          return version;
       }
    }
 
    std::string _version_full() {
-      if (version_major == "unknown") {
-         std::string version{"unknown"};
-         return version;
-      }
-      else {
-         std::string version{'v' + version_major + '.' + version_minor + '.' + version_patch + '-' + version_suffix + '-' + version_hash};
-         
-         if (version_dirty == true) {
-            version += "-dirty";
-         }
-         
+      if( version_major == "unknown" || version_major.empty() ) {
+         return "unknown";
+      } else {
+         std::string version{'v' + version_major };
+         if( !version_minor.empty() )  version += '.' + version_minor;
+         if( !version_patch.empty() )  version += '.' + version_patch;
+         if( !version_suffix.empty() ) version += '-' + version_suffix;
+         if( !version_hash.empty() )   version += '-' + version_hash;
+         if( version_dirty )           version += "-dirty";
          return version;
       }
    }

--- a/libraries/version/src/version_impl.cpp.in
+++ b/libraries/version/src/version_impl.cpp.in
@@ -14,11 +14,10 @@ namespace eosio { namespace version {
    const bool        version_dirty { @_VERSION_DIRTY_@  };
 
    std::string _version_client() {
-      if( version_major == "unknown" || version_major.empty() ) {
+      if( version_major == "unknown" || version_major.empty() || version_minor == "unknown" || version_minor.empty()) {
          return "unknown";
       } else {
-         std::string version{'v' + version_major };
-         if( !version_minor.empty() )  version += '.' + version_minor;
+         std::string version{'v' + version_major + '.' + version_minor};
          if( !version_patch.empty() )  version += '.' + version_patch;
          if( !version_suffix.empty() ) version += '-' + version_suffix;
          return version;
@@ -26,11 +25,10 @@ namespace eosio { namespace version {
    }
 
    std::string _version_full() {
-      if( version_major == "unknown" || version_major.empty() ) {
+      if( version_major == "unknown" || version_major.empty() || version_minor == "unknown" || version_minor.empty()) {
          return "unknown";
       } else {
-         std::string version{'v' + version_major };
-         if( !version_minor.empty() )  version += '.' + version_minor;
+         std::string version{'v' + version_major + '.' + version_minor};
          if( !version_patch.empty() )  version += '.' + version_patch;
          if( !version_suffix.empty() ) version += '-' + version_suffix;
          if( !version_hash.empty() )   version += '-' + version_hash;


### PR DESCRIPTION
## Change Description

- When `version_suffix` not specified in `CMakeLists.txt` version was reported as `v2.0.0-`
- Fix reported version not to have trailing separators unless specific portion of version is specified.

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
