### PR TITLE
resolve action return value hash & state history serialization discrepancy

### DIFF
--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -144,13 +144,11 @@ void apply_context::exec_one()
       r.auth_sequence[auth.actor] = next_auth_sequence( auth.actor );
    }
 
-   uint32_t version = 0;
    if( control.is_builtin_activated( builtin_protocol_feature_t::action_return_value ) ) {
-      version = set_field( version, builtin_protocol_feature_t::action_return_value, true );
       r.return_value.emplace( std::move( action_return_value ) );
    }
 
-   trx_context.executed_action_receipt_digests.emplace_back( r.digest( version ) );
+   trx_context.executed_action_receipt_digests.emplace_back( r.digest() );
 
    finalize_trace( trace, start );
 

--- a/libraries/chain/include/eosio/chain/action_receipt.hpp
+++ b/libraries/chain/include/eosio/chain/action_receipt.hpp
@@ -16,12 +16,10 @@ namespace eosio { namespace chain {
       flat_map<account_name,uint64_t> auth_sequence;
       fc::unsigned_int                code_sequence = 0; ///< total number of setcodes
       fc::unsigned_int                abi_sequence  = 0; ///< total number of setabis
-      fc::optional<std::vector<char>> return_value;      ///< return value of the action
+      fc::optional<std::vector<char>> return_value;      /**< return value of the action; optional is set if action was executed
+                                                              with return value protocol feature enabled */
 
-      /// @param version of digest to calculate
-      ///        0 for original version
-      ///        set_field( version, builtin_protocol_feature_t::action_return_value, true ) for version of digest with return_value
-      digest_type digest(uint32_t version)const {
+      digest_type digest()const {
          digest_type::encoder e;
          fc::raw::pack(e, receiver);
          fc::raw::pack(e, act_digest);
@@ -30,9 +28,8 @@ namespace eosio { namespace chain {
          fc::raw::pack(e, auth_sequence);
          fc::raw::pack(e, code_sequence);
          fc::raw::pack(e, abi_sequence);
-         if( has_field( version, builtin_protocol_feature_t::action_return_value ) ) {
-            fc::raw::pack(e, return_value);
-         }
+         if(return_value)
+            fc::raw::pack(e, *return_value);
          return e.result();
       }
    };

--- a/libraries/chain/include/eosio/chain/action_receipt.hpp
+++ b/libraries/chain/include/eosio/chain/action_receipt.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <eosio/chain/types.hpp>
-#include <eosio/chain/protocol_feature_manager.hpp>
 
 namespace eosio { namespace chain {
 

--- a/unittests/misc_tests.cpp
+++ b/unittests/misc_tests.cpp
@@ -1117,11 +1117,9 @@ BOOST_AUTO_TEST_CASE(action_receipt_digest) {
                          .auth_sequence = {{eosio::name("name"), 13}},
                          .code_sequence = 5,
                          .abi_sequence = 6 };
-      auto d = digest_type::hash(ar);
-      uint32_t version = 0;
-      version = eosio::chain::set_field( version, builtin_protocol_feature_t::action_return_value, true );
-      BOOST_REQUIRE_EQUAL( ar.digest(version), d );
-      BOOST_REQUIRE_NE( ar.digest(0), d );
+      auto d = ar.digest();
+      ar.return_value.emplace();
+      BOOST_REQUIRE_NE( ar.digest(), d );
 
    } FC_LOG_AND_RETHROW()
 }


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
Action return values are mixed in to the action_receipt's digest as an `optional<vector<char>>` when the action return value protocol feature is enabled. However when the action_receipt is serialized out via state_history, the action return value is serialized out via `vector<char>`. This discrepancy means it isn’t possible for a consumer of state history to calculate the merkle proof correctly because the hash used in nodeos is over a different serialization then state history provides.

First, this PR changes how the action return value is mixed in to the action_receipt’s digest such that it’s only hashed as a `vector<char>`. This will match how the state history serialization is performed. As a second change, action_receipt::digest() will no longer take an input to determine if it should mix in return_value. After conferring with @heifner , the intention was that the return_value optional<> will be set if and only if the action was executed with the return value protocol feature enabled. Checking this in a single common way (optional<> presence in action_receipt::digest() & optional<> presence in state_history serialization) will be clearer than doing it one way one place and another way another place.

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
