### PR TITLE
Relay block on accepted header - develop

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -2007,7 +2007,7 @@ struct controller_impl {
 
          fork_db.add( bsp );
 
-         if (conf.trusted_producers.count(b->producer)) {
+         if (self.is_trusted_producer(b->producer)) {
             trusted_producer_light_validation = true;
          };
 
@@ -3049,6 +3049,10 @@ bool controller::skip_db_sessions( ) const {
 
 bool controller::skip_trx_checks() const {
    return light_validation_allowed(my->conf.disable_replay_opts);
+}
+
+bool controller::is_trusted_producer( const account_name& producer) const {
+   return get_validation_mode() == chain::validation_mode::LIGHT || my->conf.trusted_producers.count(producer);
 }
 
 bool controller::contracts_console()const {

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -3021,12 +3021,14 @@ bool controller::light_validation_allowed(bool replay_opts_disabled_by_policy) c
    const bool consider_skipping_on_replay = (pb_status == block_status::irreversible || pb_status == block_status::validated) && !replay_opts_disabled_by_policy;
 
    // OR in a signed block and in light validation mode
-   const bool consider_skipping_on_validate = (pb_status == block_status::complete &&
-         (my->conf.block_validation_mode == validation_mode::LIGHT || my->trusted_producer_light_validation));
+   const bool consider_skipping_on_validate = pb_status == block_status::complete && light_validation_mode();
 
    return consider_skipping_on_replay || consider_skipping_on_validate;
 }
 
+bool controller::light_validation_mode() const {
+   return my->conf.block_validation_mode == validation_mode::LIGHT || my->trusted_producer_light_validation;
+}
 
 bool controller::skip_auth_check() const {
    return light_validation_allowed(my->conf.force_all_checks);

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -3021,14 +3021,12 @@ bool controller::light_validation_allowed(bool replay_opts_disabled_by_policy) c
    const bool consider_skipping_on_replay = (pb_status == block_status::irreversible || pb_status == block_status::validated) && !replay_opts_disabled_by_policy;
 
    // OR in a signed block and in light validation mode
-   const bool consider_skipping_on_validate = pb_status == block_status::complete && light_validation_mode();
+   const bool consider_skipping_on_validate = (pb_status == block_status::complete &&
+         (my->conf.block_validation_mode == validation_mode::LIGHT || my->trusted_producer_light_validation));
 
    return consider_skipping_on_replay || consider_skipping_on_validate;
 }
 
-bool controller::light_validation_mode() const {
-   return my->conf.block_validation_mode == validation_mode::LIGHT || my->trusted_producer_light_validation;
-}
 
 bool controller::skip_auth_check() const {
    return light_validation_allowed(my->conf.force_all_checks);

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -279,6 +279,7 @@ namespace eosio { namespace chain {
          bool skip_db_sessions( )const;
          bool skip_db_sessions( block_status bs )const;
          bool skip_trx_checks()const;
+         bool is_trusted_producer( const account_name& producer) const;
 
          bool contracts_console()const;
 

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -275,7 +275,6 @@ namespace eosio { namespace chain {
          int64_t set_proposed_producers( vector<producer_authority> producers );
 
          bool light_validation_allowed(bool replay_opts_disabled_by_policy) const;
-         bool light_validation_mode() const;
          bool skip_auth_check()const;
          bool skip_db_sessions( )const;
          bool skip_db_sessions( block_status bs )const;

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -275,6 +275,7 @@ namespace eosio { namespace chain {
          int64_t set_proposed_producers( vector<producer_authority> producers );
 
          bool light_validation_allowed(bool replay_opts_disabled_by_policy) const;
+         bool light_validation_mode() const;
          bool skip_auth_check()const;
          bool skip_db_sessions( )const;
          bool skip_db_sessions( block_status bs )const;

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -3087,7 +3087,7 @@ namespace eosio {
    void net_plugin_impl::on_accepted_block(const block_state_ptr& block) {
       update_chain_info();
       controller& cc = chain_plug->chain();
-      if( !cc.light_validation_mode() ) {
+      if( !cc.skip_auth_check() ) {
          dispatcher->strand.post( [this, block]() {
             fc_dlog( logger, "signaled accepted_block, blk num = ${num}, id = ${id}", ("num", block->block_num)("id", block->id) );
             dispatcher->bcast_block( block );
@@ -3099,7 +3099,7 @@ namespace eosio {
    void net_plugin_impl::on_accepted_block_header(const block_state_ptr& block) {
       update_chain_info();
       controller& cc = chain_plug->chain();
-      if( cc.light_validation_mode() ) {
+      if( cc.skip_auth_check() ) {
          dispatcher->strand.post( [this, block]() {
             fc_dlog( logger, "signaled accepted_block_header, blk num = ${num}, id = ${id}", ("num", block->block_num)("id", block->id) );
             dispatcher->bcast_block( block );

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -3087,7 +3087,7 @@ namespace eosio {
    void net_plugin_impl::on_accepted_block(const block_state_ptr& block) {
       update_chain_info();
       controller& cc = chain_plug->chain();
-      if( !cc.skip_auth_check() ) {
+      if( !cc.light_validation_mode() ) {
          dispatcher->strand.post( [this, block]() {
             fc_dlog( logger, "signaled accepted_block, blk num = ${num}, id = ${id}", ("num", block->block_num)("id", block->id) );
             dispatcher->bcast_block( block );
@@ -3099,7 +3099,7 @@ namespace eosio {
    void net_plugin_impl::on_accepted_block_header(const block_state_ptr& block) {
       update_chain_info();
       controller& cc = chain_plug->chain();
-      if( cc.skip_auth_check() ) {
+      if( cc.light_validation_mode() ) {
          dispatcher->strand.post( [this, block]() {
             fc_dlog( logger, "signaled accepted_block_header, blk num = ${num}, id = ${id}", ("num", block->block_num)("id", block->id) );
             dispatcher->bcast_block( block );

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -267,7 +267,6 @@ namespace eosio {
       std::atomic<bool>                     in_shutdown{false};
 
       compat::channels::transaction_ack::channel_type::handle  incoming_transaction_ack_subscription;
-      channels::irreversible_block::channel_type::handle       incoming_irreversible_block_subscription;
 
       uint16_t                                  thread_pool_size = 2;
       optional<eosio::chain::named_thread_pool> thread_pool;
@@ -289,6 +288,7 @@ namespace eosio {
       void start_listen_loop();
 
       void on_accepted_block( const block_state_ptr& bs );
+      void on_accepted_block_header( const block_state_ptr& bs );
       void transaction_ack(const std::pair<fc::exception_ptr, transaction_metadata_ptr>&);
       void on_irreversible_block( const block_state_ptr& blk );
 
@@ -3086,10 +3086,25 @@ namespace eosio {
    // called from application thread
    void net_plugin_impl::on_accepted_block(const block_state_ptr& block) {
       update_chain_info();
-      dispatcher->strand.post( [this, block]() {
-         fc_dlog( logger, "signaled, blk num = ${num}, id = ${id}", ("num", block->block_num)("id", block->id) );
-         dispatcher->bcast_block( block );
-      });
+      controller& cc = chain_plug->chain();
+      if( !cc.skip_auth_check() ) {
+         dispatcher->strand.post( [this, block]() {
+            fc_dlog( logger, "signaled accepted_block, blk num = ${num}, id = ${id}", ("num", block->block_num)("id", block->id) );
+            dispatcher->bcast_block( block );
+         });
+      }
+   }
+
+   // called from application thread
+   void net_plugin_impl::on_accepted_block_header(const block_state_ptr& block) {
+      update_chain_info();
+      controller& cc = chain_plug->chain();
+      if( cc.skip_auth_check() ) {
+         dispatcher->strand.post( [this, block]() {
+            fc_dlog( logger, "signaled accepted_block_header, blk num = ${num}, id = ${id}", ("num", block->block_num)("id", block->id) );
+            dispatcher->bcast_block( block );
+         });
+      }
    }
 
    // called from application thread
@@ -3433,6 +3448,9 @@ namespace eosio {
       {
          cc.accepted_block.connect( [my = my]( const block_state_ptr& s ) {
             my->on_accepted_block( s );
+         } );
+         cc.accepted_block_header.connect( [my = my]( const block_state_ptr& s ) {
+            my->on_accepted_block_header( s );
          } );
          cc.irreversible_block.connect( [my = my]( const block_state_ptr& s ) {
             my->on_irreversible_block( s );

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -180,7 +180,7 @@ namespace eosio {
 
       void bcast_transaction(const packed_transaction& trx);
       void rejected_transaction(const packed_transaction_ptr& trx, uint32_t head_blk_num);
-      void bcast_block(const block_state_ptr& bs);
+      void bcast_block( const signed_block_ptr& b, const block_id_type& id );
       void bcast_notice( const block_id_type& id );
       void rejected_block(const block_id_type& id);
 
@@ -288,7 +288,7 @@ namespace eosio {
       void start_listen_loop();
 
       void on_accepted_block( const block_state_ptr& bs );
-      void on_accepted_block_header( const block_state_ptr& bs );
+      void on_pre_accepted_block( const signed_block_ptr& bs );
       void transaction_ack(const std::pair<fc::exception_ptr, transaction_metadata_ptr>&);
       void on_irreversible_block( const block_state_ptr& blk );
 
@@ -1919,8 +1919,8 @@ namespace eosio {
    }
 
    // thread safe
-   void dispatch_manager::bcast_block(const block_state_ptr& bs) {
-      fc_dlog( logger, "bcast block ${b}", ("b", bs->block_num) );
+   void dispatch_manager::bcast_block(const signed_block_ptr& b, const block_id_type& id) {
+      fc_dlog( logger, "bcast block ${b}", ("b", b->block_num()) );
 
       if( my_impl->sync_master->syncing_with_peer() ) return;
       
@@ -1937,19 +1937,18 @@ namespace eosio {
       } );
 
       if( !have_connection ) return;
-      std::shared_ptr<std::vector<char>> send_buffer = create_send_buffer( bs->block );
+      std::shared_ptr<std::vector<char>> send_buffer = create_send_buffer( b );
 
-      for_each_block_connection( [this, bs, send_buffer]( auto& cp ) {
+      for_each_block_connection( [this, &id, bnum = b->block_num(), &send_buffer]( auto& cp ) {
          if( !cp->current() ) {
             return true;
          }
-         cp->strand.post( [this, cp, bs, send_buffer]() {
-            uint32_t bnum = bs->block_num;
+         cp->strand.post( [this, cp, id, bnum, send_buffer]() {
             std::unique_lock<std::mutex> g_conn( cp->conn_mtx );
             bool has_block = cp->last_handshake_recv.last_irreversible_block_num >= bnum;
             g_conn.unlock();
             if( !has_block ) {
-               if( !add_peer_block( bs->id, cp->connection_id ) ) {
+               if( !add_peer_block( id, cp->connection_id ) ) {
                   fc_dlog( logger, "not bcast block ${b} to ${p}", ("b", bnum)("p", cp->peer_name()) );
                   return;
                }
@@ -3084,25 +3083,24 @@ namespace eosio {
    }
 
    // called from application thread
-   void net_plugin_impl::on_accepted_block(const block_state_ptr& block) {
+   void net_plugin_impl::on_accepted_block(const block_state_ptr& bs) {
       update_chain_info();
       controller& cc = chain_plug->chain();
-      if( !cc.skip_auth_check() ) {
-         dispatcher->strand.post( [this, block]() {
-            fc_dlog( logger, "signaled accepted_block, blk num = ${num}, id = ${id}", ("num", block->block_num)("id", block->id) );
-            dispatcher->bcast_block( block );
-         });
-      }
+      dispatcher->strand.post( [this, bs]() {
+         fc_dlog( logger, "signaled accepted_block, blk num = ${num}, id = ${id}", ("num", bs->block_num)("id", bs->id) );
+         dispatcher->bcast_block( bs->block, bs->id );
+      });
    }
 
    // called from application thread
-   void net_plugin_impl::on_accepted_block_header(const block_state_ptr& block) {
+   void net_plugin_impl::on_pre_accepted_block(const signed_block_ptr& block) {
       update_chain_info();
       controller& cc = chain_plug->chain();
-      if( cc.skip_auth_check() ) {
+      if( cc.is_trusted_producer(block->producer) ) {
          dispatcher->strand.post( [this, block]() {
-            fc_dlog( logger, "signaled accepted_block_header, blk num = ${num}, id = ${id}", ("num", block->block_num)("id", block->id) );
-            dispatcher->bcast_block( block );
+            auto id = block->id();
+            fc_dlog( logger, "signaled pre_accepted_block, blk num = ${num}, id = ${id}", ("num", block->block_num())("id", id) );
+            dispatcher->bcast_block( block, id );
          });
       }
    }
@@ -3449,8 +3447,8 @@ namespace eosio {
          cc.accepted_block.connect( [my = my]( const block_state_ptr& s ) {
             my->on_accepted_block( s );
          } );
-         cc.accepted_block_header.connect( [my = my]( const block_state_ptr& s ) {
-            my->on_accepted_block_header( s );
+         cc.pre_accepted_block.connect( [my = my]( const signed_block_ptr& s ) {
+            my->on_pre_accepted_block( s );
          } );
          cc.irreversible_block.connect( [my = my]( const block_state_ptr& s ) {
             my->on_irreversible_block( s );


### PR DESCRIPTION
## Change Description

- Relay block on `pre_accepted_block` signal for trusted producer or light validation. 
- `develop` version of #8701 

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
