### PR TITLE
Correctly Sanitize git Branch and Tag Names

### DIFF
--- a/.cicd/docker-tag.sh
+++ b/.cicd/docker-tag.sh
@@ -4,8 +4,8 @@ echo '+++ :evergreen_tree: Configuring Environment'
 REPO='eosio/ci-contracts-builder'
 PREFIX='base-ubuntu-18.04'
 IMAGE="$REPO:$PREFIX-$BUILDKITE_COMMIT-$PLATFORM_TYPE"
-SANITIZED_BRANCH=$(echo "$BUILDKITE_BRANCH" | tr '/' '_')
-SANITIZED_TAG=$(echo "$BUILDKITE_TAG" | tr '/' '_')
+SANITIZED_BRANCH=$(echo "$BUILDKITE_BRANCH" | sed 's.^/..' | tr '/' '_')
+SANITIZED_TAG=$(echo "$BUILDKITE_TAG" | sed 's.^/..' | tr '/' '_')
 echo '+++ :arrow_down: Pulling Container'
 echo "Pulling \"$IMAGE\""
 docker pull "$IMAGE"

--- a/.cicd/installation-build.sh
+++ b/.cicd/installation-build.sh
@@ -2,7 +2,7 @@
 set -eo pipefail
 . ./.cicd/helpers/general.sh
 export ENABLE_INSTALL=true
-export BRANCH=$(echo $BUILDKITE_BRANCH | sed 's/\//\_/')
+export BRANCH=$(echo $BUILDKITE_BRANCH | tr '/' '_')
 export CONTRACTS_BUILDER_TAG="eosio/ci-contracts-builder:base-ubuntu-18.04"
 export ARGS="--name ci-contracts-builder-$BUILDKITE_PIPELINE_SLUG-$BUILDKITE_BUILD_NUMBER --init -v $(pwd):$MOUNTED_DIR"
 $CICD_DIR/build.sh

--- a/.cicd/installation-build.sh
+++ b/.cicd/installation-build.sh
@@ -2,7 +2,7 @@
 set -eo pipefail
 . ./.cicd/helpers/general.sh
 export ENABLE_INSTALL=true
-export BRANCH=$(echo $BUILDKITE_BRANCH | tr '/' '_')
+export BRANCH=$(echo $BUILDKITE_BRANCH | sed 's.^/..' | tr '/' '_')
 export CONTRACTS_BUILDER_TAG="eosio/ci-contracts-builder:base-ubuntu-18.04"
 export ARGS="--name ci-contracts-builder-$BUILDKITE_PIPELINE_SLUG-$BUILDKITE_BUILD_NUMBER --init -v $(pwd):$MOUNTED_DIR"
 $CICD_DIR/build.sh

--- a/.cicd/submodule-regression-check.sh
+++ b/.cicd/submodule-regression-check.sh
@@ -5,8 +5,8 @@ declare -A BASE_MAP
 
 if [[ $BUILDKITE == true ]]; then
     [[ -z $BUILDKITE_PULL_REQUEST_BASE_BRANCH ]] && echo "Unable to find BUILDKITE_PULL_REQUEST_BASE_BRANCH ENV. Skipping submodule regression check." && exit 0
-    BASE_BRANCH=$BUILDKITE_PULL_REQUEST_BASE_BRANCH
-    CURRENT_BRANCH=$BUILDKITE_BRANCH
+    BASE_BRANCH="$(echo "$BUILDKITE_PULL_REQUEST_BASE_BRANCH" | sed 's.^/..')"
+    CURRENT_BRANCH="$(echo "$BUILDKITE_BRANCH" | sed 's.^/..')"
 else
     [[ -z $GITHUB_BASE_REF ]] && echo "Cannot find \$GITHUB_BASE_REF, so we have nothing to compare submodules to. Skipping submodule regression check." && exit 0
     BASE_BRANCH=$GITHUB_BASE_REF


### PR DESCRIPTION
## Change Description
This pull request fixes an edge-case where `git` branch names with multiple forward-slash characters (`/`) in the name would cause the `Docker - Build and Install` step in Buildkite to fail because the code which sanitizes the branch name before using it in a docker image tag only replaced the first occurrence.  
  
I have fixed this by replacing all forward-slash characters with underscore characters, instead of just the first one. I have also dropped any forward-slash which appears at the beginning of a branch name, as this is meaningless and it causes the `git checkout` in the `Git Submodule Regression Check` to fail. See [this Stack Overflow answer](https://stackoverflow.com/a/3651867) for more details on valid `git` branch and tag name syntax.
  
### Examples
Here are the builds where we ran into this error:
- [Build 21180](https://buildkite.com/EOSIO/eosio/builds/21180) failed [here](https://buildkite.com/EOSIO/eosio/builds/21180#3bf97ed8-3ecc-4e21-b5b4-98d55c34253d/234-2452) with `/feature/fix-spurious-ignition-failures-again` as the branch name given to Buildkite
- [Build 21181](https://buildkite.com/EOSIO/eosio/builds/21181) failed [here](https://buildkite.com/EOSIO/eosio/builds/21181#e4de36ec-3f1e-4750-af23-414a7c147484/234-2498) with `/feature/fix-spurious-ignition-failures-again-develop` as the branch name given to Buildkite

You can see I intentionally created this pull request with a branch name containing a leading forward-slash, and several more in the middle of the name. [Build 21212](https://buildkite.com/EOSIO/eosio/builds/21212) passed with `/zach/1.8/sanitize/branch/name` as the branch name given to Buildkite.

### See Also
This set of pull requests all make the same bug fix to different versions of EOSIO:
- [Pull Request 8882](https://github.com/EOSIO/eos/pull/8882) -- `eos:develop`
- [Pull Request 8884](https://github.com/EOSIO/eos/pull/8884) -- `eos:release/2.0.x`
- [Pull Request 8885](https://github.com/EOSIO/eos/pull/8885) -- `eos:release/1.8.x`

## Consensus Changes
- [ ] Consensus Changes
None.

## API Changes
- [ ] API Changes
None.

## Documentation Additions
- [ ] Documentation Additions
None.