### PR TITLE
tests/get_table_tests.cpp: incorrect use of CORE_SYM_STR - develop

### DIFF
--- a/tests/get_table_tests.cpp
+++ b/tests/get_table_tests.cpp
@@ -345,7 +345,7 @@ BOOST_FIXTURE_TEST_CASE( get_table_by_seckey_test, TESTER ) try {
    base_tester::push_action(config::system_account_name, N(init),
                             config::system_account_name,  mutable_variant_object()
                             ("version", 0)
-                            ("core", CORE_SYM_STR));
+                            ("core", "4,SYS"));
 
    // bidname
    auto bidname = [this]( const account_name& bidder, const account_name& newname, const asset& bid ) {


### PR DESCRIPTION
plugin_test fails if core symbol is different from 4,SYS

## Change Description
plugin_test fails because the tets blockchain is created with "4.SYS", and then it pushes the init transaction using CORE_SYM_STR which may be defined differently (it is defined differently in WAX)

Cherry-pick of #8962 

Thanks @cc32d9 