### PR TITLE
cpu effort last block - 2.0

### DIFF
--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1406,7 +1406,7 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block() {
    const fc::time_point now = fc::time_point::now();
    const fc::time_point block_time = calculate_pending_block_time();
 
-   pending_block_mode previous_pending_mode = _pending_block_mode;
+   const pending_block_mode previous_pending_mode = _pending_block_mode;
    _pending_block_mode = pending_block_mode::producing;
 
    // Not our turn

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1480,7 +1480,9 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block() {
    } else if (previous_pending_mode == pending_block_mode::producing) {
       // just produced our last block of our round
       const auto start_block_time = block_time - fc::microseconds( config::block_interval_us );
+      fc_dlog(_log, "Not starting speculative block until ${bt}", ("bt", start_block_time) );
       schedule_delayed_production_loop( weak_from_this(), start_block_time);
+      return start_block_result::waiting_for_production;
    }
 
    fc_dlog(_log, "Starting block #${n} ${bt} at ${time}", ("n", hbs->block_num + 1)("bt", block_time)("time", now));
@@ -1932,7 +1934,6 @@ void producer_plugin_impl::schedule_production_loop() {
 optional<fc::time_point> producer_plugin_impl::calculate_producer_wake_up_time( const block_timestamp_type& ref_block_time ) const {
    // if we have any producers then we should at least set a timer for our next available slot
    optional<fc::time_point> wake_up_time;
-   chain::account_name producer;
    for (const auto& p : _producers) {
       auto next_producer_block_time = calculate_next_block_time(p, ref_block_time);
       if (next_producer_block_time) {
@@ -1941,11 +1942,9 @@ optional<fc::time_point> producer_plugin_impl::calculate_producer_wake_up_time( 
             // wake up with a full block interval to the deadline
             if( producer_wake_up_time < *wake_up_time ) {
                wake_up_time = producer_wake_up_time;
-               producer = p;
             }
          } else {
             wake_up_time = producer_wake_up_time;
-            producer = p;
          }
       }
    }


### PR DESCRIPTION
##  Change Description

- Extend cpu percent effort to include immediate speculative block after the last block of the production round. See #8507. This is useful because speculative execution begins immediately after last block, without this change, which prevents the sending of the last block until the speculative start_block finishes.

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
