### PR TITLE
free unknown EOS VM OC codegen versions from the code cache

### DIFF
--- a/libraries/chain/webassembly/eos-vm-oc/code_cache.cpp
+++ b/libraries/chain/webassembly/eos-vm-oc/code_cache.cpp
@@ -262,8 +262,11 @@ code_cache_base::code_cache_base(const boost::filesystem::path data_dir, const e
       for(unsigned i = 0; i < number_entries; ++i) {
          code_descriptor cd;
          fc::raw::unpack(ds, cd);
-         if(cd.codegen_version != 0)
+         if(cd.codegen_version != 0) {
+            allocator->deallocate(code_mapping + cd.code_begin);
+            allocator->deallocate(code_mapping + cd.initdata_begin);
             continue;
+         }
          _cache_index.push_back(std::move(cd));
       }
       allocator->deallocate(code_mapping + cache_header.serialized_descriptor_index);


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
Code stored in EOS VM OC's code cache has a "code gen version" attached to it. This is always the value 0 now. The idea was in the future if EOS VM OC's code generation changes (due to a new optimization, or some other improvement), nodeos could make a determination to still run code gen version 0 while code gen version 1 is being compiled. That way there is no gap in time for when EOS VM OC can be used for a contract on a nodeos upgrade.

Yes, there are considerable limitations in this approach (like that the code_descriptor layout can't change much), but it offers at least some flexibility.

There is code in place to ignore any entries in the cache with code gen version other than 0. This covers the case someone upgrades nodeos but then downgrades it. But just ignoring these entries leaks memory in the code cache. We need to free the memory when "dropping" code cache entries.

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
