### PR TITLE
New options for api nodes - develop

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -241,6 +241,8 @@ struct controller_impl {
    const chain_id_type            chain_id; // read by thread_pool threads, value will not be changed
    optional<fc::time_point>       replay_head_time;
    db_read_mode                   read_mode = db_read_mode::SPECULATIVE;
+   bool                           p2p_accept_transactions = true; ///< if false, trx over p2p network are not processed
+   bool                           api_accept_transactions = true; ///< if false, trx from api are not processed
    bool                           in_trx_requiring_checks = false; ///< if true, checks that are normally skipped on replay (e.g. auth checks) cannot be skipped
    optional<fc::microseconds>     subjective_cpu_leeway;
    bool                           trusted_producer_light_validation = false;
@@ -2674,14 +2676,10 @@ void controller::push_block( std::future<block_state_ptr>& block_state_future,
    my->push_block( block_state_future, forked_branch_cb, trx_lookup );
 }
 
-bool controller::in_immutable_mode()const{
-   return (db_mode_is_immutable(get_read_mode()));
-}
-
 transaction_trace_ptr controller::push_transaction( const transaction_metadata_ptr& trx, fc::time_point deadline,
                                                     uint32_t billed_cpu_time_us, bool explicit_billed_cpu_time ) {
    validate_db_available_size();
-   EOS_ASSERT( !in_immutable_mode(), transaction_type_exception, "push transaction not allowed in read-only mode" );
+   EOS_ASSERT( get_read_mode() != db_read_mode::IRREVERSIBLE, transaction_type_exception, "push transaction not allowed in irreversible mode" );
    EOS_ASSERT( trx && !trx->implicit && !trx->scheduled, transaction_type_exception, "Implicit/Scheduled transaction not allowed" );
    return my->push_transaction(trx, deadline, billed_cpu_time_us, explicit_billed_cpu_time );
 }
@@ -2689,7 +2687,7 @@ transaction_trace_ptr controller::push_transaction( const transaction_metadata_p
 transaction_trace_ptr controller::push_scheduled_transaction( const transaction_id_type& trxid, fc::time_point deadline,
                                                               uint32_t billed_cpu_time_us, bool explicit_billed_cpu_time )
 {
-   EOS_ASSERT( !in_immutable_mode(), transaction_type_exception, "push scheduled transaction not allowed in read-only mode" );
+   EOS_ASSERT( get_read_mode() != db_read_mode::IRREVERSIBLE, transaction_type_exception, "push scheduled transaction not allowed in irreversible mode" );
    validate_db_available_size();
    return my->push_scheduled_transaction( trxid, deadline, billed_cpu_time_us, explicit_billed_cpu_time );
 }

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -241,8 +241,6 @@ struct controller_impl {
    const chain_id_type            chain_id; // read by thread_pool threads, value will not be changed
    optional<fc::time_point>       replay_head_time;
    db_read_mode                   read_mode = db_read_mode::SPECULATIVE;
-   bool                           p2p_accept_transactions = true; ///< if false, trx over p2p network are not processed
-   bool                           api_accept_transactions = true; ///< if false, trx from api are not processed
    bool                           in_trx_requiring_checks = false; ///< if true, checks that are normally skipped on replay (e.g. auth checks) cannot be skipped
    optional<fc::microseconds>     subjective_cpu_leeway;
    bool                           trusted_producer_light_validation = false;

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -47,6 +47,7 @@ namespace eosio { namespace chain {
       SPECULATIVE,
       HEAD,
       READ_ONLY,
+      API_READ_ONLY,
       IRREVERSIBLE
    };
 

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -47,11 +47,8 @@ namespace eosio { namespace chain {
       SPECULATIVE,
       HEAD,
       READ_ONLY,
-      API,
       IRREVERSIBLE
    };
-
-   inline bool db_mode_is_immutable(db_read_mode m) {return db_read_mode::READ_ONLY == m || db_read_mode::IRREVERSIBLE ==m;}
 
    enum class validation_mode {
       FULL,

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -47,7 +47,7 @@ namespace eosio { namespace chain {
       SPECULATIVE,
       HEAD,
       READ_ONLY,
-      API_READ_ONLY,
+      API,
       IRREVERSIBLE
    };
 

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -45,8 +45,8 @@ std::ostream& operator<<(std::ostream& osm, eosio::chain::db_read_mode m) {
       osm << "head";
    } else if ( m == eosio::chain::db_read_mode::READ_ONLY ) {
       osm << "read-only";
-   } else if ( m == eosio::chain::db_read_mode::API_READ_ONLY ) {
-      osm << "api-read-only";
+   } else if ( m == eosio::chain::db_read_mode::API ) {
+      osm << "api";
    } else if ( m == eosio::chain::db_read_mode::IRREVERSIBLE ) {
       osm << "irreversible";
    }
@@ -74,8 +74,8 @@ void validate(boost::any& v,
      v = boost::any(eosio::chain::db_read_mode::HEAD);
   } else if ( s == "read-only" ) {
      v = boost::any(eosio::chain::db_read_mode::READ_ONLY);
-  } else if ( s == "api-read-only" ) {
-     v = boost::any(eosio::chain::db_read_mode::API_READ_ONLY);
+  } else if ( s == "api" ) {
+     v = boost::any(eosio::chain::db_read_mode::API);
   } else if ( s == "irreversible" ) {
      v = boost::any(eosio::chain::db_read_mode::IRREVERSIBLE);
   } else {
@@ -242,7 +242,7 @@ void chain_plugin::set_program_options(options_description& cli, options_descrip
           "In \"speculative\" mode database contains changes done up to the head block plus changes made by transactions not yet included to the blockchain.\n"
           "In \"head\" mode database contains changes done up to the current head block.\n"
           "In \"read-only\" mode database contains changes done up to the current head block and transactions cannot be pushed to the chain API.\n"
-          "In \"api-read-only\" mode database contains changes done up to the head block; only api transactions are speculatively executed.\n"
+          "In \"api\" mode database contains changes done up to the head block; only api transactions are speculatively executed.\n"
           "In \"irreversible\" mode database contains changes done up to the last irreversible block and transactions cannot be pushed to the chain API.\n"
           )
          ("validation-mode", boost::program_options::value<eosio::chain::validation_mode>()->default_value(eosio::chain::validation_mode::FULL),

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -242,7 +242,7 @@ void chain_plugin::set_program_options(options_description& cli, options_descrip
           "In \"speculative\" mode database contains changes done up to the head block plus changes made by transactions not yet included to the blockchain.\n"
           "In \"head\" mode database contains changes done up to the current head block.\n"
           "In \"read-only\" mode database contains changes done up to the current head block and transactions cannot be pushed to the chain API.\n"
-          "In \"api-read-only\" mode database contains changes done up to the head block plus changes made by api transactions but not p2p transactions. \n"
+          "In \"api-read-only\" mode database contains changes done up to the head block; only api transactions are speculatively executed.\n"
           "In \"irreversible\" mode database contains changes done up to the last irreversible block and transactions cannot be pushed to the chain API.\n"
           )
          ("validation-mode", boost::program_options::value<eosio::chain::validation_mode>()->default_value(eosio::chain::validation_mode::FULL),

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -140,7 +140,7 @@ public:
    bfs::path                        blocks_dir;
    bool                             readonly = false;
    flat_map<uint32_t,block_id_type> loaded_checkpoints;
-   bool                             p2p_accept_transactions = true;
+   bool                             accept_transactions = false;
    bool                             api_accept_transactions = true;
 
 
@@ -243,7 +243,6 @@ void chain_plugin::set_program_options(options_description& cli, options_descrip
           "In \"read-only\" mode: (DEPRECATED: see p2p-accept-transactions & api-accept-transactions) database contains state changes by only transactions in the blockchain up to the head block; transactions received via the P2P network are not relayed and transactions cannot be pushed via the chain API.\n"
           "In \"irreversible\" mode: database contains state changes by only transactions in the blockchain up to the last irreversible block; transactions received via the P2P network are not relayed and transactions cannot be pushed via the chain API.\n"
           )
-         ( "p2p-accept-transactions", bpo::value<bool>()->default_value(true), "Allow transactions received over p2p network to be evaluated and relayed if valid.")
          ( "api-accept-transactions", bpo::value<bool>()->default_value(true), "Allow API transactions to be evaluated and relayed if valid.")
          ("validation-mode", boost::program_options::value<eosio::chain::validation_mode>()->default_value(eosio::chain::validation_mode::FULL),
           "Chain validation mode (\"full\" or \"light\").\n"
@@ -1001,24 +1000,20 @@ void chain_plugin::plugin_initialize(const variables_map& options) {
       if ( options.count("read-mode") ) {
          my->chain_config->read_mode = options.at("read-mode").as<db_read_mode>();
       }
-      my->p2p_accept_transactions = options.at( "p2p-accept-transactions" ).as<bool>();
       my->api_accept_transactions = options.at( "api-accept-transactions" ).as<bool>();
 
       if( my->chain_config->read_mode == db_read_mode::IRREVERSIBLE || my->chain_config->read_mode == db_read_mode::READ_ONLY ) {
          if( my->chain_config->read_mode == db_read_mode::READ_ONLY ) {
             wlog( "read-mode = read-only is deprecated use p2p-accept-transactions = false, api-accept-transactions = false instead." );
          }
-         if( my->p2p_accept_transactions ) {
-            my->p2p_accept_transactions = false;
-            std::stringstream ss; ss << my->chain_config->read_mode;
-            wlog( "p2p-accept-transactions set to false due to read-mode: ${m}", ("m", ss.str()) );
-         }
          if( my->api_accept_transactions ) {
             my->api_accept_transactions = false;
             std::stringstream ss; ss << my->chain_config->read_mode;
             wlog( "api-accept-transactions set to false due to read-mode: ${m}", ("m", ss.str()) );
          }
-         EOS_ASSERT( no_transactions(), plugin_config_exception, "IRREVERSIBLE should configure no_transactions" );
+      }
+      if( my->api_accept_transactions ) {
+         enable_accept_transactions();
       }
 
       if ( options.count("validation-mode") ) {
@@ -1106,6 +1101,8 @@ void chain_plugin::plugin_initialize(const variables_map& options) {
 
 void chain_plugin::plugin_startup()
 { try {
+   EOS_ASSERT( my->chain_config->read_mode != db_read_mode::IRREVERSIBLE || !accept_transactions(), plugin_config_exception,
+               "read-mode = irreversible. transactions should not be enabled by enable_accept_transactions" );
    try {
       auto shutdown = [](){ return app().quit(); };
       auto check_shutdown = [](){ return app().is_quiting(); };
@@ -1398,13 +1395,18 @@ fc::microseconds chain_plugin::get_abi_serializer_max_time() const {
    return my->abi_serializer_max_time_us;
 }
 
-bool chain_plugin::p2p_accept_transactions() const {
-   return my->p2p_accept_transactions;
-}
-
 bool chain_plugin::api_accept_transactions() const{
    return my->api_accept_transactions;
 }
+
+bool chain_plugin::accept_transactions() const {
+   return my->accept_transactions;
+}
+
+void chain_plugin::enable_accept_transactions() {
+   my->accept_transactions = true;
+}
+
 
 void chain_plugin::log_guard_exception(const chain::guard_exception&e ) {
    if (e.code() == chain::database_guard_exception::code_value) {

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -43,10 +43,8 @@ std::ostream& operator<<(std::ostream& osm, eosio::chain::db_read_mode m) {
       osm << "speculative";
    } else if ( m == eosio::chain::db_read_mode::HEAD ) {
       osm << "head";
-   } else if ( m == eosio::chain::db_read_mode::READ_ONLY ) {
+   } else if ( m == eosio::chain::db_read_mode::READ_ONLY ) { // deprecated
       osm << "read-only";
-   } else if ( m == eosio::chain::db_read_mode::API ) {
-      osm << "api";
    } else if ( m == eosio::chain::db_read_mode::IRREVERSIBLE ) {
       osm << "irreversible";
    }
@@ -74,8 +72,6 @@ void validate(boost::any& v,
      v = boost::any(eosio::chain::db_read_mode::HEAD);
   } else if ( s == "read-only" ) {
      v = boost::any(eosio::chain::db_read_mode::READ_ONLY);
-  } else if ( s == "api" ) {
-     v = boost::any(eosio::chain::db_read_mode::API);
   } else if ( s == "irreversible" ) {
      v = boost::any(eosio::chain::db_read_mode::IRREVERSIBLE);
   } else {
@@ -144,6 +140,9 @@ public:
    bfs::path                        blocks_dir;
    bool                             readonly = false;
    flat_map<uint32_t,block_id_type> loaded_checkpoints;
+   bool                             p2p_accept_transactions = true;
+   bool                             api_accept_transactions = true;
+
 
    fc::optional<fork_database>      fork_db;
    fc::optional<block_log>          block_logger;
@@ -239,12 +238,13 @@ void chain_plugin::set_program_options(options_description& cli, options_descrip
           "Deferred transactions sent by accounts in this list do not have any of the subjective whitelist/blacklist checks applied to them (may specify multiple times)")
          ("read-mode", boost::program_options::value<eosio::chain::db_read_mode>()->default_value(eosio::chain::db_read_mode::SPECULATIVE),
           "Database read mode (\"speculative\", \"head\", \"read-only\", \"irreversible\").\n"
-          "In \"speculative\" mode database contains changes done up to the head block plus changes made by transactions not yet included to the blockchain.\n"
-          "In \"head\" mode database contains changes done up to the current head block.\n"
-          "In \"read-only\" mode database contains changes done up to the current head block and transactions cannot be pushed to the chain API.\n"
-          "In \"api\" mode database contains changes done up to the head block; only api transactions are speculatively executed.\n"
-          "In \"irreversible\" mode database contains changes done up to the last irreversible block and transactions cannot be pushed to the chain API.\n"
+          "In \"speculative\" mode: database contains state changes by transactions in the blockchain up to the head block as well as some transactions not yet included in the blockchain.\n"
+          "In \"head\" mode: database contains state changes by only transactions in the blockchain up to the head block; transactions received by the node are relayed if valid.\n"
+          "In \"read-only\" mode: (DEPRECATED: see p2p-accept-transactions & api-accept-transactions) database contains state changes by only transactions in the blockchain up to the head block; transactions received via the P2P network are not relayed and transactions cannot be pushed via the chain API.\n"
+          "In \"irreversible\" mode: database contains state changes by only transactions in the blockchain up to the last irreversible block; transactions received via the P2P network are not relayed and transactions cannot be pushed via the chain API.\n"
           )
+         ( "p2p-accept-transactions", bpo::value<bool>()->default_value(true), "Allow transactions received over p2p network to be evaluated and relayed if valid.")
+         ( "api-accept-transactions", bpo::value<bool>()->default_value(true), "Allow API transactions to be evaluated and relayed if valid.")
          ("validation-mode", boost::program_options::value<eosio::chain::validation_mode>()->default_value(eosio::chain::validation_mode::FULL),
           "Chain validation mode (\"full\" or \"light\").\n"
           "In \"full\" mode all incoming blocks will be fully validated.\n"
@@ -1001,6 +1001,25 @@ void chain_plugin::plugin_initialize(const variables_map& options) {
       if ( options.count("read-mode") ) {
          my->chain_config->read_mode = options.at("read-mode").as<db_read_mode>();
       }
+      my->p2p_accept_transactions = options.at( "p2p-accept-transactions" ).as<bool>();
+      my->api_accept_transactions = options.at( "api-accept-transactions" ).as<bool>();
+
+      if( my->chain_config->read_mode == db_read_mode::IRREVERSIBLE || my->chain_config->read_mode == db_read_mode::READ_ONLY ) {
+         if( my->chain_config->read_mode == db_read_mode::READ_ONLY ) {
+            wlog( "read-mode = read-only is deprecated use p2p-accept-transactions = false, api-accept-transactions = false instead." );
+         }
+         if( my->p2p_accept_transactions ) {
+            my->p2p_accept_transactions = false;
+            std::stringstream ss; ss << my->chain_config->read_mode;
+            wlog( "p2p-accept-transactions set to false due to read-mode: ${m}", ("m", ss.str()) );
+         }
+         if( my->api_accept_transactions ) {
+            my->api_accept_transactions = false;
+            std::stringstream ss; ss << my->chain_config->read_mode;
+            wlog( "api-accept-transactions set to false due to read-mode: ${m}", ("m", ss.str()) );
+         }
+         EOS_ASSERT( no_transactions(), plugin_config_exception, "IRREVERSIBLE should configure no_transactions" );
+      }
 
       if ( options.count("validation-mode") ) {
          my->chain_config->block_validation_mode = options.at("validation-mode").as<validation_mode>();
@@ -1134,14 +1153,16 @@ void chain_plugin::plugin_shutdown() {
    my->chain.reset();
 }
 
-chain_apis::read_write::read_write(controller& db, const fc::microseconds& abi_serializer_max_time)
+chain_apis::read_write::read_write(controller& db, const fc::microseconds& abi_serializer_max_time, bool api_accept_transactions)
 : db(db)
 , abi_serializer_max_time(abi_serializer_max_time)
+, api_accept_transactions(api_accept_transactions)
 {
 }
 
 void chain_apis::read_write::validate() const {
-   EOS_ASSERT( !db.in_immutable_mode(), missing_chain_api_plugin_exception, "Not allowed, node in read-only mode" );
+   EOS_ASSERT( api_accept_transactions, missing_chain_api_plugin_exception,
+               "Not allowed, node has api-accept-transactions = false" );
 }
 
 bool chain_plugin::accept_block(const signed_block_ptr& block, const block_id_type& id ) {
@@ -1375,6 +1396,14 @@ chain::chain_id_type chain_plugin::get_chain_id()const {
 
 fc::microseconds chain_plugin::get_abi_serializer_max_time() const {
    return my->abi_serializer_max_time_us;
+}
+
+bool chain_plugin::p2p_accept_transactions() const {
+   return my->p2p_accept_transactions;
+}
+
+bool chain_plugin::api_accept_transactions() const{
+   return my->api_accept_transactions;
 }
 
 void chain_plugin::log_guard_exception(const chain::guard_exception&e ) {

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -45,6 +45,8 @@ std::ostream& operator<<(std::ostream& osm, eosio::chain::db_read_mode m) {
       osm << "head";
    } else if ( m == eosio::chain::db_read_mode::READ_ONLY ) {
       osm << "read-only";
+   } else if ( m == eosio::chain::db_read_mode::API_READ_ONLY ) {
+      osm << "api-read-only";
    } else if ( m == eosio::chain::db_read_mode::IRREVERSIBLE ) {
       osm << "irreversible";
    }
@@ -72,6 +74,8 @@ void validate(boost::any& v,
      v = boost::any(eosio::chain::db_read_mode::HEAD);
   } else if ( s == "read-only" ) {
      v = boost::any(eosio::chain::db_read_mode::READ_ONLY);
+  } else if ( s == "api-read-only" ) {
+     v = boost::any(eosio::chain::db_read_mode::API_READ_ONLY);
   } else if ( s == "irreversible" ) {
      v = boost::any(eosio::chain::db_read_mode::IRREVERSIBLE);
   } else {
@@ -238,6 +242,7 @@ void chain_plugin::set_program_options(options_description& cli, options_descrip
           "In \"speculative\" mode database contains changes done up to the head block plus changes made by transactions not yet included to the blockchain.\n"
           "In \"head\" mode database contains changes done up to the current head block.\n"
           "In \"read-only\" mode database contains changes done up to the current head block and transactions cannot be pushed to the chain API.\n"
+          "In \"api-read-only\" mode database contains changes done up to the head block plus changes made by api transactions but not p2p transactions. \n"
           "In \"irreversible\" mode database contains changes done up to the last irreversible block and transactions cannot be pushed to the chain API.\n"
           )
          ("validation-mode", boost::program_options::value<eosio::chain::validation_mode>()->default_value(eosio::chain::validation_mode::FULL),

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -734,9 +734,10 @@ public:
 
    chain::chain_id_type get_chain_id() const;
    fc::microseconds get_abi_serializer_max_time() const;
-   bool p2p_accept_transactions() const;
    bool api_accept_transactions() const;
-   bool no_transactions() const { return !p2p_accept_transactions() && !api_accept_transactions(); }
+   // set true by other plugins if any plugin allows transactions
+   bool accept_transactions() const;
+   void enable_accept_transactions();
 
    static void handle_guard_exception(const chain::guard_exception& e);
    void do_hard_replay(const variables_map& options);

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -592,8 +592,9 @@ public:
 class read_write {
    controller& db;
    const fc::microseconds abi_serializer_max_time;
+   const bool api_accept_transactions;
 public:
-   read_write(controller& db, const fc::microseconds& abi_serializer_max_time);
+   read_write(controller& db, const fc::microseconds& abi_serializer_max_time, bool api_accept_transactions);
    void validate() const;
 
    using push_block_params = chain::signed_block;
@@ -704,7 +705,7 @@ public:
    void plugin_shutdown();
 
    chain_apis::read_only get_read_only_api() const { return chain_apis::read_only(chain(), get_abi_serializer_max_time()); }
-   chain_apis::read_write get_read_write_api() { return chain_apis::read_write(chain(), get_abi_serializer_max_time()); }
+   chain_apis::read_write get_read_write_api() { return chain_apis::read_write(chain(), get_abi_serializer_max_time(), p2p_accept_transactions()); }
 
    bool accept_block( const chain::signed_block_ptr& block, const chain::block_id_type& id );
    void accept_transaction(const chain::packed_transaction_ptr& trx, chain::plugin_interface::next_function<chain::transaction_trace_ptr> next);
@@ -733,6 +734,9 @@ public:
 
    chain::chain_id_type get_chain_id() const;
    fc::microseconds get_abi_serializer_max_time() const;
+   bool p2p_accept_transactions() const;
+   bool api_accept_transactions() const;
+   bool no_transactions() const { return !p2p_accept_transactions() && !api_accept_transactions(); }
 
    static void handle_guard_exception(const chain::guard_exception& e);
    void do_hard_replay(const variables_map& options);

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -705,7 +705,7 @@ public:
    void plugin_shutdown();
 
    chain_apis::read_only get_read_only_api() const { return chain_apis::read_only(chain(), get_abi_serializer_max_time()); }
-   chain_apis::read_write get_read_write_api() { return chain_apis::read_write(chain(), get_abi_serializer_max_time(), p2p_accept_transactions()); }
+   chain_apis::read_write get_read_write_api() { return chain_apis::read_write(chain(), get_abi_serializer_max_time(), api_accept_transactions()); }
 
    bool accept_block( const chain::signed_block_ptr& block, const chain::block_id_type& id );
    void accept_transaction(const chain::packed_transaction_ptr& trx, chain::plugin_interface::next_function<chain::transaction_trace_ptr> next);

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2830,7 +2830,7 @@ namespace eosio {
    }
 
    void connection::handle_message( packed_transaction_ptr trx ) {
-      if( db_mode_is_immutable(my_impl->db_read_mode) || my_impl->db_read_mode == db_read_mode::API_READ_ONLY ) {
+      if( db_mode_is_immutable(my_impl->db_read_mode) || my_impl->db_read_mode == db_read_mode::API ) {
          fc_dlog( logger, "got a txn in read only mode - dropping" );
          return;
       }

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -1922,7 +1922,7 @@ namespace eosio {
    void dispatch_manager::bcast_block(const signed_block_ptr& b, const block_id_type& id) {
       fc_dlog( logger, "bcast block ${b}", ("b", b->block_num()) );
 
-      if( my_impl->sync_master->syncing_with_peer() || my_impl->db_read_mode == db_read_mode::API_READ_ONLY ) return;
+      if( my_impl->sync_master->syncing_with_peer() ) return;
       
       bool have_connection = false;
       for_each_block_connection( [&have_connection]( auto& cp ) {

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -237,6 +237,7 @@ namespace eosio {
       int                                   max_cleanup_time_ms = 0;
       uint32_t                              max_client_count = 0;
       uint32_t                              max_nodes_per_host = 1;
+      bool                                  p2p_accept_transactions = true;
 
       /// Peer clock may be no more than 1 second skewed from our clock, including network latency.
       const std::chrono::system_clock::duration peer_authentication_interval{std::chrono::seconds{1}};
@@ -3267,6 +3268,7 @@ namespace eosio {
            "    p2p.trx.eos.io:9876:trx\n"
            "    p2p.blk.eos.io:9876:blk\n")
          ( "p2p-max-nodes-per-host", bpo::value<int>()->default_value(def_max_nodes_per_host), "Maximum number of client nodes from any single IP address")
+         ( "p2p-accept-transactions", bpo::value<bool>()->default_value(true), "Allow transactions received over p2p network to be evaluated and relayed if valid.")
          ( "agent-name", bpo::value<string>()->default_value("EOS Test Agent"), "The name supplied to identify this node amongst the peers.")
          ( "allowed-connection", bpo::value<vector<string>>()->multitoken()->default_value({"any"}, "any"), "Can be 'any' or 'producers' or 'specified' or 'none'. If 'specified', peer-key must be specified at least once. If only 'producers', peer-key is not required. 'producers' and 'specified' may be combined.")
          ( "peer-key", bpo::value<vector<string>>()->composing()->multitoken(), "Optional public key of peer allowed to connect.  May be used multiple times.")
@@ -3278,7 +3280,7 @@ namespace eosio {
          ( "net-threads", bpo::value<uint16_t>()->default_value(my->thread_pool_size),
            "Number of worker threads in net_plugin thread pool" )
          ( "sync-fetch-span", bpo::value<uint32_t>()->default_value(def_sync_fetch_span), "number of blocks to retrieve in a chunk from any individual peer during synchronization")
-         ( "use-socket-read-watermark", bpo::value<bool>()->default_value(false), "Enable expirimental socket read watermark optimization")
+         ( "use-socket-read-watermark", bpo::value<bool>()->default_value(false), "Enable experimental socket read watermark optimization")
          ( "peer-log-format", bpo::value<string>()->default_value( "[\"${_name}\" ${_ip}:${_port}]" ),
            "The string used to format peers when logging messages about them.  Variables are escaped with ${<variable name>}.\n"
            "Available Variables:\n"
@@ -3310,6 +3312,7 @@ namespace eosio {
          my->resp_expected_period = def_resp_expected_wait;
          my->max_client_count = options.at( "max-clients" ).as<int>();
          my->max_nodes_per_host = options.at( "p2p-max-nodes-per-host" ).as<int>();
+         my->p2p_accept_transactions = options.at( "p2p-accept-transactions" ).as<bool>();
 
          my->use_socket_read_watermark = options.at( "use-socket-read-watermark" ).as<bool>();
 
@@ -3394,10 +3397,13 @@ namespace eosio {
 
       chain::controller&cc = my->chain_plug->chain();
       my->db_read_mode = cc.get_read_mode();
-      if( cc.in_immutable_mode() && my->p2p_address.size() ) {
+      if( my->db_read_mode == db_read_mode::READ_ONLY ) {
+         my->p2p_accept_transactions = false;
+      }
+      if( !my->p2p_accept_transactions && my->p2p_address.size() ) {
          fc_wlog( logger, "\n"
                "**********************************\n"
-               "*         Read Only Mode         *\n"
+               "*      p2p-accept-transactions         *\n"
                "* - Transactions not forwarded - *\n"
                "**********************************\n" );
       }

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -1922,7 +1922,7 @@ namespace eosio {
    void dispatch_manager::bcast_block(const signed_block_ptr& b, const block_id_type& id) {
       fc_dlog( logger, "bcast block ${b}", ("b", b->block_num()) );
 
-      if( my_impl->sync_master->syncing_with_peer() ) return;
+      if( my_impl->sync_master->syncing_with_peer() || my_impl->db_read_mode == db_read_mode::API_READ_ONLY ) return;
       
       bool have_connection = false;
       for_each_block_connection( [&have_connection]( auto& cp ) {
@@ -2830,8 +2830,8 @@ namespace eosio {
    }
 
    void connection::handle_message( packed_transaction_ptr trx ) {
-      if( db_mode_is_immutable(my_impl->db_read_mode) ) {
-         fc_dlog( logger, "got a txn in read-only mode - dropping" );
+      if( db_mode_is_immutable(my_impl->db_read_mode) || my_impl->db_read_mode == db_read_mode::API_READ_ONLY ) {
+         fc_dlog( logger, "got a txn in read only mode - dropping" );
          return;
       }
 

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1377,7 +1377,7 @@ fc::time_point producer_plugin_impl::calculate_block_deadline( const fc::time_po
 producer_plugin_impl::start_block_result producer_plugin_impl::start_block() {
    chain::controller& chain = chain_plug->chain();
 
-   if( chain.in_immutable_mode() )
+   if( chain_plug->no_transactions() )
       return start_block_result::waiting_for_block;
 
    const auto& hbs = chain.head_block_state();

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -911,6 +911,9 @@ void producer_plugin::plugin_startup()
    EOS_ASSERT( my->_producers.empty() || chain.get_validation_mode() == chain::validation_mode::FULL, plugin_config_exception,
               "node cannot have any producer-name configured because block production is not safe when validation_mode is not \"full\"" );
 
+   EOS_ASSERT( my->_producers.empty() || !my->chain_plug->no_transactions(), plugin_config_exception,
+              "node cannot have any producer-name configured because no block production is possible with no [api|p2p]-accepted-transactions" );
+
    my->_accepted_block_connection.emplace(chain.accepted_block.connect( [this]( const auto& bsp ){ my->on_block( bsp ); } ));
    my->_accepted_block_header_connection.emplace(chain.accepted_block_header.connect( [this]( const auto& bsp ){ my->on_block_header( bsp ); } ));
    my->_irreversible_block_connection.emplace(chain.irreversible_block.connect( [this]( const auto& bsp ){ my->on_irreversible_block( bsp->block ); } ));

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -911,7 +911,7 @@ void producer_plugin::plugin_startup()
    EOS_ASSERT( my->_producers.empty() || chain.get_validation_mode() == chain::validation_mode::FULL, plugin_config_exception,
               "node cannot have any producer-name configured because block production is not safe when validation_mode is not \"full\"" );
 
-   EOS_ASSERT( my->_producers.empty() || !my->chain_plug->no_transactions(), plugin_config_exception,
+   EOS_ASSERT( my->_producers.empty() || my->chain_plug->accept_transactions(), plugin_config_exception,
               "node cannot have any producer-name configured because no block production is possible with no [api|p2p]-accepted-transactions" );
 
    my->_accepted_block_connection.emplace(chain.accepted_block.connect( [this]( const auto& bsp ){ my->on_block( bsp ); } ));
@@ -1380,7 +1380,7 @@ fc::time_point producer_plugin_impl::calculate_block_deadline( const fc::time_po
 producer_plugin_impl::start_block_result producer_plugin_impl::start_block() {
    chain::controller& chain = chain_plug->chain();
 
-   if( chain_plug->no_transactions() )
+   if( !chain_plug->accept_transactions() )
       return start_block_result::waiting_for_block;
 
    const auto& hbs = chain.head_block_state();

--- a/unittests/forked_tests.cpp
+++ b/unittests/forked_tests.cpp
@@ -390,6 +390,11 @@ BOOST_AUTO_TEST_CASE( read_modes ) try {
    BOOST_CHECK_EQUAL(head_block_num, head.control->fork_db_head_block_num());
    BOOST_CHECK_EQUAL(head_block_num, head.control->head_block_num());
 
+   tester api_read_only(setup_policy::none, db_read_mode::API_READ_ONLY);
+   push_blocks(c, api_read_only);
+   BOOST_CHECK_EQUAL(head_block_num, api_read_only.control->fork_db_head_block_num());
+   BOOST_CHECK_EQUAL(head_block_num, api_read_only.control->head_block_num());
+
    tester read_only(setup_policy::none, db_read_mode::READ_ONLY);
    push_blocks(c, read_only);
    BOOST_CHECK_EQUAL(head_block_num, read_only.control->fork_db_head_block_num());

--- a/unittests/forked_tests.cpp
+++ b/unittests/forked_tests.cpp
@@ -390,11 +390,6 @@ BOOST_AUTO_TEST_CASE( read_modes ) try {
    BOOST_CHECK_EQUAL(head_block_num, head.control->fork_db_head_block_num());
    BOOST_CHECK_EQUAL(head_block_num, head.control->head_block_num());
 
-   tester api(setup_policy::none, db_read_mode::API);
-   push_blocks(c, api);
-   BOOST_CHECK_EQUAL(head_block_num, api.control->fork_db_head_block_num());
-   BOOST_CHECK_EQUAL(head_block_num, api.control->head_block_num());
-
    tester read_only(setup_policy::none, db_read_mode::READ_ONLY);
    push_blocks(c, read_only);
    BOOST_CHECK_EQUAL(head_block_num, read_only.control->fork_db_head_block_num());

--- a/unittests/forked_tests.cpp
+++ b/unittests/forked_tests.cpp
@@ -390,10 +390,10 @@ BOOST_AUTO_TEST_CASE( read_modes ) try {
    BOOST_CHECK_EQUAL(head_block_num, head.control->fork_db_head_block_num());
    BOOST_CHECK_EQUAL(head_block_num, head.control->head_block_num());
 
-   tester api_read_only(setup_policy::none, db_read_mode::API_READ_ONLY);
-   push_blocks(c, api_read_only);
-   BOOST_CHECK_EQUAL(head_block_num, api_read_only.control->fork_db_head_block_num());
-   BOOST_CHECK_EQUAL(head_block_num, api_read_only.control->head_block_num());
+   tester api(setup_policy::none, db_read_mode::API);
+   push_blocks(c, api);
+   BOOST_CHECK_EQUAL(head_block_num, api.control->fork_db_head_block_num());
+   BOOST_CHECK_EQUAL(head_block_num, api.control->head_block_num());
 
    tester read_only(setup_policy::none, db_read_mode::READ_ONLY);
    push_blocks(c, read_only);


### PR DESCRIPTION
## Change Description

*  --p2p-accept-transactions arg (=1)    Allow transactions received over p2p 
                                        network to be evaluated and relayed if valid.
*  --api-accept-transactions arg (=1)    Allow API transactions to be evaluated 
                                        and relayed if valid.

- `read-mode = irreversible` now asserts unless:
    - `p2p-accept-transactions = false` 
    - `api-accept-transactions = false`

- Resolves #8685 by user specifying:
  - `read-mode = head`
  - `p2p-accept-transactions = false`
  - `api-accept-transactions = true`

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [x] Documentation Additions

### Updated Descriptions: 

  **--read-mode arg (=speculative)**        
- Database read mode ("speculative", "head", "read-only", "irreversible").
In "speculative" mode: database 
contains state changes by transactions 
in the blockchain up to the head block 
as well as some transactions not yet 
included in the blockchain.

- In "head" mode: database contains state
changes by only transactions in the 
blockchain up to the head block; 
transactions received by the node are 
relayed if valid.

- In "read-only" mode: (DEPRECATED: see 
p2p-accept-transactions & 
api-accept-transactions) database 
contains state changes by only 
transactions in the blockchain up to 
the head block; transactions received 
via the P2P network are not relayed and
transactions cannot be pushed via the 
chain API.

- In "irreversible" mode: database 
contains state changes by only 
transactions in the blockchain up to 
the last irreversible block; 
transactions received via the P2P 
network are not relayed and 
transactions cannot be pushed via the chain API.
   
### New Options:
                                     
  --p2p-accept-transactions arg (=1)    Allow transactions received over p2p 
                                        network to be evaluated and relayed if valid.
  --api-accept-transactions arg (=1)    Allow API transactions to be evaluated 
                                        and relayed if valid.