### PR TITLE
renamed the `trace_api_plugin` namespace to `trace_api`

### DIFF
--- a/plugins/trace_api_plugin/abi_data_handler.cpp
+++ b/plugins/trace_api_plugin/abi_data_handler.cpp
@@ -1,7 +1,7 @@
-#include <eosio/trace_api_plugin/abi_data_handler.hpp>
+#include <eosio/trace_api/abi_data_handler.hpp>
 #include <eosio/chain/abi_serializer.hpp>
 
-namespace eosio::trace_api_plugin {
+namespace eosio::trace_api {
 
    void abi_data_handler::add_abi( const chain::name& name, const chain::abi_def& abi ) {
       abi_serializer_by_account.emplace(name, std::make_shared<chain::abi_serializer>(abi, fc::microseconds::maximum()));

--- a/plugins/trace_api_plugin/include/eosio/trace_api/abi_data_handler.hpp
+++ b/plugins/trace_api_plugin/include/eosio/trace_api/abi_data_handler.hpp
@@ -1,15 +1,15 @@
 #pragma once
 
 #include <eosio/chain/abi_def.hpp>
-#include <eosio/trace_api_plugin/trace.hpp>
-#include <eosio/trace_api_plugin/common.hpp>
+#include <eosio/trace_api/trace.hpp>
+#include <eosio/trace_api/common.hpp>
 
 namespace eosio {
    namespace chain {
       struct abi_serializer;
    }
 
-   namespace trace_api_plugin {
+   namespace trace_api {
 
    /**
     * Data Handler that uses eosio::chain::abi_serializer to decode data with a known set of ABI's

--- a/plugins/trace_api_plugin/include/eosio/trace_api/base64_data_handler.hpp
+++ b/plugins/trace_api_plugin/include/eosio/trace_api/base64_data_handler.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <eosio/trace_api_plugin/trace.hpp>
-#include <eosio/trace_api_plugin/common.hpp>
+#include <eosio/trace_api/trace.hpp>
+#include <eosio/trace_api/common.hpp>
 
-namespace eosio::trace_api_plugin {
+namespace eosio::trace_api {
    class base64_data_handler {
    public:
       base64_data_handler()

--- a/plugins/trace_api_plugin/include/eosio/trace_api/chain_extraction.hpp
+++ b/plugins/trace_api_plugin/include/eosio/trace_api/chain_extraction.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
-#include <eosio/trace_api_plugin/trace.hpp>
-#include <eosio/trace_api_plugin/extract_util.hpp>
+#include <eosio/trace_api/trace.hpp>
+#include <eosio/trace_api/extract_util.hpp>
 #include <exception>
 #include <functional>
 #include <map>
 
-namespace eosio { namespace trace_api_plugin {
+namespace eosio { namespace trace_api {
 
 using chain::transaction_id_type;
 using chain::packed_transaction;

--- a/plugins/trace_api_plugin/include/eosio/trace_api/common.hpp
+++ b/plugins/trace_api_plugin/include/eosio/trace_api/common.hpp
@@ -2,7 +2,7 @@
 
 #include <tuple>
 
-namespace eosio::trace_api_plugin {
+namespace eosio::trace_api {
    template<typename R, typename ...Args>
    class optional_delegate : private std::function<R(Args...)> {
    public:
@@ -63,7 +63,7 @@ namespace eosio::trace_api_plugin {
    using exception_with_context = std::tuple<const std::exception_ptr&, char const *, uint64_t, char const *>;
 
 #define MAKE_EXCEPTION_WITH_CONTEXT(eptr) \
-   (eosio::trace_api_plugin::exception_with_context((eptr),  __FILE__, __LINE__, __func__))
+   (eosio::trace_api::exception_with_context((eptr),  __FILE__, __LINE__, __func__))
 
 
 }

--- a/plugins/trace_api_plugin/include/eosio/trace_api/configuration_utils.hpp
+++ b/plugins/trace_api_plugin/include/eosio/trace_api/configuration_utils.hpp
@@ -6,7 +6,7 @@
 #include <eosio/chain/exceptions.hpp>
 #include <eosio/chain/abi_def.hpp>
 
-namespace eosio::trace_api_plugin::configuration_utils {
+namespace eosio::trace_api::configuration_utils {
    using namespace eosio;
 
    /**

--- a/plugins/trace_api_plugin/include/eosio/trace_api/data_log.hpp
+++ b/plugins/trace_api_plugin/include/eosio/trace_api/data_log.hpp
@@ -1,10 +1,10 @@
 #pragma once
 #include <fc/variant.hpp>
-#include <eosio/trace_api_plugin/trace.hpp>
+#include <eosio/trace_api/trace.hpp>
 #include <eosio/chain/abi_def.hpp>
 #include <eosio/chain/protocol_feature_activation.hpp>
 
-namespace eosio { namespace trace_api_plugin {
+namespace eosio { namespace trace_api {
 
    using data_log_entry = fc::static_variant<
       block_trace_v0

--- a/plugins/trace_api_plugin/include/eosio/trace_api/extract_util.hpp
+++ b/plugins/trace_api_plugin/include/eosio/trace_api/extract_util.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <eosio/trace_api_plugin/trace.hpp>
+#include <eosio/trace_api/trace.hpp>
 #include <eosio/chain/block_state.hpp>
 
-namespace eosio { namespace trace_api_plugin {
+namespace eosio { namespace trace_api {
 
 /// Used by to_transaction_trace_v0 for creation of action_trace_v0
 inline action_trace_v0 to_action_trace_v0( const chain::action_trace& at ) {

--- a/plugins/trace_api_plugin/include/eosio/trace_api/metadata_log.hpp
+++ b/plugins/trace_api_plugin/include/eosio/trace_api/metadata_log.hpp
@@ -1,10 +1,10 @@
 #pragma once
 #include <fc/variant.hpp>
-#include <eosio/trace_api_plugin/trace.hpp>
+#include <eosio/trace_api/trace.hpp>
 #include <eosio/chain/abi_def.hpp>
 #include <eosio/chain/protocol_feature_activation.hpp>
 
-namespace eosio { namespace trace_api_plugin {
+namespace eosio { namespace trace_api {
    struct block_entry_v0 {
       chain::block_id_type   id;
       uint64_t               number;
@@ -22,5 +22,5 @@ namespace eosio { namespace trace_api_plugin {
 
 }}
 
-FC_REFLECT(eosio::trace_api_plugin::block_entry_v0, (id)(number)(offset));
-FC_REFLECT(eosio::trace_api_plugin::lib_entry_v0, (lib));
+FC_REFLECT(eosio::trace_api::block_entry_v0, (id)(number)(offset));
+FC_REFLECT(eosio::trace_api::lib_entry_v0, (lib));

--- a/plugins/trace_api_plugin/include/eosio/trace_api/request_handler.hpp
+++ b/plugins/trace_api_plugin/include/eosio/trace_api/request_handler.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
 #include <fc/variant.hpp>
-#include <eosio/trace_api_plugin/metadata_log.hpp>
-#include <eosio/trace_api_plugin/data_log.hpp>
-#include <eosio/trace_api_plugin/common.hpp>
+#include <eosio/trace_api/metadata_log.hpp>
+#include <eosio/trace_api/data_log.hpp>
+#include <eosio/trace_api/common.hpp>
 
-namespace eosio::trace_api_plugin {
+namespace eosio::trace_api {
    using data_handler_function = std::function<fc::variant(const action_trace_v0&, const yield_function&)>;
 
    namespace detail {

--- a/plugins/trace_api_plugin/include/eosio/trace_api/store_provider.hpp
+++ b/plugins/trace_api_plugin/include/eosio/trace_api/store_provider.hpp
@@ -4,10 +4,10 @@
 #include <fc/io/cfile.hpp>
 #include <boost/filesystem.hpp>
 #include <fc/variant.hpp>
-#include <eosio/trace_api_plugin/metadata_log.hpp>
-#include <eosio/trace_api_plugin/data_log.hpp>
+#include <eosio/trace_api/metadata_log.hpp>
+#include <eosio/trace_api/data_log.hpp>
 
-namespace eosio::trace_api_plugin {
+namespace eosio::trace_api {
    using namespace boost::filesystem;
 
    class path_does_not_exist : public std::runtime_error {
@@ -237,4 +237,4 @@ namespace eosio::trace_api_plugin {
 
 }
 
-FC_REFLECT(eosio::trace_api_plugin::slice_provider::index_header, (version))
+FC_REFLECT(eosio::trace_api::slice_provider::index_header, (version))

--- a/plugins/trace_api_plugin/include/eosio/trace_api/trace.hpp
+++ b/plugins/trace_api_plugin/include/eosio/trace_api/trace.hpp
@@ -4,7 +4,7 @@
 #include <eosio/chain/types.hpp>
 #include <eosio/chain/block.hpp>
 
-namespace eosio { namespace trace_api_plugin {
+namespace eosio { namespace trace_api {
 
    struct authorization_trace_v0 {
       chain::name account;
@@ -38,7 +38,7 @@ namespace eosio { namespace trace_api_plugin {
 
 } }
 
-FC_REFLECT(eosio::trace_api_plugin::authorization_trace_v0, (account)(permission))
-FC_REFLECT(eosio::trace_api_plugin::action_trace_v0, (global_sequence)(receiver)(account)(action)(authorization)(data))
-FC_REFLECT(eosio::trace_api_plugin::transaction_trace_v0, (id)(actions))
-FC_REFLECT(eosio::trace_api_plugin::block_trace_v0, (id)(number)(previous_id)(timestamp)(producer)(transactions))
+FC_REFLECT(eosio::trace_api::authorization_trace_v0, (account)(permission))
+FC_REFLECT(eosio::trace_api::action_trace_v0, (global_sequence)(receiver)(account)(action)(authorization)(data))
+FC_REFLECT(eosio::trace_api::transaction_trace_v0, (id)(actions))
+FC_REFLECT(eosio::trace_api::block_trace_v0, (id)(number)(previous_id)(timestamp)(producer)(transactions))

--- a/plugins/trace_api_plugin/include/eosio/trace_api/trace_api_plugin.hpp
+++ b/plugins/trace_api_plugin/include/eosio/trace_api/trace_api_plugin.hpp
@@ -7,12 +7,12 @@ namespace eosio {
    /**
     * Plugin that runs both a data extraction  and the HTTP RPC in the same application
     */
-   class _trace_api_plugin : public appbase::plugin<_trace_api_plugin> {
+   class trace_api_plugin : public appbase::plugin<trace_api_plugin> {
    public:
       APPBASE_PLUGIN_REQUIRES((chain_plugin)(http_plugin))
 
-      _trace_api_plugin();
-      virtual ~_trace_api_plugin();
+      trace_api_plugin();
+      virtual ~trace_api_plugin();
 
       virtual void set_program_options(appbase::options_description& cli, appbase::options_description& cfg) override;
 

--- a/plugins/trace_api_plugin/request_handler.cpp
+++ b/plugins/trace_api_plugin/request_handler.cpp
@@ -1,10 +1,10 @@
-#include <eosio/trace_api_plugin/request_handler.hpp>
+#include <eosio/trace_api/request_handler.hpp>
 
 #include <fc/variant_object.hpp>
 #include <fc/crypto/base64.hpp>
 
 namespace {
-   using namespace eosio::trace_api_plugin;
+   using namespace eosio::trace_api;
 
    std::string to_iso8601_datetime( const fc::time_point& t) {
       return (std::string)t + "Z";
@@ -68,7 +68,7 @@ namespace {
 
 }
 
-namespace eosio::trace_api_plugin::detail {
+namespace eosio::trace_api::detail {
    fc::variant response_formatter::process_block( const block_trace_v0& trace, bool irreversible, const data_handler_function& data_handler, const yield_function& yield ) {
       return fc::mutable_variant_object()
          ("id", trace.id.str() )

--- a/plugins/trace_api_plugin/store_provider.cpp
+++ b/plugins/trace_api_plugin/store_provider.cpp
@@ -1,4 +1,4 @@
-#include <eosio/trace_api_plugin/store_provider.hpp>
+#include <eosio/trace_api/store_provider.hpp>
 
 #include <fc/variant_object.hpp>
 #include <fc/crypto/base64.hpp>
@@ -11,7 +11,7 @@ namespace {
       static constexpr uint _max_filename_size = std::char_traits<char>::length(_trace_index_prefix) + 10 + 1 + 10 + std::char_traits<char>::length(_trace_ext) + 1; // "trace_index_" + 10-digits + '-' + 10-digits + ".log" + null-char
 }
 
-namespace eosio::trace_api_plugin {
+namespace eosio::trace_api {
    namespace bfs = boost::filesystem;
    store_provider::store_provider(const bfs::path& slice_dir, uint32_t width)
    : _slice_provider(slice_dir, width) {

--- a/plugins/trace_api_plugin/test/include/eosio/trace_api/test_common.hpp
+++ b/plugins/trace_api_plugin/test/include/eosio/trace_api/test_common.hpp
@@ -10,10 +10,10 @@
 #include <eosio/chain/block_state.hpp>
 #include <eosio/chain/name.hpp>
 
-#include <eosio/trace_api_plugin/data_log.hpp>
-#include <eosio/trace_api_plugin/metadata_log.hpp>
+#include <eosio/trace_api/data_log.hpp>
+#include <eosio/trace_api/metadata_log.hpp>
 
-namespace eosio::trace_api_plugin {
+namespace eosio::trace_api {
    /**
     * Utilities that make writing tests easier
     */

--- a/plugins/trace_api_plugin/test/test_configuration_utils.cpp
+++ b/plugins/trace_api_plugin/test/test_configuration_utils.cpp
@@ -3,11 +3,11 @@
 #include <list>
 #include <boost/filesystem.hpp>
 
-#include <eosio/trace_api_plugin/configuration_utils.hpp>
-#include <eosio/trace_api_plugin/test_common.hpp>
+#include <eosio/trace_api/configuration_utils.hpp>
+#include <eosio/trace_api/test_common.hpp>
 
 using namespace eosio;
-using namespace eosio::trace_api_plugin::configuration_utils;
+using namespace eosio::trace_api::configuration_utils;
 
 namespace bfs = boost::filesystem;
 

--- a/plugins/trace_api_plugin/test/test_data_handlers.cpp
+++ b/plugins/trace_api_plugin/test/test_data_handlers.cpp
@@ -1,14 +1,14 @@
 #define BOOST_TEST_MODULE trace_data_handlers
 #include <boost/test/included/unit_test.hpp>
 
-#include <eosio/trace_api_plugin/base64_data_handler.hpp>
-#include <eosio/trace_api_plugin/abi_data_handler.hpp>
+#include <eosio/trace_api/base64_data_handler.hpp>
+#include <eosio/trace_api/abi_data_handler.hpp>
 
-#include <eosio/trace_api_plugin/test_common.hpp>
+#include <eosio/trace_api/test_common.hpp>
 
 using namespace eosio;
-using namespace eosio::trace_api_plugin;
-using namespace eosio::trace_api_plugin::test_common;
+using namespace eosio::trace_api;
+using namespace eosio::trace_api::test_common;
 
 BOOST_AUTO_TEST_SUITE(abi_data_handler_tests)
    BOOST_AUTO_TEST_CASE(empty_data)

--- a/plugins/trace_api_plugin/test/test_extraction.cpp
+++ b/plugins/trace_api_plugin/test/test_extraction.cpp
@@ -6,12 +6,12 @@
 #include <eosio/chain/trace.hpp>
 #include <eosio/chain/transaction.hpp>
 
-#include <eosio/trace_api_plugin/test_common.hpp>
-#include <eosio/trace_api_plugin/chain_extraction.hpp>
+#include <eosio/trace_api/test_common.hpp>
+#include <eosio/trace_api/chain_extraction.hpp>
 
 using namespace eosio;
-using namespace eosio::trace_api_plugin;
-using namespace eosio::trace_api_plugin::test_common;
+using namespace eosio::trace_api;
+using namespace eosio::trace_api::test_common;
 using eosio::chain::name;
 using eosio::chain::digest_type;
 

--- a/plugins/trace_api_plugin/test/test_logging.cpp
+++ b/plugins/trace_api_plugin/test/test_logging.cpp
@@ -1,12 +1,12 @@
 #define BOOST_TEST_MODULE trace_data_logging
 #include <boost/test/included/unit_test.hpp>
-#include <eosio/trace_api_plugin/store_provider.hpp>
+#include <eosio/trace_api/store_provider.hpp>
 
-#include <eosio/trace_api_plugin/test_common.hpp>
+#include <eosio/trace_api/test_common.hpp>
 
 using namespace eosio;
-using namespace eosio::trace_api_plugin;
-using namespace eosio::trace_api_plugin::test_common;
+using namespace eosio::trace_api;
+using namespace eosio::trace_api::test_common;
 
 namespace {
 

--- a/plugins/trace_api_plugin/test/test_responses.cpp
+++ b/plugins/trace_api_plugin/test/test_responses.cpp
@@ -3,13 +3,13 @@
 
 #include <fc/variant_object.hpp>
 
-#include <eosio/trace_api_plugin/request_handler.hpp>
-#include <eosio/trace_api_plugin/base64_data_handler.hpp>
-#include <eosio/trace_api_plugin/test_common.hpp>
+#include <eosio/trace_api/request_handler.hpp>
+#include <eosio/trace_api/base64_data_handler.hpp>
+#include <eosio/trace_api/test_common.hpp>
 
 using namespace eosio;
-using namespace eosio::trace_api_plugin;
-using namespace eosio::trace_api_plugin::test_common;
+using namespace eosio::trace_api;
+using namespace eosio::trace_api::test_common;
 
 struct response_test_fixture {
    using get_block_t = std::optional<std::tuple<block_trace_v0, bool>>;

--- a/plugins/trace_api_plugin/test/test_trace_file.cpp
+++ b/plugins/trace_api_plugin/test/test_trace_file.cpp
@@ -1,13 +1,13 @@
 #define BOOST_TEST_MODULE trace_trace_file
 #include <boost/test/included/unit_test.hpp>
 #include <fc/io/cfile.hpp>
-#include <eosio/trace_api_plugin/test_common.hpp>
-#include <eosio/trace_api_plugin/store_provider.hpp>
+#include <eosio/trace_api/test_common.hpp>
+#include <eosio/trace_api/store_provider.hpp>
 #include <boost/filesystem.hpp>
 
 using namespace eosio;
-using namespace eosio::trace_api_plugin;
-using namespace eosio::trace_api_plugin::test_common;
+using namespace eosio::trace_api;
+using namespace eosio::trace_api::test_common;
 namespace bfs = boost::filesystem;
 
 namespace {

--- a/plugins/trace_api_plugin/trace_api_plugin.cpp
+++ b/plugins/trace_api_plugin/trace_api_plugin.cpp
@@ -1,12 +1,12 @@
-#include <eosio/trace_api_plugin/trace_api_plugin.hpp>
+#include <eosio/trace_api/trace_api_plugin.hpp>
 
-#include <eosio/trace_api_plugin/abi_data_handler.hpp>
-#include <eosio/trace_api_plugin/request_handler.hpp>
+#include <eosio/trace_api/abi_data_handler.hpp>
+#include <eosio/trace_api/request_handler.hpp>
 
-#include <eosio/trace_api_plugin/configuration_utils.hpp>
+#include <eosio/trace_api/configuration_utils.hpp>
 
-using namespace eosio::trace_api_plugin;
-using namespace eosio::trace_api_plugin::configuration_utils;
+using namespace eosio::trace_api;
+using namespace eosio::trace_api::configuration_utils;
 
 namespace {
    const std::string logger_name("trace_api");
@@ -167,19 +167,19 @@ struct trace_api_plugin_impl {
    fc::microseconds minimum_irreversible_trace_history = fc::microseconds::maximum();
 };
 
-_trace_api_plugin::_trace_api_plugin()
+trace_api_plugin::trace_api_plugin()
 {}
 
-_trace_api_plugin::~_trace_api_plugin()
+trace_api_plugin::~trace_api_plugin()
 {}
 
-void _trace_api_plugin::set_program_options(appbase::options_description& cli, appbase::options_description& cfg) {
+void trace_api_plugin::set_program_options(appbase::options_description& cli, appbase::options_description& cfg) {
    trace_api_common_impl::set_program_options(cli, cfg);
    trace_api_plugin_impl::set_program_options(cli, cfg);
    trace_api_rpc_plugin_impl::set_program_options(cli, cfg);
 }
 
-void _trace_api_plugin::plugin_initialize(const appbase::variables_map& options) {
+void trace_api_plugin::plugin_initialize(const appbase::variables_map& options) {
    auto common = std::make_shared<trace_api_common_impl>();
    common->plugin_initialize(options);
 
@@ -190,17 +190,17 @@ void _trace_api_plugin::plugin_initialize(const appbase::variables_map& options)
    rpc->plugin_initialize(options);
 }
 
-void _trace_api_plugin::plugin_startup() {
+void trace_api_plugin::plugin_startup() {
    my->plugin_startup();
    rpc->plugin_startup();
 }
 
-void _trace_api_plugin::plugin_shutdown() {
+void trace_api_plugin::plugin_shutdown() {
    my->plugin_shutdown();
    rpc->plugin_shutdown();
 }
 
-void _trace_api_plugin::handle_sighup() {
+void trace_api_plugin::handle_sighup() {
    fc::logger::update( logger_name, _log );
 }
 


### PR DESCRIPTION
In this PR
- [ ] renamed the `trace_api_plugin` namespace to `trace_api`
- [ ]  renamed the`_trace_api_plugin` to `trace_api_plugin`
- [ ] moved `.hpp` files to a path that matches the new namespace name
