### PR TITLE
Net plugin - new signed_block/packed_transaction support

### DIFF
--- a/libraries/chain/block.cpp
+++ b/libraries/chain/block.cpp
@@ -133,12 +133,12 @@ namespace eosio { namespace chain {
       return validate_and_extract_block_extensions( block_extensions );
    }
 
-   signed_block_v0_uptr signed_block::to_signed_block_v0() const {
+   fc::optional<signed_block_v0> signed_block::to_signed_block_v0() const {
       if (prune_state != prune_state_type::complete_legacy)
-         return signed_block_v0_uptr{};
+         return {};
 
-      auto result = std::make_unique<signed_block_v0>(*static_cast<const signed_block_header*>(this));
-      result->block_extensions = this->block_extensions;
+      signed_block_v0 result(*static_cast<const signed_block_header*>(this));
+      result.block_extensions = this->block_extensions;
 
       auto visitor = overloaded{
           [](const transaction_id_type &id) -> transaction_receipt_v0::trx_type { return id; },
@@ -148,7 +148,7 @@ namespace eosio { namespace chain {
           }};
 
       for (const transaction_receipt &r : transactions){
-         result->transactions.emplace_back(transaction_receipt_v0{r, r.trx.visit(visitor)});
+         result.transactions.emplace_back(transaction_receipt_v0{r, r.trx.visit(visitor)});
       }
       return result;
    }

--- a/libraries/chain/block.cpp
+++ b/libraries/chain/block.cpp
@@ -133,11 +133,11 @@ namespace eosio { namespace chain {
       return validate_and_extract_block_extensions( block_extensions );
    }
 
-   signed_block_v0_ptr signed_block::to_signed_block_v0() const {
+   signed_block_v0_uptr signed_block::to_signed_block_v0() const {
       if (prune_state != prune_state_type::complete_legacy)
-         return signed_block_v0_ptr{};
+         return signed_block_v0_uptr{};
 
-      auto result = std::make_shared<signed_block_v0>(*static_cast<const signed_block_header*>(this));
+      auto result = std::make_unique<signed_block_v0>(*static_cast<const signed_block_header*>(this));
       result->block_extensions = this->block_extensions;
 
       auto visitor = overloaded{

--- a/libraries/chain/include/eosio/chain/block.hpp
+++ b/libraries/chain/include/eosio/chain/block.hpp
@@ -104,7 +104,6 @@ namespace eosio { namespace chain {
    };
 
    using signed_block_v0_ptr = std::shared_ptr<const signed_block_v0>;
-   using signed_block_v0_uptr = std::unique_ptr<const signed_block_v0>;
 
    struct transaction_receipt : public transaction_receipt_header {
 
@@ -145,7 +144,7 @@ namespace eosio { namespace chain {
       signed_block& operator=(const signed_block&) = delete;
       signed_block& operator=(signed_block&&) = default;
       signed_block clone() const { return *this; }
-      signed_block_v0_uptr to_signed_block_v0() const;
+      fc::optional<signed_block_v0> to_signed_block_v0() const;
 
       fc::enum_type<uint8_t,prune_state_type> prune_state{prune_state_type::complete_legacy};
       deque<transaction_receipt>              transactions; /// new or generated transactions

--- a/libraries/chain/include/eosio/chain/block.hpp
+++ b/libraries/chain/include/eosio/chain/block.hpp
@@ -102,7 +102,9 @@ namespace eosio { namespace chain {
 
       flat_multimap<uint16_t, block_extension> validate_and_extract_extensions()const;
    };
+
    using signed_block_v0_ptr = std::shared_ptr<const signed_block_v0>;
+   using signed_block_v0_uptr = std::unique_ptr<const signed_block_v0>;
 
    struct transaction_receipt : public transaction_receipt_header {
 
@@ -143,7 +145,7 @@ namespace eosio { namespace chain {
       signed_block& operator=(const signed_block&) = delete;
       signed_block& operator=(signed_block&&) = default;
       signed_block clone() const { return *this; }
-      signed_block_v0_ptr to_signed_block_v0() const;
+      signed_block_v0_uptr to_signed_block_v0() const;
 
       fc::enum_type<uint8_t,prune_state_type> prune_state{prune_state_type::complete_legacy};
       deque<transaction_receipt>              transactions; /// new or generated transactions

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1423,7 +1423,7 @@ bool chain_plugin::export_reversible_blocks( const fc::path& reversible_dir,
          signed_block tmp;
          fc::datastream<const char *> ds( itr->packedblock.data(), itr->packedblock.size() );
          fc::raw::unpack(ds, tmp); // Verify that packed block has not been corrupted.
-         signed_block_v0_uptr v0 = tmp.to_signed_block_v0(); // store in signed_block_v0 format
+         const auto v0 = tmp.to_signed_block_v0(); // store in signed_block_v0 format
          auto packed_v0 = fc::raw::pack(*v0);
          reversible_blocks.write( packed_v0.data(), packed_v0.size() );
          end = itr->blocknum;

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1423,7 +1423,7 @@ bool chain_plugin::export_reversible_blocks( const fc::path& reversible_dir,
          signed_block tmp;
          fc::datastream<const char *> ds( itr->packedblock.data(), itr->packedblock.size() );
          fc::raw::unpack(ds, tmp); // Verify that packed block has not been corrupted.
-         signed_block_v0_ptr v0 = tmp.to_signed_block_v0(); // store in signed_block_v0 format
+         signed_block_v0_uptr v0 = tmp.to_signed_block_v0(); // store in signed_block_v0 format
          auto packed_v0 = fc::raw::pack(*v0);
          reversible_blocks.write( packed_v0.data(), packed_v0.size() );
          end = itr->blocknum;

--- a/plugins/net_plugin/include/eosio/net_plugin/protocol.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/protocol.hpp
@@ -135,6 +135,19 @@ namespace eosio {
       uint32_t end_block{0};
    };
 
+   struct generic_message {
+      go_away_message tmp; // until merge of generic message support
+   };
+
+   struct generic_support_message {
+      go_away_message tmp; // until merge of generic message support
+   };
+
+   struct trx_message_v1 {
+      fc::optional<transaction_id_type> trx_id; // only provided for large trx as trade-off for small trxs not worth it
+      packed_transaction trx;
+   };
+
    using net_message = static_variant<handshake_message,
                                       chain_size_message,
                                       go_away_message,
@@ -143,7 +156,11 @@ namespace eosio {
                                       request_message,
                                       sync_request_message,
                                       signed_block_v0,         // which = 7
-                                      packed_transaction_v0>;  // which = 8
+                                      packed_transaction_v0,   // which = 8
+                                      generic_message,         // which = 9
+                                      generic_support_message, // which = 10
+                                      signed_block,            // which = 11
+                                      trx_message_v1>;         // which = 12
 
 } // namespace eosio
 
@@ -162,6 +179,10 @@ FC_REFLECT( eosio::time_message, (org)(rec)(xmt)(dst) )
 FC_REFLECT( eosio::notice_message, (known_trx)(known_blocks) )
 FC_REFLECT( eosio::request_message, (req_trx)(req_blocks) )
 FC_REFLECT( eosio::sync_request_message, (start_block)(end_block) )
+FC_REFLECT( eosio::generic_message, (tmp) )
+FC_REFLECT( eosio::generic_support_message, (tmp) )
+FC_REFLECT( eosio::trx_message_v1, (trx_id)(trx) )
+
 
 /**
  *

--- a/plugins/net_plugin/include/eosio/net_plugin/protocol.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/protocol.hpp
@@ -135,14 +135,6 @@ namespace eosio {
       uint32_t end_block{0};
    };
 
-   struct generic_message {
-      go_away_message tmp; // until merge of generic message support
-   };
-
-   struct generic_support_message {
-      go_away_message tmp; // until merge of generic message support
-   };
-
    struct trx_message_v1 {
       fc::optional<transaction_id_type> trx_id; // only provided for large trx as trade-off for small trxs not worth it
       std::shared_ptr<packed_transaction> trx;
@@ -157,10 +149,8 @@ namespace eosio {
                                       sync_request_message,
                                       signed_block_v0,         // which = 7
                                       packed_transaction_v0,   // which = 8
-                                      generic_message,         // which = 9
-                                      generic_support_message, // which = 10
-                                      signed_block,            // which = 11
-                                      trx_message_v1>;         // which = 12
+                                      signed_block,            // which = 9
+                                      trx_message_v1>;         // which = 10
 
 } // namespace eosio
 
@@ -179,8 +169,6 @@ FC_REFLECT( eosio::time_message, (org)(rec)(xmt)(dst) )
 FC_REFLECT( eosio::notice_message, (known_trx)(known_blocks) )
 FC_REFLECT( eosio::request_message, (req_trx)(req_blocks) )
 FC_REFLECT( eosio::sync_request_message, (start_block)(end_block) )
-FC_REFLECT( eosio::generic_message, (tmp) )
-FC_REFLECT( eosio::generic_support_message, (tmp) )
 FC_REFLECT( eosio::trx_message_v1, (trx_id)(trx) )
 
 

--- a/plugins/net_plugin/include/eosio/net_plugin/protocol.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/protocol.hpp
@@ -145,7 +145,7 @@ namespace eosio {
 
    struct trx_message_v1 {
       fc::optional<transaction_id_type> trx_id; // only provided for large trx as trade-off for small trxs not worth it
-      packed_transaction trx;
+      std::shared_ptr<packed_transaction> trx;
    };
 
    using net_message = static_variant<handshake_message,

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -418,7 +418,6 @@ namespace eosio {
    constexpr uint16_t proto_explicit_sync = 1;       // version at time of eosio 1.0
    constexpr uint16_t proto_block_id_notify = 2;     // reserved. feature was removed. next net_version should be 3
    constexpr uint16_t proto_pruned_types = 3;        // supports new signed_block & packed_transaction types
-   constexpr uint16_t proto_generic_messages = 4;    // placeholder for generic messages
 
    constexpr uint16_t net_version = proto_pruned_types;
 

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2412,7 +2412,7 @@ namespace eosio {
          auto peek_ds = pending_message_buffer.create_peek_datastream();
          unsigned_int which{};
          fc::raw::unpack( peek_ds, which );
-         if( which == signed_block_v0_which ) {
+         if( which == signed_block_which || which == signed_block_v0_which ) {
             block_header bh;
             fc::raw::unpack( peek_ds, bh );
 
@@ -2453,10 +2453,16 @@ namespace eosio {
             }
 
             auto ds = pending_message_buffer.create_datastream();
-            fc::raw::unpack( ds, which ); // throw away
-            signed_block_v0 sb_v0;
-            fc::raw::unpack( ds, sb_v0 );
-            shared_ptr<signed_block> ptr = std::make_shared<signed_block>( std::move( sb_v0 ), true );
+            fc::raw::unpack( ds, which );
+            shared_ptr<signed_block> ptr;
+            if( which == signed_block_which ) {
+               ptr = std::make_shared<signed_block>();
+               fc::raw::unpack( ds, *ptr );
+            } else {
+               signed_block_v0 sb_v0;
+               fc::raw::unpack( ds, sb_v0 );
+               ptr = std::make_shared<signed_block>( std::move( sb_v0 ), true );
+            }
 
             auto is_webauthn_sig = []( const fc::crypto::signature& s ) {
                return s.which() == fc::crypto::signature::storage_type::position<fc::crypto::webauthn::signature>();

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -1268,7 +1268,7 @@ namespace eosio {
    static std::shared_ptr<std::vector<char>> create_send_buffer( const packed_transaction_ptr& trx ) {
       // const cast required, trx_message_v1 has non-const shared_ptr because FC_REFLECT does not work with const types
       fc::optional<transaction_id_type> trx_id;
-      if( trx->get_estimated_size() > 7 * sizeof(transaction_id_type) ) {
+      if( trx->get_estimated_size() > 1024 ) { // simple guess on threshold
          fc_dlog( logger, "including trx id, est size: ${es}", ("es", trx->get_estimated_size()) );
          trx_id = trx->id();
       }
@@ -2592,7 +2592,7 @@ namespace eosio {
             std::shared_ptr<packed_transaction> trx;
             fc::raw::unpack( ds, trx );
             ptr = std::move( trx );
-            EOS_ASSERT( !trx_id || *trx_id == ptr->id(), transaction_id_type_exception,
+            EOS_ASSERT( !trx_id || !ptr || *trx_id == ptr->id(), transaction_id_type_exception,
                         "Provided trx_id does not match provided packed_transaction" );
             node_transaction_state nts = {ptr->id(), ptr->expiration(), 0, connection_id};
             my_impl->dispatcher->add_peer_txn( nts );

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -391,10 +391,10 @@ namespace eosio {
    constexpr auto     def_sync_fetch_span = 100;
 
    constexpr auto     message_header_size = 4;
-   constexpr uint32_t signed_block_v0_which = 7;        // see protocol net_message
-   constexpr uint32_t packed_transaction_v0_which = 8;  // see protocol net_message
-   constexpr uint32_t signed_block_which = 9;           // see protocol net_message
-   constexpr uint32_t trx_message_v1_which = 10;        // see protocol net_message
+   constexpr uint32_t signed_block_v0_which       = net_message::tag<signed_block_v0>::value;       // see protocol net_message
+   constexpr uint32_t packed_transaction_v0_which = net_message::tag<packed_transaction_v0>::value; // see protocol net_message
+   constexpr uint32_t signed_block_which          = net_message::tag<signed_block>::value;          // see protocol net_message
+   constexpr uint32_t trx_message_v1_which        = net_message::tag<trx_message_v1>::value;        // see protocol net_message
 
    /**
     *  For a while, network version was a 16 bit value equal to the second set of 16 bits

--- a/unittests/misc_tests.cpp
+++ b/unittests/misc_tests.cpp
@@ -1020,14 +1020,14 @@ BOOST_AUTO_TEST_CASE(pruned_block_test) {
 
    t.push_transaction(trx);
    signed_block_ptr produced = t.produce_block();
-   signed_block_v0_ptr original = produced->to_signed_block_v0();
+   auto original = produced->to_signed_block_v0();
    BOOST_REQUIRE(original);
    signed_block basic(*original, true);
 
    BOOST_TEST(basic.transaction_mroot.str() == original->transaction_mroot.str());
    BOOST_TEST(basic.transaction_mroot.str() == calculate_trx_merkle(basic.transactions).str());
 
-   signed_block_v0_ptr recovered = basic.to_signed_block_v0();
+   auto recovered = basic.to_signed_block_v0();
    BOOST_REQUIRE(recovered);
    BOOST_TEST(fc::raw::pack(*original) == fc::raw::pack(*recovered));
 


### PR DESCRIPTION
## Change Description

- Add a new protocol net_plugin version `proto_pruned_types` to allow sending of `packed_transaction` and `signed_block` directly without first converting to `packed_transaction_v0` and `signed_block_v0`.
- Add new option `p2p-reject-incomplete-blocks` default `true` which will reject any non-complete `signed_block` and disconnect from the client.

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [x] Documentation Additions
  - See new option above.