### PR TITLE
reset the new handler

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -327,7 +327,6 @@ struct controller_impl {
       set_activation_handler<builtin_protocol_feature_t::webauthn_key>();
       set_activation_handler<builtin_protocol_feature_t::wtmsig_block_signatures>();
 
-
       self.irreversible_block.connect([this](const block_state_ptr& bsp) {
          wasmif.current_lib(bsp->block_num);
       });

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -315,8 +315,6 @@ struct controller_impl {
     read_mode( cfg.read_mode ),
     thread_pool( "chain", cfg.thread_pool_size )
    {
-
-      // reset the
       fork_db.open( [this]( block_timestamp_type timestamp,
                             const flat_set<digest_type>& cur_features,
                             const vector<digest_type>& new_features )

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -219,7 +219,7 @@ struct controller_impl {
    // LLVM sets the new handler, we need to reset this to throw a bad_alloc exception so we can possibly exit cleanly
    // and not just abort.
    struct reset_new_handler {
-      reset_new_handler() { /* std::set_new_handler([](){ throw std::bad_alloc(); });*/ }
+      reset_new_handler() { std::set_new_handler([](){ throw std::bad_alloc(); }); }
    };
 
    reset_new_handler              rnh; // placed here to allow for this to be set before constructing the other fields

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -57,7 +57,6 @@ namespace eosio { namespace chain {
 
    class controller {
       public:
-
          struct config {
             flat_set<account_name>   sender_bypass_whiteblacklist;
             flat_set<account_name>   actor_whitelist;

--- a/unittests/misc_tests.cpp
+++ b/unittests/misc_tests.cpp
@@ -1110,6 +1110,16 @@ BOOST_AUTO_TEST_CASE(stable_priority_queue_test) {
   } FC_LOG_AND_RETHROW()
 }
 
+// test that std::bad_alloc is being thrown
+BOOST_AUTO_TEST_CASE(bad_alloc_test) {
+   tester t; // force a controller to be constructed and set the new_handler
+   int* ptr = nullptr;
+   const auto fail = [&]() {
+      ptr = new int[std::numeric_limits<int64_t>::max()/16];
+   };
+   BOOST_CHECK_THROW( fail(), std::bad_alloc );
+   BOOST_CHECK( ptr == nullptr );
+}
 
 BOOST_AUTO_TEST_SUITE_END()
 


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
Because LLVM sets the new_handler to abort when new cannot allocate any more memory, we've lost the ability to exit cleanly in some instances and not corrupt the DB.  This fix should reset the new_handler to throw `std::bad_alloc` and use the old behavior of EOSIO.

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
