### PR TITLE
Remove new block id notify feature - develop

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -1520,8 +1520,8 @@ namespace eosio {
 
       if( sync_state == in_sync ) {
          set_state( lib_catchup );
-         sync_next_expected_num = std::max( lib_num + 1, sync_next_expected_num );
       }
+      sync_next_expected_num = std::max( lib_num + 1, sync_next_expected_num );
 
       fc_ilog( logger, "Catching up with chain, our last req is ${cc}, theirs is ${t} peer ${p}",
                ("cc", sync_last_requested_num)( "t", target )( "p", c->peer_name() ) );

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -1921,6 +1921,8 @@ namespace eosio {
    void dispatch_manager::bcast_block(const block_state_ptr& bs) {
       fc_dlog( logger, "bcast block ${b}", ("b", bs->block_num) );
 
+      if( my_impl->sync_master->syncing_with_peer() ) return;
+      
       bool have_connection = false;
       for_each_block_connection( [&have_connection]( auto& cp ) {
          peer_dlog( cp, "socket_is_open ${s}, connecting ${c}, syncing ${ss}",


### PR DESCRIPTION
## Change Description

- Remove new block id notify feature as it doesn't actually improve performance and actually causes issues with large # of connections.
- Since this was the only new net protocol feature added in 2.0, the net protocol version has been reverted to 1.8 .. 1.0 version.
- Do not send blocks when syncing with peer.
- Fix first sync asking for less than lib.

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
