### PR TITLE
Add possibility to run .cicd scripts from different environments

### DIFF
--- a/.cicd/build.sh
+++ b/.cicd/build.sh
@@ -3,7 +3,7 @@ set -eo pipefail
 . ./.cicd/helpers/general.sh
 mkdir -p $BUILD_DIR
 CMAKE_EXTRAS="-DCMAKE_BUILD_TYPE='Release' -DENABLE_MULTIVERSION_PROTOCOL_TEST=true -DBUILD_MONGO_DB_PLUGIN=true"
-if [[ "$(uname)" == 'Darwin' ]]; then
+if [[ "$(uname)" == 'Darwin' && $FORCE_LINUX != true ]]; then
     # You can't use chained commands in execute
     if [[ "$GITHUB_ACTIONS" == 'true' ]]; then
         export PINNED=false
@@ -48,6 +48,8 @@ else # Linux
         [[ "$ENABLE_INSTALL" == 'true' ]] && COMMANDS="$COMMANDS && make install"
     elif [[ "$GITHUB_ACTIONS" == 'true' ]]; then
         ARGS="$ARGS -e JOBS"
+        COMMANDS="$BUILD_COMMANDS"
+    else
         COMMANDS="$BUILD_COMMANDS"
     fi
     . $HELPERS_DIR/file-hash.sh $CICD_DIR/platforms/$PLATFORM_TYPE/$IMAGE_TAG.dockerfile

--- a/.cicd/helpers/file-hash.sh
+++ b/.cicd/helpers/file-hash.sh
@@ -4,4 +4,4 @@ set -eo pipefail
 FILE_NAME=$(basename $1 | awk '{split($0,a,/\.(d|s)/); print a[1] }')
 export DETERMINED_HASH=$(sha1sum $1 | awk '{ print $1 }')
 export HASHED_IMAGE_TAG="eos-${FILE_NAME}-${DETERMINED_HASH}"
-export FULL_TAG="eosio/ci:$HASHED_IMAGE_TAG"
+export FULL_TAG="${IMAGE_NAME:-"eosio/ci"}:$HASHED_IMAGE_TAG"


### PR DESCRIPTION
## Change Description

I know that everything under `.cicd` folder is not supported and could change at any moment, and it's for internal usages.

I've used them internally to build the base pinned images as well as the packages and it much more convenient to use your scripts than build mine from scratch.

I understand this could be declined, but I hope you will consider them as with those small changes, it's possible to use them pretty much as-is (if you know what you do).

#### With FORCE_LINUX=true, you can run the Docker version in `build.sh` and `package.sh` scripts

When running the scripts from Mac OS X, it was always picking up the Darwin conditional
paths in the script. `FORCE_LINUX=true` can be used on a Mac OS X environment to run
the scripts.

#### Fix shell expansion in `package.sh`

In the packaging script, there is a Docker pre command that add executable bit permission
on *.sh scripts in the `build/packages` folder. However, without the escaping, the shell
expansion was performed in the `package.sh` script execution directly instead of being
delayed so that the expansion is performed inside the `docker run` call!

I suspect this worked in your CI system because execution of `package.sh` in performed in
such way that filesystem layout of `package.sh` and filesystem layout of `docker run` were
the same and as such, the expanded `chmod 755 file1.sh file2.sh` command was correctly
working inside the container.

The shell expansion via the `*` is now escaped which correctly delays the expansion until
it's in the `docker run` execution environment.

#### Conditional buildkite-agent upload

Now, the upload task is performed only  if BUILDKITE env is set to `true`, so it's possible
to run the script without having to upload the actual package.

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
