### PR TITLE
improve action_trace grows

### DIFF
--- a/libraries/chain/include/eosio/chain/trace.hpp
+++ b/libraries/chain/include/eosio/chain/trace.hpp
@@ -28,6 +28,8 @@ namespace eosio { namespace chain {
                      uint32_t closest_unnotified_ancestor_action_ordinal );
       action_trace(){}
 
+      action_trace(action_trace &&) = default;
+
       fc::unsigned_int                action_ordinal;
       fc::unsigned_int                creator_action_ordinal;
       fc::unsigned_int                closest_unnotified_ancestor_action_ordinal;

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -557,7 +557,9 @@ namespace eosio { namespace chain {
    {
       uint32_t new_action_ordinal = trace->action_traces.size() + 1;
 
-      trace->action_traces.reserve( new_action_ordinal );
+      if (trace->action_traces.capacity() < new_action_ordinal) {
+         trace->action_traces.reserve( std::max((size_t)new_action_ordinal, trace->action_traces.capacity() * 2 ));
+      }
 
       const action& provided_action = get_action_trace( action_ordinal ).act;
 

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -258,6 +258,8 @@ namespace eosio { namespace chain {
    void transaction_context::exec() {
       EOS_ASSERT( is_initialized, transaction_exception, "must first initialize" );
 
+      trace->action_traces.reserve( trx.context_free_actions.size() + trx.actions.size());
+
       if( apply_context_free ) {
          for( const auto& act : trx.context_free_actions ) {
             schedule_action( act, act.account, true, 0, 0 );


### PR DESCRIPTION
## Change Description
This improves the way of creating action_trace when applying transactions, probably results in better performance. maybe a workaround for #8588 for non-producing nodes.

## Consensus Changes
No.

## API Changes
No.

## Documentation Additions
No.