### PR TITLE
Relay block on accepted header - 1.8

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1831,7 +1831,7 @@ struct controller_impl {
 
          fork_db.add( bsp );
 
-         if (conf.trusted_producers.count(b->producer)) {
+         if (self.is_trusted_producer(b->producer)) {
             trusted_producer_light_validation = true;
          };
 
@@ -2884,6 +2884,10 @@ bool controller::skip_db_sessions( ) const {
 
 bool controller::skip_trx_checks() const {
    return light_validation_allowed(my->conf.disable_replay_opts);
+}
+
+bool controller::is_trusted_producer( const account_name& producer) const {
+   return get_validation_mode() == chain::validation_mode::LIGHT || my->conf.trusted_producers.count(producer);
 }
 
 bool controller::contracts_console()const {

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -2856,14 +2856,12 @@ bool controller::light_validation_allowed(bool replay_opts_disabled_by_policy) c
    const bool consider_skipping_on_replay = (pb_status == block_status::irreversible || pb_status == block_status::validated) && !replay_opts_disabled_by_policy;
 
    // OR in a signed block and in light validation mode
-   const bool consider_skipping_on_validate = pb_status == block_status::complete && light_validation_mode();
+   const bool consider_skipping_on_validate = (pb_status == block_status::complete &&
+         (my->conf.block_validation_mode == validation_mode::LIGHT || my->trusted_producer_light_validation));
 
    return consider_skipping_on_replay || consider_skipping_on_validate;
 }
 
-bool controller::light_validation_mode() const {
-   return my->conf.block_validation_mode == validation_mode::LIGHT || my->trusted_producer_light_validation;
-}
 
 bool controller::skip_auth_check() const {
    return light_validation_allowed(my->conf.force_all_checks);

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -2856,12 +2856,14 @@ bool controller::light_validation_allowed(bool replay_opts_disabled_by_policy) c
    const bool consider_skipping_on_replay = (pb_status == block_status::irreversible || pb_status == block_status::validated) && !replay_opts_disabled_by_policy;
 
    // OR in a signed block and in light validation mode
-   const bool consider_skipping_on_validate = (pb_status == block_status::complete &&
-         (my->conf.block_validation_mode == validation_mode::LIGHT || my->trusted_producer_light_validation));
+   const bool consider_skipping_on_validate = pb_status == block_status::complete && light_validation_mode();
 
    return consider_skipping_on_replay || consider_skipping_on_validate;
 }
 
+bool controller::light_validation_mode() const {
+   return my->conf.block_validation_mode == validation_mode::LIGHT || my->trusted_producer_light_validation;
+}
 
 bool controller::skip_auth_check() const {
    return light_validation_allowed(my->conf.force_all_checks);

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -267,6 +267,7 @@ namespace eosio { namespace chain {
          bool skip_db_sessions( )const;
          bool skip_db_sessions( block_status bs )const;
          bool skip_trx_checks()const;
+         bool is_trusted_producer( const account_name& producer) const;
 
          bool contracts_console()const;
 

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -263,7 +263,6 @@ namespace eosio { namespace chain {
          int64_t set_proposed_producers( vector<producer_key> producers );
 
          bool light_validation_allowed(bool replay_opts_disabled_by_policy) const;
-         bool light_validation_mode() const;
          bool skip_auth_check()const;
          bool skip_db_sessions( )const;
          bool skip_db_sessions( block_status bs )const;

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -263,6 +263,7 @@ namespace eosio { namespace chain {
          int64_t set_proposed_producers( vector<producer_key> producers );
 
          bool light_validation_allowed(bool replay_opts_disabled_by_policy) const;
+         bool light_validation_mode() const;
          bool skip_auth_check()const;
          bool skip_db_sessions( )const;
          bool skip_db_sessions( block_status bs )const;

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2805,14 +2805,14 @@ namespace eosio {
    }
 
    void net_plugin_impl::accepted_block(const block_state_ptr& block) {
-      if( !cc.skip_auth_check() ) {
+      if( !cc.light_validation_mode() ) {
          fc_dlog(logger,"signaled accepted_block, id = ${id}",("id", block->id));
          dispatcher->bcast_block(block);
       }
    }
 
    void net_plugin_impl::accepted_block_header(const block_state_ptr& block) {
-      if( cc.skip_auth_check() ) {
+      if( cc.light_validation_mode() ) {
          fc_dlog(logger,"signaled accepted_block_header, id = ${id}",("id", block->id));
          dispatcher->bcast_block(block);
       }


### PR DESCRIPTION
## Change Description

- Relay block on `pre_accepted_block` signal for trusted producer or light validation. 

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
