### PR TITLE
Read-only with drop-late-block - 1.8

### DIFF
--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -218,7 +218,7 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
       std::set<chain::account_name>                             _producers;
       boost::asio::deadline_timer                               _timer;
       std::map<chain::account_name, uint32_t>                   _producer_watermarks;
-      pending_block_mode                                        _pending_block_mode;
+      pending_block_mode                                        _pending_block_mode = pending_block_mode::speculating;
       transaction_id_with_expiry_index                          _persistent_transactions;
       fc::optional<named_thread_pool>                           _thread_pool;
 


### PR DESCRIPTION
## Change Description

- Fix read-only mode with drop-late-block feature with simplified `on_incoming_block` check

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
