### PR TITLE
fix EOS VM OC monitor thread name

### DIFF
--- a/libraries/chain/webassembly/eos-vm-oc/code_cache.cpp
+++ b/libraries/chain/webassembly/eos-vm-oc/code_cache.cpp
@@ -49,7 +49,7 @@ code_cache_async::code_cache_async(const bfs::path data_dir, const eosvmoc::conf
    wait_on_compile_monitor_message();
 
    _monitor_reply_thread = std::thread([this]() {
-      fc::set_thread_name("oc-monitor");
+      fc::set_os_thread_name("oc-monitor");
       _ctx.run();
    });
 }


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
`set_thread_name()` only sets the internal fc thread name, not the OS thread name

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
