### PR TITLE
Trace api Automatic Slice File cleanup

### DIFF
--- a/plugins/trace_api_plugin/include/eosio/trace_api/store_provider.hpp
+++ b/plugins/trace_api_plugin/include/eosio/trace_api/store_provider.hpp
@@ -126,10 +126,11 @@ namespace eosio::trace_api {
        * @param state : indicate if the file is going to be written to (appended) or read
        * @param index_file : the cfile that will be set to the appropriate slice filename (always)
        *                     and opened to that file (if it was found)
+       * @param open_file : indicate if the file should be opened (if found) or not
        * @return the true if file was found (i.e. already existed), if not found index_file
        *         is set to the appropriate file, but not open
        */
-      bool find_index_slice(uint32_t slice_number, open_state state, fc::cfile& index_file) const;
+      bool find_index_slice(uint32_t slice_number, open_state state, fc::cfile& index_file, bool open_file = true) const;
 
       /**
        * Find or create the trace file associated with the indicated slice_number
@@ -149,10 +150,11 @@ namespace eosio::trace_api {
        * @param state : indicate if the file is going to be written to (appended) or read
        * @param trace_file : the cfile that will be set to the appropriate slice filename (always)
        *                     and opened to that file (if it was found)
+       * @param open_file : indicate if the file should be opened (if found) or not
        * @return the true if file was found (i.e. already existed), if not found index_file
        *         is set to the appropriate file, but not open
        */
-      bool find_trace_slice(uint32_t slice_number, open_state state, fc::cfile& trace_file) const;
+      bool find_trace_slice(uint32_t slice_number, open_state state, fc::cfile& trace_file, bool open_file = true) const;
 
       /**
        * Find or create a trace and index file pair
@@ -174,7 +176,7 @@ namespace eosio::trace_api {
    private:
       // returns true if slice is found, slice_file will always be set to the appropriate path for
       // the slice_prefix and slice_number, but will only be opened if found
-      bool find_slice(const char* slice_prefix, uint32_t slice_number, fc::cfile& slice_file) const;
+      bool find_slice(const char* slice_prefix, uint32_t slice_number, fc::cfile& slice_file, bool open_file) const;
 
       // take an index file that is initialized to a file and open it and write its header
       void create_new_index_slice_file(fc::cfile& index_file) const;

--- a/plugins/trace_api_plugin/store_provider.cpp
+++ b/plugins/trace_api_plugin/store_provider.cpp
@@ -136,6 +136,9 @@ namespace eosio::trace_api {
       if( append ) {
          trace_file.seek_end(0);
       }
+      else {
+         trace_file.seek(0); // ensure we are at the start of the file
+      }
       return true;
    }
 

--- a/plugins/trace_api_plugin/store_provider.cpp
+++ b/plugins/trace_api_plugin/store_provider.cpp
@@ -122,9 +122,6 @@ namespace eosio::trace_api {
       if( !found ) {
          trace_file.open(fc::cfile::create_or_update_rw_mode);
       }
-      else if( append ) {
-         trace_file.seek_end(0);
-      }
 
       return found;
    }

--- a/plugins/trace_api_plugin/trace_api_plugin.cpp
+++ b/plugins/trace_api_plugin/trace_api_plugin.cpp
@@ -252,25 +252,9 @@ struct trace_api_plugin_impl {
 
    static void set_program_options(appbase::options_description& cli, appbase::options_description& cfg) {
       auto cfg_options = cfg.add_options();
-      cfg_options("trace-minimum-irreversible-history-us", bpo::value<uint64_t>()->default_value(-1),
-                  "the minimum amount of history, as defined by time, this node will keep after it becomes irreversible\n"
-                  "this value can be specified as a number of microseconds or\n"
-                  "a value of \"-1\" will disable automatic maintenance of the trace slice files\n"
-                  );
    }
 
    void plugin_initialize(const appbase::variables_map& options) {
-      if( options.count("trace-minimum-irreversible-history-us") ) {
-         auto value = options.at("trace-minimum-irreversible-history-us").as<uint64_t>();
-         if ( value == -1 ) {
-            minimum_irreversible_trace_history = fc::microseconds::maximum();
-         } else if (value >= 0) {
-            minimum_irreversible_trace_history = fc::microseconds(value);
-         } else {
-            EOS_THROW(chain::plugin_config_exception, "trace-minimum-irreversible-history-us must be either a positive number or -1");
-         }
-      }
-
       auto log_exceptions_and_shutdown = [](const exception_with_context& e) {
          log_exception(e, fc::log_level::error);
          app().quit();
@@ -310,7 +294,6 @@ struct trace_api_plugin_impl {
    }
 
    std::shared_ptr<trace_api_common_impl> common;
-   fc::microseconds minimum_irreversible_trace_history = fc::microseconds::maximum();
 
    using chain_extraction_t = chain_extraction_impl_type<shared_store_provider<store_provider>>;
    std::shared_ptr<chain_extraction_t> extraction;

--- a/plugins/trace_api_plugin/trace_api_plugin.cpp
+++ b/plugins/trace_api_plugin/trace_api_plugin.cpp
@@ -129,7 +129,7 @@ struct trace_api_common_impl {
    boost::filesystem::path trace_dir;
    uint32_t slice_stride = 0;
 
-   optional<uint32_t> minimum_irreversible_history_blocks;
+   std::optional<uint32_t> minimum_irreversible_history_blocks;
    static constexpr uint32_t manual_slice_file_value = -1;
 
    std::shared_ptr<store_provider> store;

--- a/plugins/trace_api_plugin/trace_api_plugin.cpp
+++ b/plugins/trace_api_plugin/trace_api_plugin.cpp
@@ -115,9 +115,9 @@ struct trace_api_common_impl {
       slice_stride = options.at("trace-slice-stride").as<uint32_t>();
 
       const char* trace_minimum_irreversible_history_blocks = "trace-minimum-irreversible-history-blocks";
-      const int32_t blocks = options.at(trace_minimum_irreversible_history_blocks).as<int32_t>();
+      const int32_t blocks = options.at("trace-minimum-irreversible-history-blocks").as<int32_t>();
       EOS_ASSERT(blocks >= -1, chain::plugin_config_exception,
-                 "\"${blocks}\" must be greater to or equal to -1.",("blocks",trace_minimum_irreversible_history_blocks));
+                 "\"trace-minimum-irreversible-history-blocks\" must be greater to or equal to -1.");
       if (blocks > manual_slice_file_value) {
          minimum_irreversible_history_blocks = blocks;
       }

--- a/plugins/trace_api_plugin/trace_api_plugin.cpp
+++ b/plugins/trace_api_plugin/trace_api_plugin.cpp
@@ -185,7 +185,7 @@ struct trace_api_rpc_plugin_impl : public std::enable_shared_from_this<trace_api
                     "Trace API is not configured with ABIs and trace-no-abis is not set");
       }
 
-      request_handler = std::make_shared<request_handler_t>(
+      req_handler = std::make_shared<request_handler_t>(
          shared_store_provider<store_provider>(common->store),
          abi_data_handler::shared_provider(data_handler)
       );
@@ -224,7 +224,7 @@ struct trace_api_rpc_plugin_impl : public std::enable_shared_from_this<trace_api
 
          try {
 
-            auto resp = that->request_handler->get_block_trace(*block_number);
+            auto resp = that->req_handler->get_block_trace(*block_number);
             if (resp.is_null()) {
                error_results results{404, "Block trace missing"};
                cb( 404, fc::variant( results ));
@@ -243,7 +243,7 @@ struct trace_api_rpc_plugin_impl : public std::enable_shared_from_this<trace_api
    std::shared_ptr<trace_api_common_impl> common;
 
    using request_handler_t = request_handler<shared_store_provider<store_provider>, abi_data_handler::shared_provider>;
-   std::shared_ptr<request_handler_t> request_handler;
+   std::shared_ptr<request_handler_t> req_handler;
 };
 
 struct trace_api_plugin_impl {

--- a/plugins/trace_api_plugin/trace_api_plugin.cpp
+++ b/plugins/trace_api_plugin/trace_api_plugin.cpp
@@ -114,7 +114,6 @@ struct trace_api_common_impl {
 
       slice_stride = options.at("trace-slice-stride").as<uint32_t>();
 
-      const char* trace_minimum_irreversible_history_blocks = "trace-minimum-irreversible-history-blocks";
       const int32_t blocks = options.at("trace-minimum-irreversible-history-blocks").as<int32_t>();
       EOS_ASSERT(blocks >= -1, chain::plugin_config_exception,
                  "\"trace-minimum-irreversible-history-blocks\" must be greater to or equal to -1.");


### PR DESCRIPTION

## Change Description
- Added feature to automatically cleanup slices when data is no longer required.
- Added config parameter to indicate how many files at a minimum to keep after lib.
- Minor fixes.

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
