### PR TITLE
http_plugin shutdown - develop

### DIFF
--- a/plugins/http_plugin/http_plugin.cpp
+++ b/plugins/http_plugin/http_plugin.cpp
@@ -691,6 +691,8 @@ namespace eosio {
       if( my->thread_pool ) {
          my->thread_pool->stop();
       }
+
+      app().post( 0, [me = my](){} ); // keep my pointer alive until queue is drained
    }
 
    void http_plugin::add_handler(const string& url, const url_handler& handler) {

--- a/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
@@ -98,7 +98,7 @@ namespace eosio {
         get_supported_apis_result get_supported_apis()const;
 
       private:
-        std::unique_ptr<class http_plugin_impl> my;
+        std::shared_ptr<class http_plugin_impl> my;
    };
 
    /**


### PR DESCRIPTION
## Change Description

- Keep `http_plugin_impl` alive until all application thread posted jobs finish.
- Resolves #8450

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
