### PR TITLE
Skip all authorization checks

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1838,7 +1838,7 @@ struct controller_impl {
          EOS_ASSERT( (s == controller::block_status::irreversible || s == controller::block_status::validated),
                      block_validate_exception, "invalid block status for replay" );
          emit( self.pre_accepted_block, b );
-         const bool skip_validate_signee = !conf.force_all_checks;
+         const bool skip_validate_signee = conf.skip_all_checks || !conf.force_all_checks;
 
          auto bsp = std::make_shared<block_state>(
                         *head,
@@ -2839,7 +2839,7 @@ bool controller::light_validation_allowed(bool replay_opts_disabled_by_policy) c
 
 
 bool controller::skip_auth_check() const {
-   return light_validation_allowed(my->conf.force_all_checks);
+   return light_validation_allowed(!my->conf.skip_all_checks && my->conf.force_all_checks);
 }
 
 bool controller::skip_db_sessions( block_status bs ) const {

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -2839,7 +2839,7 @@ bool controller::light_validation_allowed(bool replay_opts_disabled_by_policy) c
 
 
 bool controller::skip_auth_check() const {
-   return light_validation_allowed(!my->conf.skip_all_checks && my->conf.force_all_checks);
+   return my->conf.skip_all_checks || light_validation_allowed(my->conf.force_all_checks);
 }
 
 bool controller::skip_db_sessions( block_status bs ) const {

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -73,6 +73,7 @@ namespace eosio { namespace chain {
             uint16_t                 thread_pool_size       =  chain::config::default_controller_thread_pool_size;
             bool                     read_only              =  false;
             bool                     force_all_checks       =  false;
+            bool                     skip_all_checks        =  false;
             bool                     disable_replay_opts    =  false;
             bool                     contracts_console      =  false;
             bool                     allow_ram_billing_in_notify = false;

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -289,6 +289,8 @@ void chain_plugin::set_program_options(options_description& cli, options_descrip
           "recovers reversible block database if that database is in a bad state")
          ("force-all-checks", bpo::bool_switch()->default_value(false),
           "do not skip any checks that can be skipped while replaying irreversible blocks")
+         ("skip-all-checks", bpo::bool_switch()->default_value(false),
+          "skip all checks that can be skipped while processing blocks")
          ("disable-replay-opts", bpo::bool_switch()->default_value(false),
           "disable optimizations that specifically target replay")
          ("replay-blockchain", bpo::bool_switch()->default_value(false),
@@ -670,6 +672,7 @@ void chain_plugin::plugin_initialize(const variables_map& options) {
          my->chain_config->wasm_runtime = *my->wasm_runtime;
 
       my->chain_config->force_all_checks = options.at( "force-all-checks" ).as<bool>();
+      my->chain_config->skip_all_checks = options.at( "skip-all-checks" ).as<bool>();
       my->chain_config->disable_replay_opts = options.at( "disable-replay-opts" ).as<bool>();
       my->chain_config->contracts_console = options.at( "contracts-console" ).as<bool>();
       my->chain_config->allow_ram_billing_in_notify = options.at( "disable-ram-billing-notify-checks" ).as<bool>();


### PR DESCRIPTION
This change adds a new producer config `skip_all_checks`, which skips signee validation and authorization checks.

This will allow running emulation API nodes, where an execution trace can be returned from the node to emulate the traces, estimated CPU, estimated NET, etc without actually requiring the authorization/signatures.