### PR TITLE
remove llvm@7 from macos build as it isn't used at the moment

### DIFF
--- a/.cicd/platforms/unpinned/macos-10.15-unpinned.sh
+++ b/.cicd/platforms/unpinned/macos-10.15-unpinned.sh
@@ -3,7 +3,7 @@ set -eo pipefail
 VERSION=1
 export SDKROOT="$(xcrun --sdk macosx --show-sdk-path)"
 brew update
-brew install git cmake python libtool libusb graphviz automake wget gmp llvm@7 pkgconfig doxygen openssl jq boost || :
+brew install git cmake python libtool libusb graphviz automake wget gmp pkgconfig doxygen openssl jq boost || :
 # install mongoDB
 cd ~
 curl -OL https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-3.6.3.tgz


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
This also has the side effect of shaking the CI's cage to generate a new unpinned build image; the current one appears damaged due to the curl pkg-config issue.

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
