### PR TITLE
Net plugin handshake

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -1787,6 +1787,7 @@ namespace eosio {
             set_state( head_catchup );
          } else {
             set_state( in_sync );
+            send_handshakes();
          }
       } else if( state == lib_catchup ) {
          if( blk_num == sync_known_lib_num ) {

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2733,7 +2733,7 @@ namespace eosio {
          break;
       case last_irr_catch_up: {
          std::unique_lock<std::mutex> g_conn( conn_mtx );
-         last_handshake_recv.head_num = msg.known_trx.pending;
+         last_handshake_recv.head_num = msg.known_blocks.pending;
          g_conn.unlock();
          break;
       }

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -1183,6 +1183,7 @@ namespace eosio {
          } else {
             c->strand.post( [c, num]() {
                peer_ilog( c, "enqueue sync, unable to fetch block ${num}", ("num", num) );
+               c->send_handshake();
             });
          }
       });

--- a/tests/testUtils.py
+++ b/tests/testUtils.py
@@ -10,6 +10,7 @@ import inspect
 import json
 import shlex
 import socket
+from datetime import datetime
 from sys import stdout
 from sys import exit
 import traceback
@@ -76,6 +77,7 @@ class Utils:
     def Print(*args, **kwargs):
         stackDepth=len(inspect.stack())-2
         s=' '*stackDepth
+        stdout.write(datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%f "))
         stdout.write(s)
         print(*args, **kwargs)
 


### PR DESCRIPTION
## Change Description

- Send handshake when done syncing for case where node has moved while syncing
- When unable to fetch a block during sync send handshake. This was sending a go away message before which was too aggressive.
- Clear out queue buffer always on async write callback otherwise non-empty queue prevents send on re-connect.
- Fix calculation of peer lib on lib catchup

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
