### PR TITLE
Fix broken Docker build of C7 pinned image.

### DIFF
--- a/.cicd/platforms/pinned/centos-7.7-pinned.dockerfile
+++ b/.cicd/platforms/pinned/centos-7.7-pinned.dockerfile
@@ -18,7 +18,6 @@ RUN curl -LO https://github.com/Kitware/CMake/releases/download/v3.16.2/cmake-3.
     make -j$(nproc) && \
     make install && \
     rm -rf cmake-3.16.2.tar.gz cmake-3.16.2
-COPY ./scripts/clang-devtoolset8-support.patch /tmp/clang-devtoolset8-support.patch
 # build clang10
 RUN git clone --single-branch --branch llvmorg-10.0.0 https://github.com/llvm/llvm-project clang10 && \
     mkdir /clang10/build && cd /clang10/build && \


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
The `eosio-base-images` pipeline has been failing. This is due to PR #8922 removing a file that Docker was expecting to exist and to copy into the container:
- Removed old copy step in pinned CentOS 7 Dockerfile.

### See:
[eosio-base-images 103](https://buildkite.com/EOSIO/eosio-base-images/builds/103#44062d30-c4e9-4dca-9ee0-0bdf6d5c2ebc/155-7727) | Step failing due to removed file.
[eosio 21424](https://buildkite.com/EOSIO/eosio/builds/21424#a415441c-d073-4f7c-88e1-d14c1fd4b6d2) | Docker build and EOS build both passing now.

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
