### PR TITLE
Added concept of data handlers to trace_api_plugin

### DIFF
--- a/plugins/trace_api_plugin/CMakeLists.txt
+++ b/plugins/trace_api_plugin/CMakeLists.txt
@@ -1,6 +1,7 @@
 file(GLOB HEADERS "include/eosio/trace_api_plugin/*.hpp")
 add_library( trace_api_plugin
              request_handler.cpp
+             abi_data_handler.cpp
              trace_api_plugin.cpp
              ${HEADERS} )
 

--- a/plugins/trace_api_plugin/abi_data_handler.cpp
+++ b/plugins/trace_api_plugin/abi_data_handler.cpp
@@ -1,0 +1,20 @@
+#include <eosio/trace_api_plugin/abi_data_handler.hpp>
+#include <eosio/chain/abi_serializer.hpp>
+#include <eosio/trace_api_plugin/request_handler.hpp>
+
+namespace eosio::trace_api_plugin {
+
+   void abi_data_handler::add_abi( const chain::name& name, const chain::abi_def& abi ) {
+      abi_serializer_by_account.emplace(name, std::make_shared<chain::abi_serializer>(abi, fc::microseconds::maximum()));
+   }
+
+   fc::variant abi_data_handler::process_data(const action_trace_v0& action, const fc::time_point& deadline) {
+      if (abi_serializer_by_account.count(action.account) == 0) {
+         return fc::to_hex(action.data.data(), action.data.size());
+      }
+
+      const auto& serializer_p = abi_serializer_by_account.at(action.account);
+      auto type_name = serializer_p->get_action_type(action.action);
+      return serializer_p->binary_to_variant( type_name, action.data, fc::microseconds::maximum() );
+   }
+}

--- a/plugins/trace_api_plugin/include/eosio/trace_api_plugin/abi_data_handler.hpp
+++ b/plugins/trace_api_plugin/include/eosio/trace_api_plugin/abi_data_handler.hpp
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <eosio/chain/abi_def.hpp>
+#include <eosio/trace_api_plugin/trace.hpp>
+
+namespace eosio {
+   namespace chain {
+      struct abi_serializer;
+   }
+
+   namespace trace_api_plugin {
+
+   /**
+    * Data Handler that uses eosio::chain::abi_serializer to decode data with a known set of ABI's
+    * Can be used directly as a Data_handler_provider OR shared between request_handlers using the
+    * ::shared_provider abstraction.
+    */
+   class abi_data_handler {
+   public:
+      abi_data_handler()
+      {
+      }
+
+      /**
+       * Add an ABI definition to this data handler
+       * @param name - the name of the account/contract that this ABI belongs to
+       * @param abi - the ABI definition of that ABI
+       */
+      void add_abi( const chain::name& name, const chain::abi_def& abi );
+
+      /**
+       * Given an action trace, produce a variant that represents the `data` field in the trace
+       *
+       * @param action - trace of the action including metadata necessary for finding the ABI
+       * @param deadline - deadline for processing
+       * @return variant representing the `data` field of the action
+       */
+      fc::variant process_data( const action_trace_v0& action, const fc::time_point& deadline);
+
+      /**
+       * Utility class that allows mulitple request_handlers to share the same abi_data_handler
+       */
+      class shared_provider {
+         public:
+         explicit shared_provider(const std::shared_ptr<abi_data_handler>& handler)
+         :handler(handler)
+         {}
+
+         fc::variant process_data( const action_trace_v0& action, const fc::time_point& deadline) {
+            return handler->process_data(action, deadline);
+         }
+
+         std::shared_ptr<abi_data_handler> handler;
+      };
+
+   private:
+      std::map<chain::name, std::shared_ptr<chain::abi_serializer>> abi_serializer_by_account;
+   };
+} }

--- a/plugins/trace_api_plugin/include/eosio/trace_api_plugin/abi_data_handler.hpp
+++ b/plugins/trace_api_plugin/include/eosio/trace_api_plugin/abi_data_handler.hpp
@@ -17,7 +17,8 @@ namespace eosio {
     */
    class abi_data_handler {
    public:
-      abi_data_handler()
+      explicit abi_data_handler(std::function<void(const std::exception_ptr&)> log = {})
+      :log(log)
       {
       }
 
@@ -55,5 +56,6 @@ namespace eosio {
 
    private:
       std::map<chain::name, std::shared_ptr<chain::abi_serializer>> abi_serializer_by_account;
+      std::function<void(const std::exception_ptr&)> log;
    };
 } }

--- a/plugins/trace_api_plugin/include/eosio/trace_api_plugin/base64_data_handler.hpp
+++ b/plugins/trace_api_plugin/include/eosio/trace_api_plugin/base64_data_handler.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <eosio/trace_api_plugin/trace.hpp>
+
+namespace eosio::trace_api_plugin {
+   class base64_data_handler {
+   public:
+      base64_data_handler()
+      {}
+
+      fc::variant process_data( const action_trace_v0& action, const fc::time_point& ) {
+         return fc::base64_encode(action.data.data(), action.data.size());
+      }
+   };
+}

--- a/plugins/trace_api_plugin/include/eosio/trace_api_plugin/request_handler.hpp
+++ b/plugins/trace_api_plugin/include/eosio/trace_api_plugin/request_handler.hpp
@@ -41,8 +41,8 @@ namespace eosio::trace_api_plugin {
    class request_handler {
    public:
       request_handler(LogfileProvider&& logfile_provider, DataHandlerProvider&& data_handler_provider, const now_function& now)
-      :logfile_provider(logfile_provider)
-      ,data_handler_provider(data_handler_provider)
+      :logfile_provider(std::move(logfile_provider))
+      ,data_handler_provider(std::move(data_handler_provider))
       ,now(now)
       {
       }

--- a/plugins/trace_api_plugin/test/CMakeLists.txt
+++ b/plugins/trace_api_plugin/test/CMakeLists.txt
@@ -15,3 +15,9 @@ target_link_libraries( test_responses trace_api_plugin )
 target_include_directories( test_responses PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" )
 
 add_test(NAME test_responses COMMAND plugins/trace_api_plugin/test/test_responses WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+
+add_executable( test_data_handlers test_data_handlers.cpp )
+target_link_libraries( test_data_handlers trace_api_plugin )
+target_include_directories( test_data_handlers PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" )
+
+add_test(NAME test_data_handlers COMMAND plugins/trace_api_plugin/test/test_data_handlers WORKING_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/plugins/trace_api_plugin/test/test_data_handlers.cpp
+++ b/plugins/trace_api_plugin/test/test_data_handlers.cpp
@@ -1,0 +1,141 @@
+#define BOOST_TEST_MODULE trace_data_handlers
+#include <boost/test/included/unit_test.hpp>
+
+#include <eosio/trace_api_plugin/base64_data_handler.hpp>
+#include <eosio/trace_api_plugin/abi_data_handler.hpp>
+
+#include <eosio/trace_api_plugin/test_common.hpp>
+
+using namespace eosio;
+using namespace eosio::trace_api_plugin;
+using namespace eosio::trace_api_plugin::test_common;
+
+BOOST_AUTO_TEST_SUITE(abi_data_handler_tests)
+   BOOST_AUTO_TEST_CASE(empty_data)
+   {
+      auto action = action_trace_v0 {
+         0, "alice"_n, "alice"_n, "foo"_n, {}, {}
+      };
+      abi_data_handler handler;
+
+      auto expected = fc::variant("");
+      auto actual = handler.process_data(action, fc::time_point::maximum());
+
+      BOOST_TEST(to_kv(expected) == to_kv(actual), boost::test_tools::per_element());
+   }
+
+   BOOST_AUTO_TEST_CASE(no_abi)
+   {
+      auto action = action_trace_v0 {
+         0, "alice"_n, "alice"_n, "foo"_n, {}, {0x00, 0x01, 0x02, 0x03}
+      };
+      abi_data_handler handler;
+
+      auto expected = fc::variant("00010203");
+      auto actual = handler.process_data(action, fc::time_point::maximum());
+
+      BOOST_TEST(to_kv(expected) == to_kv(actual), boost::test_tools::per_element());
+   }
+
+   BOOST_AUTO_TEST_CASE(basic_abi)
+   {
+      auto action = action_trace_v0 {
+            0, "alice"_n, "alice"_n, "foo"_n, {}, {0x00, 0x01, 0x02, 0x03}
+      };
+
+      auto abi = chain::abi_def ( {},
+         {
+            { "foo", "", { {"a", "varuint32"}, {"b", "varuint32"}, {"c", "varuint32"}, {"d", "varuint32"} } }
+         },
+         {
+            { "foo"_n, "foo", ""}
+         },
+         {}, {}, {}
+      );
+      abi.version = "eosio::abi/1.";
+      
+      abi_data_handler handler;
+      handler.add_abi("alice"_n, abi);
+
+      fc::variant expected = fc::mutable_variant_object()
+         ("a", 0)
+         ("b", 1)
+         ("c", 2)
+         ("d", 3);
+
+      auto actual = handler.process_data(action, fc::time_point::maximum());
+
+      BOOST_TEST(to_kv(expected) == to_kv(actual), boost::test_tools::per_element());
+   }
+   
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE(base64_data_handler_tests)
+   BOOST_AUTO_TEST_CASE(empty_data)
+   {
+      auto action = action_trace_v0 {
+         0, "alice"_n, "alice"_n, "foo"_n, {}, {}
+      };
+      base64_data_handler handler;
+
+      auto expected = fc::variant("");
+      auto actual = handler.process_data(action, fc::time_point::maximum());
+
+      BOOST_TEST(to_kv(expected) == to_kv(actual), boost::test_tools::per_element());
+   }
+
+   BOOST_AUTO_TEST_CASE(aligned_data)
+   {
+      auto action = action_trace_v0 {
+         0, "alice"_n, "alice"_n, "foo"_n, {}, { 0x00, 0x01, 0x02 }
+      };
+      base64_data_handler handler;
+
+      auto expected = fc::variant("AAEC");
+      auto actual = handler.process_data(action, fc::time_point::maximum());
+
+      BOOST_TEST(to_kv(expected) == to_kv(actual), boost::test_tools::per_element());
+   }
+
+   BOOST_AUTO_TEST_CASE(single_padded_data)
+   {
+      auto action = action_trace_v0 {
+            0, "alice"_n, "alice"_n, "foo"_n, {}, { 0x00, 0x01 }
+      };
+      base64_data_handler handler;
+
+      auto expected = fc::variant("AAE=");
+      auto actual = handler.process_data(action, fc::time_point::maximum());
+
+      BOOST_TEST(to_kv(expected) == to_kv(actual), boost::test_tools::per_element());
+   }
+
+   BOOST_AUTO_TEST_CASE(double_padded_data)
+   {
+      auto action = action_trace_v0 {
+            0, "alice"_n, "alice"_n, "foo"_n, {}, { 0x00 }
+      };
+      base64_data_handler handler;
+
+      auto expected = fc::variant("AA==");
+      auto actual = handler.process_data(action, fc::time_point::maximum());
+
+      BOOST_TEST(to_kv(expected) == to_kv(actual), boost::test_tools::per_element());
+   }
+
+   BOOST_AUTO_TEST_CASE(special_chars_data)
+   {
+      auto action = action_trace_v0 {
+            0, "alice"_n, "alice"_n, "foo"_n, {}, { static_cast<char>(0xFF), static_cast<char>(0xE0) }
+      };
+      base64_data_handler handler;
+
+      auto expected = fc::variant("/+A=");
+      auto actual = handler.process_data(action, fc::time_point::maximum());
+
+      BOOST_TEST(to_kv(expected) == to_kv(actual), boost::test_tools::per_element());
+   }
+
+BOOST_AUTO_TEST_SUITE_END()
+

--- a/plugins/trace_api_plugin/test/test_responses.cpp
+++ b/plugins/trace_api_plugin/test/test_responses.cpp
@@ -74,7 +74,7 @@ struct response_test_fixture {
       response_test_fixture& fixture;
    };
 
-   struct mock_data_handler_provider {>
+   struct mock_data_handler_provider {
       fc::variant process_data(const action_trace_v0& action, const fc::time_point&) {
          return fc::to_hex(action.data.data(), action.data.size());
       }


### PR DESCRIPTION
data handlers are used to parse action data and are distinct from the response subsystem to maintain separation of concerns.  In this PR:

- [ ] : mock data handler for the existing response tests
- [ ] : base64 data handler for reference
- [ ] : abi data handler with support for a dictionary of abi's shared amongst multiple response handlers 

the abi data handler supports an injected logger function to separate the logging of exceptions that cause it to revert to hex encoding from logic of producing data

Unfortunately, abi_serializer has a native concept of "now" which makes it difficult to test easily.  As such, there is no deadline provided to the abi serialization process inside a single action.   The response processor will enforce deadlines between actions and there is no descent into recursive ABI'd structures (like `eosio.msig`) so this should be a minimal attack surface. 