### PR TITLE
Optimize push_transaction

### DIFF
--- a/libraries/chain/block_state.cpp
+++ b/libraries/chain/block_state.cpp
@@ -88,7 +88,7 @@ namespace eosio { namespace chain {
 
    block_state::block_state( pending_block_header_state&& cur,
                              signed_block_ptr&& b,
-                             vector<transaction_metadata_ptr>&& trx_metas,
+                             deque<transaction_metadata_ptr>&& trx_metas,
                              const protocol_feature_set& pfs,
                              const std::function<void( block_timestamp_type,
                                                        const flat_set<digest_type>&,

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1076,16 +1076,19 @@ struct controller_impl {
       auto& bb = pending->_block_stage.get<building_block>();
       auto orig_trx_receipts_size           = bb._pending_trx_receipts.size();
       auto orig_trx_metas_size              = bb._pending_trx_metas.size();
+      auto orig_trx_receipt_digests_size    = bb._pending_trx_receipt_digests.size();
       auto orig_action_receipt_digests_size = bb._action_receipt_digests.size();
 
       std::function<void()> callback = [this,
             orig_trx_receipts_size,
             orig_trx_metas_size,
+            orig_trx_receipt_digests_size,
             orig_action_receipt_digests_size]()
       {
          auto& bb = pending->_block_stage.get<building_block>();
          bb._pending_trx_receipts.resize(orig_trx_receipts_size);
          bb._pending_trx_metas.resize(orig_trx_metas_size);
+         bb._pending_trx_receipt_digests.resize(orig_trx_receipt_digests_size);
          bb._action_receipt_digests.resize(orig_action_receipt_digests_size);
       };
 

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1523,9 +1523,6 @@ struct controller_impl {
       auto& bb = pending->_block_stage.get<building_block>();
       const auto& pbhs = bb._pending_block_header_state;
 
-      const auto& gpo = self.get_global_properties();
-
-      // modify state of speculative block only if we are in speculative read mode (otherwise we need clean state for head or read-only modes)
       if ( read_mode == db_read_mode::SPECULATIVE || pending->_block_status != controller::block_status::incomplete )
       {
          const auto& pso = db.get<protocol_state_object>();
@@ -1593,6 +1590,8 @@ struct controller_impl {
                }
             });
          }
+
+         const auto& gpo = self.get_global_properties();
 
          if( gpo.proposed_schedule_block_num.valid() && // if there is a proposed schedule that was proposed in a block ...
              ( *gpo.proposed_schedule_block_num <= pbhs.dpos_irreversible_blocknum ) && // ... that has now become irreversible ...

--- a/libraries/chain/include/eosio/chain/abi_serializer.hpp
+++ b/libraries/chain/include/eosio/chain/abi_serializer.hpp
@@ -614,6 +614,23 @@ namespace impl {
       }
 
       /**
+       * template which overloads extract for deque of types which contain ABI information in their trees
+       * for these members we call ::extract in order to trigger further processing
+       */
+      template<typename M, typename Resolver, require_abi_t<M> = 1>
+      static void extract( const variant& v, deque<M>& o, Resolver resolver, abi_traverse_context& ctx )
+      {
+         auto h = ctx.enter_scope();
+         const variants& array = v.get_array();
+         o.clear();
+         for( auto itr = array.begin(); itr != array.end(); ++itr ) {
+            M o_iter;
+            extract(*itr, o_iter, resolver, ctx);
+            o.emplace_back(std::move(o_iter));
+         }
+      }
+
+      /**
        * template which overloads extract for shared_ptr of types which contain ABI information in their trees
        * for these members we call ::extract in order to trigger further processing
        */

--- a/libraries/chain/include/eosio/chain/abi_serializer.hpp
+++ b/libraries/chain/include/eosio/chain/abi_serializer.hpp
@@ -306,11 +306,11 @@ namespace impl {
       static void add( mutable_variant_object &mvo, const char* name, const M& v, Resolver resolver, abi_traverse_context& ctx );
 
       /**
-       * template which overloads add for vectors of types which contain ABI information in their trees
+       * template which overloads add for containers of types which contain ABI information in their trees
        * for these members we call ::add in order to trigger further processing
        */
-      template<typename M, typename Resolver, require_abi_t<M> = 1>
-      static void add( mutable_variant_object &mvo, const char* name, const vector<M>& v, Resolver resolver, abi_traverse_context& ctx )
+      template<template <typename, typename...> class C, typename M, typename Resolver, require_abi_t<M> = 1>
+      static void add( mutable_variant_object &mvo, const char* name, const C<M>& v, Resolver resolver, abi_traverse_context& ctx )
       {
          auto h = ctx.enter_scope();
          vector<variant> array;

--- a/libraries/chain/include/eosio/chain/abi_serializer.hpp
+++ b/libraries/chain/include/eosio/chain/abi_serializer.hpp
@@ -306,15 +306,33 @@ namespace impl {
       static void add( mutable_variant_object &mvo, const char* name, const M& v, Resolver resolver, abi_traverse_context& ctx );
 
       /**
-       * template which overloads add for containers of types which contain ABI information in their trees
+       * template which overloads add for vectors of types which contain ABI information in their trees
        * for these members we call ::add in order to trigger further processing
        */
-      template<template <typename, typename...> class C, typename M, typename Resolver, require_abi_t<M> = 1>
-      static void add( mutable_variant_object &mvo, const char* name, const C<M>& v, Resolver resolver, abi_traverse_context& ctx )
+      template<typename M, typename Resolver, require_abi_t<M> = 1>
+      static void add( mutable_variant_object &mvo, const char* name, const vector<M>& v, Resolver resolver, abi_traverse_context& ctx )
       {
          auto h = ctx.enter_scope();
          vector<variant> array;
          array.reserve(v.size());
+
+         for (const auto& iter: v) {
+            mutable_variant_object elem_mvo;
+            add(elem_mvo, "_", iter, resolver, ctx);
+            array.emplace_back(std::move(elem_mvo["_"]));
+         }
+         mvo(name, std::move(array));
+      }
+
+      /**
+       * template which overloads add for deques of types which contain ABI information in their trees
+       * for these members we call ::add in order to trigger further processing
+       */
+      template<typename M, typename Resolver, require_abi_t<M> = 1>
+      static void add( mutable_variant_object &mvo, const char* name, const deque<M>& v, Resolver resolver, abi_traverse_context& ctx )
+      {
+         auto h = ctx.enter_scope();
+         deque<variant> array;
 
          for (const auto& iter: v) {
             mutable_variant_object elem_mvo;

--- a/libraries/chain/include/eosio/chain/block.hpp
+++ b/libraries/chain/include/eosio/chain/block.hpp
@@ -96,7 +96,7 @@ namespace eosio { namespace chain {
       signed_block& operator=(const signed_block&) = delete;
       signed_block clone() const { return *this; }
 
-      vector<transaction_receipt>   transactions; /// new or generated transactions
+      deque<transaction_receipt>    transactions; /// new or generated transactions
       extensions_type               block_extensions;
 
       flat_multimap<uint16_t, block_extension> validate_and_extract_extensions()const;

--- a/libraries/chain/include/eosio/chain/block_state.hpp
+++ b/libraries/chain/include/eosio/chain/block_state.hpp
@@ -19,7 +19,7 @@ namespace eosio { namespace chain {
 
       block_state( pending_block_header_state&& cur,
                    signed_block_ptr&& b, // unsigned block
-                   vector<transaction_metadata_ptr>&& trx_metas,
+                   deque<transaction_metadata_ptr>&& trx_metas,
                    const protocol_feature_set& pfs,
                    const std::function<void( block_timestamp_type,
                                              const flat_set<digest_type>&,
@@ -44,24 +44,24 @@ namespace eosio { namespace chain {
       bool is_valid()const { return validated; }
       bool is_pub_keys_recovered()const { return _pub_keys_recovered; }
 
-      vector<transaction_metadata_ptr> extract_trxs_metas() {
+      deque<transaction_metadata_ptr> extract_trxs_metas() {
          _pub_keys_recovered = false;
          auto result = std::move( _cached_trxs );
          _cached_trxs.clear();
          return result;
       }
-      void set_trxs_metas( vector<transaction_metadata_ptr>&& trxs_metas, bool keys_recovered ) {
+      void set_trxs_metas( deque<transaction_metadata_ptr>&& trxs_metas, bool keys_recovered ) {
          _pub_keys_recovered = keys_recovered;
          _cached_trxs = std::move( trxs_metas );
       }
-      const vector<transaction_metadata_ptr>& trxs_metas()const { return _cached_trxs; }
+      const deque<transaction_metadata_ptr>& trxs_metas()const { return _cached_trxs; }
 
       bool                                                validated = false;
 
       bool                                                _pub_keys_recovered = false;
       /// this data is redundant with the data stored in block, but facilitates
       /// recapturing transactions when we pop a block
-      vector<transaction_metadata_ptr>                    _cached_trxs;
+      deque<transaction_metadata_ptr>                     _cached_trxs;
    };
 
    using block_state_ptr = std::shared_ptr<block_state>;

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -140,7 +140,7 @@ namespace eosio { namespace chain {
          /**
           * @return transactions applied in aborted block
           */
-         vector<transaction_metadata_ptr> abort_block();
+         deque<transaction_metadata_ptr> abort_block();
 
          /**
           *
@@ -219,7 +219,7 @@ namespace eosio { namespace chain {
          const block_signing_authority& pending_block_signing_authority()const;
          optional<block_id_type>        pending_producer_block_id()const;
 
-         const vector<transaction_receipt>& get_pending_trx_receipts()const;
+         const deque<transaction_receipt>& get_pending_trx_receipts()const;
 
          const producer_authority_schedule&    active_producers()const;
          const producer_authority_schedule&    pending_producers()const;

--- a/libraries/chain/include/eosio/chain/merkle.hpp
+++ b/libraries/chain/include/eosio/chain/merkle.hpp
@@ -17,6 +17,6 @@ namespace eosio { namespace chain {
    /**
     *  Calculates the merkle root of a set of digests, if ids is odd it will duplicate the last id.
     */
-   digest_type merkle( vector<digest_type> ids );
+   digest_type merkle( deque<digest_type> ids );
 
 } } /// eosio::chain

--- a/libraries/chain/include/eosio/chain/transaction_context.hpp
+++ b/libraries/chain/include/eosio/chain/transaction_context.hpp
@@ -113,7 +113,7 @@ namespace eosio { namespace chain {
          fc::time_point                published;
 
 
-         vector<action_receipt>        executed;
+         vector<digest_type>           executed_action_receipt_digests;
          flat_set<account_name>        bill_to_accounts;
          flat_set<account_name>        validate_ram_usage;
 

--- a/libraries/chain/include/eosio/chain/transaction_context.hpp
+++ b/libraries/chain/include/eosio/chain/transaction_context.hpp
@@ -113,7 +113,7 @@ namespace eosio { namespace chain {
          fc::time_point                published;
 
 
-         vector<digest_type>           executed_action_receipt_digests;
+         deque<digest_type>            executed_action_receipt_digests;
          flat_set<account_name>        bill_to_accounts;
          flat_set<account_name>        validate_ram_usage;
 

--- a/libraries/chain/include/eosio/chain/types.hpp
+++ b/libraries/chain/include/eosio/chain/types.hpp
@@ -18,6 +18,9 @@
 #include <fc/fixed_string.hpp>
 #include <fc/crypto/private_key.hpp>
 
+#include <boost/version.hpp>
+#include <boost/container/deque.hpp>
+
 #include <memory>
 #include <vector>
 #include <deque>

--- a/libraries/chain/include/eosio/chain/types.hpp
+++ b/libraries/chain/include/eosio/chain/types.hpp
@@ -47,7 +47,6 @@ namespace eosio { namespace chain {
    using                               std::vector;
    using                               std::unordered_map;
    using                               std::string;
-   using                               std::deque;
    using                               std::shared_ptr;
    using                               std::weak_ptr;
    using                               std::unique_ptr;
@@ -83,6 +82,16 @@ namespace eosio { namespace chain {
    using public_key_type  = fc::crypto::public_key;
    using private_key_type = fc::crypto::private_key;
    using signature_type   = fc::crypto::signature;
+
+#if BOOST_VERSION >= 107100
+   // configurable boost deque performs much better than std::deque in our use cases
+   using block_1024_option_t = boost::container::deque_options< boost::container::block_size<1024u> >::type;
+   template<typename T>
+   using deque = boost::container::deque< T, void, block_1024_option_t >;
+#else
+   template<typename T>
+   using deque = std::deque<T>;
+#endif
 
    struct void_t{};
 

--- a/libraries/chain/include/eosio/chain/unapplied_transaction_queue.hpp
+++ b/libraries/chain/include/eosio/chain/unapplied_transaction_queue.hpp
@@ -168,7 +168,7 @@ public:
       }
    }
 
-   void add_aborted( std::vector<transaction_metadata_ptr> aborted_trxs ) {
+   void add_aborted( std::deque<transaction_metadata_ptr> aborted_trxs ) {
       if( mode == process_mode::non_speculative || mode == process_mode::speculative_non_producer ) return;
       for( auto& trx : aborted_trxs ) {
          fc::time_point expiry = trx->packed_trx()->expiration();

--- a/libraries/chain/include/eosio/chain/unapplied_transaction_queue.hpp
+++ b/libraries/chain/include/eosio/chain/unapplied_transaction_queue.hpp
@@ -168,7 +168,7 @@ public:
       }
    }
 
-   void add_aborted( std::deque<transaction_metadata_ptr> aborted_trxs ) {
+   void add_aborted( deque<transaction_metadata_ptr> aborted_trxs ) {
       if( mode == process_mode::non_speculative || mode == process_mode::speculative_non_producer ) return;
       for( auto& trx : aborted_trxs ) {
          fc::time_point expiry = trx->packed_trx()->expiration();

--- a/libraries/chain/merkle.cpp
+++ b/libraries/chain/merkle.cpp
@@ -32,7 +32,7 @@ bool is_canonical_right(const digest_type& val) {
 }
 
 
-digest_type merkle(vector<digest_type> ids) {
+digest_type merkle(deque<digest_type> ids) {
    if( 0 == ids.size() ) { return digest_type(); }
 
    while( ids.size() > 1 ) {

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -65,7 +65,7 @@ namespace eosio { namespace chain {
       trace->block_num = c.head_block_num() + 1;
       trace->block_time = c.pending_block_time();
       trace->producer_block_id = c.pending_producer_block_id();
-      executed.reserve( trx.total_actions() );
+      executed_action_receipt_digests.reserve( trx.total_actions() );
    }
 
    void transaction_context::disallow_transaction_extensions( const char* error_msg )const {

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -65,7 +65,6 @@ namespace eosio { namespace chain {
       trace->block_num = c.head_block_num() + 1;
       trace->block_time = c.pending_block_time();
       trace->producer_block_id = c.pending_producer_block_id();
-      executed_action_receipt_digests.reserve( trx.total_actions() );
    }
 
    void transaction_context::disallow_transaction_extensions( const char* error_msg )const {

--- a/plugins/history_plugin/history_plugin.cpp
+++ b/plugins/history_plugin/history_plugin.cpp
@@ -491,7 +491,7 @@ namespace eosio {
 
             auto blk = chain.fetch_block_by_number( result.block_num );
             if( blk || chain.is_building_block() ) {
-               const vector<transaction_receipt>& receipts = blk ? blk->transactions : chain.get_pending_trx_receipts();
+               const auto& receipts = blk ? blk->transactions : chain.get_pending_trx_receipts();
                for (const auto &receipt: receipts) {
                     if (receipt.trx.contains<packed_transaction>()) {
                         auto &pt = receipt.trx.get<packed_transaction>();

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -37,7 +37,6 @@ using boost::multi_index_container;
 
 using std::string;
 using std::vector;
-using std::deque;
 using boost::signals2::scoped_connection;
 
 #undef FC_LOG_AND_DROP

--- a/unittests/block_tests.cpp
+++ b/unittests/block_tests.cpp
@@ -64,9 +64,8 @@ std::pair<signed_block_ptr, signed_block_ptr> corrupt_trx_in_block(validating_te
    copy_b->transactions.back().trx = invalid_packed_tx;
 
    // Re-calculate the transaction merkle
-   vector<digest_type> trx_digests;
+   deque<digest_type> trx_digests;
    const auto& trxs = copy_b->transactions;
-   trx_digests.reserve( trxs.size() );
    for( const auto& a : trxs )
       trx_digests.emplace_back( a.digest() );
    copy_b->transaction_mroot = merkle( move(trx_digests) );
@@ -217,7 +216,7 @@ BOOST_FIXTURE_TEST_CASE( abort_block_transactions, validating_tester) { try {
 
       control->get_account( a ); // throws if it does not exist
 
-      vector<transaction_metadata_ptr> unapplied_trxs = control->abort_block();
+      auto unapplied_trxs = control->abort_block();
 
       // verify transaction returned from abort_block()
       BOOST_REQUIRE_EQUAL( 1,  unapplied_trxs.size() );
@@ -268,7 +267,7 @@ BOOST_FIXTURE_TEST_CASE( abort_block_transactions_tester, validating_tester) { t
 
       control->get_account( a ); // throws if it does not exist
 
-      vector<transaction_metadata_ptr> unapplied_trxs = control->abort_block(); // should be empty now
+      auto unapplied_trxs = control->abort_block(); // should be empty now
 
       BOOST_REQUIRE_EQUAL( 0,  unapplied_trxs.size() );
 

--- a/unittests/unapplied_transaction_queue_tests.cpp
+++ b/unittests/unapplied_transaction_queue_tests.cpp
@@ -31,7 +31,7 @@ auto next( unapplied_transaction_queue& q ) {
    return trx;
 }
 
-auto create_test_block_state( std::vector<transaction_metadata_ptr> trx_metas ) {
+auto create_test_block_state( std::deque<transaction_metadata_ptr> trx_metas ) {
    signed_block_ptr block = std::make_shared<signed_block>();
    for( auto& trx_meta : trx_metas ) {
       block->transactions.emplace_back( *trx_meta->packed_trx() );

--- a/unittests/unapplied_transaction_queue_tests.cpp
+++ b/unittests/unapplied_transaction_queue_tests.cpp
@@ -31,7 +31,7 @@ auto next( unapplied_transaction_queue& q ) {
    return trx;
 }
 
-auto create_test_block_state( std::deque<transaction_metadata_ptr> trx_metas ) {
+auto create_test_block_state( deque<transaction_metadata_ptr> trx_metas ) {
    signed_block_ptr block = std::make_shared<signed_block>();
    for( auto& trx_meta : trx_metas ) {
       block->transactions.emplace_back( *trx_meta->packed_trx() );


### PR DESCRIPTION
## Change Description

- Optimize `push_transaction` by using deque instead of vector to avoid vector having to reallocate and move transaction receipts and max transaction metas in block.
- `std::deque` used for boost < 1.71 now since configurable `boost::container::deque` is not available until boost 1.71. boost deque used if boost >= 1.71 available.
- Calculate `action_receipt` digest at action execution time to avoid copying of `action_receipts` and to bill for hash.
- Calculate `transaction_receipt` digest at transaction execution time to bill for hash.

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
