### PR TITLE
Net plugin sync priority - 2.0

### DIFF
--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -79,9 +79,7 @@ void chain_api_plugin::plugin_startup() {
    ro_api.set_shorten_abi_errors( !_http_plugin.verbose_errors() );
 
    _http_plugin.add_api({
-      CHAIN_RO_CALL(get_info, 200)
-    }, appbase::priority::medium);
-   _http_plugin.add_api({
+      CHAIN_RO_CALL(get_info, 200l),
       CHAIN_RO_CALL(get_activated_protocol_features, 200),
       CHAIN_RO_CALL(get_block, 200),
       CHAIN_RO_CALL(get_block_header_state, 200),

--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -79,7 +79,9 @@ void chain_api_plugin::plugin_startup() {
    ro_api.set_shorten_abi_errors( !_http_plugin.verbose_errors() );
 
    _http_plugin.add_api({
-      CHAIN_RO_CALL(get_info, 200l),
+      CHAIN_RO_CALL(get_info, 200)
+    }, appbase::priority::medium);
+   _http_plugin.add_api({
       CHAIN_RO_CALL(get_activated_protocol_features, 200),
       CHAIN_RO_CALL(get_block, 200),
       CHAIN_RO_CALL(get_block_header_state, 200),

--- a/plugins/http_plugin/http_plugin.cpp
+++ b/plugins/http_plugin/http_plugin.cpp
@@ -140,7 +140,8 @@ namespace eosio {
 
    class http_plugin_impl {
       public:
-         map<string,url_handler>  url_handlers;
+         // key -> priority, url_handler
+         map<string,std::pair<int,url_handler>>  url_handlers;
          optional<tcp::endpoint>  listen_endpoint;
          string                   access_control_allow_origin;
          string                   access_control_allow_headers;
@@ -327,7 +328,7 @@ namespace eosio {
                if( handler_itr != url_handlers.end()) {
                   con->defer_http_response();
                   bytes_in_flight += body.size();
-                  app().post( appbase::priority::low,
+                  app().post( handler_itr->second.first,
                               [&ioc = thread_pool->get_executor(), &bytes_in_flight = this->bytes_in_flight,
                                handler_itr, this, resource{std::move( resource )}, body{std::move( body )}, con]() mutable {
                      const size_t body_size = body.size();
@@ -695,9 +696,9 @@ namespace eosio {
       app().post( 0, [me = my](){} ); // keep my pointer alive until queue is drained
    }
 
-   void http_plugin::add_handler(const string& url, const url_handler& handler) {
+   void http_plugin::add_handler(const string& url, const url_handler& handler, int priority) {
       fc_ilog( logger, "add api url: ${c}", ("c", url) );
-      my->url_handlers.insert(std::make_pair(url,handler));
+      my->url_handlers.insert(std::make_pair(url,std::make_pair(priority, handler)));
    }
 
    void http_plugin::handle_exception( const char *api_name, const char *call_name, const string& body, url_response_callback cb ) {

--- a/plugins/http_plugin/http_plugin.cpp
+++ b/plugins/http_plugin/http_plugin.cpp
@@ -338,7 +338,7 @@ namespace eosio {
                         return;
                      }
                      try {
-                        handler_itr->second( std::move( resource ), std::move( body ),
+                        handler_itr->second.second( std::move( resource ), std::move( body ),
                                  [&ioc, &bytes_in_flight, con, this]( int code, fc::variant response_body ) {
                            size_t response_size = 0;
                            try {

--- a/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
@@ -77,8 +77,8 @@ namespace eosio {
         void plugin_shutdown();
         void handle_sighup() override;
 
-        void add_handler(const string& url, const url_handler&, int priority = appbase::priority::low);
-        void add_api(const api_description& api, int priority = appbase::priority::low) {
+        void add_handler(const string& url, const url_handler&, int priority = appbase::priority::medium_low);
+        void add_api(const api_description& api, int priority = appbase::priority::medium_low) {
            for (const auto& call : api)
               add_handler(call.first, call.second, priority);
         }

--- a/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
@@ -77,10 +77,10 @@ namespace eosio {
         void plugin_shutdown();
         void handle_sighup() override;
 
-        void add_handler(const string& url, const url_handler&);
-        void add_api(const api_description& api) {
+        void add_handler(const string& url, const url_handler&, int priority = appbase::priority::low);
+        void add_api(const api_description& api, int priority = appbase::priority::low) {
            for (const auto& call : api)
-              add_handler(call.first, call.second);
+              add_handler(call.first, call.second, priority);
         }
 
         // standard exception handling for api handlers

--- a/plugins/net_api_plugin/net_api_plugin.cpp
+++ b/plugins/net_api_plugin/net_api_plugin.cpp
@@ -75,7 +75,7 @@ void net_api_plugin::plugin_startup() {
             INVOKE_R_V(net_mgr, connections), 201),
     //   CALL(net, net_mgr, open,
     //        INVOKE_V_R(net_mgr, open, std::string), 200),
-   });
+   }, appbase::priority::medium);
 }
 
 void net_api_plugin::plugin_initialize(const variables_map& options) {

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2882,7 +2882,8 @@ namespace eosio {
    // called from connection strand
    void connection::handle_message( const block_id_type& id, signed_block_ptr ptr ) {
       peer_dlog( this, "received signed_block ${id}", ("id", ptr->block_num() ) );
-      app().post(priority::high, [ptr{std::move(ptr)}, id, c = shared_from_this()]() mutable {
+      auto priority = my_impl->sync_master->syncing_with_peer() ? priority::medium : priority::high;
+      app().post(priority, [ptr{std::move(ptr)}, id, c = shared_from_this()]() mutable {
          c->process_signed_block( id, std::move( ptr ) );
       });
    }

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2606,7 +2606,7 @@ namespace eosio {
 
          uint32_t peer_lib = msg.last_irreversible_block_num;
          connection_wptr weak = shared_from_this();
-         app().post( priority::low, [peer_lib, chain_plug = my_impl->chain_plug, weak{std::move(weak)},
+         app().post( priority::medium, [peer_lib, chain_plug = my_impl->chain_plug, weak{std::move(weak)},
                                      msg_lib_id = msg.last_irreversible_block_id]() {
             connection_ptr c = weak.lock();
             if( !c ) return;

--- a/plugins/producer_api_plugin/producer_api_plugin.cpp
+++ b/plugins/producer_api_plugin/producer_api_plugin.cpp
@@ -124,7 +124,7 @@ void producer_api_plugin::plugin_startup() {
                                  producer_plugin::get_supported_protocol_features_params), 201),
        CALL(producer, producer, get_account_ram_corrections,
             INVOKE_R_R(producer, get_account_ram_corrections, producer_plugin::get_account_ram_corrections_params), 201),
-   });
+   }, appbase::priority::medium);
 }
 
 void producer_api_plugin::plugin_initialize(const variables_map& options) {


### PR DESCRIPTION
## Change Description

- During syncing nodeos can often be too busy to process api requests as api requests run at low priority. 
  -- Change `producer_api_plugin` and `net_api_plugin` api requests to medium priority
  -- While syncing process blocks at medium priority
  -- Change all other api calls to medium_low priority

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
