### PR TITLE
Chainlib support for replacing keys

### DIFF
--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -365,6 +365,9 @@ namespace eosio { namespace chain {
 
       static fc::optional<chain_id_type> extract_chain_id_from_db( const path& state_dir );
 
+         void replace_producer_keys( const public_key_type& key );
+         void replace_account_keys( name account, const public_key_type& key );
+
       private:
          friend class apply_context;
          friend class transaction_context;

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -366,7 +366,7 @@ namespace eosio { namespace chain {
       static fc::optional<chain_id_type> extract_chain_id_from_db( const path& state_dir );
 
          void replace_producer_keys( const public_key_type& key );
-         void replace_account_keys( name account, const public_key_type& key );
+         void replace_account_keys( name account, name permission, const public_key_type& key );
 
       private:
          friend class apply_context;


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

This adds minimal support to chainlib for replacing keys. The initial use case is in `eosio-tester`, which exposes these new functions. Unlike prior PRs, this PR:
* Doesn't assume the need to replace production keys implies the need to replace owner and active
* Doesn't assume a particular system contract
* Allows replacing owner and active on arbitrary accounts
* Doesn't provide either command-line options or new utilities for accessing this functionality

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
