### PR TITLE
[1.7.x] Mac OSX steps need a min of 1 hour

### DIFF
--- a/.cicd/generate-pipeline.sh
+++ b/.cicd/generate-pipeline.sh
@@ -187,7 +187,7 @@ EOF
             - 'registry_1'
             - 'registry_2'
           pre-execute-sleep: 5
-    timeout: ${TIMEOUT:-20}
+    timeout: ${TIMEOUT:-60}
     agents:
       - "queue=mac-anka-node-fleet"
     skip: \${SKIP_$(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_UPCASE)_$(echo "$PLATFORM_JSON" | jq -r .VERSION_MAJOR)$(echo "$PLATFORM_JSON" | jq -r .VERSION_MINOR)}${SKIP_UNIT_TESTS}
@@ -236,7 +236,7 @@ EOF
             - 'registry_1'
             - 'registry_2'
           pre-execute-sleep: 5
-    timeout: ${TIMEOUT:-20}
+    timeout: ${TIMEOUT:-60}
     agents:
       - "queue=mac-anka-node-fleet"
     skip: \${SKIP_$(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_UPCASE)_$(echo "$PLATFORM_JSON" | jq -r .VERSION_MAJOR)$(echo "$PLATFORM_JSON" | jq -r .VERSION_MINOR)}${SKIP_SERIAL_TESTS}
@@ -399,7 +399,7 @@ cat <<EOF
           pre-execute-sleep: 5
     agents:
       - "queue=mac-anka-node-fleet"
-    timeout: ${TIMEOUT:-10}
+    timeout: ${TIMEOUT:-60}
     skip: ${SKIP_MACOS_10_13}${SKIP_PACKAGE_BUILDER}${SKIP_MAC}
 
   - label: ":darwin: macOS 10.14 - Package Builder"
@@ -422,7 +422,7 @@ cat <<EOF
           pre-execute-sleep: 5
     agents:
       - "queue=mac-anka-node-fleet"
-    timeout: ${TIMEOUT:-10}
+    timeout: ${TIMEOUT:-60}
     skip: ${SKIP_MACOS_10_14}${SKIP_PACKAGE_BUILDER}${SKIP_MAC}
 
   - label: ":ubuntu: Ubuntu 18.04 - Contract Builder"


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

Problem: We recently deleted all Templates and Tags from all hosts and recreated them from scratch. We noticed a problem where the downloading of the new tag from the registry took longer than some of the timeouts due to the amount of pull/download requests (even with two registries).

Solution: Set a minimum of an hour timeout for mac steps.

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
