### PR TITLE
[1.8.x] Actions rerun fixes.

### DIFF
--- a/.cicd/submodule-regression-check.sh
+++ b/.cicd/submodule-regression-check.sh
@@ -10,7 +10,7 @@ if [[ $BUILDKITE == true ]]; then
 else
     [[ -z $GITHUB_BASE_REF ]] && echo "Cannot find \$GITHUB_BASE_REF, so we have nothing to compare submodules to. Skipping submodule regression check." && exit 0
     BASE_BRANCH=$GITHUB_BASE_REF
-    CURRENT_BRANCH=$GITHUB_SHA
+    CURRENT_BRANCH="refs/remotes/pull/$PR_NUMBER/merge"
 fi
 
 echo "getting submodule info for $CURRENT_BRANCH"
@@ -24,12 +24,6 @@ git submodule update --init 1> /dev/null
 while read -r a b; do
     BASE_MAP[$a]=$b
 done < <(git submodule --quiet foreach --recursive 'echo $path `git log -1 --format=%ct`')
-
-# We need to switch back to the PR ref/head so we can git log properly
-if [[ $BUILDKITE != true ]]; then
-    echo "git fetch origin +$GITHUB_REF:"
-    git fetch origin +${GITHUB_REF}: 1> /dev/null
-fi
 
 echo "switching back to $CURRENT_BRANCH..."
 echo "git checkout -qf $CURRENT_BRANCH"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,9 @@
 name: Pull Request
 on: [pull_request]
 
+env:
+  PR_NUMBER: ${{ toJson(github.event.number) }}
+
 jobs:
   submodule_regression_check:
     if: github.event.pull_request.base.repo.id != github.event.pull_request.head.repo.id
@@ -8,9 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
-        with:
-          submodules: recursive
+        run: |
+          git clone https://github.com/${GITHUB_REPOSITORY} .
+          git fetch -v --prune origin +refs/pull/${PR_NUMBER}/merge:refs/remotes/pull/${PR_NUMBER}/merge
+          git checkout --force --progress refs/remotes/pull/${PR_NUMBER}/merge
+          git submodule sync --recursive
+          git submodule update --init --force --recursive
       - name: Submodule Regression Check
         run: ./.cicd/submodule-regression-check.sh
 
@@ -21,9 +27,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
-        with:
-          submodules: recursive
+        run: |
+          git clone https://github.com/${GITHUB_REPOSITORY} .
+          git fetch -v --prune origin +refs/pull/${PR_NUMBER}/merge:refs/remotes/pull/${PR_NUMBER}/merge
+          git checkout --force --progress refs/remotes/pull/${PR_NUMBER}/merge
+          git submodule sync --recursive
+          git submodule update --init --force --recursive
       - name: Build
         run: | 
           ./.cicd/build.sh
@@ -42,9 +51,12 @@ jobs:
     needs: amazon_linux-2-build
     steps:
       - name: Checkout
-        uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
-        with:
-          submodules: recursive
+        run: |
+          git clone https://github.com/${GITHUB_REPOSITORY} .
+          git fetch -v --prune origin +refs/pull/${PR_NUMBER}/merge:refs/remotes/pull/${PR_NUMBER}/merge
+          git checkout --force --progress refs/remotes/pull/${PR_NUMBER}/merge
+          git submodule sync --recursive
+          git submodule update --init --force --recursive
       - name: Download Build Artifact
         uses: actions/download-artifact@v1
         with:
@@ -62,9 +74,12 @@ jobs:
     needs: amazon_linux-2-build
     steps:
       - name: Checkout
-        uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
-        with:
-          submodules: recursive
+        run: |
+          git clone https://github.com/${GITHUB_REPOSITORY} .
+          git fetch -v --prune origin +refs/pull/${PR_NUMBER}/merge:refs/remotes/pull/${PR_NUMBER}/merge
+          git checkout --force --progress refs/remotes/pull/${PR_NUMBER}/merge
+          git submodule sync --recursive
+          git submodule update --init --force --recursive
       - name: Download Build Artifact
         uses: actions/download-artifact@v1
         with:
@@ -84,9 +99,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
-        with:
-          submodules: recursive
+        run: |
+          git clone https://github.com/${GITHUB_REPOSITORY} .
+          git fetch -v --prune origin +refs/pull/${PR_NUMBER}/merge:refs/remotes/pull/${PR_NUMBER}/merge
+          git checkout --force --progress refs/remotes/pull/${PR_NUMBER}/merge
+          git submodule sync --recursive
+          git submodule update --init --force --recursive
       - name: Build
         run: | 
           ./.cicd/build.sh
@@ -105,9 +123,12 @@ jobs:
     needs: centos-77-build
     steps:
       - name: Checkout
-        uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
-        with:
-          submodules: recursive
+        run: |
+          git clone https://github.com/${GITHUB_REPOSITORY} .
+          git fetch -v --prune origin +refs/pull/${PR_NUMBER}/merge:refs/remotes/pull/${PR_NUMBER}/merge
+          git checkout --force --progress refs/remotes/pull/${PR_NUMBER}/merge
+          git submodule sync --recursive
+          git submodule update --init --force --recursive
       - name: Download Build Artifact
         uses: actions/download-artifact@v1
         with:
@@ -125,9 +146,12 @@ jobs:
     needs: centos-77-build
     steps:
       - name: Checkout
-        uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
-        with:
-          submodules: recursive
+        run: |
+          git clone https://github.com/${GITHUB_REPOSITORY} .
+          git fetch -v --prune origin +refs/pull/${PR_NUMBER}/merge:refs/remotes/pull/${PR_NUMBER}/merge
+          git checkout --force --progress refs/remotes/pull/${PR_NUMBER}/merge
+          git submodule sync --recursive
+          git submodule update --init --force --recursive
       - name: Download Build Artifact
         uses: actions/download-artifact@v1
         with:
@@ -147,9 +171,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
-        with:
-          submodules: recursive
+        run: |
+          git clone https://github.com/${GITHUB_REPOSITORY} .
+          git fetch -v --prune origin +refs/pull/${PR_NUMBER}/merge:refs/remotes/pull/${PR_NUMBER}/merge
+          git checkout --force --progress refs/remotes/pull/${PR_NUMBER}/merge
+          git submodule sync --recursive
+          git submodule update --init --force --recursive
       - name: Build
         run: | 
           ./.cicd/build.sh
@@ -168,9 +195,12 @@ jobs:
     needs: ubuntu-1604-build
     steps:
       - name: Checkout
-        uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
-        with:
-          submodules: recursive
+        run: |
+          git clone https://github.com/${GITHUB_REPOSITORY} .
+          git fetch -v --prune origin +refs/pull/${PR_NUMBER}/merge:refs/remotes/pull/${PR_NUMBER}/merge
+          git checkout --force --progress refs/remotes/pull/${PR_NUMBER}/merge
+          git submodule sync --recursive
+          git submodule update --init --force --recursive
       - name: Download Build Artifact
         uses: actions/download-artifact@v1
         with:
@@ -188,9 +218,12 @@ jobs:
     needs: ubuntu-1604-build
     steps:
       - name: Checkout
-        uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
-        with:
-          submodules: recursive
+        run: |
+          git clone https://github.com/${GITHUB_REPOSITORY} .
+          git fetch -v --prune origin +refs/pull/${PR_NUMBER}/merge:refs/remotes/pull/${PR_NUMBER}/merge
+          git checkout --force --progress refs/remotes/pull/${PR_NUMBER}/merge
+          git submodule sync --recursive
+          git submodule update --init --force --recursive
       - name: Download Build Artifact
         uses: actions/download-artifact@v1
         with:
@@ -210,9 +243,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
-        with:
-          submodules: recursive
+        run: |
+          git clone https://github.com/${GITHUB_REPOSITORY} .
+          git fetch -v --prune origin +refs/pull/${PR_NUMBER}/merge:refs/remotes/pull/${PR_NUMBER}/merge
+          git checkout --force --progress refs/remotes/pull/${PR_NUMBER}/merge
+          git submodule sync --recursive
+          git submodule update --init --force --recursive
       - name: Build
         run: | 
           ./.cicd/build.sh
@@ -231,9 +267,12 @@ jobs:
     needs: ubuntu-1804-build
     steps:
       - name: Checkout
-        uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
-        with:
-          submodules: recursive
+        run: |
+          git clone https://github.com/${GITHUB_REPOSITORY} .
+          git fetch -v --prune origin +refs/pull/${PR_NUMBER}/merge:refs/remotes/pull/${PR_NUMBER}/merge
+          git checkout --force --progress refs/remotes/pull/${PR_NUMBER}/merge
+          git submodule sync --recursive
+          git submodule update --init --force --recursive
       - name: Download Build Artifact
         uses: actions/download-artifact@v1
         with:
@@ -251,9 +290,12 @@ jobs:
     needs: ubuntu-1804-build
     steps:
       - name: Checkout
-        uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
-        with:
-          submodules: recursive
+        run: |
+          git clone https://github.com/${GITHUB_REPOSITORY} .
+          git fetch -v --prune origin +refs/pull/${PR_NUMBER}/merge:refs/remotes/pull/${PR_NUMBER}/merge
+          git checkout --force --progress refs/remotes/pull/${PR_NUMBER}/merge
+          git submodule sync --recursive
+          git submodule update --init --force --recursive
       - name: Download Build Artifact
         uses: actions/download-artifact@v1
         with:
@@ -273,9 +315,12 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
-        with:
-          submodules: recursive
+        run: |
+          git clone https://github.com/${GITHUB_REPOSITORY} .
+          git fetch -v --prune origin +refs/pull/${PR_NUMBER}/merge:refs/remotes/pull/${PR_NUMBER}/merge
+          git checkout --force --progress refs/remotes/pull/${PR_NUMBER}/merge
+          git submodule sync --recursive
+          git submodule update --init --force --recursive
       - name: Build
         run: | 
           ./.cicd/platforms/unpinned/macos-10.14-unpinned.sh
@@ -292,9 +337,12 @@ jobs:
     needs: macos-1015-build
     steps:
       - name: Checkout
-        uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
-        with:
-          submodules: recursive
+        run: |
+          git clone https://github.com/${GITHUB_REPOSITORY} .
+          git fetch -v --prune origin +refs/pull/${PR_NUMBER}/merge:refs/remotes/pull/${PR_NUMBER}/merge
+          git checkout --force --progress refs/remotes/pull/${PR_NUMBER}/merge
+          git submodule sync --recursive
+          git submodule update --init --force --recursive
       - name: Download Build Artifact
         uses: actions/download-artifact@v1
         with:
@@ -310,9 +358,12 @@ jobs:
     needs: macos-1015-build
     steps:
       - name: Checkout
-        uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
-        with:
-          submodules: recursive
+        run: |
+          git clone https://github.com/${GITHUB_REPOSITORY} .
+          git fetch -v --prune origin +refs/pull/${PR_NUMBER}/merge:refs/remotes/pull/${PR_NUMBER}/merge
+          git checkout --force --progress refs/remotes/pull/${PR_NUMBER}/merge
+          git submodule sync --recursive
+          git submodule update --init --force --recursive
       - name: Download Build Artifact
         uses: actions/download-artifact@v1
         with:


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
Fixed an issue regarding checkouts when rerunning a failed forked PR:
- Removed use of Actions checkout plugin for several reasons:
  - Version 1 of the plugin does not handle the race condition between the "merge commit" being created in Github and trying to checkout this commit.
  - Version 2 of the plugin addressed the above issue... but does not allow submodules to be checked out automatically.
  - We can use v2 of the plugin and manually checkout submodules... but v2 of the plugin does not checkout the full history of the repo, required for the submodule regression check.
  - Actions-based environment variables are set incorrectly on PR reruns of forked repositories...
- Replaced Actions plugin with our own checkout steps:
  - Clone the full repo.
  - Checkout the specific ref tied to the pull request number. We can do this because the workflow only runs on pull request events and reruns trigger a pull request event. Both cases contain the PR number.
  - Perform our own submodule checkout steps to grab the entire repository.
- Update submodule regression checker.
  - Checkout the specific ref tied to the pull request number when called from Actions.

See:
[Actions](https://github.com/EOSIO/eos/actions/runs/46221169) | This Actions run builds a forked PR could be retried and checked out the codebase correctly.

[Build 20768](https://buildkite.com/EOSIO/eosio/builds/20768) | Buildkite run showing expected behavior with submodule regression check.

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
