### PR TITLE
Fix spurious HTTP related test failure [develop] (round 2)

### DIFF
--- a/testnet.template
+++ b/testnet.template
@@ -51,7 +51,7 @@ echo "FEATURE_DIGESTS: $FEATURE_DIGESTS" >> $logfile
 
 echo "http-server-address = $wdaddr" > $wddir/config.ini
 
-programs/keosd/keosd --config-dir $wddir --data-dir $wddir 2> $wddir/wdlog.txt &
+programs/keosd/keosd --config-dir $wddir --data-dir $wddir --http-max-response-time-ms 99999 2> $wddir/wdlog.txt &
 echo $$ > ignition_wallet.pid
 echo keosd log in $wddir/wdlog.txt >> $logfile
 sleep 1


### PR DESCRIPTION
set `http-max-response-time-ms` to a really large number for the ignition wallet service

This is a temporary fix until #8862 is resolved when it should be set to `-1`