### PR TITLE
explicitly link to zlib when compiling executables using the add_eosio_test_executable macro

### DIFF
--- a/CMakeModules/EosioTester.cmake.in
+++ b/CMakeModules/EosioTester.cmake.in
@@ -54,7 +54,7 @@ if ( "${CMAKE_BUILD_TYPE}" STREQUAL "Debug" )
    find_library(libsecp256k1 secp256k1_debug @CMAKE_INSTALL_PREFIX@/lib64 @CMAKE_INSTALL_PREFIX@/lib)
 else()
    find_library(libfc fc @CMAKE_INSTALL_PREFIX@/lib64 @CMAKE_INSTALL_PREFIX@/lib)
-   find_library(libsecp256k1 secp256k1 @CMAKE_INSTALL_PREFIX@/lib64 @CMAKE_INSTALL_PREFIX@/lib)  
+   find_library(libsecp256k1 secp256k1 @CMAKE_INSTALL_PREFIX@/lib64 @CMAKE_INSTALL_PREFIX@/lib)
 endif()
 
 find_library(libwasm WASM @CMAKE_INSTALL_PREFIX@/lib64 @CMAKE_INSTALL_PREFIX@/lib)
@@ -106,6 +106,7 @@ macro(add_eosio_test_executable test_name)
        ${Boost_SYSTEM_LIBRARY}
        ${Boost_CHRONO_LIBRARY}
        ${Boost_IOSTREAMS_LIBRARY}
+       "-lz" # Needed by Boost iostreams
        ${Boost_DATE_TIME_LIBRARY}
 
        ${LLVM_LIBS}

--- a/CMakeModules/EosioTesterBuild.cmake.in
+++ b/CMakeModules/EosioTesterBuild.cmake.in
@@ -50,7 +50,7 @@ find_library(libchain eosio_chain @CMAKE_BINARY_DIR@/libraries/chain)
 if ( "${CMAKE_BUILD_TYPE}" STREQUAL "Debug" )
    find_library(libfc fc_debug @CMAKE_BINARY_DIR@/libraries/fc)
    find_library(libsecp256k1 secp256k1_debug @CMAKE_BINARY_DIR@/libraries/fc/secp256k1)
-   
+
 else()
    find_library(libfc fc @CMAKE_BINARY_DIR@/libraries/fc)
    find_library(libsecp256k1 secp256k1 @CMAKE_BINARY_DIR@/libraries/fc/secp256k1)
@@ -105,6 +105,7 @@ macro(add_eosio_test_executable test_name)
        ${Boost_SYSTEM_LIBRARY}
        ${Boost_CHRONO_LIBRARY}
        ${Boost_IOSTREAMS_LIBRARY}
+       "-lz" # Needed by Boost iostreams
        ${Boost_DATE_TIME_LIBRARY}
 
        ${LLVM_LIBS}


### PR DESCRIPTION
## Change Description

Boost iostreams has a dependency on zlib. Unfortunately the CMake modules that find Boost do not automatically bring in that library dependency when adding `${Boost_IOSTREAMS_LIBRARY}` to `target_link_libraries` for a test executable. This hasn't been an issue in the past because the LLVM dependency has also brought in zlib as a dependency. However, with WAVM now removed and EOS VM OC not support on Mac, LLVM is not needed as a dependency when compiling the current develop branch of EOSIO on Mac. So without the explicit addition of `-lz`, the unit tests of eosio.contract built on Mac with the develop branch of EOSIO as its dependency led to linking errors (unresolved zlib symbols). There was no problem on Linux, and therefore no issues with CICD system of eosio.contracts (see verification of that [here](https://buildkite.com/EOSIO/eosio-dot-contracts/builds/743)), because EOS VM OC is supported on Linux and so the Linux build of EOSIO was bringing in LLVM and through it the `-lz` link option.

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions

