### PR TITLE
Make /bin/df ignore $BLOCKSIZE - 2.0

### DIFF
--- a/scripts/helpers/general.sh
+++ b/scripts/helpers/general.sh
@@ -64,21 +64,14 @@ function set_system_vars() {
         export OS_MIN=$(echo "${OS_VER}" | cut -d'.' -f2)
         export OS_PATCH=$(echo "${OS_VER}" | cut -d'.' -f3)
         export MEM_GIG=$(($(sysctl -in hw.memsize) / 1024 / 1024 /1024))
-        export DISK_INSTALL=$(df -h . | tail -1 | tr -s ' ' | cut -d\  -f1 || cut -d' ' -f1)
-        export blksize=$(df . | head -1 | awk '{print $2}' | cut -d- -f1)
-        export gbfactor=$(( 1073741824 / blksize ))
-        export total_blks=$(df . | tail -1 | awk '{print $2}')
-        export avail_blks=$(df . | tail -1 | awk '{print $4}')
-        export DISK_TOTAL=$((total_blks / gbfactor ))
-        export DISK_AVAIL=$((avail_blks / gbfactor ))
     else
-        export DISK_INSTALL=$( df -h . | tail -1 | tr -s ' ' | cut -d\  -f1 )
-        export DISK_TOTAL_KB=$( df . | tail -1 | awk '{print $2}' )
-        export DISK_AVAIL_KB=$( df . | tail -1 | awk '{print $4}' )
         export MEM_GIG=$(( ( ( $(cat /proc/meminfo | grep MemTotal | awk '{print $2}') / 1000 ) / 1000 ) ))
-        export DISK_TOTAL=$(( DISK_TOTAL_KB / 1048576 ))
-        export DISK_AVAIL=$(( DISK_AVAIL_KB / 1048576 ))
     fi
+    local IFS=' '
+    set `df -k . | tail -1`
+    export DISK_INSTALL=$1
+    export DISK_TOTAL=$(($2 / 1024 / 1024))
+    export DISK_AVAIL=$(($4 / 1024 / 1024))
     export JOBS=${JOBS:-$(( MEM_GIG > CPU_CORES ? CPU_CORES : MEM_GIG ))}
 }
 


### PR DESCRIPTION
This is the 2.0 counterpart of https://github.com/EOSIO/eos/pull/8959

## Change Description

When called without any parameter to override the block size, `/bin/df` uses the `$BLOCKSIZE` environment variable. That variable may contain units like K, M, G, etc.

Before this commit, `general.sh` took the value of `$BLOCKSIZE` from the output of `df` and used it in arithmetic expressions, which broke them because of the unit suffixes.

This commit adds the highly portable `-k` option to the `df` invocation to explicitly set the value of block size to 1024.

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
