### PR TITLE
Fix double titles in plugins

### DIFF
--- a/docs/01_nodeos/03_plugins/chain_api_plugin/index.md
+++ b/docs/01_nodeos/03_plugins/chain_api_plugin/index.md
@@ -1,5 +1,3 @@
-# chain_api_plugin
-
 ## Description
 
 The `chain_api_plugin` exposes functionality from the [`chain_plugin`](../chain_plugin/index.md) to the RPC API interface managed by the [`http_plugin`](../http_plugin/index.md).

--- a/docs/01_nodeos/03_plugins/chain_plugin/index.md
+++ b/docs/01_nodeos/03_plugins/chain_plugin/index.md
@@ -1,5 +1,3 @@
-# chain_plugin
-
 ## Description
 
 The `chain_plugin` is a core plugin required to process and aggregate chain data on an EOSIO node.

--- a/docs/01_nodeos/03_plugins/db_size_api_plugin/index.md
+++ b/docs/01_nodeos/03_plugins/db_size_api_plugin/index.md
@@ -1,5 +1,3 @@
-# db_size_api_plugin
-
 ## Description
 
 The `db_size_api_plugin` retrieves analytics about the blockchain.

--- a/docs/01_nodeos/03_plugins/faucet_testnet_plugin/index.md
+++ b/docs/01_nodeos/03_plugins/faucet_testnet_plugin/index.md
@@ -1,5 +1,3 @@
-# faucet_testnet_plugin
-
 ## Description
 
 The `faucet_testnet_plugin` provides an interface that assists in the automation of distributing tokens on an EOSIO testnet.

--- a/docs/01_nodeos/03_plugins/history_api_plugin/index.md
+++ b/docs/01_nodeos/03_plugins/history_api_plugin/index.md
@@ -1,5 +1,3 @@
-# history_api_plugin
-
 [[warning | Deprecation Notice]]
 | The `history_plugin` that the `history_api_plugin` depends upon is deprecated and will no longer be maintained. Please use the [`state_history_plugin`](../state_history_plugin/index.md) instead.
 

--- a/docs/01_nodeos/03_plugins/history_plugin/index.md
+++ b/docs/01_nodeos/03_plugins/history_plugin/index.md
@@ -1,5 +1,3 @@
-# history_plugin
-
 [[warning | Deprecation Notice]]
 | The `history_plugin` is deprecated and will no longer be maintained. Please use the [`state_history_plugin`](../state_history_plugin/index.md) instead.
 

--- a/docs/01_nodeos/03_plugins/http_client_plugin/index.md
+++ b/docs/01_nodeos/03_plugins/http_client_plugin/index.md
@@ -1,5 +1,3 @@
-# http_client_plugin
-
 ## Description
 
 The `http_client_plugin`  is an internal utility plugin, providing the `producer_plugin` the ability to use securely an external `keosd` instance as its block signer. It can only be used when the `producer_plugin` is configured to produce blocks.

--- a/docs/01_nodeos/03_plugins/http_plugin/index.md
+++ b/docs/01_nodeos/03_plugins/http_plugin/index.md
@@ -1,5 +1,3 @@
-# http_plugin
-
 ## Description
 
 The `http_plugin` is a core plugin supported by both `nodeos` and `keosd`. The plugin is required to enable any RPC API functionality provided by a `nodeos` or `keosd` instance.

--- a/docs/01_nodeos/03_plugins/index.md
+++ b/docs/01_nodeos/03_plugins/index.md
@@ -23,6 +23,7 @@ For information on specific plugins, just select from the list below:
 * [`state_history_plugin`](state_history_plugin/index.md)
 * [`test_control_api_plugin`](test_control_api_plugin/index.md)
 * [`test_control_plugin`](test_control_plugin/index.md)
+* [`trace_plugin`](trace_api_plugin/index.md)
 * [`txn_test_gen_plugin`](txn_test_gen_plugin/index.md)
 
 [[info | Nodeos is modular]]

--- a/docs/01_nodeos/03_plugins/index.md
+++ b/docs/01_nodeos/03_plugins/index.md
@@ -23,7 +23,7 @@ For information on specific plugins, just select from the list below:
 * [`state_history_plugin`](state_history_plugin/index.md)
 * [`test_control_api_plugin`](test_control_api_plugin/index.md)
 * [`test_control_plugin`](test_control_plugin/index.md)
-* [`trace_plugin`](trace_api_plugin/index.md)
+* [`trace_api_plugin`](trace_api_plugin/index.md)
 * [`txn_test_gen_plugin`](txn_test_gen_plugin/index.md)
 
 [[info | Nodeos is modular]]

--- a/docs/01_nodeos/03_plugins/login_plugin/index.md
+++ b/docs/01_nodeos/03_plugins/login_plugin/index.md
@@ -1,5 +1,3 @@
-# login_plugin
-
 ## Description
 
 The `login_plugin` supports the concept of applications authenticating with the EOSIO blockchain. The `login_plugin` API allows an application to verify whether an account is allowed to sign in order to satisfy a specified authority.

--- a/docs/01_nodeos/03_plugins/mongo_db_plugin/index.md
+++ b/docs/01_nodeos/03_plugins/mongo_db_plugin/index.md
@@ -1,5 +1,3 @@
-# mongo_db_plugin
-
 [[warning | Deprecation Notice]]
 | The `mongo_db_plugin` is deprecated and will no longer be maintained. Please refer to the [`state_history_plugin`](../state_history_plugin/index.md) and the [`history-tools`](../state_history_plugin/index.md#history-tools) for better options to archive blockchain data.
 

--- a/docs/01_nodeos/03_plugins/net_api_plugin/index.md
+++ b/docs/01_nodeos/03_plugins/net_api_plugin/index.md
@@ -1,5 +1,3 @@
-# net_api_plugin
-
 ## Description
 
 The `net_api_plugin` exposes functionality from the `net_plugin` to the RPC API interface managed by the `http_plugin`.

--- a/docs/01_nodeos/03_plugins/net_plugin/index.md
+++ b/docs/01_nodeos/03_plugins/net_plugin/index.md
@@ -1,5 +1,3 @@
-# net_plugin
-
 ## Description
 
 The `net_plugin` provides an authenticated p2p protocol to persistently synchronize nodes.

--- a/docs/01_nodeos/03_plugins/producer_api_plugin/index.md
+++ b/docs/01_nodeos/03_plugins/producer_api_plugin/index.md
@@ -1,5 +1,3 @@
-# producer_api_plugin
-
 ## Description
 
 The `producer_api_plugin` exposes a number of endpoints for the [`producer_plugin`](../producer_plugin/index.md) to the RPC API interface managed by the [`http_plugin`](../http_plugin/index.md).

--- a/docs/01_nodeos/03_plugins/producer_plugin/index.md
+++ b/docs/01_nodeos/03_plugins/producer_plugin/index.md
@@ -1,4 +1,3 @@
-# producer_plugin
 
 ## Description
 

--- a/docs/01_nodeos/03_plugins/state_history_plugin/index.md
+++ b/docs/01_nodeos/03_plugins/state_history_plugin/index.md
@@ -1,4 +1,3 @@
-# state_history_plugin
 
 ## Description
 

--- a/docs/01_nodeos/03_plugins/test_control_api_plugin/index.md
+++ b/docs/01_nodeos/03_plugins/test_control_api_plugin/index.md
@@ -1,4 +1,3 @@
-# test_control_api_plugin
 
 ## Description
 

--- a/docs/01_nodeos/03_plugins/test_control_plugin/index.md
+++ b/docs/01_nodeos/03_plugins/test_control_plugin/index.md
@@ -1,4 +1,3 @@
-# test_control_plugin
 
 ## Description
 

--- a/docs/01_nodeos/03_plugins/trace_api_plugin/index.md
+++ b/docs/01_nodeos/03_plugins/trace_api_plugin/index.md
@@ -1,4 +1,3 @@
-# trace_api_plugin
 
 ## Overview
 

--- a/docs/01_nodeos/03_plugins/txn_test_gen_plugin/index.md
+++ b/docs/01_nodeos/03_plugins/txn_test_gen_plugin/index.md
@@ -1,4 +1,3 @@
-# txn_test_gen_plugin
 
 ## Description
 

--- a/docs/03_keosd/15_plugins/wallet_api_plugin/index.md
+++ b/docs/03_keosd/15_plugins/wallet_api_plugin/index.md
@@ -1,5 +1,3 @@
-# wallet_api_plugin
-
 ## Description
 
 The `wallet_api_plugin` exposes functionality from the [`wallet_plugin`](../wallet_plugin/index.md) to the RPC API interface managed by the [`http_plugin`](../http_plugin/index.md).

--- a/docs/03_keosd/15_plugins/wallet_plugin/index.md
+++ b/docs/03_keosd/15_plugins/wallet_plugin/index.md
@@ -1,5 +1,3 @@
-# wallet_plugin
-
 ## Description
 
 The `wallet_plugin` adds access to wallet functionality from a node.


### PR DESCRIPTION
Remove the title on each plugin pages

Sibling PR #8843 into `develop`
Depends on PR #8844 

<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
