### PR TITLE
Enhance 'connections' API.

### DIFF
--- a/libraries/chain/include/eosio/chain/exceptions.hpp
+++ b/libraries/chain/include/eosio/chain/exceptions.hpp
@@ -568,7 +568,7 @@ namespace eosio { namespace chain {
       FC_DECLARE_DERIVED_EXCEPTION( invalid_reversible_blocks_dir,             reversible_blocks_exception,
                                     3180001, "Invalid reversible blocks directory" )
       FC_DECLARE_DERIVED_EXCEPTION( reversible_blocks_backup_dir_exist,          reversible_blocks_exception,
-                                    3180002, "Backup directory for reversible blocks already existg" )
+                                    3180002, "Backup directory for reversible blocks already exists" )
       FC_DECLARE_DERIVED_EXCEPTION( gap_in_reversible_blocks_db,          reversible_blocks_exception,
                                     3180003, "Gap in the reversible blocks database" )
 

--- a/plugins/net_plugin/include/eosio/net_plugin/net_plugin.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/net_plugin.hpp
@@ -10,7 +10,10 @@ namespace eosio {
       string            peer;
       bool              connecting = false;
       bool              syncing    = false;
-      handshake_message last_handshake;
+      uint32_t          last_block{0};
+      string            last_status{"never connected"};
+      handshake_message last_handshake_recv;
+      handshake_message last_handshake_sent;
    };
 
    class net_plugin : public appbase::plugin<net_plugin>
@@ -38,4 +41,4 @@ namespace eosio {
 
 }
 
-FC_REFLECT( eosio::connection_status, (peer)(connecting)(syncing)(last_handshake) )
+FC_REFLECT( eosio::connection_status, (peer)(connecting)(syncing)(last_block)(last_status)(last_handshake_recv)(last_handshake_sent) )


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
Add a last block field, last status string, and copy of the outgoing handshake message.
Resolves #8258.

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [x] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->

`last_handshake` field has been renamed to `last_handshake_recv` to better characterize it alongside the new `last_handshake_sent` field.

## Documentation Additions
- [x] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->

Samples of results of `/v1/net/connections` API need to be updated and expanded to include the various common scenarios.