### PR TITLE
Increase get info priority to medium high

### DIFF
--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -79,7 +79,7 @@ void chain_api_plugin::plugin_startup() {
    ro_api.set_shorten_abi_errors( !_http_plugin.verbose_errors() );
 
    _http_plugin.add_api({
-      CHAIN_RO_CALL(get_info, 200)}, appbase::priority::medium);
+      CHAIN_RO_CALL(get_info, 200)}, appbase::priority::medium_high);
    _http_plugin.add_api({
       CHAIN_RO_CALL(get_activated_protocol_features, 200),
       CHAIN_RO_CALL(get_block, 200),


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
related issue #8655
Raise the priority of get_info call for better user response time.

Call tests (30 minutes, 16 threads):
Thread 0, run 8783 times, total(s): 1799.95, avg(ms): 204.94, min(ms): 26.27, max(ms): 20048.91
Thread 1, run 8893 times, total(s): 1800.00, avg(ms): 202.41, min(ms): 22.18, max(ms): 1103.01
Thread 2, run 8904 times, total(s): 1800.00, avg(ms): 202.16, min(ms): 23.07, max(ms): 1096.16
Thread 3, run 8902 times, total(s): 1799.97, avg(ms): 202.20, min(ms): 23.01, max(ms): 1109.02
Thread 4, run 8903 times, total(s): 1799.97, avg(ms): 202.18, min(ms): 23.67, max(ms): 1084.24
Thread 5, run 8898 times, total(s): 1799.98, avg(ms): 202.29, min(ms): 23.92, max(ms): 1100.79
Thread 6, run 8898 times, total(s): 1799.98, avg(ms): 202.29, min(ms): 23.11, max(ms): 1100.67
Thread 7, run 8901 times, total(s): 1799.97, avg(ms): 202.22, min(ms): 23.82, max(ms): 1101.24
Thread 8, run 8901 times, total(s): 1799.97, avg(ms): 202.22, min(ms): 26.60, max(ms): 1104.36
Thread 9, run 8912 times, total(s): 1799.97, avg(ms): 201.97, min(ms): 24.14, max(ms): 1101.28
Thread 10, run 8905 times, total(s): 1799.97, avg(ms): 202.13, min(ms): 26.16, max(ms): 1078.42
Thread 11, run 8912 times, total(s): 1799.97, avg(ms): 201.97, min(ms): 24.14, max(ms): 1100.37
Thread 12, run 8906 times, total(s): 1799.97, avg(ms): 202.11, min(ms): 25.64, max(ms): 1095.99
Thread 13, run 8909 times, total(s): 1799.97, avg(ms): 202.04, min(ms): 22.83, max(ms): 1114.09
Thread 14, run 8902 times, total(s): 1799.97, avg(ms): 202.20, min(ms): 24.95, max(ms): 1095.62
Thread 15, run 8900 times, total(s): 1799.99, avg(ms): 202.25, min(ms): 24.39, max(ms): 1108.46

The max time is 20 sec.  it is an improvement, not an ultimate solution yet.

BTW, during get_info calls, NOT seen a significant impact on nodeos syncing latency time, 

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
