### PR TITLE
migrate response subsystem to the new store read API

### DIFF
--- a/plugins/trace_api_plugin/request_handler.cpp
+++ b/plugins/trace_api_plugin/request_handler.cpp
@@ -72,9 +72,7 @@ namespace {
 }
 
 namespace eosio::trace_api_plugin::detail {
-   fc::variant response_formatter::process_block( const block_trace_v0& trace, const  std::optional<lib_entry_v0>& best_lib, const data_handler_function& data_handler, const now_function& now, const fc::time_point& deadline ) {
-      bool final = best_lib && (best_lib->lib >= trace.number);
-
+   fc::variant response_formatter::process_block( const block_trace_v0& trace, bool irreversible, const data_handler_function& data_handler, const now_function& now, const fc::time_point& deadline ) {
       auto yield = [&now, &deadline]() {
          if (now() >= deadline) {
             throw deadline_exceeded("Provided deadline exceeded while processing transaction data");
@@ -85,7 +83,7 @@ namespace eosio::trace_api_plugin::detail {
          ("id", trace.id.str() )
          ("number", trace.number )
          ("previous_id", trace.previous_id.str() )
-         ("status", final ? "irreversible" : "pending" )
+         ("status", irreversible ? "irreversible" : "pending" )
          ("timestamp", to_iso8601_datetime(trace.timestamp))
          ("producer", trace.producer.to_string())
          ("transactions", process_transactions(trace.transactions, data_handler, yield ));

--- a/plugins/trace_api_plugin/test/test_responses.cpp
+++ b/plugins/trace_api_plugin/test/test_responses.cpp
@@ -12,7 +12,7 @@ using namespace eosio::trace_api_plugin;
 using namespace eosio::trace_api_plugin::test_common;
 
 struct response_test_fixture {
-
+   using get_block_t = std::optional<std::tuple<block_trace_v0, bool>>;
    /**
     * MOCK implementation of the logfile input API
     */
@@ -22,55 +22,15 @@ struct response_test_fixture {
       {}
 
       /**
-       * Read from the data log
-       * @param block_height : the block_height of the data being read
-       * @param offset : the offset in the datalog to read
-       * @return empty optional if the data log does not exist, data otherwise
-       * @throws std::exception : when the data is not the correct type or if the log is corrupt in some way
-       *
+       * Read the trace for a given block
+       * @param block_height : the height of the data being read
+       * @return empty optional if the data cannot be read OTHERWISE
+       *         optional containing a 2-tuple of the block_trace and a flag indicating irreversibility
+       * @throws bad_data_exception : if the data is corrupt in some way
        */
-      std::optional<data_log_entry> read_data_log( uint32_t block_height, uint64_t offset ) {
-         if (fixture.data_log.count(offset) == 0) {
-            return {};
-         } else {
-            const auto& res = fixture.data_log.at(offset);
-            if (res.contains<std::exception_ptr>()) {
-               std::rethrow_exception(res.get<std::exception_ptr>());
-            } else {
-               return res.get<data_log_entry>();
-            }
-         }
+      get_block_t get_block(uint32_t height) {
+         return fixture.mock_get_block(height);
       }
-
-      /**
-       * Read the metadata log font-to-back starting at an offset passing each entry to a provided functor/lambda
-       *
-       * @tparam Fn : type of the functor/lambda
-       * @param block_height : height of the requested data
-       * @param offset : initial offset to read from
-       * @param fn : the functor/lambda
-       * @return the highest offset read during this scan
-       */
-      template<typename Fn>
-      uint64_t scan_metadata_log_from( uint32_t block_height, uint64_t offset, Fn&& fn ) {
-         uint64_t cur = offset;
-         for (; cur < fixture.metadata_log.size(); cur++) {
-            const auto& entry = fixture.metadata_log.at(cur);
-            if (entry.contains<std::exception_ptr>()) {
-               std::rethrow_exception(entry.get<std::exception_ptr>());
-            }
-
-            if (entry.contains<metadata_log_entry>()) {
-               if (!fn(entry)) {
-                  break;
-               }
-            }
-         }
-
-         return cur;
-      }
-
-
       response_test_fixture& fixture;
    };
 
@@ -106,8 +66,7 @@ struct response_test_fixture {
    }
 
    // fixture data and methods
-   std::vector<fc::static_variant<std::exception_ptr, metadata_log_entry>> metadata_log = {};
-   std::map<uint64_t, fc::static_variant<std::exception_ptr, data_log_entry>> data_log = {};
+   std::function<get_block_t(uint32_t)> mock_get_block;
    std::function<fc::time_point()> mock_now = []() -> fc::time_point { return fc::time_point::now(); };
    std::function<fc::variant(const action_trace_v0&, const fc::time_point&)> mock_data_handler = default_mock_data_handler;
 
@@ -118,22 +77,13 @@ struct response_test_fixture {
 BOOST_AUTO_TEST_SUITE(trace_responses)
    BOOST_FIXTURE_TEST_CASE(basic_empty_block_response, response_test_fixture)
    {
-      metadata_log = decltype(metadata_log){
-         metadata_log_entry{ block_entry_v0 { "b000000000000000000000000000000000000000000000000000000000000001"_h, 1, 0 } }
-      };
-
-      data_log = decltype(data_log) {
-         {
-            0,
-            data_log_entry{ block_trace_v0 {
-               "b000000000000000000000000000000000000000000000000000000000000001"_h,
-               1,
-               "0000000000000000000000000000000000000000000000000000000000000000"_h,
-               chain::block_timestamp_type(0),
-               "bp.one"_n,
-               {}
-            }}
-         }
+      auto block_trace = block_trace_v0 {
+         "b000000000000000000000000000000000000000000000000000000000000001"_h,
+         1,
+         "0000000000000000000000000000000000000000000000000000000000000000"_h,
+         chain::block_timestamp_type(0),
+         "bp.one"_n,
+         {}
       };
 
       fc::variant expected_response = fc::mutable_variant_object()
@@ -146,6 +96,11 @@ BOOST_AUTO_TEST_SUITE(trace_responses)
          ("transactions", fc::variants() )
       ;
 
+      mock_get_block = [&block_trace]( uint32_t height ) -> get_block_t {
+         BOOST_TEST(height == 1);
+         return std::make_tuple(block_trace, false);
+      };
+
       fc::variant actual_response = get_block_trace( 1 );
 
       BOOST_TEST(to_kv(expected_response) == to_kv(actual_response), boost::test_tools::per_element());
@@ -153,33 +108,24 @@ BOOST_AUTO_TEST_SUITE(trace_responses)
 
    BOOST_FIXTURE_TEST_CASE(basic_block_response, response_test_fixture)
    {
-      metadata_log = decltype(metadata_log){
-         metadata_log_entry { block_entry_v0 { "b000000000000000000000000000000000000000000000000000000000000001"_h, 1, 0 } }
-      };
-
-      data_log = decltype(data_log) {
+      auto block_trace = block_trace_v0 {
+         "b000000000000000000000000000000000000000000000000000000000000001"_h,
+         1,
+         "0000000000000000000000000000000000000000000000000000000000000000"_h,
+         chain::block_timestamp_type(0),
+         "bp.one"_n,
          {
-            0,
-            data_log_entry{ block_trace_v0 {
-               "b000000000000000000000000000000000000000000000000000000000000001"_h,
-               1,
-               "0000000000000000000000000000000000000000000000000000000000000000"_h,
-               chain::block_timestamp_type(0),
-               "bp.one"_n,
+            {
+               "0000000000000000000000000000000000000000000000000000000000000001"_h,
                {
                   {
-                     "0000000000000000000000000000000000000000000000000000000000000001"_h,
-                     {
-                        {
-                           0,
-                           "receiver"_n, "contract"_n, "action"_n,
-                           {{ "alice"_n, "active"_n }},
-                           { 0x00, 0x01, 0x02, 0x03 }
-                        }
-                     }
+                     0,
+                     "receiver"_n, "contract"_n, "action"_n,
+                     {{ "alice"_n, "active"_n }},
+                     { 0x00, 0x01, 0x02, 0x03 }
                   }
                }
-            }}
+            }
          }
       };
 
@@ -210,6 +156,11 @@ BOOST_AUTO_TEST_SUITE(trace_responses)
          }))
       ;
 
+      mock_get_block = [&block_trace]( uint32_t height ) -> get_block_t {
+         BOOST_TEST(height == 1);
+         return std::make_tuple(block_trace, false);
+      };
+
       fc::variant actual_response = get_block_trace( 1 );
 
       BOOST_TEST(to_kv(expected_response) == to_kv(actual_response), boost::test_tools::per_element());
@@ -217,34 +168,24 @@ BOOST_AUTO_TEST_SUITE(trace_responses)
 
    BOOST_FIXTURE_TEST_CASE(basic_block_response_no_params, response_test_fixture)
    {
-      metadata_log = decltype(metadata_log){
-         metadata_log_entry { block_entry_v0 { "b000000000000000000000000000000000000000000000000000000000000001"_h, 1, 0 } }
-      };
-
-      data_log = decltype(data_log) {
+      auto block_trace = block_trace_v0 {
+         "b000000000000000000000000000000000000000000000000000000000000001"_h,
+         1,
+         "0000000000000000000000000000000000000000000000000000000000000000"_h,
+         chain::block_timestamp_type(0),
+         "bp.one"_n,
          {
-            0,
-            data_log_entry{ block_trace_v0 {
-               "b000000000000000000000000000000000000000000000000000000000000001"_h,
-               1,
-               "0000000000000000000000000000000000000000000000000000000000000000"_h,
-               chain::block_timestamp_type(0),
-               "bp.one"_n,
+            {
+               "0000000000000000000000000000000000000000000000000000000000000001"_h,
                {
                   {
-                     "0000000000000000000000000000000000000000000000000000000000000001"_h,
-                     chain::transaction_receipt_header::executed,
-                     {
-                        {
-                           0,
-                           "receiver"_n, "contract"_n, "action"_n,
-                           {{ "alice"_n, "active"_n }},
-                           { 0x00, 0x01, 0x02, 0x03 }
-                        }
-                     }
+                     0,
+                     "receiver"_n, "contract"_n, "action"_n,
+                     {{ "alice"_n, "active"_n }},
+                     { 0x00, 0x01, 0x02, 0x03 }
                   }
                }
-            }}
+            }
          }
       };
 
@@ -258,7 +199,6 @@ BOOST_AUTO_TEST_SUITE(trace_responses)
          ("transactions", fc::variants({
             fc::mutable_variant_object()
                ("id", "0000000000000000000000000000000000000000000000000000000000000001")
-               ("status", "executed")
                ("actions", fc::variants({
                   fc::mutable_variant_object()
                      ("receiver", "receiver")
@@ -274,6 +214,11 @@ BOOST_AUTO_TEST_SUITE(trace_responses)
          }))
       ;
 
+      mock_get_block = [&block_trace]( uint32_t height ) -> get_block_t {
+         BOOST_TEST(height == 1);
+         return std::make_tuple(block_trace, false);
+      };
+
       // simulate an inability to parse the parameters
       mock_data_handler = [](const action_trace_v0&, const fc::time_point&) -> fc::variant {
          return {};
@@ -284,37 +229,18 @@ BOOST_AUTO_TEST_SUITE(trace_responses)
       BOOST_TEST(to_kv(expected_response) == to_kv(actual_response), boost::test_tools::per_element());
    }
 
-   BOOST_FIXTURE_TEST_CASE(lib_edge_response, response_test_fixture)
+   BOOST_FIXTURE_TEST_CASE(lib_response, response_test_fixture)
    {
-      metadata_log = decltype(metadata_log){
-         metadata_log_entry { block_entry_v0 { "b000000000000000000000000000000000000000000000000000000000000001"_h, 1, 0 } }
+      auto block_trace = block_trace_v0 {
+         "b000000000000000000000000000000000000000000000000000000000000001"_h,
+         1,
+         "0000000000000000000000000000000000000000000000000000000000000000"_h,
+         chain::block_timestamp_type(0),
+         "bp.one"_n,
+         {}
       };
 
-      data_log = decltype(data_log) {
-         {
-            0,
-            data_log_entry{ block_trace_v0 {
-               "b000000000000000000000000000000000000000000000000000000000000001"_h,
-               1,
-               "0000000000000000000000000000000000000000000000000000000000000000"_h,
-               chain::block_timestamp_type(0),
-               "bp.one"_n,
-               {}
-            }}
-         }
-      };
-
-      fc::variant expected_pending_response = fc::mutable_variant_object()
-         ("id", "b000000000000000000000000000000000000000000000000000000000000001")
-         ("number", 1)
-         ("previous_id", "0000000000000000000000000000000000000000000000000000000000000000")
-         ("status", "pending")
-         ("timestamp", "2000-01-01T00:00:00.000Z")
-         ("producer", "bp.one")
-         ("transactions", fc::variants() )
-      ;
-
-      fc::variant expected_irreversible_response = fc::mutable_variant_object()
+      fc::variant expected_response = fc::mutable_variant_object()
          ("id", "b000000000000000000000000000000000000000000000000000000000000001")
          ("number", 1)
          ("previous_id", "0000000000000000000000000000000000000000000000000000000000000000")
@@ -324,101 +250,21 @@ BOOST_AUTO_TEST_SUITE(trace_responses)
          ("transactions", fc::variants() )
       ;
 
-      fc::variant pending_response = get_block_trace( 1 );
-      BOOST_TEST(to_kv(expected_pending_response) == to_kv(pending_response), boost::test_tools::per_element());
-
-      // push an entry to the metadata log that marks that block as LIB
-      metadata_log.emplace_back( metadata_log_entry { lib_entry_v0{ 1 } } );
-
-      fc::variant irreversible_response = get_block_trace( 1 );
-      BOOST_TEST(to_kv(expected_irreversible_response) == to_kv(irreversible_response), boost::test_tools::per_element());
-
-   }
-
-   BOOST_FIXTURE_TEST_CASE(better_block_edge_response, response_test_fixture)
-   {
-      metadata_log = decltype(metadata_log){
-         metadata_log_entry { block_entry_v0 { "b000000000000000000000000000000000000000000000000000000000000001"_h, 1, 0 } }
+      mock_get_block = [&block_trace]( uint32_t height ) -> get_block_t {
+         BOOST_TEST(height == 1);
+         return std::make_tuple(block_trace, true);
       };
 
-      data_log = decltype(data_log) {
-         {
-            0,
-            data_log_entry{ block_trace_v0 {
-               "b000000000000000000000000000000000000000000000000000000000000001"_h,
-               1,
-               "0000000000000000000000000000000000000000000000000000000000000000"_h,
-               chain::block_timestamp_type(0),
-               "bp.one"_n,
-               {}
-            }}
-         }
-      };
+      fc::variant response = get_block_trace( 1 );
+      BOOST_TEST(to_kv(expected_response) == to_kv(response), boost::test_tools::per_element());
 
-      fc::variant expected_original_response = fc::mutable_variant_object()
-         ("id", "b000000000000000000000000000000000000000000000000000000000000001")
-         ("number", 1)
-         ("previous_id", "0000000000000000000000000000000000000000000000000000000000000000")
-         ("status", "pending")
-         ("timestamp", "2000-01-01T00:00:00.000Z")
-         ("producer", "bp.one")
-         ("transactions", fc::variants() )
-      ;
-
-      fc::variant expected_updated_response = fc::mutable_variant_object()
-         ("id", "b000000000000000000000000000000000000000000000000000000000000002")
-         ("number", 1)
-         ("previous_id", "0000000000000000000000000000000000000000000000000000000000000000")
-         ("status", "pending")
-         ("timestamp", "2000-01-01T00:00:00.500Z")
-         ("producer", "bp.two")
-         ("transactions", fc::variants() )
-      ;
-
-      fc::variant original_response = get_block_trace( 1 );
-      BOOST_TEST(to_kv(expected_original_response) == to_kv(original_response), boost::test_tools::per_element());
-
-      // add more data
-      const uint64_t updated_block_offset = 2;
-      data_log[updated_block_offset] = {
-         data_log_entry{ block_trace_v0 {
-            "b000000000000000000000000000000000000000000000000000000000000002"_h,
-            1,
-            "0000000000000000000000000000000000000000000000000000000000000000"_h,
-            chain::block_timestamp_type(1),
-            "bp.two"_n,
-            {}
-         }}
-      };
-
-      // push an entry to the metadata log that marks that block as LIB
-      metadata_log.emplace_back(metadata_log_entry { block_entry_v0 { "b000000000000000000000000000000000000000000000000000000000000002"_h, 1, updated_block_offset } });
-
-      fc::variant irreversible_response = get_block_trace( 1 );
-      BOOST_TEST(to_kv(expected_updated_response) == to_kv(irreversible_response), boost::test_tools::per_element());
    }
 
    BOOST_FIXTURE_TEST_CASE(corrupt_block_data, response_test_fixture)
    {
-      metadata_log = decltype(metadata_log){
-         metadata_log_entry { block_entry_v0 { "b000000000000000000000000000000000000000000000000000000000000001"_h, 1, 0 } }
-      };
-
-      data_log = decltype(data_log) {
-         {
-            0,
-            std::make_exception_ptr(std::runtime_error("BAD DATA"))
-         }
-      };
-
-      BOOST_REQUIRE_THROW(get_block_trace( 1 ), bad_data_exception);
-   }
-
-   BOOST_FIXTURE_TEST_CASE(corrupt_block_metadata, response_test_fixture)
-   {
-      metadata_log = decltype(metadata_log){
-         metadata_log_entry { block_entry_v0 { "b000000000000000000000000000000000000000000000000000000000000001"_h, 1, 0 } },
-         std::make_exception_ptr(std::runtime_error("BAD METADATA"))
+      mock_get_block = []( uint32_t height ) -> get_block_t {
+         BOOST_TEST(height == 1);
+         throw bad_data_exception("mock exception");
       };
 
       BOOST_REQUIRE_THROW(get_block_trace( 1 ), bad_data_exception);
@@ -426,29 +272,9 @@ BOOST_AUTO_TEST_SUITE(trace_responses)
 
    BOOST_FIXTURE_TEST_CASE(missing_block_data, response_test_fixture)
    {
-      metadata_log = decltype(metadata_log){
-         metadata_log_entry { block_entry_v0 { "b000000000000000000000000000000000000000000000000000000000000001"_h, 1, 0 } }
-      };
-
-      fc::variant null_response = get_block_trace( 1 );
-
-      BOOST_TEST(null_response.is_null());
-   }
-
-   BOOST_FIXTURE_TEST_CASE(missing_block_metadata, response_test_fixture)
-   {
-      data_log = decltype(data_log) {
-         {
-            0,
-            data_log_entry{ block_trace_v0 {
-               "b000000000000000000000000000000000000000000000000000000000000001"_h,
-               1,
-               "0000000000000000000000000000000000000000000000000000000000000000"_h,
-               chain::block_timestamp_type(0),
-               "bp.one"_n,
-               {}
-            }}
-         }
+      mock_get_block = []( uint32_t height ) -> get_block_t {
+         BOOST_TEST(height == 1);
+         return {};
       };
 
       fc::variant null_response = get_block_trace( 1 );
@@ -458,34 +284,30 @@ BOOST_AUTO_TEST_SUITE(trace_responses)
 
    BOOST_FIXTURE_TEST_CASE(deadline_throws, response_test_fixture)
    {
-      metadata_log = decltype(metadata_log){
-         metadata_log_entry { block_entry_v0 { "b000000000000000000000000000000000000000000000000000000000000001"_h, 1, 0 } }
-      };
-
-      data_log = decltype(data_log) {
+      auto block_trace = block_trace_v0 {
+         "b000000000000000000000000000000000000000000000000000000000000001"_h,
+         1,
+         "0000000000000000000000000000000000000000000000000000000000000000"_h,
+         chain::block_timestamp_type(0),
+         "bp.one"_n,
          {
-            0,
-            data_log_entry{ block_trace_v0 {
-               "b000000000000000000000000000000000000000000000000000000000000001"_h,
-               1,
-               "0000000000000000000000000000000000000000000000000000000000000000"_h,
-               chain::block_timestamp_type(0),
-               "bp.one"_n,
+            {
+               "0000000000000000000000000000000000000000000000000000000000000001"_h,
                {
                   {
-                     "0000000000000000000000000000000000000000000000000000000000000001"_h,
-                     {
-                        {
-                           0,
-                           "receiver"_n, "contract"_n, "action"_n,
-                           {{ "alice"_n, "active"_n }},
-                           { 0x00, 0x01, 0x02, 0x03 }
-                        }
-                     }
+                     0,
+                     "receiver"_n, "contract"_n, "action"_n,
+                     {{ "alice"_n, "active"_n }},
+                     { 0x00, 0x01, 0x02, 0x03 }
                   }
                }
-            }}
+            }
          }
+      };
+
+      mock_get_block = [&block_trace]( uint32_t height ) -> get_block_t {
+         BOOST_TEST(height == 1);
+         return std::make_tuple(block_trace, false);
       };
 
       auto deadline = fc::time_point(fc::microseconds(1));
@@ -497,7 +319,6 @@ BOOST_AUTO_TEST_SUITE(trace_responses)
             return fc::time_point();
          }
       };
-
 
       BOOST_REQUIRE_THROW(get_block_trace( 1, deadline ), deadline_exceeded);
    }


### PR DESCRIPTION
In this PR:
- [ ] Migrated to the new API:
```c++
/**
 * Return the best block trace and whether it is irreversible or not, given a height
 * 
 * @param height - the block height requested
 * @return empty optional if the associated data is missing Otherwise
 *         Tuple of block data and true/false if the block is irrevesible/pending
 * @throws bad_data_exception - if the underlying data is corrupt in some way
 */
std::optional<std::tuple<block_trace_v0, bool>> get_block(uint32_t height);
```
- [ ] Adjust tests with mock provider
- [ ] Remove tests that were testing lower levels of the system (log mechanics etc) which are no longer exposed
- [ ] fixed "merges in the night" conflict between #8770 removing `status` and #8774 adding a new test with it.

### Open Questions
- [ ] Should we add a `fc::time_point deadline` parameter to this interface to maintain the previous invariant that long lasting log scans can be terminated OR is the time spent scanning bound by slice size and therefore well understood.