### PR TITLE
use http async api support for Trace API get_block [develop]

### DIFF
--- a/plugins/trace_api_plugin/trace_api_plugin.cpp
+++ b/plugins/trace_api_plugin/trace_api_plugin.cpp
@@ -235,7 +235,7 @@ struct trace_api_rpc_plugin_impl : public std::enable_shared_from_this<trace_api
       auto& http = app().get_plugin<http_plugin>();
       fc::microseconds max_response_time = http.get_max_response_time();
 
-      http.add_handler("/v1/trace_api/get_block",
+      http.add_async_handler("/v1/trace_api/get_block",
             [wthis=weak_from_this(), max_response_time](std::string, std::string body, url_response_callback cb)
       {
          auto that = wthis.lock();


### PR DESCRIPTION
**This is a cherry-pick up-port of #8881**

migrate `v1/trace_api/get_block` to the "async" http support.  This is an internal only change that should remove all of the burden of servicing Trace API RPC requests from the main application thread.