### PR TITLE
CPU block effort - 2.0

### DIFF
--- a/libraries/chain/include/eosio/chain/config.hpp
+++ b/libraries/chain/include/eosio/chain/config.hpp
@@ -79,6 +79,7 @@ const static uint32_t   default_max_inline_action_size         = 4 * 1024;   // 
 const static uint16_t   default_max_inline_action_depth        = 4;
 const static uint16_t   default_max_auth_depth                 = 6;
 const static uint32_t   default_sig_cpu_bill_pct               = 50 * percent_1; // billable percentage of signature recovery
+const static uint32_t   default_cpu_duty_cycle_pct             = 80 * percent_1; // percentage of block time used for producing block
 const static uint16_t   default_controller_thread_pool_size    = 2;
 const static uint32_t   default_max_variable_signature_length  = 16384u;
 

--- a/libraries/chain/include/eosio/chain/config.hpp
+++ b/libraries/chain/include/eosio/chain/config.hpp
@@ -79,7 +79,7 @@ const static uint32_t   default_max_inline_action_size         = 4 * 1024;   // 
 const static uint16_t   default_max_inline_action_depth        = 4;
 const static uint16_t   default_max_auth_depth                 = 6;
 const static uint32_t   default_sig_cpu_bill_pct               = 50 * percent_1; // billable percentage of signature recovery
-const static uint32_t   default_cpu_duty_cycle_pct             = 80 * percent_1; // percentage of block time used for producing block
+const static uint32_t   default_block_cpu_effort_pct           = 80 * percent_1; // percentage of block time used for producing block
 const static uint16_t   default_controller_thread_pool_size    = 2;
 const static uint32_t   default_max_variable_signature_length  = 16384u;
 

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1452,8 +1452,8 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block() {
    }
 
    if (_pending_block_mode == pending_block_mode::producing) {
-      const auto current_block_time = block_time - fc::microseconds( config::block_interval_us );
-      const auto next_producer_block_time = calculate_next_block_time( scheduled_producer.producer_name, current_block_time );
+      const auto pending_start_block_time = block_time - fc::microseconds( config::block_interval_us );
+      const auto next_producer_block_time = calculate_next_block_time( scheduled_producer.producer_name, pending_start_block_time );
       if (next_producer_block_time) {
          const auto start_block_time = *next_producer_block_time - fc::microseconds( config::block_interval_us );
          fc_dlog(_log, "Next block #${n} start: ${bt} block time: ${dt}",

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1402,7 +1402,6 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block() {
    const fc::time_point block_time = calculate_pending_block_time();
 
    _pending_block_mode = pending_block_mode::producing;
-   _cpu_duty_cycle_on = true;
 
    // Not our turn
    const auto& scheduled_producer = hbs->get_scheduled_producer(block_time);
@@ -1463,13 +1462,14 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block() {
          fc_dlog(_log, "Next block #${n} start: ${bt} block time: ${dt}",
                  ("n", hbs->block_num + 1)("bt", start_block_time)("dt", *next_producer_block_time));
          if( now < start_block_time && start_block_time < *next_producer_block_time ) {
-            fc_dlog(_log, "Duty cycle off for ${n}", ("n", hbs->block_num + 1) );
+            fc_dlog(_log, "Not producing block, duty cycle off for ${n} ${bt}", ("n", hbs->block_num + 1)("bt", *next_producer_block_time) );
             _cpu_duty_cycle_on = false;
             schedule_delayed_production_loop(weak_from_this(), start_block_time);
             return start_block_result::waiting_for_production;
          }
       }
    }
+   _cpu_duty_cycle_on = true;
 
    fc_dlog(_log, "Starting block #${n} ${bt} at ${time}", ("n", hbs->block_num + 1)("bt", block_time)("time", now));
 

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1452,17 +1452,13 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block() {
    }
 
    if (_pending_block_mode == pending_block_mode::producing) {
-      const auto pending_start_block_time = block_time - fc::microseconds( config::block_interval_us );
-      const auto next_producer_block_time = calculate_next_block_time( scheduled_producer.producer_name, pending_start_block_time );
-      if (next_producer_block_time) {
-         const auto start_block_time = *next_producer_block_time - fc::microseconds( config::block_interval_us );
-         fc_dlog(_log, "Next block #${n} start: ${bt} block time: ${dt}",
-                 ("n", hbs->block_num + 1)("bt", start_block_time)("dt", *next_producer_block_time));
-         if( now < start_block_time && start_block_time < *next_producer_block_time ) {
-            fc_dlog(_log, "Not producing block waiting for production window ${n} ${bt}", ("n", hbs->block_num + 1)("bt", *next_producer_block_time) );
-            schedule_delayed_production_loop(weak_from_this(), start_block_time);
-            return start_block_result::waiting_for_production;
-         }
+      const auto start_block_time = block_time - fc::microseconds( config::block_interval_us );
+      fc_dlog(_log, "Next block #${n} start: ${bt} block time: ${dt}",
+              ("n", hbs->block_num + 1)("bt", start_block_time)("dt", block_time));
+      if( now < start_block_time ) {
+         fc_dlog(_log, "Not producing block waiting for production window ${n} ${bt}", ("n", hbs->block_num + 1)("bt", block_time) );
+         schedule_delayed_production_loop(weak_from_this(), start_block_time);
+         return start_block_result::waiting_for_production;
       }
    }
 

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -245,6 +245,13 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
       // keep a expected ratio between defer txn and incoming txn
       double _incoming_defer_ratio = 1.0; // 1:1
 
+      // amount of block producing window to use for producing a block
+      uint32_t _cpu_duty_cycle_pct = chain::config::default_cpu_duty_cycle_pct;
+      // calculated from cpu_duty_cycle_pct, negative block offset in us
+      fc::microseconds _cpu_duty_cycle_offset_us;
+      // on when producing a block: _pending_block_mode == pending_block_mode::producing && in cpu_duty_cycle_pct
+      bool _cpu_duty_cycle_on = true;
+
       // path to write the snapshots to
       bfs::path _snapshots_dir;
 
@@ -584,7 +591,8 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
       enum class start_block_result {
          succeeded,
          failed,
-         waiting,
+         waiting_for_block,
+         waiting_for_production,
          exhausted
       };
 
@@ -669,6 +677,8 @@ void producer_plugin::set_program_options(
           "ratio between incoming transations and deferred transactions when both are exhausted")
          ("incoming-transaction-queue-size-mb", bpo::value<uint16_t>()->default_value( 1024 ),
           "Maximum size (in MiB) of the incoming transaction queue. Exceeding this value will subjectively drop transaction with resource exhaustion.")
+         ("cpu-duty-cycle-pct", bpo::value<uint32_t>()->default_value(config::default_cpu_duty_cycle_pct / config::percent_1),
+          "Percentage of cpu block production time used to produce block. Whole number percentages, e.g. 80 for 80%")
          ("producer-threads", bpo::value<uint16_t>()->default_value(config::default_controller_thread_pool_size),
           "Number of worker threads in producer thread pool")
          ("snapshots-dir", bpo::value<bfs::path>()->default_value("snapshots"),
@@ -824,6 +834,13 @@ void producer_plugin::plugin_initialize(const boost::program_options::variables_
    my->_pending_incoming_transactions.set_max_incoming_transaction_queue_size( max_incoming_transaction_queue_size );
 
    my->_incoming_defer_ratio = options.at("incoming-defer-ratio").as<double>();
+
+   my->_cpu_duty_cycle_pct = options.at("cpu-duty-cycle-pct").as<uint32_t>();
+   EOS_ASSERT( my->_cpu_duty_cycle_pct >= 0 && my->_cpu_duty_cycle_pct <= 100, plugin_config_exception,
+               "cpu-duty-cycle-pct must be 0 - 100, ${pct}", ("pct", my->_cpu_duty_cycle_pct) );
+   my->_cpu_duty_cycle_pct *= config::percent_1;
+   my->_cpu_duty_cycle_offset_us = fc::microseconds(
+         -EOS_PERCENT( config::block_interval_us, chain::config::percent_100 - my->_cpu_duty_cycle_pct ) );
 
    auto thread_pool_size = options.at( "producer-threads" ).as<uint16_t>();
    EOS_ASSERT( thread_pool_size > 0, plugin_config_exception,
@@ -1356,14 +1373,16 @@ fc::time_point producer_plugin_impl::calculate_pending_block_time() const {
 
 fc::time_point producer_plugin_impl::calculate_block_deadline( const fc::time_point& block_time ) const {
    bool last_block = ((block_timestamp_type(block_time).slot % config::producer_repetitions) == config::producer_repetitions - 1);
-   return block_time + fc::microseconds(last_block ? _last_block_time_offset_us : _produce_time_offset_us);
+   fc::microseconds offset_us( last_block ? _last_block_time_offset_us : _produce_time_offset_us );
+   offset_us = std::min( offset_us, _cpu_duty_cycle_offset_us );
+   return block_time + offset_us;
 }
 
 producer_plugin_impl::start_block_result producer_plugin_impl::start_block() {
    chain::controller& chain = chain_plug->chain();
 
    if( chain.in_immutable_mode() )
-      return start_block_result::waiting;
+      return start_block_result::waiting_for_block;
 
    const auto& hbs = chain.head_block_state();
 
@@ -1373,6 +1392,7 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block() {
    const fc::time_point block_time = calculate_pending_block_time();
 
    _pending_block_mode = pending_block_mode::producing;
+   _cpu_duty_cycle_on = true;
 
    // Not our turn
    const auto& scheduled_producer = hbs->get_scheduled_producer(block_time);
@@ -1422,8 +1442,22 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block() {
    if (_pending_block_mode == pending_block_mode::speculating) {
       auto head_block_age = now - chain.head_block_time();
       if (head_block_age > fc::seconds(5))
-         return start_block_result::waiting;
+         return start_block_result::waiting_for_block;
    }
+
+   if (_pending_block_mode == pending_block_mode::producing) {
+      const auto next_producer_block_time = calculate_next_block_time( scheduled_producer.producer_name, block_time );
+      if (next_producer_block_time) {
+         const auto start_block_time = *next_producer_block_time - fc::microseconds( config::block_interval_us );
+         const fc::time_point deadline = calculate_block_deadline( block_time );
+         if( now < start_block_time || now > deadline ) {
+            _cpu_duty_cycle_on = false;
+            return start_block_result::waiting_for_production;
+         }
+      }
+   }
+
+   fc_dlog(_log, "Starting block ${bt} at ${time}", ("bt", block_time)("time", now));
 
    try {
       uint16_t blocks_to_confirm = 0;
@@ -1804,7 +1838,7 @@ void producer_plugin_impl::schedule_production_loop() {
                 self->schedule_production_loop();
              }
           } ) );
-   } else if (result == start_block_result::waiting){
+   } else if (result == start_block_result::waiting_for_block){
       if (!_producers.empty() && !production_disabled_by_policy()) {
          fc_dlog(_log, "Waiting till another block is received and scheduling Speculative/Production Change");
          schedule_delayed_production_loop(weak_this, calculate_pending_block_time());
@@ -1812,6 +1846,10 @@ void producer_plugin_impl::schedule_production_loop() {
          fc_dlog(_log, "Waiting till another block is received");
          // nothing to do until more blocks arrive
       }
+
+   } else if (result == start_block_result::waiting_for_production) {
+      fc_dlog(_log, "Scheduling Production Start");
+      schedule_delayed_production_loop(weak_this, calculate_pending_block_time());
 
    } else if (_pending_block_mode == pending_block_mode::producing) {
 

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1453,8 +1453,6 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block() {
 
    if (_pending_block_mode == pending_block_mode::producing) {
       const auto start_block_time = block_time - fc::microseconds( config::block_interval_us );
-      fc_dlog(_log, "Next block #${n} start: ${bt} block time: ${dt}",
-              ("n", hbs->block_num + 1)("bt", start_block_time)("dt", block_time));
       if( now < start_block_time ) {
          fc_dlog(_log, "Not producing block waiting for production window ${n} ${bt}", ("n", hbs->block_num + 1)("bt", block_time) );
          // start_block_time instead of block_time because scheduled_delayed_production_loop calculates next block time from given time

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1456,12 +1456,13 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block() {
    }
 
    if (_pending_block_mode == pending_block_mode::producing) {
-      const auto next_producer_block_time = calculate_next_block_time( scheduled_producer.producer_name, block_time );
+      const auto current_block_time = block_time - fc::microseconds( config::block_interval_us );
+      const auto next_producer_block_time = calculate_next_block_time( scheduled_producer.producer_name, current_block_time );
       if (next_producer_block_time) {
-         const auto start_block_time = *next_producer_block_time - fc::microseconds( 2 * config::block_interval_us );
-         const fc::time_point deadline = calculate_block_deadline( block_time );
-         fc_dlog(_log, "Next block #${n} start: ${bt} deadline: ${dt}", ("n", hbs->block_num + 1)("bt", start_block_time)("dt", deadline));
-         if( now < start_block_time && start_block_time < deadline ) {
+         const auto start_block_time = *next_producer_block_time - fc::microseconds( config::block_interval_us );
+         fc_dlog(_log, "Next block #${n} start: ${bt} block time: ${dt}",
+                 ("n", hbs->block_num + 1)("bt", start_block_time)("dt", *next_producer_block_time));
+         if( now < start_block_time && start_block_time < *next_producer_block_time ) {
             fc_dlog(_log, "Duty cycle off for ${n}", ("n", hbs->block_num + 1) );
             _cpu_duty_cycle_on = false;
             schedule_delayed_production_loop(weak_from_this(), start_block_time);

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -665,9 +665,9 @@ void producer_plugin::set_program_options(
           "Offset of non last block producing time in microseconds. Valid range 0 .. -block_time.")
          ("last-block-time-offset-us", boost::program_options::value<int32_t>()->default_value(-200000),
           "Offset of last block producing time in microseconds. Valid range 0 .. -block_time.")
-         ("cpu-duty-cycle-pct", bpo::value<uint32_t>()->default_value(config::default_cpu_duty_cycle_pct / config::percent_1),
+         ("cpu-effort-percent", bpo::value<uint32_t>()->default_value(config::default_block_cpu_effort_pct / config::percent_1),
           "Percentage of cpu block production time used to produce block. Whole number percentages, e.g. 80 for 80%")
-         ("last-block-cpu-duty-cycle-pct", bpo::value<uint32_t>()->default_value(config::default_cpu_duty_cycle_pct / config::percent_1),
+         ("last-block-cpu-effort-percent", bpo::value<uint32_t>()->default_value(config::default_block_cpu_effort_pct / config::percent_1),
           "Percentage of cpu block production time used to produce last block. Whole number percentages, e.g. 80 for 80%")
          ("max-scheduled-transaction-time-per-block-ms", boost::program_options::value<int32_t>()->default_value(100),
           "Maximum wall-clock time, in milliseconds, spent retiring scheduled transactions in any block before returning to normal transaction processing.")
@@ -818,22 +818,22 @@ void producer_plugin::plugin_initialize(const boost::program_options::variables_
    EOS_ASSERT( my->_last_block_time_offset_us <= 0 && my->_last_block_time_offset_us >= -config::block_interval_us, plugin_config_exception,
                "last-block-time-offset-us ${o} must be 0 .. -${bi}", ("bi", config::block_interval_us)("o", my->_last_block_time_offset_us) );
 
-   uint32_t cpu_duty_cycle_pct = options.at("cpu-duty-cycle-pct").as<uint32_t>();
-   EOS_ASSERT( cpu_duty_cycle_pct >= 0 && cpu_duty_cycle_pct <= 100, plugin_config_exception,
-               "cpu-duty-cycle-pct ${pct} must be 0 - 100", ("pct", cpu_duty_cycle_pct) );
-   cpu_duty_cycle_pct *= config::percent_1;
-   int32_t cpu_duty_cycle_offset_us =
-         -EOS_PERCENT( config::block_interval_us, chain::config::percent_100 - cpu_duty_cycle_pct );
+   uint32_t cpu_effort_pct = options.at("cpu-effort-percent").as<uint32_t>();
+   EOS_ASSERT( cpu_effort_pct >= 0 && cpu_effort_pct <= 100, plugin_config_exception,
+               "cpu-effort-percent ${pct} must be 0 - 100", ("pct", cpu_effort_pct) );
+      cpu_effort_pct *= config::percent_1;
+   int32_t cpu_effort_offset_us =
+         -EOS_PERCENT( config::block_interval_us, chain::config::percent_100 - cpu_effort_pct );
 
-   uint32_t last_block_cpu_duty_cycle_pct = options.at("last-block-cpu-duty-cycle-pct").as<uint32_t>();
-   EOS_ASSERT( last_block_cpu_duty_cycle_pct >= 0 && last_block_cpu_duty_cycle_pct <= 100, plugin_config_exception,
-               "last-block-cpu-duty-cycle-pct ${pct} must be 0 - 100", ("pct", last_block_cpu_duty_cycle_pct) );
-   last_block_cpu_duty_cycle_pct *= config::percent_1;
-   int32_t last_block_cpu_duty_cycle_offset_us =
-         -EOS_PERCENT( config::block_interval_us, chain::config::percent_100 - last_block_cpu_duty_cycle_pct );
+   uint32_t last_block_cpu_effort_pct = options.at("last-block-cpu-effort-percent").as<uint32_t>();
+   EOS_ASSERT( last_block_cpu_effort_pct >= 0 && last_block_cpu_effort_pct <= 100, plugin_config_exception,
+               "last-block-cpu-effort-percent ${pct} must be 0 - 100", ("pct", last_block_cpu_effort_pct) );
+      last_block_cpu_effort_pct *= config::percent_1;
+   int32_t last_block_cpu_effort_offset_us =
+         -EOS_PERCENT( config::block_interval_us, chain::config::percent_100 - last_block_cpu_effort_pct );
 
-   my->_produce_time_offset_us = std::min( my->_produce_time_offset_us, cpu_duty_cycle_offset_us );
-   my->_last_block_time_offset_us = std::min( my->_last_block_time_offset_us, last_block_cpu_duty_cycle_offset_us );
+   my->_produce_time_offset_us = std::min( my->_produce_time_offset_us, cpu_effort_offset_us );
+   my->_last_block_time_offset_us = std::min( my->_last_block_time_offset_us, last_block_cpu_effort_offset_us );
 
    my->_max_scheduled_transaction_time_per_block_ms = options.at("max-scheduled-transaction-time-per-block-ms").as<int32_t>();
 

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -659,9 +659,9 @@ void producer_plugin::set_program_options(
          ("greylist-limit", boost::program_options::value<uint32_t>()->default_value(1000),
           "Limit (between 1 and 1000) on the multiple that CPU/NET virtual resources can extend during low usage (only enforced subjectively; use 1000 to not enforce any limit)")
          ("produce-time-offset-us", boost::program_options::value<int32_t>()->default_value(0),
-          "Offset of non last block producing time in microseconds. Valid range 0 .. -block_time.")
+          "Offset of non last block producing time in microseconds. Valid range 0 .. -block_time_interval.")
          ("last-block-time-offset-us", boost::program_options::value<int32_t>()->default_value(-200000),
-          "Offset of last block producing time in microseconds. Valid range 0 .. -block_time.")
+          "Offset of last block producing time in microseconds. Valid range 0 .. -block_time_interval.")
          ("cpu-effort-percent", bpo::value<uint32_t>()->default_value(config::default_block_cpu_effort_pct / config::percent_1),
           "Percentage of cpu block production time used to produce block. Whole number percentages, e.g. 80 for 80%")
          ("last-block-cpu-effort-percent", bpo::value<uint32_t>()->default_value(config::default_block_cpu_effort_pct / config::percent_1),


### PR DESCRIPTION
## Change Description

CPU block effort provides a mechanism to restrict the amount of time a producer is processing transactions for inclusion into a block. It also controls the time a producer will finalize/produce and transmit a block. Block construction now always begins at whole or half seconds for the next block.

Added new options `cpu-effort-percent` & `last-block-cpu-effort-percent` defaulted to 80%. Percentage of cpu block production time used to produce block. Whole number percentages, e.g. 80 for 80%.

These options allow time outside of `start_block` for other system activity such as net_plugin sending/receiving blocks, signing of block, etc.

Existing options `produce-time-offset-us` & `last-block-time-offset-us` have been modified to constrain configurable values from `0 .. -block_time_interval` where currently block_time_interval is 500,000us. Positive values are no longer allowed.

The default value of `produce-time-offset-us` is now effectively `-100000` since `cpu-effort-percent` is defaulted to `80%`.

These four options now all fold into restricting the amount of time spent processing transactions into a block. The `last-block-*` options constrain the final 12th block of the producer's round. The other two options constrain the remaining blocks of the round, 1-11. The more constraining amount is used. For example, `--cpu-effort-percent 80 --produce-time-offset-us -300000` will constrain transaction processing to `200ms` as `80% x 500ms = 400ms` and `500ms - 300ms = 200ms`.

Other examples:
  `--cpu-effort-percent 70 --produce-time-offset-us -100000` provides 350ms for transaction processing.
  `--last-block-cpu-effort-percent 70 --last-block-time-offset-us -400000` provides 100ms for transaction processing for the last block of the round

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes


## Documentation Additions
- [x] Documentation Additions

See above.