### PR TITLE
Use NET bill in transaction receipt during light validation mode

### DIFF
--- a/libraries/chain/include/eosio/chain/transaction_context.hpp
+++ b/libraries/chain/include/eosio/chain/transaction_context.hpp
@@ -65,6 +65,12 @@ namespace eosio { namespace chain {
             check_net_usage(); 
          }
 
+         inline void round_up_net_usage() {
+            if( explicit_net_usage ) return;
+            net_usage = ((net_usage + 7)/8)*8; // Round up to nearest multiple of word size (8 bytes)
+            check_net_usage();
+         }
+
          void check_net_usage()const;
 
          void checktime()const;

--- a/libraries/chain/include/eosio/chain/transaction_context.hpp
+++ b/libraries/chain/include/eosio/chain/transaction_context.hpp
@@ -31,7 +31,9 @@ namespace eosio { namespace chain {
 
    class transaction_context {
       private:
-         void init( uint64_t initial_net_usage);
+         void init( uint64_t initial_net_usage );
+
+         void init_for_input_trx_common( uint64_t initial_net_usage, bool skip_recording );
 
       public:
 
@@ -45,7 +47,10 @@ namespace eosio { namespace chain {
 
          void init_for_input_trx( uint64_t packed_trx_unprunable_size,
                                   uint64_t packed_trx_prunable_size,
-                                  bool skip_recording);
+                                  bool skip_recording );
+
+         void init_for_input_trx_with_explicit_net( uint32_t explicit_net_usage_words,
+                                                    bool skip_recording );
 
          void init_for_deferred_trx( fc::time_point published );
 
@@ -54,7 +59,11 @@ namespace eosio { namespace chain {
          void squash();
          void undo();
 
-         inline void add_net_usage( uint64_t u ) { net_usage += u; check_net_usage(); }
+         inline void add_net_usage( uint64_t u ) { 
+            if( explicit_net_usage ) return;
+            net_usage += u;
+            check_net_usage(); 
+         }
 
          void check_net_usage()const;
 
@@ -156,6 +165,7 @@ namespace eosio { namespace chain {
          bool                          net_limit_due_to_greylist = false;
          uint64_t                      eager_net_limit = 0;
          uint64_t&                     net_usage; /// reference to trace->net_usage
+         bool                          explicit_net_usage = false;
 
          bool                          cpu_limit_due_to_greylist = false;
 

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -343,11 +343,8 @@ namespace eosio { namespace chain {
 
       eager_net_limit = net_limit;
 
-      if( explicit_net_usage ) {
-         check_net_usage();    // Should already be rounded. Just check NET usage satisfies limits.
-      } else {
-         round_up_net_usage(); // Round up to nearest multiple of word size (8 bytes) and check NET usage satisfies limits.
-      }
+      round_up_net_usage(); // Round up to nearest multiple of word size (8 bytes).
+      check_net_usage();    // Check that NET usage satisfies limits (even when explicit_net_usage is true).
 
       auto now = fc::time_point::now();
       trace->elapsed = now - start;

--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -639,6 +639,18 @@ namespace eosio { namespace testing {
    };
 
    /**
+    * Utility predicate to check whether an fc::exception code is equivalent to a given value
+    */
+   struct fc_exception_code_is {
+      fc_exception_code_is( int64_t code )
+            : expected( code ) {}
+
+      bool operator()( const fc::exception& ex );
+
+      int64_t expected;
+   };
+
+   /**
     * Utility predicate to check whether an fc::exception message is equivalent to a given string
     */
    struct fc_exception_message_is {

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -1153,6 +1153,15 @@ namespace eosio { namespace testing {
       preactivate_protocol_features( preactivations );
    }
 
+   bool fc_exception_code_is::operator()( const fc::exception& ex ) {
+      bool match = (ex.code() == expected);
+      if( !match ) {
+         auto message = ex.get_log().at( 0 ).get_message();
+         BOOST_TEST_MESSAGE( "LOG: expected code: " << expected << ", actual code: " << ex.code() << ", message: " << message );
+      }
+      return match;
+   }
+
    bool fc_exception_message_is::operator()( const fc::exception& ex ) {
       auto message = ex.get_log().at( 0 ).get_message();
       bool match = (message == expected);

--- a/unittests/resource_limits_test.cpp
+++ b/unittests/resource_limits_test.cpp
@@ -4,6 +4,8 @@
 #include <eosio/chain/resource_limits.hpp>
 #include <eosio/chain/config.hpp>
 #include <eosio/testing/chainbase_fixture.hpp>
+#include <eosio/testing/tester.hpp>
+#include "fork_test_utilities.hpp"
 
 #include <boost/test/unit_test.hpp>
 
@@ -417,5 +419,142 @@ BOOST_AUTO_TEST_SUITE(resource_limits_test)
 
    } FC_LOG_AND_RETHROW()
 
+   BOOST_AUTO_TEST_CASE(light_net_validation) try {
+      tester main( setup_policy::preactivate_feature_and_new_bios );
+      tester validator( setup_policy::none );
+      tester validator2( setup_policy::none );
 
-   BOOST_AUTO_TEST_SUITE_END()
+      name test_account("alice");
+      name test_account2("bob");
+
+      constexpr int64_t net_weight = 1;
+      constexpr int64_t other_net_weight = 1'000'000'000;
+
+      signed_block_ptr trigger_block;
+
+      // Create test account with limited NET quota
+      main.create_accounts( {test_account, test_account2} );
+      main.push_action( config::system_account_name, N(setalimits), config::system_account_name, fc::mutable_variant_object()
+         ("account",    test_account)
+         ("ram_bytes",  -1)
+         ("net_weight", net_weight)
+         ("cpu_weight", -1)
+      );
+      main.push_action( config::system_account_name, N(setalimits), config::system_account_name, fc::mutable_variant_object()
+         ("account",    test_account2)
+         ("ram_bytes",  -1)
+         ("net_weight", other_net_weight)
+         ("cpu_weight", -1)
+      );
+      main.produce_block();
+
+      // Sync validator and validator2 nodes with the main node as of this state.
+      push_blocks( main, validator );
+      push_blocks( main, validator2 );
+
+      // Restart validator2 node in light validation mode.
+      {
+         validator2.close();
+         auto cfg = validator2.get_config();
+         cfg.block_validation_mode = validation_mode::LIGHT;
+         validator2.init( cfg );
+      }
+
+      const auto& rlm = main.control->get_resource_limits_manager();
+
+      // NET quota of test account should be enough to support one but not two reqauth transactions.
+      int64_t before_net_usage = rlm.get_account_net_limit_ex( test_account ).first.used;
+      main.push_action( config::system_account_name, N(reqauth), test_account, fc::mutable_variant_object()("from", "alice"), 6 );
+      int64_t after_net_usage = rlm.get_account_net_limit_ex( test_account ).first.used;
+      int64_t reqauth_net_usage_delta = after_net_usage - before_net_usage;
+      BOOST_REQUIRE_EXCEPTION( 
+         main.push_action( config::system_account_name, N(reqauth), test_account, fc::mutable_variant_object()("from", "alice"), 7 ),
+         fc::exception, fc_exception_code_is( tx_net_usage_exceeded::code_value )
+      );
+      trigger_block = main.produce_block();
+
+      auto main_schedule_hash = main.control->head_block_state()->pending_schedule.schedule_hash;
+      auto main_block_mroot   = main.control->head_block_state()->blockroot_merkle.get_root();
+
+      // Modify NET bill in transaction receipt within trigger block to cause the NET usage of test account to exceed its quota.
+      {
+         // Increase the NET usage in the reqauth transaction receipt.
+         trigger_block->transactions.back().net_usage_words.value = 2*((reqauth_net_usage_delta + 7)/8); // double the NET bill
+
+         // Re-calculate the transaction merkle
+         deque<digest_type> trx_digests;
+         const auto& trxs = trigger_block->transactions;
+         for( const auto& a : trxs )
+            trx_digests.emplace_back( a.digest() );
+         trigger_block->transaction_mroot = merkle( move(trx_digests) );
+
+         // Re-sign the block
+         auto header_bmroot = digest_type::hash( std::make_pair( trigger_block->digest(), main_block_mroot ) );
+         auto sig_digest = digest_type::hash( std::make_pair(header_bmroot, main_schedule_hash ) );
+         trigger_block->producer_signature = main.get_private_key(config::system_account_name, "active").sign(sig_digest);
+      }
+
+      // Push trigger block to validator node.
+      // This should fail because the NET bill calculated by the fully-validating node will differ from the one in the block.
+      {
+         auto bs = validator.control->create_block_state_future( trigger_block );
+         validator.control->abort_block();
+         BOOST_REQUIRE_EXCEPTION(
+            validator.control->push_block( bs, forked_branch_callback{}, trx_meta_cache_lookup{} ), 
+            fc::exception, fc_exception_message_is( "receipt does not match" )
+         );
+      }
+
+      // Push trigger block to validator2 node.
+      // This should still cause a NET failure, but will no longer be due to a receipt mismatch.
+      // Because validator2 is in light validation mode, it does not compute the NET bill itself and instead only relies on the value in the block.
+      // The failure will be due to failing to satisfy the invariant in resource_limits_manager::add_transaction_usage
+      // because the NET bill in the block is too high.
+      {
+         auto bs = validator2.control->create_block_state_future( trigger_block );
+         validator2.control->abort_block();
+         BOOST_REQUIRE_EXCEPTION(
+            validator2.control->push_block( bs, forked_branch_callback{}, trx_meta_cache_lookup{} ), 
+            fc::exception, fc_exception_code_is( tx_net_usage_exceeded::code_value )
+         );
+      }
+
+      // Modify NET bill in transaction receipt within trigger block to be lower than what it originally was.
+      {
+         // Increase the NET usage in the reqauth transaction receipt.
+         trigger_block->transactions.back().net_usage_words.value = ((reqauth_net_usage_delta + 7)/8)/2; // half the original NET bill
+
+         // Re-calculate the transaction merkle
+         deque<digest_type> trx_digests;
+         const auto& trxs = trigger_block->transactions;
+         for( const auto& a : trxs )
+            trx_digests.emplace_back( a.digest() );
+         trigger_block->transaction_mroot = merkle( move(trx_digests) );
+
+         // Re-sign the block
+         auto header_bmroot = digest_type::hash( std::make_pair( trigger_block->digest(), main_block_mroot ) );
+         auto sig_digest = digest_type::hash( std::make_pair(header_bmroot, main_schedule_hash ) );
+         trigger_block->producer_signature = main.get_private_key(config::system_account_name, "active").sign(sig_digest);
+      }
+
+      // Push new trigger block to validator node.
+      // This should still fail because the NET bill is incorrect.
+      {
+         auto bs = validator.control->create_block_state_future( trigger_block );
+         validator.control->abort_block();
+         BOOST_REQUIRE_EXCEPTION(
+            validator.control->push_block( bs, forked_branch_callback{}, trx_meta_cache_lookup{} ), 
+            fc::exception, fc_exception_message_is( "receipt does not match" )
+         );
+      }
+
+      // Push new trigger block to validator2 node.
+      // Because validator2 is in light validation mode, this will not fail despite the fact that the NET bill is incorrect.
+      {
+         auto bs = validator2.control->create_block_state_future( trigger_block );
+         validator2.control->abort_block();
+         validator2.control->push_block( bs, forked_branch_callback{}, trx_meta_cache_lookup{} );
+      }
+   } FC_LOG_AND_RETHROW()
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/unittests/resource_limits_test.cpp
+++ b/unittests/resource_limits_test.cpp
@@ -508,8 +508,7 @@ BOOST_AUTO_TEST_SUITE(resource_limits_test)
       // Push trigger block to validator2 node.
       // This should still cause a NET failure, but will no longer be due to a receipt mismatch.
       // Because validator2 is in light validation mode, it does not compute the NET bill itself and instead only relies on the value in the block.
-      // The failure will be due to failing to satisfy the invariant in resource_limits_manager::add_transaction_usage
-      // because the NET bill in the block is too high.
+      // The failure will be due to failing check_net_usage within transaction_context::finalize because the NET bill in the block is too high.
       {
          auto bs = validator2.control->create_block_state_future( trigger_block );
          validator2.control->abort_block();


### PR DESCRIPTION
## Change Description

Since the NET bill is objective, a node in full validation mode is able to calculate what the NET bill for a transaction should be. Even with this change, a node in full validation mode will always compute the NET bill rather than blindly trusting the NET bill provided by the producer in the transaction receipt and it will reject the block if there is a mismatch. 

However, with the changes in this PR, a node operating in a mode where the normal transaction checks are skipped (light validation mode or applying a block by a trusted producer) will now simply use the NET bill provided by the producer in the transaction receipt rather than computing the amount itself. This sets the stage for later changes that allow a light validation node to apply a block that may have had some context-free data within the block removed, which would make it impossible to calculate the correct NET bill.

This PR also adds a new unit test, `resource_limits_test/light_net_validation`, to test the new behavior.

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
