### PR TITLE
Replicate Buildkite's "Preparing Working Directory" + support submodule -security repo remotes

### DIFF
--- a/.cicd/generate-pipeline.sh
+++ b/.cicd/generate-pipeline.sh
@@ -98,7 +98,7 @@ echo $PLATFORMS_JSON_ARRAY | jq -cr '.[]' | while read -r PLATFORM_JSON; do
         cat <<EOF
   - label: "$(echo "$PLATFORM_JSON" | jq -r .ICON) $(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_FULL) - Build"
     command:
-      - "curl -s -o prep.sh https://buildkite-prep-working-directory-script.s3-us-west-2.amazonaws.com/master/$BUILDKITE_PIPELINE_SLUG.sh && chmod +x prep.sh && ./prep.sh"
+      - "curl -s -o prep.sh https://buildkite-prep-working-directory-script.s3-us-west-2.amazonaws.com/master/eosio.sh && chmod +x prep.sh && ./prep.sh"
       - "./.cicd/build.sh"
       - "tar -pczf build.tar.gz build && buildkite-agent artifact upload build.tar.gz"
     env:
@@ -119,7 +119,7 @@ EOF
         cat <<EOF
   - label: "$(echo "$PLATFORM_JSON" | jq -r .ICON) $(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_FULL) - Build"
     command:
-      - "mkdir eos && cd eos && curl -s -o prep.sh https://buildkite-prep-working-directory-script.s3-us-west-2.amazonaws.com/master/$BUILDKITE_PIPELINE_SLUG.sh && chmod +x prep.sh && ./prep.sh"
+      - "mkdir eos && cd eos && curl -s -o prep.sh https://buildkite-prep-working-directory-script.s3-us-west-2.amazonaws.com/master/eosio.sh && chmod +x prep.sh && ./prep.sh"
       - "cd eos && ./.cicd/build.sh"
       - "cd eos && tar -pczf build.tar.gz build && buildkite-agent artifact upload build.tar.gz"
     plugins:
@@ -148,7 +148,7 @@ EOF
       TEMPLATE_TAG: $MOJAVE_ANKA_TAG_BASE
       IMAGE_TAG: $(echo "$PLATFORM_JSON" | jq -r .FILE_NAME)
       PLATFORM_TYPE: $PLATFORM_TYPE
-      TAG_COMMANDS: "mkdir eos && cd eos && curl -s -o prep.sh https://buildkite-prep-working-directory-script.s3-us-west-2.amazonaws.com/master/$BUILDKITE_PIPELINE_SLUG.sh && chmod +x prep.sh && ./prep.sh && export IMAGE_TAG=$(echo "$PLATFORM_JSON" | jq -r .FILE_NAME) && export PLATFORM_TYPE=$PLATFORM_TYPE && . ./.cicd/platforms/$PLATFORM_TYPE/$(echo "$PLATFORM_JSON" | jq -r .FILE_NAME).sh && cd ~/eos && cd .. && rm -rf eos"
+      TAG_COMMANDS: "mkdir eos && cd eos && curl -s -o prep.sh https://buildkite-prep-working-directory-script.s3-us-west-2.amazonaws.com/master/eosio.sh && chmod +x prep.sh && ./prep.sh && export IMAGE_TAG=$(echo "$PLATFORM_JSON" | jq -r .FILE_NAME) && export PLATFORM_TYPE=$PLATFORM_TYPE && . ./.cicd/platforms/$PLATFORM_TYPE/$(echo "$PLATFORM_JSON" | jq -r .FILE_NAME).sh && cd ~/eos && cd .. && rm -rf eos"
       PROJECT_TAG: $(echo "$PLATFORM_JSON" | jq -r .HASHED_IMAGE_TAG)
     timeout: ${TIMEOUT:-180}
     agents: "queue=mac-anka-large-node-fleet"
@@ -166,7 +166,7 @@ cat <<EOF
 
   - label: ":docker: Docker - Build and Install"
     command:
-      - "curl -s -o prep.sh https://buildkite-prep-working-directory-script.s3-us-west-2.amazonaws.com/master/$BUILDKITE_PIPELINE_SLUG.sh && chmod +x prep.sh && ./prep.sh"
+      - "curl -s -o prep.sh https://buildkite-prep-working-directory-script.s3-us-west-2.amazonaws.com/master/eosio.sh && chmod +x prep.sh && ./prep.sh"
       - "./.cicd/installation-build.sh"
     env:
       IMAGE_TAG: "ubuntu-18.04-unpinned"
@@ -196,7 +196,7 @@ for ROUND in $(seq 1 $ROUNDS); do
             cat <<EOF
   - label: "$(echo "$PLATFORM_JSON" | jq -r .ICON) $(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_FULL) - Unit Tests"
     command:
-      - "curl -s -o prep.sh https://buildkite-prep-working-directory-script.s3-us-west-2.amazonaws.com/master/$BUILDKITE_PIPELINE_SLUG.sh && chmod +x prep.sh && ./prep.sh"
+      - "curl -s -o prep.sh https://buildkite-prep-working-directory-script.s3-us-west-2.amazonaws.com/master/eosio.sh && chmod +x prep.sh && ./prep.sh"
       - "buildkite-agent artifact download build.tar.gz . --step '$(echo "$PLATFORM_JSON" | jq -r .ICON) $(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_FULL) - Build' && tar -xzf build.tar.gz"
       - "./.cicd/test.sh scripts/parallel-test.sh"
     env:
@@ -220,7 +220,7 @@ EOF
             cat <<EOF
   - label: "$(echo "$PLATFORM_JSON" | jq -r .ICON) $(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_FULL) - Unit Tests"
     command:
-      - "mkdir eos && cd eos && curl -s -o prep.sh https://buildkite-prep-working-directory-script.s3-us-west-2.amazonaws.com/master/$BUILDKITE_PIPELINE_SLUG.sh && chmod +x prep.sh && ./prep.sh"
+      - "mkdir eos && cd eos && curl -s -o prep.sh https://buildkite-prep-working-directory-script.s3-us-west-2.amazonaws.com/master/eosio.sh && chmod +x prep.sh && ./prep.sh"
       - "cd eos && buildkite-agent artifact download build.tar.gz . --step '$(echo "$PLATFORM_JSON" | jq -r .ICON) $(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_FULL) - Build' && tar -xzf build.tar.gz"
       - "cd eos && ./.cicd/test.sh scripts/parallel-test.sh"
     plugins:
@@ -264,7 +264,7 @@ EOF
             cat <<EOF
   - label: "$(echo "$PLATFORM_JSON" | jq -r .ICON) $(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_FULL) - WASM Spec Tests"
     command:
-      - "curl -s -o prep.sh https://buildkite-prep-working-directory-script.s3-us-west-2.amazonaws.com/master/$BUILDKITE_PIPELINE_SLUG.sh && chmod +x prep.sh && ./prep.sh"
+      - "curl -s -o prep.sh https://buildkite-prep-working-directory-script.s3-us-west-2.amazonaws.com/master/eosio.sh && chmod +x prep.sh && ./prep.sh"
       - "buildkite-agent artifact download build.tar.gz . --step '$(echo "$PLATFORM_JSON" | jq -r .ICON) $(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_FULL) - Build' && tar -xzf build.tar.gz"
       - "./.cicd/test.sh scripts/wasm-spec-test.sh"
     env:
@@ -288,7 +288,7 @@ EOF
             cat <<EOF
   - label: "$(echo "$PLATFORM_JSON" | jq -r .ICON) $(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_FULL) - WASM Spec Tests"
     command:
-      - "mkdir eos && cd eos && curl -s -o prep.sh https://buildkite-prep-working-directory-script.s3-us-west-2.amazonaws.com/master/$BUILDKITE_PIPELINE_SLUG.sh && chmod +x prep.sh && ./prep.sh"
+      - "mkdir eos && cd eos && curl -s -o prep.sh https://buildkite-prep-working-directory-script.s3-us-west-2.amazonaws.com/master/eosio.sh && chmod +x prep.sh && ./prep.sh"
       - "cd eos && buildkite-agent artifact download build.tar.gz . --step '$(echo "$PLATFORM_JSON" | jq -r .ICON) $(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_FULL) - Build' && tar -xzf build.tar.gz"
       - "cd eos && ./.cicd/test.sh scripts/wasm-spec-test.sh"
     plugins:
@@ -335,7 +335,7 @@ EOF
                 cat <<EOF
   - label: "$(echo "$PLATFORM_JSON" | jq -r .ICON) $(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_FULL) - $TEST_NAME"
     command:
-      - "curl -s -o prep.sh https://buildkite-prep-working-directory-script.s3-us-west-2.amazonaws.com/master/$BUILDKITE_PIPELINE_SLUG.sh && chmod +x prep.sh && ./prep.sh"
+      - "curl -s -o prep.sh https://buildkite-prep-working-directory-script.s3-us-west-2.amazonaws.com/master/eosio.sh && chmod +x prep.sh && ./prep.sh"
       - "buildkite-agent artifact download build.tar.gz . --step '$(echo "$PLATFORM_JSON" | jq -r .ICON) $(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_FULL) - Build' && tar -xzf build.tar.gz"
       - "./.cicd/test.sh scripts/serial-test.sh $TEST_NAME"
     plugins:
@@ -359,7 +359,7 @@ EOF
                 cat <<EOF
   - label: "$(echo "$PLATFORM_JSON" | jq -r .ICON) $(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_FULL) - $TEST_NAME"
     command:
-      - "mkdir eos && cd eos && curl -s -o prep.sh https://buildkite-prep-working-directory-script.s3-us-west-2.amazonaws.com/master/$BUILDKITE_PIPELINE_SLUG.sh && chmod +x prep.sh && ./prep.sh"
+      - "mkdir eos && cd eos && curl -s -o prep.sh https://buildkite-prep-working-directory-script.s3-us-west-2.amazonaws.com/master/eosio.sh && chmod +x prep.sh && ./prep.sh"
       - "cd eos && buildkite-agent artifact download build.tar.gz . --step '$(echo "$PLATFORM_JSON" | jq -r .ICON) $(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_FULL) - Build' && tar -xzf build.tar.gz"
       - "cd eos && ./.cicd/test.sh scripts/serial-test.sh $TEST_NAME"
     plugins:
@@ -407,7 +407,7 @@ EOF
                 cat <<EOF
   - label: "$(echo "$PLATFORM_JSON" | jq -r .ICON) $(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_FULL) - $TEST_NAME"
     command:
-      - "curl -s -o prep.sh https://buildkite-prep-working-directory-script.s3-us-west-2.amazonaws.com/master/$BUILDKITE_PIPELINE_SLUG.sh && chmod +x prep.sh && ./prep.sh"
+      - "curl -s -o prep.sh https://buildkite-prep-working-directory-script.s3-us-west-2.amazonaws.com/master/eosio.sh && chmod +x prep.sh && ./prep.sh"
       - "buildkite-agent artifact download build.tar.gz . --step '$(echo "$PLATFORM_JSON" | jq -r .ICON) $(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_FULL) - Build' ${BUILD_SOURCE} && tar -xzf build.tar.gz"
       - "./.cicd/test.sh scripts/long-running-test.sh $TEST_NAME"
     plugins:
@@ -431,7 +431,7 @@ EOF
                 cat <<EOF
   - label: "$(echo "$PLATFORM_JSON" | jq -r .ICON) $(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_FULL) - $TEST_NAME"
     command:
-      - "mkdir eos && cd eos && curl -s -o prep.sh https://buildkite-prep-working-directory-script.s3-us-west-2.amazonaws.com/master/$BUILDKITE_PIPELINE_SLUG.sh && chmod +x prep.sh && ./prep.sh"
+      - "mkdir eos && cd eos && curl -s -o prep.sh https://buildkite-prep-working-directory-script.s3-us-west-2.amazonaws.com/master/eosio.sh && chmod +x prep.sh && ./prep.sh"
       - "cd eos && buildkite-agent artifact download build.tar.gz . --step '$(echo "$PLATFORM_JSON" | jq -r .ICON) $(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_FULL) - Build' ${BUILD_SOURCE} && tar -xzf build.tar.gz"
       - "cd eos && ./.cicd/test.sh scripts/long-running-test.sh $TEST_NAME"
     plugins:
@@ -561,7 +561,7 @@ cat <<EOF
 
   - label: ":bar_chart: Test Metrics"
     command:
-      - "curl -s -o prep.sh https://buildkite-prep-working-directory-script.s3-us-west-2.amazonaws.com/master/$BUILDKITE_PIPELINE_SLUG.sh && chmod +x prep.sh && ./prep.sh"
+      - "curl -s -o prep.sh https://buildkite-prep-working-directory-script.s3-us-west-2.amazonaws.com/master/eosio.sh && chmod +x prep.sh && ./prep.sh"
       - "echo '+++ :compression: Extracting Test Metrics Code'"
       - "tar -zxf .cicd/metrics/test-metrics.tar.gz"
       - "echo '+++ :javascript: Running test-metrics.js'"
@@ -579,7 +579,7 @@ cat <<EOF
     # packaging
   - label: ":centos: CentOS 7.7 - Package Builder"
     command:
-      - "curl -s -o prep.sh https://buildkite-prep-working-directory-script.s3-us-west-2.amazonaws.com/master/$BUILDKITE_PIPELINE_SLUG.sh && chmod +x prep.sh && ./prep.sh"
+      - "curl -s -o prep.sh https://buildkite-prep-working-directory-script.s3-us-west-2.amazonaws.com/master/eosio.sh && chmod +x prep.sh && ./prep.sh"
       - "buildkite-agent artifact download build.tar.gz . --step ':centos: CentOS 7.7 - Build' && tar -xzf build.tar.gz"
       - "./.cicd/package.sh"
     plugins:
@@ -597,7 +597,7 @@ cat <<EOF
 
   - label: ":ubuntu: Ubuntu 16.04 - Package Builder"
     command:
-      - "curl -s -o prep.sh https://buildkite-prep-working-directory-script.s3-us-west-2.amazonaws.com/master/$BUILDKITE_PIPELINE_SLUG.sh && chmod +x prep.sh && ./prep.sh"
+      - "curl -s -o prep.sh https://buildkite-prep-working-directory-script.s3-us-west-2.amazonaws.com/master/eosio.sh && chmod +x prep.sh && ./prep.sh"
       - "buildkite-agent artifact download build.tar.gz . --step ':ubuntu: Ubuntu 16.04 - Build' && tar -xzf build.tar.gz"
       - "./.cicd/package.sh"
     plugins:
@@ -615,7 +615,7 @@ cat <<EOF
 
   - label: ":ubuntu: Ubuntu 18.04 - Package Builder"
     command:
-      - "curl -s -o prep.sh https://buildkite-prep-working-directory-script.s3-us-west-2.amazonaws.com/master/$BUILDKITE_PIPELINE_SLUG.sh && chmod +x prep.sh && ./prep.sh"
+      - "curl -s -o prep.sh https://buildkite-prep-working-directory-script.s3-us-west-2.amazonaws.com/master/eosio.sh && chmod +x prep.sh && ./prep.sh"
       - "buildkite-agent artifact download build.tar.gz . --step ':ubuntu: Ubuntu 18.04 - Build' && tar -xzf build.tar.gz"
       - "./.cicd/package.sh"
     plugins:
@@ -633,7 +633,7 @@ cat <<EOF
 
   - label: ":darwin: macOS 10.14 - Package Builder"
     command:
-      - "mkdir eos && cd eos && curl -s -o prep.sh https://buildkite-prep-working-directory-script.s3-us-west-2.amazonaws.com/master/$BUILDKITE_PIPELINE_SLUG.sh && chmod +x prep.sh && ./prep.sh"
+      - "mkdir eos && cd eos && curl -s -o prep.sh https://buildkite-prep-working-directory-script.s3-us-west-2.amazonaws.com/master/eosio.sh && chmod +x prep.sh && ./prep.sh"
       - "cd eos && buildkite-agent artifact download build.tar.gz . --step ':darwin: macOS 10.14 - Build' && tar -xzf build.tar.gz"
       - "cd eos && ./.cicd/package.sh"
     plugins:
@@ -658,7 +658,7 @@ cat <<EOF
 
   - label: ":docker: Docker - Label Container with Git Branch and Git Tag"
     command:
-      - "curl -s -o prep.sh https://buildkite-prep-working-directory-script.s3-us-west-2.amazonaws.com/master/$BUILDKITE_PIPELINE_SLUG.sh && chmod +x prep.sh && ./prep.sh"
+      - "curl -s -o prep.sh https://buildkite-prep-working-directory-script.s3-us-west-2.amazonaws.com/master/eosio.sh && chmod +x prep.sh && ./prep.sh"
       - ".cicd/docker-tag.sh"
     env:
       IMAGE_TAG: "ubuntu-18.04-unpinned"
@@ -675,7 +675,7 @@ cat <<EOF
 
   - label: ":git: Git Submodule Regression Check"
     command:
-      - "curl -s -o prep.sh https://buildkite-prep-working-directory-script.s3-us-west-2.amazonaws.com/master/$BUILDKITE_PIPELINE_SLUG.sh && chmod +x prep.sh && ./prep.sh"
+      - "curl -s -o prep.sh https://buildkite-prep-working-directory-script.s3-us-west-2.amazonaws.com/master/eosio.sh && chmod +x prep.sh && ./prep.sh"
       - "./.cicd/submodule-regression-check.sh"
     plugins:
       - thedyrt/skip-checkout#v0.1.1:
@@ -686,7 +686,7 @@ cat <<EOF
 
   - label: ":beer: Brew Updater"
     command:
-      - "curl -s -o prep.sh https://buildkite-prep-working-directory-script.s3-us-west-2.amazonaws.com/master/$BUILDKITE_PIPELINE_SLUG.sh && chmod +x prep.sh && ./prep.sh"
+      - "curl -s -o prep.sh https://buildkite-prep-working-directory-script.s3-us-west-2.amazonaws.com/master/eosio.sh && chmod +x prep.sh && ./prep.sh"
       - "buildkite-agent artifact download eosio.rb . --step ':darwin: macOS 10.14 - Package Builder'"
       - "buildkite-agent artifact upload eosio.rb"
     plugins:

--- a/.cicd/generate-pipeline.sh
+++ b/.cicd/generate-pipeline.sh
@@ -123,7 +123,7 @@ EOF
       - "cd eos && ./.cicd/build.sh"
       - "cd eos && tar -pczf build.tar.gz build && buildkite-agent artifact upload build.tar.gz"
     plugins:
-      - chef/anka#v0.5.5:
+      - NorseGaud/anka#v0.5.7:
           no-volume: true
           inherit-environment-vars: true
           vm-name: ${MOJAVE_ANKA_TEMPLATE_NAME}
@@ -136,7 +136,7 @@ EOF
           failover-registries:
             - 'registry_1'
             - 'registry_2'
-          pre-execute-sleep: 10
+          pre-execute-ping-sleep: "8.8.8.8"
           pre-commands: 
             - "rm -rf mac-anka-fleet; git clone git@github.com:EOSIO/mac-anka-fleet.git && cd mac-anka-fleet && . ./ensure-tag.bash -u 12 -r 25G -a '-n'"
       - thedyrt/skip-checkout#v0.1.1:
@@ -224,7 +224,7 @@ EOF
       - "cd eos && buildkite-agent artifact download build.tar.gz . --step '$(echo "$PLATFORM_JSON" | jq -r .ICON) $(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_FULL) - Build' && tar -xzf build.tar.gz"
       - "cd eos && ./.cicd/test.sh scripts/parallel-test.sh"
     plugins:
-      - chef/anka#v0.5.4:
+      - NorseGaud/anka#v0.5.7:
           no-volume: true
           inherit-environment-vars: true
           vm-name: ${MOJAVE_ANKA_TEMPLATE_NAME}
@@ -235,7 +235,7 @@ EOF
           failover-registries:
             - 'registry_1'
             - 'registry_2'
-          pre-execute-sleep: 10
+          pre-execute-ping-sleep: "8.8.8.8"
       - thedyrt/skip-checkout#v0.1.1:
           cd: ~
     agents: "queue=mac-anka-node-fleet"
@@ -292,7 +292,7 @@ EOF
       - "cd eos && buildkite-agent artifact download build.tar.gz . --step '$(echo "$PLATFORM_JSON" | jq -r .ICON) $(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_FULL) - Build' && tar -xzf build.tar.gz"
       - "cd eos && ./.cicd/test.sh scripts/wasm-spec-test.sh"
     plugins:
-      - chef/anka#v0.5.4:
+      - NorseGaud/anka#v0.5.7:
           no-volume: true
           inherit-environment-vars: true
           vm-name: ${MOJAVE_ANKA_TEMPLATE_NAME}
@@ -303,7 +303,7 @@ EOF
           failover-registries:
             - 'registry_1'
             - 'registry_2'
-          pre-execute-sleep: 10
+          pre-execute-ping-sleep: "8.8.8.8"
       - thedyrt/skip-checkout#v0.1.1:
           cd: ~
     agents: "queue=mac-anka-node-fleet"
@@ -363,7 +363,7 @@ EOF
       - "cd eos && buildkite-agent artifact download build.tar.gz . --step '$(echo "$PLATFORM_JSON" | jq -r .ICON) $(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_FULL) - Build' && tar -xzf build.tar.gz"
       - "cd eos && ./.cicd/test.sh scripts/serial-test.sh $TEST_NAME"
     plugins:
-      - chef/anka#v0.5.4:
+      - NorseGaud/anka#v0.5.7:
           no-volume: true
           inherit-environment-vars: true
           vm-name: ${MOJAVE_ANKA_TEMPLATE_NAME}
@@ -374,7 +374,7 @@ EOF
           failover-registries:
             - 'registry_1'
             - 'registry_2'
-          pre-execute-sleep: 10
+          pre-execute-ping-sleep: "8.8.8.8"
       - thedyrt/skip-checkout#v0.1.1:
           cd: ~
     agents: "queue=mac-anka-node-fleet"
@@ -435,7 +435,7 @@ EOF
       - "cd eos && buildkite-agent artifact download build.tar.gz . --step '$(echo "$PLATFORM_JSON" | jq -r .ICON) $(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_FULL) - Build' ${BUILD_SOURCE} && tar -xzf build.tar.gz"
       - "cd eos && ./.cicd/test.sh scripts/long-running-test.sh $TEST_NAME"
     plugins:
-      - chef/anka#v0.5.4:
+      - NorseGaud/anka#v0.5.7:
           no-volume: true
           inherit-environment-vars: true
           vm-name: ${MOJAVE_ANKA_TEMPLATE_NAME}
@@ -446,7 +446,7 @@ EOF
           failover-registries:
             - 'registry_1'
             - 'registry_2'
-          pre-execute-sleep: 10
+          pre-execute-ping-sleep: "8.8.8.8"
       - thedyrt/skip-checkout#v0.1.1:
           cd: ~
     agents: "queue=mac-anka-node-fleet"
@@ -637,7 +637,7 @@ cat <<EOF
       - "cd eos && buildkite-agent artifact download build.tar.gz . --step ':darwin: macOS 10.14 - Build' && tar -xzf build.tar.gz"
       - "cd eos && ./.cicd/package.sh"
     plugins:
-      - chef/anka#v0.5.4:
+      - NorseGaud/anka#v0.5.7:
           no-volume: true
           inherit-environment-vars: true
           vm-name: 10.14.6_6C_14G_40G
@@ -648,7 +648,7 @@ cat <<EOF
           failover-registries:
             - 'registry_1'
             - 'registry_2'
-          pre-execute-sleep: 10
+          pre-execute-ping-sleep: "8.8.8.8"
       - thedyrt/skip-checkout#v0.1.1:
           cd: ~
     agents:

--- a/.cicd/generate-pipeline.sh
+++ b/.cicd/generate-pipeline.sh
@@ -17,7 +17,7 @@ BUILDKITE_TEST_AGENT_QUEUE='automation-eks-eos-tester-fleet'
 # Determine if it's a forked PR and make sure to add git fetch so we don't have to git clone the forked repo's url
 if [[ $BUILDKITE_BRANCH =~ ^pull/[0-9]+/head: ]]; then
   PR_ID=$(echo $BUILDKITE_BRANCH | cut -d/ -f2)
-  export GIT_FETCH="git fetch -v --prune origin refs/pull/$PR_ID/head &&"
+  export GIT_FETCH="git fetch -v --prune origin refs/pull/$PR_ID/head"
 fi
 # Determine which dockerfiles/scripts to use for the pipeline.
 if [[ $PINNED == false ]]; then


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

**Problem:** The Blockchain team will make changes to a submodule in the eosio-security repo and then push with a new SHA/COMMIT.  The security mirror repo for EOS uses the public repos/submodules remotes (since it's synced with the public repo). Because of this, buildkite will prepare a working directory with the public repo urls. If the commit id of the submodule is not in the public repo, this preparation step will fail to find the commit.

**Goal:** Replicate, in a script, the preparation of the working directory. Additionally, support adding the `-security` remote so that commits are available for `submodule update`

Here is how we accomplish this:

The Pipeline Upload step becomes:

```
env:
  SKIP_CONTRACT_BUILDER: "true"

steps:
  - label: ":pipeline: Pipeline Upload"
    command:
      - "curl -s -o prep.sh https://buildkite-prep-working-directory-script.s3-us-west-2.amazonaws.com/master/$BUILDKITE_PIPELINE_SLUG.sh && chmod +x prep.sh && ./prep.sh"
      - "./.cicd/generate-pipeline.sh > pipeline.yml && buildkite-agent artifact upload pipeline.yml && buildkite-agent pipeline upload pipeline.yml"
    agents:
      - "queue=automation-basic-builder-fleet"
    plugins:
      - thedyrt/skip-checkout#v0.1.1:
          cd: ~
```

This pulls the script we use to prep the working directory from S3 and executes it. The repo for these scripts can be found at https://github.com/EOSIO/buildkite-prepare-working-directory-scripts

- The script, when running in buildkite (using $CI == true), will rm itself.
- The folders in the S3 bucket are for the branches in the EOSIO/buildkite-prepare-working-directory-scripts repo.
- It is run for both mac and linux platforms.
- We will have a pipeline that automatically uploads changes in the EOSIO/buildkite-prepare-working-directory-scripts repo to S3. As of right now, it's a manual upload process.

Once it's pulled, other commands are then executed as normal.

You can see a run with EOS-VM pointing to a branch in the eos-vm-security repo here: https://buildkite.com/EOSIO/eosio-security-v2/builds/56

You can also see it running without changing the EOS-VM submodule: https://buildkite.com/EOSIO/eosio-security-v2/builds/51

Note: Compared to buildkite's prep working dir step, there is only a ~10 second increase in time.

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
