### PR TITLE
remove gettext/libintl dependency

### DIFF
--- a/.cicd/platforms/centos-7.6-unpinned.dockerfile
+++ b/.cicd/platforms/centos-7.6-unpinned.dockerfile
@@ -7,7 +7,7 @@ RUN yum update -y && \
     yum --enablerepo=extras install -y devtoolset-8 && \
     yum --enablerepo=extras install -y which git autoconf automake libtool make bzip2 doxygen \
     graphviz bzip2-devel openssl-devel gmp-devel ocaml libicu-devel \
-    python python-devel rh-python36 gettext-devel file libusbx-devel \
+    python python-devel rh-python36 file libusbx-devel \
     libcurl-devel patch vim-common jq llvm-toolset-7.0-llvm-devel llvm-toolset-7.0-llvm-static
 # build cmake.
 RUN curl -LO https://cmake.org/files/v3.13/cmake-3.13.2.tar.gz && \

--- a/.cicd/platforms/centos-7.6.dockerfile
+++ b/.cicd/platforms/centos-7.6.dockerfile
@@ -7,7 +7,7 @@ RUN yum update -y && \
     yum --enablerepo=extras install -y devtoolset-8 && \
     yum --enablerepo=extras install -y which git autoconf automake libtool make bzip2 doxygen \
     graphviz bzip2-devel openssl-devel gmp-devel ocaml libicu-devel \
-    python python-devel rh-python36 gettext-devel file libusbx-devel \
+    python python-devel rh-python36 file libusbx-devel \
     libcurl-devel patch vim-common jq
 # build cmake.
 RUN curl -LO https://cmake.org/files/v3.13/cmake-3.13.2.tar.gz && \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,10 +10,6 @@ endif()
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules")
 
-if (UNIX AND APPLE)
-   list(APPEND CMAKE_PREFIX_PATH "/usr/local/opt/gettext")
-endif()
-
 include( GNUInstallDirs )
 include( InstallDirectoryPermissions )
 include( MASSigning )

--- a/programs/cleos/CMakeLists.txt
+++ b/programs/cleos/CMakeLists.txt
@@ -10,8 +10,6 @@ if( GPERFTOOLS_FOUND )
     list( APPEND PLATFORM_SPECIFIC_LIBS tcmalloc )
 endif()
 
-find_package(Intl REQUIRED)
-
 set(LOCALEDIR ${CMAKE_INSTALL_PREFIX}/share/locale)
 set(LOCALEDOMAIN ${CLI_CLIENT_EXECUTABLE_NAME})
 configure_file(config.hpp.in config.hpp ESCAPE_QUOTES)

--- a/programs/cleos/localize.hpp
+++ b/programs/cleos/localize.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <libintl.h>
 #include <fc/variant.hpp>
 
 namespace eosio { namespace client { namespace localize {
@@ -13,7 +12,7 @@ namespace eosio { namespace client { namespace localize {
    inline auto localized_with_variant( const char* raw_fmt, const fc::variant_object& args) {
       if (raw_fmt != nullptr) {
          try {
-            return fc::format_string(::gettext(raw_fmt), args);
+            return fc::format_string(raw_fmt, args);
          } catch (...) {
          }
          return std::string(raw_fmt);

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -2391,9 +2391,6 @@ CLI::callback_t header_opt_callback = [](CLI::results_t res) {
 };
 
 int main( int argc, char** argv ) {
-   setlocale(LC_ALL, "");
-   bindtextdomain(locale_domain, locale_path);
-   textdomain(locale_domain);
    fc::logger::get(DEFAULT_LOGGER).set_log_level(fc::log_level::debug);
    context = eosio::client::http::create_http_context();
    wallet_url = default_wallet_url;

--- a/scripts/eosio_build.sh
+++ b/scripts/eosio_build.sh
@@ -181,9 +181,7 @@ if [[ $ARCH == "Linux" ]]; then
 fi
 
 if [ "$ARCH" == "Darwin" ]; then
-   # opt/gettext: cleos requires Intl, which requires gettext; it's keg only though and we don't want to force linking: https://github.com/EOSIO/eos/issues/2240#issuecomment-396309884
    # EOSIO_INSTALL_DIR/lib/cmake: mongo_db_plugin.cpp:25:10: fatal error: 'bsoncxx/builder/basic/kvp.hpp' file not found
-   CMAKE_PREFIX_PATHS="/usr/local/opt/gettext;${EOSIO_INSTALL_DIR}"
    FILE="${SCRIPT_DIR}/eosio_build_darwin.sh"
    OPENSSL_ROOT_DIR=/usr/local/opt/openssl
    export CMAKE=${CMAKE}

--- a/scripts/generate_bottle.sh
+++ b/scripts/generate_bottle.sh
@@ -43,7 +43,6 @@ echo "class Eosio < Formula
    option :universal
 
    depends_on \"gmp\"
-   depends_on \"gettext\"
    depends_on \"openssl\"
    depends_on \"libusb\"
    depends_on :macos => :mojave


### PR DESCRIPTION


<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
gettext is only used for cleos localization support. But, cleos has not had any effort to translate it nor is that effort on any short term roadmap AFAIK. Remove this dependency for now as it's an LGPL dep and causing some grief. When we get back around to localizing cleos we can reevaluate this need; it's possible something like boost::locale would be a better fit.

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
