### PR TITLE
Post State history callback as medium priority - 1.8

### DIFF
--- a/plugins/state_history_plugin/state_history_plugin.cpp
+++ b/plugins/state_history_plugin/state_history_plugin.cpp
@@ -186,10 +186,10 @@ struct state_history_plugin_impl : std::enable_shared_from_this<state_history_pl
          socket_stream->next_layer().set_option(boost::asio::ip::tcp::no_delay(true));
          socket_stream->next_layer().set_option(boost::asio::socket_base::send_buffer_size(1024 * 1024));
          socket_stream->next_layer().set_option(boost::asio::socket_base::receive_buffer_size(1024 * 1024));
-         socket_stream->async_accept([self = shared_from_this(), this](boost::system::error_code ec) {
-            callback(ec, "async_accept", [&] {
-               start_read();
-               send(state_history_plugin_abi);
+         socket_stream->async_accept([self = shared_from_this()](boost::system::error_code ec) {
+            self->callback(ec, "async_accept", [self] {
+               self->start_read();
+               self->send(state_history_plugin_abi);
             });
          });
       }
@@ -197,15 +197,15 @@ struct state_history_plugin_impl : std::enable_shared_from_this<state_history_pl
       void start_read() {
          auto in_buffer = std::make_shared<boost::beast::flat_buffer>();
          socket_stream->async_read(
-             *in_buffer, [self = shared_from_this(), this, in_buffer](boost::system::error_code ec, size_t) {
-                callback(ec, "async_read", [&] {
+             *in_buffer, [self = shared_from_this(), in_buffer](boost::system::error_code ec, size_t) {
+                self->callback(ec, "async_read", [self, in_buffer] {
                    auto d = boost::asio::buffer_cast<char const*>(boost::beast::buffers_front(in_buffer->data()));
                    auto s = boost::asio::buffer_size(in_buffer->data());
                    fc::datastream<const char*> ds(d, s);
                    state_request               req;
                    fc::raw::unpack(ds, req);
-                   req.visit(*this);
-                   start_read();
+                   req.visit(*self);
+                   self->start_read();
                 });
              });
       }
@@ -231,11 +231,11 @@ struct state_history_plugin_impl : std::enable_shared_from_this<state_history_pl
          sent_abi = true;
          socket_stream->async_write( //
              boost::asio::buffer(send_queue[0]),
-             [self = shared_from_this(), this](boost::system::error_code ec, size_t) {
-                callback(ec, "async_write", [&] {
-                   send_queue.erase(send_queue.begin());
-                   sending = false;
-                   send();
+             [self = shared_from_this()](boost::system::error_code ec, size_t) {
+                self->callback(ec, "async_write", [self] {
+                   self->send_queue.erase(self->send_queue.begin());
+                   self->sending = false;
+                   self->send();
                 });
              });
       }

--- a/plugins/state_history_plugin/state_history_plugin.cpp
+++ b/plugins/state_history_plugin/state_history_plugin.cpp
@@ -330,11 +330,13 @@ struct state_history_plugin_impl : std::enable_shared_from_this<state_history_pl
 
       template <typename F>
       void callback(boost::system::error_code ec, const char* what, F f) {
-         if (plugin->stopping)
-            return;
-         if (ec)
-            return on_fail(ec, what);
-         catch_and_close(f);
+         app().post( priority::medium, [=]() {
+            if( plugin->stopping )
+               return;
+            if( ec )
+               return on_fail( ec, what );
+            catch_and_close( f );
+         } );
       }
 
       void on_fail(boost::system::error_code ec, const char* what) {


### PR DESCRIPTION
## Change Description

- Currently `state_history_plugin` (ship) executes as highest priority since it never schedules with the appbase priority queue. Change callbacks in ship to execute at medium priority.

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
