### PR TITLE
Produce block immediately if exhausted - 2.0

### DIFF
--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -605,8 +605,7 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
       start_block_result start_block();
 
       fc::time_point calculate_pending_block_time() const;
-      int32_t calculate_block_offset( const fc::time_point& block_time ) const;
-      fc::time_point calculate_block_deadline( const fc::time_point& block_time ) const;
+      fc::time_point calculate_block_deadline( const fc::time_point& ) const;
       void schedule_delayed_production_loop(const std::weak_ptr<producer_plugin_impl>& weak_this, optional<fc::time_point> wake_up_time);
       optional<fc::time_point> calculate_producer_wake_up_time( const block_timestamp_type& ref_block_time ) const;
 
@@ -1412,13 +1411,9 @@ fc::time_point producer_plugin_impl::calculate_pending_block_time() const {
    return block_time;
 }
 
-int32_t producer_plugin_impl::calculate_block_offset( const fc::time_point& block_time ) const {
-   bool last_block = ((block_timestamp_type(block_time).slot % config::producer_repetitions) == config::producer_repetitions - 1);
-   return last_block ? _last_block_time_offset_us : _produce_time_offset_us;
-}
-
 fc::time_point producer_plugin_impl::calculate_block_deadline( const fc::time_point& block_time ) const {
-   return block_time + fc::microseconds( calculate_block_offset( block_time ) );
+   bool last_block = ((block_timestamp_type(block_time).slot % config::producer_repetitions) == config::producer_repetitions - 1);
+   return block_time + fc::microseconds(last_block ? _last_block_time_offset_us : _produce_time_offset_us);
 }
 
 producer_plugin_impl::start_block_result producer_plugin_impl::start_block() {

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1887,11 +1887,11 @@ bool producer_plugin_impl::process_incoming_trxs( const fc::time_point& deadline
 bool producer_plugin_impl::block_is_exhausted() const {
    const chain::controller& chain = chain_plug->chain();
    const auto& rl = chain.get_resource_limits_manager();
-   const uint32_t offset = calculate_block_offset( chain.pending_block_time() );
+   const auto offset = calculate_block_offset( chain.pending_block_time() );
 
-   const uint64_t cpu_limit = rl.get_block_cpu_limit();
+   const auto cpu_limit = rl.get_block_cpu_limit();
    if( (cpu_limit + offset) < _max_block_cpu_usage_threshold_us ) return true;
-   const uint64_t net_limit = rl.get_block_net_limit();
+   const auto net_limit = rl.get_block_net_limit();
    if( net_limit < _max_block_net_usage_threshold_bytes ) return true;
    return false;
 }

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -540,6 +540,7 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
                deadline = block_deadline;
             }
 
+            fc_dlog( _log, "push incoming" );
             auto trace = chain.push_transaction( trx, deadline );
             if( trace->except ) {
                if( failure_is_subjective( *trace->except, deadline_is_subjective )) {

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -526,7 +526,6 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
             }
 
             if( !chain.is_building_block()) {
-               fc_dlog( _log, "add to pending" );
                _pending_incoming_transactions.add( trx, persist_until_expired, next );
                return true;
             }
@@ -540,7 +539,6 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
                deadline = block_deadline;
             }
 
-            fc_dlog( _log, "push incoming" );
             auto trace = chain.push_transaction( trx, deadline );
             if( trace->except ) {
                if( failure_is_subjective( *trace->except, deadline_is_subjective )) {

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1953,17 +1953,9 @@ void producer_plugin_impl::schedule_maybe_produce_block( bool exhausted ) {
                ("num", chain.head_block_num() + 1)( "time", deadline ) );
    } else {
       EOS_ASSERT( chain.is_building_block(), missing_pending_block_state, "producing without pending_block_state" );
-      auto expect_time = chain.pending_block_time() - fc::microseconds( config::block_interval_us );
-      // ship this block off up to 1 block time earlier or immediately
-      if( exhausted || fc::time_point::now() >= expect_time ) {
          _timer.expires_from_now( boost::posix_time::microseconds( 0 ) );
-         fc_dlog( _log, "Scheduling Block Production on Exhausted Block #${num} immediately",
-                  ("num", chain.head_block_num() + 1) );
-      } else {
-         _timer.expires_at( epoch + boost::posix_time::microseconds( expect_time.time_since_epoch().count() ) );
-         fc_dlog( _log, "Scheduling Block Production on Exhausted Block #${num} at ${time}",
-                  ("num", chain.head_block_num() + 1)( "time", expect_time ) );
-      }
+      fc_dlog( _log, "Scheduling Block Production on Exhausted Block #${num} immediately",
+               ("num", chain.head_block_num() + 1) );
    }
 
    _timer.async_wait( app().get_priority_queue().wrap( priority::high,

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -548,13 +548,13 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
                               ("block_num", chain.head_block_num() + 1)
                               ("prod", chain.pending_block_producer())
                               ("txid", trx->id()));
-                     if( block_is_exhausted() ) {
-                        schedule_maybe_produce_block( true );
-                        exhausted = true;
-                     }
                   } else {
                      fc_dlog( _trx_trace_log, "[TRX_TRACE] Speculative execution COULD NOT FIT tx: ${txid} RETRYING",
                               ("txid", trx->id()));
+                  }
+                  if( block_is_exhausted() ) {
+                     schedule_maybe_produce_block( true );
+                     exhausted = true;
                   }
                } else {
                   auto e_ptr = trace->except->dynamic_copy_exception();

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -553,7 +553,9 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
                               ("txid", trx->id()));
                   }
                   if( block_is_exhausted() ) {
-                     schedule_maybe_produce_block( true );
+                     if( _pending_block_mode == pending_block_mode::producing ) {
+                        schedule_maybe_produce_block( true );
+                     }
                      exhausted = true;
                   }
                } else {

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1890,6 +1890,7 @@ bool producer_plugin_impl::block_is_exhausted() const {
    const auto offset = calculate_block_offset( chain.pending_block_time() );
 
    const auto cpu_limit = rl.get_block_cpu_limit();
+   fc_dlog( _log, "is_exhausted cpu_limit ${cl} offset ${o} max ${m}", ("cl", cpu_limit)("o", offset)("m", _max_block_cpu_usage_threshold_us) );
    if( (cpu_limit + offset) < _max_block_cpu_usage_threshold_us ) return true;
    const auto net_limit = rl.get_block_net_limit();
    if( net_limit < _max_block_net_usage_threshold_bytes ) return true;

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -516,18 +516,18 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
                      std::make_shared<expired_tx_exception>(
                            FC_LOG_MESSAGE( error, "expired transaction ${id}, expiration ${e}, block time ${bt}",
                                            ("id", id)("e", trx->packed_trx()->expiration())( "bt", bt )))));
-               return exhausted;
+               return true;
             }
 
             if( chain.is_known_unexpired_transaction( id )) {
                send_response( std::static_pointer_cast<fc::exception>( std::make_shared<tx_duplicate>(
                      FC_LOG_MESSAGE( error, "duplicate transaction ${id}", ("id", id)))) );
-               return exhausted;
+               return true;
             }
 
             if( !chain.is_building_block()) {
                _pending_incoming_transactions.add( trx, persist_until_expired, next );
-               return exhausted;
+               return true;
             }
 
             auto deadline = fc::time_point::now() + fc::milliseconds( _max_transaction_time_ms );
@@ -577,7 +577,7 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
             chain_plugin::handle_bad_alloc();
          } CATCH_AND_CALL(send_response);
 
-         return exhausted;
+         return !exhausted;
       }
 
 

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -601,7 +601,7 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
       start_block_result start_block();
 
       fc::time_point calculate_pending_block_time() const;
-      uint32_t calculate_block_offset( const fc::time_point& block_time ) const;
+      int32_t calculate_block_offset( const fc::time_point& block_time ) const;
       fc::time_point calculate_block_deadline( const fc::time_point& block_time ) const;
       void schedule_delayed_production_loop(const std::weak_ptr<producer_plugin_impl>& weak_this, optional<fc::time_point> wake_up_time);
       optional<fc::time_point> calculate_producer_wake_up_time( const block_timestamp_type& ref_block_time ) const;
@@ -1408,7 +1408,7 @@ fc::time_point producer_plugin_impl::calculate_pending_block_time() const {
    return block_time;
 }
 
-uint32_t producer_plugin_impl::calculate_block_offset( const fc::time_point& block_time ) const {
+int32_t producer_plugin_impl::calculate_block_offset( const fc::time_point& block_time ) const {
    bool last_block = ((block_timestamp_type(block_time).slot % config::producer_repetitions) == config::producer_repetitions - 1);
    return last_block ? _last_block_time_offset_us : _produce_time_offset_us;
 }

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1887,11 +1887,9 @@ bool producer_plugin_impl::process_incoming_trxs( const fc::time_point& deadline
 bool producer_plugin_impl::block_is_exhausted() const {
    const chain::controller& chain = chain_plug->chain();
    const auto& rl = chain.get_resource_limits_manager();
-   const int64_t offset = calculate_block_offset( chain.pending_block_time() );
 
    const uint64_t cpu_limit = rl.get_block_cpu_limit();
-   const int64_t cpu_usage = static_cast<int64_t>(cpu_limit) + offset;
-   if( cpu_usage < static_cast<int64_t>(_max_block_cpu_usage_threshold_us) ) return true;
+   if( cpu_limit < _max_block_cpu_usage_threshold_us ) return true;
    const uint64_t net_limit = rl.get_block_net_limit();
    if( net_limit < _max_block_net_usage_threshold_bytes ) return true;
    return false;

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1887,12 +1887,13 @@ bool producer_plugin_impl::process_incoming_trxs( const fc::time_point& deadline
 bool producer_plugin_impl::block_is_exhausted() const {
    const chain::controller& chain = chain_plug->chain();
    const auto& rl = chain.get_resource_limits_manager();
-   const auto offset = calculate_block_offset( chain.pending_block_time() );
+   const int64_t offset = calculate_block_offset( chain.pending_block_time() );
 
-   const auto cpu_limit = rl.get_block_cpu_limit();
+   const uint64_t cpu_limit = rl.get_block_cpu_limit();
    fc_dlog( _log, "is_exhausted cpu_limit ${cl} offset ${o} max ${m}", ("cl", cpu_limit)("o", offset)("m", _max_block_cpu_usage_threshold_us) );
-   if( (cpu_limit + offset) < _max_block_cpu_usage_threshold_us ) return true;
-   const auto net_limit = rl.get_block_net_limit();
+   const int64_t cpu_usage = static_cast<int64_t>(cpu_limit) + offset;
+   if( cpu_usage < static_cast<int64_t>(_max_block_cpu_usage_threshold_us) ) return true;
+   const uint64_t net_limit = rl.get_block_net_limit();
    if( net_limit < _max_block_net_usage_threshold_bytes ) return true;
    return false;
 }

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -184,6 +184,7 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
       void schedule_maybe_produce_block( bool exhausted );
       void produce_block();
       bool maybe_produce_block();
+      bool block_is_exhausted() const;
       bool remove_expired_persisted_trxs( const fc::time_point& deadline );
       bool remove_expired_blacklisted_trxs( const fc::time_point& deadline );
       bool process_unapplied_trxs( const fc::time_point& deadline );
@@ -208,6 +209,8 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
       fc::microseconds                                          _max_irreversible_block_age_us;
       int32_t                                                   _produce_time_offset_us = 0;
       int32_t                                                   _last_block_time_offset_us = 0;
+      uint32_t                                                  _max_block_cpu_usage_threshold_us = 0;
+      uint32_t                                                  _max_block_net_usage_threshold_bytes = 0;
       int32_t                                                   _max_scheduled_transaction_time_per_block_ms = 0;
       fc::time_point                                            _irreversible_block_time;
       fc::microseconds                                          _keosd_provider_timeout_us;
@@ -544,7 +547,9 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
                               ("block_num", chain.head_block_num() + 1)
                               ("prod", chain.pending_block_producer())
                               ("txid", trx->id()));
-                     schedule_maybe_produce_block( true );
+                     if( block_is_exhausted() ) {
+                        schedule_maybe_produce_block( true );
+                     }
                   } else {
                      fc_dlog( _trx_trace_log, "[TRX_TRACE] Speculative execution COULD NOT FIT tx: ${txid} RETRYING",
                               ("txid", trx->id()));
@@ -596,7 +601,8 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
       start_block_result start_block();
 
       fc::time_point calculate_pending_block_time() const;
-      fc::time_point calculate_block_deadline( const fc::time_point& ) const;
+      uint32_t calculate_block_offset( const fc::time_point& block_time ) const;
+      fc::time_point calculate_block_deadline( const fc::time_point& block_time ) const;
       void schedule_delayed_production_loop(const std::weak_ptr<producer_plugin_impl>& weak_this, optional<fc::time_point> wake_up_time);
       optional<fc::time_point> calculate_producer_wake_up_time( const block_timestamp_type& ref_block_time ) const;
 
@@ -674,6 +680,10 @@ void producer_plugin::set_program_options(
           "Percentage of cpu block production time used to produce block. Whole number percentages, e.g. 80 for 80%")
          ("last-block-cpu-effort-percent", bpo::value<uint32_t>()->default_value(config::default_block_cpu_effort_pct / config::percent_1),
           "Percentage of cpu block production time used to produce last block. Whole number percentages, e.g. 80 for 80%")
+         ("max-block-cpu-usage-threshold-us", bpo::value<uint32_t>()->default_value( 1000 ),
+          "Threshold of cpu block production to consider block full; when within threshold of max-block-cpu-usage no additional transactions will be attempted")
+         ("max-block-net-usage-threshold-bytes", bpo::value<uint32_t>()->default_value( 1024 ),
+          "Threshold of net block production to consider block full; when within threshold of max-block-net-usage no additional transactions will be attempted")
          ("max-scheduled-transaction-time-per-block-ms", boost::program_options::value<int32_t>()->default_value(100),
           "Maximum wall-clock time, in milliseconds, spent retiring scheduled transactions in any block before returning to normal transaction processing.")
          ("subjective-cpu-leeway-us", boost::program_options::value<int32_t>()->default_value( config::default_subjective_cpu_leeway_us ),
@@ -839,6 +849,12 @@ void producer_plugin::plugin_initialize(const boost::program_options::variables_
 
    my->_produce_time_offset_us = std::min( my->_produce_time_offset_us, cpu_effort_offset_us );
    my->_last_block_time_offset_us = std::min( my->_last_block_time_offset_us, last_block_cpu_effort_offset_us );
+
+   my->_max_block_cpu_usage_threshold_us = options.at( "max-block-cpu-usage-threshold-us" ).as<uint32_t>();
+   EOS_ASSERT( my->_max_block_cpu_usage_threshold_us < config::block_interval_us, plugin_config_exception,
+               "max-block-cpu-usage-threshold-us ${t} must be 0 .. ${bi}", ("bi", config::block_interval_us)("t", my->_max_block_cpu_usage_threshold_us) );
+
+   my->_max_block_net_usage_threshold_bytes = options.at( "max-block-net-usage-threshold-bytes" ).as<uint32_t>();
 
    my->_max_scheduled_transaction_time_per_block_ms = options.at("max-scheduled-transaction-time-per-block-ms").as<int32_t>();
 
@@ -1392,9 +1408,13 @@ fc::time_point producer_plugin_impl::calculate_pending_block_time() const {
    return block_time;
 }
 
-fc::time_point producer_plugin_impl::calculate_block_deadline( const fc::time_point& block_time ) const {
+uint32_t producer_plugin_impl::calculate_block_offset( const fc::time_point& block_time ) const {
    bool last_block = ((block_timestamp_type(block_time).slot % config::producer_repetitions) == config::producer_repetitions - 1);
-   return block_time + fc::microseconds(last_block ? _last_block_time_offset_us : _produce_time_offset_us);
+   return last_block ? _last_block_time_offset_us : _produce_time_offset_us;
+}
+
+fc::time_point producer_plugin_impl::calculate_block_deadline( const fc::time_point& block_time ) const {
+   return block_time + fc::microseconds( calculate_block_offset( block_time ) );
 }
 
 producer_plugin_impl::start_block_result producer_plugin_impl::start_block() {
@@ -1580,7 +1600,8 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block() {
                );
             }
             // may exhaust scheduled_trx_deadline but not preprocess_deadline, exhausted preprocess_deadline checked below
-            process_scheduled_and_incoming_trxs( scheduled_trx_deadline, pending_incoming_process_limit );
+            if( !process_scheduled_and_incoming_trxs( scheduled_trx_deadline, pending_incoming_process_limit ) )
+               return start_block_result::exhausted;
          }
 
          if( app().is_quiting() ) // db guard exception above in LOG_AND_DROP could have called app().quit()
@@ -1707,9 +1728,11 @@ bool producer_plugin_impl::process_unapplied_trxs( const fc::time_point& deadlin
             auto trace = chain.push_transaction( trx, trx_deadline );
             if( trace->except ) {
                if( failure_is_subjective( *trace->except, deadline_is_subjective ) ) {
-                  exhausted = true;
-                  // don't erase, subjective failure so try again next time
-                  break;
+                  if( block_is_exhausted() ) {
+                     exhausted = true;
+                     // don't erase, subjective failure so try again next time
+                     break;
+                  }
                } else {
                   // this failed our configured maximum transaction time, we don't want to replay it
                   ++num_failed;
@@ -1799,8 +1822,10 @@ bool producer_plugin_impl::process_scheduled_and_incoming_trxs( const fc::time_p
          auto trace = chain.push_scheduled_transaction(trx_id, trx_deadline);
          if (trace->except) {
             if (failure_is_subjective(*trace->except, deadline_is_subjective)) {
-               exhausted = true;
-               break;
+               if( block_is_exhausted() ) {
+                  exhausted = true;
+                  break;
+               }
             } else {
                auto expiration = fc::time_point::now() + fc::seconds(chain.get_global_properties().configuration.deferred_trx_expiration_window);
                // this failed our configured maximum transaction time, we don't want to replay it add it to a blacklist
@@ -1847,6 +1872,18 @@ bool producer_plugin_impl::process_incoming_trxs( const fc::time_point& deadline
       fc_dlog(_log, "Processed ${n} pending transactions, ${p} left", ("n", processed)("p", _pending_incoming_transactions.size()));
    }
    return !exhausted;
+}
+
+bool producer_plugin_impl::block_is_exhausted() const {
+   const chain::controller& chain = chain_plug->chain();
+   const auto& rl = chain.get_resource_limits_manager();
+   const uint32_t offset = calculate_block_offset( chain.pending_block_time() );
+
+   const uint64_t cpu_limit = rl.get_block_cpu_limit();
+   if( (cpu_limit + offset) < _max_block_cpu_usage_threshold_us ) return true;
+   const uint64_t net_limit = rl.get_block_net_limit();
+   if( net_limit < _max_block_net_usage_threshold_bytes ) return true;
+   return false;
 }
 
 // Example:


### PR DESCRIPTION
## Change Description

- Resolves #8649 
- Do not wait for the end of `cpu-effort-percent` to produce block if `max_block_cpu_usage` or `max_block_net_usage` is reached. Produce block immediately upon exhaustion.
- This can increase `a` in https://github.com/EOSIO/eos/issues/8650 when `cpu-effort-percent`  is greater than `max_block_cpu_usage` as the block will be produced when `max_block_*_usage` is hit instead of waiting for the `cpu-effort-percent` window to expire.

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [x] Documentation Additions

- New configuration options:
  - `max-block-cpu-usage-threshold-us`
Threshold of CPU block production to consider block full; when within threshold of max-block-cpu-usage block can be produced immediately. Default value 5000.
  - `max-block-net-usage-threshold-bytes`
Threshold of NET block production to consider block full; when within threshold of max-block-net-usage block can be produced immediately. Default value 1024.
