### PR TITLE
Trx prune reflect

### DIFF
--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -804,18 +804,18 @@ int apply_context::get_action( uint32_t type, uint32_t index, char* buffer, size
 
 int apply_context::get_context_free_data( uint32_t index, char* buffer, size_t buffer_size )const
 {
-   const prunable_transaction_data::prunable_data_type& data = trx_context.packed_trx.get_prunable_data().prunable_data;
+   const packed_transaction::prunable_data_type::prunable_data_t& data = trx_context.packed_trx.get_prunable_data().prunable_data;
    const bytes* cfd = nullptr;
-   if( data.contains<prunable_transaction_data::none>() || data.contains<prunable_transaction_data::signatures_only>() ) {
-   } else if( data.contains<prunable_transaction_data::partial>() ) {
-      if( index >= data.get<prunable_transaction_data::partial>().context_free_segments.size() ) return -1;
+   if( data.contains<packed_transaction::prunable_data_type::none>() || data.contains<packed_transaction::prunable_data_type::signatures_only>() ) {
+   } else if( data.contains<packed_transaction::prunable_data_type::partial>() ) {
+      if( index >= data.get<packed_transaction::prunable_data_type::partial>().context_free_segments.size() ) return -1;
 
       cfd = trx_context.packed_trx.get_context_free_data(index);
    } else {
       const std::vector<bytes>& context_free_data =
-            data.contains<prunable_transaction_data::full_legacy>() ?
-               data.get<prunable_transaction_data::full_legacy>().context_free_segments :
-               data.get<prunable_transaction_data::full>().context_free_segments;
+            data.contains<packed_transaction::prunable_data_type::full_legacy>() ?
+               data.get<packed_transaction::prunable_data_type::full_legacy>().context_free_segments :
+               data.get<packed_transaction::prunable_data_type::full>().context_free_segments;
       if( index >= context_free_data.size() ) return -1;
 
       cfd = &context_free_data[index];

--- a/libraries/chain/block.cpp
+++ b/libraries/chain/block.cpp
@@ -143,7 +143,7 @@ namespace eosio { namespace chain {
       auto visitor = overloaded{
           [](const transaction_id_type &id) -> transaction_receipt_v0::trx_type { return id; },
           [](const packed_transaction &trx) -> transaction_receipt_v0::trx_type {
-             const auto& legacy = trx.get_prunable_data().prunable_data.get<prunable_transaction_data::full_legacy>();
+             const auto& legacy = trx.get_prunable_data().prunable_data.get<packed_transaction::prunable_data_type::full_legacy>();
              return packed_transaction_v0(trx.get_packed_transaction(), legacy.signatures, legacy.packed_context_free_data, trx.get_compression());
           }};
 

--- a/libraries/chain/include/eosio/chain/abi_serializer.hpp
+++ b/libraries/chain/include/eosio/chain/abi_serializer.hpp
@@ -482,15 +482,15 @@ namespace impl {
          const auto& trx = ptrx.get_transaction();
          mvo("id", trx.id());
          const auto* sigs = ptrx.get_signatures();
-         if( ptrx.get_prunable_data().prunable_data.contains<prunable_transaction_data::full_legacy>() ) {
-            const auto& legacy = ptrx.get_prunable_data().prunable_data.get<prunable_transaction_data::full_legacy>();
+         if( ptrx.get_prunable_data().prunable_data.contains<packed_transaction::prunable_data_type::full_legacy>() ) {
+            const auto& legacy = ptrx.get_prunable_data().prunable_data.get<packed_transaction::prunable_data_type::full_legacy>();
             mvo("signatures", legacy.signatures );
          } else {
             mvo("signatures", vector<signature_type>());
          }
          mvo("compression", ptrx.get_compression());
-         if( ptrx.get_prunable_data().prunable_data.contains<prunable_transaction_data::full_legacy>() ) {
-            const auto& legacy = ptrx.get_prunable_data().prunable_data.get<prunable_transaction_data::full_legacy>();
+         if( ptrx.get_prunable_data().prunable_data.contains<packed_transaction::prunable_data_type::full_legacy>() ) {
+            const auto& legacy = ptrx.get_prunable_data().prunable_data.get<packed_transaction::prunable_data_type::full_legacy>();
             mvo("packed_context_free_data", legacy.packed_context_free_data);
             mvo("context_free_data", legacy.context_free_segments);
          } else {

--- a/libraries/chain/include/eosio/chain/transaction.hpp
+++ b/libraries/chain/include/eosio/chain/transaction.hpp
@@ -197,8 +197,6 @@ namespace eosio { namespace chain {
       friend struct packed_transaction;
       void reflector_init();
    private:
-     friend struct pruned_transaction;
-     friend struct prunable_data;
      vector<signature_type>                   signatures;
      fc::enum_type<uint8_t, compression_type> compression;
      bytes                                    packed_context_free_data;

--- a/libraries/chain/transaction.cpp
+++ b/libraries/chain/transaction.cpp
@@ -256,7 +256,7 @@ static bytes zlib_compress_transaction(const transaction& t) {
    return out;
 }
 
-packed_transaction_v0::packed_transaction_v0(const bytes& packed_txn, const vector<signature_type>& sigs, const bytes& packed_cfd, compression_type _compression )
+packed_transaction_v0::packed_transaction_v0(const bytes& packed_txn, const vector<signature_type>& sigs, const bytes& packed_cfd, compression_type _compression)
 :signatures(sigs)
 ,compression(_compression)
 ,packed_context_free_data(packed_cfd)
@@ -423,21 +423,21 @@ digest_type packed_transaction::prunable_data_type::digest() const {
 
 static constexpr std::size_t digest_pack_size = 32;
 
-static std::size_t padded_pack_size( const packed_transaction::prunable_data_type::none& obj, packed_transaction::prunable_data_type::compression_type) {
+static std::size_t padded_pack_size(const packed_transaction::prunable_data_type::none& obj, packed_transaction::prunable_data_type::compression_type) {
    std::size_t result = fc::raw::pack_size(obj);
    EOS_ASSERT(result == digest_pack_size, packed_transaction_type_exception, "Unexpected size of packed digest");
    return result;
 }
 
-static std::size_t padded_pack_size( const packed_transaction::prunable_data_type::signatures_only& obj, packed_transaction::prunable_data_type::compression_type) {
+static std::size_t padded_pack_size(const packed_transaction::prunable_data_type::signatures_only& obj, packed_transaction::prunable_data_type::compression_type) {
    return fc::raw::pack_size(obj);
 }
 
-static std::size_t padded_pack_size( const packed_transaction::prunable_data_type::partial& obj, packed_transaction::prunable_data_type::compression_type segment_compression) {
+static std::size_t padded_pack_size(const packed_transaction::prunable_data_type::partial& obj, packed_transaction::prunable_data_type::compression_type segment_compression) {
      EOS_THROW(tx_prune_exception, "unimplemented");
 }
 
-static std::size_t padded_pack_size( const packed_transaction::prunable_data_type::full& obj, packed_transaction::prunable_data_type::compression_type segment_compression) {
+static std::size_t padded_pack_size(const packed_transaction::prunable_data_type::full& obj, packed_transaction::prunable_data_type::compression_type segment_compression) {
    EOS_THROW(tx_prune_exception, "unimplemented");
 #if 0
    std::size_t context_free_size = fc::raw::pack_size(fc::unsigned_int(obj.context_free_segments.size()));
@@ -450,11 +450,11 @@ static std::size_t padded_pack_size( const packed_transaction::prunable_data_typ
 #endif
 }
 
-static std::size_t padded_pack_size( const packed_transaction::prunable_data_type::full_legacy& obj, packed_transaction::prunable_data_type::compression_type) {
+static std::size_t padded_pack_size(const packed_transaction::prunable_data_type::full_legacy& obj, packed_transaction::prunable_data_type::compression_type) {
   return std::max(fc::raw::pack_size(obj), digest_pack_size);
 }
 
-std::size_t packed_transaction::prunable_data_type::maximum_pruned_pack_size( packed_transaction::prunable_data_type::compression_type compression) const {
+std::size_t packed_transaction::prunable_data_type::maximum_pruned_pack_size(packed_transaction::prunable_data_type::compression_type compression) const {
    return 1 + prunable_data.visit([&](const auto& t){ return padded_pack_size(t, compression); });
 }
 
@@ -495,10 +495,10 @@ packed_transaction::packed_transaction(const packed_transaction_v0& other, bool 
 
 packed_transaction::packed_transaction(packed_transaction_v0&& other, bool legacy)
  : compression(other.compression),
-   prunable_data(legacy ? prunable_data_type{prunable_data_type::full_legacy{std::move( other.signatures),
+   prunable_data(legacy ? prunable_data_type{prunable_data_type::full_legacy{std::move(other.signatures),
                                                                              std::move(other.packed_context_free_data),
                                                                              std::move(other.unpacked_trx.context_free_data) } }
-                        : prunable_data_type{prunable_data_type::full{std::move( other.signatures),
+                        : prunable_data_type{prunable_data_type::full{std::move(other.signatures),
                                                                       std::move(other.unpacked_trx.context_free_data) } }),
    packed_trx(std::move(other.packed_trx)),
    unpacked_trx(std::move(other.unpacked_trx)),
@@ -605,9 +605,9 @@ const vector<bytes>* packed_transaction::get_context_free_data()const {
    }
 }
 
-const bytes* maybe_get_context_free_data( const packed_transaction::prunable_data_type::none&, std::size_t) { return nullptr; }
-const bytes* maybe_get_context_free_data( const packed_transaction::prunable_data_type::signatures_only&, std::size_t) { return nullptr; }
-const bytes* maybe_get_context_free_data( const packed_transaction::prunable_data_type::partial& p, std::size_t i) {
+const bytes* maybe_get_context_free_data(const packed_transaction::prunable_data_type::none&, std::size_t) { return nullptr; }
+const bytes* maybe_get_context_free_data(const packed_transaction::prunable_data_type::signatures_only&, std::size_t) { return nullptr; }
+const bytes* maybe_get_context_free_data(const packed_transaction::prunable_data_type::partial& p, std::size_t i) {
    if( p.context_free_segments.size() <= i ) return nullptr;
    return p.context_free_segments[i].visit(
          overloaded{
@@ -615,11 +615,11 @@ const bytes* maybe_get_context_free_data( const packed_transaction::prunable_dat
                []( const bytes& vec ) { return &vec; }
          } );
 }
-const bytes* maybe_get_context_free_data( const packed_transaction::prunable_data_type::full_legacy& full_leg, std::size_t i) {
+const bytes* maybe_get_context_free_data(const packed_transaction::prunable_data_type::full_legacy& full_leg, std::size_t i) {
    if( full_leg.context_free_segments.size() <= i ) return nullptr;
    return &full_leg.context_free_segments[i];
 }
-const bytes* maybe_get_context_free_data( const packed_transaction::prunable_data_type::full& f, std::size_t i) {
+const bytes* maybe_get_context_free_data(const packed_transaction::prunable_data_type::full& f, std::size_t i) {
    if( f.context_free_segments.size() <= i ) return nullptr;
    return &f.context_free_segments[i];
 }

--- a/libraries/chain/transaction.cpp
+++ b/libraries/chain/transaction.cpp
@@ -390,54 +390,54 @@ void packed_transaction_v0::local_pack_context_free_data()
    packed_context_free_data = pack_context_free_data(unpacked_trx.context_free_data, compression);
 }
 
-prunable_transaction_data prunable_transaction_data::prune_all() const {
-   return { prunable_transaction_data::none{ digest() } };
+packed_transaction::prunable_data_type packed_transaction::prunable_data_type::prune_all() const {
+   return {packed_transaction::prunable_data_type::none{digest() } };
 }
 
-static digest_type prunable_digest(const prunable_transaction_data::none& obj) {
+static digest_type prunable_digest(const packed_transaction::prunable_data_type::none& obj) {
    return obj.prunable_digest;
 }
 
-static digest_type prunable_digest(const prunable_transaction_data::partial& obj) {
+static digest_type prunable_digest(const packed_transaction::prunable_data_type::partial& obj) {
    EOS_THROW(tx_prune_exception, "unimplemented");
 }
 
-static digest_type prunable_digest(const prunable_transaction_data::signatures_only& obj) {
+static digest_type prunable_digest(const packed_transaction::prunable_data_type::signatures_only& obj) {
    EOS_THROW(tx_prune_exception, "unimplemented");
 }
 
-static digest_type prunable_digest(const prunable_transaction_data::full& obj) {
+static digest_type prunable_digest(const packed_transaction::prunable_data_type::full& obj) {
    EOS_THROW(tx_prune_exception, "unimplemented");
 }
 
-static digest_type prunable_digest(const prunable_transaction_data::full_legacy& obj) {
+static digest_type prunable_digest(const packed_transaction::prunable_data_type::full_legacy& obj) {
    digest_type::encoder prunable;
    fc::raw::pack( prunable, obj.signatures );
    fc::raw::pack( prunable, obj.packed_context_free_data );
    return prunable.result();
 }
 
-digest_type prunable_transaction_data::digest() const {
+digest_type packed_transaction::prunable_data_type::digest() const {
    return prunable_data.visit( [](const auto& obj) { return prunable_digest(obj); } );
 }
 
 static constexpr std::size_t digest_pack_size = 32;
 
-static std::size_t padded_pack_size(const prunable_transaction_data::none& obj, prunable_transaction_data::compression_type) {
+static std::size_t padded_pack_size( const packed_transaction::prunable_data_type::none& obj, packed_transaction::prunable_data_type::compression_type) {
    std::size_t result = fc::raw::pack_size(obj);
    EOS_ASSERT(result == digest_pack_size, packed_transaction_type_exception, "Unexpected size of packed digest");
    return result;
 }
 
-static std::size_t padded_pack_size(const prunable_transaction_data::signatures_only& obj, prunable_transaction_data::compression_type) {
+static std::size_t padded_pack_size( const packed_transaction::prunable_data_type::signatures_only& obj, packed_transaction::prunable_data_type::compression_type) {
    return fc::raw::pack_size(obj);
 }
 
-static std::size_t padded_pack_size(const prunable_transaction_data::partial& obj, prunable_transaction_data::compression_type segment_compression) {
+static std::size_t padded_pack_size( const packed_transaction::prunable_data_type::partial& obj, packed_transaction::prunable_data_type::compression_type segment_compression) {
      EOS_THROW(tx_prune_exception, "unimplemented");
 }
 
-static std::size_t padded_pack_size(const prunable_transaction_data::full& obj, prunable_transaction_data::compression_type segment_compression) {
+static std::size_t padded_pack_size( const packed_transaction::prunable_data_type::full& obj, packed_transaction::prunable_data_type::compression_type segment_compression) {
    EOS_THROW(tx_prune_exception, "unimplemented");
 #if 0
    std::size_t context_free_size = fc::raw::pack_size(fc::unsigned_int(obj.context_free_segments.size()));
@@ -450,22 +450,22 @@ static std::size_t padded_pack_size(const prunable_transaction_data::full& obj, 
 #endif
 }
 
-static std::size_t padded_pack_size(const prunable_transaction_data::full_legacy& obj, prunable_transaction_data::compression_type) {
+static std::size_t padded_pack_size( const packed_transaction::prunable_data_type::full_legacy& obj, packed_transaction::prunable_data_type::compression_type) {
   return std::max(fc::raw::pack_size(obj), digest_pack_size);
 }
 
-std::size_t prunable_transaction_data::maximum_pruned_pack_size(prunable_transaction_data::compression_type compression) const {
+std::size_t packed_transaction::prunable_data_type::maximum_pruned_pack_size( packed_transaction::prunable_data_type::compression_type compression) const {
    return 1 + prunable_data.visit([&](const auto& t){ return padded_pack_size(t, compression); });
 }
 
-static prunable_transaction_data make_prunable_transaction_data( bool legacy, vector<signature_type> signatures,
-                                                                 vector<bytes> context_free_data,
-                                                                 packed_transaction::compression_type _compression ) {
+static packed_transaction::prunable_data_type make_prunable_transaction_data( bool legacy, vector<signature_type> signatures,
+                                                                              vector<bytes> context_free_data,
+                                                                              packed_transaction::compression_type _compression ) {
    if(legacy) {
       bytes packed_cfd = pack_context_free_data( context_free_data, _compression );
-      return { prunable_transaction_data::full_legacy{ std::move(signatures), std::move(packed_cfd), std::move(context_free_data) } };
+      return {packed_transaction::prunable_data_type::full_legacy{std::move( signatures), std::move( packed_cfd), std::move( context_free_data) } };
    } else {
-      return { prunable_transaction_data::full{ std::move(signatures), std::move(context_free_data) } };
+      return {packed_transaction::prunable_data_type::full{std::move( signatures), std::move( context_free_data) } };
    }
 }
 
@@ -481,11 +481,11 @@ packed_transaction::packed_transaction(signed_transaction t, bool legacy, compre
 
 packed_transaction::packed_transaction(const packed_transaction_v0& other, bool legacy)
  : compression(other.compression),
-   prunable_data(legacy ? prunable_transaction_data{ prunable_transaction_data::full_legacy{ other.signatures,
-                                                                                             other.packed_context_free_data,
-                                                                                             other.unpacked_trx.context_free_data } }
-                        : prunable_transaction_data{ prunable_transaction_data::full{ other.signatures,
-                                                                                      other.unpacked_trx.context_free_data } }),
+   prunable_data(legacy ? prunable_data_type{prunable_data_type::full_legacy{other.signatures,
+                                                                             other.packed_context_free_data,
+                                                                             other.unpacked_trx.context_free_data } }
+                        : prunable_data_type{prunable_data_type::full{other.signatures,
+                                                                      other.unpacked_trx.context_free_data } }),
    packed_trx(other.packed_trx),
    unpacked_trx(other.unpacked_trx),
    trx_id(other.id())
@@ -495,11 +495,11 @@ packed_transaction::packed_transaction(const packed_transaction_v0& other, bool 
 
 packed_transaction::packed_transaction(packed_transaction_v0&& other, bool legacy)
  : compression(other.compression),
-   prunable_data(legacy ? prunable_transaction_data{ prunable_transaction_data::full_legacy{ std::move(other.signatures),
-                                                                                             std::move(other.packed_context_free_data),
-                                                                                             std::move(other.unpacked_trx.context_free_data) } }
-                        : prunable_transaction_data{ prunable_transaction_data::full{ std::move(other.signatures),
-                                                                                      std::move(other.unpacked_trx.context_free_data) } }),
+   prunable_data(legacy ? prunable_data_type{prunable_data_type::full_legacy{std::move( other.signatures),
+                                                                             std::move(other.packed_context_free_data),
+                                                                             std::move(other.unpacked_trx.context_free_data) } }
+                        : prunable_data_type{prunable_data_type::full{std::move( other.signatures),
+                                                                      std::move(other.unpacked_trx.context_free_data) } }),
    packed_trx(std::move(other.packed_trx)),
    unpacked_trx(std::move(other.unpacked_trx)),
    trx_id(other.id())
@@ -523,14 +523,14 @@ uint32_t packed_transaction::get_unprunable_size()const {
    return static_cast<uint32_t>(size);
 }
 
-static uint32_t get_prunable_size_impl(const prunable_transaction_data::full_legacy& obj) {
+static uint32_t get_prunable_size_impl(const packed_transaction::prunable_data_type::full_legacy& obj) {
    uint64_t size = fc::raw::pack_size(obj.signatures);
    size += obj.packed_context_free_data.size();
    EOS_ASSERT( size <= std::numeric_limits<uint32_t>::max(), tx_too_big, "packed_transaction is too big" );
    return static_cast<uint32_t>(size);
 }
 
-static uint32_t get_prunable_size_impl(const prunable_transaction_data::full&) {
+static uint32_t get_prunable_size_impl(const packed_transaction::prunable_data_type::full&) {
    EOS_THROW(tx_prune_exception, "unimplemented");
 }
 
@@ -550,7 +550,7 @@ uint32_t packed_transaction::calculate_estimated_size() const {
          for( const auto& v : vec ) s += v.size();
          return s;
       },
-      [](const std::vector<prunable_transaction_data::segment_type>& vec) {
+      [](const std::vector<prunable_data_type::segment_type>& vec) {
          uint32_t s = 0;
          for( const auto& v : vec ) {
             s += v.visit( overloaded{
@@ -562,17 +562,17 @@ uint32_t packed_transaction::calculate_estimated_size() const {
       }
    };
    auto visitor = overloaded{
-         [](const prunable_transaction_data::none& v) { return 0ul; },
-         [](const prunable_transaction_data::signatures_only& v) {
+         [](const prunable_data_type::none& v) { return 0ul; },
+         [](const prunable_data_type::signatures_only& v) {
             return v.signatures.size() * sizeof(signature_type);
          },
-         [&](const prunable_transaction_data::partial& v) {
+         [&](const prunable_data_type::partial& v) {
             return v.signatures.size() * sizeof(signature_type) + est_size(v.context_free_segments);
          },
-         [&](const prunable_transaction_data::full& v) {
+         [&](const prunable_data_type::full& v) {
             return v.signatures.size() * sizeof(signature_type) + est_size(v.context_free_segments);
          },
-         [&](const prunable_transaction_data::full_legacy& v) {
+         [&](const prunable_data_type::full_legacy& v) {
             return v.signatures.size() * sizeof(signature_type) + v.packed_context_free_data.size() + est_size(v.context_free_segments);
          }
    };
@@ -590,24 +590,24 @@ digest_type packed_transaction::packed_digest()const {
 
 template<typename T>
 static auto maybe_get_signatures(const T& obj) -> decltype(&obj.signatures) { return &obj.signatures; }
-static auto maybe_get_signatures(const prunable_transaction_data::none&) -> const std::vector<signature_type>* { return nullptr; }
+static auto maybe_get_signatures(const packed_transaction::prunable_data_type::none&) -> const std::vector<signature_type>* { return nullptr; }
 const vector<signature_type>* packed_transaction::get_signatures()const {
    return prunable_data.prunable_data.visit([](const auto& obj) { return maybe_get_signatures(obj); });
 }
 
 const vector<bytes>* packed_transaction::get_context_free_data()const {
-   if( prunable_data.prunable_data.contains<prunable_transaction_data::full>() ) {
-      return &prunable_data.prunable_data.get<prunable_transaction_data::full>().context_free_segments;
-   } else if( prunable_data.prunable_data.contains<prunable_transaction_data::full_legacy>() ) {
-      return &prunable_data.prunable_data.get<prunable_transaction_data::full_legacy>().context_free_segments;
+   if( prunable_data.prunable_data.contains<prunable_data_type::full>() ) {
+      return &prunable_data.prunable_data.get<prunable_data_type::full>().context_free_segments;
+   } else if( prunable_data.prunable_data.contains<prunable_data_type::full_legacy>() ) {
+      return &prunable_data.prunable_data.get<prunable_data_type::full_legacy>().context_free_segments;
    } else {
       return nullptr;
    }
 }
 
-const bytes* maybe_get_context_free_data(const prunable_transaction_data::none&, std::size_t) { return nullptr; }
-const bytes* maybe_get_context_free_data(const prunable_transaction_data::signatures_only&, std::size_t) { return nullptr; }
-const bytes* maybe_get_context_free_data(const prunable_transaction_data::partial& p, std::size_t i) {
+const bytes* maybe_get_context_free_data( const packed_transaction::prunable_data_type::none&, std::size_t) { return nullptr; }
+const bytes* maybe_get_context_free_data( const packed_transaction::prunable_data_type::signatures_only&, std::size_t) { return nullptr; }
+const bytes* maybe_get_context_free_data( const packed_transaction::prunable_data_type::partial& p, std::size_t i) {
    if( p.context_free_segments.size() <= i ) return nullptr;
    return p.context_free_segments[i].visit(
          overloaded{
@@ -615,11 +615,11 @@ const bytes* maybe_get_context_free_data(const prunable_transaction_data::partia
                []( const bytes& vec ) { return &vec; }
          } );
 }
-const bytes* maybe_get_context_free_data(const prunable_transaction_data::full_legacy& full_leg, std::size_t i) {
+const bytes* maybe_get_context_free_data( const packed_transaction::prunable_data_type::full_legacy& full_leg, std::size_t i) {
    if( full_leg.context_free_segments.size() <= i ) return nullptr;
    return &full_leg.context_free_segments[i];
 }
-const bytes* maybe_get_context_free_data(const prunable_transaction_data::full& f, std::size_t i) {
+const bytes* maybe_get_context_free_data( const packed_transaction::prunable_data_type::full& f, std::size_t i) {
    if( f.context_free_segments.size() <= i ) return nullptr;
    return &f.context_free_segments[i];
 }
@@ -644,6 +644,10 @@ void packed_transaction::reflector_init()
    EOS_ASSERT( unpacked_trx.expiration == time_point_sec(), tx_decompression_error, "packed_transaction already unpacked" );
    unpacked_trx = unpack_transaction(packed_trx, compression);
    trx_id = unpacked_trx.id();
+   if( prunable_data.prunable_data.contains<prunable_data_type::full_legacy>() ) {
+      auto& legacy = prunable_data.prunable_data.get<prunable_data_type::full_legacy>();
+      legacy.context_free_segments = unpack_context_free_data( legacy.packed_context_free_data, compression );
+   }
    estimated_size = calculate_estimated_size();
 }
 

--- a/pipeline.jsonc
+++ b/pipeline.jsonc
@@ -40,7 +40,7 @@
         "test":
         [
             {
-                "commit": "8f96b7a03f28b2ec1f03d37779bba294cded9ba7"
+                "commit": "90c0e870e55d25853fc49a08be2cd683fbc4fa31"
             }
         ]
     }

--- a/unittests/misc_tests.cpp
+++ b/unittests/misc_tests.cpp
@@ -722,7 +722,8 @@ BOOST_AUTO_TEST_CASE(transaction_test) { try {
             ("name", "nonce")
             ("data", fc::raw::pack(std::string("dummy")))
          })
-      );
+      )
+      ("context_free_data", vector<bytes>{{'d','u','m','m','y',' ','d','a','t','a'}});
 
    abi_serializer::from_variant(pretty_trx, trx, test.get_resolver(), abi_serializer::create_yield_function( test.abi_serializer_max_time ));
 
@@ -796,6 +797,10 @@ BOOST_AUTO_TEST_CASE(transaction_test) { try {
    BOOST_CHECK_EQUAL(pkt.id(), pkt4.get_transaction().id());
    BOOST_CHECK_EQUAL(true, trx.expiration == pkt4.expiration());
    BOOST_CHECK_EQUAL(true, trx.expiration == pkt4.get_transaction().expiration);
+   BOOST_REQUIRE(pkt.get_context_free_data() != nullptr);
+   BOOST_REQUIRE(pkt4.get_context_free_data() != nullptr);
+   BOOST_REQUIRE_EQUAL(pkt.get_context_free_data()->size(), pkt4.get_context_free_data()->size());
+   BOOST_CHECK(std::equal(pkt.get_context_free_data()->begin(), pkt.get_context_free_data()->end(), pkt4.get_context_free_data()->begin()));
    keys.clear();
    pkt4.to_packed_transaction_v0()->get_signed_transaction().get_signature_keys(test.control->get_chain_id(), fc::time_point::maximum(), keys);
    BOOST_CHECK_EQUAL(1u, keys.size());
@@ -866,7 +871,8 @@ BOOST_AUTO_TEST_CASE(transaction_metadata_test) { try {
             ("name", "nonce")
             ("data", fc::raw::pack(std::string("dummy data")))
          })
-      );
+      )
+      ("context_free_data", vector<bytes>{{'d','u','m','m','y',' ','d','a','t','a'}});
 
       abi_serializer::from_variant(pretty_trx, trx, test.get_resolver(), abi_serializer::create_yield_function( test.abi_serializer_max_time ));
 
@@ -919,43 +925,43 @@ BOOST_AUTO_TEST_CASE(transaction_metadata_test) { try {
 
 BOOST_AUTO_TEST_CASE(prunable_transaction_data_test) {
    {
-      prunable_transaction_data basic{prunable_transaction_data::full_legacy{{}, {}}};
-      prunable_transaction_data pruned = prunable_transaction_data(basic).prune_all();
-      BOOST_TEST(basic.maximum_pruned_pack_size(prunable_transaction_data::compression_type::none) >=
-                 pruned.maximum_pruned_pack_size(prunable_transaction_data::compression_type::none));
-      BOOST_TEST(fc::raw::pack_size(basic) <= basic.maximum_pruned_pack_size(prunable_transaction_data::compression_type::none));
-      BOOST_TEST(fc::raw::pack_size(pruned) <= pruned.maximum_pruned_pack_size(prunable_transaction_data::compression_type::none));
+      packed_transaction::prunable_data_type basic{packed_transaction::prunable_data_type::full_legacy{{}, {}}};
+      packed_transaction::prunable_data_type pruned = packed_transaction::prunable_data_type( basic).prune_all();
+      BOOST_TEST( basic.maximum_pruned_pack_size( packed_transaction::prunable_data_type::compression_type::none) >=
+                  pruned.maximum_pruned_pack_size( packed_transaction::prunable_data_type::compression_type::none));
+      BOOST_TEST(fc::raw::pack_size(basic) <= basic.maximum_pruned_pack_size( packed_transaction::prunable_data_type::compression_type::none));
+      BOOST_TEST(fc::raw::pack_size(pruned) <= pruned.maximum_pruned_pack_size( packed_transaction::prunable_data_type::compression_type::none));
       BOOST_TEST(basic.digest().str() == pruned.digest().str());
    }
 
    bytes large_bytes(48);
    {
-      prunable_transaction_data basic{prunable_transaction_data::full_legacy{{}, fc::raw::pack(std::vector(4, large_bytes))}};
-      prunable_transaction_data pruned = prunable_transaction_data(basic).prune_all();
-      BOOST_TEST(basic.maximum_pruned_pack_size(prunable_transaction_data::compression_type::none) >=
-                 pruned.maximum_pruned_pack_size(prunable_transaction_data::compression_type::none));
-      BOOST_TEST(fc::raw::pack_size(basic) <= basic.maximum_pruned_pack_size(prunable_transaction_data::compression_type::none));
-      BOOST_TEST(fc::raw::pack_size(pruned) <= pruned.maximum_pruned_pack_size(prunable_transaction_data::compression_type::none));
+      packed_transaction::prunable_data_type basic{packed_transaction::prunable_data_type::full_legacy{{}, fc::raw::pack( std::vector( 4, large_bytes))}};
+      packed_transaction::prunable_data_type pruned = packed_transaction::prunable_data_type(basic).prune_all();
+      BOOST_TEST( basic.maximum_pruned_pack_size( packed_transaction::prunable_data_type::compression_type::none) >=
+                  pruned.maximum_pruned_pack_size( packed_transaction::prunable_data_type::compression_type::none));
+      BOOST_TEST(fc::raw::pack_size(basic) <= basic.maximum_pruned_pack_size( packed_transaction::prunable_data_type::compression_type::none));
+      BOOST_TEST(fc::raw::pack_size(pruned) <= pruned.maximum_pruned_pack_size( packed_transaction::prunable_data_type::compression_type::none));
       BOOST_TEST(basic.digest().str() == pruned.digest().str());
    }
 
    {
-      prunable_transaction_data basic{prunable_transaction_data::full_legacy{std::vector(4, signature_type()), fc::raw::pack(std::vector(4, large_bytes))}};
-      prunable_transaction_data pruned = prunable_transaction_data(basic).prune_all();
-      BOOST_TEST(basic.maximum_pruned_pack_size(prunable_transaction_data::compression_type::none) >=
-                 pruned.maximum_pruned_pack_size(prunable_transaction_data::compression_type::none));
-      BOOST_TEST(fc::raw::pack_size(basic) <= basic.maximum_pruned_pack_size(prunable_transaction_data::compression_type::none));
-      BOOST_TEST(fc::raw::pack_size(pruned) <= pruned.maximum_pruned_pack_size(prunable_transaction_data::compression_type::none));
+      packed_transaction::prunable_data_type basic{packed_transaction::prunable_data_type::full_legacy{std::vector( 4, signature_type()), fc::raw::pack( std::vector( 4, large_bytes))}};
+      packed_transaction::prunable_data_type pruned = packed_transaction::prunable_data_type(basic).prune_all();
+      BOOST_TEST( basic.maximum_pruned_pack_size( packed_transaction::prunable_data_type::compression_type::none) >=
+                  pruned.maximum_pruned_pack_size( packed_transaction::prunable_data_type::compression_type::none));
+      BOOST_TEST(fc::raw::pack_size(basic) <= basic.maximum_pruned_pack_size( packed_transaction::prunable_data_type::compression_type::none));
+      BOOST_TEST(fc::raw::pack_size(pruned) <= pruned.maximum_pruned_pack_size( packed_transaction::prunable_data_type::compression_type::none));
       BOOST_TEST(basic.digest().str() == pruned.digest().str());
    }
 
    {
-      prunable_transaction_data basic{prunable_transaction_data::full_legacy{std::vector(4, signature_type()), {}}};
-      prunable_transaction_data pruned = prunable_transaction_data(basic).prune_all();
-      BOOST_TEST(basic.maximum_pruned_pack_size(prunable_transaction_data::compression_type::none) >=
-                 pruned.maximum_pruned_pack_size(prunable_transaction_data::compression_type::none));
-      BOOST_TEST(fc::raw::pack_size(basic) <= basic.maximum_pruned_pack_size(prunable_transaction_data::compression_type::none));
-      BOOST_TEST(fc::raw::pack_size(pruned) <= pruned.maximum_pruned_pack_size(prunable_transaction_data::compression_type::none));
+      packed_transaction::prunable_data_type basic{packed_transaction::prunable_data_type::full_legacy{std::vector( 4, signature_type()), {}}};
+      packed_transaction::prunable_data_type pruned = packed_transaction::prunable_data_type(basic).prune_all();
+      BOOST_TEST( basic.maximum_pruned_pack_size( packed_transaction::prunable_data_type::compression_type::none) >=
+                  pruned.maximum_pruned_pack_size( packed_transaction::prunable_data_type::compression_type::none));
+      BOOST_TEST(fc::raw::pack_size(basic) <= basic.maximum_pruned_pack_size( packed_transaction::prunable_data_type::compression_type::none));
+      BOOST_TEST(fc::raw::pack_size(pruned) <= pruned.maximum_pruned_pack_size( packed_transaction::prunable_data_type::compression_type::none));
       BOOST_TEST(basic.digest().str() == pruned.digest().str());
    }
 }


### PR DESCRIPTION
## Change Description

- Fixed reflection issue with `prunable_data_type::full_legacy` `context_free_data`. 
- Moved `prunable_data_type` into `packed_transaction` since it needs the `reflector_init` of `packed_transaction` to unpack correctly.

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
