### PR TITLE
fix pinned builds on fresh macOS install

### DIFF
--- a/scripts/helpers/eosio.sh
+++ b/scripts/helpers/eosio.sh
@@ -250,13 +250,15 @@ function ensure-boost() {
         if [[ $ARCH == "Linux" ]] && $PIN_COMPILER; then
             B2_FLAGS="toolset=clang cxxflags='-stdlib=libc++ -D__STRICT_ANSI__ -nostdinc++ -I${CLANG_ROOT}/include/c++/v1' linkflags='-stdlib=libc++' link=static threading=multi --with-iostreams --with-date_time --with-filesystem --with-system --with-program_options --with-chrono --with-test -q -j${JOBS} install"
             BOOTSTRAP_FLAGS="--with-toolset=clang"
+        elif $PIN_COMPILER; then
+            local SDKROOT="$(xcrun --sdk macosx --show-sdk-path)"
         fi
-		execute bash -c "cd $SRC_DIR && \
+        execute bash -c "cd $SRC_DIR && \
         curl -LO https://dl.bintray.com/boostorg/release/$BOOST_VERSION_MAJOR.$BOOST_VERSION_MINOR.$BOOST_VERSION_PATCH/source/boost_$BOOST_VERSION.tar.bz2 \
         && tar -xjf boost_$BOOST_VERSION.tar.bz2 \
         && cd $BOOST_ROOT \
-        && ./bootstrap.sh ${BOOTSTRAP_FLAGS} --prefix=$BOOST_ROOT \
-        && ./b2 ${B2_FLAGS} \
+        && SDKROOT="$SDKROOT" ./bootstrap.sh ${BOOTSTRAP_FLAGS} --prefix=$BOOST_ROOT \
+        && SDKROOT="$SDKROOT" ./b2 ${B2_FLAGS} \
         && cd .. \
         && rm -f boost_$BOOST_VERSION.tar.bz2 \
         && rm -rf $BOOST_LINK_LOCATION"        


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
When running `eosio_build.sh -P` on a fresh macOS 10.14.6 install it fails when trying to bootstrap Boost’s build system. This failure is new to 2.0+ and appears to be due to a significant change in boost’s build system in 1.71 compared to the previous 1.70 used in 1.8.x.

A little background: on macOS, by default, C header files (like `stdlib.h`) are not installed in to `/usr/include`. Instead, they are kept inside the development tool app bundle such as in `/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk`. “apple clang” from Xcode or command line tools (such as unpinned build would use) is smart enough to use these headers automatically based on your configuration (`xcode-select` etc). “vanilla clang” (such as a pinned build would use) cannot figure this out on its own: you must pass either `-isysroot` with the correct path or set the environment variable `SDKROOT` to the correct path.

For reasons that are not entirely clear to me, the old build system in boost 1.70 (used in 1.8.x releases) is not using the pinned compiler. This means that in 1.8.x, Boost is built with apple clang which doesn’t require any of the shenanigans like isysroot/SDKROOT. It also means we’re building boost with a different compiler than nodeos for 1.8.x, quite troubling but probably not worth fixing at 1.8’s late lifecycle.

The new build system in boost 1.71 does use the pinned compiler as desired and expected. However, the vanilla clang compiler is unable to find any C header files and fails to bootstrap or build boost. This PR exposes `SDKROOT` to vanilla clang when bootstrapping and building boost so that C header files can be found.

cmake projects (such as when building LLVM or building EOSIO) do not require this workaround because cmake is smart enough to figure out the appropriate setting and pass it as `-isysroot` on its own. So, there is no need to try and persist `SDKROOT` beyond the time needed to build Boost.

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
