### PR TITLE
Tests: forked block signal, forked block trxs

### DIFF
--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -175,6 +175,8 @@ namespace eosio { namespace testing {
          virtual signed_block_ptr produce_block( fc::microseconds skip_time = fc::milliseconds(config::block_interval_ms) ) = 0;
          virtual signed_block_ptr produce_empty_block( fc::microseconds skip_time = fc::milliseconds(config::block_interval_ms) ) = 0;
          virtual signed_block_ptr finish_block() = 0;
+         // produce one block and return traces for all applied transactions, both failed and executed
+         signed_block_ptr     produce_block( std::vector<transaction_trace_ptr>& traces );
          void                 produce_blocks( uint32_t n = 1, bool empty = false );
          void                 produce_blocks_until_end_of_round();
          void                 produce_blocks_for_n_rounds(const uint32_t num_of_rounds = 1);
@@ -413,7 +415,10 @@ namespace eosio { namespace testing {
          }
 
       protected:
-         signed_block_ptr _produce_block( fc::microseconds skip_time, bool skip_pending_trxs = false );
+         signed_block_ptr _produce_block( fc::microseconds skip_time, bool skip_pending_trxs );
+         signed_block_ptr _produce_block( fc::microseconds skip_time, bool skip_pending_trxs,
+                                          bool no_throw, std::vector<transaction_trace_ptr>& traces );
+
          void             _start_block(fc::time_point block_time);
          signed_block_ptr _finish_block();
 
@@ -477,6 +482,8 @@ namespace eosio { namespace testing {
             init(cfg);
          }
       }
+
+      using base_tester::produce_block;
 
       signed_block_ptr produce_block( fc::microseconds skip_time = fc::milliseconds(config::block_interval_ms) )override {
          return _produce_block(skip_time, false);


### PR DESCRIPTION
## Change Description

- Test: Verify forked blocks signal `accepted_block`
- Test: Verify trx tapos to forked block are not re-applied

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
