### PR TITLE
Fix bios boot python script due to 2.0.x changes

### DIFF
--- a/tutorials/bios-boot-tutorial/README.md
+++ b/tutorials/bios-boot-tutorial/README.md
@@ -7,38 +7,69 @@ The `bios-boot-tutorial.py` script simulates the EOSIO bios boot sequence.
 1. Python 3.x
 2. CMake
 3. git
+4. g++
+5. build-essentials
+6. pip3
+7. openssl
+8. curl
+9. jq
+10. psmisc
+
 
 ``Steps``:
 
 1. Install eosio binaries by following the steps outlined in below tutorial
-[Install eosio binaries](https://github.com/EOSIO/eos#mac-os-x-brew-install)
+[Install eosio binaries](https://github.com/EOSIO/eos/tree/release/2.0.x#mac-os-x-brew-install).
 
-2. Install eosio.cdt binaries by following the steps outlined in below tutorial
-[Install eosio.cdt binaries](https://github.com/EOSIO/eosio.cdt#binary-releases)
+2. Install eosio.cdt version 1.6.3 binaries by following the steps outlined in below tutorial
+[Install eosio.cdt binaries](https://github.com/EOSIO/eosio.cdt/tree/release/1.6.x#binary-releases).
 
-3. Compile eosio.contracts
+3. Compile `eosio.contracts` version 1.8.x.
+
+```bash
+$ cd ~
+$ git clone https://github.com/EOSIO/eosio.contracts.git eosio.contracts-1.8.x
+$ cd ./eosio.contracts-1.8.x/
+$ git checkout release/1.8.x
+$ ./build.sh
+$ cd ./build/contracts/
+$ pwd
+
+```
+
+4. Make note of the directory where the contracts were compiled. 
+The last command in the previous step printed on the bash console the contracts' directory, make note of it, we'll reference it from now on as `EOSIO_OLD_CONTRACTS_DIRECTORY`.
+
+5. Install eosio.cdt version 1.7.0 binaries by following the steps outlined in below tutorial, make sure you uninstall the previous one first.
+[Install eosio.cdt binaries](https://github.com/EOSIO/eosio.cdt/tree/release/1.7.x#binary-releases)
+
+6. Compile `eosio.contracts` sources version 1.9.0
 
 ```bash
 $ cd ~
 $ git clone https://github.com/EOSIO/eosio.contracts.git
 $ cd ./eosio.contracts/
+$ git checkout release/1.9.x
 $ ./build.sh
+$ cd ./build/contracts/
 $ pwd
 
 ```
 
-4. Make note of the directory where the contracts were compiled
+7. Make note of the directory where the contracts were compiled
 The last command in the previous step printed on the bash console the contracts' directory, make note of it, we'll reference it from now on as `EOSIO_CONTRACTS_DIRECTORY`
 
-5. Launch the `bios-boot-tutorial.py` script
-Minimal command line to launch the script below, make sure you replace `EOSIO_CONTRACTS_DIRECTORY` with actual directory
+
+8. Launch the `bios-boot-tutorial.py` script. 
+The command line to launch the script, make sure you replace `EOSIO_OLD_CONTRACTS_DIRECTORY` and `EOSIO_CONTRACTS_DIRECTORY` with actual directory paths.
 
 ```bash
 $ cd ~
 $ git clone https://github.com/EOSIO/eos.git
 $ cd ./eos/tutorials/bios-boot-tutorial/
-$ python3 bios-boot-tutorial.py --cleos="cleos --wallet-url http://127.0.0.1:6666 " --nodeos=nodeos --keosd=keosd --contracts-dir="/EOSIO_CONTRACTS_DIRECTORY/" -a
-
+$ python3 bios-boot-tutorial.py --cleos="cleos --wallet-url http://127.0.0.1:6666 " --nodeos=nodeos --keosd=keosd --contracts-dir="EOSIO_CONTRACTS_DIRECTORY" --old-contracts-dir="EOSIO_OLD_CONTRACTS_DIRECTORY" -w -a
 ```
+
+6. At this point, when the script has finished running without error, you have a functional EOSIO based blockchain running locally with an latest version of `eosio.system` contract, 31 block producers out of which 21 active, `eosio` account resigned, 200k+ accounts with staked tokens, and votes allocated to each block producer. Enjoy exploring your freshly booted blockchain.
 
 See [EOSIO Documentation Wiki: Tutorial - Bios Boot](https://github.com/EOSIO/eos/wiki/Tutorial-Bios-Boot-Sequence) for additional information.

--- a/tutorials/bios-boot-tutorial/bios-boot-tutorial.py
+++ b/tutorials/bios-boot-tutorial/bios-boot-tutorial.py
@@ -41,7 +41,7 @@ def run(args):
 
 def retry(args):
     while True:
-        print('bios-boot-tutorial.py:', args)
+        print('bios-boot-tutorial.py: ', args)
         logFile.write(args + '\n')
         if subprocess.call(args, shell=True):
             print('*** Retry')
@@ -103,6 +103,7 @@ def startNode(nodeIndex, account):
     cmd = (
         args.nodeos +
         '    --max-irreversible-block-age -1'
+        '    --max-transaction-time=1000'
         '    --contracts-console'
         '    --genesis-json ' + os.path.abspath(args.genesis) +
         '    --blocks-dir ' + os.path.abspath(dir) + '/blocks'
@@ -118,6 +119,8 @@ def startNode(nodeIndex, account):
         '    --private-key \'["' + account['pub'] + '","' + account['pvt'] + '"]\''
         '    --plugin eosio::http_plugin'
         '    --plugin eosio::chain_api_plugin'
+        '    --plugin eosio::chain_plugin'
+        '    --plugin eosio::producer_api_plugin'
         '    --plugin eosio::producer_plugin' +
         otherOpts)
     with open(dir + 'stderr', mode='w') as f:
@@ -293,9 +296,53 @@ def stepCreateTokens():
     run(args.cleos + 'push action eosio.token issue \'["eosio", "%s", "memo"]\' -p eosio' % intToCurrency(totalAllocation))
     sleep(1)
 def stepSetSystemContract():
-    retry(args.cleos + 'set contract eosio ' + args.contracts_dir + '/eosio.system/')
+    # All of the protocol upgrade features introduced in v1.8 first require a special protocol 
+    # feature (codename PREACTIVATE_FEATURE) to be activated and for an updated version of the system 
+    # contract that makes use of the functionality introduced by that feature to be deployed. 
+
+    # activate PREACTIVATE_FEATURE before installing eosio.system
+    retry('curl -X POST http://127.0.0.1:%d' % args.http_port + 
+        '/v1/producer/schedule_protocol_feature_activations ' +
+        '-d \'{"protocol_features_to_activate": ["0ec7e080177b2c02b278d5088611686b49d739925a92d9bfcacd7fc6b74053bd"]}\'')
+    sleep(3)
+
+    # install eosio.system the older version first
+    retry(args.cleos + 'set contract eosio ' + args.old_contracts_dir + '/eosio.system/')
+    sleep(3)
+
+    # activate remaining features
+    # GET_SENDER
+    retry(args.cleos + 'push action eosio activate \'["f0af56d2c5a48d60a4a5b5c903edfb7db3a736a94ed589d0b797df33ff9d3e1d"]\' -p eosio')
+    # FORWARD_SETCODE
+    retry(args.cleos + 'push action eosio activate \'["2652f5f96006294109b3dd0bbde63693f55324af452b799ee137a81a905eed25"]\' -p eosio')
+    # ONLY_BILL_FIRST_AUTHORIZER
+    retry(args.cleos + 'push action eosio activate \'["8ba52fe7a3956c5cd3a656a3174b931d3bb2abb45578befc59f283ecd816a405"]\' -p eosio')
+    # RESTRICT_ACTION_TO_SELF
+    retry(args.cleos + 'push action eosio activate \'["ad9e3d8f650687709fd68f4b90b41f7d825a365b02c23a636cef88ac2ac00c43"]\' -p eosio@active')
+    # DISALLOW_EMPTY_PRODUCER_SCHEDULE
+    retry(args.cleos + 'push action eosio activate \'["68dcaa34c0517d19666e6b33add67351d8c5f69e999ca1e37931bc410a297428"]\' -p eosio@active')
+     # FIX_LINKAUTH_RESTRICTION
+    retry(args.cleos + 'push action eosio activate \'["e0fb64b1085cc5538970158d05a009c24e276fb94e1a0bf6a528b48fbc4ff526"]\' -p eosio@active')
+     # REPLACE_DEFERRED
+    retry(args.cleos + 'push action eosio activate \'["ef43112c6543b88db2283a2e077278c315ae2c84719a8b25f25cc88565fbea99"]\' -p eosio@active')
+    # NO_DUPLICATE_DEFERRED_ID
+    retry(args.cleos + 'push action eosio activate \'["4a90c00d55454dc5b059055ca213579c6ea856967712a56017487886a4d4cc0f"]\' -p eosio@active')
+    # ONLY_LINK_TO_EXISTING_PERMISSION
+    retry(args.cleos + 'push action eosio activate \'["1a99a59d87e06e09ec5b028a9cbb7749b4a5ad8819004365d02dc4379a8b7241"]\' -p eosio@active')
+    # RAM_RESTRICTIONS
+    retry(args.cleos + 'push action eosio activate \'["4e7bf348da00a945489b2a681749eb56f5de00b900014e137ddae39f48f69d67"]\' -p eosio@active')
+    # WEBAUTHN_KEY
+    retry(args.cleos + 'push action eosio activate \'["4fca8bd82bbd181e714e283f83e1b45d95ca5af40fb89ad3977b653c448f78c2"]\' -p eosio@active')
+    # WTMSIG_BLOCK_SIGNATURES
+    retry(args.cleos + 'push action eosio activate \'["299dcb6af692324b899b39f16d5a530a33062804e41f09dc97e9f156b4476707"]\' -p eosio@active')
     sleep(1)
+
     run(args.cleos + 'push action eosio setpriv' + jsonArg(['eosio.msig', 1]) + '-p eosio@active')
+
+    # install eosio.system latest version
+    retry(args.cleos + 'set contract eosio ' + args.contracts_dir + '/eosio.system/')
+    sleep(3)
+
 def stepInitSystemContract():
     run(args.cleos + 'push action eosio init' + jsonArg(['0', '4,' + args.symbol]) + '-p eosio@active')
     sleep(1)
@@ -355,7 +402,8 @@ parser.add_argument('--private-Key', metavar='', help="EOSIO Private Key", defau
 parser.add_argument('--cleos', metavar='', help="Cleos command", default='../../build/programs/cleos/cleos --wallet-url http://127.0.0.1:6666 ')
 parser.add_argument('--nodeos', metavar='', help="Path to nodeos binary", default='../../build/programs/nodeos/nodeos')
 parser.add_argument('--keosd', metavar='', help="Path to keosd binary", default='../../build/programs/keosd/keosd')
-parser.add_argument('--contracts-dir', metavar='', help="Path to contracts directory", default='../../build/contracts/')
+parser.add_argument('--contracts-dir', metavar='', help="Path to latest contracts directory", default='../../build/contracts/')
+parser.add_argument('--old-contracts-dir', metavar='', help="Path to 1.8.x contracts directory", default='../../build/contracts/')
 parser.add_argument('--nodes-dir', metavar='', help="Path to nodes directory", default='./nodes/')
 parser.add_argument('--genesis', metavar='', help="Path to genesis.json", default="./genesis.json")
 parser.add_argument('--wallet-dir', metavar='', help="Path to wallet directory", default='./wallet/')


### PR DESCRIPTION
### Change Description

Script was modified to:
1. Activate `PREACTIVATE_FEATURE` first
2. Deploy eosio.system version 1.8.0
2. Add all protocol features, including those introduced by 2.0.x
3. Deploy eosio.system version 1.9.0

Updated README.md file with steps to build the eosio.contracts older version as well.

Resolves #8261

- [x] Documentation Updates
