### PR TITLE
transactions in progress

### DIFF
--- a/libraries/chain/include/eosio/chain/unapplied_transaction_queue.hpp
+++ b/libraries/chain/include/eosio/chain/unapplied_transaction_queue.hpp
@@ -129,8 +129,7 @@ public:
                                         ("id", itr->id())("e", itr->trx_meta->packed_trx()->expiration())
                                         ("bt", pending_block_time) ) ) ) );
          }
-
-         removed( itr, false );
+         removed( itr );
          persisted_by_expiry.erase( itr );
       }
       return true;
@@ -146,6 +145,10 @@ public:
             if( itr != queue.get<by_trx_id>().end() ) {
                if( itr->trx_type != trx_enum_type::persisted &&
                    itr->trx_type != trx_enum_type::incoming_persisted ) {
+                  if( itr->next ) {
+                     itr->next( std::static_pointer_cast<fc::exception>( std::make_shared<tx_duplicate>(
+                                   FC_LOG_MESSAGE( info, "duplicate transaction ${id}", ("id", itr->trx_meta->id())))));
+                  }
                   removed( itr );
                   idx.erase( itr );
                }
@@ -221,9 +224,9 @@ public:
    iterator incoming_begin() { return queue.get<by_type>().lower_bound( trx_enum_type::incoming_persisted ); }
    iterator incoming_end() { return queue.get<by_type>().end(); } // if changed to upper_bound, verify usage performance
 
-   /// callers responsibilty to call next() if applicable
+   /// caller's responsibilty to call next() if applicable
    iterator erase( iterator itr ) {
-      removed( itr, false );
+      removed( itr );
       return queue.get<by_type>().erase( itr );
    }
 
@@ -243,14 +246,9 @@ private:
    }
 
    template<typename Itr>
-   void removed( Itr itr, bool call_next = true ) {
+   void removed( Itr itr ) {
       if( itr->trx_type == trx_enum_type::incoming || itr->trx_type == trx_enum_type::incoming_persisted ) {
          --incoming_count;
-      }
-      if( call_next && itr->next ) {
-         transaction_trace_ptr trace = std::make_shared<transaction_trace>();
-         trace->id = itr->trx_meta->id();
-         itr->next( trace );
       }
       size_in_bytes -= calc_size( itr->trx_meta );
    }

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1596,12 +1596,14 @@ bool producer_plugin_impl::process_unapplied_trxs( const fc::time_point& deadlin
                } else {
                   // this failed our configured maximum transaction time, we don't want to replay it
                   ++num_failed;
+                  if( itr->next ) itr->next( trace );
                   itr = _unapplied_transactions.erase( itr );
                   continue;
                }
             } else {
                ++num_applied;
                if( itr->trx_type != trx_enum_type::persisted ) {
+                  if( itr->next ) itr->next( trace );
                   itr = _unapplied_transactions.erase( itr );
                   continue;
                }


### PR DESCRIPTION
## Change Description

- `net_plugin` uses a callback on transaction processing to track size of transactions in progress. Therefore we need to always call transaction callback for proper accounting of transactions in progress.

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
