### PR TITLE
Rename action_id type for GCC - develop

### DIFF
--- a/libraries/chain/include/eosio/chain/transaction_context.hpp
+++ b/libraries/chain/include/eosio/chain/transaction_context.hpp
@@ -11,9 +11,9 @@ namespace eosio { namespace chain {
     * to record on-going execution id/index of all actions executed
     * by a given transaction.
     */
-   class action_id {
+   class action_id_type {
       public:
-        action_id(): id(0) {}
+        action_id_type(): id(0) {}
 
         inline void increment() { id++; }
         inline uint32_t current() const { return id; }
@@ -181,7 +181,7 @@ namespace eosio { namespace chain {
          transaction_checktime_timer   transaction_timer;
 
          /// kept to track ids of action_traces push via this transaction
-         action_id                     action_id;
+         action_id_type                action_id;
 
       private:
          bool                          is_initialized = false;


### PR DESCRIPTION
## Change Description

- GCC does not like types and attributes with the same name.

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
