### PR TITLE
Add possibility to run .cicd scripts from different environments (2.0.x Backport)

### DIFF
--- a/.cicd/build.sh
+++ b/.cicd/build.sh
@@ -3,7 +3,7 @@ set -eo pipefail
 . ./.cicd/helpers/general.sh
 mkdir -p $BUILD_DIR
 CMAKE_EXTRAS="-DCMAKE_BUILD_TYPE='Release' -DENABLE_MULTIVERSION_PROTOCOL_TEST=true -DBUILD_MONGO_DB_PLUGIN=true"
-if [[ "$(uname)" == 'Darwin' ]]; then
+if [[ "$(uname)" == 'Darwin' && $FORCE_LINUX != true ]]; then
     # You can't use chained commands in execute
     if [[ "$GITHUB_ACTIONS" == 'true' ]]; then
         export PINNED=false
@@ -38,6 +38,8 @@ else # Linux
         [[ "$ENABLE_INSTALL" == 'true' ]] && COMMANDS="$COMMANDS && make install"
     elif [[ "$GITHUB_ACTIONS" == 'true' ]]; then
         ARGS="$ARGS -e JOBS"
+        COMMANDS="$BUILD_COMMANDS"
+    else
         COMMANDS="$BUILD_COMMANDS"
     fi
     . $HELPERS_DIR/file-hash.sh $CICD_DIR/platforms/$PLATFORM_TYPE/$IMAGE_TAG.dockerfile

--- a/.cicd/helpers/file-hash.sh
+++ b/.cicd/helpers/file-hash.sh
@@ -4,4 +4,4 @@ set -eo pipefail
 FILE_NAME=$(basename $1 | awk '{split($0,a,/\.(d|s)/); print a[1] }')
 export DETERMINED_HASH=$(sha1sum $1 | awk '{ print $1 }')
 export HASHED_IMAGE_TAG="eos-${FILE_NAME}-${DETERMINED_HASH}"
-export FULL_TAG="eosio/ci:$HASHED_IMAGE_TAG"
+export FULL_TAG="${IMAGE_NAME:-"eosio/ci"}:$HASHED_IMAGE_TAG"


### PR DESCRIPTION
## Change Description
Backport to `release/2.0.x` branch of PR #8865 

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
