### PR TITLE
Handle socket close before async callback - develop

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -1105,6 +1105,7 @@ namespace eosio {
                if( !c->socket_is_open() || socket != c->socket ) {
                   fc_ilog( logger, "async write socket ${r} before callback: ${p}",
                            ("r", c->socket_is_open() ? "changed" : "closed")("p", c->peer_name()) );
+                  c->close();
                   return;
                }
 


### PR DESCRIPTION
## Change Description

- Clean up internal state when socket closed before async callback otherwise `net_plugin` is confused on re-connect. Specifically, the handshake generation needs to be reset.

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
