### PR TITLE
Trace api extraction - onerror test

### DIFF
--- a/plugins/trace_api_plugin/include/eosio/trace_api_plugin/chain_extraction.hpp
+++ b/plugins/trace_api_plugin/include/eosio/trace_api_plugin/chain_extraction.hpp
@@ -18,7 +18,6 @@ public:
     * Chain Extractor for capturing transaction traces, action traces, and block info.
     * @param store provider of append_data_log & append_metadata_log
     * @param except_handler called on exceptions, logging if any is left to the user
-    * @param shutdown called when this class determines application should shutdown because of fatal error
     */
    chain_extraction_impl_type( StoreProvider store, std::function<void(std::exception_ptr)> except_handler )
    : store(std::move(store))
@@ -99,7 +98,7 @@ private:
          cached_traces.clear();
          onblock_trace.reset();
 
-         uint64_t offset = store.append_data_log( std::move( bt ));
+         uint64_t offset = store.append_data_log( std::move( bt ) );
          store.append_metadata_log( block_entry_v0{.id = block_state->id, .number = block_state->block_num, .offset = offset} );
 
       } catch( ... ) {

--- a/plugins/trace_api_plugin/include/eosio/trace_api_plugin/extract_util.hpp
+++ b/plugins/trace_api_plugin/include/eosio/trace_api_plugin/extract_util.hpp
@@ -25,13 +25,16 @@ inline action_trace_v0 to_action_trace_v0( const chain::action_trace& at ) {
 /// @return transaction_trace_v0 with populated action_trace_v0
 inline transaction_trace_v0 to_transaction_trace_v0( const chain::transaction_trace_ptr& t ) {
    transaction_trace_v0 r;
-   r.id = t->id;
-   if( t->receipt ) { // if no receipt leave as default hard_fail
-      r.status = t->receipt->status;
+   if( !t->failed_dtrx_trace ) {
+      r.id = t->id;
+   } else {
+      r.id = t->failed_dtrx_trace->id; // report the failed trx id since that is the id known to user
    }
    r.actions.reserve( t->action_traces.size());
    for( const auto& at : t->action_traces ) {
-      r.actions.emplace_back( to_action_trace_v0( at ));
+      if( !at.context_free ) { // not including CFA at this time
+         r.actions.emplace_back( to_action_trace_v0( at ));
+      }
    }
    return r;
 }

--- a/plugins/trace_api_plugin/include/eosio/trace_api_plugin/trace.hpp
+++ b/plugins/trace_api_plugin/include/eosio/trace_api_plugin/trace.hpp
@@ -24,7 +24,6 @@ namespace eosio { namespace trace_api_plugin {
       using status_type = chain::transaction_receipt_header::status_enum;
 
       chain::transaction_id_type    id = {};
-      status_type                   status = status_type::hard_fail;
       std::vector<action_trace_v0>  actions = {};
    };
 
@@ -41,5 +40,5 @@ namespace eosio { namespace trace_api_plugin {
 
 FC_REFLECT(eosio::trace_api_plugin::authorization_trace_v0, (account)(permission))
 FC_REFLECT(eosio::trace_api_plugin::action_trace_v0, (global_sequence)(receiver)(account)(action)(authorization)(data))
-FC_REFLECT(eosio::trace_api_plugin::transaction_trace_v0, (id)(status)(actions))
+FC_REFLECT(eosio::trace_api_plugin::transaction_trace_v0, (id)(actions))
 FC_REFLECT(eosio::trace_api_plugin::block_trace_v0, (id)(number)(previous_id)(timestamp)(producer)(transactions))

--- a/plugins/trace_api_plugin/request_handler.cpp
+++ b/plugins/trace_api_plugin/request_handler.cpp
@@ -10,23 +10,6 @@ namespace {
       return (std::string)t + "Z";
    }
 
-   std::string to_status_string( transaction_trace_v0::status_type status ) {
-      switch (status) {
-         case transaction_trace_v0::status_type::executed :
-            return "executed";
-         case transaction_trace_v0::status_type::delayed :
-            return "delayed";
-         case transaction_trace_v0::status_type::expired :
-            return "expired";
-         case transaction_trace_v0::status_type::hard_fail :
-            return "hard_fail";
-         case transaction_trace_v0::status_type::soft_fail :
-            return "soft_fail";
-         default:
-            throw bad_data_exception(std::string("Encountered unknown status type in data: ") + std::to_string(status));
-      }
-   }
-
    template<typename Yield>
    fc::variants process_authorizations(const std::vector<authorization_trace_v0>& authorizations, Yield&& yield ) {
       fc::variants result;
@@ -73,7 +56,6 @@ namespace {
 
          result.emplace_back(fc::mutable_variant_object()
             ("id", t.id.str())
-            ("status", to_status_string(t.status))
             ("actions", process_actions(t.actions, data_handler, std::forward<Yield>(yield)))
          );
       }

--- a/plugins/trace_api_plugin/test/include/eosio/trace_api_plugin/test_common.hpp
+++ b/plugins/trace_api_plugin/test/include/eosio/trace_api_plugin/test_common.hpp
@@ -83,7 +83,6 @@ namespace eosio::trace_api_plugin {
    bool operator==(const transaction_trace_v0& lhs,  const transaction_trace_v0& rhs) {
       return
          lhs.id == rhs.id &&
-         lhs.status == rhs.status &&
          lhs.actions == rhs.actions;
    }
 

--- a/plugins/trace_api_plugin/test/test_extraction.cpp
+++ b/plugins/trace_api_plugin/test/test_extraction.cpp
@@ -1,6 +1,8 @@
 #define BOOST_TEST_MODULE trace_data_extraction
 #include <boost/test/included/unit_test.hpp>
 
+#include <eosio/chain/types.hpp>
+#include <eosio/chain/contract_types.hpp>
 #include <eosio/chain/trace.hpp>
 #include <eosio/chain/transaction.hpp>
 #include <eosio/chain/block.hpp>
@@ -50,6 +52,18 @@ namespace {
       return result;
    }
 
+   chain::bytes make_onerror_data( const chain::onerror& one ) {
+      fc::datastream<size_t> ps;
+      fc::raw::pack(ps, one);
+      chain::bytes result(ps.tellp());
+
+      if( result.size() ) {
+         fc::datastream<char*>  ds( result.data(), size_t(result.size()) );
+         fc::raw::pack(ds, one);
+      }
+      return result;
+   }
+
    auto get_private_key( name keyname, std::string role = "owner" ) {
       auto secret = fc::sha256::hash( keyname.to_string() + role );
       return chain::private_key_type::regenerate<fc::ecc::private_key_shim>( secret );
@@ -62,6 +76,11 @@ namespace {
    auto make_transfer_action( chain::name from, chain::name to, chain::asset quantity, std::string memo ) {
       return chain::action( std::vector<chain::permission_level> {{from, chain::config::active_name}},
                             "eosio.token"_n, "transfer"_n, make_transfer_data( from, to, quantity, std::move(memo) ) );
+   }
+
+   auto make_onerror_action( chain::name creator, chain::uint128_t sender_id ) {
+      return chain::action( std::vector<chain::permission_level>{{creator, chain::config::active_name}},
+                                chain::onerror{ sender_id, "test ", 4 });
    }
 
    auto make_packed_trx( std::vector<chain::action> actions ) {
@@ -340,6 +359,56 @@ BOOST_AUTO_TEST_SUITE(block_extraction)
                      "fred"_n, "eosio.token"_n, "transfer"_n,
                      {{ "fred"_n, "active"_n }},
                      make_transfer_data( "fred"_n, "bob"_n, "0.0001 SYS"_t, "Memo!" )
+                  }
+               }
+            }
+         }
+      };
+
+      BOOST_REQUIRE_EQUAL(max_lib, 0);
+      BOOST_REQUIRE(block_entry_for_height.count(1) > 0);
+      BOOST_REQUIRE_EQUAL(block_entry_for_height.at(1), expected_entry);
+      BOOST_REQUIRE(data_log.size() >= expected_entry.offset);
+      BOOST_REQUIRE(data_log.at(expected_entry.offset).contains<block_trace_v0>());
+      BOOST_REQUIRE_EQUAL(data_log.at(expected_entry.offset).get<block_trace_v0>(), expected_trace);
+   }
+
+   BOOST_FIXTURE_TEST_CASE(onerror_transaction_block, extraction_test_fixture)
+   {
+      auto onerror_act = make_onerror_action( "alice"_n, 1 );
+      auto actt1 = make_action_trace( 0, onerror_act, "eosio.token"_n );
+      auto ptrx1 = make_packed_trx( { onerror_act } );
+
+      auto act2 = make_transfer_action( "bob"_n, "alice"_n, "0.0001 SYS"_t, "Memo!" );
+      auto actt2 = make_action_trace( 1, act2, "bob"_n );
+      auto transfer_trx = make_packed_trx( { act2 } );
+
+      auto onerror_trace = make_transaction_trace( ptrx1.id(), 1, 1, chain::transaction_receipt_header::executed,
+                              { actt1 } );
+      auto transfer_trace = make_transaction_trace( transfer_trx.id(), 1, 1, chain::transaction_receipt_header::soft_fail,
+                                                   { actt2 } );
+      onerror_trace->failed_dtrx_trace = transfer_trace;
+
+      signal_applied_transaction( onerror_trace, transfer_trx.get_signed_transaction() );
+
+      auto bsp1 = make_block_state( chain::block_id_type(), 1, 1, "bp.one"_n,
+            { chain::packed_transaction(transfer_trx) } );
+      signal_accepted_block( bsp1 );
+
+      const uint64_t expected_lib = 0;
+      const block_entry_v0 expected_entry { bsp1->id, 1, 0 };
+
+      const block_trace_v0 expected_trace { bsp1->id, 1, bsp1->prev(), chain::block_timestamp_type(1), "bp.one"_n,
+         {
+            {
+               ptrx1.id(),
+               chain::transaction_receipt_header::executed,
+               {
+                  {
+                     0,
+                     "eosio.token"_n, "eosio"_n, "onerror"_n,
+                     {{ "alice"_n, "active"_n }},
+                     make_onerror_data( chain::onerror{ 1, "test ", 4 } )
                   }
                }
             }

--- a/plugins/trace_api_plugin/test/test_extraction.cpp
+++ b/plugins/trace_api_plugin/test/test_extraction.cpp
@@ -258,7 +258,6 @@ BOOST_AUTO_TEST_SUITE(block_extraction)
          {
             {
                ptrx1.id(),
-               chain::transaction_receipt_header::executed,
                {
                   {
                      0,
@@ -328,7 +327,6 @@ BOOST_AUTO_TEST_SUITE(block_extraction)
          {
             {
                ptrx1.id(),
-               chain::transaction_receipt_header::executed,
                {
                   {
                      0,
@@ -340,7 +338,6 @@ BOOST_AUTO_TEST_SUITE(block_extraction)
             },
             {
                ptrx2.id(),
-               chain::transaction_receipt_header::executed,
                {
                   {
                      1,
@@ -352,7 +349,6 @@ BOOST_AUTO_TEST_SUITE(block_extraction)
             },
             {
                ptrx3.id(),
-               chain::transaction_receipt_header::executed,
                {
                   {
                      2,
@@ -401,8 +397,7 @@ BOOST_AUTO_TEST_SUITE(block_extraction)
       const block_trace_v0 expected_trace { bsp1->id, 1, bsp1->prev(), chain::block_timestamp_type(1), "bp.one"_n,
          {
             {
-               ptrx1.id(),
-               chain::transaction_receipt_header::executed,
+               transfer_trx.id(), // transfer_trx.id() because that is the trx id known to the user
                {
                   {
                      0,

--- a/plugins/trace_api_plugin/test/test_responses.cpp
+++ b/plugins/trace_api_plugin/test/test_responses.cpp
@@ -157,7 +157,6 @@ BOOST_AUTO_TEST_SUITE(trace_responses)
                {
                   {
                      "0000000000000000000000000000000000000000000000000000000000000001"_h,
-                     chain::transaction_receipt_header::executed,
                      {
                         {
                            0,
@@ -182,7 +181,6 @@ BOOST_AUTO_TEST_SUITE(trace_responses)
          ("transactions", fc::variants({
             fc::mutable_variant_object()
                ("id", "0000000000000000000000000000000000000000000000000000000000000001")
-               ("status", "executed")
                ("actions", fc::variants({
                   fc::mutable_variant_object()
                      ("receiver", "receiver")
@@ -393,7 +391,6 @@ BOOST_AUTO_TEST_SUITE(trace_responses)
                {
                   {
                      "0000000000000000000000000000000000000000000000000000000000000001"_h,
-                     chain::transaction_receipt_header::executed,
                      {
                         {
                            0,


### PR DESCRIPTION
## Change Description

- Do not report context free actions.
- Only report executed transactions.
  - soft_fail `onerror` transaction reported with the id of the input transaction since that is the id the user knows about.
- Remove `transaction_trace_v0` status since they are all `executed` except for the `soft_fail` which would be confusing to users.
 
## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
