### PR TITLE
Replace bc with shell arithmetic - develop

### DIFF
--- a/scripts/helpers/general.sh
+++ b/scripts/helpers/general.sh
@@ -63,7 +63,7 @@ function set_system_vars() {
         export OS_MAJ=$(echo "${OS_VER}" | cut -d'.' -f1)
         export OS_MIN=$(echo "${OS_VER}" | cut -d'.' -f2)
         export OS_PATCH=$(echo "${OS_VER}" | cut -d'.' -f3)
-        export MEM_GIG=$(bc <<< "($(sysctl -in hw.memsize) / 1024000000)")
+        export MEM_GIG=$(($(sysctl -in hw.memsize) / 1024 / 1024 /1024))
         export DISK_INSTALL=$(df -h . | tail -1 | tr -s ' ' | cut -d\  -f1 || cut -d' ' -f1)
         export blksize=$(df . | head -1 | awk '{print $2}' | cut -d- -f1)
         export gbfactor=$(( 1073741824 / blksize ))


### PR DESCRIPTION
This is the `develop` counterpart of https://github.com/EOSIO/eos/pull/8949.

## Change Description

The variable `MEM_GIG` was computed using `bc`, an arbitrary precision calculator. That caused a numeric comparison that used that variable in `scripts/eosio_build_darwin.sh` to fail when the scale was set to a value greater than zero in the user's `~/.bc` configuration file.

This commit fixes the problem by switching to shell arithmetic when computing `MEM_GIG`.

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
