### PR TITLE
Fix mutliple version protocol test intermittent failure - 1.8

### DIFF
--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -950,6 +950,7 @@ void producer_plugin::handle_sighup() {
 }
 
 void producer_plugin::pause() {
+   ilog("Producer paused.");
    my->_pause_production = true;
 }
 
@@ -961,7 +962,10 @@ void producer_plugin::resume() {
    if (my->_pending_block_mode == pending_block_mode::speculating) {
       chain::controller& chain = my->chain_plug->chain();
       chain.abort_block();
+      ilog("Producer resumed. Scheduling production.");
       my->schedule_production_loop();
+   } else {
+      ilog("Producer resumed.");
    }
 }
 

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -950,7 +950,7 @@ void producer_plugin::handle_sighup() {
 }
 
 void producer_plugin::pause() {
-   ilog("Producer paused.");
+   fc_ilog(_log, "Producer paused.");
    my->_pause_production = true;
 }
 
@@ -962,10 +962,10 @@ void producer_plugin::resume() {
    if (my->_pending_block_mode == pending_block_mode::speculating) {
       chain::controller& chain = my->chain_plug->chain();
       chain.abort_block();
-      ilog("Producer resumed. Scheduling production.");
+      fc_ilog(_log, "Producer resumed. Scheduling production.");
       my->schedule_production_loop();
    } else {
-      ilog("Producer resumed.");
+      fc_ilog(_log, "Producer resumed.");
    }
 }
 

--- a/tests/nodeos_forked_chain_test.py
+++ b/tests/nodeos_forked_chain_test.py
@@ -272,7 +272,8 @@ try:
             blockProducer=node.getBlockProducerByNum(blockNum)
 
         if producerToSlot[lastBlockProducer]["count"]!=inRowCountPerProducer:
-            Utils.errorExit("Producer %s, in slot %d, expected to produce %d blocks but produced %d blocks" % (blockProducer, slot, inRowCountPerProducer, producerToSlot[lastBlockProducer]["count"]))
+            Utils.errorExit("Producer %s, in slot %d, expected to produce %d blocks but produced %d blocks.  At block number %d." %
+                            (lastBlockProducer, slot, inRowCountPerProducer, producerToSlot[lastBlockProducer]["count"], blockNum-1))
 
         if blockProducer==productionCycle[0]:
             break

--- a/tests/nodeos_multiple_version_protocol_feature_test.py
+++ b/tests/nodeos_multiple_version_protocol_feature_test.py
@@ -110,7 +110,7 @@ try:
         for node in allNodes:
             if not node.killed: node.processCurlCmd("producer", "resume", "")
 
-    def shouldNodesBeInSync(nodes:[Node]):
+    def areNodesInSync(nodes:[Node]):
         # Pause all block production to ensure the head is not moving
         pauseBlockProductions()
         time.sleep(1) # Wait for some time to ensure all blocks are propagated
@@ -122,7 +122,7 @@ try:
         return len(set(headBlockIds)) == 1
 
     # Before everything starts, all nodes (new version and old version) should be in sync
-    assert shouldNodesBeInSync(allNodes), "Nodes are not in sync before preactivation"
+    assert areNodesInSync(allNodes), "Nodes are not in sync before preactivation"
 
     # First, we are going to test the case where:
     # - 1st node has valid earliest_allowed_activation_time
@@ -140,13 +140,13 @@ try:
     assert shouldNodeContainPreactivateFeature(newNodes[0]), "1st node should contain PREACTIVATE FEATURE"
     assert not (shouldNodeContainPreactivateFeature(newNodes[1]) or shouldNodeContainPreactivateFeature(newNodes[2])), \
            "2nd and 3rd node should not contain PREACTIVATE FEATURE"
-    assert shouldNodesBeInSync([newNodes[1], newNodes[2], oldNode]), "2nd, 3rd and 4th node should be in sync"
-    assert not shouldNodesBeInSync(allNodes), "1st node should be out of sync with the rest nodes"
+    assert areNodesInSync([newNodes[1], newNodes[2], oldNode]), "2nd, 3rd and 4th node should be in sync"
+    assert not areNodesInSync(allNodes), "1st node should be out of sync with the rest nodes"
 
     waitForOneRound()
 
     assert not shouldNodeContainPreactivateFeature(newNodes[0]), "PREACTIVATE_FEATURE should be dropped"
-    assert shouldNodesBeInSync(allNodes), "All nodes should be in sync"
+    assert areNodesInSync(allNodes), "All nodes should be in sync"
 
     # Then we set the earliest_allowed_activation_time of 2nd node and 3rd node with valid value
     # Once the 1st node activate PREACTIVATE_FEATURE, all of them should have PREACTIVATE_FEATURE activated in the next block
@@ -160,8 +160,8 @@ try:
     libBeforePreactivation = newNodes[0].getIrreversibleBlockNum()
     newNodes[0].activatePreactivateFeature()
 
-    assert shouldNodesBeInSync(newNodes), "New nodes should be in sync"
-    assert not shouldNodesBeInSync(allNodes), "Nodes should not be in sync after preactivation"
+    assert areNodesInSync(newNodes), "New nodes should be in sync"
+    assert not areNodesInSync(allNodes), "Nodes should not be in sync after preactivation"
     for node in newNodes: assert shouldNodeContainPreactivateFeature(node), "New node should contain PREACTIVATE_FEATURE"
 
     activatedBlockNum = newNodes[0].getHeadBlockNum() # The PREACTIVATE_FEATURE should have been activated before or at this block num
@@ -188,7 +188,7 @@ try:
     restartNode(oldNode, oldNodeId, chainArg="--replay", nodeosPath="programs/nodeos/nodeos")
     time.sleep(2) # Give some time to replay
 
-    assert shouldNodesBeInSync(allNodes), "All nodes should be in sync"
+    assert areNodesInSync(allNodes), "All nodes should be in sync"
     assert shouldNodeContainPreactivateFeature(oldNode), "4th node should contain PREACTIVATE_FEATURE"
 
     testSuccessful = True

--- a/tests/nodeos_multiple_version_protocol_feature_test.py
+++ b/tests/nodeos_multiple_version_protocol_feature_test.py
@@ -84,6 +84,8 @@ try:
     }
     Utils.Print("Alternate Version Labels File is {}".format(alternateVersionLabelsFile))
     assert exists(alternateVersionLabelsFile), "Alternate version labels file does not exist"
+    # version 1.7 did not provide a default value for "--last-block-time-offset-us" so this is needed to
+    # avoid dropping late blocks
     assert cluster.launch(pnodes=4, totalNodes=4, prodCount=1, totalProducers=4,
                           extraNodeosArgs=" --plugin eosio::producer_api_plugin ",
                           useBiosBootFile=False,

--- a/tests/nodeos_multiple_version_protocol_feature_test.py
+++ b/tests/nodeos_multiple_version_protocol_feature_test.py
@@ -113,7 +113,7 @@ try:
     def areNodesInSync(nodes:[Node]):
         # Pause all block production to ensure the head is not moving
         pauseBlockProductions()
-        time.sleep(1) # Wait for some time to ensure all blocks are propagated
+        time.sleep(2) # Wait for some time to ensure all blocks are propagated
         headBlockIds = []
         for node in nodes:
             headBlockId = node.getInfo()["head_block_id"]

--- a/tests/nodeos_multiple_version_protocol_feature_test.py
+++ b/tests/nodeos_multiple_version_protocol_feature_test.py
@@ -90,7 +90,8 @@ try:
                           specificExtraNodeosArgs={
                              0:"--http-max-response-time-ms 990000",
                              1:"--http-max-response-time-ms 990000",
-                             2:"--http-max-response-time-ms 990000"},
+                             2:"--http-max-response-time-ms 990000",
+                             3:"--last-block-time-offset-us -200000"},
                           onlySetProds=True,
                           pfSetupPolicy=PFSetupPolicy.NONE,
                           alternateVersionLabelsFile=alternateVersionLabelsFile,


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
Fixed error in test due to 1.7 version producer producing block just as next block starts it production window and thus rejecting that block, just as production for all producers is paused.  Added logging to indicate producer is paused or resumed. Also other test cleanup and updated error message of forked_chain_test.

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
