### PR TITLE
noop change to macos-10.14-unpinned.sh to regen CI image, 2.0

### DIFF
--- a/.cicd/platforms/unpinned/macos-10.14-unpinned.sh
+++ b/.cicd/platforms/unpinned/macos-10.14-unpinned.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -eo pipefail
-VERSION=1
+VERSION=2
 brew update
 brew install git cmake python libtool libusb graphviz automake wget gmp llvm@7 pkgconfig doxygen openssl@1.1 jq boost || :
 # install mongoDB


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
The unpinned 10.14 build image looks sick due to the pkgconfig issue. noop change to poke the CI image generator

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
