### PR TITLE
llvm 10 support for EOS VM OC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,8 +69,8 @@ if(CMAKE_SIZEOF_VOID_P EQUAL 8 AND NOT WIN32)
       # EOS VM OC requires LLVM, but move the check up here to a central location so that the EosioTester.cmakes
       # can be created with the exact version found
       find_package(LLVM REQUIRED CONFIG)
-      if(LLVM_VERSION_MAJOR VERSION_LESS 7 OR LLVM_VERSION_MAJOR VERSION_GREATER 9)
-	      message(FATAL_ERROR "EOSIO requires an LLVM version 7.0 to 9.0")
+      if(LLVM_VERSION_MAJOR VERSION_LESS 7 OR LLVM_VERSION_MAJOR VERSION_GREATER 10)
+	      message(FATAL_ERROR "EOSIO requires an LLVM version 7.0 to 10.0")
       endif()
    endif()
 endif()

--- a/libraries/chain/webassembly/eos-vm-oc/LLVMEmitIR.cpp
+++ b/libraries/chain/webassembly/eos-vm-oc/LLVMEmitIR.cpp
@@ -874,18 +874,17 @@ namespace LLVMJIT
 		//
 		// Load/store operators
 		//
-#if LLVM_VERSION_MAJOR < 10
-		#define EMIT_LOAD_OP(valueTypeId,name,llvmMemoryType,naturalAlignmentLog2,conversionOp) \
+		#define EMIT_LOAD_OP(valueTypeId,name,llvmMemoryType,naturalAlignmentLog2,conversionOp,alignmentParam) \
 			void valueTypeId##_##name(LoadOrStoreImm<naturalAlignmentLog2> imm) \
 			{ \
 				auto byteIndex = pop(); \
 				auto pointer = coerceByteIndexToPointer(byteIndex,imm.offset,llvmMemoryType); \
 				auto load = irBuilder.CreateLoad(pointer); \
-				load->setAlignment(1); \
+				load->setAlignment(alignmentParam); \
 				load->setVolatile(true); \
 				push(conversionOp(load,asLLVMType(ValueType::valueTypeId))); \
 			}
-		#define EMIT_STORE_OP(valueTypeId,name,llvmMemoryType,naturalAlignmentLog2,conversionOp) \
+		#define EMIT_STORE_OP(valueTypeId,name,llvmMemoryType,naturalAlignmentLog2,conversionOp,alignmentParam) \
 			void valueTypeId##_##name(LoadOrStoreImm<naturalAlignmentLog2> imm) \
 			{ \
 				auto value = pop(); \
@@ -894,47 +893,31 @@ namespace LLVMJIT
 				auto memoryValue = conversionOp(value,llvmMemoryType); \
 				auto store = irBuilder.CreateStore(memoryValue,pointer); \
 				store->setVolatile(true); \
-				store->setAlignment(1); \
+				store->setAlignment(alignmentParam); \
 			}
-#else
-		#define EMIT_LOAD_OP(valueTypeId,name,llvmMemoryType,naturalAlignmentLog2,conversionOp) \
-			void valueTypeId##_##name(LoadOrStoreImm<naturalAlignmentLog2> imm) \
-			{ \
-				auto byteIndex = pop(); \
-				auto pointer = coerceByteIndexToPointer(byteIndex,imm.offset,llvmMemoryType); \
-				auto load = irBuilder.CreateLoad(pointer); \
-				load->setAlignment(llvm::MaybeAlign(1)); \
-				load->setVolatile(true); \
-				push(conversionOp(load,asLLVMType(ValueType::valueTypeId))); \
-			}
-		#define EMIT_STORE_OP(valueTypeId,name,llvmMemoryType,naturalAlignmentLog2,conversionOp) \
-			void valueTypeId##_##name(LoadOrStoreImm<naturalAlignmentLog2> imm) \
-			{ \
-				auto value = pop(); \
-				auto byteIndex = pop(); \
-				auto pointer = coerceByteIndexToPointer(byteIndex,imm.offset,llvmMemoryType); \
-				auto memoryValue = conversionOp(value,llvmMemoryType); \
-				auto store = irBuilder.CreateStore(memoryValue,pointer); \
-				store->setVolatile(true); \
-				store->setAlignment(llvm::MaybeAlign(1)); \
-			}
-#endif
+
 		llvm::Value* identityConversion(llvm::Value* value,llvm::Type* type) { return value; }
 
-		EMIT_LOAD_OP(i32,load8_s,llvmI8Type,0,irBuilder.CreateSExt)  EMIT_LOAD_OP(i32,load8_u,llvmI8Type,0,irBuilder.CreateZExt)
-		EMIT_LOAD_OP(i32,load16_s,llvmI16Type,1,irBuilder.CreateSExt) EMIT_LOAD_OP(i32,load16_u,llvmI16Type,1,irBuilder.CreateZExt)
-		EMIT_LOAD_OP(i64,load8_s,llvmI8Type,0,irBuilder.CreateSExt)  EMIT_LOAD_OP(i64,load8_u,llvmI8Type,0,irBuilder.CreateZExt)
-		EMIT_LOAD_OP(i64,load16_s,llvmI16Type,1,irBuilder.CreateSExt)  EMIT_LOAD_OP(i64,load16_u,llvmI16Type,1,irBuilder.CreateZExt)
-		EMIT_LOAD_OP(i64,load32_s,llvmI32Type,2,irBuilder.CreateSExt)  EMIT_LOAD_OP(i64,load32_u,llvmI32Type,2,irBuilder.CreateZExt)
+#if LLVM_VERSION_MAJOR < 10
+   #define LOAD_STORE_ALIGNMENT_PARAM 1
+#else
+   #define LOAD_STORE_ALIGNMENT_PARAM llvm::MaybeAlign(1)
+#endif
 
-		EMIT_LOAD_OP(i32,load,llvmI32Type,2,identityConversion) EMIT_LOAD_OP(i64,load,llvmI64Type,3,identityConversion)
-		EMIT_LOAD_OP(f32,load,llvmF32Type,2,identityConversion) EMIT_LOAD_OP(f64,load,llvmF64Type,3,identityConversion)
+		EMIT_LOAD_OP(i32,load8_s,llvmI8Type,0,irBuilder.CreateSExt,LOAD_STORE_ALIGNMENT_PARAM)  EMIT_LOAD_OP(i32,load8_u,llvmI8Type,0,irBuilder.CreateZExt,LOAD_STORE_ALIGNMENT_PARAM)
+		EMIT_LOAD_OP(i32,load16_s,llvmI16Type,1,irBuilder.CreateSExt,LOAD_STORE_ALIGNMENT_PARAM) EMIT_LOAD_OP(i32,load16_u,llvmI16Type,1,irBuilder.CreateZExt,LOAD_STORE_ALIGNMENT_PARAM)
+		EMIT_LOAD_OP(i64,load8_s,llvmI8Type,0,irBuilder.CreateSExt,LOAD_STORE_ALIGNMENT_PARAM)  EMIT_LOAD_OP(i64,load8_u,llvmI8Type,0,irBuilder.CreateZExt,LOAD_STORE_ALIGNMENT_PARAM)
+		EMIT_LOAD_OP(i64,load16_s,llvmI16Type,1,irBuilder.CreateSExt,LOAD_STORE_ALIGNMENT_PARAM)  EMIT_LOAD_OP(i64,load16_u,llvmI16Type,1,irBuilder.CreateZExt,LOAD_STORE_ALIGNMENT_PARAM)
+		EMIT_LOAD_OP(i64,load32_s,llvmI32Type,2,irBuilder.CreateSExt,LOAD_STORE_ALIGNMENT_PARAM)  EMIT_LOAD_OP(i64,load32_u,llvmI32Type,2,irBuilder.CreateZExt,LOAD_STORE_ALIGNMENT_PARAM)
 
-		EMIT_STORE_OP(i32,store8,llvmI8Type,0,irBuilder.CreateTrunc) EMIT_STORE_OP(i64,store8,llvmI8Type,0,irBuilder.CreateTrunc)
-		EMIT_STORE_OP(i32,store16,llvmI16Type,1,irBuilder.CreateTrunc) EMIT_STORE_OP(i64,store16,llvmI16Type,1,irBuilder.CreateTrunc)
-		EMIT_STORE_OP(i32,store,llvmI32Type,2,irBuilder.CreateTrunc) EMIT_STORE_OP(i64,store32,llvmI32Type,2,irBuilder.CreateTrunc)
-		EMIT_STORE_OP(i64,store,llvmI64Type,3,identityConversion)
-		EMIT_STORE_OP(f32,store,llvmF32Type,2,identityConversion) EMIT_STORE_OP(f64,store,llvmF64Type,3,identityConversion)
+		EMIT_LOAD_OP(i32,load,llvmI32Type,2,identityConversion,LOAD_STORE_ALIGNMENT_PARAM) EMIT_LOAD_OP(i64,load,llvmI64Type,3,identityConversion,LOAD_STORE_ALIGNMENT_PARAM)
+		EMIT_LOAD_OP(f32,load,llvmF32Type,2,identityConversion,LOAD_STORE_ALIGNMENT_PARAM) EMIT_LOAD_OP(f64,load,llvmF64Type,3,identityConversion,LOAD_STORE_ALIGNMENT_PARAM)
+
+		EMIT_STORE_OP(i32,store8,llvmI8Type,0,irBuilder.CreateTrunc,LOAD_STORE_ALIGNMENT_PARAM) EMIT_STORE_OP(i64,store8,llvmI8Type,0,irBuilder.CreateTrunc,LOAD_STORE_ALIGNMENT_PARAM)
+		EMIT_STORE_OP(i32,store16,llvmI16Type,1,irBuilder.CreateTrunc,LOAD_STORE_ALIGNMENT_PARAM) EMIT_STORE_OP(i64,store16,llvmI16Type,1,irBuilder.CreateTrunc,LOAD_STORE_ALIGNMENT_PARAM)
+		EMIT_STORE_OP(i32,store,llvmI32Type,2,irBuilder.CreateTrunc,LOAD_STORE_ALIGNMENT_PARAM) EMIT_STORE_OP(i64,store32,llvmI32Type,2,irBuilder.CreateTrunc,LOAD_STORE_ALIGNMENT_PARAM)
+		EMIT_STORE_OP(i64,store,llvmI64Type,3,identityConversion,LOAD_STORE_ALIGNMENT_PARAM)
+		EMIT_STORE_OP(f32,store,llvmF32Type,2,identityConversion,LOAD_STORE_ALIGNMENT_PARAM) EMIT_STORE_OP(f64,store,llvmF64Type,3,identityConversion,LOAD_STORE_ALIGNMENT_PARAM)
 
 		//
 		// Numeric operator macros

--- a/libraries/chain/webassembly/eos-vm-oc/LLVMEmitIR.cpp
+++ b/libraries/chain/webassembly/eos-vm-oc/LLVMEmitIR.cpp
@@ -874,7 +874,7 @@ namespace LLVMJIT
 		//
 		// Load/store operators
 		//
-#if LLVM_VERSION_MAJOR < 9
+#if LLVM_VERSION_MAJOR < 10
 		#define EMIT_LOAD_OP(valueTypeId,name,llvmMemoryType,naturalAlignmentLog2,conversionOp) \
 			void valueTypeId##_##name(LoadOrStoreImm<naturalAlignmentLog2> imm) \
 			{ \

--- a/libraries/chain/webassembly/eos-vm-oc/LLVMJIT.cpp
+++ b/libraries/chain/webassembly/eos-vm-oc/LLVMJIT.cpp
@@ -168,7 +168,7 @@ namespace LLVMJIT
 	struct JITModule
 	{
 		JITModule() {
-			objectLayer = llvm::make_unique<llvm::orc::LegacyRTDyldObjectLinkingLayer>(ES,[this](llvm::orc::VModuleKey K) {
+			objectLayer = std::make_unique<llvm::orc::LegacyRTDyldObjectLinkingLayer>(ES,[this](llvm::orc::VModuleKey K) {
 									return llvm::orc::LegacyRTDyldObjectLinkingLayer::Resources{
 										unitmemorymanager, std::make_shared<llvm::orc::NullResolver>()
 										};
@@ -197,7 +197,7 @@ namespace LLVMJIT
 							  }
 							  );
 			objectLayer->setProcessAllSections(true);
-			compileLayer = llvm::make_unique<CompileLayer>(*objectLayer,llvm::orc::SimpleCompiler(*targetMachine));
+			compileLayer = std::make_unique<CompileLayer>(*objectLayer,llvm::orc::SimpleCompiler(*targetMachine));
 		}
 
 		void compile(llvm::Module* llvmModule);


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
Minor changes to update EOS VM OC to work with LLVM 10. Tested against rc1, passed all tests.

ORCv1, the LLVM API EOS VM OC is using, was expected to be removed in 10 but it has survived. Sounds like almost certain it will be removed for 11 though, so updating to the ORCv2 API will be a requirement soon.

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
