### PR TITLE
trace_api_plugin yield timeout - develop

### DIFF
--- a/plugins/http_plugin/http_plugin.cpp
+++ b/plugins/http_plugin/http_plugin.cpp
@@ -726,11 +726,13 @@ namespace eosio {
          } catch (fc::exception& e) {
             error_results results{500, "Internal Service Error", error_results::error_info(e, verbose_http_errors)};
             cb( 500, fc::variant( results ));
-            if (e.code() != chain::greylist_net_usage_exceeded::code_value && e.code() != chain::greylist_cpu_usage_exceeded::code_value) {
+            if (e.code() != chain::greylist_net_usage_exceeded::code_value &&
+                e.code() != chain::greylist_cpu_usage_exceeded::code_value &&
+                e.code() != fc::timeout_exception::code_value ) {
                fc_elog( logger, "FC Exception encountered while processing ${api}.${call}",
                         ("api", api_name)( "call", call_name ) );
-               fc_dlog( logger, "Exception Details: ${e}", ("e", e.to_detail_string()) );
             }
+            fc_dlog( logger, "Exception Details: ${e}", ("e", e.to_detail_string()) );
          } catch (std::exception& e) {
             error_results results{500, "Internal Service Error", error_results::error_info(fc::exception( FC_LOG_MESSAGE( error, e.what())), verbose_http_errors)};
             cb( 500, fc::variant( results ));
@@ -770,6 +772,10 @@ namespace eosio {
       }
 
       return result;
+   }
+
+   fc::microseconds http_plugin::get_max_response_time()const {
+      return my->max_response_time;
    }
 
    std::istream& operator>>(std::istream& in, https_ecdh_curve_t& curve) {

--- a/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
@@ -97,7 +97,10 @@ namespace eosio {
 
         get_supported_apis_result get_supported_apis()const;
 
-      private:
+        /// @return the configured http-max-response-time-ms
+        fc::microseconds get_max_response_time()const;
+
+   private:
         std::shared_ptr<class http_plugin_impl> my;
    };
 

--- a/plugins/trace_api_plugin/include/eosio/trace_api/abi_data_handler.hpp
+++ b/plugins/trace_api_plugin/include/eosio/trace_api/abi_data_handler.hpp
@@ -18,7 +18,7 @@ namespace eosio {
     */
    class abi_data_handler {
    public:
-      explicit abi_data_handler( exception_handler except_handler = {} )
+      explicit abi_data_handler( exception_handler except_handler )
       :except_handler( std::move( except_handler ) )
       {
       }
@@ -37,7 +37,7 @@ namespace eosio {
        * @param yield - a yield function to allow cooperation during long running tasks
        * @return variant representing the `data` field of the action interpreted by known ABIs OR an empty variant
        */
-      fc::variant process_data( const action_trace_v0& action, const yield_function& yield = {});
+      fc::variant process_data( const action_trace_v0& action, const yield_function& yield );
 
       /**
        * Utility class that allows mulitple request_handlers to share the same abi_data_handler
@@ -48,7 +48,7 @@ namespace eosio {
          :handler(handler)
          {}
 
-         fc::variant process_data( const action_trace_v0& action, const yield_function& yield = {}) {
+         fc::variant process_data( const action_trace_v0& action, const yield_function& yield ) {
             return handler->process_data(action, yield);
          }
 

--- a/plugins/trace_api_plugin/test/test_data_handlers.cpp
+++ b/plugins/trace_api_plugin/test/test_data_handlers.cpp
@@ -15,10 +15,10 @@ BOOST_AUTO_TEST_SUITE(abi_data_handler_tests)
       auto action = action_trace_v0 {
          0, "alice"_n, "alice"_n, "foo"_n, {}, {}
       };
-      abi_data_handler handler;
+      abi_data_handler handler(exception_handler{});
 
       auto expected = fc::variant();
-      auto actual = handler.process_data(action);
+      auto actual = handler.process_data(action, [](){});
 
       BOOST_TEST(to_kv(expected) == to_kv(actual), boost::test_tools::per_element());
    }
@@ -28,10 +28,10 @@ BOOST_AUTO_TEST_SUITE(abi_data_handler_tests)
       auto action = action_trace_v0 {
          0, "alice"_n, "alice"_n, "foo"_n, {}, {0x00, 0x01, 0x02, 0x03}
       };
-      abi_data_handler handler;
+      abi_data_handler handler(exception_handler{});
 
       auto expected = fc::variant();
-      auto actual = handler.process_data(action);
+      auto actual = handler.process_data(action, [](){});
 
       BOOST_TEST(to_kv(expected) == to_kv(actual), boost::test_tools::per_element());
    }
@@ -52,8 +52,8 @@ BOOST_AUTO_TEST_SUITE(abi_data_handler_tests)
          {}, {}, {}
       );
       abi.version = "eosio::abi/1.";
-      
-      abi_data_handler handler;
+
+      abi_data_handler handler(exception_handler{});
       handler.add_abi("alice"_n, abi);
 
       fc::variant expected = fc::mutable_variant_object()
@@ -62,7 +62,7 @@ BOOST_AUTO_TEST_SUITE(abi_data_handler_tests)
          ("c", 2)
          ("d", 3);
 
-      auto actual = handler.process_data(action);
+      auto actual = handler.process_data(action, [](){});
 
       BOOST_TEST(to_kv(expected) == to_kv(actual), boost::test_tools::per_element());
    }
@@ -84,12 +84,12 @@ BOOST_AUTO_TEST_SUITE(abi_data_handler_tests)
       );
       abi.version = "eosio::abi/1.";
 
-      abi_data_handler handler;
+      abi_data_handler handler(exception_handler{});
       handler.add_abi("alice"_n, abi);
 
       auto expected = fc::variant();
 
-      auto actual = handler.process_data(action);
+      auto actual = handler.process_data(action, [](){});
 
       BOOST_TEST(to_kv(expected) == to_kv(actual), boost::test_tools::per_element());
    }
@@ -117,7 +117,7 @@ BOOST_AUTO_TEST_SUITE(abi_data_handler_tests)
 
       auto expected = fc::variant();
 
-      auto actual = handler.process_data(action);
+      auto actual = handler.process_data(action, [](){});
 
       BOOST_TEST(to_kv(expected) == to_kv(actual), boost::test_tools::per_element());
       BOOST_TEST(log_called);


### PR DESCRIPTION
## Change Description

- `trace_api_plugin` now honors `http-max-response-time-ms` as a specification of retrieval and ABI processing time. `http-max-response-time-ms` is also the time allowed for `http_plugin` conversion to JSON. Maximum time allowed for `trace_api_plugin` `get_block` is now 2x `http-max-response-time-ms`
- Modified `http_plugin` logging to not error log on `timeout_exception`.
- Future work: add yield capability to `http_plugin` `url_handler` so `http-max-response-ms` can be used as a specification of complete time allowed for api calls e.g. `get_table_rows` allowing the removal of hard-coded 10ms limit.

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
