### PR TITLE
[Develop] Added better sleep pre-execute for Anka commands + boost fix

### DIFF
--- a/.cicd/build-scripts.yml
+++ b/.cicd/build-scripts.yml
@@ -32,7 +32,7 @@ steps:
       - "git clone git@github.com:EOSIO/eos.git eos && cd eos &&  git checkout -f $BUILDKITE_BRANCH && git submodule update --init --recursive"
       - "cd eos && ./scripts/eosio_build.sh -P -y"
     plugins:
-      - chef/anka#v0.5.5:
+      - NorseGaud/anka#v0.5.7:
           debug: true
           vm-name: "10.14.6_6C_14G_40G"
           no-volume: true
@@ -41,7 +41,7 @@ steps:
           always-pull: true
           wait-network: true
           vm-registry-tag: "clean::cicd::git-ssh::nas::brew::buildkite-agent"
-          pre-execute-sleep: 10
+          pre-execute-ping-sleep: "8.8.8.8"
           failover-registries:
           - "registry_1"
           - "registry_2"
@@ -108,7 +108,7 @@ steps:
       - "git clone git@github.com:EOSIO/eos.git eos && cd eos &&  git checkout -f $BUILDKITE_BRANCH && git submodule update --init --recursive"
       - "cd eos && ./scripts/eosio_build.sh -y"
     plugins:
-      - chef/anka#v0.5.5:
+      - NorseGaud/anka#v0.5.7:
           debug: true
           vm-name: "10.14.6_6C_14G_40G"
           no-volume: true
@@ -117,7 +117,7 @@ steps:
           always-pull: true
           wait-network: true
           vm-registry-tag: "clean::cicd::git-ssh::nas::brew::buildkite-agent"
-          pre-execute-sleep: 10
+          pre-execute-ping-sleep: "8.8.8.8"
           failover-registries:
           - "registry_1"
           - "registry_2"

--- a/.cicd/generate-pipeline.sh
+++ b/.cicd/generate-pipeline.sh
@@ -120,7 +120,7 @@ EOF
       - "cd eos && ./.cicd/build.sh"
       - "cd eos && tar -pczf build.tar.gz build && buildkite-agent artifact upload build.tar.gz"
     plugins:
-      - chef/anka#v0.5.5:
+      - NorseGaud/anka#v0.5.7:
           no-volume: true
           inherit-environment-vars: true
           vm-name: ${MOJAVE_ANKA_TEMPLATE_NAME}

--- a/.cicd/generate-pipeline.sh
+++ b/.cicd/generate-pipeline.sh
@@ -133,7 +133,7 @@ EOF
           failover-registries:
             - 'registry_1'
             - 'registry_2'
-          pre-execute-sleep: 10
+          pre-execute-ping-sleep: "8.8.8.8"
           pre-commands: 
             - "rm -rf mac-anka-fleet; git clone git@github.com:EOSIO/mac-anka-fleet.git && cd mac-anka-fleet && . ./ensure-tag.bash -u 12 -r 25G -a '-n'"
       - thedyrt/skip-checkout#v0.1.1:
@@ -212,7 +212,7 @@ EOF
       - "cd eos && buildkite-agent artifact download build.tar.gz . --step '$(echo "$PLATFORM_JSON" | jq -r .ICON) $(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_FULL) - Build' && tar -xzf build.tar.gz"
       - "cd eos && ./.cicd/test.sh scripts/parallel-test.sh"
     plugins:
-      - chef/anka#v0.5.4:
+      - NorseGaud/anka#v0.5.7:
           no-volume: true
           inherit-environment-vars: true
           vm-name: ${MOJAVE_ANKA_TEMPLATE_NAME}
@@ -223,7 +223,7 @@ EOF
           failover-registries:
             - 'registry_1'
             - 'registry_2'
-          pre-execute-sleep: 10
+          pre-execute-ping-sleep: "8.8.8.8"
       - thedyrt/skip-checkout#v0.1.1:
           cd: ~
     agents: "queue=mac-anka-node-fleet"
@@ -276,7 +276,7 @@ EOF
       - "cd eos && buildkite-agent artifact download build.tar.gz . --step '$(echo "$PLATFORM_JSON" | jq -r .ICON) $(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_FULL) - Build' && tar -xzf build.tar.gz"
       - "cd eos && ./.cicd/test.sh scripts/wasm-spec-test.sh"
     plugins:
-      - chef/anka#v0.5.4:
+      - NorseGaud/anka#v0.5.7:
           no-volume: true
           inherit-environment-vars: true
           vm-name: ${MOJAVE_ANKA_TEMPLATE_NAME}
@@ -287,7 +287,7 @@ EOF
           failover-registries:
             - 'registry_1'
             - 'registry_2'
-          pre-execute-sleep: 10
+          pre-execute-ping-sleep: "8.8.8.8"
       - thedyrt/skip-checkout#v0.1.1:
           cd: ~
     agents: "queue=mac-anka-node-fleet"
@@ -349,7 +349,7 @@ EOF
       - "cd eos && buildkite-agent artifact download build.tar.gz . --step '$(echo "$PLATFORM_JSON" | jq -r .ICON) $(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_FULL) - Build' && tar -xzf build.tar.gz"
       - "cd eos && ./.cicd/test.sh scripts/serial-test.sh $TEST_NAME"
     plugins:
-      - chef/anka#v0.5.4:
+      - NorseGaud/anka#v0.5.7:
           no-volume: true
           inherit-environment-vars: true
           vm-name: ${MOJAVE_ANKA_TEMPLATE_NAME}
@@ -360,7 +360,7 @@ EOF
           failover-registries:
             - 'registry_1'
             - 'registry_2'
-          pre-execute-sleep: 10
+          pre-execute-ping-sleep: "8.8.8.8"
       - thedyrt/skip-checkout#v0.1.1:
           cd: ~
     agents: "queue=mac-anka-node-fleet"
@@ -423,7 +423,7 @@ EOF
       - "cd eos && buildkite-agent artifact download build.tar.gz . --step '$(echo "$PLATFORM_JSON" | jq -r .ICON) $(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_FULL) - Build' ${BUILD_SOURCE} && tar -xzf build.tar.gz"
       - "cd eos && ./.cicd/test.sh scripts/long-running-test.sh $TEST_NAME"
     plugins:
-      - chef/anka#v0.5.4:
+      - NorseGaud/anka#v0.5.7:
           no-volume: true
           inherit-environment-vars: true
           vm-name: ${MOJAVE_ANKA_TEMPLATE_NAME}
@@ -434,7 +434,7 @@ EOF
           failover-registries:
             - 'registry_1'
             - 'registry_2'
-          pre-execute-sleep: 10
+          pre-execute-ping-sleep: "8.8.8.8"
       - thedyrt/skip-checkout#v0.1.1:
           cd: ~
     agents: "queue=mac-anka-node-fleet"
@@ -633,7 +633,7 @@ cat <<EOF
       - "cd eos && buildkite-agent artifact download build.tar.gz . --step ':darwin: macOS 10.14 - Build' && tar -xzf build.tar.gz"
       - "cd eos && ./.cicd/package.sh"
     plugins:
-      - chef/anka#v0.5.4:
+      - NorseGaud/anka#v0.5.7:
           no-volume: true
           inherit-environment-vars: true
           vm-name: 10.14.6_6C_14G_40G
@@ -644,7 +644,7 @@ cat <<EOF
           failover-registries:
             - 'registry_1'
             - 'registry_2'
-          pre-execute-sleep: 10
+          pre-execute-ping-sleep: "8.8.8.8"
       - thedyrt/skip-checkout#v0.1.1:
           cd: ~
     agents:

--- a/.cicd/platforms/pinned/macos-10.14-pinned.sh
+++ b/.cicd/platforms/pinned/macos-10.14-pinned.sh
@@ -49,11 +49,13 @@ sudo make install
 cd ../..
 rm -rf clang8
 # install boost from source
+## Boost Fix: eosio/install/bin/../include/c++/v1/stdlib.h:94:15: fatal error: 'stdlib.h' file not found
+export SDKROOT="$(xcrun --sdk macosx --show-sdk-path)"
 curl -LO https://dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.tar.bz2
 tar -xjf boost_1_71_0.tar.bz2
 cd boost_1_71_0
 ./bootstrap.sh --prefix=/usr/local
-sudo ./b2 --with-iostreams --with-date_time --with-filesystem --with-system --with-program_options --with-chrono --with-test -q -j$(getconf _NPROCESSORS_ONLN) install
+sudo SDKROOT="$SDKROOT" ./b2 --with-iostreams --with-date_time --with-filesystem --with-system --with-program_options --with-chrono --with-test -q -j$(getconf _NPROCESSORS_ONLN) install
 cd ..
 sudo rm -rf boost_1_71_0.tar.bz2 boost_1_71_0
 # install mongodb


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

Problem: A networking init limitation in the anka software forces us to sleep before commands to wait for it to initialize fully. Using an integer for the seconds we need to sleep is not flexible enough.

Solution: Use a while loop with ping (in anka buildkite plugin v0.5.7) to sleep as long as we need to, until the ping gets a response.

Problem 2: Boost refuses to install without SDKROOT set SDKROOT="$(xcrun --sdk macosx --show-sdk-path)". Our CI/CD dep script doesn't set it, so it fails to build the tag.

Solution: Added the necessary SDKROOT env

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
