### PR TITLE
Get info priority - 2.0

### DIFF
--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -79,7 +79,8 @@ void chain_api_plugin::plugin_startup() {
    ro_api.set_shorten_abi_errors( !_http_plugin.verbose_errors() );
 
    _http_plugin.add_api({
-      CHAIN_RO_CALL(get_info, 200l),
+      CHAIN_RO_CALL(get_info, 200)}, appbase::priority::medium);
+   _http_plugin.add_api({
       CHAIN_RO_CALL(get_activated_protocol_features, 200),
       CHAIN_RO_CALL(get_block, 200),
       CHAIN_RO_CALL(get_block_header_state, 200),


### PR DESCRIPTION
## Change Description

- Change the priority of `get_info` to `medium` which is the same as syncing since it is useful to be able to `get_info` while nodeos is busy syncing. 

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
