### PR TITLE
Add a way to query nodeos reversible db size - added an api endpoint …

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -2455,6 +2455,8 @@ chainbase::database& controller::mutable_db()const { return my->db; }
 
 const fork_database& controller::fork_db()const { return my->fork_db; }
 
+const chainbase::database& controller::reversible_db()const { return my->reversible_blocks; }
+
 void controller::preactivate_feature( const digest_type& feature_digest ) {
    const auto& pfs = my->protocol_features.get_protocol_feature_set();
    auto cur_time = pending_block_time();

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -171,6 +171,7 @@ namespace eosio { namespace chain {
          boost::asio::io_context& get_thread_pool();
 
          const chainbase::database& db()const;
+         const chainbase::database& reversible_db() const;
 
          const fork_database& fork_db()const;
 

--- a/plugins/db_size_api_plugin/db_size_api_plugin.cpp
+++ b/plugins/db_size_api_plugin/db_size_api_plugin.cpp
@@ -28,11 +28,12 @@ void db_size_api_plugin::plugin_startup() {
    app().get_plugin<http_plugin>().add_api({
        CALL(db_size, this, get,
             INVOKE_R_V(this, get), 200),
+       CALL(db_size, this, get_reversible,
+            INVOKE_R_V(this, get_reversible), 200),
    });
 }
 
-db_size_stats db_size_api_plugin::get() {
-   const chainbase::database& db = app().get_plugin<chain_plugin>().chain().db();
+db_size_stats db_size_api_plugin::get_db_stats(const chainbase::database& db) {
    db_size_stats ret;
 
    ret.free_bytes = db.get_segment_manager()->get_free_memory();
@@ -44,6 +45,14 @@ db_size_stats db_size_api_plugin::get() {
       ret.indices.emplace_back(db_size_index_count{i.second, i.first});
 
    return ret;
+}
+
+db_size_stats db_size_api_plugin::get() {
+   return get_db_stats(app().get_plugin<chain_plugin>().chain().db());
+}
+
+db_size_stats db_size_api_plugin::get_reversible() {
+   return get_db_stats(app().get_plugin<chain_plugin>().chain().reversible_db());
 }
 
 #undef INVOKE_R_V

--- a/plugins/db_size_api_plugin/include/eosio/db_size_api_plugin/db_size_api_plugin.hpp
+++ b/plugins/db_size_api_plugin/include/eosio/db_size_api_plugin/db_size_api_plugin.hpp
@@ -38,8 +38,10 @@ public:
    void plugin_shutdown() {}
 
    db_size_stats get();
+   db_size_stats get_reversible();
 
 private:
+   db_size_stats get_db_stats(const chainbase::database& );
 };
 
 }


### PR DESCRIPTION
…located in db_size/get_reversible

<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
Add a way to query nodeos reversible db size. #8242 

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [X] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->
An api endpoint located in db_size/get_reversible was added

## Documentation Additions
- [x] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
