### PR TITLE
Import boost 1.70 bugfix for clang version check

### DIFF
--- a/scripts/boost-1_70-clang-version-check.patch
+++ b/scripts/boost-1_70-clang-version-check.patch
@@ -1,0 +1,31 @@
+From b3a59d265929a213f02a451bb63cea75d668a4d9 Mon Sep 17 00:00:00 2001
+From: Bo Anderson <mail@boanderson.me>
+Date: Thu, 2 Apr 2020 01:31:47 +0100
+Subject: [PATCH] Fix compiler version check on macOS (#560)
+
+Fixes #440.
+---
+ src/tools/darwin.jam | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/src/tools/darwin.jam b/src/tools/darwin.jam
+index 8d477410b0..97e7ecb851 100644
+--- a/src/tools/darwin.jam
++++ b/src/tools/darwin.jam
+@@ -137,13 +137,14 @@ rule init ( version ? : command * : options * : requirement * )
+     # - Set the toolset generic common options.
+     common.handle-options darwin : $(condition) : $(command) : $(options) ;
+     
++    real-version = [ regex.split $(real-version) \\. ] ;
+     # - GCC 4.0 and higher in Darwin does not have -fcoalesce-templates.
+-    if $(real-version) < "4.0.0"
++    if [ version.version-less $(real-version) : 4 0 ]
+     {
+         flags darwin.compile.c++ OPTIONS $(condition) : -fcoalesce-templates ;
+     }
+     # - GCC 4.2 and higher in Darwin does not have -Wno-long-double.
+-    if $(real-version) < "4.2.0"
++    if [ version.version-less $(real-version) : 4 2 ]
+     {
+         flags darwin.compile OPTIONS $(condition) : -Wno-long-double ;
+     }

--- a/scripts/helpers/eosio.sh
+++ b/scripts/helpers/eosio.sh
@@ -256,6 +256,9 @@ function ensure-boost() {
         curl -LO https://dl.bintray.com/boostorg/release/$BOOST_VERSION_MAJOR.$BOOST_VERSION_MINOR.$BOOST_VERSION_PATCH/source/boost_$BOOST_VERSION.tar.bz2 \
         && tar -xjf boost_$BOOST_VERSION.tar.bz2 \
         && cd $BOOST_ROOT \
+        && (if [[ \"$BOOST_VERSION_MAJOR.$BOOST_VERSION_MINOR\" = '1.70' ]]; then \
+            patch tools/build/src/tools/darwin.jam < \"$REPO_ROOT/scripts/boost-1_70-clang-version-check.patch\"; \
+        fi) \
         && ./bootstrap.sh ${BOOTSTRAP_FLAGS} --prefix=$BOOST_ROOT \
         && ./b2 ${B2_FLAGS} \
         && cd .. \


### PR DESCRIPTION
## Change Description

Fixes #8915

This commit applies a patch to boost version 1.70, which incorrectly used lexicographical comparison of compiler versions, so version 11 was considered less than 4. As a result, BJam passed the `-fcoalesce-templates` option (which was not supported since GCC 4.0) to compiler versions 10+, which in turn broke eos build.

See https://github.com/boostorg/build/issues/440 for details.

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
