### PR TITLE
Support Running ALL Tests in One Build

### DIFF
--- a/.cicd/generate-pipeline.sh
+++ b/.cicd/generate-pipeline.sh
@@ -36,7 +36,10 @@ for FILE in $(ls $CICD_DIR/platforms/$PLATFORM_TYPE); do
     # macos-10.14
     # ubuntu-16.04
     # skip Mojave if it's anything but the post-merge build
-    [[ "$RUN_ALL_TESTS" == 'true' || "SKIP_MACOS_10_14" == 'false' ]] || [[ $FILE_NAME =~ 'macos-10.14' ]] && ( [[ $BUILDKITE_SOURCE != 'webhook' ]] || [[ $BUILDKITE_PULL_REQUEST != false ]] || [[ ! $BUILDKITE_MESSAGE =~ 'Merge pull request' ]] ) && export SKIP_MACOS_10_14=true && continue
+    if [[ "$FILE_NAME" =~ 'macos-10.14' && "$SKIP_MACOS_10_14" != 'false' && "$RUN_ALL_TESTS" != 'true' && ( "$BUILDKITE_SOURCE" != 'webhook' || "$BUILDKITE_PULL_REQUEST" != 'false' || ! "$BUILDKITE_MESSAGE" =~ 'Merge pull request' ) ]]; then
+        export SKIP_MACOS_10_14='true'
+        continue
+    fi
     export PLATFORM_NAME="$(echo $FILE_NAME | cut -d- -f1 | sed 's/os/OS/g')"
     # macOS
     # ubuntu

--- a/.cicd/generate-pipeline.sh
+++ b/.cicd/generate-pipeline.sh
@@ -93,7 +93,7 @@ if [[ ! -z ${BUILDKITE_TRIGGERED_FROM_BUILD_ID} ]]; then
 fi
 export BUILD_SOURCE=${BUILD_SOURCE:---build \$BUILDKITE_BUILD_ID}
 # set trigger_job if master/release/develop branch and webhook
-if [[ ! $BUILDKITE_PIPELINE_SLUG =~ 'lrt' ]] && [[ $BUILDKITE_BRANCH =~ ^release/[0-9]+\.[0-9]+\.x$ || $BUILDKITE_BRANCH =~ ^master$ || $BUILDKITE_BRANCH =~ ^develop$ ]]; then
+if [[ ! $BUILDKITE_PIPELINE_SLUG =~ 'lrt' ]] && [[ $BUILDKITE_BRANCH =~ ^release/[0-9]+\.[0-9]+\.x$ || $BUILDKITE_BRANCH =~ ^master$ || $BUILDKITE_BRANCH =~ ^develop$ || "$SKIP_LONG_RUNNING_TESTS" == 'false' ]]; then
     [[ $BUILDKITE_SOURCE != 'schedule' ]] && export TRIGGER_JOB=true
 fi
 # run LRTs synchronously when running full test suite

--- a/.cicd/generate-pipeline.sh
+++ b/.cicd/generate-pipeline.sh
@@ -36,7 +36,7 @@ for FILE in $(ls $CICD_DIR/platforms/$PLATFORM_TYPE); do
     # macos-10.14
     # ubuntu-16.04
     # skip Mojave if it's anything but the post-merge build
-    [[ "$RUN_ALL_TESTS" == 'true' ]] || [[ $FILE_NAME =~ 'macos-10.14' ]] && ( [[ $BUILDKITE_SOURCE != 'webhook' ]] || [[ $BUILDKITE_PULL_REQUEST != false ]] || [[ ! $BUILDKITE_MESSAGE =~ 'Merge pull request' ]] ) && export SKIP_MACOS_10_14=true && continue
+    [[ "$RUN_ALL_TESTS" == 'true' || "SKIP_MACOS_10_14" == 'false' ]] || [[ $FILE_NAME =~ 'macos-10.14' ]] && ( [[ $BUILDKITE_SOURCE != 'webhook' ]] || [[ $BUILDKITE_PULL_REQUEST != false ]] || [[ ! $BUILDKITE_MESSAGE =~ 'Merge pull request' ]] ) && export SKIP_MACOS_10_14=true && continue
     export PLATFORM_NAME="$(echo $FILE_NAME | cut -d- -f1 | sed 's/os/OS/g')"
     # macOS
     # ubuntu

--- a/.cicd/generate-pipeline.sh
+++ b/.cicd/generate-pipeline.sh
@@ -100,8 +100,9 @@ if [[ ! $BUILDKITE_PIPELINE_SLUG =~ 'lrt' ]] && [[ $BUILDKITE_BRANCH =~ ^release
     [[ $BUILDKITE_SOURCE != 'schedule' ]] && export TRIGGER_JOB=true
 fi
 # run LRTs synchronously when running full test suite
-if [[ "$RUN_ALL_TESTS" == 'true' ]]; then
-    [[ "$SKIP_LONG_RUNNING_TESTS" != 'true' ]] && export SKIP_LONG_RUNNING_TESTS='false' && export TRIGGER_JOB='false'
+if [[ "$RUN_ALL_TESTS" == 'true' && "$SKIP_LONG_RUNNING_TESTS" != 'true' ]]; then
+    export SKIP_LONG_RUNNING_TESTS='false'
+    export TRIGGER_JOB='false'
 fi
 oIFS="$IFS"
 IFS=$''

--- a/.cicd/generate-pipeline.sh
+++ b/.cicd/generate-pipeline.sh
@@ -36,7 +36,7 @@ for FILE in $(ls $CICD_DIR/platforms/$PLATFORM_TYPE); do
     # macos-10.14
     # ubuntu-16.04
     # skip Mojave if it's anything but the post-merge build
-    [[ $FILE_NAME =~ 'macos-10.14' ]] && ( [[ $BUILDKITE_SOURCE != 'webhook' ]] || [[ $BUILDKITE_PULL_REQUEST != false ]] || [[ ! $BUILDKITE_MESSAGE =~ 'Merge pull request' ]] ) && export SKIP_MACOS_10_14=true && continue
+    [[ "$RUN_ALL_TESTS" == 'true' ]] || [[ $FILE_NAME =~ 'macos-10.14' ]] && ( [[ $BUILDKITE_SOURCE != 'webhook' ]] || [[ $BUILDKITE_PULL_REQUEST != false ]] || [[ ! $BUILDKITE_MESSAGE =~ 'Merge pull request' ]] ) && export SKIP_MACOS_10_14=true && continue
     export PLATFORM_NAME="$(echo $FILE_NAME | cut -d- -f1 | sed 's/os/OS/g')"
     # macOS
     # ubuntu

--- a/.cicd/generate-pipeline.sh
+++ b/.cicd/generate-pipeline.sh
@@ -96,6 +96,10 @@ export BUILD_SOURCE=${BUILD_SOURCE:---build \$BUILDKITE_BUILD_ID}
 if [[ ! $BUILDKITE_PIPELINE_SLUG =~ 'lrt' ]] && [[ $BUILDKITE_BRANCH =~ ^release/[0-9]+\.[0-9]+\.x$ || $BUILDKITE_BRANCH =~ ^master$ || $BUILDKITE_BRANCH =~ ^develop$ ]]; then
     [[ $BUILDKITE_SOURCE != 'schedule' ]] && export TRIGGER_JOB=true
 fi
+# run LRTs synchronously when running full test suite
+if [[ "$RUN_ALL_TESTS" == 'true' ]]; then
+    [[ "$SKIP_LONG_RUNNING_TESTS" != 'true' ]] && export SKIP_LONG_RUNNING_TESTS='false' && export TRIGGER_JOB='false'
+fi
 oIFS="$IFS"
 IFS=$''
 nIFS=$IFS # fix array splitting (\n won't work)

--- a/.cicd/generate-pipeline.sh
+++ b/.cicd/generate-pipeline.sh
@@ -457,7 +457,7 @@ EOF
     fi
 done
 # Execute multiversion test
-if ( [[ ! $PINNED == false ]] ); then
+if [[ ! "$PINNED" == 'false' || "$SKIP_MULTIVERSION_TEST" == 'false' ]]; then
         cat <<EOF
   - label: ":pipeline: Multiversion Test"
     command: 


### PR DESCRIPTION
## Change Description
This pull request enables engineers to start a build with `RUN_ALL_TESTS` set to `true` to run ALL tests in the CICD pipeline, for example, to include the time-consuming post-merge checks on a pre-merge build.   
   
Pinned and unpinned builds and tests must still be done in separate builds due to step (AKA Buildkite job) name collisions. This is possible to do, but the cost and risk of changing the step names and updating the infrastructure built around them is not worth the tradeoff, as we have learned in the past.  
  
### Tested Working
Some builds show the pipeline step generation and then were cancelled so as not to waste agents, while other builds show pipeline step generation and passing tests.
- Pinned
  - [Build 21525](https://buildkite.com/EOSIO/eosio/builds/21525) -- normal build
  - [Build 21526](https://buildkite.com/EOSIO/eosio/builds/21526) -- ran all tests by setting `RUN_ALL_TESTS='true'`
- Unpinned
  - [Build 1541](https://buildkite.com/EOSIO/eosio-build-unpinned/builds/1541) -- normal build
  - [Build 1555](https://buildkite.com/EOSIO/eosio-build-unpinned/builds/1555) -- ran all tests by setting `RUN_ALL_TESTS='true'`
  
### See Also
- [Pull request 8961](https://github.com/EOSIO/eos/pull/8961) -- `eos:develop`
- [Pull request 8968](https://github.com/EOSIO/eos/pull/8968) -- `eos:release/2.0.x`
- [Pull request 8969](https://github.com/EOSIO/eos/pull/8969) -- `eos:release/1.8.x`

## Consensus Changes
- [ ] Consensus Changes
None.

## API Changes
- [ ] API Changes
None.

## Documentation Additions
- [ ] Documentation Additions
None.