### PR TITLE
[1.8.x] Added better sleep pre-execute for Anka commands + boost fix

### DIFF
--- a/.cicd/generate-pipeline.sh
+++ b/.cicd/generate-pipeline.sh
@@ -111,7 +111,7 @@ EOF
       - "cd eos && ./.cicd/build.sh"
       - "cd eos && tar -pczf build.tar.gz build && buildkite-agent artifact upload build.tar.gz"
     plugins:
-      - chef/anka#v0.5.5:
+      - NorseGaud/anka#v0.5.7:
           no-volume: true
           inherit-environment-vars: true
           vm-name: ${MOJAVE_ANKA_TEMPLATE_NAME}
@@ -124,7 +124,7 @@ EOF
           failover-registries:
             - 'registry_1'
             - 'registry_2'
-          pre-execute-sleep: 10
+          pre-execute-ping-sleep: "8.8.8.8"
           pre-commands: 
             - "git clone git@github.com:EOSIO/mac-anka-fleet.git && cd mac-anka-fleet && . ./ensure-tag.bash -u 12 -r 25G -a '-n'"
     env:
@@ -191,7 +191,7 @@ EOF
       - "cd eos && buildkite-agent artifact download build.tar.gz . --step '$(echo "$PLATFORM_JSON" | jq -r .ICON) $(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_FULL) - Build' && tar -xzf build.tar.gz"
       - "cd eos && ./.cicd/test.sh scripts/parallel-test.sh"
     plugins:
-      - chef/anka#v0.5.4:
+      - NorseGaud/anka#v0.5.7:
           no-volume: true
           inherit-environment-vars: true
           vm-name: ${MOJAVE_ANKA_TEMPLATE_NAME}
@@ -202,7 +202,7 @@ EOF
           failover-registries:
             - 'registry_1'
             - 'registry_2'
-          pre-execute-sleep: 10
+          pre-execute-ping-sleep: "8.8.8.8"
     agents: "queue=mac-anka-node-fleet"
     retry:
       manual:
@@ -245,7 +245,7 @@ EOF
       - "cd eos && buildkite-agent artifact download build.tar.gz . --step '$(echo "$PLATFORM_JSON" | jq -r .ICON) $(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_FULL) - Build' && tar -xzf build.tar.gz"
       - "cd eos && ./.cicd/test.sh scripts/serial-test.sh $TEST_NAME"
     plugins:
-      - chef/anka#v0.5.4:
+      - NorseGaud/anka#v0.5.7:
           no-volume: true
           inherit-environment-vars: true
           vm-name: ${MOJAVE_ANKA_TEMPLATE_NAME}
@@ -256,7 +256,7 @@ EOF
           failover-registries:
             - 'registry_1'
             - 'registry_2'
-          pre-execute-sleep: 10
+          pre-execute-ping-sleep: "8.8.8.8"
     agents: "queue=mac-anka-node-fleet"
     retry:
       manual:
@@ -301,7 +301,7 @@ EOF
       - "cd eos && buildkite-agent artifact download build.tar.gz . --step '$(echo "$PLATFORM_JSON" | jq -r .ICON) $(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_FULL) - Build' ${BUILD_SOURCE} && tar -xzf build.tar.gz"
       - "cd eos && ./.cicd/test.sh scripts/long-running-test.sh $TEST_NAME"
     plugins:
-      - chef/anka#v0.5.4:
+      - NorseGaud/anka#v0.5.7:
           no-volume: true
           inherit-environment-vars: true
           vm-name: ${MOJAVE_ANKA_TEMPLATE_NAME}
@@ -312,7 +312,7 @@ EOF
           failover-registries:
             - 'registry_1'
             - 'registry_2'
-          pre-execute-sleep: 10
+          pre-execute-ping-sleep: "8.8.8.8"
     agents: "queue=mac-anka-node-fleet"
     retry:
       manual:
@@ -478,7 +478,7 @@ cat <<EOF
       - "cd eos && buildkite-agent artifact download build.tar.gz . --step ':darwin: macOS 10.14 - Build' && tar -xzf build.tar.gz"
       - "cd eos && ./.cicd/package.sh"
     plugins:
-      - chef/anka#v0.5.4:
+      - NorseGaud/anka#v0.5.7:
           no-volume: true
           inherit-environment-vars: true
           vm-name: 10.14.6_6C_14G_40G
@@ -489,7 +489,7 @@ cat <<EOF
           failover-registries:
             - 'registry_1'
             - 'registry_2'
-          pre-execute-sleep: 10
+          pre-execute-ping-sleep: "8.8.8.8"
     agents:
       - "queue=mac-anka-node-fleet"
     timeout: ${TIMEOUT:-10}

--- a/.cicd/generate-pipeline.sh
+++ b/.cicd/generate-pipeline.sh
@@ -134,7 +134,7 @@ EOF
       TEMPLATE_TAG: $MOJAVE_ANKA_TAG_BASE
       IMAGE_TAG: $(echo "$PLATFORM_JSON" | jq -r .FILE_NAME)
       PLATFORM_TYPE: $PLATFORM_TYPE
-      TAG_COMMANDS: "git clone ${BUILDKITE_PULL_REQUEST_REPO:-$BUILDKITE_REPO} eos && cd eos && $GIT_FETCH git checkout -f $BUILDKITE_COMMIT && git submodule update --init --recursive && export IMAGE_TAG=$(echo "$PLATFORM_JSON" | jq -r .FILE_NAME) && export PLATFORM_TYPE=$PLATFORM_TYPE && . ./.cicd/platforms/$PLATFORM_TYPE/$(echo "$PLATFORM_JSON" | jq -r .FILE_NAME).sh && cd ~/eos && cd .. && rm -rf eos"
+      TAG_COMMANDS: "git clone ${BUILDKITE_PULL_REQUEST_REPO:-$BUILDKITE_REPO} eos && cd eos && $GIT_FETCH git checkout -f \$BUILDKITE_COMMIT && git submodule update --init --recursive && export IMAGE_TAG=$(echo "$PLATFORM_JSON" | jq -r .FILE_NAME) && export PLATFORM_TYPE=$PLATFORM_TYPE && . ./.cicd/platforms/$PLATFORM_TYPE/$(echo "$PLATFORM_JSON" | jq -r .FILE_NAME).sh && cd ~/eos && cd .. && rm -rf eos"
       PROJECT_TAG: $(echo "$PLATFORM_JSON" | jq -r .HASHED_IMAGE_TAG)
     timeout: ${TIMEOUT:-180}
     agents: "queue=mac-anka-large-node-fleet"

--- a/.cicd/platforms/pinned/macos-10.14-pinned.sh
+++ b/.cicd/platforms/pinned/macos-10.14-pinned.sh
@@ -59,11 +59,13 @@ sudo make install
 cd ../..
 rm -rf llvm
 # install boost from source
+## Boost Fix: eosio/install/bin/../include/c++/v1/stdlib.h:94:15: fatal error: 'stdlib.h' file not found
+export SDKROOT="$(xcrun --sdk macosx --show-sdk-path)"
 curl -LO https://dl.bintray.com/boostorg/release/1.70.0/source/boost_1_70_0.tar.bz2
 tar -xjf boost_1_70_0.tar.bz2
 cd boost_1_70_0
 ./bootstrap.sh --prefix=/usr/local
-sudo ./b2 --with-iostreams --with-date_time --with-filesystem --with-system --with-program_options --with-chrono --with-test -q -j$(getconf _NPROCESSORS_ONLN) install
+sudo SDKROOT="$SDKROOT" ./b2 --with-iostreams --with-date_time --with-filesystem --with-system --with-program_options --with-chrono --with-test -q -j$(getconf _NPROCESSORS_ONLN) install
 cd ..
 sudo rm -rf boost_1_70_0.tar.bz2 boost_1_70_0  
 # install mongoDB

--- a/.cicd/platforms/unpinned/macos-10.14-unpinned.sh
+++ b/.cicd/platforms/unpinned/macos-10.14-unpinned.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -eo pipefail
-VERSION=1
+VERSION=2
 brew update
 brew install git cmake python@2 python libtool libusb graphviz automake wget gmp pkgconfig doxygen openssl@1.1 jq boost || :
 # install llvm 4 from source

--- a/.cicd/platforms/unpinned/macos-10.14-unpinned.sh
+++ b/.cicd/platforms/unpinned/macos-10.14-unpinned.sh
@@ -5,6 +5,7 @@ brew update
 brew install git cmake python@2 python libtool libusb graphviz automake wget gmp pkgconfig doxygen openssl@1.1 jq boost || :
 # install llvm 4 from source
 git clone --depth 1 --single-branch --branch release_40 https://github.com/llvm-mirror/llvm.git llvm
+[[ ! -d llvm ]] && echo "something is wrong" && exit 1
 cd llvm
 mkdir build
 cd build

--- a/.cicd/platforms/unpinned/macos-10.14-unpinned.sh
+++ b/.cicd/platforms/unpinned/macos-10.14-unpinned.sh
@@ -3,18 +3,19 @@ set -eo pipefail
 VERSION=1
 brew update
 brew install git cmake python@2 python libtool libusb graphviz automake wget gmp pkgconfig doxygen openssl@1.1 jq boost || :
-# install llvm 4 from source
-git clone --depth 1 --single-branch --branch release_40 https://github.com/llvm-mirror/llvm.git llvm
-[[ ! -d llvm ]] && echo "something is wrong" && exit 1
-cd llvm
-mkdir build
-cd build
-cmake -G 'Unix Makefiles' -DCMAKE_INSTALL_PREFIX='/usr/local' -DLLVM_TARGETS_TO_BUILD='host' -DLLVM_BUILD_TOOLS=false -DLLVM_ENABLE_RTTI=1 -DCMAKE_BUILD_TYPE=Release ..
-make -j $(getconf _NPROCESSORS_ONLN)
-sudo make install
-cd ../..
+echo "install llvm 4 from source..."
+git clone --depth 1 --single-branch --branch release_40 https://github.com/llvm-mirror/llvm.git llvm && \
+cd llvm && \
+mkdir -p build && \
+cd build && \
+cmake -G 'Unix Makefiles' -DCMAKE_INSTALL_PREFIX='/usr/local' -DLLVM_TARGETS_TO_BUILD='host' -DLLVM_BUILD_TOOLS=false -DLLVM_ENABLE_RTTI=1 -DCMAKE_BUILD_TYPE=Release .. && \
+make -j $(getconf _NPROCESSORS_ONLN) && \
+sudo make install && \
+cd ../.. && \
 rm -rf llvm
-# install mongoDB
+
+exit 1
+echo "Installing mongodb..."
 cd ~
 curl -OL https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-3.6.3.tgz
 tar -xzf mongodb-osx-ssl-x86_64-3.6.3.tgz

--- a/.cicd/platforms/unpinned/macos-10.14-unpinned.sh
+++ b/.cicd/platforms/unpinned/macos-10.14-unpinned.sh
@@ -3,19 +3,17 @@ set -eo pipefail
 VERSION=1
 brew update
 brew install git cmake python@2 python libtool libusb graphviz automake wget gmp pkgconfig doxygen openssl@1.1 jq boost || :
-echo "install llvm 4 from source..."
-git clone --depth 1 --single-branch --branch release_40 https://github.com/llvm-mirror/llvm.git llvm && \
-cd llvm && \
-mkdir -p build && \
-cd build && \
-cmake -G 'Unix Makefiles' -DCMAKE_INSTALL_PREFIX='/usr/local' -DLLVM_TARGETS_TO_BUILD='host' -DLLVM_BUILD_TOOLS=false -DLLVM_ENABLE_RTTI=1 -DCMAKE_BUILD_TYPE=Release .. && \
-make -j $(getconf _NPROCESSORS_ONLN) && \
-sudo make install && \
-cd ../.. && \
+# install llvm 4 from source
+git clone --depth 1 --single-branch --branch release_40 https://github.com/llvm-mirror/llvm.git llvm
+cd llvm
+mkdir build
+cd build
+cmake -G 'Unix Makefiles' -DCMAKE_INSTALL_PREFIX='/usr/local' -DLLVM_TARGETS_TO_BUILD='host' -DLLVM_BUILD_TOOLS=false -DLLVM_ENABLE_RTTI=1 -DCMAKE_BUILD_TYPE=Release ..
+make -j $(getconf _NPROCESSORS_ONLN)
+sudo make install
+cd ../..
 rm -rf llvm
-
-exit 1
-echo "Installing mongodb..."
+# install mongoDB
 cd ~
 curl -OL https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-3.6.3.tgz
 tar -xzf mongodb-osx-ssl-x86_64-3.6.3.tgz


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

Problem: A networking init limitation in the anka software forces us to sleep before commands to wait for it to initialize fully. Using an integer for the seconds we need to sleep is not flexible enough.

Solution: Use a while loop with ping (in anka buildkite plugin v0.5.7) to sleep as long as we need to, until the ping gets a response.

Problem 2: Boost refuses to install without SDKROOT set SDKROOT="$(xcrun --sdk macosx --show-sdk-path)". Our CI/CD dep script doesn't set it, so it fails to build the tag.

Solution: Added the necessary SDKROOT env

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
