### PR TITLE
P2p read only - develop

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -3366,8 +3366,11 @@ namespace eosio {
       chain::controller&cc = my->chain_plug->chain();
       my->db_read_mode = cc.get_read_mode();
       if( cc.in_immutable_mode() && my->p2p_address.size() ) {
-         my->p2p_address.clear();
-         fc_wlog( logger, "node in read-only mode disabling incoming p2p connections" );
+         fc_wlog( logger, "\n"
+               "************************************\n"
+               "*        Read Only Mode            *\n"
+               "* - Transactions not forwarded   - *\n"
+               "************************************\n" );
       }
 
       tcp::endpoint listen_endpoint;

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -3367,10 +3367,10 @@ namespace eosio {
       my->db_read_mode = cc.get_read_mode();
       if( cc.in_immutable_mode() && my->p2p_address.size() ) {
          fc_wlog( logger, "\n"
-               "************************************\n"
-               "*        Read Only Mode            *\n"
-               "* - Transactions not forwarded   - *\n"
-               "************************************\n" );
+               "**********************************\n"
+               "*         Read Only Mode         *\n"
+               "* - Transactions not forwarded - *\n"
+               "**********************************\n" );
       }
 
       tcp::endpoint listen_endpoint;


### PR DESCRIPTION
## Change Description

- Resolves #8580 
- Allow incoming connections when `--read-mode` is `read-only` and `irreversible`. Incoming connections were originally intended to be prevented to avoid accidental connections from external clients who would have no indication that their transactions were not being evaluated or forwarded on the p2p network. However, this restriction was not actually enforced in v1.8.x. #8580 indicates there are valid use cases for allowing incoming connections. Specifically if you are wanting to setup a relay node between two block producers where transactions do not need to flow as they come in through other relay nodes that are not in read-only mode.
- Added clear warning log message to address #7886
- Ref: #8583 

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
