### PR TITLE
Trace API Plugin and configuration scaffolding 

### DIFF
--- a/plugins/trace_api_plugin/CMakeLists.txt
+++ b/plugins/trace_api_plugin/CMakeLists.txt
@@ -5,7 +5,7 @@ add_library( trace_api_plugin
              trace_api_plugin.cpp
              ${HEADERS} )
 
-target_link_libraries( trace_api_plugin chain_plugin eosio_chain appbase )
+target_link_libraries( trace_api_plugin chain_plugin http_plugin eosio_chain appbase )
 target_include_directories( trace_api_plugin PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" )
 
 add_subdirectory( test )

--- a/plugins/trace_api_plugin/abi_data_handler.cpp
+++ b/plugins/trace_api_plugin/abi_data_handler.cpp
@@ -1,6 +1,5 @@
 #include <eosio/trace_api_plugin/abi_data_handler.hpp>
 #include <eosio/chain/abi_serializer.hpp>
-#include <eosio/trace_api_plugin/request_handler.hpp>
 
 namespace eosio::trace_api_plugin {
 
@@ -17,7 +16,7 @@ namespace eosio::trace_api_plugin {
             try {
                return serializer_p->binary_to_variant(type_name, action.data, fc::microseconds::maximum());
             } catch (...) {
-               if (log) log(std::current_exception());
+               if (log) log(MAKE_EXCEPTION_WITH_CONTEXT(std::current_exception()));
             }
          }
       }

--- a/plugins/trace_api_plugin/include/eosio/trace_api_plugin/abi_data_handler.hpp
+++ b/plugins/trace_api_plugin/include/eosio/trace_api_plugin/abi_data_handler.hpp
@@ -2,6 +2,7 @@
 
 #include <eosio/chain/abi_def.hpp>
 #include <eosio/trace_api_plugin/trace.hpp>
+#include <eosio/trace_api_plugin/common.hpp>
 
 namespace eosio {
    namespace chain {
@@ -17,7 +18,7 @@ namespace eosio {
     */
    class abi_data_handler {
    public:
-      explicit abi_data_handler(std::function<void(const std::exception_ptr&)> log = {})
+      explicit abi_data_handler(std::function<void(const exception_with_context&)> log = {})
       :log(log)
       {
       }
@@ -56,6 +57,6 @@ namespace eosio {
 
    private:
       std::map<chain::name, std::shared_ptr<chain::abi_serializer>> abi_serializer_by_account;
-      std::function<void(const std::exception_ptr&)> log;
+      std::function<void(const exception_with_context&)> log;
    };
 } }

--- a/plugins/trace_api_plugin/include/eosio/trace_api_plugin/common.hpp
+++ b/plugins/trace_api_plugin/include/eosio/trace_api_plugin/common.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <tuple>
+
+namespace eosio::trace_api_plugin {
+
+   using now_function = std::function<fc::time_point()>;
+
+   /**
+    * Exceptions
+    */
+   class deadline_exceeded : public std::runtime_error {
+   public:
+      explicit deadline_exceeded(const char* what_arg)
+      :std::runtime_error(what_arg)
+      {}
+      explicit deadline_exceeded(const std::string& what_arg)
+            :std::runtime_error(what_arg)
+      {}
+   };
+
+   class bad_data_exception : public std::runtime_error {
+   public:
+      explicit bad_data_exception(const char* what_arg)
+      :std::runtime_error(what_arg)
+      {}
+
+      explicit bad_data_exception(const std::string& what_arg)
+      :std::runtime_error(what_arg)
+      {}
+   };
+
+   using exception_with_context = std::tuple<const std::exception_ptr&, char const *, uint64_t, char const *>;
+
+#define MAKE_EXCEPTION_WITH_CONTEXT(eptr) \
+   (eosio::trace_api_plugin::exception_with_context((eptr),  __FILE__, __LINE__, __func__))
+
+
+}

--- a/plugins/trace_api_plugin/include/eosio/trace_api_plugin/configuration_utils.hpp
+++ b/plugins/trace_api_plugin/include/eosio/trace_api_plugin/configuration_utils.hpp
@@ -10,48 +10,6 @@ namespace eosio::trace_api_plugin::configuration_utils {
    using namespace eosio;
 
    /**
-    * Give a string, parse a quantity of microseconds from it where the string is either
-    *  - a number of seconds
-    *  - a number with a suffix indicating Seconds, Minutes, Hours, Days, or Weeks
-    *  - "-1" meaning maximum
-    *
-    * @param str - the input string
-    * @return the indicated number of microseconds
-    * @throws plugin_config_exception if the string is not in one of the above forms
-    */
-   fc::microseconds parse_microseconds(const std::string& str) {
-      if (str == "-1") {
-         return fc::microseconds::maximum();
-      }
-
-      std::regex r("^([0-9]+)([smhdw])?$");
-      std::smatch m;
-      std::regex_search(str, m, r);
-
-      EOS_ASSERT(!m.empty(), chain::plugin_config_exception, "string is not a positive number with an optional suffix OR -1");
-      int64_t number = std::stoll(m[1]);
-      int64_t mult = 1'000'000;
-
-      if (m.size() == 3 && m[2].length() != 0) {
-         auto suffix = m[2].str();
-         if (suffix == "m") {
-            mult *= 60;
-         } else if (suffix == "h") {
-            mult *= 60 * 60;
-         } else if (suffix == "d") {
-            mult *= 60 * 60 * 24;
-         } else if (suffix == "w") {
-            mult *= 60 * 60 * 24 * 7;
-         }
-      }
-
-      auto final = number * mult;
-      EOS_ASSERT(final / mult == number, chain::plugin_config_exception, "specified time overflows, use \"-1\" to represent infinite time");
-
-      return fc::microseconds(final);
-   }
-
-   /**
     * Give a string which is either a JSON-encoded ABI or a path (absolute) to a file that contains a
     * JSON-encoded ABI, return the parsed ABI
     *

--- a/plugins/trace_api_plugin/include/eosio/trace_api_plugin/configuration_utils.hpp
+++ b/plugins/trace_api_plugin/include/eosio/trace_api_plugin/configuration_utils.hpp
@@ -1,0 +1,99 @@
+#pragma once
+
+#include <regex>
+#include <fc/filesystem.hpp>
+#include <fc/io/json.hpp>
+#include <eosio/chain/exceptions.hpp>
+#include <eosio/chain/abi_def.hpp>
+
+namespace eosio::trace_api_plugin::configuration_utils {
+   using namespace eosio;
+
+   /**
+    * Give a string, parse a quantity of microseconds from it where the string is either
+    *  - a number of seconds
+    *  - a number with a suffix indicating Seconds, Minutes, Hours, Days, or Weeks
+    *  - "-1" meaning maximum
+    *
+    * @param str - the input string
+    * @return the indicated number of microseconds
+    * @throws plugin_config_exception if the string is not in one of the above forms
+    */
+   fc::microseconds parse_microseconds(const std::string& str) {
+      if (str == "-1") {
+         return fc::microseconds::maximum();
+      }
+
+      std::regex r("^([0-9]+)([smhdw])?$");
+      std::smatch m;
+      std::regex_search(str, m, r);
+
+      EOS_ASSERT(!m.empty(), chain::plugin_config_exception, "string is not a positive number with an optional suffix OR -1");
+      int64_t number = std::stoll(m[1]);
+      int64_t mult = 1'000'000;
+
+      if (m.size() == 3 && m[2].length() != 0) {
+         auto suffix = m[2].str();
+         if (suffix == "m") {
+            mult *= 60;
+         } else if (suffix == "h") {
+            mult *= 60 * 60;
+         } else if (suffix == "d") {
+            mult *= 60 * 60 * 24;
+         } else if (suffix == "w") {
+            mult *= 60 * 60 * 24 * 7;
+         }
+      }
+
+      auto final = number * mult;
+      EOS_ASSERT(final / mult == number, chain::plugin_config_exception, "specified time overflows, use \"-1\" to represent infinite time");
+
+      return fc::microseconds(final);
+   }
+
+   /**
+    * Give a string which is either a JSON-encoded ABI or a path (absolute) to a file that contains a
+    * JSON-encoded ABI, return the parsed ABI
+    *
+    * @param file_or_str - a string that is either an ABI or path
+    * @return the ABI implied
+    * @throws json_parse_exception if the JSON is malformed
+    */
+   chain::abi_def abi_def_from_file_or_str(const std::string& file_or_str)
+   {
+      fc::variant abi_variant;
+      std::regex r("^[ \t]*[\{\[\"]");
+      if ( !std::regex_search(file_or_str, r) ) {
+         EOS_ASSERT(fc::exists(file_or_str) && !fc::is_directory(file_or_str), chain::plugin_config_exception, "${path} does not exist or is not a file", ("path", file_or_str));
+         try {
+            abi_variant = fc::json::from_file(file_or_str);
+         } EOS_RETHROW_EXCEPTIONS(chain::json_parse_exception, "Fail to parse JSON from file: ${file}", ("file", file_or_str));
+
+      } else {
+         try {
+            abi_variant = fc::json::from_string(file_or_str);
+         } EOS_RETHROW_EXCEPTIONS(chain::json_parse_exception, "Fail to parse JSON from string: ${string}", ("string", file_or_str));
+      }
+
+      chain::abi_def result;
+      fc::from_variant(abi_variant, result);
+      return result;
+   }
+
+   /**
+    * Given a string in the form <key>=<value> where key cannot contain an `=` character and value can contain anything
+    * return a pair of the two independent strings
+    *
+    * @param input
+    * @return
+    */
+   std::pair<std::string, std::string> parse_kv_pairs( const std::string& input ) {
+      EOS_ASSERT(!input.empty(), chain::plugin_config_exception, "Key-Value Pair is Empty");
+      auto delim = input.find("=");
+      EOS_ASSERT(delim != std::string::npos, chain::plugin_config_exception, "Missing \"=\"");
+      EOS_ASSERT(delim != 0, chain::plugin_config_exception, "Missing Key");
+      EOS_ASSERT(delim + 1 != input.size(), chain::plugin_config_exception, "Missing Value");
+      return std::make_pair(input.substr(0, delim), input.substr(delim + 1));
+   }
+
+}

--- a/plugins/trace_api_plugin/include/eosio/trace_api_plugin/request_handler.hpp
+++ b/plugins/trace_api_plugin/include/eosio/trace_api_plugin/request_handler.hpp
@@ -3,10 +3,9 @@
 #include <fc/variant.hpp>
 #include <eosio/trace_api_plugin/metadata_log.hpp>
 #include <eosio/trace_api_plugin/data_log.hpp>
+#include <eosio/trace_api_plugin/common.hpp>
 
 namespace eosio::trace_api_plugin {
-
-   using now_function = std::function<fc::time_point()>;
    using data_handler_function = std::function<fc::variant(const action_trace_v0&)>;
 
    namespace detail {
@@ -15,27 +14,6 @@ namespace eosio::trace_api_plugin {
          static fc::variant process_block( const block_trace_v0& trace, const  std::optional<lib_entry_v0>& best_lib, const data_handler_function& data_handler, const now_function& now, const fc::time_point& deadline );
       };
    }
-
-   class deadline_exceeded : public std::runtime_error {
-   public:
-      explicit deadline_exceeded(const char* what_arg)
-      :std::runtime_error(what_arg)
-      {}
-      explicit deadline_exceeded(const std::string& what_arg)
-            :std::runtime_error(what_arg)
-      {}
-   };
-
-   class bad_data_exception : public std::runtime_error {
-   public:
-      explicit bad_data_exception(const char* what_arg)
-      :std::runtime_error(what_arg)
-      {}
-
-      explicit bad_data_exception(const std::string& what_arg)
-      :std::runtime_error(what_arg)
-      {}
-   };
 
    template<typename LogfileProvider, typename DataHandlerProvider>
    class request_handler {

--- a/plugins/trace_api_plugin/include/eosio/trace_api_plugin/trace_api_plugin.hpp
+++ b/plugins/trace_api_plugin/include/eosio/trace_api_plugin/trace_api_plugin.hpp
@@ -1,0 +1,51 @@
+#pragma once
+#include <appbase/application.hpp>
+#include <eosio/chain_plugin/chain_plugin.hpp>
+#include <eosio/http_plugin/http_plugin.hpp>
+
+namespace eosio {
+   /**
+    * Plugin that runs both a data extraction  and the HTTP RPC in the same application
+    */
+   class trace_api_plugin : public appbase::plugin<trace_api_plugin> {
+   public:
+      APPBASE_PLUGIN_REQUIRES((chain_plugin)(http_plugin))
+
+      trace_api_plugin();
+      virtual ~trace_api_plugin();
+
+      virtual void set_program_options(appbase::options_description& cli, appbase::options_description& cfg) override;
+
+      void plugin_initialize(const appbase::variables_map& options);
+      void plugin_startup();
+      void plugin_shutdown();
+
+      void handle_sighup() override;
+
+   private:
+      std::shared_ptr<struct trace_api_plugin_impl>     my;
+      std::shared_ptr<struct trace_api_rpc_plugin_impl> rpc;
+   };
+
+   /**
+    * Plugin that only runs the RPC
+    */
+   class trace_api_rpc_plugin : public appbase::plugin<trace_api_rpc_plugin> {
+   public:
+      APPBASE_PLUGIN_REQUIRES((http_plugin))
+
+      trace_api_rpc_plugin();
+      virtual ~trace_api_rpc_plugin();
+
+      virtual void set_program_options(appbase::options_description& cli, appbase::options_description& cfg) override;
+
+      void plugin_initialize(const appbase::variables_map& options);
+      void plugin_startup();
+      void plugin_shutdown();
+
+      void handle_sighup() override;
+
+   private:
+      std::shared_ptr<struct trace_api_rpc_plugin_impl> rpc;
+   };
+}

--- a/plugins/trace_api_plugin/include/eosio/trace_api_plugin/trace_api_plugin.hpp
+++ b/plugins/trace_api_plugin/include/eosio/trace_api_plugin/trace_api_plugin.hpp
@@ -7,12 +7,12 @@ namespace eosio {
    /**
     * Plugin that runs both a data extraction  and the HTTP RPC in the same application
     */
-   class trace_api_plugin : public appbase::plugin<trace_api_plugin> {
+   class _trace_api_plugin : public appbase::plugin<_trace_api_plugin> {
    public:
       APPBASE_PLUGIN_REQUIRES((chain_plugin)(http_plugin))
 
-      trace_api_plugin();
-      virtual ~trace_api_plugin();
+      _trace_api_plugin();
+      virtual ~_trace_api_plugin();
 
       virtual void set_program_options(appbase::options_description& cli, appbase::options_description& cfg) override;
 

--- a/plugins/trace_api_plugin/test/CMakeLists.txt
+++ b/plugins/trace_api_plugin/test/CMakeLists.txt
@@ -21,3 +21,9 @@ target_link_libraries( test_data_handlers trace_api_plugin )
 target_include_directories( test_data_handlers PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" )
 
 add_test(NAME test_data_handlers COMMAND plugins/trace_api_plugin/test/test_data_handlers WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+
+add_executable( test_configuration_utils test_configuration_utils.cpp )
+target_link_libraries( test_configuration_utils trace_api_plugin )
+target_include_directories( test_configuration_utils PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" )
+
+add_test(NAME test_configuration_utils COMMAND plugins/trace_api_plugin/test/test_configuration_utils WORKING_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/plugins/trace_api_plugin/test/include/eosio/trace_api_plugin/test_common.hpp
+++ b/plugins/trace_api_plugin/test/include/eosio/trace_api_plugin/test_common.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
 #include <fc/io/json.hpp>
+#include <fc/io/raw.hpp>
 
+#include <eosio/chain/abi_def.hpp>
 #include <eosio/chain/asset.hpp>
 #include <eosio/chain/name.hpp>
 
@@ -135,6 +137,27 @@ namespace fc {
    template<typename ...Ts>
    std::ostream& operator<<(std::ostream &os, const fc::static_variant<Ts...>& v ) {
       os << fc::json::to_string(v, fc::time_point::maximum());
+      return os;
+   }
+
+   std::ostream& operator<<(std::ostream &os, const fc::microseconds& t ) {
+      os << t.count();
+      return os;
+   }
+
+}
+
+namespace eosio::chain {
+   bool operator==(const abi_def& lhs, const abi_def& rhs) {
+      return fc::raw::pack(lhs) == fc::raw::pack(rhs);
+   }
+
+   bool operator!=(const abi_def& lhs, const abi_def& rhs) {
+      return !(lhs == rhs);
+   }
+
+   std::ostream& operator<<(std::ostream& os, const abi_def& abi) {
+      os << fc::json::to_string(abi, fc::time_point::maximum());
       return os;
    }
 }

--- a/plugins/trace_api_plugin/test/test_configuration_utils.cpp
+++ b/plugins/trace_api_plugin/test/test_configuration_utils.cpp
@@ -34,38 +34,6 @@ struct temp_file_fixture {
 };
 
 BOOST_AUTO_TEST_SUITE(configuration_utils_tests)
-   BOOST_AUTO_TEST_CASE(parse_microseconds_test)
-   {
-      // basic tests
-      BOOST_TEST( parse_microseconds("-1") == fc::microseconds::maximum() );
-      BOOST_TEST( parse_microseconds("0")  == fc::microseconds(0) );
-      BOOST_TEST( parse_microseconds("1")  == fc::microseconds(1'000'000) );
-      BOOST_TEST( parse_microseconds("1s") == fc::microseconds(1'000'000) );
-      BOOST_TEST( parse_microseconds("1m") == fc::microseconds(60'000'000) );
-      BOOST_TEST( parse_microseconds("1h") == fc::microseconds(3'600'000'000) );
-      BOOST_TEST( parse_microseconds("1d") == fc::microseconds(86'400'000'000) );
-      BOOST_TEST( parse_microseconds("1w") == fc::microseconds(604'800'000'000) );
-
-      // leading zeros OK!
-      BOOST_TEST( parse_microseconds("0001s") == fc::microseconds(1'000'000) );
-
-      // negatives other than -1 not OK!
-      BOOST_REQUIRE_THROW(parse_microseconds("-2"), chain::plugin_config_exception);
-
-      // decimals not OK!
-      BOOST_REQUIRE_THROW(parse_microseconds("1.0s"), chain::plugin_config_exception);
-
-      // bad suffix not OK
-      BOOST_REQUIRE_THROW(parse_microseconds("1y"), chain::plugin_config_exception);
-
-      // letters not OK
-      BOOST_REQUIRE_THROW(parse_microseconds("xyz"), chain::plugin_config_exception);
-
-      // Overflow not OK
-      BOOST_REQUIRE_THROW(parse_microseconds("15250285w"), chain::plugin_config_exception);
-
-   }
-
    BOOST_AUTO_TEST_CASE(parse_kv_pairs_test)
    {
       using spair = std::pair<std::string, std::string>;

--- a/plugins/trace_api_plugin/test/test_configuration_utils.cpp
+++ b/plugins/trace_api_plugin/test/test_configuration_utils.cpp
@@ -1,0 +1,117 @@
+#define BOOST_TEST_MODULE trace_configuration_utils
+#include <boost/test/included/unit_test.hpp>
+#include <list>
+#include <boost/filesystem.hpp>
+
+#include <eosio/trace_api_plugin/configuration_utils.hpp>
+#include <eosio/trace_api_plugin/test_common.hpp>
+
+using namespace eosio;
+using namespace eosio::trace_api_plugin::configuration_utils;
+
+namespace bfs = boost::filesystem;
+
+struct temp_file_fixture {
+   temp_file_fixture() {}
+
+   ~temp_file_fixture() {
+      for (const auto& p: paths) {
+         if (bfs::exists(p)) {
+            bfs::remove(p);
+         }
+      }
+   }
+
+   std::string create_temp_file( const std::string& contents ) {
+      auto path = bfs::temp_directory_path() / bfs::unique_path();
+      auto os = bfs::ofstream(path, std::ios_base::out);
+      os << contents;
+      os.close();
+      return paths.emplace_back(std::move(path)).generic_string();
+   }
+
+   std::list<bfs::path> paths;
+};
+
+BOOST_AUTO_TEST_SUITE(configuration_utils_tests)
+   BOOST_AUTO_TEST_CASE(parse_microseconds_test)
+   {
+      // basic tests
+      BOOST_TEST( parse_microseconds("-1") == fc::microseconds::maximum() );
+      BOOST_TEST( parse_microseconds("0")  == fc::microseconds(0) );
+      BOOST_TEST( parse_microseconds("1")  == fc::microseconds(1'000'000) );
+      BOOST_TEST( parse_microseconds("1s") == fc::microseconds(1'000'000) );
+      BOOST_TEST( parse_microseconds("1m") == fc::microseconds(60'000'000) );
+      BOOST_TEST( parse_microseconds("1h") == fc::microseconds(3'600'000'000) );
+      BOOST_TEST( parse_microseconds("1d") == fc::microseconds(86'400'000'000) );
+      BOOST_TEST( parse_microseconds("1w") == fc::microseconds(604'800'000'000) );
+
+      // leading zeros OK!
+      BOOST_TEST( parse_microseconds("0001s") == fc::microseconds(1'000'000) );
+
+      // negatives other than -1 not OK!
+      BOOST_REQUIRE_THROW(parse_microseconds("-2"), chain::plugin_config_exception);
+
+      // decimals not OK!
+      BOOST_REQUIRE_THROW(parse_microseconds("1.0s"), chain::plugin_config_exception);
+
+      // bad suffix not OK
+      BOOST_REQUIRE_THROW(parse_microseconds("1y"), chain::plugin_config_exception);
+
+      // letters not OK
+      BOOST_REQUIRE_THROW(parse_microseconds("xyz"), chain::plugin_config_exception);
+
+      // Overflow not OK
+      BOOST_REQUIRE_THROW(parse_microseconds("15250285w"), chain::plugin_config_exception);
+
+   }
+
+   BOOST_AUTO_TEST_CASE(parse_kv_pairs_test)
+   {
+      using spair = std::pair<std::string, std::string>;
+
+      // basic
+      BOOST_TEST( parse_kv_pairs("a=b") == spair("a", "b") );
+      BOOST_TEST( parse_kv_pairs("a==b") == spair("a", "=b") );
+      BOOST_TEST( parse_kv_pairs("a={}:\"=") == spair("a", "{}:\"=") );
+      BOOST_TEST( parse_kv_pairs("{}:\"=a") == spair("{}:\"", "a") );
+
+      // missing key not OK
+      BOOST_REQUIRE_THROW(parse_kv_pairs("=b"), chain::plugin_config_exception);
+
+      // missing value not OK
+      BOOST_REQUIRE_THROW(parse_kv_pairs("a="), chain::plugin_config_exception);
+
+      // missing = not OK
+      BOOST_REQUIRE_THROW(parse_kv_pairs("a"), chain::plugin_config_exception);
+
+      // emptynot OK
+      BOOST_REQUIRE_THROW(parse_kv_pairs(""), chain::plugin_config_exception);
+
+   }
+
+   BOOST_FIXTURE_TEST_CASE(abi_def_from_file_or_str_test, temp_file_fixture)
+   {
+      auto good_json = std::string("{\"version\" : \"test string please ignore\"}");
+      auto good_json_filename = create_temp_file(good_json);
+
+      auto good_abi = chain::abi_def();
+      good_abi.version = "test string please ignore";
+
+      auto bad_json  = std::string("{{\"version\":oops\"}");
+      auto bad_json_filename = create_temp_file(bad_json);
+      auto bad_filename = (bfs::temp_directory_path() / bfs::unique_path()).generic_string();
+      auto directory_name = bfs::temp_directory_path().generic_string();
+
+      // good cases
+      BOOST_TEST( abi_def_from_file_or_str(good_json) == good_abi );
+      BOOST_TEST( abi_def_from_file_or_str(good_json_filename) == good_abi );
+
+      // bad cases
+      BOOST_REQUIRE_THROW( abi_def_from_file_or_str(bad_json), chain::json_parse_exception );
+      BOOST_REQUIRE_THROW( abi_def_from_file_or_str(bad_json_filename), chain::json_parse_exception );
+      BOOST_REQUIRE_THROW( abi_def_from_file_or_str(bad_filename), chain::plugin_config_exception );
+      BOOST_REQUIRE_THROW( abi_def_from_file_or_str(directory_name), chain::plugin_config_exception );
+   }
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/plugins/trace_api_plugin/test/test_data_handlers.cpp
+++ b/plugins/trace_api_plugin/test/test_data_handlers.cpp
@@ -113,7 +113,7 @@ BOOST_AUTO_TEST_SUITE(abi_data_handler_tests)
       abi.version = "eosio::abi/1.";
 
       bool log_called = false;
-      abi_data_handler handler([&log_called](const std::exception_ptr& ){log_called = true;});
+      abi_data_handler handler([&log_called](const exception_with_context& ){log_called = true;});
       handler.add_abi("alice"_n, abi);
 
       auto expected = fc::variant("000102");

--- a/plugins/trace_api_plugin/trace_api_plugin.cpp
+++ b/plugins/trace_api_plugin/trace_api_plugin.cpp
@@ -1,0 +1,243 @@
+#include <eosio/trace_api_plugin/trace_api_plugin.hpp>
+
+#include <regex>
+#include <fc/io/json.hpp>
+#include <eosio/trace_api_plugin/abi_data_handler.hpp>
+#include <eosio/trace_api_plugin/request_handler.hpp>
+
+using namespace eosio::trace_api_plugin;
+
+namespace {
+   const std::string logger_name("trace_api");
+   fc::logger _log;
+
+   std::string to_detail_string(const std::exception_ptr& e) {
+      try {
+         std::rethrow_exception(e);
+      } catch (fc::exception& er) {
+         return er.to_detail_string();
+      } catch (const std::exception& e) {
+         fc::exception fce(
+               FC_LOG_MESSAGE(warn, "std::exception: ${what}: ", ("what", e.what())),
+               fc::std_exception_code,
+               BOOST_CORE_TYPEID(e).name(),
+               e.what());
+         return fce.to_detail_string();
+      } catch (...) {
+         fc::unhandled_exception e(
+               FC_LOG_MESSAGE(warn, "unknown: ",),
+               std::current_exception());
+         return e.to_detail_string();
+      }
+   }
+
+   void log_exception( const exception_with_context& e, fc::log_level level ) {
+      if( _log.is_enabled( level ) ) {
+         auto detail_string = to_detail_string(std::get<0>(e));
+         auto context = fc::log_context( level, std::get<1>(e), std::get<2>(e), std::get<3>(e) );
+         _log.log(fc::log_message( context, detail_string ));
+      }
+   }
+}
+
+namespace eosio {
+
+/**
+ * A common source for information shared between the extraction process and the RPC process
+ */
+struct trace_api_common_impl {
+   static void set_program_options(appbase::options_description& cli, appbase::options_description& cfg) {
+      auto cfg_options = cfg.add_options();
+      cfg_options("trace-dir", bpo::value<bfs::path>()->default_value("traces"),
+                  "the location of the trace directory (absolute path or relative to application data dir)");
+      cfg_options("slice-stride", bpo::value<uint32_t>()->default_value(10'000),
+                  "the number of blocks each \"slice\" of trace data will contain on the filesystem");
+   }
+
+   void plugin_initialize(const appbase::variables_map& options) {
+      auto dir_option = options.at("trace-dir").as<bfs::path>();
+      if (dir_option.is_relative())
+         trace_dir = app().data_dir() / dir_option;
+      else
+         trace_dir = dir_option;
+
+      slice_stride = options.at("slice-stride").as<uint32_t>();
+   }
+
+   // common configuration paramters
+   boost::filesystem::path trace_dir;
+   uint32_t slice_stride = 0;
+};
+
+/**
+ * Interface with the RPC process
+ */
+struct trace_api_rpc_plugin_impl {
+   trace_api_rpc_plugin_impl( const std::shared_ptr<trace_api_common_impl>& common )
+   :common(common) {}
+
+   static void set_program_options(appbase::options_description& cli, appbase::options_description& cfg) {
+      auto cfg_options = cfg.add_options();
+      cfg_options("trace-rpc-abi", bpo::value<vector<string>>()->composing(),
+                  "ABIs used when decoding trace RPC responses, specified as \"Key=Value\" pairs in the form <account-name>=<abi-def>\n"
+                  "Where <abi-def> can be:\n"
+                  "   a valid JSON-encoded ABI as a string\n"
+                  "   an absolute path to a file containing a valid JSON-encoded ABI\n"
+                  "   a relative path from `data-dir` to a file containing a valid JSON-encoded ABI\n"
+                  );
+   }
+
+   static chain::abi_def abi_def_from_file_or_str(const string& file_or_str)
+   {
+      fc::variant abi_variant;
+      std::regex r("^[ \t]*[\{\[]");
+      if ( !std::regex_search(file_or_str, r) && fc::is_regular_file(file_or_str) ) {
+         try {
+            abi_variant = fc::json::from_file(file_or_str);
+         } EOS_RETHROW_EXCEPTIONS(chain::json_parse_exception, "Fail to parse JSON from file: ${file}", ("file", file_or_str));
+
+      } else {
+         try {
+            abi_variant = fc::json::from_string(file_or_str);
+         } EOS_RETHROW_EXCEPTIONS(chain::json_parse_exception, "Fail to parse JSON from string: ${string}", ("string", file_or_str));
+      }
+
+      chain::abi_def result;
+      fc::from_variant(abi_variant, result);
+      return result;
+   }
+
+   void plugin_initialize(const appbase::variables_map& options) {
+      data_handler = std::make_shared<abi_data_handler>([](const exception_with_context& e){
+         log_exception(exception_with_context, fc::log_level::debug);
+      });
+
+      if( options.count("trace-rpc-abi") ) {
+         const std::vector<std::string> key_value_pairs = options["trace-rpc-abi"].as<std::vector<std::string>>();
+         for (const auto& entry : key_value_pairs) {
+            try {
+               auto delim = entry.find("=");
+               EOS_ASSERT(delim != std::string::npos, chain::plugin_config_exception, "Missing \"=\"");
+               auto account_str = entry.substr(0, delim);
+               auto abi_json_or_path = entry.substr(delim + 1);
+
+               auto account = chain::name(account_str);
+               auto abi = abi_def_from_file_or_str(abi_json_or_path);
+
+               data_handler->add_abi(account, abi);
+            } catch (...) {
+               elog("Malformed trace-rpc-abi provider: \"${val}\", ignoring!", ("val", entry));
+            }
+         }
+      }
+   }
+
+   void plugin_startup() {
+   }
+
+   void plugin_shutdown() {
+   }
+
+   std::shared_ptr<trace_api_common_impl> common;
+   std::shared_ptr<abi_data_handler> data_handler;
+};
+
+struct trace_api_plugin_impl {
+   trace_api_plugin_impl( const std::shared_ptr<trace_api_common_impl>& common )
+   :common(common) {}
+
+   static void set_program_options(appbase::options_description& cli, appbase::options_description& cfg) {
+      auto cfg_options = cfg.add_options();
+      cfg_options("minimum-irreversible-trace-history", bpo::value<std::string>()->default_value("-1"),
+                  "the minimum amount of history, as defined by time, this node will keep after it becomes irreversible\n"
+                  "this value can be specified as a number of seconds or using the following suffixes:\n"
+                  "  \"s\" : the value is in seconds\n"
+                  "  \"m\" : the value is in minutes\n"
+                  "  \"h\" : the value is in hours\n"
+                  "  \"d\" : the value is in days\n"
+                  "  \"w\" : the value is in weeks\n"
+                  "a value of \"-1\" will disable automatic maintenance of the trace slice files\n"
+                  );
+   }
+
+   void plugin_initialize(const appbase::variables_map& options) {
+   }
+
+   void plugin_startup() {
+   }
+
+   void plugin_shutdown() {
+   }
+
+   std::shared_ptr<trace_api_common_impl> common;
+};
+
+trace_api_plugin::trace_api_plugin()
+{}
+
+trace_api_plugin::~trace_api_plugin()
+{}
+
+void trace_api_plugin::set_program_options(appbase::options_description& cli, appbase::options_description& cfg) {
+   trace_api_common_impl::set_program_options(cli, cfg);
+   trace_api_plugin_impl::set_program_options(cli, cfg);
+   trace_api_rpc_plugin_impl::set_program_options(cli, cfg);
+}
+
+void trace_api_plugin::plugin_initialize(const appbase::variables_map& options) {
+   auto common = std::make_shared<trace_api_common_impl>();
+   common->plugin_initialize(options);
+
+   my = std::make_shared<trace_api_plugin_impl>(common);
+   my->plugin_initialize(options);
+
+   rpc = std::make_shared<trace_api_rpc_plugin_impl>(common);
+   rpc->plugin_initialize(options);
+}
+
+void trace_api_plugin::plugin_startup() {
+   my->plugin_startup();
+   rpc->plugin_startup();
+}
+
+void trace_api_plugin::plugin_shutdown() {
+   my->plugin_shutdown();
+   rpc->plugin_shutdown();
+}
+
+void trace_api_plugin::handle_sighup() {
+   fc::logger::update( logger_name, _log );
+}
+
+trace_api_rpc_plugin::trace_api_rpc_plugin()
+{}
+
+trace_api_rpc_plugin::~trace_api_rpc_plugin()
+{}
+
+void trace_api_rpc_plugin::set_program_options(appbase::options_description& cli, appbase::options_description& cfg) {
+   trace_api_common_impl::set_program_options(cli, cfg);
+   trace_api_rpc_plugin_impl::set_program_options(cli, cfg);
+}
+
+void trace_api_rpc_plugin::plugin_initialize(const appbase::variables_map& options) {
+   auto common = std::make_shared<trace_api_common_impl>();
+   common->plugin_initialize(options);
+
+   rpc = std::make_shared<trace_api_rpc_plugin_impl>(common);
+   rpc->plugin_initialize(options);
+}
+
+void trace_api_rpc_plugin::plugin_startup() {
+   rpc->plugin_startup();
+}
+
+void trace_api_rpc_plugin::plugin_shutdown() {
+   rpc->plugin_shutdown();
+}
+
+void trace_api_rpc_plugin::handle_sighup() {
+   fc::logger::update( logger_name, _log );
+}
+
+}


### PR DESCRIPTION
In this PR:
- [ ] basic plugin scaffolding for (2) plugins
  - a full system plugin `_trace_api_plugin` (temp name until the namespace is renamed)
  - a plugin that only serves the RPC api `trace_api_rpc_plugin` 
  - only the full system will be linked in and available to `nodeos`
  - the rpc plugin is laying the ground work for an independent process  and to force separation of internal logic
- [ ] new header and test with what little testable logic fell out of configuration code
- [ ] new concept for adding `context` to exceptions so that logging appropriately correlates messages to the code that produced them.  There is an example of how this is wired in through the `abi_data_handler` so that the throwing code can provide the context to the injected log function. 