### PR TITLE
[2.0.x] Docker name collision fix

### DIFF
--- a/.cicd/docker-tag.sh
+++ b/.cicd/docker-tag.sh
@@ -3,7 +3,7 @@ set -eo pipefail
 echo '+++ :evergreen_tree: Configuring Environment'
 REPO='eosio/ci-contracts-builder'
 PREFIX='base-ubuntu-18.04'
-IMAGE="$REPO:$PREFIX-$BUILDKITE_COMMIT"
+IMAGE="$REPO:$PREFIX-$BUILDKITE_COMMIT-$PLATFORM_TYPE"
 SANITIZED_BRANCH=$(echo "$BUILDKITE_BRANCH" | tr '/' '_')
 SANITIZED_TAG=$(echo "$BUILDKITE_TAG" | tr '/' '_')
 echo '+++ :arrow_down: Pulling Container'

--- a/.cicd/installation-build.sh
+++ b/.cicd/installation-build.sh
@@ -4,11 +4,13 @@ set -eo pipefail
 export ENABLE_INSTALL=true
 export BRANCH=$(echo $BUILDKITE_BRANCH | sed 's/\//\_/')
 export CONTRACTS_BUILDER_TAG="eosio/ci-contracts-builder:base-ubuntu-18.04"
-export ARGS="--name ci-contracts-builder-$BUILDKITE_COMMIT --init -v $(pwd):$MOUNTED_DIR"
+export ARGS="--name ci-contracts-builder-$BUILDKITE_PIPELINE_SLUG-$BUILDKITE_BUILD_NUMBER --init -v $(pwd):$MOUNTED_DIR"
 $CICD_DIR/build.sh
-docker commit ci-contracts-builder-$BUILDKITE_COMMIT $CONTRACTS_BUILDER_TAG-$BUILDKITE_COMMIT
-docker commit ci-contracts-builder-$BUILDKITE_COMMIT $CONTRACTS_BUILDER_TAG-$BRANCH-$BUILDKITE_COMMIT
+docker commit ci-contracts-builder-$BUILDKITE_PIPELINE_SLUG-$BUILDKITE_BUILD_NUMBER $CONTRACTS_BUILDER_TAG-$BUILDKITE_COMMIT
+docker commit ci-contracts-builder-$BUILDKITE_PIPELINE_SLUG-$BUILDKITE_BUILD_NUMBER $CONTRACTS_BUILDER_TAG-$BUILDKITE_COMMIT-$PLATFORM_TYPE
+docker commit ci-contracts-builder-$BUILDKITE_PIPELINE_SLUG-$BUILDKITE_BUILD_NUMBER $CONTRACTS_BUILDER_TAG-$BRANCH-$BUILDKITE_COMMIT
 docker push $CONTRACTS_BUILDER_TAG-$BUILDKITE_COMMIT
+docker push $CONTRACTS_BUILDER_TAG-$BUILDKITE_COMMIT-$PLATFORM_TYPE
 docker push $CONTRACTS_BUILDER_TAG-$BRANCH-$BUILDKITE_COMMIT
-docker stop ci-contracts-builder-$BUILDKITE_COMMIT
-docker rm ci-contracts-builder-$BUILDKITE_COMMIT
+docker stop ci-contracts-builder-$BUILDKITE_PIPELINE_SLUG-$BUILDKITE_BUILD_NUMBER
+docker rm ci-contracts-builder-$BUILDKITE_PIPELINE_SLUG-$BUILDKITE_BUILD_NUMBER


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
Quick fix for Docker name collision during CICD as seen [here](https://buildkite.com/EOSIO/eosio/builds/20077#8a287463-512f-4696-891f-0d714a249405/116-133). This issue frequently occurred on PR creation due to multiple builds across many pipelines being created at once. We would "luck" out and have this step land on the same builder node:
- Renamed Docker container used to build/install EOS in "Docker - Build and Install" step to be unique: `ci-contracts-builder-$BUILDKITE_PIPELINE_SLUG-$BUILDKITE_BUILD_NUMBER`.
- Allow "Docker - Label Container with Git Branch and Git Tag" step to run on unpinned builds.
- Added new tag pushed to Docker: `$CONTRACTS_BUILDER_TAG-$BUILDKITE_COMMIT-$PLATFORM_TYPE`
- Additional tags applied in "Docker - Label Container with Git Branch and Git Tag" step use the `$CONTRACTS_BUILDER_TAG-$BUILDKITE_COMMIT-$PLATFORM_TYPE` tag.
  - These changes allow us to update these pipeline steps later and have separate sync tests or Contracts build with pinned and unpinned images.
  - No impact made to downstream builds/tests at this time. They still rely on the existing `$CONTRACTS_BUILDER_TAG-$BUILDKITE_COMMIT` tag which is still the same image as before.

See:
[Build #20102](https://buildkite.com/EOSIO/eosio/builds/20102#75f10a4b-775f-46fb-be9a-ec9847a2b00f) and [Build #1191](https://buildkite.com/EOSIO/eosio-build-unpinned/builds/1191#d7dcadd6-c8e1-4778-8c46-12dddf6a5ebd) | This pair of builds performed the "Docker - Build and Install" step on the same builder node at the same time. This shows that the name conflict issue is resolved.
[Build #377](https://buildkite.com/EOSIO/eosio-sync-from-genesis/builds/377) and [Build #228](https://buildkite.com/EOSIO/eosio-resume-from-state/builds/228) | This pair of builds shows the downstream sync tests are not impacted by this change.
[Build #1019](https://buildkite.com/EOSIO/eosio-dot-contracts/builds/1019) | This Contracts build shows no impact by this change.

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
