### PR TITLE
Expire blacklisted scheduled transactions by LIB time - 2.0

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -2834,8 +2834,8 @@ block_id_type controller::last_irreversible_block_id() const {
    return get_block_id_for_num( lib_num );
 }
 
-block_timestamp_type controller::last_irreversible_block_timestamp() const {
-   return my->fork_db.root()->header.timestamp;
+time_point controller::last_irreversible_block_time() const {
+   return my->fork_db.root()->header.timestamp.to_time_point();
 }
 
 

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -2834,6 +2834,11 @@ block_id_type controller::last_irreversible_block_id() const {
    return get_block_id_for_num( lib_num );
 }
 
+block_timestamp_type controller::last_irreversible_block_timestamp() const {
+   return my->fork_db.root()->header.timestamp;
+}
+
+
 const dynamic_global_property_object& controller::get_dynamic_global_properties()const {
   return my->db.get<dynamic_global_property_object>();
 }

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -226,7 +226,7 @@ namespace eosio { namespace chain {
 
          uint32_t last_irreversible_block_num() const;
          block_id_type last_irreversible_block_id() const;
-         block_timestamp_type last_irreversible_block_timestamp() const;
+         time_point last_irreversible_block_time() const;
 
          signed_block_ptr fetch_block_by_number( uint32_t block_num )const;
          signed_block_ptr fetch_block_by_id( block_id_type id )const;

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -226,6 +226,7 @@ namespace eosio { namespace chain {
 
          uint32_t last_irreversible_block_num() const;
          block_id_type last_irreversible_block_id() const;
+         block_timestamp_type last_irreversible_block_timestamp() const;
 
          signed_block_ptr fetch_block_by_number( uint32_t block_num )const;
          signed_block_ptr fetch_block_by_id( block_id_type id )const;

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1678,7 +1678,7 @@ bool producer_plugin_impl::remove_expired_blacklisted_trxs( const fc::time_point
    auto& blacklist_by_expiry = _blacklisted_transactions.get<by_expiry>();
    if(!blacklist_by_expiry.empty()) {
       const chain::controller& chain = chain_plug->chain();
-      const auto lib_time = chain.last_irreversible_block_timestamp().to_time_point();
+      const auto lib_time = chain.last_irreversible_block_time();
 
       int num_expired = 0;
       int orig_count = _blacklisted_transactions.size();

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1676,12 +1676,14 @@ bool producer_plugin_impl::remove_expired_blacklisted_trxs( const fc::time_point
 {
    bool exhausted = false;
    auto& blacklist_by_expiry = _blacklisted_transactions.get<by_expiry>();
-   auto now = fc::time_point::now();
    if(!blacklist_by_expiry.empty()) {
+      const chain::controller& chain = chain_plug->chain();
+      const auto lib_time = chain.last_irreversible_block_timestamp().to_time_point();
+
       int num_expired = 0;
       int orig_count = _blacklisted_transactions.size();
 
-      while (!blacklist_by_expiry.empty() && blacklist_by_expiry.begin()->expiry <= now) {
+      while (!blacklist_by_expiry.empty() && blacklist_by_expiry.begin()->expiry <= lib_time) {
          if (deadline <= fc::time_point::now()) {
             exhausted = true;
             break;
@@ -1779,12 +1781,13 @@ void producer_plugin_impl::process_scheduled_and_incoming_trxs( const fc::time_p
          continue; // do not allow schedule and execute in same block
       }
 
-      const transaction_id_type trx_id = sch_itr->trx_id; // make copy since reference could be invalidated
-      if (blacklist_by_id.find(trx_id) != blacklist_by_id.end()) {
+      if (blacklist_by_id.find(sch_itr->trx_id) != blacklist_by_id.end()) {
          ++sch_itr;
          continue;
       }
 
+      const transaction_id_type trx_id = sch_itr->trx_id; // make copy since reference could be invalidated
+      const auto sch_expiration = sch_itr->expiration;
       auto sch_itr_next = sch_itr; // save off next since sch_itr may be invalidated by loop
       ++sch_itr_next;
       const auto next_delay_until = sch_itr_next != sch_idx.end() ? sch_itr_next->delay_until : sch_itr->delay_until;
@@ -1829,9 +1832,8 @@ void producer_plugin_impl::process_scheduled_and_incoming_trxs( const fc::time_p
                   break;
                }
             } else {
-               auto expiration = fc::time_point::now() + fc::seconds(chain.get_global_properties().configuration.deferred_trx_expiration_window);
                // this failed our configured maximum transaction time, we don't want to replay it add it to a blacklist
-               _blacklisted_transactions.insert(transaction_id_with_expiry{trx_id, expiration});
+               _blacklisted_transactions.insert(transaction_id_with_expiry{trx_id, sch_expiration});
                num_failed++;
             }
          } else {


### PR DESCRIPTION
## Change Description

- Use LIB time for removal of blacklisted scheduled transactions instead of `now`.

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
