### PR TITLE
Added block log v4

### DIFF
--- a/libraries/chain/block_log.cpp
+++ b/libraries/chain/block_log.cpp
@@ -36,7 +36,7 @@ namespace eosio { namespace chain {
     *            compression_status and pruned_block.
     */
 
-   enum Versions {
+   enum versions {
       initial_version = 1,
       block_x_start_version = 2,
       genesis_state_or_chain_id_version = 3,

--- a/libraries/chain/block_log.cpp
+++ b/libraries/chain/block_log.cpp
@@ -68,7 +68,7 @@ namespace eosio { namespace chain {
          entry.compression = static_cast<packed_transaction::cf_compression_type>(compression);
          EOS_ASSERT(entry.compression == packed_transaction::cf_compression_type::none, block_log_exception,
                   "Only support compression_type none");
-         fc::raw::unpack(ds, static_cast<signed_block&>(entry));
+         static_cast<signed_block&>(entry).unpack(ds, entry.compression);
          uint64_t current_stream_offset = get_stream_pos(ds) - start_pos;
 
          int64_t bytes_to_skip = static_cast<int64_t>(entry.offset) - sizeof(uint64_t) - current_stream_offset;

--- a/libraries/chain/block_log.cpp
+++ b/libraries/chain/block_log.cpp
@@ -909,7 +909,6 @@ namespace eosio { namespace chain {
             std::vector<char> buffer(max_block_size);
             fc::datastream<char*> stream(buffer.data(), buffer.size());
             static_cast<signed_block&>(entry).pack(stream, entry.compression);
-            EOS_ASSERT(buffer.size() <= max_block_size, block_log_exception, "Not enough space reserved in block log entry to serialize pruned block.");
             my->block_file.write(buffer.data(), buffer.size());
             my->block_file.flush();
          }

--- a/libraries/chain/block_log.cpp
+++ b/libraries/chain/block_log.cpp
@@ -4,7 +4,9 @@
 #include <fc/bitutil.hpp>
 #include <fc/io/cfile.hpp>
 #include <fc/io/raw.hpp>
-
+#include <boost/iostreams/device/mapped_file.hpp>
+#include <boost/filesystem.hpp>
+#include <variant>
 
 #define LOG_READ  (std::ios::in | std::ios::binary)
 #define LOG_WRITE (std::ios::out | std::ios::binary | std::ios::app)
@@ -31,21 +33,86 @@ namespace eosio { namespace chain {
     *            this is in the form of an first_block_num that is written immediately after the version
     * Version 3: improvement on version 2 to not require the genesis state be provided when not starting
     *            from block 1
+    * Version 4: changes the block entry from the serialization of signed_block to a tuple of offset to next entry,
+    *            compression_status and pruned_block.
     */
-   const uint32_t block_log::max_supported_version = 3;
+   const uint32_t block_log::max_supported_version = 4;
 
    namespace detail {
       using unique_file = std::unique_ptr<FILE, decltype(&fclose)>;
 
+      /// calculate the offset from the start of serialized block entry to block start
+      int offset_to_block_start(uint32_t version) { 
+         if (version < 4) return 0;
+         return sizeof(uint32_t) + 1;
+      }
+
+      class log_entry_v4 : public signed_block {
+      public:
+         packed_transaction::cf_compression_type compression = packed_transaction::cf_compression_type::none;
+         uint32_t offset = 0;
+      };
+
+
+      template <typename Stream>
+      void unpack(Stream& ds, log_entry_v4& entry){
+         auto start_pos = ds.tellp();
+         fc::raw::unpack(ds, entry.offset);
+         uint8_t compression;
+         fc::raw::unpack(ds, compression);
+         entry.compression = static_cast<packed_transaction::cf_compression_type>(compression);
+         EOS_ASSERT(entry.compression == packed_transaction::cf_compression_type::none, block_log_exception,
+                  "Only support compression_type none");
+         fc::raw::unpack(ds, static_cast<signed_block&>(entry));
+         EOS_ASSERT(ds.tellp() - start_pos + sizeof(uint64_t) == entry.offset , block_log_exception,
+                  "Invalid block log entry offset");
+      }
+
+      std::vector<char> pack(const signed_block& block, packed_transaction::cf_compression_type compression) {
+         // In version 4 of the irreversible blocks log format, these log entries consists of the following in order:
+         //    1. An uint32_t offset from the start of this log entry to the start of the next log entry.
+         //    2. An uint8_t indicating the compression status for the serialization of the pruned_block following this.
+         //    3. The serialization of a pruned_block representation of the block for the entry including padding.
+
+         std::size_t padded_size = block.maximum_pruned_pack_size(compression);
+         std::vector<char> buffer(padded_size + offset_to_block_start(4));
+         fc::datastream<char*> stream(buffer.data(), buffer.size());
+
+         uint32_t offset      = buffer.size() + sizeof(uint64_t);
+         stream.write((char*)&offset, sizeof(offset));
+         fc::raw::pack(stream, static_cast<uint8_t>(compression));
+         block.pack(stream, compression);
+         return buffer;
+      }
+
+      std::vector<char> pack(const log_entry_v4& entry) {
+         return pack(static_cast<const signed_block&>(entry), entry.compression);
+      }
+
+      using log_entry = std::variant<log_entry_v4, signed_block>;
+
+      template <typename Stream>
+      void unpack(Stream& ds, log_entry& entry) {
+         std::visit(
+             overloaded{[&ds](signed_block& v) { fc::raw::unpack(ds, v); }, [&ds](log_entry_v4& v) { unpack(ds, v); }},
+             entry);
+      }
+
+      std::vector<char> pack(const log_entry& entry) {
+         return std::visit(overloaded{[](const signed_block& v) { return fc::raw::pack(v); },
+                                      [](const log_entry_v4& v) { return pack(v); }},
+                           entry);
+      }
+
       class block_log_impl {
          public:
-            signed_block_ptr         head;
-            fc::cfile                block_file;
-            fc::cfile                index_file;
-            bool                     open_files = false;
-            bool                     genesis_written_to_block_log = false;
-            uint32_t                 version = 0;
-            uint32_t                 first_block_num = 0;
+            signed_block_ptr head;
+            fc::cfile        block_file;
+            fc::cfile        index_file;
+            bool             open_files                   = false;
+            bool             genesis_written_to_block_log = false;
+            uint32_t         version                      = 0;
+            uint32_t         first_block_num              = 0;
 
             inline void check_open_files() {
                if( !open_files ) {
@@ -63,7 +130,8 @@ namespace eosio { namespace chain {
             }
 
             template<typename T>
-            void reset( const T& t, const signed_block_ptr& genesis_block, uint32_t first_block_num );
+            void reset( const T& t, const signed_block_ptr& first_block,
+                        packed_transaction::cf_compression_type segment_compression, uint32_t first_block_num );
 
             void write( const genesis_state& gs );
 
@@ -71,10 +139,32 @@ namespace eosio { namespace chain {
 
             void flush();
 
-            uint64_t append(const signed_block_ptr& b);
+            uint64_t append(const signed_block_ptr& b, packed_transaction::cf_compression_type segment_compression);
 
             template <typename ChainContext, typename Lambda>
             static fc::optional<ChainContext> extract_chain_context( const fc::path& data_dir, Lambda&& lambda );
+
+            uint64_t write_log_entry(const signed_block& b,
+                                     packed_transaction::cf_compression_type segment_compression);
+
+            void read_block_header(block_header& bh, uint64_t file_pos);
+            std::unique_ptr<signed_block> read_block(uint64_t pos);
+            void read_head();
+
+            
+
+            static int blknum_offset_from_block_entry(uint32_t block_log_version) { 
+
+               //to derive blknum_offset==14 see block_header.hpp and note on disk struct is packed
+               //   block_timestamp_type timestamp;                  //bytes 0:3
+               //   account_name         producer;                   //bytes 4:11
+               //   uint16_t             confirmed;                  //bytes 12:13
+               //   block_id_type        previous;                   //bytes 14:45, low 4 bytes is big endian block number of previous block
+               
+               int blknum_offset = 14;
+               blknum_offset += detail::offset_to_block_start(block_log_version);
+               return blknum_offset;
+            }
       };
 
       void detail::block_log_impl::reopen() {
@@ -178,7 +268,11 @@ namespace eosio { namespace chain {
          FILE* const _file;
          const std::string _filename;
       };
-   }
+}}} // namespace eosio::chain::detail
+
+FC_REFLECT_DERIVED(eosio::chain::detail::log_entry_v4, (eosio::chain::signed_block), (compression)(offset) )
+
+namespace eosio { namespace chain {
 
    block_log::block_log(const fc::path& data_dir)
    :my(new detail::block_log_impl()) {
@@ -249,7 +343,7 @@ namespace eosio { namespace chain {
             my->first_block_num = 1;
          }
 
-         my->head = read_head();
+         my->read_head();
 
          if (index_size) {
             ilog("Index is nonempty");
@@ -280,11 +374,31 @@ namespace eosio { namespace chain {
       }
    }
 
-   uint64_t block_log::append(const signed_block_ptr& b) {
-      return my->append(b);
+   uint64_t detail::block_log_impl::write_log_entry(const signed_block& b, packed_transaction::cf_compression_type segment_compression) {
+      uint64_t pos = block_file.tellp();
+      std::vector<char> buffer;
+     
+      if (version >= 4)  {
+         buffer = detail::pack(b, segment_compression);
+      } else {
+#warning: TODO avoid heap allocation
+         auto block_ptr = b.to_signed_block_v0();
+         EOS_ASSERT(block_ptr, block_log_append_fail, "Unable to convert block to legacy format");
+         EOS_ASSERT(segment_compression == packed_transaction::cf_compression_type::none, block_log_append_fail,
+            "the compression must be \"none\" for legacy format");
+         buffer = fc::raw::pack(*block_ptr);
+      }
+      block_file.write(buffer.data(), buffer.size());
+      block_file.write((char*)&pos, sizeof(pos));
+      index_file.write((char*)&pos, sizeof(pos));
+      return pos;
    }
 
-   uint64_t detail::block_log_impl::append(const signed_block_ptr& b) {
+   uint64_t block_log::append(const signed_block_ptr& b, packed_transaction::cf_compression_type segment_compression) {
+      return my->append(b, segment_compression);
+   }
+
+   uint64_t detail::block_log_impl::append(const  signed_block_ptr& b, packed_transaction::cf_compression_type segment_compression) {
       try {
          EOS_ASSERT( genesis_written_to_block_log, block_log_append_fail, "Cannot append to block log until the genesis is first written" );
 
@@ -292,16 +406,14 @@ namespace eosio { namespace chain {
 
          block_file.seek_end(0);
          index_file.seek_end(0);
-         uint64_t pos = block_file.tellp();
          EOS_ASSERT(index_file.tellp() == sizeof(uint64_t) * (b->block_num() - first_block_num),
                    block_log_append_fail,
                    "Append to index file occuring at wrong position.",
                    ("position", (uint64_t) index_file.tellp())
                    ("expected", (b->block_num() - first_block_num) * sizeof(uint64_t)));
-         auto data = fc::raw::pack(*b);
-         block_file.write(data.data(), data.size());
-         block_file.write((char*)&pos, sizeof(pos));
-         index_file.write((char*)&pos, sizeof(pos));
+
+         auto pos = write_log_entry(*b, segment_compression);
+
          head = b;
 
          flush();
@@ -321,7 +433,7 @@ namespace eosio { namespace chain {
    }
 
    template<typename T>
-   void detail::block_log_impl::reset( const T& t, const signed_block_ptr& first_block, uint32_t first_bnum ) {
+   void detail::block_log_impl::reset( const T& t, const signed_block_ptr& first_block, packed_transaction::cf_compression_type segment_compression, uint32_t first_bnum ) {
       close();
 
       fc::remove_all( block_file.get_file_path() );
@@ -343,8 +455,11 @@ namespace eosio { namespace chain {
       auto totem = block_log::npos;
       block_file.write((char*)&totem, sizeof(totem));
 
+      // version must be assigned before this->append() because it is used inside this->append()
+      version = block_log::max_supported_version;
+
       if (first_block) {
-         append(first_block);
+         append(first_block, segment_compression);
       } else {
          head.reset();
       }
@@ -354,21 +469,20 @@ namespace eosio { namespace chain {
       static_assert( block_log::max_supported_version > 0, "a version number of zero is not supported" );
 
       // going back to write correct version to indicate that all block log header data writes completed successfully
-      version = block_log::max_supported_version;
       block_file.seek( 0 );
       block_file.write( (char*)&version, sizeof(version) );
       block_file.seek( pos );
       flush();
    }
 
-   void block_log::reset( const genesis_state& gs, const signed_block_ptr& first_block ) {
-      my->reset(gs, first_block, 1);
+   void block_log::reset( const genesis_state& gs, const signed_block_ptr& first_block, packed_transaction::cf_compression_type segment_compression ) {
+      my->reset(gs, first_block, segment_compression, 1);
    }
 
    void block_log::reset( const chain_id_type& chain_id, uint32_t first_block_num ) {
       EOS_ASSERT( first_block_num > 1, block_log_exception,
                   "Block log version ${ver} needs to be created with a genesis state if starting from block number 1." );
-      my->reset(chain_id, signed_block_ptr(), first_block_num);
+      my->reset(chain_id, signed_block_ptr(), packed_transaction::cf_compression_type::none, first_block_num);
    }
 
    void detail::block_log_impl::write( const genesis_state& gs ) {
@@ -380,32 +494,43 @@ namespace eosio { namespace chain {
       block_file << chain_id;
    }
 
-   signed_block_ptr block_log::read_block(uint64_t pos)const {
-      my->check_open_files();
-
-      my->block_file.seek(pos);
-      signed_block_ptr result = std::make_shared<signed_block>();
-      auto ds = my->block_file.create_datastream();
-      fc::raw::unpack(ds, *result);
-      return result;
+   std::unique_ptr<signed_block> detail::block_log_impl::read_block(uint64_t pos) {
+      block_file.seek(pos);
+      auto ds = block_file.create_datastream();
+      if (version >= 4) {
+         auto entry = std::make_unique<log_entry_v4>();
+         unpack(ds, *entry);
+         return entry;
+      } else {
+         signed_block_v0 block;
+         fc::raw::unpack(ds, block);
+         return std::make_unique<signed_block>(std::move(block), true);
+      }
    }
 
-   void block_log::read_block_header(block_header& bh, uint64_t pos)const {
-      my->check_open_files();
+   void detail::block_log_impl::read_block_header(block_header& bh, uint64_t pos) {
+      block_file.seek(pos);
+      auto ds = block_file.create_datastream();
 
-      my->block_file.seek(pos);
-      auto ds = my->block_file.create_datastream();
+      if (version >= 4 ) {
+         uint32_t offset;
+         uint8_t  compression;
+         fc::raw::unpack(ds, offset);
+         fc::raw::unpack(ds, compression);
+         EOS_ASSERT( compression == static_cast<uint8_t>(packed_transaction::cf_compression_type::none), block_log_exception ,
+                     "Only \"none\" compression type is supported.");
+      }
       fc::raw::unpack(ds, bh);
    }
 
-   signed_block_ptr block_log::read_block_by_num(uint32_t block_num)const {
+   std::unique_ptr<signed_block> block_log::read_signed_block_by_num(uint32_t block_num) const {
       try {
-         signed_block_ptr b;
+         std::unique_ptr<signed_block> b;
          uint64_t pos = get_block_pos(block_num);
          if (pos != npos) {
-            b = read_block(pos);
-            EOS_ASSERT(b->block_num() == block_num, reversible_blocks_exception,
-                      "Wrong block was read from block log.", ("returned", b->block_num())("expected", block_num));
+            b = my->read_block(pos);
+            EOS_ASSERT(b->block_num() == block_num, block_log_exception,
+                      "Wrong block was read from block log.");
          }
          return b;
       } FC_LOG_AND_RETHROW()
@@ -416,7 +541,7 @@ namespace eosio { namespace chain {
          uint64_t pos = get_block_pos(block_num);
          if (pos != npos) {
             block_header bh;
-            read_block_header(bh, pos);
+            my->read_block_header(bh, pos);
             EOS_ASSERT(bh.block_num() == block_num, reversible_blocks_exception,
                        "Wrong block header was read from block log.", ("returned", bh.block_num())("expected", block_num));
             return bh.calculate_id();
@@ -435,26 +560,18 @@ namespace eosio { namespace chain {
       return pos;
    }
 
-   signed_block_ptr block_log::read_head()const {
-      my->check_open_files();
 
+   void detail::block_log_impl::read_head() {
       uint64_t pos;
 
-      // Check that the file is not empty
-      my->block_file.seek_end(0);
-      if (my->block_file.tellp() <= sizeof(pos))
-         return {};
-
-      my->block_file.seek_end(-sizeof(pos));
-      my->block_file.read((char*)&pos, sizeof(pos));
-      if (pos != npos) {
-         return read_block(pos);
-      } else {
-         return {};
-      }
+      block_file.seek_end(-sizeof(pos));
+      block_file.read((char*)&pos, sizeof(pos));
+      if (pos != block_log::npos) {
+         head = read_block(pos);
+      } 
    }
 
-   const signed_block_ptr& block_log::head()const {
+   const signed_block_ptr& block_log::head() const {
       return my->head;
    }
 
@@ -503,7 +620,7 @@ namespace eosio { namespace chain {
       index.complete();
    }
 
-   fc::path block_log::repair_log( const fc::path& data_dir, uint32_t truncate_at_block ) {
+   fc::path block_log::repair_log(const fc::path& data_dir, uint32_t truncate_at_block) {
       ilog("Recovering Block Log...");
       EOS_ASSERT( fc::is_directory(data_dir) && fc::is_regular_file(data_dir / "blocks.log"), block_log_not_found,
                  "Block log not found in '${blocks_dir}'", ("blocks_dir", data_dir)          );
@@ -597,52 +714,57 @@ namespace eosio { namespace chain {
          new_block_stream.write( (char*)&actual_totem, sizeof(actual_totem) );
       }
 
-      std::exception_ptr     except_ptr;
-      vector<char>           incomplete_block_data;
-      optional<signed_block> bad_block;
-      uint32_t               block_num = 0;
+      std::exception_ptr          except_ptr;
+      vector<char>                incomplete_block_data;
+      optional<detail::log_entry> bad_block;
+      uint32_t                    block_num = 0;
 
-      block_id_type previous;
+      block_id_type expected_previous;
 
       uint64_t pos = old_block_stream.tellg();
-      while( pos < end_pos ) {
-         signed_block tmp;
 
+      detail::log_entry entry;
+      if (version < 4) {
+         entry.emplace<signed_block>();
+      }
+
+      while( pos < end_pos ) {
          try {
-            fc::raw::unpack(old_block_stream, tmp);
-         } catch( ... ) {
+            unpack(old_block_stream, entry);
+         } catch (...) {
             except_ptr = std::current_exception();
             incomplete_block_data.resize( end_pos - pos );
             old_block_stream.read( incomplete_block_data.data(), incomplete_block_data.size() );
             break;
          }
 
-         auto id = tmp.calculate_id();
-         if( block_header::num_from_id(previous) + 1 != block_header::num_from_id(id) ) {
+         auto id = std::visit([](const auto& v) { return v.calculate_id(); }, entry);
+         if( block_header::num_from_id(expected_previous) + 1 != block_header::num_from_id(id) ) {
             elog( "Block ${num} (${id}) skips blocks. Previous block in block log is block ${prev_num} (${previous})",
                   ("num", block_header::num_from_id(id))("id", id)
-                  ("prev_num", block_header::num_from_id(previous))("previous", previous) );
+                  ("prev_num", block_header::num_from_id(expected_previous))("previous", expected_previous) );
          }
-         if( previous != tmp.previous ) {
+         auto actual_previous = std::visit([](const auto& v) { return v.previous; }, entry);
+         if( expected_previous != actual_previous ) {
             elog( "Block ${num} (${id}) does not link back to previous block. "
                   "Expected previous: ${expected}. Actual previous: ${actual}.",
-                  ("num", block_header::num_from_id(id))("id", id)("expected", previous)("actual", tmp.previous) );
+                  ("num", block_header::num_from_id(id))("id", id)("expected", expected_previous)("actual", actual_previous) );
          }
-         previous = id;
+         expected_previous = id;
 
          uint64_t tmp_pos = std::numeric_limits<uint64_t>::max();
          if( (static_cast<uint64_t>(old_block_stream.tellg()) + sizeof(pos)) <= end_pos ) {
             old_block_stream.read( reinterpret_cast<char*>(&tmp_pos), sizeof(tmp_pos) );
          }
          if( pos != tmp_pos ) {
-            bad_block.emplace(std::move(tmp));
+            bad_block.emplace(std::move(entry));
             break;
          }
 
-         auto data = fc::raw::pack(tmp);
+         auto data = detail::pack(entry);
          new_block_stream.write( data.data(), data.size() );
          new_block_stream.write( reinterpret_cast<char*>(&pos), sizeof(pos) );
-         block_num = tmp.block_num();
+         block_num = std::visit([](const auto& v) { return v.block_num(); }, entry);
          if(block_num % 1000 == 0)
             ilog( "Recovered block ${num}", ("num", block_num) );
          pos = new_block_stream.tellp();
@@ -651,7 +773,7 @@ namespace eosio { namespace chain {
       }
 
       if( bad_block.valid() ) {
-         ilog( "Recovered only up to block number ${num}. Last block in block log was not properly committed.", ("num", block_num) );
+         ilog("Recovered only up to block number ${num}. Last block in block log was not properly committed", ("num", block_num));
       } else if( except_ptr ) {
          std::string error_msg;
 
@@ -741,6 +863,47 @@ namespace eosio { namespace chain {
       }));
    }
 
+   bool prune(packed_transaction& ptx) {
+      ptx.prune_all();
+      return true;
+   }
+   
+   void block_log::prune_transactions(uint32_t block_num, const std::vector<transaction_id_type>& ids) {
+      try {
+         EOS_ASSERT( my->version >= 4, block_log_exception,
+                     "The block log version ${version} does not support transaction pruning.", ("version", my->version) );
+         uint64_t pos = get_block_pos(block_num);
+         EOS_ASSERT( pos != npos, block_log_exception,
+                     "Specified block_num ${block_num} does not exist in block log.", ("block_num", block_num) );
+
+         detail::log_entry_v4 entry;   
+         my->block_file.seek(pos);
+         auto ds = my->block_file.create_datastream();
+         unpack(ds, entry);
+
+         EOS_ASSERT(entry.block_num() == block_num, block_log_exception,
+                     "Wrong block was read from block log.");
+
+         auto pruner = overloaded{[](transaction_id_type&) { return false; },
+                                  [&ids](packed_transaction& ptx) { return  std::find(ids.begin(), ids.end(), ptx.id()) != ids.end() && prune(ptx); }};
+
+         bool pruned = false;
+         for (auto& trx : entry.transactions) {
+            pruned |= trx.trx.visit(pruner);
+         }
+
+         if (pruned) {
+            my->block_file.seek(pos);
+            std::vector<char> buffer = detail::pack(entry);
+            EOS_ASSERT(buffer.size() <= entry.offset, block_log_exception, "Not enough space reserved in block log entry to serialize pruned block.");
+            my->block_file.write(buffer.data(), buffer.size());
+            my->block_file.flush();
+         }
+      }
+      FC_LOG_AND_RETHROW()
+   }
+
+   
    detail::reverse_iterator::reverse_iterator()
    : _file(nullptr, &fclose)
    , _buffer_ptr(std::make_unique<char[]>(_buf_len)) {
@@ -751,6 +914,8 @@ namespace eosio { namespace chain {
       _file.reset( FC_FOPEN(_block_file_name.c_str(), "r"));
       EOS_ASSERT( _file, block_log_exception, "Could not open Block log file at '${blocks_log}'", ("blocks_log", _block_file_name) );
       _end_of_buffer_position = _unset_position;
+
+      // TODO: reimplemented with mapped_file_source and verify_log_preamble_and_return_version()
 
       //read block log to see if version 1 or 2 and get first blocknum (implicit 1 if version 1)
       _version = 0;
@@ -787,10 +952,9 @@ namespace eosio { namespace chain {
       uint32_t bnum = 0;
       if (block_pos >= _start_of_buffer_position) {
          const uint32_t index_of_block = block_pos - _start_of_buffer_position;
-         bnum = *reinterpret_cast<uint32_t*>(buf + index_of_block + trim_data::blknum_offset);  //block number of previous block (is big endian)
-      }
-      else {
-         const auto blknum_offset_pos = block_pos + trim_data::blknum_offset;
+         bnum = *reinterpret_cast<uint32_t*>(buf + index_of_block + block_log_impl::blknum_offset_from_block_entry(_version));  //block number of previous block (is big endian)
+      } else {
+         const auto blknum_offset_pos = block_pos + block_log_impl::blknum_offset_from_block_entry(_version);
          auto status = fseek(_file.get(), blknum_offset_pos, SEEK_SET);
          EOS_ASSERT( status == 0, block_log_exception, "Could not seek in '${blocks_log}' to position: ${pos}. Returned status: ${status}", ("blocks_log", _block_file_name)("pos", blknum_offset_pos)("status", status) );
          auto size = fread((void*)&bnum, sizeof(bnum), 1, _file.get());
@@ -943,6 +1107,23 @@ namespace eosio { namespace chain {
       return std::clamp(version, min_supported_version, max_supported_version) == version;
    }
 
+   struct trim_data {            //used by trim_blocklog_front(), trim_blocklog_end(), and smoke_test()
+      trim_data(fc::path block_dir);
+      ~trim_data();
+      uint64_t block_index(uint32_t n) const;
+      uint64_t block_pos(uint32_t n);
+      fc::path block_file_name, index_file_name;        //full pathname for blocks.log and blocks.index
+      uint32_t version = 0;                              //blocklog version
+      uint32_t first_block = 0;                          //first block in blocks.log
+      uint32_t last_block = 0;                          //last block in blocks.log
+      FILE* blk_in = nullptr;                            //C style files for reading blocks.log and blocks.index
+      FILE* ind_in = nullptr;                            //C style files for reading blocks.log and blocks.index
+      //we use low level file IO because it is distinctly faster than C++ filebuf or iostream
+      uint64_t first_block_pos = 0;                      //file position in blocks.log for the first block in the log
+      chain_id_type chain_id;
+   };
+
+
    bool block_log::trim_blocklog_front(const fc::path& block_dir, const fc::path& temp_dir, uint32_t truncate_at_block) {
       using namespace std;
       EOS_ASSERT( block_dir != temp_dir, block_log_exception, "block_dir and temp_dir need to be different directories" );
@@ -972,8 +1153,8 @@ namespace eosio { namespace chain {
       new_block_file.close();
       new_block_file.open( LOG_RW_C );
 
-      static_assert( block_log::max_supported_version == 3,
-                     "Code was written to support version 3 format, need to update this code for latest format." );
+      static_assert( block_log::max_supported_version == 4,
+                     "Code was written to support format of version 4, need to update this code for latest format." );
       uint32_t version = block_log::max_supported_version;
       new_block_file.seek(0);
       new_block_file.write((char*)&version, sizeof(version));
@@ -1058,11 +1239,9 @@ namespace eosio { namespace chain {
 
       using namespace std;
       block_file_name = block_dir / "blocks.log";
-      index_file_name = block_dir / "blocks.index";
       blk_in = FC_FOPEN(block_file_name.generic_string().c_str(), "rb");
       EOS_ASSERT( blk_in != nullptr, block_log_not_found, "cannot read file ${file}", ("file",block_file_name.string()) );
-      ind_in = FC_FOPEN(index_file_name.generic_string().c_str(), "rb");
-      EOS_ASSERT( ind_in != nullptr, block_log_not_found, "cannot read file ${file}", ("file",index_file_name.string()) );
+
       auto size = fread((void*)&version,sizeof(version), 1, blk_in);
       EOS_ASSERT( size == 1, block_log_unsupported_version, "invalid format for file ${file}", ("file",block_file_name.string()));
       ilog("block log version= ${version}",("version",version));
@@ -1106,6 +1285,10 @@ namespace eosio { namespace chain {
       }
 
       const uint64_t start_of_blocks = ftell(blk_in);
+
+      index_file_name = block_dir / "blocks.index";
+      ind_in = FC_FOPEN(index_file_name.generic_string().c_str(), "rb");
+      EOS_ASSERT( ind_in != nullptr, block_log_not_found, "cannot read file ${file}", ("file",index_file_name.string()) );
 
       const auto status = fseek(ind_in, 0, SEEK_END);                //get length of blocks.index (gives number of blocks)
       EOS_ASSERT( status == 0, block_log_exception, "cannot seek to ${file} end", ("file", index_file_name.string()) );
@@ -1155,7 +1338,7 @@ namespace eosio { namespace chain {
       EOS_ASSERT( size == 1, block_log_exception, "cannot read ${file} entry for block ${b}", ("file", index_file_name.string())("b",n) );
 
       //read blocks.log and verify block number n is found at the determined file position
-      const auto calc_blknum_pos = block_n_pos + blknum_offset;
+      const auto calc_blknum_pos = block_n_pos + detail::block_log_impl::blknum_offset_from_block_entry(version);
       status = fseek(blk_in, calc_blknum_pos, SEEK_SET);
       EOS_ASSERT( status == 0, block_log_exception, "cannot seek to ${file} ${pos} from beginning of file", ("file", block_file_name.string())("pos", calc_blknum_pos) );
       const uint64_t block_offset_pos = ftell(blk_in);
@@ -1171,4 +1354,53 @@ namespace eosio { namespace chain {
       return block_n_pos;
    }
 
-   } } /// eosio::chain
+   int block_log::trim_blocklog_end(fc::path block_dir, uint32_t n) {       //n is last block to keep (remove later blocks)
+      trim_data td(block_dir);
+
+      ilog("In directory ${block_dir} will trim all blocks after block ${n} from ${block_file} and ${index_file}",
+         ("block_dir", block_dir.generic_string())("n", n)("block_file",td.block_file_name.generic_string())("index_file", td.index_file_name.generic_string()));
+
+      if (n < td.first_block) {
+         dlog("All blocks are after block ${n} so do nothing (trim_end would delete entire blocks.log)",("n", n));
+         return 1;
+      }
+      if (n >= td.last_block) {
+         dlog("There are no blocks after block ${n} so do nothing",("n", n));
+         return 2;
+      }
+      const uint64_t end_of_new_file = td.block_pos(n + 1);
+      boost::filesystem::resize_file(td.block_file_name, end_of_new_file);
+      const uint64_t index_end= td.block_index(n) + sizeof(uint64_t);             //advance past record for block n
+      boost::filesystem::resize_file(td.index_file_name, index_end);
+      ilog("blocks.index has been trimmed to ${index_end} bytes", ("index_end", index_end));
+      return 0;
+   }
+
+   void block_log::smoke_test(fc::path block_dir) {
+      trim_data td(block_dir);
+      auto status = fseek(td.blk_in, -sizeof(uint64_t), SEEK_END);             //get last_block from blocks.log, compare to from blocks.index
+      EOS_ASSERT( status == 0, block_log_exception, "cannot seek to ${file} ${pos} from beginning of file", ("file", td.block_file_name.string())("pos", sizeof(uint64_t)) );
+      uint64_t file_pos;
+      auto size = fread((void*)&file_pos, sizeof(uint64_t), 1, td.blk_in);
+      EOS_ASSERT( size == 1, block_log_exception, "${file} read fails", ("file", td.block_file_name.string()) );
+      int blknum_offset = detail::block_log_impl::blknum_offset_from_block_entry(td.version);
+      status            = fseek(td.blk_in, file_pos + blknum_offset, SEEK_SET);
+      EOS_ASSERT( status == 0, block_log_exception, "cannot seek to ${file} ${pos} from beginning of file", ("file", td.block_file_name.string())("pos", file_pos + blknum_offset) );
+      uint32_t bnum;
+      size = fread((void*)&bnum, sizeof(uint32_t), 1, td.blk_in);
+      EOS_ASSERT( size == 1, block_log_exception, "${file} read fails", ("file", td.block_file_name.string()) );
+      bnum = fc::endian_reverse_u32(bnum) + 1;                       //convert from big endian to little endian and add 1
+      EOS_ASSERT( td.last_block == bnum, block_log_exception, "blocks.log says last block is ${lb} which disagrees with blocks.index", ("lb", bnum) );
+      ilog("blocks.log and blocks.index agree on number of blocks");
+      uint32_t delta = (td.last_block + 8 - td.first_block) >> 3;
+      if (delta < 1)
+         delta = 1;
+      for (uint32_t n = td.first_block; ; n += delta) {
+         if (n > td.last_block)
+            n = td.last_block;
+         td.block_pos(n);                                 //check block 'n' is where blocks.index says
+         if (n == td.last_block)
+            break;
+      }
+   }
+}} /// eosio::chain

--- a/libraries/chain/block_log.cpp
+++ b/libraries/chain/block_log.cpp
@@ -84,7 +84,9 @@ namespace eosio { namespace chain {
          //    3. The serialization of a pruned_block representation of the block for the entry including padding.
 
          std::size_t padded_size = block.maximum_pruned_pack_size(compression);
-         std::vector<char> buffer(padded_size + offset_to_block_start(block_log::max_supported_version));
+         static_assert( block_log::max_supported_version == 4,
+                     "Code was written to support format of version 4, need to update this code for latest format." );
+         std::vector<char>     buffer(padded_size + offset_to_block_start(block_log::max_supported_version));
          fc::datastream<char*> stream(buffer.data(), buffer.size());
 
          uint32_t offset      = buffer.size() + sizeof(uint64_t);

--- a/libraries/chain/include/eosio/chain/block_header.hpp
+++ b/libraries/chain/include/eosio/chain/block_header.hpp
@@ -75,7 +75,7 @@ namespace eosio { namespace chain {
    {
       signature_type    producer_signature;
    };
-
+   
 } } /// namespace eosio::chain
 
 FC_REFLECT(eosio::chain::block_header,

--- a/libraries/chain/include/eosio/chain/block_log.hpp
+++ b/libraries/chain/include/eosio/chain/block_log.hpp
@@ -79,7 +79,11 @@ namespace eosio { namespace chain {
 
          static bool trim_blocklog_front(const fc::path& block_dir, const fc::path& temp_dir, uint32_t truncate_at_block);
          static int  trim_blocklog_end(fc::path block_dir, uint32_t n);
-         static void smoke_test(fc::path block_dir);
+
+         /**
+          * @param n Only test 1 block out of every n blocks. If n is 0, it is maximum between 1 and the ceiling of the total number blocks divided by 8.
+          */
+         static void smoke_test(fc::path block_dir, uint32_t n);
 
    private:
          void open(const fc::path& data_dir);

--- a/libraries/chain/include/eosio/chain/block_log.hpp
+++ b/libraries/chain/include/eosio/chain/block_log.hpp
@@ -12,9 +12,9 @@ namespace eosio { namespace chain {
     * linked list of blocks. There is a secondary index file of only block positions that enables
     * O(1) random access lookup by block number.
     *
-    * +---------+----------------+---------+----------------+-----+------------+-------------------+
-    * | Block 1 | Pos of Block 1 | Block 2 | Pos of Block 2 | ... | Head Block | Pos of Head Block |
-    * +---------+----------------+---------+----------------+-----+------------+-------------------+
+    * +---------------+----------------+---------------+----------------+-----+------------------+-------------------+
+    * | Block 1 Entry | Pos of Block 1 | Block 2 Entry | Pos of Block 2 | ... | Head Block Entry | Pos of Head Block |
+    * +---------------+----------------+---------------+----------------+-----+------------------+-------------------+
     *
     * +----------------+----------------+-----+-------------------+
     * | Pos of Block 1 | Pos of Block 2 | ... | Pos of Head Block |
@@ -38,26 +38,25 @@ namespace eosio { namespace chain {
          block_log(block_log&& other);
          ~block_log();
 
-         uint64_t append(const signed_block_ptr& b);
-         void flush();
-         void reset( const genesis_state& gs, const signed_block_ptr& genesis_block );
-         void reset( const chain_id_type& chain_id, uint32_t first_block_num );
+         uint64_t append(const signed_block_ptr& block, packed_transaction::cf_compression_type segment_compression);
 
-         signed_block_ptr read_block(uint64_t file_pos)const;
-         void             read_block_header(block_header& bh, uint64_t file_pos)const;
-         signed_block_ptr read_block_by_num(uint32_t block_num)const;
+         void flush();
+
+         void reset( const genesis_state& gs, const signed_block_ptr& genesis_block, packed_transaction::cf_compression_type segment_compression);
+         void reset( const chain_id_type& chain_id, uint32_t first_block_num );
+         
          block_id_type    read_block_id_by_num(uint32_t block_num)const;
-         signed_block_ptr read_block_by_id(const block_id_type& id)const {
-            return read_block_by_num(block_header::num_from_id(id));
-         }
+
+         std::unique_ptr<signed_block>   read_signed_block_by_num(uint32_t block_num) const;
 
          /**
           * Return offset of block in file, or block_log::npos if it does not exist.
           */
-         uint64_t get_block_pos(uint32_t block_num) const;
-         signed_block_ptr        read_head()const;
-         const signed_block_ptr& head()const;
-         uint32_t                first_block_num() const;
+         uint64_t                       get_block_pos(uint32_t block_num) const;
+         const signed_block_ptr&        head() const;
+         uint32_t                       first_block_num() const;
+
+         void prune_transactions(uint32_t block_num, const vector<transaction_id_type>& ids);
 
          static const uint64_t npos = std::numeric_limits<uint64_t>::max();
 
@@ -79,35 +78,13 @@ namespace eosio { namespace chain {
          static bool is_supported_version(uint32_t version);
 
          static bool trim_blocklog_front(const fc::path& block_dir, const fc::path& temp_dir, uint32_t truncate_at_block);
+         static int  trim_blocklog_end(fc::path block_dir, uint32_t n);
+         static void smoke_test(fc::path block_dir);
 
    private:
          void open(const fc::path& data_dir);
          void construct_index();
 
          std::unique_ptr<detail::block_log_impl> my;
-   };
-
-//to derive blknum_offset==14 see block_header.hpp and note on disk struct is packed
-//   block_timestamp_type timestamp;                  //bytes 0:3
-//   account_name         producer;                   //bytes 4:11
-//   uint16_t             confirmed;                  //bytes 12:13
-//   block_id_type        previous;                   //bytes 14:45, low 4 bytes is big endian block number of previous block
-
-   struct trim_data {            //used by trim_blocklog_front(), trim_blocklog_end(), and smoke_test()
-      trim_data(fc::path block_dir);
-      ~trim_data();
-      uint64_t block_index(uint32_t n) const;
-      uint64_t block_pos(uint32_t n);
-      fc::path block_file_name, index_file_name;        //full pathname for blocks.log and blocks.index
-      uint32_t version = 0;                              //blocklog version
-      uint32_t first_block = 0;                          //first block in blocks.log
-      uint32_t last_block = 0;                          //last block in blocks.log
-      FILE* blk_in = nullptr;                            //C style files for reading blocks.log and blocks.index
-      FILE* ind_in = nullptr;                            //C style files for reading blocks.log and blocks.index
-      //we use low level file IO because it is distinctly faster than C++ filebuf or iostream
-      uint64_t first_block_pos = 0;                      //file position in blocks.log for the first block in the log
-      chain_id_type chain_id;
-
-      static constexpr int blknum_offset{14};            //offset from start of block to 4 byte block number, valid for the only allowed versions
    };
 } }

--- a/libraries/chain/include/eosio/chain/block_log.hpp
+++ b/libraries/chain/include/eosio/chain/block_log.hpp
@@ -56,7 +56,10 @@ namespace eosio { namespace chain {
          const signed_block_ptr&        head() const;
          uint32_t                       first_block_num() const;
 
-         void prune_transactions(uint32_t block_num, const vector<transaction_id_type>& ids);
+         /**
+          *  @returns The number of transactions been pruned
+          **/
+         size_t prune_transactions(uint32_t block_num, const vector<transaction_id_type>& ids);
 
          static const uint64_t npos = std::numeric_limits<uint64_t>::max();
 

--- a/libraries/chain/include/eosio/chain/transaction.hpp
+++ b/libraries/chain/include/eosio/chain/transaction.hpp
@@ -70,12 +70,6 @@ namespace eosio { namespace chain {
       uint8_t                max_cpu_usage_ms    = 0; /// upper limit on the total CPU time billed for this transaction
       fc::unsigned_int       delay_sec           = 0UL; /// number of seconds to delay this transaction for during which it may be canceled.
 
-      /**
-       * @return the absolute block number given the relative ref_block_num
-       */
-      block_num_type get_ref_blocknum( block_num_type head_blocknum )const {
-         return ((head_blocknum/0xffff)*0xffff) + head_blocknum%0xffff;
-      }
       void set_reference_block( const block_id_type& reference_block );
       bool verify_reference_block( const block_id_type& reference_block )const;
       void validate()const;

--- a/libraries/chain/include/eosio/chain/transaction.hpp
+++ b/libraries/chain/include/eosio/chain/transaction.hpp
@@ -203,10 +203,12 @@ namespace eosio { namespace chain {
       friend struct packed_transaction;
       void reflector_init();
    private:
-      vector<signature_type>                  signatures;
-      fc::enum_type<uint8_t,compression_type> compression;
-      bytes                                   packed_context_free_data;
-      bytes                                   packed_trx;
+     friend struct pruned_transaction;
+     friend struct prunable_transaction_data;
+     vector<signature_type>                   signatures;
+     fc::enum_type<uint8_t, compression_type> compression;
+     bytes                                    packed_context_free_data;
+     bytes                                    packed_trx;
 
    private:
       // cache unpacked trx, for thread safety do not modify after construction

--- a/pipeline.jsonc
+++ b/pipeline.jsonc
@@ -40,7 +40,7 @@
         "test":
         [
             {
-                "commit": "17f1fc9c6b20d30b4febd9a69c61c7bee237f3b9"
+                "commit": "8f96b7a03f28b2ec1f03d37779bba294cded9ba7"
             }
         ]
     }

--- a/programs/eosio-blocklog/main.cpp
+++ b/programs/eosio-blocklog/main.cpp
@@ -228,7 +228,7 @@ bool trim_blocklog_front(bfs::path block_dir, uint32_t n) {        //n is first 
 void smoke_test(bfs::path block_dir) {
    using namespace std;
    cout << "\nSmoke test of blocks.log and blocks.index in directory " << block_dir << '\n';
-   block_log::smoke_test(block_dir);
+   block_log::smoke_test(block_dir, 0);
    cout << "\nno problems found\n"; // if get here there were no exceptions
 }
 

--- a/programs/eosio-blocklog/main.cpp
+++ b/programs/eosio-blocklog/main.cpp
@@ -68,7 +68,7 @@ struct report_time {
 void blocklog::read_log() {
    report_time rt("reading log");
    block_log block_logger(blocks_dir);
-   const auto end = block_logger.read_head();
+   const auto end = block_logger.head();
    EOS_ASSERT( end, block_log_exception, "No blocks found in block log" );
    EOS_ASSERT( end->block_num() > 1, block_log_exception, "Only one block found in block log" );
 
@@ -118,10 +118,9 @@ void blocklog::read_log() {
    if (as_json_array)
       *out << "[";
    uint32_t block_num = (first_block < 1) ? 1 : first_block;
-   signed_block_ptr next;
    fc::variant pretty_output;
    const fc::microseconds deadline = fc::seconds(10);
-   auto print_block = [&](signed_block_ptr& next) {
+   auto print_block = [&](auto& next) {
       abi_serializer::to_variant(*next,
                                  pretty_output,
                                  []( account_name n ) { return optional<abi_serializer>(); },
@@ -140,10 +139,12 @@ void blocklog::read_log() {
          *out << fc::json::to_pretty_string(v) << "\n";
    };
    bool contains_obj = false;
-   while((block_num <= last_block) && (next = block_logger.read_block_by_num( block_num ))) {
+   while( block_num <= last_block ) {
+      auto sb = block_logger.read_signed_block_by_num( block_num );
+      if( !sb ) break;
       if (as_json_array && contains_obj)
          *out << ",";
-      print_block(next);
+      print_block(sb);
       ++block_num;
       contains_obj = true;
    }
@@ -210,26 +211,10 @@ void blocklog::initialize(const variables_map& options) {
 }
 
 int trim_blocklog_end(bfs::path block_dir, uint32_t n) {       //n is last block to keep (remove later blocks)
-   report_time rt("trimming blocklog end");
-   using namespace std;
-   trim_data td(block_dir);
-   cout << "\nIn directory " << block_dir << " will trim all blocks after block " << n << " from "
-        << td.block_file_name.generic_string() << " and " << td.index_file_name.generic_string() << ".\n";
-   if (n < td.first_block) {
-      cerr << "All blocks are after block " << n << " so do nothing (trim_end would delete entire blocks.log)\n";
-      return 1;
-   }
-   if (n >= td.last_block) {
-      cerr << "There are no blocks after block " << n << " so do nothing\n";
-      return 2;
-   }
-   const uint64_t end_of_new_file = td.block_pos(n + 1);
-   bfs::resize_file(td.block_file_name, end_of_new_file);
-   const uint64_t index_end= td.block_index(n) + sizeof(uint64_t);             //advance past record for block n
-   bfs::resize_file(td.index_file_name, index_end);
-   cout << "blocks.index has been trimmed to " << index_end << " bytes\n";
+   report_time rt("trimming blocklog end");   
+   int ret = block_log::trim_blocklog_end(block_dir, n);
    rt.report();
-   return 0;
+   return ret;
 }
 
 bool trim_blocklog_front(bfs::path block_dir, uint32_t n) {        //n is first block to keep (remove prior blocks)
@@ -243,31 +228,8 @@ bool trim_blocklog_front(bfs::path block_dir, uint32_t n) {        //n is first 
 void smoke_test(bfs::path block_dir) {
    using namespace std;
    cout << "\nSmoke test of blocks.log and blocks.index in directory " << block_dir << '\n';
-   trim_data td(block_dir);
-   auto status = fseek(td.blk_in, -sizeof(uint64_t), SEEK_END);             //get last_block from blocks.log, compare to from blocks.index
-   EOS_ASSERT( status == 0, block_log_exception, "cannot seek to ${file} ${pos} from beginning of file", ("file", td.block_file_name.string())("pos", sizeof(uint64_t)) );
-   uint64_t file_pos;
-   auto size = fread((void*)&file_pos, sizeof(uint64_t), 1, td.blk_in);
-   EOS_ASSERT( size == 1, block_log_exception, "${file} read fails", ("file", td.block_file_name.string()) );
-   status = fseek(td.blk_in, file_pos + trim_data::blknum_offset, SEEK_SET);
-   EOS_ASSERT( status == 0, block_log_exception, "cannot seek to ${file} ${pos} from beginning of file", ("file", td.block_file_name.string())("pos", file_pos + trim_data::blknum_offset) );
-   uint32_t bnum;
-   size = fread((void*)&bnum, sizeof(uint32_t), 1, td.blk_in);
-   EOS_ASSERT( size == 1, block_log_exception, "${file} read fails", ("file", td.block_file_name.string()) );
-   bnum = endian_reverse_u32(bnum) + 1;                       //convert from big endian to little endian and add 1
-   EOS_ASSERT( td.last_block == bnum, block_log_exception, "blocks.log says last block is ${lb} which disagrees with blocks.index", ("lb", bnum) );
-   cout << "blocks.log and blocks.index agree on number of blocks\n";
-   uint32_t delta = (td.last_block + 8 - td.first_block) >> 3;
-   if (delta < 1)
-      delta = 1;
-   for (uint32_t n = td.first_block; ; n += delta) {
-      if (n > td.last_block)
-         n = td.last_block;
-      td.block_pos(n);                                 //check block 'n' is where blocks.index says
-      if (n == td.last_block)
-         break;
-   }
-   cout << "\nno problems found\n";                         //if get here there were no exceptions
+   block_log::smoke_test(block_dir);
+   cout << "\nno problems found\n"; // if get here there were no exceptions
 }
 
 int main(int argc, char** argv) {

--- a/tests/nodeos_multiple_version_protocol_feature_test.py
+++ b/tests/nodeos_multiple_version_protocol_feature_test.py
@@ -195,12 +195,11 @@ try:
     oldNode.relaunch(oldNodeId, chainArg="--import-reversible-blocks {}".format(portableRevBlkPath), timeout=1, nodeosPath="programs/nodeos/nodeos")
     os.remove(portableRevBlkPath)
 
-# TODO re-enable in PR 8891
-#    restartNode(oldNode, oldNodeId, chainArg="--replay", nodeosPath="programs/nodeos/nodeos")
-#    time.sleep(2) # Give some time to replay
-#
-#    assert areNodesInSync(allNodes), "All nodes should be in sync"
-#    assert shouldNodeContainPreactivateFeature(oldNode), "4th node should contain PREACTIVATE_FEATURE"
+    restartNode(oldNode, oldNodeId, chainArg="--replay", nodeosPath="programs/nodeos/nodeos")
+    time.sleep(2) # Give some time to replay
+
+    assert areNodesInSync(allNodes), "All nodes should be in sync"
+    assert shouldNodeContainPreactivateFeature(oldNode), "4th node should contain PREACTIVATE_FEATURE"
 
     testSuccessful = True
 finally:

--- a/unittests/restart_chain_tests.cpp
+++ b/unittests/restart_chain_tests.cpp
@@ -250,7 +250,7 @@ BOOST_AUTO_TEST_CASE(test_restart_with_different_chain_id) {
 }
 
 BOOST_FIXTURE_TEST_CASE(test_restart_from_block_log, restart_from_block_log_test_fixture) {
-   BOOST_REQUIRE_NO_THROW(block_log::smoke_test(chain.get_config().blocks_dir));
+   BOOST_REQUIRE_NO_THROW(block_log::smoke_test(chain.get_config().blocks_dir, 1));
 }
 
 BOOST_FIXTURE_TEST_CASE(test_restart_from_trimed_block_log, restart_from_block_log_test_fixture) {
@@ -264,8 +264,10 @@ BOOST_FIXTURE_TEST_CASE(test_light_validation_restart_from_block_log, light_vali
 }
 
 BOOST_FIXTURE_TEST_CASE(test_light_validation_restart_from_block_log_with_pruned_trx, light_validation_restart_from_block_log_test_fixture) {
-   block_log blog(chain.get_config().blocks_dir);
+   const auto& blocks_dir = chain.get_config().blocks_dir;
+   block_log blog(blocks_dir);
    BOOST_REQUIRE_NO_THROW(blog.prune_transactions(trace->block_num, std::vector<transaction_id_type>{trace->id}));
+   BOOST_REQUIRE_NO_THROW(block_log::repair_log(blocks_dir));
 }
 
 BOOST_AUTO_TEST_CASE(test_trim_blocklog_front) {
@@ -283,7 +285,7 @@ BOOST_AUTO_TEST_CASE(test_trim_blocklog_front) {
    bfs::copy(blocks_dir / "blocks.index", temp1 / "blocks.index");
    auto temp2 = bfs::unique_path();
    BOOST_REQUIRE_NO_THROW(block_log::trim_blocklog_front(temp1, temp2, 10));
-   BOOST_REQUIRE_NO_THROW(block_log::smoke_test(temp1));
+   BOOST_REQUIRE_NO_THROW(block_log::smoke_test(temp1, 1));
    bfs::remove_all(temp1);
    bfs::remove_all(temp2);
 }

--- a/unittests/restart_chain_tests.cpp
+++ b/unittests/restart_chain_tests.cpp
@@ -266,7 +266,7 @@ BOOST_FIXTURE_TEST_CASE(test_light_validation_restart_from_block_log, light_vali
 BOOST_FIXTURE_TEST_CASE(test_light_validation_restart_from_block_log_with_pruned_trx, light_validation_restart_from_block_log_test_fixture) {
    const auto& blocks_dir = chain.get_config().blocks_dir;
    block_log blog(blocks_dir);
-   BOOST_REQUIRE_NO_THROW(blog.prune_transactions(trace->block_num, std::vector<transaction_id_type>{trace->id}));
+   BOOST_CHECK(blog.prune_transactions(trace->block_num, std::vector<transaction_id_type>{trace->id}) == 1);
    BOOST_REQUIRE_NO_THROW(block_log::repair_log(blocks_dir));
 }
 


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
This PR create fro block log version 4 which changes each block entry from the serialization of signed_block to the tuple of offset to the next entry, compression_status and pruned_block.

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [x] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->
Some member functions uses signed_block_ptr are marked as deprecated. The usages of those should be replaced by their counterparts with pruned_block_ptr in the future. 

## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
