### PR TITLE
Fix Spurious HTTP related test failure [develop]

### DIFF
--- a/testnet.template
+++ b/testnet.template
@@ -51,7 +51,7 @@ echo "FEATURE_DIGESTS: $FEATURE_DIGESTS" >> $logfile
 
 echo "http-server-address = $wdaddr" > $wddir/config.ini
 
-programs/keosd/keosd --config-dir $wddir --data-dir $wddir 2> $wddir/wdlog.txt &
+programs/keosd/keosd --config-dir $wddir --data-dir $wddir --http-max-response-time-ms -1 2> $wddir/wdlog.txt &
 echo $$ > ignition_wallet.pid
 echo keosd log in $wddir/wdlog.txt >> $logfile
 sleep 1


### PR DESCRIPTION
Do not enforce an `http-max-response-time-ms` for the ignition wallet in `testnet.template`.  These responses are not large and sometimes burps happen
