### PR TITLE
Debian Package: Make sure root is owner/group when building dpkg.

### DIFF
--- a/scripts/generate_deb.sh
+++ b/scripts/generate_deb.sh
@@ -53,6 +53,6 @@ export SSUBPREFIX
 . ./generate_tarball.sh ${NAME}
 echo "Unpacking tarball: ${NAME}.tar.gz..."
 tar -xzvf ${NAME}.tar.gz -C ${PROJECT} || exit 1
-dpkg-deb --build ${PROJECT} || exit 1
+dpkg-deb --build --root-owner-group ${PROJECT} || exit 1
 mv ${PROJECT}.deb ${NAME}.deb || exit 1
 rm -r ${PROJECT} || exit 1


### PR DESCRIPTION


<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

Just passing `--root-owner-group` to `dpkg` in `scripts/generate_deb.sh`. Without this flag files in the .deb files are owned by the user running the script. 

The official .deb files from this repo has root as owner group. so this change should just make it easier to create the same packages as the official ones.

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
