### PR TITLE
net_plugin remove sync w/peer check - develop

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -1886,7 +1886,6 @@ namespace eosio {
    void dispatch_manager::bcast_block(const block_state_ptr& bs) {
       fc_dlog( logger, "bcast block ${b}", ("b", bs->block_num) );
 
-      if( my_impl->sync_master->syncing_with_peer() ) return;
       bool have_connection = false;
       for_each_block_connection( [&have_connection]( auto& cp ) {
          peer_dlog( cp, "socket_is_open ${s}, connecting ${c}, syncing ${ss}",


### PR DESCRIPTION
## Change Description

- net_plugin moves in/out of syncing with peer state. Avoiding broadcasting blocks can cause peers to not receive blocks they are expecting. We handle unexpected blocks safely, so this check added in 2.0 is causing more harm than good.

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
