### PR TITLE
[develop] Removed unnecessary sleep option from Anka plugin

### DIFF
--- a/.cicd/build-scripts.yml
+++ b/.cicd/build-scripts.yml
@@ -41,7 +41,7 @@ steps:
           always-pull: true
           wait-network: true
           vm-registry-tag: "clean::cicd::git-ssh::nas::brew::buildkite-agent"
-          pre-execute-ping-sleep: "8.8.8.8"
+          
           failover-registries:
           - "registry_1"
           - "registry_2"
@@ -117,7 +117,7 @@ steps:
           always-pull: true
           wait-network: true
           vm-registry-tag: "clean::cicd::git-ssh::nas::brew::buildkite-agent"
-          pre-execute-ping-sleep: "8.8.8.8"
+          
           failover-registries:
           - "registry_1"
           - "registry_2"

--- a/.cicd/build-scripts.yml
+++ b/.cicd/build-scripts.yml
@@ -41,7 +41,6 @@ steps:
           always-pull: true
           wait-network: true
           vm-registry-tag: "clean::cicd::git-ssh::nas::brew::buildkite-agent"
-          
           failover-registries:
           - "registry_1"
           - "registry_2"
@@ -117,7 +116,6 @@ steps:
           always-pull: true
           wait-network: true
           vm-registry-tag: "clean::cicd::git-ssh::nas::brew::buildkite-agent"
-          
           failover-registries:
           - "registry_1"
           - "registry_2"

--- a/.cicd/generate-pipeline.sh
+++ b/.cicd/generate-pipeline.sh
@@ -133,7 +133,6 @@ EOF
           failover-registries:
             - 'registry_1'
             - 'registry_2'
-          
           pre-commands: 
             - "rm -rf mac-anka-fleet; git clone git@github.com:EOSIO/mac-anka-fleet.git && cd mac-anka-fleet && . ./ensure-tag.bash -u 12 -r 25G -a '-n'"
       - thedyrt/skip-checkout#v0.1.1:
@@ -223,7 +222,6 @@ EOF
           failover-registries:
             - 'registry_1'
             - 'registry_2'
-          
       - thedyrt/skip-checkout#v0.1.1:
           cd: ~
     agents: "queue=mac-anka-node-fleet"
@@ -287,7 +285,6 @@ EOF
           failover-registries:
             - 'registry_1'
             - 'registry_2'
-          
       - thedyrt/skip-checkout#v0.1.1:
           cd: ~
     agents: "queue=mac-anka-node-fleet"
@@ -360,7 +357,6 @@ EOF
           failover-registries:
             - 'registry_1'
             - 'registry_2'
-          
       - thedyrt/skip-checkout#v0.1.1:
           cd: ~
     agents: "queue=mac-anka-node-fleet"
@@ -434,7 +430,6 @@ EOF
           failover-registries:
             - 'registry_1'
             - 'registry_2'
-          
       - thedyrt/skip-checkout#v0.1.1:
           cd: ~
     agents: "queue=mac-anka-node-fleet"
@@ -641,7 +636,6 @@ cat <<EOF
           failover-registries:
             - 'registry_1'
             - 'registry_2'
-          
       - thedyrt/skip-checkout#v0.1.1:
           cd: ~
     agents:

--- a/.cicd/generate-pipeline.sh
+++ b/.cicd/generate-pipeline.sh
@@ -133,7 +133,7 @@ EOF
           failover-registries:
             - 'registry_1'
             - 'registry_2'
-          pre-execute-ping-sleep: "8.8.8.8"
+          
           pre-commands: 
             - "rm -rf mac-anka-fleet; git clone git@github.com:EOSIO/mac-anka-fleet.git && cd mac-anka-fleet && . ./ensure-tag.bash -u 12 -r 25G -a '-n'"
       - thedyrt/skip-checkout#v0.1.1:
@@ -223,7 +223,7 @@ EOF
           failover-registries:
             - 'registry_1'
             - 'registry_2'
-          pre-execute-ping-sleep: "8.8.8.8"
+          
       - thedyrt/skip-checkout#v0.1.1:
           cd: ~
     agents: "queue=mac-anka-node-fleet"
@@ -287,7 +287,7 @@ EOF
           failover-registries:
             - 'registry_1'
             - 'registry_2'
-          pre-execute-ping-sleep: "8.8.8.8"
+          
       - thedyrt/skip-checkout#v0.1.1:
           cd: ~
     agents: "queue=mac-anka-node-fleet"
@@ -360,7 +360,7 @@ EOF
           failover-registries:
             - 'registry_1'
             - 'registry_2'
-          pre-execute-ping-sleep: "8.8.8.8"
+          
       - thedyrt/skip-checkout#v0.1.1:
           cd: ~
     agents: "queue=mac-anka-node-fleet"
@@ -434,7 +434,7 @@ EOF
           failover-registries:
             - 'registry_1'
             - 'registry_2'
-          pre-execute-ping-sleep: "8.8.8.8"
+          
       - thedyrt/skip-checkout#v0.1.1:
           cd: ~
     agents: "queue=mac-anka-node-fleet"
@@ -641,7 +641,7 @@ cat <<EOF
           failover-registries:
             - 'registry_1'
             - 'registry_2'
-          pre-execute-ping-sleep: "8.8.8.8"
+          
       - thedyrt/skip-checkout#v0.1.1:
           cd: ~
     agents:


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

We've upgraded Anka to 2.2.0 and confirmed the new version eliminates the need for the pre-command-ping-sleep.

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
