### PR TITLE
support transaction finalization tracking

### DIFF
--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -14,11 +14,12 @@ add_subdirectory(wallet_plugin)
 add_subdirectory(wallet_api_plugin)
 add_subdirectory(txn_test_gen_plugin)
 add_subdirectory(db_size_api_plugin)
-#add_subdirectory(faucet_testnet_plugin)
+# add_subdirectory(faucet_testnet_plugin)
 add_subdirectory(mongo_db_plugin)
 add_subdirectory(login_plugin)
 add_subdirectory(test_control_plugin)
 add_subdirectory(test_control_api_plugin)
+add_subdirectory(chain_api_v2_plugin)
 
 # Forward variables to top level so packaging picks them up
 set(CPACK_DEBIAN_PACKAGE_DEPENDS ${CPACK_DEBIAN_PACKAGE_DEPENDS} PARENT_SCOPE)

--- a/plugins/chain_api_v2_plugin/CMakeLists.txt
+++ b/plugins/chain_api_v2_plugin/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_library(chain_api_v2_plugin chain_api_v2_plugin.cpp)
+
+target_link_libraries(chain_api_v2_plugin chain_plugin http_plugin appbase)
+target_include_directories(chain_api_v2_plugin
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")

--- a/plugins/chain_api_v2_plugin/README.md
+++ b/plugins/chain_api_v2_plugin/README.md
@@ -1,0 +1,29 @@
+# Chain API v2 Plugin
+
+This plugin provides new APIs to send a transaction to EOS blockchain and then wait for its finalization.
+
+Here are the list of new APIs in this plugin.
+
+* Push a transaction to be tracked, the server would response when at least one producer accepts it.
+    * URL: `/v2/chain/push_transaction`
+    * Method: `POST`
+    * Body Params: same with `/v1/chain/push_transaction`
+    * Success Response: same with `/v1/chain/push_transaction`
+    * Error Response: same with `/v1/chain/push_transaction`
+* Send a transaction to be tracked, the server would response when at least one producer accepts it.
+    * URL: `/v2/chain/send_transaction`
+    * Method: `POST`
+    * Body Params: same with `/v1/chain/send_transaction`
+    * Success Response: same with `/v1/chain/send_transaction`
+    * Error Response: same with `/v1/chain/send_transaction`
+* Wait for a tracked transaction to be finalized.
+    * URL: `/v2/chain/wait_transaction`
+    * Method: `POST`
+    * Body Params: `{"transaction_id": "{the tracked transaction id}" }`
+    * Success Response: `201 Created`
+    * Error Response:
+        * `403 Forbidden`: there is already a pending waiting request on the transaction.
+        * `404 Not Found`:
+            * the transaction is not sent through `/v2/chain/push_transaction` or `/v2/chain/send_transaction`, or
+            * the expiration time of the transaction is earlier than latest irreversible block received by the server.
+        * `504 Gateway Timeout`: the transaction expires.

--- a/plugins/chain_api_v2_plugin/chain_api_v2_plugin.cpp
+++ b/plugins/chain_api_v2_plugin/chain_api_v2_plugin.cpp
@@ -1,0 +1,220 @@
+#include <boost/signals2/connection.hpp>
+#include <eosio/chain/controller.hpp>
+#include <eosio/chain/exceptions.hpp>
+#include <eosio/chain_api_v2_plugin/chain_api_v2_plugin.hpp>
+#include <eosio/chain_plugin/chain_plugin.hpp>
+#include <eosio/http_plugin/http_plugin.hpp>
+#include <fc/io/json.hpp>
+#include <fc/reflect/reflect.hpp>
+#include <fc/log/log_message.hpp>
+
+#include <deque>
+#include <functional>
+#include <queue>
+#include <unordered_map>
+
+namespace eosio {
+using namespace chain;
+using boost::signals2::scoped_connection;
+using eosio::chain::controller;
+static appbase::abstract_plugin& _chain_api_v2_plugin = app().register_plugin<chain_api_v2_plugin>();
+
+fc::variant make_error_results(uint16_t status_code, const char* role, const char* message) {
+   auto log = FC_LOG_MESSAGE(error, message);
+   return fc::variant(error_results{status_code, role, error_results::error_info(fc::exception({log}), false)});
+}
+
+struct pending_response {
+   pending_response(const url_response_callback& cb, chain_apis::read_write::push_transaction_results& r)
+       : trx_result_cb(cb)
+       , push_trx_result(r) {}
+   uint32_t                                         block_num = 0;
+   url_response_callback                            trx_result_cb;
+   url_response_callback                            wait_result_cb;
+   chain_apis::read_write::push_transaction_results push_trx_result;
+
+   void send_push_response() { trx_result_cb(202, fc::variant(push_trx_result)); }
+   void send_wait_response(uint32_t num) {
+      if (wait_result_cb)
+         wait_result_cb(201, fc::variant_object("block_num", num));
+      else
+         block_num = num;
+   }
+   void send_expired() {
+      if (wait_result_cb) {
+         wait_result_cb( 504, make_error_results(504, "Gateway Timeout", "transaction expired"));
+      }
+   }
+};
+
+struct expiration_queue_element {
+   fc::time_point      expiration;
+   transaction_id_type transaction_id;
+};
+
+struct expiration_queue_element_cmp {
+   bool operator()(const expiration_queue_element& lhs, const expiration_queue_element& rhs) const {
+      return lhs.expiration > rhs.expiration;
+   }
+};
+
+using pending_responses_t = std::unordered_map<transaction_id_type, pending_response>;
+using expiration_queue_t =
+    std::priority_queue<expiration_queue_element, std::deque<expiration_queue_element>, expiration_queue_element_cmp>;
+
+class chain_api_v2_plugin_impl {
+ public:
+   chain_api_v2_plugin_impl(chain_plugin& chain_plug)
+       : db(chain_plug.chain())
+       , rw_api(chain_plug.get_read_write_api()) {
+      accepted_block_connection.emplace(
+          db.accepted_block.connect([this](const block_state_ptr& p) { on_accepted_block(p); }));
+
+      irreversible_block_connection.emplace(
+          db.irreversible_block.connect([this](const block_state_ptr& p) { on_irreversible_block(p); }));
+   }
+
+   using api_handler = decltype(&chain_apis::read_write::push_transaction);
+
+   void handle_transaction_request(string, string body, url_response_callback cb, const char* action,
+                                   api_handler handler);
+   void handle_wait_transaction_request(string, string body, url_response_callback cb);
+   void on_accepted_block(const block_state_ptr& block_state);
+   void on_irreversible_block(const block_state_ptr& block_state);
+   void clear_expired(fc::time_point timestamp);
+
+   controller&                     db;
+   chain_apis::read_write          rw_api;
+   fc::optional<scoped_connection> accepted_block_connection;
+   fc::optional<scoped_connection> irreversible_block_connection;
+   pending_responses_t             pending_responses;
+   expiration_queue_t              expiration_queue;
+};
+
+chain_api_v2_plugin::chain_api_v2_plugin() {}
+chain_api_v2_plugin::~chain_api_v2_plugin() {}
+
+void chain_api_v2_plugin::set_program_options(options_description&, options_description& cfg) {}
+void chain_api_v2_plugin::plugin_initialize(const variables_map& options) {}
+
+void chain_api_v2_plugin::plugin_startup() {
+
+   auto& chain_plug = app().register_plugin<chain_plugin>();
+   auto& http_plug  = app().register_plugin<http_plugin>();
+
+   my.reset(new chain_api_v2_plugin_impl(chain_plug));
+
+   http_plug.add_handler(std::string("/v2/chain/push_transaction"),
+                         [impl = my.get()](string r, string body, url_response_callback cb) mutable {
+                            impl->handle_transaction_request(r, body, cb, "push_transaction",
+                                                             &chain_apis::read_write::push_transaction);
+                         });
+
+   http_plug.add_handler(std::string("/v2/chain/send_transaction"),
+                         [impl = my.get()](string r, string body, url_response_callback cb) mutable {
+                            impl->handle_transaction_request(r, body, cb, "send_transaction",
+                                                             &chain_apis::read_write::send_transaction);
+                         });
+
+   http_plug.add_handler(std::string("/v2/chain/wait_transaction"),
+                         [impl = my.get()](string r, string body, url_response_callback cb) mutable {
+                            impl->handle_wait_transaction_request(r, body, cb);
+                         });
+}
+
+void chain_api_v2_plugin::plugin_shutdown() {}
+
+void chain_api_v2_plugin_impl::handle_transaction_request(string, string body, url_response_callback cb,
+                                                          const char*                           action,
+                                                          chain_api_v2_plugin_impl::api_handler method) {
+   try {
+      rw_api.validate();
+      auto params = fc::json::from_string(body).as<chain_apis::read_write::push_transaction_params>();
+      auto next =
+          [this, cb, body, action](
+              const fc::static_variant<fc::exception_ptr, chain_apis::read_write::push_transaction_results>& result) {
+             if (result.contains<fc::exception_ptr>()) {
+                try {
+                   result.get<fc::exception_ptr>()->dynamic_rethrow_exception();
+                } catch (...) {
+                   http_plugin::handle_exception("v2/chain", action, body, cb);
+                }
+             } else {
+                auto push_trx_result = result.get<chain_apis::read_write::push_transaction_results>();
+
+                pending_responses.emplace(push_trx_result.transaction_id, pending_response{cb, push_trx_result});
+                expiration_queue.push({push_trx_result.expiration, push_trx_result.transaction_id});
+             }
+          };
+
+      std::invoke(method, rw_api, params, next);
+   } catch (...) {
+      http_plugin::handle_exception("v2/chain", action, body, cb);
+   }
+}
+
+void chain_api_v2_plugin_impl::handle_wait_transaction_request(string, string body, url_response_callback cb) {
+
+   try {
+      rw_api.validate();
+      transaction_id_type id =
+          fc::json::from_string(body).as<fc::variant_object>()["transaction_id"].as<transaction_id_type>();
+
+      auto itr = pending_responses.find(id);
+      if (itr == pending_responses.end()) {
+         cb(404, make_error_results(404, "Not Found", "the specified transaction is not currently tracked"));
+      } else if (itr->second.block_num > 0) {
+         cb(201, fc::variant_object("block_num", itr->second.block_num));
+      } else if (!itr->second.wait_result_cb){
+         itr->second.wait_result_cb = cb;
+      } else {
+         cb(403, make_error_results(403, "Forbidden", "pending wait on the transaction existed"));
+      }
+
+   } catch (...) {
+      http_plugin::handle_exception("v2/chain", "wait_transaction", body, cb);
+   }
+}
+
+void chain_api_v2_plugin_impl::on_accepted_block(const block_state_ptr& block_state) {
+   for (auto& receipt : block_state->block->transactions) {
+      auto id = receipt.trx.contains<packed_transaction>()
+                    ? receipt.trx.get<packed_transaction>().get_transaction().id()
+                    : receipt.trx.get<transaction_id_type>();
+
+      auto itr = pending_responses.find(id);
+      if (itr != pending_responses.end()) {
+         itr->second.send_push_response();
+      }
+   }
+}
+
+void chain_api_v2_plugin_impl::on_irreversible_block(const block_state_ptr& block_state) {
+   for (auto& receipt : block_state->block->transactions) {
+      auto id = receipt.trx.contains<packed_transaction>()
+                    ? receipt.trx.get<packed_transaction>().get_transaction().id()
+                    : receipt.trx.get<transaction_id_type>();
+
+      auto itr = pending_responses.find(id);
+      if (itr != pending_responses.end()) {
+         itr->second.send_wait_response(block_state->block->block_num());
+         pending_responses.erase(itr);
+      }
+   }
+
+   clear_expired(block_state->block->timestamp.to_time_point());
+}
+
+void chain_api_v2_plugin_impl::clear_expired(fc::time_point timestamp) {
+
+   while (expiration_queue.size() && expiration_queue.top().expiration < timestamp) {
+      auto id  = expiration_queue.top().transaction_id;
+      auto itr = pending_responses.find(id);
+      if (itr != pending_responses.end()) {
+         itr->second.send_expired();
+         pending_responses.erase(itr);
+      }
+      expiration_queue.pop();
+   }
+}
+} // namespace eosio

--- a/plugins/chain_api_v2_plugin/include/eosio/chain_api_v2_plugin/chain_api_v2_plugin.hpp
+++ b/plugins/chain_api_v2_plugin/include/eosio/chain_api_v2_plugin/chain_api_v2_plugin.hpp
@@ -1,0 +1,27 @@
+#pragma once
+#include <appbase/application.hpp>
+
+namespace eosio {
+
+using namespace appbase;
+
+/**
+ *  This is a template plugin, intended to serve as a starting point for making new plugins
+ */
+class chain_api_v2_plugin : public appbase::plugin<chain_api_v2_plugin> {
+ public:
+   chain_api_v2_plugin();
+   virtual ~chain_api_v2_plugin();
+
+   APPBASE_PLUGIN_REQUIRES()
+   virtual void set_program_options(options_description&, options_description& cfg) override;
+
+   void plugin_initialize(const variables_map& options);
+   void plugin_startup();
+   void plugin_shutdown();
+
+ private:
+   std::unique_ptr<class chain_api_v2_plugin_impl> my;
+};
+
+} // namespace eosio

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -2089,8 +2089,10 @@ void read_write::push_transaction(const read_write::push_transaction_params& par
          abi_serializer::from_variant(params, *pretty_input, resolver, abi_serializer_max_time);
       } EOS_RETHROW_EXCEPTIONS(chain::packed_transaction_type_exception, "Invalid packed transaction")
 
+      auto expiration = pretty_input->expiration();
+
       app().get_method<incoming::methods::transaction_async>()(pretty_input, true,
-            [this, next](const fc::static_variant<fc::exception_ptr, transaction_trace_ptr>& result) -> void {
+            [this, next, expiration](const fc::static_variant<fc::exception_ptr, transaction_trace_ptr>& result) -> void {
          if (result.contains<fc::exception_ptr>()) {
             next(result.get<fc::exception_ptr>());
          } else {
@@ -2152,7 +2154,7 @@ void read_write::push_transaction(const read_write::push_transaction_params& par
                }
 
                const chain::transaction_id_type& id = trx_trace_ptr->id;
-               next(read_write::push_transaction_results{id, output});
+               next(read_write::push_transaction_results{id, expiration, output});
             } CATCH_AND_CALL(next);
          }
       });
@@ -2167,7 +2169,8 @@ static void push_recurse(read_write* rw, int index, const std::shared_ptr<read_w
    auto wrapped_next = [=](const fc::static_variant<fc::exception_ptr, read_write::push_transaction_results>& result) {
       if (result.contains<fc::exception_ptr>()) {
          const auto& e = result.get<fc::exception_ptr>();
-         results->emplace_back( read_write::push_transaction_results{ transaction_id_type(), fc::mutable_variant_object( "error", e->to_detail_string() ) } );
+         results->emplace_back(read_write::push_transaction_results{
+             transaction_id_type(), fc::time_point_sec{}, fc::mutable_variant_object("error", e->to_detail_string())});
       } else {
          const auto& r = result.get<read_write::push_transaction_results>();
          results->emplace_back( r );
@@ -2208,8 +2211,10 @@ void read_write::send_transaction(const read_write::send_transaction_params& par
          abi_serializer::from_variant(params, *pretty_input, resolver, abi_serializer_max_time);
       } EOS_RETHROW_EXCEPTIONS(chain::packed_transaction_type_exception, "Invalid packed transaction")
 
+      auto expiration = pretty_input->expiration();
+
       app().get_method<incoming::methods::transaction_async>()(pretty_input, true,
-            [this, next](const fc::static_variant<fc::exception_ptr, transaction_trace_ptr>& result) -> void {
+            [this, next, expiration](const fc::static_variant<fc::exception_ptr, transaction_trace_ptr>& result) -> void {
          if (result.contains<fc::exception_ptr>()) {
             next(result.get<fc::exception_ptr>());
          } else {
@@ -2224,7 +2229,7 @@ void read_write::send_transaction(const read_write::send_transaction_params& par
                }
 
                const chain::transaction_id_type& id = trx_trace_ptr->id;
-               next(read_write::send_transaction_results{id, output});
+               next(read_write::send_transaction_results{id, expiration, output});
             } CATCH_AND_CALL(next);
          }
       });

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -603,6 +603,7 @@ public:
    using push_transaction_params = fc::variant_object;
    struct push_transaction_results {
       chain::transaction_id_type  transaction_id;
+      fc::time_point_sec          expiration;
       fc::variant                 processed;
    };
    void push_transaction(const push_transaction_params& params, chain::plugin_interface::next_function<push_transaction_results> next);

--- a/programs/cleos/httpc.hpp
+++ b/programs/cleos/httpc.hpp
@@ -82,6 +82,9 @@ namespace eosio { namespace client { namespace http {
    const string get_info_func = chain_func_base + "/get_info";
    const string send_txn_func = chain_func_base + "/send_transaction";
    const string push_txn_func = chain_func_base + "/push_transaction";
+   const string send_txn_v2_func = "/v2/chain/send_transaction";
+   const string push_txn_v2_func = "/v2/chain/push_transaction";
+   const string wait_trx_func = "/v2/chain/wait_transaction";
    const string push_txns_func = chain_func_base + "/push_transactions";
    const string json_to_bin_func = chain_func_base + "/abi_json_to_bin";
    const string get_block_func = chain_func_base + "/get_block";

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -185,6 +185,8 @@ uint32_t tx_max_net_usage = 0;
 
 uint32_t delaysec = 0;
 
+bool track_txn= false;
+
 vector<string> tx_permission;
 
 eosio::client::http::http_context context;
@@ -385,11 +387,13 @@ fc::variant push_transaction( signed_transaction& trx, const std::vector<public_
    }
 
    if (!tx_dont_broadcast) {
+      fc::variant arg(packed_transaction(trx, compression));
+
       if (tx_use_old_rpc) {
-         return call(push_txn_func, packed_transaction(trx, compression));
+         return track_txn ? call(push_txn_v2_func, arg) : call(push_txn_func, arg);
       } else {
          try {
-            return call(send_txn_func, packed_transaction(trx, compression));
+            return track_txn ? call(send_txn_v2_func, arg) : call(send_txn_func, arg);
          }
          catch (chain::missing_chain_api_plugin_exception &) {
             std::cerr << "New RPC send_transaction may not be supported. Add flag --use-old-rpc to use old RPC push_transaction instead." << std::endl;
@@ -3464,6 +3468,7 @@ int main( int argc, char** argv ) {
    actionsSubcommand->add_option("action", action,
                                  localized("A JSON string or filename defining the action to execute on the contract"), true)->required();
    actionsSubcommand->add_option("data", data, localized("The arguments to the contract"))->required();
+   actionsSubcommand->add_flag("--track", track_txn, localized("Enable transaction tracking via wait_transaction (requires enabling chain_api_v2 plugin)."));
 
    add_standard_transaction_options_plus_signing(actionsSubcommand);
    actionsSubcommand->set_callback([&] {
@@ -3481,6 +3486,7 @@ int main( int argc, char** argv ) {
    string trx_to_push;
    auto trxSubcommand = push->add_subcommand("transaction", localized("Push an arbitrary JSON transaction"));
    trxSubcommand->add_option("transaction", trx_to_push, localized("The JSON string or filename defining the transaction to push"))->required();
+   trxSubcommand->add_flag("--track", track_txn, localized("Enable transaction finalization tracking via wait_transaction (requires enabling chain v2 plugin)."));
    add_standard_transaction_options_plus_signing(trxSubcommand);
 
    trxSubcommand->set_callback([&] {
@@ -3506,6 +3512,14 @@ int main( int argc, char** argv ) {
       std::cout << fc::json::to_pretty_string(trxs_result) << std::endl;
    });
 
+   // wait transaction
+   string trxId;
+   auto wait = app.add_subcommand("wait_transaction", localized("Wait a tracked transaction in the blockchain to become finalized (requires enabling chain_api_v2 plugin)"), false);
+   auto waitSubcommand = wait->add_option("transaction", trxId, localized("the transaction id to wait"));
+   wait->set_callback([&] {
+      auto wait_result = call(wait_trx_func, fc::variant_object("transaction_id", trxId));
+      std::cout << fc::json::to_pretty_string(wait_result) << std::endl;
+   });
 
    // multisig subcommand
    auto msig = app.add_subcommand("multisig", localized("Multisig contract commands"), false);

--- a/programs/eosio-launcher/main.cpp
+++ b/programs/eosio-launcher/main.cpp
@@ -1143,6 +1143,7 @@ launcher_def::write_config_file (tn_node_def &node) {
   }
   cfg << "plugin = eosio::net_plugin\n";
   cfg << "plugin = eosio::chain_api_plugin\n"
+      << "plugin = eosio::chain_api_v2_plugin\n"
       << "plugin = eosio::history_api_plugin\n";
   cfg.close();
 }

--- a/programs/nodeos/CMakeLists.txt
+++ b/programs/nodeos/CMakeLists.txt
@@ -48,6 +48,7 @@ target_link_libraries( ${NODE_EXECUTABLE_NAME}
         PRIVATE -Wl,${whole_archive_flag} state_history_plugin       -Wl,${no_whole_archive_flag}
         PRIVATE -Wl,${whole_archive_flag} history_api_plugin         -Wl,${no_whole_archive_flag}
         PRIVATE -Wl,${whole_archive_flag} chain_api_plugin           -Wl,${no_whole_archive_flag}
+        PRIVATE -Wl,${whole_archive_flag} chain_api_v2_plugin        -Wl,${no_whole_archive_flag}
         PRIVATE -Wl,${whole_archive_flag} net_plugin                 -Wl,${no_whole_archive_flag}
         PRIVATE -Wl,${whole_archive_flag} net_api_plugin             -Wl,${no_whole_archive_flag}
 #        PRIVATE -Wl,${whole_archive_flag} faucet_testnet_plugin      -Wl,${no_whole_archive_flag}


### PR DESCRIPTION
## Change Description
This PR create a new plugin 'chain_api_v2' which allows users to push or sent transactions and then wait for their finalization.

More documentation is in `plugins/chain_api_v2_plugin/README.md`

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [x] Documentation Additions
