### PR TITLE
llvm 10 support for EOS VM OC - 2.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,8 +73,8 @@ if(CMAKE_SIZEOF_VOID_P EQUAL 8 AND NOT WIN32)
       # EOS VM OC requires LLVM, but move the check up here to a central location so that the EosioTester.cmakes
       # can be created with the exact version found
       find_package(LLVM REQUIRED CONFIG)
-      if(LLVM_VERSION_MAJOR VERSION_LESS 7 OR LLVM_VERSION_MAJOR VERSION_GREATER 9)
-	      message(FATAL_ERROR "EOSIO requires an LLVM version 7.0 to 9.0")
+      if(LLVM_VERSION_MAJOR VERSION_LESS 7 OR LLVM_VERSION_MAJOR VERSION_GREATER 10)
+	      message(FATAL_ERROR "EOSIO requires an LLVM version 7.0 to 10.0")
       endif()
    endif()
 endif()

--- a/libraries/chain/webassembly/eos-vm-oc/LLVMJIT.cpp
+++ b/libraries/chain/webassembly/eos-vm-oc/LLVMJIT.cpp
@@ -168,7 +168,7 @@ namespace LLVMJIT
 	struct JITModule
 	{
 		JITModule() {
-			objectLayer = llvm::make_unique<llvm::orc::LegacyRTDyldObjectLinkingLayer>(ES,[this](llvm::orc::VModuleKey K) {
+			objectLayer = std::make_unique<llvm::orc::LegacyRTDyldObjectLinkingLayer>(ES,[this](llvm::orc::VModuleKey K) {
 									return llvm::orc::LegacyRTDyldObjectLinkingLayer::Resources{
 										unitmemorymanager, std::make_shared<llvm::orc::NullResolver>()
 										};
@@ -197,7 +197,7 @@ namespace LLVMJIT
 							  }
 							  );
 			objectLayer->setProcessAllSections(true);
-			compileLayer = llvm::make_unique<CompileLayer>(*objectLayer,llvm::orc::SimpleCompiler(*targetMachine));
+			compileLayer = std::make_unique<CompileLayer>(*objectLayer,llvm::orc::SimpleCompiler(*targetMachine));
 		}
 
 		void compile(llvm::Module* llvmModule);


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
This is a backport of #8465 to 2.0. Ubuntu 20.04 has switched to LLVM 10.0 late in its cycle; to ensure easy out-of-the-box building on that platform we need LLVM 10 support.

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
