### PR TITLE
increase tester state size - 1.8

### DIFF
--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -373,7 +373,7 @@ namespace eosio { namespace testing {
          controller::config vcfg;
          vcfg.blocks_dir      = tempdir.path() / std::string("v_").append(config::default_blocks_dir_name);
          vcfg.state_dir  = tempdir.path() /  std::string("v_").append(config::default_state_dir_name);
-         vcfg.state_size = 1024*1024*8;
+         vcfg.state_size = 1024*1024*16;
          vcfg.state_guard_size = 0;
          vcfg.reversible_cache_size = 1024*1024*8;
          vcfg.reversible_guard_size = 0;

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -125,7 +125,7 @@ namespace eosio { namespace testing {
    void base_tester::init(const setup_policy policy, db_read_mode read_mode) {
       cfg.blocks_dir      = tempdir.path() / config::default_blocks_dir_name;
       cfg.state_dir  = tempdir.path() / config::default_state_dir_name;
-      cfg.state_size = 1024*1024*8;
+      cfg.state_size = 1024*1024*16;
       cfg.state_guard_size = 0;
       cfg.reversible_cache_size = 1024*1024*8;
       cfg.reversible_guard_size = 0;


### PR DESCRIPTION
## Change Description

Increase default state size of chains used in unit testing from 8 MiB to 16 MiB.

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions