### PR TITLE
Net plugin post - 2.0

### DIFF
--- a/libraries/chain/thread_utils.cpp
+++ b/libraries/chain/thread_utils.cpp
@@ -9,6 +9,7 @@ namespace eosio { namespace chain {
 //
 named_thread_pool::named_thread_pool( std::string name_prefix, size_t num_threads )
 : _thread_pool( num_threads )
+, _ioc( num_threads )
 {
    _ioc_work.emplace( boost::asio::make_work_guard( _ioc ) );
    for( size_t i = 0; i < num_threads; ++i ) {

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -3085,7 +3085,7 @@ namespace eosio {
 
    // called from application thread
    void net_plugin_impl::transaction_ack(const std::pair<fc::exception_ptr, transaction_metadata_ptr>& results) {
-      boost::asio::post( my_impl->thread_pool->get_executor(), [this, results]() {
+      dispatcher->strand.post( [this, results]() {
          const auto& id = results.second->id();
          if (results.first) {
             fc_dlog( logger, "signaled NACK, trx-id = ${id} : ${why}", ("id", id)( "why", results.first->to_detail_string() ) );


### PR DESCRIPTION
## Change Description

- Possible fix for #8542. 
- Provide # threads hint to `boost::asio::io_context` constructor
- Post dispatch calls through dispatcher strand.

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
