### PR TITLE
Exit transaction early when insufficient account cpu - develop

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1421,7 +1421,6 @@ struct controller_impl {
                                            bool explicit_billed_cpu_time )
    {
       EOS_ASSERT(deadline != fc::time_point(), transaction_exception, "deadline cannot be uninitialized");
-      EOS_ASSERT( !explicit_billed_cpu_time || (billed_cpu_time_us > 0), transaction_exception, "no billed_cpu_time_us provided for explicit billing");
 
       transaction_trace_ptr trace;
       try {

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1363,9 +1363,12 @@ struct controller_impl {
             int64_t account_cpu_limit = 0;
             std::tie( std::ignore, account_cpu_limit, std::ignore, std::ignore ) = trx_context.max_bandwidth_billed_accounts_can_pay( true );
 
-            cpu_time_to_bill_us = static_cast<uint32_t>( std::min( std::min( static_cast<int64_t>(cpu_time_to_bill_us),
-                                                                             account_cpu_limit                          ),
-                                                                   trx_context.initial_objective_duration_limit.count()    ) );
+            uint32_t limited_cpu_time_to_bill_us = static_cast<uint32_t>( std::min(
+                  std::min( static_cast<int64_t>(cpu_time_to_bill_us), account_cpu_limit ),
+                  trx_context.initial_objective_duration_limit.count() ) );
+            EOS_ASSERT( !explicit_billed_cpu_time || (cpu_time_to_bill_us == limited_cpu_time_to_bill_us),
+                        transaction_exception, "cpu to bill ${cpu} != limited ${limit}", ("cpu", cpu_time_to_bill_us)("limit", limited_cpu_time_to_bill_us) );
+            cpu_time_to_bill_us = limited_cpu_time_to_bill_us;
          }
 
          resource_limits.add_transaction_usage( trx_context.bill_to_accounts, cpu_time_to_bill_us, 0,

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1215,6 +1215,13 @@ struct controller_impl {
 
    transaction_trace_ptr push_scheduled_transaction( const generated_transaction_object& gto, fc::time_point deadline, uint32_t billed_cpu_time_us, bool explicit_billed_cpu_time = false )
    { try {
+
+      const bool validating = !self.is_producing_block();
+      if( validating ) {
+         EOS_ASSERT( explicit_billed_cpu_time && billed_cpu_time_us > 0, transaction_exception,
+                     "validating requires explicit billing" );
+      }
+
       maybe_session undo_session;
       if ( !self.skip_db_sessions() )
          undo_session = maybe_session(db);
@@ -1321,7 +1328,6 @@ struct controller_impl {
       trx_context.undo();
 
       // Only subjective OR soft OR hard failure logic below:
-      const bool validating = !self.is_producing_block();
 
       if( gtrx.sender != account_name() && !(validating ? failure_is_subjective(*trace->except) : scheduled_failure_is_subjective(*trace->except))) {
          // Attempt error handling for the generated transaction.
@@ -1415,6 +1421,9 @@ struct controller_impl {
                                            bool explicit_billed_cpu_time )
    {
       EOS_ASSERT(deadline != fc::time_point(), transaction_exception, "deadline cannot be uninitialized");
+      if( explicit_billed_cpu_time ) {
+         EOS_ASSERT( billed_cpu_time_us > 0, transaction_exception, "no billed_cpu_time_us provided");
+      }
 
       transaction_trace_ptr trace;
       try {

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1217,10 +1217,7 @@ struct controller_impl {
    { try {
 
       const bool validating = !self.is_producing_block();
-      if( validating ) {
-         EOS_ASSERT( explicit_billed_cpu_time && billed_cpu_time_us > 0, transaction_exception,
-                     "validating requires explicit billing" );
-      }
+      EOS_ASSERT( !validating || (explicit_billed_cpu_time && billed_cpu_time_us > 0), transaction_exception, "validating requires explicit billing" );
 
       maybe_session undo_session;
       if ( !self.skip_db_sessions() )
@@ -1421,9 +1418,7 @@ struct controller_impl {
                                            bool explicit_billed_cpu_time )
    {
       EOS_ASSERT(deadline != fc::time_point(), transaction_exception, "deadline cannot be uninitialized");
-      if( explicit_billed_cpu_time ) {
-         EOS_ASSERT( billed_cpu_time_us > 0, transaction_exception, "no billed_cpu_time_us provided");
-      }
+      EOS_ASSERT( !explicit_billed_cpu_time || (billed_cpu_time_us > 0), transaction_exception, "no billed_cpu_time_us provided for explicit billing");
 
       transaction_trace_ptr trace;
       try {

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -2680,11 +2680,12 @@ transaction_trace_ptr controller::push_transaction( const transaction_metadata_p
    return my->push_transaction(trx, deadline, billed_cpu_time_us, explicit_billed_cpu_time );
 }
 
-transaction_trace_ptr controller::push_scheduled_transaction( const transaction_id_type& trxid, fc::time_point deadline, uint32_t billed_cpu_time_us )
+transaction_trace_ptr controller::push_scheduled_transaction( const transaction_id_type& trxid, fc::time_point deadline,
+                                                              uint32_t billed_cpu_time_us, bool explicit_billed_cpu_time )
 {
    EOS_ASSERT( !in_immutable_mode(), transaction_type_exception, "push scheduled transaction not allowed in read-only mode" );
    validate_db_available_size();
-   return my->push_scheduled_transaction( trxid, deadline, billed_cpu_time_us, billed_cpu_time_us > 0 );
+   return my->push_scheduled_transaction( trxid, deadline, billed_cpu_time_us, explicit_billed_cpu_time );
 }
 
 const flat_set<account_name>& controller::get_actor_whitelist() const {

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1217,7 +1217,7 @@ struct controller_impl {
    { try {
 
       const bool validating = !self.is_producing_block();
-      EOS_ASSERT( !validating || (explicit_billed_cpu_time && billed_cpu_time_us > 0), transaction_exception, "validating requires explicit billing" );
+      EOS_ASSERT( !validating || explicit_billed_cpu_time, transaction_exception, "validating requires explicit billing" );
 
       maybe_session undo_session;
       if ( !self.skip_db_sessions() )

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -152,7 +152,8 @@ namespace eosio { namespace chain {
           * Attempt to execute a specific transaction in our deferred trx database
           *
           */
-         transaction_trace_ptr push_scheduled_transaction( const transaction_id_type& scheduled, fc::time_point deadline, uint32_t billed_cpu_time_us = 0 );
+         transaction_trace_ptr push_scheduled_transaction( const transaction_id_type& scheduled, fc::time_point deadline,
+                                                           uint32_t billed_cpu_time_us, bool explicit_billed_cpu_time );
 
          block_state_ptr finalize_block( const signer_callback_type& signer_callback );
          void sign_block( const signer_callback_type& signer_callback );

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -145,7 +145,8 @@ namespace eosio { namespace chain {
          /**
           *
           */
-         transaction_trace_ptr push_transaction( const transaction_metadata_ptr& trx, fc::time_point deadline, uint32_t billed_cpu_time_us = 0 );
+         transaction_trace_ptr push_transaction( const transaction_metadata_ptr& trx, fc::time_point deadline,
+                                                 uint32_t billed_cpu_time_us, bool explicit_billed_cpu_time );
 
          /**
           * Attempt to execute a specific transaction in our deferred trx database

--- a/libraries/chain/include/eosio/chain/transaction_context.hpp
+++ b/libraries/chain/include/eosio/chain/transaction_context.hpp
@@ -96,8 +96,8 @@ namespace eosio { namespace chain {
          void schedule_transaction();
          void record_transaction( const transaction_id_type& id, fc::time_point_sec expire );
 
-         void validate_cpu_usage_to_bill( int64_t u, bool check_minimum = true )const;
-         void validate_account_cpu_usage( int64_t billed_cpu_time_us, int64_t account_cpu_limit )const;
+         void validate_cpu_usage_to_bill( int64_t billed_us, int64_t account_cpu_limit, bool check_minimum )const;
+         void validate_account_cpu_usage( int64_t billed_us, int64_t account_cpu_limit, bool estimate )const;
 
          void disallow_transaction_extensions( const char* error_msg )const;
 

--- a/libraries/chain/include/eosio/chain/transaction_context.hpp
+++ b/libraries/chain/include/eosio/chain/transaction_context.hpp
@@ -97,6 +97,7 @@ namespace eosio { namespace chain {
          void record_transaction( const transaction_id_type& id, fc::time_point_sec expire );
 
          void validate_cpu_usage_to_bill( int64_t u, bool check_minimum = true )const;
+         void validate_account_cpu_usage( int64_t billed_cpu_time_us, int64_t account_cpu_limit )const;
 
          void disallow_transaction_extensions( const char* error_msg )const;
 

--- a/libraries/chain/include/eosio/chain/transaction_metadata.hpp
+++ b/libraries/chain/include/eosio/chain/transaction_metadata.hpp
@@ -34,7 +34,8 @@ class transaction_metadata {
    public:
       const bool                                                 implicit;
       const bool                                                 scheduled;
-      bool                                                       accepted = false;  // not thread safe
+      bool                                                       accepted = false;       // not thread safe
+      uint32_t                                                   billed_cpu_time_us = 0; // not thread safe
 
    private:
       struct private_type{};

--- a/libraries/chain/resource_limits.cpp
+++ b/libraries/chain/resource_limits.cpp
@@ -386,13 +386,17 @@ std::pair<account_resource_limit, bool> resource_limits_manager::get_account_cpu
    account_resource_limit arl;
 
    uint128_t window_size = config.account_cpu_usage_average_window;
-   uint64_t  greylisted_virtual_cpu_limit = config.cpu_limit_parameters.max * greylist_limit;
 
    bool greylisted = false;
    uint128_t virtual_cpu_capacity_in_window = window_size;
-   if( greylisted_virtual_cpu_limit < state.virtual_cpu_limit ) {
-      virtual_cpu_capacity_in_window *= greylisted_virtual_cpu_limit;
-      greylisted = true;
+   if( greylist_limit < config::maximum_elastic_resource_multiplier ) {
+      uint64_t greylisted_virtual_cpu_limit = config.cpu_limit_parameters.max * greylist_limit;
+      if( greylisted_virtual_cpu_limit < state.virtual_cpu_limit ) {
+         virtual_cpu_capacity_in_window *= greylisted_virtual_cpu_limit;
+         greylisted = true;
+      } else {
+         virtual_cpu_capacity_in_window *= state.virtual_cpu_limit;
+      }
    } else {
       virtual_cpu_capacity_in_window *= state.virtual_cpu_limit;
    }
@@ -433,13 +437,17 @@ std::pair<account_resource_limit, bool> resource_limits_manager::get_account_net
    account_resource_limit arl;
 
    uint128_t window_size = config.account_net_usage_average_window;
-   uint64_t  greylisted_virtual_net_limit = config.net_limit_parameters.max * greylist_limit;
 
    bool greylisted = false;
    uint128_t virtual_network_capacity_in_window = window_size;
-   if( greylisted_virtual_net_limit < state.virtual_net_limit ) {
-      virtual_network_capacity_in_window *= greylisted_virtual_net_limit;
-      greylisted = true;
+   if( greylist_limit < config::maximum_elastic_resource_multiplier ) {
+      uint64_t greylisted_virtual_net_limit = config.net_limit_parameters.max * greylist_limit;
+      if( greylisted_virtual_net_limit < state.virtual_net_limit ) {
+         virtual_network_capacity_in_window *= greylisted_virtual_net_limit;
+         greylisted = true;
+      } else {
+         virtual_network_capacity_in_window *= state.virtual_net_limit;
+      }
    } else {
       virtual_network_capacity_in_window *= state.virtual_net_limit;
    }

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -535,6 +535,9 @@ namespace eosio { namespace chain {
          }
       }
 
+      EOS_ASSERT( (!force_elastic_limits && control.is_producing_block()) || (!greylisted_cpu && !greylisted_net),
+                  transaction_exception, "greylisted when not producing block" );
+
       return std::make_tuple(account_net_limit, account_cpu_limit, greylisted_net, greylisted_cpu);
    }
 

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -458,21 +458,25 @@ namespace eosio { namespace chain {
    }
 
    void transaction_context::validate_account_cpu_usage( int64_t billed_cpu_time_us, int64_t account_cpu_limit )const {
-      if( account_cpu_limit < billed_cpu_time_us && !control.skip_trx_checks() ) {
-         if( billing_timer_exception_code == block_cpu_usage_exceeded::code_value ) {
+      if( (billed_cpu_time_us > 0) && !control.skip_trx_checks() ) {
+         const bool cpu_limited_by_account = (account_cpu_limit <= objective_duration_limit.count());
+
+         if( !cpu_limited_by_account && (billing_timer_exception_code == block_cpu_usage_exceeded::code_value) ) {
             EOS_ASSERT( billed_cpu_time_us <= objective_duration_limit.count(),
                         block_cpu_usage_exceeded,
                         "estimated CPU time (${billed} us) is greater than the billable CPU time left in the block (${billable} us)",
                         ("billed", billed_cpu_time_us)( "billable", objective_duration_limit.count() )
             );
          } else {
-            if( cpu_limit_due_to_greylist ) {
-               EOS_ASSERT( false, greylist_cpu_usage_exceeded,
+            if( cpu_limited_by_account && cpu_limit_due_to_greylist ) {
+               EOS_ASSERT( billed_cpu_time_us <= account_cpu_limit, greylist_cpu_usage_exceeded,
                            "estimated CPU time (${billed} us) is greater than the maximum greylisted billable CPU time for the transaction (${billable} us)",
                            ("billed", billed_cpu_time_us)( "billable", account_cpu_limit )
                );
             } else {
-               EOS_ASSERT( false, tx_cpu_usage_exceeded,
+               // exceeds trx.max_cpu_usage_ms or cfg.max_transaction_cpu_usage if objective_duration_limit is greater
+               const int64_t cpu_limit = (cpu_limited_by_account ? account_cpu_limit : objective_duration_limit.count());
+               EOS_ASSERT( billed_cpu_time_us <= cpu_limit, tx_cpu_usage_exceeded,
                            "estimated CPU time (${billed} us) is greater than the maximum billable CPU time for the transaction (${billable} us)",
                            ("billed", billed_cpu_time_us)( "billable", account_cpu_limit )
                );

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -172,7 +172,7 @@ namespace eosio { namespace chain {
 
       if( !explicit_billed_cpu_time ) {
          if( account_cpu_limit < billed_cpu_time_us ) { // if account no longer has enough cpu to exec trx, don't try
-            EOS_THROW( deadline_exception, "account cpu ${cpu} not sufficient for trx ${t}us",
+            EOS_THROW( tx_cpu_usage_exceeded, "account cpu ${cpu} not sufficient for trx ${t}us",
                        ("cpu", account_cpu_limit)( "t", billed_cpu_time_us ) );
          }
       }

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -119,7 +119,7 @@ namespace eosio { namespace chain {
 
       initial_objective_duration_limit = objective_duration_limit;
 
-      if( billed_cpu_time_us > 0 ) // could also call on explicit_billed_cpu_time but it would be redundant
+      if( explicit_billed_cpu_time )
          validate_cpu_usage_to_bill( billed_cpu_time_us, false ); // Fail early if the amount to be billed is too high
 
       // Record accounts to be billed for network and CPU usage
@@ -168,6 +168,13 @@ namespace eosio { namespace chain {
          deadline_exception_code = deadline_exception::code_value;
       } else {
          deadline_exception_code = billing_timer_exception_code;
+      }
+
+      if( !explicit_billed_cpu_time ) {
+         if( account_cpu_limit < billed_cpu_time_us ) { // if account no longer has enough cpu to exec trx, don't try
+            EOS_THROW( deadline_exception, "account cpu ${cpu} not sufficient for trx ${t}us",
+                       ("cpu", account_cpu_limit)( "t", billed_cpu_time_us ) );
+         }
       }
 
       eager_net_limit = (eager_net_limit/8)*8; // Round down to nearest multiple of word size (8 bytes) so check_net_usage can be efficient

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -333,7 +333,7 @@ namespace eosio { namespace testing {
          vector<transaction_id_type> scheduled_trxs;
          while ((scheduled_trxs = get_scheduled_transactions()).size() > 0 ) {
             for( const auto& trx : scheduled_trxs ) {
-               auto trace = control->push_scheduled_transaction( trx, fc::time_point::maximum(), DEFAULT_BILLED_CPU_TIME_US );
+               auto trace = control->push_scheduled_transaction( trx, fc::time_point::maximum(), DEFAULT_BILLED_CPU_TIME_US, false );
                if( trace->except ) {
                   trace->except->dynamic_rethrow_exception();
                }

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -323,7 +323,7 @@ namespace eosio { namespace testing {
 
       if( !skip_pending_trxs ) {
          for( auto itr = unapplied_transactions.begin(); itr != unapplied_transactions.end();  ) {
-            auto trace = control->push_transaction( itr->trx_meta, fc::time_point::maximum(), DEFAULT_BILLED_CPU_TIME_US, true );
+            auto trace = control->push_transaction( itr->trx_meta, fc::time_point::maximum(), itr->trx_meta->billed_cpu_time_us, false );
             if(trace->except) {
                trace->except->dynamic_rethrow_exception();
             }
@@ -333,7 +333,7 @@ namespace eosio { namespace testing {
          vector<transaction_id_type> scheduled_trxs;
          while ((scheduled_trxs = get_scheduled_transactions()).size() > 0 ) {
             for( const auto& trx : scheduled_trxs ) {
-               auto trace = control->push_scheduled_transaction( trx, fc::time_point::maximum(), DEFAULT_BILLED_CPU_TIME_US, false );
+               auto trace = control->push_scheduled_transaction( trx, fc::time_point::maximum(), 0, false );
                if( trace->except ) {
                   trace->except->dynamic_rethrow_exception();
                }

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -323,7 +323,7 @@ namespace eosio { namespace testing {
 
       if( !skip_pending_trxs ) {
          for( auto itr = unapplied_transactions.begin(); itr != unapplied_transactions.end();  ) {
-            auto trace = control->push_transaction( itr->trx_meta, fc::time_point::maximum(), itr->trx_meta->billed_cpu_time_us, false );
+            auto trace = control->push_transaction( itr->trx_meta, fc::time_point::maximum(), DEFAULT_BILLED_CPU_TIME_US, true );
             if(trace->except) {
                trace->except->dynamic_rethrow_exception();
             }
@@ -333,7 +333,7 @@ namespace eosio { namespace testing {
          vector<transaction_id_type> scheduled_trxs;
          while ((scheduled_trxs = get_scheduled_transactions()).size() > 0 ) {
             for( const auto& trx : scheduled_trxs ) {
-               auto trace = control->push_scheduled_transaction( trx, fc::time_point::maximum(), 0, false );
+               auto trace = control->push_scheduled_transaction( trx, fc::time_point::maximum(), DEFAULT_BILLED_CPU_TIME_US, true );
                if( trace->except ) {
                   trace->except->dynamic_rethrow_exception();
                }

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -323,7 +323,7 @@ namespace eosio { namespace testing {
 
       if( !skip_pending_trxs ) {
          for( auto itr = unapplied_transactions.begin(); itr != unapplied_transactions.end();  ) {
-            auto trace = control->push_transaction( itr->trx_meta, fc::time_point::maximum(), DEFAULT_BILLED_CPU_TIME_US );
+            auto trace = control->push_transaction( itr->trx_meta, fc::time_point::maximum(), DEFAULT_BILLED_CPU_TIME_US, true );
             if(trace->except) {
                trace->except->dynamic_rethrow_exception();
             }
@@ -535,7 +535,7 @@ namespace eosio { namespace testing {
             fc::microseconds::maximum() :
             fc::microseconds( deadline - fc::time_point::now() );
       auto fut = transaction_metadata::start_recover_keys( ptrx, control->get_thread_pool(), control->get_chain_id(), time_limit );
-      auto r = control->push_transaction( fut.get(), deadline, billed_cpu_time_us );
+      auto r = control->push_transaction( fut.get(), deadline, billed_cpu_time_us, billed_cpu_time_us > 0 );
       if( r->except_ptr ) std::rethrow_exception( r->except_ptr );
       if( r->except ) throw *r->except;
       return r;
@@ -560,7 +560,7 @@ namespace eosio { namespace testing {
             fc::microseconds( deadline - fc::time_point::now() );
       auto ptrx = std::make_shared<packed_transaction>( trx, c );
       auto fut = transaction_metadata::start_recover_keys( ptrx, control->get_thread_pool(), control->get_chain_id(), time_limit );
-      auto r = control->push_transaction( fut.get(), deadline, billed_cpu_time_us );
+      auto r = control->push_transaction( fut.get(), deadline, billed_cpu_time_us, billed_cpu_time_us > 0 );
       if (no_throw) return r;
       if( r->except_ptr ) std::rethrow_exception( r->except_ptr );
       if( r->except)  throw *r->except;

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1715,13 +1715,13 @@ bool producer_plugin_impl::process_scheduled_and_incoming_trxs( const fc::time_p
    auto sch_itr = sch_idx.begin();
    while( sch_itr != sch_idx.end() ) {
       if( sch_itr->delay_until > pending_block_time) break;    // not scheduled yet
-      if( sch_itr->published >= pending_block_time ) {
-         ++sch_itr;
-         continue; // do not allow schedule and execute in same block
-      }
       if( deadline <= fc::time_point::now() ) {
          exhausted = true;
          break;
+      }
+      if( sch_itr->published >= pending_block_time ) {
+         ++sch_itr;
+         continue; // do not allow schedule and execute in same block
       }
 
       const transaction_id_type trx_id = sch_itr->trx_id; // make copy since reference could be invalidated

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -492,7 +492,7 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
                deadline = block_deadline;
             }
 
-            auto trace = chain.push_transaction( trx, deadline );
+            auto trace = chain.push_transaction( trx, deadline, trx->billed_cpu_time_us, false );
             if( trace->except ) {
                if( failure_is_subjective( *trace->except, deadline_is_subjective )) {
                   _unapplied_transactions.add_incoming( trx, persist_until_expired, next );
@@ -1667,7 +1667,7 @@ bool producer_plugin_impl::process_unapplied_trxs( const fc::time_point& deadlin
                trx_deadline = deadline;
             }
 
-            auto trace = chain.push_transaction( trx, trx_deadline );
+            auto trace = chain.push_transaction( trx, trx_deadline, trx->billed_cpu_time_us, false );
             if( trace->except ) {
                if( failure_is_subjective( *trace->except, deadline_is_subjective ) ) {
                   exhausted = true;

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1769,7 +1769,7 @@ bool producer_plugin_impl::process_scheduled_and_incoming_trxs( const fc::time_p
             trx_deadline = deadline;
          }
 
-         auto trace = chain.push_scheduled_transaction(trx_id, trx_deadline);
+         auto trace = chain.push_scheduled_transaction(trx_id, trx_deadline, 0, false);
          if (trace->except) {
             if (failure_is_subjective(*trace->except, deadline_is_subjective)) {
                exhausted = true;

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -76,7 +76,7 @@ using namespace eosio::chain;
 using namespace eosio::chain::plugin_interface;
 
 namespace {
-   bool failure_is_subjective(const fc::exception& e, bool deadline_is_subjective) {
+   bool block_is_exhausted(const fc::exception& e, bool deadline_is_subjective) {
       auto code = e.code();
       return (code == block_cpu_usage_exceeded::code_value) ||
              (code == block_net_usage_exceeded::code_value) ||
@@ -494,7 +494,7 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
 
             auto trace = chain.push_transaction( trx, deadline, trx->billed_cpu_time_us, false );
             if( trace->except ) {
-               if( failure_is_subjective( *trace->except, deadline_is_subjective )) {
+               if( block_is_exhausted( *trace->except, deadline_is_subjective )) {
                   _unapplied_transactions.add_incoming( trx, persist_until_expired, next );
                   if( _pending_block_mode == pending_block_mode::producing ) {
                      fc_dlog( _trx_trace_log, "[TRX_TRACE] Block ${block_num} for producer ${prod} COULD NOT FIT, tx: ${txid} RETRYING ",
@@ -1669,10 +1669,8 @@ bool producer_plugin_impl::process_unapplied_trxs( const fc::time_point& deadlin
 
             auto trace = chain.push_transaction( trx, trx_deadline, trx->billed_cpu_time_us, false );
             if( trace->except ) {
-               if( failure_is_subjective( *trace->except, deadline_is_subjective ) ) {
-                  exhausted = true;
+               if( block_is_exhausted( *trace->except, deadline_is_subjective ) ) {
                   // don't erase, subjective failure so try again next time
-                  break;
                } else {
                   // this failed our configured maximum transaction time, we don't want to replay it
                   ++num_failed;
@@ -1771,9 +1769,8 @@ bool producer_plugin_impl::process_scheduled_and_incoming_trxs( const fc::time_p
 
          auto trace = chain.push_scheduled_transaction(trx_id, trx_deadline, 0, false);
          if (trace->except) {
-            if (failure_is_subjective(*trace->except, deadline_is_subjective)) {
-               exhausted = true;
-               break;
+            if (block_is_exhausted(*trace->except, deadline_is_subjective)) {
+               // do not blacklist
             } else {
                auto expiration = fc::time_point::now() + fc::seconds(chain.get_global_properties().configuration.deferred_trx_expiration_window);
                // this failed our configured maximum transaction time, we don't want to replay it add it to a blacklist

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -76,7 +76,7 @@ using namespace eosio::chain;
 using namespace eosio::chain::plugin_interface;
 
 namespace {
-   bool block_is_exhausted(const fc::exception& e, bool deadline_is_subjective) {
+   bool exception_is_exhausted(const fc::exception& e, bool deadline_is_subjective) {
       auto code = e.code();
       return (code == block_cpu_usage_exceeded::code_value) ||
              (code == block_net_usage_exceeded::code_value) ||
@@ -494,7 +494,7 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
 
             auto trace = chain.push_transaction( trx, deadline, trx->billed_cpu_time_us, false );
             if( trace->except ) {
-               if( block_is_exhausted( *trace->except, deadline_is_subjective )) {
+               if( exception_is_exhausted( *trace->except, deadline_is_subjective )) {
                   _unapplied_transactions.add_incoming( trx, persist_until_expired, next );
                   if( _pending_block_mode == pending_block_mode::producing ) {
                      fc_dlog( _trx_trace_log, "[TRX_TRACE] Block ${block_num} for producer ${prod} COULD NOT FIT, tx: ${txid} RETRYING ",
@@ -1669,7 +1669,7 @@ bool producer_plugin_impl::process_unapplied_trxs( const fc::time_point& deadlin
 
             auto trace = chain.push_transaction( trx, trx_deadline, trx->billed_cpu_time_us, false );
             if( trace->except ) {
-               if( block_is_exhausted( *trace->except, deadline_is_subjective ) ) {
+               if( exception_is_exhausted( *trace->except, deadline_is_subjective ) ) {
                   // don't erase, subjective failure so try again next time
                } else {
                   // this failed our configured maximum transaction time, we don't want to replay it
@@ -1769,7 +1769,7 @@ bool producer_plugin_impl::process_scheduled_and_incoming_trxs( const fc::time_p
 
          auto trace = chain.push_scheduled_transaction(trx_id, trx_deadline, 0, false);
          if (trace->except) {
-            if (block_is_exhausted(*trace->except, deadline_is_subjective)) {
+            if (exception_is_exhausted(*trace->except, deadline_is_subjective)) {
                // do not blacklist
             } else {
                auto expiration = fc::time_point::now() + fc::seconds(chain.get_global_properties().configuration.deferred_trx_expiration_window);

--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -1191,10 +1191,11 @@ BOOST_FIXTURE_TEST_CASE(deferred_transaction_tests, TESTER) { try {
       produce_blocks( 3 );
 
       //check that only one deferred transaction executed
+      auto billed_cpu_time_us = control->get_global_properties().configuration.min_transaction_cpu_usage;
       auto dtrxs = get_scheduled_transactions();
       BOOST_CHECK_EQUAL(dtrxs.size(), 1);
       for (const auto& trx: dtrxs) {
-         control->push_scheduled_transaction(trx, fc::time_point::maximum(), 0, false);
+         control->push_scheduled_transaction(trx, fc::time_point::maximum(), billed_cpu_time_us, true);
       }
       BOOST_CHECK_EQUAL(1, count);
       BOOST_CHECK(trace);

--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -1168,7 +1168,7 @@ BOOST_FIXTURE_TEST_CASE(deferred_transaction_tests, TESTER) { try {
       auto dtrxs = get_scheduled_transactions();
       BOOST_CHECK_EQUAL(dtrxs.size(), 1);
       for (const auto& trx: dtrxs) {
-         control->push_scheduled_transaction(trx, fc::time_point::maximum());
+         control->push_scheduled_transaction(trx, fc::time_point::maximum(), 0, false);
       }
       BOOST_CHECK_EQUAL(1, count);
       BOOST_REQUIRE(trace);
@@ -1194,7 +1194,7 @@ BOOST_FIXTURE_TEST_CASE(deferred_transaction_tests, TESTER) { try {
       auto dtrxs = get_scheduled_transactions();
       BOOST_CHECK_EQUAL(dtrxs.size(), 1);
       for (const auto& trx: dtrxs) {
-         control->push_scheduled_transaction(trx, fc::time_point::maximum());
+         control->push_scheduled_transaction(trx, fc::time_point::maximum(), 0, false);
       }
       BOOST_CHECK_EQUAL(1, count);
       BOOST_CHECK(trace);

--- a/unittests/delay_tests.cpp
+++ b/unittests/delay_tests.cpp
@@ -75,7 +75,7 @@ BOOST_FIXTURE_TEST_CASE( delay_error_create_account, validating_tester) { try {
    auto scheduled_trxs = get_scheduled_transactions();
    BOOST_REQUIRE_EQUAL(scheduled_trxs.size(), 1u);
 
-   auto dtrace = control->push_scheduled_transaction(scheduled_trxs.front(), fc::time_point::maximum());
+   auto dtrace = control->push_scheduled_transaction(scheduled_trxs.front(), fc::time_point::maximum(), 0, false);
    BOOST_REQUIRE_EQUAL(dtrace->except.valid(), true);
    BOOST_REQUIRE_EQUAL(dtrace->except->code(), missing_auth_exception::code_value);
 

--- a/unittests/delay_tests.cpp
+++ b/unittests/delay_tests.cpp
@@ -75,7 +75,8 @@ BOOST_FIXTURE_TEST_CASE( delay_error_create_account, validating_tester) { try {
    auto scheduled_trxs = get_scheduled_transactions();
    BOOST_REQUIRE_EQUAL(scheduled_trxs.size(), 1u);
 
-   auto dtrace = control->push_scheduled_transaction(scheduled_trxs.front(), fc::time_point::maximum(), 0, false);
+   auto billed_cpu_time_us = control->get_global_properties().configuration.min_transaction_cpu_usage;
+   auto dtrace = control->push_scheduled_transaction(scheduled_trxs.front(), fc::time_point::maximum(), billed_cpu_time_us, true);
    BOOST_REQUIRE_EQUAL(dtrace->except.valid(), true);
    BOOST_REQUIRE_EQUAL(dtrace->except->code(), missing_auth_exception::code_value);
 

--- a/unittests/wasm_tests.cpp
+++ b/unittests/wasm_tests.cpp
@@ -2009,11 +2009,11 @@ BOOST_AUTO_TEST_CASE( billed_cpu_test ) try {
 
    ptrx = create_trx(0);
    BOOST_CHECK_LT( cpu_limit_after_update, max_cpu_time_us ); // needs to be less or this just tests the same thing as max_cpu_time_us test above
-   // indicate non-explicit billing at our account cpu limit, will allow this trx to run
+   // indicate non-explicit billing at our account cpu limit, will allow this trx to run, but only bills for actual use
    push_trx( ptrx, fc::time_point::maximum(), cpu_limit_after_update, false );
 
    ptrx = create_trx(0);
-   // indicate explicit billing at over our account cpu limit, not allowed sinze explicit billing is objective
+   // indicate explicit billing at over our account cpu limit, not allowed
    cpu_limit_after_update = mgr.get_account_cpu_limit(acc).first;
    BOOST_CHECK_THROW( push_trx( ptrx, fc::time_point::maximum(), cpu_limit_after_update+1, true ), tx_cpu_usage_exceeded );
 

--- a/unittests/wasm_tests.cpp
+++ b/unittests/wasm_tests.cpp
@@ -3,6 +3,7 @@
 
 #include <eosio/chain/abi_serializer.hpp>
 #include <eosio/chain/exceptions.hpp>
+#include <eosio/chain/global_property_object.hpp>
 #include <eosio/chain/resource_limits.hpp>
 #include <eosio/chain/wasm_eosio_constraints.hpp>
 #include <eosio/chain/wast_to_wasm.hpp>
@@ -1905,26 +1906,22 @@ BOOST_AUTO_TEST_CASE( billed_cpu_test ) try {
    account_name user = N( user );
    chain.create_accounts( {acc, user} );
 
-   transaction_trace_ptr trace;
-   auto check = [&](uint32_t billed_cpu_time_us) -> bool {
+   auto create_trx = [&](auto trx_max_ms) {
       chain.produce_blocks( 1 );
       signed_transaction trx;
       trx.actions.emplace_back( vector<permission_level>{{acc, config::active_name}},
                                 assertdef {1, "Should Not Assert!"} );
       chain.set_transaction_headers( trx );
+      trx.max_cpu_usage_ms = trx_max_ms;
       trx.sign( chain.get_private_key( acc, "active" ), chain.control->get_chain_id() );
-      try {
-         packed_transaction ptrx( trx );
-         trace = chain.push_transaction( ptrx, fc::time_point::maximum(), billed_cpu_time_us );
-         chain.produce_blocks( 1 );
-         return true;
-      } catch( tx_cpu_usage_exceeded& ) {
-         return false;
-      }
+      return packed_transaction( trx );
    };
 
-   BOOST_REQUIRE_EQUAL(true, check(0)); // no limits, should pass
+   auto ptrx = create_trx(0);
+   // no limits, just verifying trx
+   chain.push_transaction( ptrx, fc::time_point::maximum(), 0 ); // 0 for non-explicit billing
 
+   // setup account acc with large limits
    chain.push_action( config::system_account_name, N(setalimits), config::system_account_name, fc::mutable_variant_object()
          ("account", user)
          ("ram_bytes", -1)
@@ -1940,13 +1937,51 @@ BOOST_AUTO_TEST_CASE( billed_cpu_test ) try {
 
    chain.produce_block();
 
-   auto cpu_limit = mgr.get_account_cpu_limit_ex(acc, 1).first.max;
+   auto max_cpu_time_us = chain.control->get_global_properties().configuration.max_transaction_cpu_usage;
+   auto min_cpu_time_us = chain.control->get_global_properties().configuration.min_transaction_cpu_usage;
 
-   wdump((cpu_limit));
-   BOOST_REQUIRE_EQUAL(true, check(0));
+   ptrx = create_trx(0);
+   // large limits on account acc. expect to pass
+   chain.push_transaction( ptrx, fc::time_point::maximum(), 0 ); // 0 for non-explicit billing
 
-   // say it is going to take 1 more than we have
-   BOOST_REQUIRE_EQUAL(false, check(cpu_limit+1));
+   ptrx = create_trx(0);
+   // indicate explicit billing at transaction max
+   chain.push_transaction( ptrx, fc::time_point::maximum(), max_cpu_time_us );
+
+   // do not allow to bill greater than chain configured max
+   ptrx = create_trx(0);
+   // indicate explicit billing at max + 1
+   BOOST_CHECK_THROW( chain.push_transaction( ptrx, fc::time_point::maximum(), max_cpu_time_us + 1 ), tx_cpu_usage_exceeded );
+
+   // allow to bill at trx configured max
+   ptrx = create_trx(5); // set trx max at 5ms
+   // indicate explicit billing at max
+   chain.push_transaction( ptrx, fc::time_point::maximum(), 5 * 1000 );
+
+   // do not allow to bill greater than trx configured max
+   ptrx = create_trx(5); // set trx max at 5ms
+   // indicate explicit billing at max + 1
+   BOOST_CHECK_THROW( chain.push_transaction( ptrx, fc::time_point::maximum(), 5 * 1000 + 1 ), tx_cpu_usage_exceeded );
+
+   // bill at minimum
+   ptrx = create_trx(0);
+   // indicate explicit billing at transaction minimum
+   chain.push_transaction( ptrx, fc::time_point::maximum(), min_cpu_time_us );
+
+   // do not allow to bill less than minimum
+   ptrx = create_trx(0);
+   // indicate explicit billing at minimum-1
+   BOOST_CHECK_THROW( chain.push_transaction( ptrx, fc::time_point::maximum(), min_cpu_time_us - 1 ), transaction_exception );
+
+   ptrx = create_trx(0);
+   auto cpu_limit = mgr.get_account_cpu_limit_ex(acc).first.max;
+   // indicate explicit billing at our account cpu limit
+   BOOST_CHECK_THROW( chain.push_transaction( ptrx, fc::time_point::maximum(), cpu_limit ), tx_cpu_usage_exceeded );
+
+   ptrx = create_trx(0);
+   cpu_limit = mgr.get_account_cpu_limit_ex(acc).first.max;
+   // indicate explicit billing with 1 more than our account cpu limit
+   BOOST_CHECK_THROW( chain.push_transaction( ptrx, fc::time_point::maximum(), cpu_limit+1 ), tx_cpu_usage_exceeded );
 
 } FC_LOG_AND_RETHROW()
 

--- a/unittests/wasm_tests.cpp
+++ b/unittests/wasm_tests.cpp
@@ -1925,6 +1925,7 @@ BOOST_AUTO_TEST_CASE( billed_cpu_test ) try {
       auto r = chain.control->push_transaction( trx, deadline, billed_cpu_time_us, explicit_billed_cpu_time );
       if( r->except_ptr ) std::rethrow_exception( r->except_ptr );
       if( r->except ) throw *r->except;
+      return r;
    };
 
    auto ptrx = create_trx(0);
@@ -1950,34 +1951,38 @@ BOOST_AUTO_TEST_CASE( billed_cpu_test ) try {
    auto max_cpu_time_us = chain.control->get_global_properties().configuration.max_transaction_cpu_usage;
    auto min_cpu_time_us = chain.control->get_global_properties().configuration.min_transaction_cpu_usage;
 
-   ptrx = create_trx(0);
-   // large limits on account acc. expect to pass
-   push_trx( ptrx, fc::time_point::maximum(), 0, false ); // non-explicit billing
-   chain.produce_block();
+   auto cpu_limit = mgr.get_account_cpu_limit(acc).first; // huge limit ~17s
 
-   auto cpu_limit = mgr.get_account_cpu_limit(acc).first;
+   ptrx = create_trx(0);
    BOOST_CHECK_LT( max_cpu_time_us, cpu_limit ); // max_cpu_time_us has to be less than cpu_limit to actually test max and not account
-
-   ptrx = create_trx(0);
    // indicate explicit billing at transaction max, max_cpu_time_us has to be greater than account cpu time
    push_trx( ptrx, fc::time_point::maximum(), max_cpu_time_us, true );
    chain.produce_block();
 
+   cpu_limit = mgr.get_account_cpu_limit(acc).first;
+
    // do not allow to bill greater than chain configured max, objective failure even with explicit billing for over max
    ptrx = create_trx(0);
+   BOOST_CHECK_LT( max_cpu_time_us + 1, cpu_limit ); // max_cpu_time_us+1 has to be less than cpu_limit to actually test max and not account
    // indicate explicit billing at max + 1
-   BOOST_CHECK_THROW( push_trx( ptrx, fc::time_point::maximum(), max_cpu_time_us + 1, true ), tx_cpu_usage_exceeded );
+   BOOST_CHECK_EXCEPTION( push_trx( ptrx, fc::time_point::maximum(), max_cpu_time_us + 1, true ), tx_cpu_usage_exceeded,
+                          fc_exception_message_starts_with( "billed") );
 
    // allow to bill at trx configured max
    ptrx = create_trx(5); // set trx max at 5ms
+   BOOST_CHECK_LT( 5 * 1000, cpu_limit ); // 5ms has to be less than cpu_limit to actually test trx max and not account
    // indicate explicit billing at max
    push_trx( ptrx, fc::time_point::maximum(), 5 * 1000, true );
    chain.produce_block();
 
+   cpu_limit = mgr.get_account_cpu_limit(acc).first; // update after last trx
+
    // do not allow to bill greater than trx configured max, objective failure even with explicit billing for over max
    ptrx = create_trx(5); // set trx max at 5ms
+   BOOST_CHECK_LT( 5 * 1000 + 1, cpu_limit ); // 5ms has to be less than cpu_limit to actually test trx max and not account
    // indicate explicit billing at max + 1
-   BOOST_CHECK_THROW( push_trx( ptrx, fc::time_point::maximum(), 5 * 1000 + 1, true ), tx_cpu_usage_exceeded );
+   BOOST_CHECK_EXCEPTION( push_trx( ptrx, fc::time_point::maximum(), 5 * 1000 + 1, true ), tx_cpu_usage_exceeded,
+                          fc_exception_message_starts_with("billed") );
 
    // bill at minimum
    ptrx = create_trx(0);
@@ -1988,35 +1993,42 @@ BOOST_AUTO_TEST_CASE( billed_cpu_test ) try {
    // do not allow to bill less than minimum
    ptrx = create_trx(0);
    // indicate explicit billing at minimum-1, objective failure even with explicit billing for under min
-   BOOST_CHECK_THROW( push_trx( ptrx, fc::time_point::maximum(), min_cpu_time_us - 1, true ), transaction_exception );
+   BOOST_CHECK_EXCEPTION( push_trx( ptrx, fc::time_point::maximum(), min_cpu_time_us - 1, true ), transaction_exception,
+                          fc_exception_message_starts_with("cannot bill CPU time less than the minimum") );
 
    chain.push_action( config::system_account_name, N(setalimits), config::system_account_name, fc::mutable_variant_object()
          ("account", acc)
          ("ram_bytes", -1)
-         ("net_weight", 99)
-         ("cpu_weight", 99)
+         ("net_weight", 75)
+         ("cpu_weight", 75) // ~130ms
    );
 
    chain.produce_block();
-   // update account usage for this block so get_account_cpu_limit returns correct amount
-   resource_limits_manager& rl = chain.control->get_mutable_resource_limits_manager();
-   rl.update_account_usage( {acc}, block_timestamp_type(chain.control->pending_block_time()).slot );
-   auto cpu_limit_after_update = mgr.get_account_cpu_limit(acc).first;
+   chain.produce_block( fc::days(1) ); // produce for one day to reset account cpu
+
+   cpu_limit = mgr.get_account_cpu_limit_ex(acc).first.max;
 
    ptrx = create_trx(0);
-   // indicate non-explicit billing with 1 more than our account cpu limit, triggers optimization check #8636 and fails trx
-   BOOST_CHECK_THROW( push_trx( ptrx, fc::time_point::maximum(), cpu_limit_after_update+1, false ), tx_cpu_usage_exceeded );
+   BOOST_CHECK_LT( cpu_limit+1, max_cpu_time_us ); // needs to be less or this just tests the same thing as max_cpu_time_us test above
+   // indicate non-explicit billing with 1 more than our account cpu limit, triggers optimization check #8638 and fails trx
+   BOOST_CHECK_EXCEPTION( push_trx( ptrx, fc::time_point::maximum(), cpu_limit+1, false ), tx_cpu_usage_exceeded,
+                          fc_exception_message_starts_with("estimated") );
 
    ptrx = create_trx(0);
-   BOOST_CHECK_LT( cpu_limit_after_update, max_cpu_time_us ); // needs to be less or this just tests the same thing as max_cpu_time_us test above
+   BOOST_CHECK_LT( cpu_limit, max_cpu_time_us );
    // indicate non-explicit billing at our account cpu limit, will allow this trx to run, but only bills for actual use
-   push_trx( ptrx, fc::time_point::maximum(), cpu_limit_after_update, false );
+   auto r = push_trx( ptrx, fc::time_point::maximum(), cpu_limit, false );
+   BOOST_CHECK_LT( r->receipt->cpu_usage_us, cpu_limit ); // verify not billed at provided bill amount when explicit_billed_cpu_time=false
+
+   chain.produce_block();
+   chain.produce_block( fc::days(1) ); // produce for one day to reset account cpu
 
    ptrx = create_trx(0);
+   BOOST_CHECK_LT( cpu_limit+1, max_cpu_time_us ); // needs to be less or this just tests the same thing as max_cpu_time_us test above
    // indicate explicit billing at over our account cpu limit, not allowed
-   cpu_limit_after_update = mgr.get_account_cpu_limit(acc).first;
-   BOOST_CHECK_THROW( push_trx( ptrx, fc::time_point::maximum(), cpu_limit_after_update+1, true ), tx_cpu_usage_exceeded );
-
+   cpu_limit = mgr.get_account_cpu_limit_ex(acc).first.max;
+   BOOST_CHECK_EXCEPTION( push_trx( ptrx, fc::time_point::maximum(), cpu_limit+1, true ), tx_cpu_usage_exceeded,
+                          fc_exception_message_starts_with("billed") );
 
 } FC_LOG_AND_RETHROW()
 


### PR DESCRIPTION
## Change Description

- Check to make sure account has enough cpu to execute already executed transactions. Do not attempt to execute if not enough account cpu.
- Add more explicit handling of greylisted accounts to avoid greylisting during validation.
- `develop` version of #8638 

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
