### PR TITLE
Account Query DB : Proposal to maintain get_(key|controlled)_accounts [2.0]

### DIFF
--- a/plugins/chain_api_plugin/chain.swagger.yaml
+++ b/plugins/chain_api_plugin/chain.swagger.yaml
@@ -692,14 +692,16 @@ paths:
               properties:
                 accounts:
                   type: array
-                  description: List of authorizing accounts
+                  description: List of authorizing accounts and/or actor/permissions
                   items:
-                    type: string
+                    anyOf:
+                      - $ref: "https://eosio.github.io/schemata/v2.0/oas/Name.yaml"
+                      - $ref: "https://eosio.github.io/schemata/v2.0/oas/Authority.yaml"
                 keys:
                   type: array
                   description: List of authorizing keys
                   items:
-                    type: string
+                    $ref: "https://eosio.github.io/schemata/v2.0/oas/PublicKey.yaml"
       responses:
         "200":
           description: OK

--- a/plugins/chain_api_plugin/chain.swagger.yaml
+++ b/plugins/chain_api_plugin/chain.swagger.yaml
@@ -680,3 +680,61 @@ paths:
                   more:
                     type: integer
                     description: "In case there's more activated protocol features than the input parameter `limit` requested, returns the ordinal of the next activated protocol feature which was not returned, otherwise zero."
+  /get_accounts_by_authorizers:
+    post:
+      description: Given a set of account names and public keys, find all account permission authorities that are, in part or whole, satisfiable
+      operationId: get_accounts_by_authorizers
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                accounts:
+                  type: array
+                  description: List of authorizing accounts
+                  items:
+                    type: string
+                keys:
+                  type: array
+                  description: List of authorizing keys
+                  items:
+                    type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                description: Result containing a list of accounts which are authorized, in whole or part, by the provided accounts and keys
+                required:
+                  - accounts
+                properties:
+                  accounts:
+                    type: array
+                    description: An array of each account,permission,authorizing-data triplet in the response
+                    items:
+                      type: object
+                      description: the information for a single account,permission,authorizing-data triplet
+                      required:
+                        - account_name
+                        - permission_name
+                        - authorizer
+                        - weight
+                        - threshold
+                      properties:
+                        account_name:
+                          $ref: "https://eosio.github.io/schemata/v2.0/oas/Name.yaml"
+                        permission_name:
+                          $ref: "https://eosio.github.io/schemata/v2.0/oas/Name.yaml"
+                        authorizer:
+                          oneOf:
+                            - $ref: "https://eosio.github.io/schemata/v2.0/oas/PublicKey.yaml"
+                            - $ref: "https://eosio.github.io/schemata/v2.0/oas/Authority.yaml"
+                        weight:
+                          type: "integer"
+                          description: the weight that this authorizer adds to satisfy the permission
+                        threshold:
+                          type: "integer"
+                          description: the sum of weights that must be met or exceeded to satisfy the permission

--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -66,7 +66,6 @@ namespace {
    [api_handle](string, string body, url_response_callback cb) mutable { \
           api_handle.validate(); \
           try { \
-             if (body.empty()) body = "{}"; \
              auto params = parse_params<api_namespace::call_name ## _params>(body);\
              fc::variant result( api_handle.call_name( std::move(params) ) ); \
              cb(http_response_code, std::move(result)); \

--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -35,7 +35,7 @@ namespace {
    template<typename T>
    T parse_params(const std::string& body) {
       if (body.empty()) {
-         return {};
+         EOS_THROW(chain::invalid_http_request, "A Request body is required");
       }
 
       try {

--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -141,7 +141,7 @@ void chain_api_plugin::plugin_startup() {
    });
 
    if (chain.account_queries_enabled()) {
-      _http_plugin.add_api({
+      _http_plugin.add_async_api({
          CHAIN_RO_CALL_WITH_400(get_accounts_by_authorizers, 200),
       });
    }

--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -34,13 +34,17 @@ struct async_result_visitor : public fc::visitor<fc::variant> {
 namespace {
    template<typename T>
    T parse_params(const std::string& body) {
-     if (body.empty()) {
-       return {};
-     }
+      if (body.empty()) {
+         return {};
+      }
 
-     try {
-       return fc::json::from_string(body).as<T>();
-     } EOS_RETHROW_EXCEPTIONS(chain::invalid_http_request, "Unable to parse valid input from ${body}", ("body", body));
+      try {
+        try {
+           return fc::json::from_string(body).as<T>();
+        } catch (const chain::chain_exception& e) { // EOS_RETHROW_EXCEPTIONS does not re-type these so, re-code it
+          throw fc::exception(e);
+        }
+      } EOS_RETHROW_EXCEPTIONS(chain::invalid_http_request, "Unable to parse valid input from POST body");
    }
 }
 

--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -31,6 +31,19 @@ struct async_result_visitor : public fc::visitor<fc::variant> {
    }
 };
 
+namespace {
+   template<typename T>
+   T parse_params(const std::string& body) {
+     if (body.empty()) {
+       return {};
+     }
+
+     try {
+       return fc::json::from_string(body).as<T>();
+     } EOS_RETHROW_EXCEPTIONS(chain::invalid_http_request, "Unable to parse valid input from ${body}", ("body", body));
+   }
+}
+
 #define CALL(api_name, api_handle, api_namespace, call_name, http_response_code) \
 {std::string("/v1/" #api_name "/" #call_name), \
    [api_handle](string, string body, url_response_callback cb) mutable { \
@@ -38,6 +51,20 @@ struct async_result_visitor : public fc::visitor<fc::variant> {
           try { \
              if (body.empty()) body = "{}"; \
              fc::variant result( api_handle.call_name(fc::json::from_string(body).as<api_namespace::call_name ## _params>()) ); \
+             cb(http_response_code, std::move(result)); \
+          } catch (...) { \
+             http_plugin::handle_exception(#api_name, #call_name, body, cb); \
+          } \
+       }}
+
+#define CALL_WITH_400(api_name, api_handle, api_namespace, call_name, http_response_code) \
+{std::string("/v1/" #api_name "/" #call_name), \
+   [api_handle](string, string body, url_response_callback cb) mutable { \
+          api_handle.validate(); \
+          try { \
+             if (body.empty()) body = "{}"; \
+             auto params = parse_params<api_namespace::call_name ## _params>(body);\
+             fc::variant result( api_handle.call_name( std::move(params) ) ); \
              cb(http_response_code, std::move(result)); \
           } catch (...) { \
              http_plugin::handle_exception(#api_name, #call_name, body, cb); \
@@ -68,6 +95,8 @@ struct async_result_visitor : public fc::visitor<fc::variant> {
 #define CHAIN_RW_CALL(call_name, http_response_code) CALL(chain, rw_api, chain_apis::read_write, call_name, http_response_code)
 #define CHAIN_RO_CALL_ASYNC(call_name, call_result, http_response_code) CALL_ASYNC(chain, ro_api, chain_apis::read_only, call_name, call_result, http_response_code)
 #define CHAIN_RW_CALL_ASYNC(call_name, call_result, http_response_code) CALL_ASYNC(chain, rw_api, chain_apis::read_write, call_name, call_result, http_response_code)
+
+#define CHAIN_RO_CALL_WITH_400(call_name, http_response_code) CALL_WITH_400(chain, ro_api, chain_apis::read_only, call_name, http_response_code)
 
 void chain_api_plugin::plugin_startup() {
    ilog( "starting chain_api_plugin" );
@@ -110,7 +139,7 @@ void chain_api_plugin::plugin_startup() {
 
    if (chain.account_queries_enabled()) {
       _http_plugin.add_api({
-         CHAIN_RO_CALL(get_accounts_by_authorizers, 200),
+         CHAIN_RO_CALL_WITH_400(get_accounts_by_authorizers, 200),
       });
    }
 }

--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -72,8 +72,9 @@ struct async_result_visitor : public fc::visitor<fc::variant> {
 void chain_api_plugin::plugin_startup() {
    ilog( "starting chain_api_plugin" );
    my.reset(new chain_api_plugin_impl(app().get_plugin<chain_plugin>().chain()));
-   auto ro_api = app().get_plugin<chain_plugin>().get_read_only_api();
-   auto rw_api = app().get_plugin<chain_plugin>().get_read_write_api();
+   auto& chain = app().get_plugin<chain_plugin>();
+   auto ro_api = chain.get_read_only_api();
+   auto rw_api = chain.get_read_write_api();
 
    auto& _http_plugin = app().get_plugin<http_plugin>();
    ro_api.set_shorten_abi_errors( !_http_plugin.verbose_errors() );
@@ -106,6 +107,12 @@ void chain_api_plugin::plugin_startup() {
       CHAIN_RW_CALL_ASYNC(push_transactions, chain_apis::read_write::push_transactions_results, 202),
       CHAIN_RW_CALL_ASYNC(send_transaction, chain_apis::read_write::send_transaction_results, 202)
    });
+
+   if (chain.account_queries_enabled()) {
+      _http_plugin.add_api({
+         CHAIN_RO_CALL(get_accounts_by_authorizers, 200),
+      });
+   }
 }
 
 void chain_api_plugin::plugin_shutdown() {}

--- a/plugins/chain_plugin/CMakeLists.txt
+++ b/plugins/chain_plugin/CMakeLists.txt
@@ -1,5 +1,6 @@
 file(GLOB HEADERS "include/eosio/chain_plugin/*.hpp")
 add_library( chain_plugin
+             account_query_db.cpp
              chain_plugin.cpp
              ${HEADERS} )
 

--- a/plugins/chain_plugin/account_query_db.cpp
+++ b/plugins/chain_plugin/account_query_db.cpp
@@ -71,6 +71,15 @@ namespace {
    }
 
    using name_pair_t = eosio::chain_apis::account_query_db::get_accounts_by_authorizers_params::account_level;
+
+   template<typename Output, typename Input>
+   auto make_optional_authorizer(const Input& authorizer) -> fc::optional<Output> {
+      if constexpr (std::is_same_v<Input, Output>) {
+         return authorizer;
+      } else {
+         return {};
+      }
+   }
 }
 
 namespace std {
@@ -344,12 +353,11 @@ namespace eosio::chain_apis {
           * Add a single result entry
           */
          auto push_result = [&result](const auto& po, const auto& authorizer, auto weight) {
-            fc::variant v;
-            fc::to_variant(authorizer, v);
             result.accounts.emplace_back(result_t::account_result{
                   po.owner,
                   po.name,
-                  v,
+                  make_optional_authorizer<chain::permission_level>(authorizer),
+                  make_optional_authorizer<chain::public_key_type>(authorizer),
                   weight,
                   po.auth.threshold
             });

--- a/plugins/chain_plugin/account_query_db.cpp
+++ b/plugins/chain_plugin/account_query_db.cpp
@@ -59,7 +59,7 @@ namespace {
     * @return
     */
    bool is_onblock(const chain::transaction_trace_ptr& p) {
-      if (p->action_traces.size() != 1)
+      if (p->action_traces.empty())
          return false;
       const auto& act = p->action_traces[0].act;
       if (act.account != eosio::chain::config::system_account_name || act.name != N(onblock) ||

--- a/plugins/chain_plugin/account_query_db.cpp
+++ b/plugins/chain_plugin/account_query_db.cpp
@@ -97,7 +97,7 @@ namespace eosio::chain_apis {
        * blockchain state at the current HEAD
        */
       void build_account_query_map() {
-         ilog("Building account query maps");
+         ilog("Building account query DB");
          auto start = fc::time_point::now();
          const auto& index = controller.db().get_index<chain::permission_index>().indices().get<by_id>();
 
@@ -106,7 +106,7 @@ namespace eosio::chain_apis {
             add_to_bimaps(*pi, po);
          }
          auto duration = fc::time_point::now() - start;
-         ilog("Finished building account query maps in ${sec}", ("sec", (duration.count() / 1'000'000.0 )));
+         ilog("Finished building account query DB in ${sec}", ("sec", (duration.count() / 1'000'000.0 )));
       }
 
       /**

--- a/plugins/chain_plugin/account_query_db.cpp
+++ b/plugins/chain_plugin/account_query_db.cpp
@@ -1,0 +1,329 @@
+#include <eosio/chain_plugin/account_query_db.hpp>
+
+#include <eosio/chain/contract_types.hpp>
+#include <eosio/chain/controller.hpp>
+#include <eosio/chain/permission_object.hpp>
+
+#include <boost/multi_index_container.hpp>
+#include <boost/multi_index/ordered_index.hpp>
+#include <boost/multi_index/composite_key.hpp>
+#include <boost/multi_index/member.hpp>
+
+#include <boost/bimap.hpp>
+#include <boost/bimap/multiset_of.hpp>
+#include <boost/bimap/set_of.hpp>
+
+using namespace eosio;
+using namespace boost::multi_index;
+using namespace boost::bimaps;
+
+namespace {
+   struct permission_info {
+      chain::name owner;
+      chain::name name;
+      fc::time_point last_updated;
+
+      using cref = std::reference_wrapper<const permission_info>;
+   };
+
+   struct by_owner_name;
+   struct by_last_updated;
+
+   using permission_info_index_t = multi_index_container<
+      permission_info,
+      indexed_by<
+         ordered_unique<
+            tag<by_owner_name>,
+            composite_key<permission_info,
+               member<permission_info, chain::name, &permission_info::owner>,
+               member<permission_info, chain::name, &permission_info::name>
+            >
+         >,
+         ordered_non_unique<
+            tag<by_last_updated>,
+            member<permission_info, fc::time_point, &permission_info::last_updated>
+         >
+      >
+   >;
+
+   bool is_onblock(const chain::transaction_trace_ptr& p) {
+      if (p->action_traces.size() != 1)
+         return false;
+      const auto& act = p->action_traces[0].act;
+      if (act.account != eosio::chain::config::system_account_name || act.name != N(onblock) ||
+          act.authorization.size() != 1)
+         return false;
+      const auto& auth = act.authorization[0];
+      return auth.actor == eosio::chain::config::system_account_name &&
+             auth.permission == eosio::chain::config::active_name;
+   }
+}
+
+namespace std {
+   template<>
+   struct less<permission_info::cref> {
+      bool operator()( const permission_info::cref& lhs, const permission_info::cref& rhs ) const {
+         return std::uintptr_t(&lhs.get()) < std::uintptr_t(&rhs.get());
+      }
+   };
+}
+
+namespace eosio::chain_apis {
+   struct account_query_db_impl {
+      account_query_db_impl(const chain::controller& controller)
+      :controller(controller)
+      {}
+
+      void build_account_query_map() {
+         ilog("Building account query maps");
+         auto start = fc::time_point::now();
+         const auto& index = controller.db().get_index<chain::permission_index>().indices().get<by_id>();
+
+         for (const auto& po : index ) {
+            const auto& pi = permission_info_index.emplace( permission_info{ po.owner, po.name, po.last_updated } ).first;
+            add_to_bimaps(*pi, po);
+         }
+         auto duration = fc::time_point::now() - start;
+         ilog("Finished building account query maps in ${sec}", ("sec", (duration.count() / 1'000'000.0 )));
+      }
+
+      void add_to_bimaps( const permission_info& pi, const chain::permission_object& po ) {
+         for (const auto& a : po.auth.accounts) {
+            name_bimap.insert(name_bimap_t::value_type {a.permission.actor, pi});
+         }
+
+         for (const auto& k: po.auth.keys) {
+            key_bimap.insert(key_bimap_t::value_type {(chain::public_key_type)k.key, pi});
+         }
+      }
+
+      void remove_from_bimaps( const permission_info& p ) {
+         const auto name_range = name_bimap.right.equal_range(p);
+         name_bimap.right.erase(name_range.first, name_range.second);
+
+         const auto key_range = key_bimap.right.equal_range(p);
+         key_bimap.right.erase(key_range.first, key_range.second);
+      }
+
+      void rollback_to_before( const fc::time_point& t ) {
+         auto& index = permission_info_index.get<by_last_updated>();
+         const auto& permission_by_owner = controller.db().get_index<chain::permission_index>().indices().get<chain::by_owner>();
+
+         while (!index.empty()) {
+            const auto& pi = (*index.rbegin());
+            if (pi.last_updated < t) {
+               break;
+            }
+
+            // remove this entry from the bimaps
+            remove_from_bimaps(pi);
+
+            auto itr = permission_by_owner.find(std::make_tuple(pi.owner, pi.name));
+            if (itr == permission_by_owner.end()) {
+               // this permission does not exist at this point in the chains history
+               index.erase(index.iterator_to(pi));
+            } else {
+               const auto& po = *itr;
+               index.modify(index.iterator_to(pi), [&po](auto& mutable_pi) {
+                  mutable_pi.last_updated = po.last_updated;
+               });
+               add_to_bimaps(pi, po);
+            }
+         }
+      }
+
+      void cache_transaction_trace( const chain::transaction_trace_ptr& trace ) {
+         if( !trace->receipt ) return;
+         // include only executed transactions; soft_fail included so that onerror (and any inlines via onerror) are included
+         if((trace->receipt->status != chain::transaction_receipt_header::executed &&
+             trace->receipt->status != chain::transaction_receipt_header::soft_fail)) {
+            return;
+         }
+         if( is_onblock( trace )) {
+            onblock_trace.emplace( trace );
+         } else if( trace->failed_dtrx_trace ) {
+            cached_trace_map[trace->failed_dtrx_trace->id] = trace;
+         } else {
+            cached_trace_map[trace->id] = trace;
+         }
+      }
+
+      void commit_block(const chain::block_state_ptr& bsp ) {
+         using permission_set_t = std::set<name_pair_t>;
+
+         permission_set_t updated;
+         permission_set_t deleted;
+
+         auto process_trace = [&](const chain::transaction_trace_ptr& trace) {
+            for( const auto& at : trace->action_traces ) {
+               if (std::tie(at.receiver, at.act.account) != std::tie(chain::config::system_account_name,chain::config::system_account_name)) {
+                  continue;
+               }
+
+               if (at.act.name == chain::updateauth::get_name()) {
+                  auto data = at.act.data_as<chain::updateauth>();
+                  auto itr = updated.emplace(data.account, data.permission).first;
+                  deleted.erase(*itr);
+               } else if (at.act.name == chain::deleteauth::get_name()) {
+                  auto data = at.act.data_as<chain::deleteauth>();
+                  auto itr = deleted.emplace(data.account, data.permission).first;
+                  updated.erase(*itr);
+               }
+            }
+         };
+
+         rollback_to_before(bsp->block->timestamp.to_time_point());
+
+         if( onblock_trace )
+            process_trace(*onblock_trace);
+
+         for( const auto& r : bsp->block->transactions ) {
+            chain::transaction_id_type id;
+            if( r.trx.contains<chain::transaction_id_type>()) {
+               id = r.trx.get<chain::transaction_id_type>();
+            } else {
+               id = r.trx.get<chain::packed_transaction>().id();
+            }
+
+            const auto it = cached_trace_map.find( id );
+            if( it != cached_trace_map.end() ) {
+               process_trace( it->second );
+            }
+         }
+
+         auto& index = permission_info_index.get<by_owner_name>();
+         const auto& permission_by_owner = controller.db().get_index<chain::permission_index>().indices().get<chain::by_owner>();
+
+         for (const auto& up: updated) {
+            auto source_itr = permission_by_owner.find(up);
+            EOS_ASSERT(source_itr != permission_by_owner.end(), chain::plugin_exception, "chain data is missing");
+            auto itr = index.find(up);
+            if (itr == index.end()) {
+               const auto& po = *source_itr;
+               index.emplace(permission_info{ po.owner, po.name, po.last_updated });
+            } else {
+               remove_from_bimaps(*itr);
+               index.modify(itr, [&](auto& mutable_pi){
+                  mutable_pi.last_updated = source_itr->last_updated;
+               });
+            }
+
+            add_to_bimaps(*itr, *source_itr);
+         }
+
+         for (const auto& dp: deleted) {
+            auto itr = index.find(dp);
+            if (itr != index.end()) {
+               remove_from_bimaps(*itr);
+               index.erase(itr);
+            }
+         }
+
+         cached_trace_map.clear();
+         onblock_trace.reset();
+      }
+
+      account_query_db::get_accounts_by_authorizers_result
+      get_accounts_by_authorizers( const account_query_db::get_accounts_by_authorizers_params& args) const {
+         using result_t = account_query_db::get_accounts_by_authorizers_result;
+         result_t result;
+
+         auto account_set = std::set<chain::name>(args.accounts.begin(), args.accounts.end());
+         auto key_set = std::set<chain::public_key_type>(args.keys.begin(), args.keys.end());
+         auto permission_set = std::set<name_pair_t>();
+
+         for (const auto& a: account_set) {
+            auto range = name_bimap.left.equal_range(a);
+            for (auto itr = range.first; itr != range.second; ++itr) {
+               const auto& pi = itr->second.get();
+               permission_set.emplace(std::make_tuple(pi.owner, pi.name));
+            }
+         }
+
+         for (const auto& k: key_set) {
+            auto range = key_bimap.left.equal_range(k);
+            for (auto itr = range.first; itr != range.second; ++itr) {
+               const auto& pi = itr->second.get();
+               permission_set.emplace(std::make_tuple(pi.owner, pi.name));
+            }
+         }
+
+         const auto& permission_by_owner = controller.db().get_index<chain::permission_index>().indices().get<chain::by_owner>();
+         for (const auto& p: permission_set) {
+            const auto& iter = permission_by_owner.find(p);
+            EOS_ASSERT(iter != permission_by_owner.end(), chain::plugin_exception, "chain data mismatch");
+            const auto& po = *iter;
+
+            for (const auto& a : po.auth.accounts) {
+               if (account_set.count(a.permission.actor)) {
+                  fc::variant v;
+                  fc::to_variant(a.permission, v);
+                  result.accounts.emplace_back(result_t::account_result{
+                        po.owner,
+                        po.name,
+                        v,
+                        a.weight,
+                        po.auth.threshold
+                  });
+               }
+            }
+
+            for (const auto& k: po.auth.keys) {
+               auto pk = (chain::public_key_type)k.key;
+               if (key_set.count(pk)) {
+                  fc::variant v;
+                  fc::to_variant(pk, v);
+                  result.accounts.emplace_back(result_t::account_result{
+                        po.owner,
+                        po.name,
+                        v,
+                        k.weight,
+                        po.auth.threshold
+                  });
+               }
+            }
+         }
+
+         return result;
+      }
+
+      using name_pair_t = std::tuple<chain::name, chain::name>;
+      using name_bimap_t = bimap<multiset_of<chain::name>, set_of<permission_info::cref>>;
+      using key_bimap_t = bimap<multiset_of<chain::public_key_type>, set_of<permission_info::cref>>;
+      using cached_trace_map_t = std::map<chain::transaction_id_type, chain::transaction_trace_ptr>;
+      using onblock_trace_t = std::optional<chain::transaction_trace_ptr>;
+
+      const chain::controller&   controller;
+      permission_info_index_t    permission_info_index;
+      name_bimap_t               name_bimap;
+      key_bimap_t                key_bimap;
+      cached_trace_map_t         cached_trace_map;
+      onblock_trace_t            onblock_trace;
+   };
+
+   account_query_db::account_query_db( const chain::controller& controller )
+   :_impl(std::make_unique<account_query_db_impl>(controller))
+   {
+      _impl->build_account_query_map();
+   }
+
+   account_query_db::~account_query_db() = default;
+   account_query_db & account_query_db::operator=(account_query_db &&) = default;
+
+   void account_query_db::cache_transaction_trace( const chain::transaction_trace_ptr& trace ) {
+      try {
+         _impl->cache_transaction_trace(trace);
+      } FC_LOG_AND_DROP(("ACCOUNT DB cache_transaction_trace ERROR"));
+   }
+
+   void account_query_db::commit_block(const chain::block_state_ptr& block ) {
+      try {
+         _impl->commit_block(block);
+      } FC_LOG_AND_DROP(("ACCOUNT DB commit_block ERROR"));
+   }
+
+   account_query_db::get_accounts_by_authorizers_result account_query_db::get_accounts_by_authorizers( const account_query_db::get_accounts_by_authorizers_params& args) const {
+      return _impl->get_accounts_by_authorizers(args);
+   }
+
+}

--- a/plugins/chain_plugin/account_query_db.cpp
+++ b/plugins/chain_plugin/account_query_db.cpp
@@ -200,7 +200,7 @@ namespace eosio::chain_apis {
             auto itr = index.find(up);
             if (itr == index.end()) {
                const auto& po = *source_itr;
-               index.emplace(permission_info{ po.owner, po.name, po.last_updated });
+               itr = index.emplace(permission_info{ po.owner, po.name, po.last_updated }).first;
             } else {
                remove_from_bimaps(*itr);
                index.modify(itr, [&](auto& mutable_pi){

--- a/plugins/chain_plugin/account_query_db.cpp
+++ b/plugins/chain_plugin/account_query_db.cpp
@@ -318,7 +318,7 @@ namespace eosio::chain_apis {
                   // construct a range between the lower bound of the given account and the lower bound of the
                   // next possible account name
                   const auto begin = name_bimap.left.lower_bound(a);
-                  const auto next_account_name = chain::name(a.actor.to_uint64_t());
+                  const auto next_account_name = chain::name(a.actor.to_uint64_t() + 1);
                   const auto end = name_bimap.left.lower_bound(name_pair_t{next_account_name,a.permission});
                   return std::make_pair(begin, end);
                } else {

--- a/plugins/chain_plugin/account_query_db.cpp
+++ b/plugins/chain_plugin/account_query_db.cpp
@@ -183,6 +183,7 @@ namespace eosio::chain_apis {
       }
 
       bool is_rollback_required( const chain::block_state_ptr& bsp ) const {
+         std::shared_lock read_lock(rw_mutex);
          const auto t = bsp->block->timestamp.to_time_point();
          const auto& index = permission_info_index.get<by_last_updated>();
 

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1148,7 +1148,7 @@ void chain_plugin::plugin_startup()
       try {
          my->_account_query_db.emplace(*my->chain);
          my->account_queries_enabled = true;
-      } FC_LOG_AND_DROP(("Unabled to enable account queries"));
+      } FC_LOG_AND_DROP(("Unable to enable account queries"));
    }
 
 

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -142,6 +142,7 @@ public:
    flat_map<uint32_t,block_id_type> loaded_checkpoints;
    bool                             accept_transactions = false;
    bool                             api_accept_transactions = true;
+   bool                             account_queries_enabled = false;
 
 
    fc::optional<fork_database>      fork_db;
@@ -182,6 +183,28 @@ public:
    fc::optional<scoped_connection>                                   accepted_transaction_connection;
    fc::optional<scoped_connection>                                   applied_transaction_connection;
 
+
+   using permission_key = std::tuple<name, name>;
+   std::multimap<name, permission_key> authorizing_account_to_permission;
+   std::multimap<public_key_type, permission_key> authorizing_key_to_permission;
+
+   void build_account_query_map() {
+      ilog("Building account query maps");
+      auto start = fc::time_point::now();
+      const auto& index = chain->db().get_index<permission_index>().indices().get<by_id>();
+      for (const auto& e : index) {
+         permission_key key = std::make_tuple(e.owner, e.name);
+         for (const auto& a : e.auth.accounts) {
+            authorizing_account_to_permission.emplace(a.permission.actor, key);
+         }
+
+         for (const auto& k: e.auth.keys) {
+            authorizing_key_to_permission.emplace((public_key_type)k.key, key);
+         }
+      }
+      auto duration = fc::time_point::now() - start;
+      ilog("Finished building account query maps in ${sec}", ("sec", (duration.count() / 1'000'000.0 )));
+   }
 };
 
 chain_plugin::chain_plugin()
@@ -277,6 +300,7 @@ void chain_plugin::set_program_options(options_description& cli, options_descrip
          }), "Number of threads to use for EOS VM OC tier-up")
          ("eos-vm-oc-enable", bpo::bool_switch(), "Enable EOS VM OC tier-up runtime")
 #endif
+         ("enable-account-queries", bpo::value<bool>()->default_value(false), "enable queries to find accounts by various metadata.")
          ;
 
 // TODO: rate limiting
@@ -1030,6 +1054,8 @@ void chain_plugin::plugin_initialize(const variables_map& options) {
          my->chain_config->eosvmoc_tierup = true;
 #endif
 
+      my->account_queries_enabled = options.at("enable-account-queries").as<bool>();
+
       my->chain.emplace( *my->chain_config, std::move(pfs), *chain_id );
 
       // set up method providers
@@ -1130,6 +1156,16 @@ void chain_plugin::plugin_startup()
    }
 
    my->chain_config.reset();
+
+   if (my->account_queries_enabled) {
+      my->account_queries_enabled = false;
+      try {
+         my->build_account_query_map();
+         my->account_queries_enabled = true;
+      } FC_LOG_AND_DROP(("Unabled to enable account queries"));
+   }
+
+
 } FC_CAPTURE_AND_RETHROW() }
 
 void chain_plugin::plugin_shutdown() {
@@ -1433,6 +1469,11 @@ void chain_plugin::handle_bad_alloc() {
    //return -2 -- it's what programs/nodeos/main.cpp reports for std::exception
    std::_Exit(-2);
 }
+
+bool chain_plugin::account_queries_enabled() const {
+   return my->account_queries_enabled;
+}
+
 
 namespace chain_apis {
 
@@ -2534,6 +2575,11 @@ read_only::get_required_keys_result read_only::get_required_keys( const get_requ
 
 read_only::get_transaction_id_result read_only::get_transaction_id( const read_only::get_transaction_id_params& params)const {
    return params.id();
+}
+
+read_only::get_accounts_by_authorizers_result read_only::get_accounts_by_authorizers( const read_only::get_accounts_by_authorizers_params& args) const
+{
+   return {};
 }
 
 namespace detail {

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -184,27 +184,7 @@ public:
    fc::optional<scoped_connection>                                   applied_transaction_connection;
 
 
-   using permission_key = std::tuple<name, name>;
-   std::multimap<name, permission_key> authorizing_account_to_permission;
-   std::multimap<public_key_type, permission_key> authorizing_key_to_permission;
-
-   void build_account_query_map() {
-      ilog("Building account query maps");
-      auto start = fc::time_point::now();
-      const auto& index = chain->db().get_index<permission_index>().indices().get<by_id>();
-      for (const auto& e : index) {
-         permission_key key = std::make_tuple(e.owner, e.name);
-         for (const auto& a : e.auth.accounts) {
-            authorizing_account_to_permission.emplace(a.permission.actor, key);
-         }
-
-         for (const auto& k: e.auth.keys) {
-            authorizing_key_to_permission.emplace((public_key_type)k.key, key);
-         }
-      }
-      auto duration = fc::time_point::now() - start;
-      ilog("Finished building account query maps in ${sec}", ("sec", (duration.count() / 1'000'000.0 )));
-   }
+   fc::optional<chain_apis::account_query_db>                        _account_query_db;
 };
 
 chain_plugin::chain_plugin()
@@ -1098,6 +1078,9 @@ void chain_plugin::plugin_initialize(const variables_map& options) {
             } );
 
       my->accepted_block_connection = my->chain->accepted_block.connect( [this]( const block_state_ptr& blk ) {
+         if (my->_account_query_db) {
+            my->_account_query_db->commit_block(blk);
+         }
          my->accepted_block_channel.publish( priority::high, blk );
       } );
 
@@ -1112,6 +1095,9 @@ void chain_plugin::plugin_initialize(const variables_map& options) {
 
       my->applied_transaction_connection = my->chain->applied_transaction.connect(
             [this]( std::tuple<const transaction_trace_ptr&, const signed_transaction&> t ) {
+               if (my->_account_query_db) {
+                  my->_account_query_db->cache_transaction_trace(std::get<0>(t));
+               }
                my->applied_transaction_channel.publish( priority::low, std::get<0>(t) );
             } );
 
@@ -1160,7 +1146,7 @@ void chain_plugin::plugin_startup()
    if (my->account_queries_enabled) {
       my->account_queries_enabled = false;
       try {
-         my->build_account_query_map();
+         my->_account_query_db.emplace(*my->chain);
          my->account_queries_enabled = true;
       } FC_LOG_AND_DROP(("Unabled to enable account queries"));
    }
@@ -1191,6 +1177,11 @@ void chain_apis::read_write::validate() const {
    EOS_ASSERT( api_accept_transactions, missing_chain_api_plugin_exception,
                "Not allowed, node has api-accept-transactions = false" );
 }
+
+chain_apis::read_only chain_plugin::get_read_only_api() const {
+   return chain_apis::read_only(chain(), my->_account_query_db, get_abi_serializer_max_time());
+}
+
 
 bool chain_plugin::accept_block(const signed_block_ptr& block, const block_id_type& id ) {
    return my->incoming_block_sync_method(block, id);
@@ -2577,9 +2568,10 @@ read_only::get_transaction_id_result read_only::get_transaction_id( const read_o
    return params.id();
 }
 
-read_only::get_accounts_by_authorizers_result read_only::get_accounts_by_authorizers( const read_only::get_accounts_by_authorizers_params& args) const
+account_query_db::get_accounts_by_authorizers_result read_only::get_accounts_by_authorizers( const account_query_db::get_accounts_by_authorizers_params& args) const
 {
-   return {};
+   EOS_ASSERT(aqdb.valid(), plugin_config_exception, "Account Queries being accessed when not enabled");
+   return aqdb->get_accounts_by_authorizers(args);
 }
 
 namespace detail {

--- a/plugins/chain_plugin/include/eosio/chain_plugin/account_query_db.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/account_query_db.hpp
@@ -4,22 +4,55 @@
 #include <eosio/chain/trace.hpp>
 
 namespace eosio::chain_apis {
+   /**
+    * This class manages the ephemeral indices and data that provide the `get_accounts_by_authorizers` RPC call
+    * There is no persistence and the indices/caches are recreated when the class is instantiated based on the
+    * current state of the chain.
+    */
    class account_query_db {
    public:
+
+      /**
+       * Instantiate a new account query DB from the given chain controller
+       * The caller is expected to manage lifetimes such that this controller reference does not go stale
+       * for the life of the account query DB
+       * @param chain - controller to read data from
+       */
       account_query_db( const class eosio::chain::controller& chain );
       ~account_query_db();
 
+      /**
+       * Allow moving the account query DB (including by assignment)
+       */
       account_query_db(account_query_db&&);
       account_query_db& operator=(account_query_db&&);
 
+      /**
+       * Add a transaction trace to the account query DB that has been applied to the contoller even though it may
+       * not yet be committed to by a block.
+       *
+       * @param trace
+       */
       void cache_transaction_trace( const chain::transaction_trace_ptr& trace );
+
+      /**
+       * Add a block to the account query DB, committing all the cached traces it represents and dumping any
+       * uncommitted traces.
+       * @param block
+       */
       void commit_block(const chain::block_state_ptr& block );
 
+      /**
+       * parameters for the get_accounts_by_authorizers RPC
+       */
       struct get_accounts_by_authorizers_params{
          std::vector<chain::name> accounts;
          std::vector<chain::public_key_type> keys;
       };
 
+      /**
+       * Result of the get_accounts_by_authorizers RPC
+       */
       struct get_accounts_by_authorizers_result{
          struct account_result {
             chain::name         account_name;
@@ -31,6 +64,13 @@ namespace eosio::chain_apis {
 
          std::vector<account_result> accounts;
       };
+      /**
+       * Given a set of account names and public keys, find all account permission authorities that are, in part or whole,
+       * satisfiable.
+       *
+       * @param args
+       * @return
+       */
       get_accounts_by_authorizers_result get_accounts_by_authorizers( const get_accounts_by_authorizers_params& args) const;
 
    private:

--- a/plugins/chain_plugin/include/eosio/chain_plugin/account_query_db.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/account_query_db.hpp
@@ -59,11 +59,12 @@ namespace eosio::chain_apis {
        */
       struct get_accounts_by_authorizers_result{
          struct account_result {
-            chain::name         account_name;
-            chain::name         permission_name;
-            fc::variant         authorizer;
-            chain::weight_type  weight;
-            uint32_t            threshold;
+            chain::name                            account_name;
+            chain::name                            permission_name;
+            fc::optional<chain::permission_level>  authorizing_account;
+            fc::optional<chain::public_key_type>   authorizing_key;
+            chain::weight_type                     weight;
+            uint32_t                               threshold;
          };
 
          std::vector<account_result> accounts;
@@ -121,5 +122,5 @@ namespace fc {
 }
 
 FC_REFLECT( eosio::chain_apis::account_query_db::get_accounts_by_authorizers_params, (accounts)(keys))
-FC_REFLECT( eosio::chain_apis::account_query_db::get_accounts_by_authorizers_result::account_result, (account_name)(permission_name)(authorizer)(weight)(threshold))
+FC_REFLECT( eosio::chain_apis::account_query_db::get_accounts_by_authorizers_result::account_result, (account_name)(permission_name)(authorizing_account)(authorizing_key)(weight)(threshold))
 FC_REFLECT( eosio::chain_apis::account_query_db::get_accounts_by_authorizers_result, (accounts))

--- a/plugins/chain_plugin/include/eosio/chain_plugin/account_query_db.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/account_query_db.hpp
@@ -96,7 +96,7 @@ namespace fc {
          v = a.actor.to_string();
       } else {
          v = mutable_variant_object()
-            ("account", a.actor.to_string())
+            ("actor", a.actor.to_string())
             ("permission", a.permission.to_string());
       }
    }

--- a/plugins/chain_plugin/include/eosio/chain_plugin/account_query_db.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/account_query_db.hpp
@@ -1,0 +1,44 @@
+#pragma once
+#include <eosio/chain/types.hpp>
+#include <eosio/chain/block_state.hpp>
+#include <eosio/chain/trace.hpp>
+
+namespace eosio::chain_apis {
+   class account_query_db {
+   public:
+      account_query_db( const class eosio::chain::controller& chain );
+      ~account_query_db();
+
+      account_query_db(account_query_db&&);
+      account_query_db& operator=(account_query_db&&);
+
+      void cache_transaction_trace( const chain::transaction_trace_ptr& trace );
+      void commit_block(const chain::block_state_ptr& block );
+
+      struct get_accounts_by_authorizers_params{
+         std::vector<chain::name> accounts;
+         std::vector<chain::public_key_type> keys;
+      };
+
+      struct get_accounts_by_authorizers_result{
+         struct account_result {
+            chain::name         account_name;
+            chain::name         permission_name;
+            fc::variant         authorizer;
+            chain::weight_type  weight;
+            uint32_t            threshold;
+         };
+
+         std::vector<account_result> accounts;
+      };
+      get_accounts_by_authorizers_result get_accounts_by_authorizers( const get_accounts_by_authorizers_params& args) const;
+
+   private:
+      std::unique_ptr<struct account_query_db_impl> _impl;
+   };
+
+}
+
+FC_REFLECT( eosio::chain_apis::account_query_db::get_accounts_by_authorizers_params, (accounts)(keys))
+FC_REFLECT( eosio::chain_apis::account_query_db::get_accounts_by_authorizers_result::account_result, (account_name)(permission_name)(authorizer)(weight)(threshold))
+FC_REFLECT( eosio::chain_apis::account_query_db::get_accounts_by_authorizers_result, (accounts))

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -16,6 +16,8 @@
 #include <boost/container/flat_set.hpp>
 #include <boost/multiprecision/cpp_int.hpp>
 
+#include <eosio/chain_plugin/account_query_db.hpp>
+
 #include <fc/static_variant.hpp>
 
 namespace fc { class variant; }
@@ -78,14 +80,15 @@ string convert_to_string(const float128_t& source, const string& key_type, const
 
 class read_only {
    const controller& db;
+   const fc::optional<account_query_db>& aqdb;
    const fc::microseconds abi_serializer_max_time;
    bool  shorten_abi_errors = true;
 
 public:
    static const string KEYi64;
 
-   read_only(const controller& db, const fc::microseconds& abi_serializer_max_time)
-      : db(db), abi_serializer_max_time(abi_serializer_max_time) {}
+   read_only(const controller& db, const fc::optional<account_query_db>& aqdb, const fc::microseconds& abi_serializer_max_time)
+      : db(db), aqdb(aqdb), abi_serializer_max_time(abi_serializer_max_time) {}
 
    void validate() const {}
 
@@ -584,22 +587,8 @@ public:
       return result;
    }
 
-   struct get_accounts_by_authorizers_params{
-      std::vector<chain::name> accounts;
-      std::vector<chain::public_key_type> keys;
-   };
-
-   struct get_accounts_by_authorizers_result{
-      struct account_result {
-         chain::name         account_name;
-         chain::name         permission_name;
-         fc::variant         authorizer;
-         chain::weight_type  weight;
-         uint32_t            threshold;
-      };
-
-      std::vector<account_result> accounts;
-   };
+   using get_accounts_by_authorizers_result = account_query_db::get_accounts_by_authorizers_result;
+   using get_accounts_by_authorizers_params = account_query_db::get_accounts_by_authorizers_params;
    get_accounts_by_authorizers_result get_accounts_by_authorizers( const get_accounts_by_authorizers_params& args) const;
 
    chain::symbol extract_core_symbol()const;
@@ -722,8 +711,8 @@ public:
    void plugin_startup();
    void plugin_shutdown();
 
-   chain_apis::read_only get_read_only_api() const { return chain_apis::read_only(chain(), get_abi_serializer_max_time()); }
    chain_apis::read_write get_read_write_api() { return chain_apis::read_write(chain(), get_abi_serializer_max_time(), api_accept_transactions()); }
+   chain_apis::read_only get_read_only_api() const;
 
    bool accept_block( const chain::signed_block_ptr& block, const chain::block_id_type& id );
    void accept_transaction(const chain::packed_transaction_ptr& trx, chain::plugin_interface::next_function<chain::transaction_trace_ptr> next);
@@ -829,7 +818,4 @@ FC_REFLECT( eosio::chain_apis::read_only::abi_bin_to_json_params, (code)(action)
 FC_REFLECT( eosio::chain_apis::read_only::abi_bin_to_json_result, (args) )
 FC_REFLECT( eosio::chain_apis::read_only::get_required_keys_params, (transaction)(available_keys) )
 FC_REFLECT( eosio::chain_apis::read_only::get_required_keys_result, (required_keys) )
-FC_REFLECT( eosio::chain_apis::read_only::get_accounts_by_authorizers_params, (accounts)(keys))
-FC_REFLECT( eosio::chain_apis::read_only::get_accounts_by_authorizers_result::account_result, (account_name)(permission_name)(authorizer)(weight)(threshold))
-FC_REFLECT( eosio::chain_apis::read_only::get_accounts_by_authorizers_result, (accounts))
 

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -584,6 +584,24 @@ public:
       return result;
    }
 
+   struct get_accounts_by_authorizers_params{
+      std::vector<chain::name> accounts;
+      std::vector<chain::public_key_type> keys;
+   };
+
+   struct get_accounts_by_authorizers_result{
+      struct account_result {
+         chain::name         account_name;
+         chain::name         permission_name;
+         fc::variant         authorizer;
+         chain::weight_type  weight;
+         uint32_t            threshold;
+      };
+
+      std::vector<account_result> accounts;
+   };
+   get_accounts_by_authorizers_result get_accounts_by_authorizers( const get_accounts_by_authorizers_params& args) const;
+
    chain::symbol extract_core_symbol()const;
 
    friend struct resolver_factory<read_only>;
@@ -744,6 +762,8 @@ public:
 
    static void handle_db_exhaustion();
    static void handle_bad_alloc();
+
+   bool account_queries_enabled() const;
 private:
    static void log_guard_exception(const chain::guard_exception& e);
 
@@ -809,3 +829,7 @@ FC_REFLECT( eosio::chain_apis::read_only::abi_bin_to_json_params, (code)(action)
 FC_REFLECT( eosio::chain_apis::read_only::abi_bin_to_json_result, (args) )
 FC_REFLECT( eosio::chain_apis::read_only::get_required_keys_params, (transaction)(available_keys) )
 FC_REFLECT( eosio::chain_apis::read_only::get_required_keys_result, (required_keys) )
+FC_REFLECT( eosio::chain_apis::read_only::get_accounts_by_authorizers_params, (accounts)(keys))
+FC_REFLECT( eosio::chain_apis::read_only::get_accounts_by_authorizers_result::account_result, (account_name)(permission_name)(authorizer)(weight)(threshold))
+FC_REFLECT( eosio::chain_apis::read_only::get_accounts_by_authorizers_result, (accounts))
+

--- a/plugins/http_plugin/http_plugin.cpp
+++ b/plugins/http_plugin/http_plugin.cpp
@@ -903,6 +903,9 @@ namespace eosio {
          } catch (chain::unknown_block_exception& e) {
             error_results results{400, "Unknown Block", error_results::error_info(e, verbose_http_errors)};
             cb( 400, fc::variant( results ));
+         } catch (chain::invalid_http_request& e) {
+            error_results results{400, "Invalid Request", error_results::error_info(e, verbose_http_errors)};
+            cb( 400, fc::variant( results ));
          } catch (chain::unsatisfied_authorization& e) {
             error_results results{401, "UnAuthorized", error_results::error_info(e, verbose_http_errors)};
             cb( 401, fc::variant( results ));

--- a/tests/chain_plugin_tests.cpp
+++ b/tests/chain_plugin_tests.cpp
@@ -89,7 +89,7 @@ BOOST_FIXTURE_TEST_CASE( get_block_with_invalid_abi, TESTER ) try {
    char headnumstr[20];
    sprintf(headnumstr, "%d", headnum);
    chain_apis::read_only::get_block_params param{headnumstr};
-   chain_apis::read_only plugin(*(this->control), fc::microseconds::maximum());
+   chain_apis::read_only plugin(*(this->control), {}, fc::microseconds::maximum());
 
    // block should be decoded successfully
    std::string block_str = json::to_pretty_string(plugin.get_block(param));

--- a/tests/get_table_tests.cpp
+++ b/tests/get_table_tests.cpp
@@ -89,7 +89,7 @@ BOOST_FIXTURE_TEST_CASE( get_scope_test, TESTER ) try {
    produce_blocks(1);
 
    // iterate over scope
-   eosio::chain_apis::read_only plugin(*(this->control), fc::microseconds::maximum());
+   eosio::chain_apis::read_only plugin(*(this->control), {}, fc::microseconds::maximum());
    eosio::chain_apis::read_only::get_table_by_scope_params param{N(eosio.token), N(accounts), "inita", "", 10};
    eosio::chain_apis::read_only::get_table_by_scope_result result = plugin.read_only::get_table_by_scope(param);
 
@@ -194,7 +194,7 @@ BOOST_FIXTURE_TEST_CASE( get_table_test, TESTER ) try {
    produce_blocks(1);
 
    // get table: normal case
-   eosio::chain_apis::read_only plugin(*(this->control), fc::microseconds::maximum());
+   eosio::chain_apis::read_only plugin(*(this->control), {}, fc::microseconds::maximum());
    eosio::chain_apis::read_only::get_table_rows_params p;
    p.code = N(eosio.token);
    p.scope = "inita";
@@ -363,7 +363,7 @@ BOOST_FIXTURE_TEST_CASE( get_table_by_seckey_test, TESTER ) try {
    produce_blocks(1);
 
    // get table: normal case
-   eosio::chain_apis::read_only plugin(*(this->control), fc::microseconds::maximum());
+   eosio::chain_apis::read_only plugin(*(this->control), {}, fc::microseconds::maximum());
    eosio::chain_apis::read_only::get_table_rows_params p;
    p.code = N(eosio);
    p.scope = "eosio";
@@ -515,7 +515,7 @@ BOOST_FIXTURE_TEST_CASE( get_table_next_key_test, TESTER ) try {
    // }
 
 
-   chain_apis::read_only plugin(*(this->control), fc::microseconds::maximum());
+   chain_apis::read_only plugin(*(this->control), {}, fc::microseconds::maximum());
    chain_apis::read_only::get_table_rows_params params{
       .json=true,
       .code=N(test),


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description

This is a proposed *optional* addition to `chain_plugin` and `chain_api_plugin` that provides a superset of the deprecated `history_api_plugin`'s `get_key_accounts` and `get_controlled_accounts` RPC methods.  While we have many other solutions covering the history access that the `history_api_plugin` provided, none easily covered this use case for wallets and other end-users.  

This solution builds the associated indices on start-up and, as a result, does not suffer from the brittle issues that the `history_api_plugin` had.  It also means it can be added to or removed from any operating `nodeos` at any time.  This does impose a penalty on start-up times. 
 Timings on a modest cloud VM* indicated that these indices can be built for a node synced with the EOS Public Network @ block 113060000 in about 15-20 seconds.  **Note: this penalty is only imposed if the Account Query DB is enabled (see below).**

The solution will watch the chain as it processes and update the indices accordingly.  This process has minimal overhead on the operating node.

*modest VM had 2x 2.0-2.2 gHz vCPUs

## API Changes
- [x] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->

### `POST /v1/chain/get_accounts_by_authorizers`

This is the single endpoint that produces a superset of the information provided by `get_key_accounts` and `get_controlled_accounts`.

#### Request format
The basic request payload is the following JSON:
```javascript
{
   "accounts": [
      //<zero or more account name strings or {actor, permission} objects>
   ],
   "keys":[
      //<zero or more public key strings>
   ]
}
```

Account entries that are only account names have an implicit wildcard permission which matches any permission level from that account.  This can be explicitly set to an empty string or a specific permission level.  For instance:

```javascript
{
   "accounts": [
      "eosio"
   ]
}
```
will list all accounts authorized in part or whole by `eosio` whereas:
```javascript
{
   "accounts": [
      { "actor": "eosio", "permission": "eosio.code" }
   ]
}
```
will only list accounts authorized specifically by `eosio@eosio.code`

Omitting `accounts` or `keys` indicates that those arrays would be empty if explicit.

#### Response format
The basic response format is the following JSON:
```javascript
{
   "accounts" : [
      // one entry per authorized {account, permission, authorizing account|key} triplet
      {
         "account_name" : "",            // the name of the authorized account
         "permission_name" : "",         // the permission level on that authorized account
         "authorizing_key" : "PUB_...",  // [optional] present when entry included due to a listed key
         "authorizing_account" : {       // [optional] present when entry included due to a listed account
            "actor" : "",                // the name of the authorizing account
            "permission" : "",           // the name of the permission required to authorize as this account 
         },
         "weight" : 1,                   // the weight this authorization has in this permission
         "threshold": 1                  // the threshold needed to satisfy this permission
      },
     // additional entries...
   ]
}
```
#### Porting Hints

##### `get_key_accounts`
```bash
$ curl http://127.0.0.1:8888/v1/history/get_key_accounts -d '{"public_key":"EOS..."}' | jq '.account_names[]'
```
becomes:

```bash
$ curl http://127.0.0.1:8888/v1/chain/get_accounts_by_authorizers -d '{"keys":["EOS..."]}' 2>/dev/null | jq '[.accounts[].account_name] | unique'
```

##### `get_controlled_accounts`
```bash
$ curl http://127.0.0.1:8888/v1/history/get_controlled_accounts -d '{"controlling_account":"alice"}' | jq '.controlled_accounts[]'
```
becomes:

```bash
$ curl http://127.0.0.1:8888/v1/chain/get_accounts_by_authorizers -d '{"accounts":["alice"]}' 2>/dev/null | jq '[.accounts[].account_name] | unique'
```

###### Batch fetches

In addition to single value queries, you can add as many account names or public keys to the request as needed.   The result will be the union of all the individual responses saving time when determining a set of accounts from various authorization materials. 

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## Documentation Additions
- [x] Documentation Additions

### `--enable-account-queries`

*default: false*

Boolean that indicates whether the Account Query DB should be initialized at start-up and maintained for the life of this instance.  if set to `true` then the RPC endpoint for `/v1/chain/get_accounts_by_authorizers` will be registered otherwise it will not be present and requests to that endpoint will return `404` errors. 


<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
