### PR TITLE
Trace API plugin - yield pattern

### DIFF
--- a/plugins/trace_api_plugin/abi_data_handler.cpp
+++ b/plugins/trace_api_plugin/abi_data_handler.cpp
@@ -7,7 +7,7 @@ namespace eosio::trace_api_plugin {
       abi_serializer_by_account.emplace(name, std::make_shared<chain::abi_serializer>(abi, fc::microseconds::maximum()));
    }
 
-   fc::variant abi_data_handler::process_data(const action_trace_v0& action, const fc::time_point& deadline) {
+   fc::variant abi_data_handler::process_data(const action_trace_v0& action, const yield_function& yield ) {
       if (abi_serializer_by_account.count(action.account) > 0) {
          const auto& serializer_p = abi_serializer_by_account.at(action.account);
          auto type_name = serializer_p->get_action_type(action.action);

--- a/plugins/trace_api_plugin/include/eosio/trace_api_plugin/abi_data_handler.hpp
+++ b/plugins/trace_api_plugin/include/eosio/trace_api_plugin/abi_data_handler.hpp
@@ -34,10 +34,10 @@ namespace eosio {
        * Given an action trace, produce a variant that represents the `data` field in the trace
        *
        * @param action - trace of the action including metadata necessary for finding the ABI
-       * @param deadline - deadline for processing
+       * @param yield - a yield function to allow cooperation during long running tasks
        * @return variant representing the `data` field of the action interpreted by known ABIs OR an empty variant
        */
-      fc::variant process_data( const action_trace_v0& action, const fc::time_point& deadline);
+      fc::variant process_data( const action_trace_v0& action, const yield_function& yield = {});
 
       /**
        * Utility class that allows mulitple request_handlers to share the same abi_data_handler
@@ -48,8 +48,8 @@ namespace eosio {
          :handler(handler)
          {}
 
-         fc::variant process_data( const action_trace_v0& action, const fc::time_point& deadline) {
-            return handler->process_data(action, deadline);
+         fc::variant process_data( const action_trace_v0& action, const yield_function& yield = {}) {
+            return handler->process_data(action, yield);
          }
 
          std::shared_ptr<abi_data_handler> handler;

--- a/plugins/trace_api_plugin/include/eosio/trace_api_plugin/base64_data_handler.hpp
+++ b/plugins/trace_api_plugin/include/eosio/trace_api_plugin/base64_data_handler.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <eosio/trace_api_plugin/trace.hpp>
+#include <eosio/trace_api_plugin/common.hpp>
 
 namespace eosio::trace_api_plugin {
    class base64_data_handler {
@@ -8,7 +9,7 @@ namespace eosio::trace_api_plugin {
       base64_data_handler()
       {}
 
-      fc::variant process_data( const action_trace_v0& action, const fc::time_point& ) {
+      fc::variant process_data( const action_trace_v0& action, const yield_function& = {} ) {
          return fc::base64_encode(action.data.data(), action.data.size());
       }
    };

--- a/plugins/trace_api_plugin/include/eosio/trace_api_plugin/common.hpp
+++ b/plugins/trace_api_plugin/include/eosio/trace_api_plugin/common.hpp
@@ -4,18 +4,30 @@
 
 namespace eosio::trace_api_plugin {
 
-   using now_function = std::function<fc::time_point()>;
+   /**
+    * A function used to separate cooperative or external concerns from long running tasks
+    * calling code should expect that this can throw yield_exception and gracefully unwind if it does
+    * @throws yield_exception if the provided yield needs to terminate the long running process for any reason
+    */
+   using yield_function = std::function<void()>;
+
+   template<typename F, typename ...Args>
+   void call_if_set(F&& f, Args&&  ...args ) {
+      if (static_cast<bool>(f))
+         std::forward<F>(f)(std::forward<Args>(args)...);
+   }
 
    /**
     * Exceptions
     */
-   class deadline_exceeded : public std::runtime_error {
-   public:
-      explicit deadline_exceeded(const char* what_arg)
+   class yield_exception : public std::runtime_error {
+      public:
+      explicit yield_exception(const char* what_arg)
       :std::runtime_error(what_arg)
       {}
-      explicit deadline_exceeded(const std::string& what_arg)
-            :std::runtime_error(what_arg)
+
+      explicit yield_exception(const std::string& what_arg)
+      :std::runtime_error(what_arg)
       {}
    };
 

--- a/plugins/trace_api_plugin/include/eosio/trace_api_plugin/request_handler.hpp
+++ b/plugins/trace_api_plugin/include/eosio/trace_api_plugin/request_handler.hpp
@@ -36,7 +36,7 @@ namespace eosio::trace_api_plugin {
        * @throws bad_data_exception when there are issues with the underlying data preventing processing.
        */
       fc::variant get_block_trace( uint32_t block_height, const yield_function& yield = {}) {
-         auto data = logfile_provider.get_block(block_height);
+         auto data = logfile_provider.get_block(block_height, yield);
          if (!data) {
             return {};
          }

--- a/plugins/trace_api_plugin/include/eosio/trace_api_plugin/request_handler.hpp
+++ b/plugins/trace_api_plugin/include/eosio/trace_api_plugin/request_handler.hpp
@@ -41,7 +41,7 @@ namespace eosio::trace_api_plugin {
             return {};
          }
 
-         call_if_set(yield);
+         yield();
 
          auto data_handler = [this](const action_trace_v0& action, const yield_function& yield) -> fc::variant {
             return data_handler_provider.process_data(action, yield);

--- a/plugins/trace_api_plugin/request_handler.cpp
+++ b/plugins/trace_api_plugin/request_handler.cpp
@@ -10,12 +10,11 @@ namespace {
       return (std::string)t + "Z";
    }
 
-   template<typename Yield>
-   fc::variants process_authorizations(const std::vector<authorization_trace_v0>& authorizations, Yield&& yield ) {
+   fc::variants process_authorizations(const std::vector<authorization_trace_v0>& authorizations, const yield_function& yield ) {
       fc::variants result;
       result.reserve(authorizations.size());
       for ( const auto& a: authorizations) {
-         yield();
+         call_if_set(yield);
 
          result.emplace_back(fc::mutable_variant_object()
             ("account", a.account.to_string())
@@ -27,21 +26,20 @@ namespace {
 
    }
 
-   template<typename Yield>
-   fc::variants process_actions(const std::vector<action_trace_v0>& actions, const data_handler_function& data_handler, Yield&& yield ) {
+   fc::variants process_actions(const std::vector<action_trace_v0>& actions, const data_handler_function& data_handler, const yield_function& yield ) {
       fc::variants result;
       result.reserve(actions.size());
       for ( const auto& a: actions) {
-         yield();
+         call_if_set(yield);
 
          auto action_variant = fc::mutable_variant_object()
                ("receiver", a.receiver.to_string())
                ("account", a.account.to_string())
                ("action", a.action.to_string())
-               ("authorization", process_authorizations(a.authorization, std::forward<Yield>(yield)))
+               ("authorization", process_authorizations(a.authorization, yield))
                ("data", fc::to_hex(a.data.data(), a.data.size()));
 
-         auto params = data_handler(a);
+         auto params = data_handler(a, yield);
          if (!params.is_null()) {
             action_variant("params", params);
          }
@@ -53,16 +51,15 @@ namespace {
 
    }
 
-   template<typename Yield>
-   fc::variants process_transactions(const std::vector<transaction_trace_v0>& transactions, const data_handler_function& data_handler, Yield&& yield  ) {
+   fc::variants process_transactions(const std::vector<transaction_trace_v0>& transactions, const data_handler_function& data_handler, const yield_function& yield ) {
       fc::variants result;
       result.reserve(transactions.size());
       for ( const auto& t: transactions) {
-         yield();
+         call_if_set(yield);
 
          result.emplace_back(fc::mutable_variant_object()
             ("id", t.id.str())
-            ("actions", process_actions(t.actions, data_handler, std::forward<Yield>(yield)))
+            ("actions", process_actions(t.actions, data_handler, yield))
          );
       }
 
@@ -72,13 +69,7 @@ namespace {
 }
 
 namespace eosio::trace_api_plugin::detail {
-   fc::variant response_formatter::process_block( const block_trace_v0& trace, bool irreversible, const data_handler_function& data_handler, const now_function& now, const fc::time_point& deadline ) {
-      auto yield = [&now, &deadline]() {
-         if (now() >= deadline) {
-            throw deadline_exceeded("Provided deadline exceeded while processing transaction data");
-         }
-      };
-
+   fc::variant response_formatter::process_block( const block_trace_v0& trace, bool irreversible, const data_handler_function& data_handler, const yield_function& yield ) {
       return fc::mutable_variant_object()
          ("id", trace.id.str() )
          ("number", trace.number )

--- a/plugins/trace_api_plugin/request_handler.cpp
+++ b/plugins/trace_api_plugin/request_handler.cpp
@@ -14,7 +14,7 @@ namespace {
       fc::variants result;
       result.reserve(authorizations.size());
       for ( const auto& a: authorizations) {
-         call_if_set(yield);
+         yield();
 
          result.emplace_back(fc::mutable_variant_object()
             ("account", a.account.to_string())
@@ -30,7 +30,7 @@ namespace {
       fc::variants result;
       result.reserve(actions.size());
       for ( const auto& a: actions) {
-         call_if_set(yield);
+         yield();
 
          auto action_variant = fc::mutable_variant_object()
                ("receiver", a.receiver.to_string())
@@ -55,7 +55,7 @@ namespace {
       fc::variants result;
       result.reserve(transactions.size());
       for ( const auto& t: transactions) {
-         call_if_set(yield);
+         yield();
 
          result.emplace_back(fc::mutable_variant_object()
             ("id", t.id.str())

--- a/plugins/trace_api_plugin/test/test_data_handlers.cpp
+++ b/plugins/trace_api_plugin/test/test_data_handlers.cpp
@@ -19,7 +19,7 @@ BOOST_AUTO_TEST_SUITE(abi_data_handler_tests)
       abi_data_handler handler;
 
       auto expected = fc::variant();
-      auto actual = handler.process_data(action, fc::time_point::maximum());
+      auto actual = handler.process_data(action);
 
       BOOST_TEST(to_kv(expected) == to_kv(actual), boost::test_tools::per_element());
    }
@@ -32,7 +32,7 @@ BOOST_AUTO_TEST_SUITE(abi_data_handler_tests)
       abi_data_handler handler;
 
       auto expected = fc::variant();
-      auto actual = handler.process_data(action, fc::time_point::maximum());
+      auto actual = handler.process_data(action);
 
       BOOST_TEST(to_kv(expected) == to_kv(actual), boost::test_tools::per_element());
    }
@@ -63,7 +63,7 @@ BOOST_AUTO_TEST_SUITE(abi_data_handler_tests)
          ("c", 2)
          ("d", 3);
 
-      auto actual = handler.process_data(action, fc::time_point::maximum());
+      auto actual = handler.process_data(action);
 
       BOOST_TEST(to_kv(expected) == to_kv(actual), boost::test_tools::per_element());
    }
@@ -90,7 +90,7 @@ BOOST_AUTO_TEST_SUITE(abi_data_handler_tests)
 
       auto expected = fc::variant();
 
-      auto actual = handler.process_data(action, fc::time_point::maximum());
+      auto actual = handler.process_data(action);
 
       BOOST_TEST(to_kv(expected) == to_kv(actual), boost::test_tools::per_element());
    }
@@ -118,7 +118,7 @@ BOOST_AUTO_TEST_SUITE(abi_data_handler_tests)
 
       auto expected = fc::variant();
 
-      auto actual = handler.process_data(action, fc::time_point::maximum());
+      auto actual = handler.process_data(action);
 
       BOOST_TEST(to_kv(expected) == to_kv(actual), boost::test_tools::per_element());
       BOOST_TEST(log_called);
@@ -135,7 +135,7 @@ BOOST_AUTO_TEST_SUITE(base64_data_handler_tests)
       base64_data_handler handler;
 
       auto expected = fc::variant("");
-      auto actual = handler.process_data(action, fc::time_point::maximum());
+      auto actual = handler.process_data(action);
 
       BOOST_TEST(to_kv(expected) == to_kv(actual), boost::test_tools::per_element());
    }
@@ -148,7 +148,7 @@ BOOST_AUTO_TEST_SUITE(base64_data_handler_tests)
       base64_data_handler handler;
 
       auto expected = fc::variant("AAEC");
-      auto actual = handler.process_data(action, fc::time_point::maximum());
+      auto actual = handler.process_data(action);
 
       BOOST_TEST(to_kv(expected) == to_kv(actual), boost::test_tools::per_element());
    }
@@ -161,7 +161,7 @@ BOOST_AUTO_TEST_SUITE(base64_data_handler_tests)
       base64_data_handler handler;
 
       auto expected = fc::variant("AAE=");
-      auto actual = handler.process_data(action, fc::time_point::maximum());
+      auto actual = handler.process_data(action);
 
       BOOST_TEST(to_kv(expected) == to_kv(actual), boost::test_tools::per_element());
    }
@@ -174,7 +174,7 @@ BOOST_AUTO_TEST_SUITE(base64_data_handler_tests)
       base64_data_handler handler;
 
       auto expected = fc::variant("AA==");
-      auto actual = handler.process_data(action, fc::time_point::maximum());
+      auto actual = handler.process_data(action);
 
       BOOST_TEST(to_kv(expected) == to_kv(actual), boost::test_tools::per_element());
    }
@@ -187,7 +187,7 @@ BOOST_AUTO_TEST_SUITE(base64_data_handler_tests)
       base64_data_handler handler;
 
       auto expected = fc::variant("/+A=");
-      auto actual = handler.process_data(action, fc::time_point::maximum());
+      auto actual = handler.process_data(action);
 
       BOOST_TEST(to_kv(expected) == to_kv(actual), boost::test_tools::per_element());
    }


### PR DESCRIPTION
In this PR:
- [ ] Move away from deadlines and concepts of time to a "yield pattern"
  - a `yield_function` takes no parameters, returns no values, and may sometimes throw a `yield_exception` which should bubble out of a long-running task to the top-level caller once the task gracefully terminates itself.  In most cases, this can just throw all the way out.  

### Why?

There are many reasons why the caller of a potentially long running task may have set a deadline before.  Some of them did not need to be destructive, such as processing a "critical" priority task queue with guaranteed maximum latency when the queue rarely has a task.   In this case, a yield function can intelligently check for the presence of a critical task before terminating the cooperative task instead of always terminating it so that the caller can potentially service the queue. 

Additionally, even in use-cases where time is the only consideration this pattern allows the caller to define what the source of that time is.  This is useful for unit tests when having a hard-coded dependency on the system clock can cause non-determinism or difficulty constructing tests. 