### PR TITLE
fix a compile error, change std::optional to fc::optional.

### DIFF
--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -278,7 +278,7 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
          }
       }
 
-      std::optional<uint32_t> get_watermark( account_name producer ) const {
+      fc::optional<uint32_t> get_watermark( account_name producer ) const {
          auto itr = _producer_watermarks.find( producer );
 
          if( itr == _producer_watermarks.end() ) return {};


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
std::optional will cause compile error like ：
/Users/zzc/Develop/eos/cmake-build-debug --target producer_plugin -- -j 2
......
plugins/producer_plugin/CMakeFiles/producer_plugin.dir/producer_plugin.cpp.o
/Users/zzc/Develop/eos/plugins/producer_plugin/producer_plugin.cpp:281:7: error: no template named 'optional' in namespace 'std'; did you mean simply 'optional'?
      std::optional<uint32_t> get_watermark( account_name producer ) const {
      ^~~~~~~~~~~~~
      optional
/Users/zzc/Develop/eos/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp:36:14: note: 'optional' declared here
   using fc::optional;
             ^
1 error generated.

And fc::optional works well.

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
