### PR TITLE
reduce stored block numbers to 32bit values to match protocol

### DIFF
--- a/plugins/trace_api_plugin/include/eosio/trace_api/metadata_log.hpp
+++ b/plugins/trace_api_plugin/include/eosio/trace_api/metadata_log.hpp
@@ -7,12 +7,12 @@
 namespace eosio { namespace trace_api {
    struct block_entry_v0 {
       chain::block_id_type   id;
-      uint64_t               number;
+      uint32_t               number;
       uint64_t               offset;
    };
 
    struct lib_entry_v0 {
-      uint64_t               lib;
+      uint32_t               lib;
    };
 
    using metadata_log_entry = fc::static_variant<

--- a/plugins/trace_api_plugin/include/eosio/trace_api/trace.hpp
+++ b/plugins/trace_api_plugin/include/eosio/trace_api/trace.hpp
@@ -29,7 +29,7 @@ namespace eosio { namespace trace_api {
 
    struct block_trace_v0 {
       chain::block_id_type               id = {};
-      uint64_t                           number = {};
+      uint32_t                           number = {};
       chain::block_id_type               previous_id = {};
       chain::block_timestamp_type        timestamp = chain::block_timestamp_type(0);
       chain::name                        producer = {};

--- a/plugins/trace_api_plugin/test/test_extraction.cpp
+++ b/plugins/trace_api_plugin/test/test_extraction.cpp
@@ -152,7 +152,7 @@ BOOST_AUTO_TEST_SUITE(block_extraction)
             { chain::packed_transaction(ptrx1) } );
       signal_accepted_block( bsp1 );
       
-      const uint64_t expected_lib = 0;
+      const uint32_t expected_lib = 0;
       const block_trace_v0 expected_trace { bsp1->id, 1, bsp1->prev(), chain::block_timestamp_type(1), "bp.one"_n,
          {
             {
@@ -216,7 +216,7 @@ BOOST_AUTO_TEST_SUITE(block_extraction)
             { chain::packed_transaction(ptrx1), chain::packed_transaction(ptrx2), chain::packed_transaction(ptrx3) } );
       signal_accepted_block( bsp1 );
 
-      const uint64_t expected_lib = 0;
+      const uint32_t expected_lib = 0;
       const block_trace_v0 expected_trace { bsp1->id, 1, bsp1->prev(), chain::block_timestamp_type(1), "bp.one"_n,
          {
             {
@@ -283,7 +283,7 @@ BOOST_AUTO_TEST_SUITE(block_extraction)
             { chain::packed_transaction(transfer_trx) } );
       signal_accepted_block( bsp1 );
 
-      const uint64_t expected_lib = 0;
+      const uint32_t expected_lib = 0;
       const block_trace_v0 expected_trace { bsp1->id, 1, bsp1->prev(), chain::block_timestamp_type(1), "bp.one"_n,
          {
             {

--- a/plugins/trace_api_plugin/test/test_trace_file.cpp
+++ b/plugins/trace_api_plugin/test/test_trace_file.cpp
@@ -385,7 +385,7 @@ BOOST_AUTO_TEST_SUITE(slice_tests)
       sp.append(bt);
       sp.append_lib(54);
       sp.append(bt2);
-      const uint64_t bt_bn = bt.number;
+      const uint32_t bt_bn = bt.number;
       bool found_block = false;
       bool lib_seen = false;
       const uint64_t first_offset = sp.scan_metadata_log_from(9, 0, [&](const metadata_log_entry& e) -> bool {


### PR DESCRIPTION
in this PR:
- [ ] `lib` and `number` in the associated entries are now `uint32_t` which matches the underlying protocol restrictions