### PR TITLE
Implement SHiP v1

### DIFF
--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -806,7 +806,7 @@ int apply_context::get_context_free_data( uint32_t index, char* buffer, size_t b
 {
    const packed_transaction::prunable_data_type::prunable_data_t& data = trx_context.packed_trx.get_prunable_data().prunable_data;
    const bytes* cfd = nullptr;
-   if( data.contains<packed_transaction::prunable_data_type::none>() || data.contains<packed_transaction::prunable_data_type::signatures_only>() ) {
+   if( data.contains<packed_transaction::prunable_data_type::none>() ) {
    } else if( data.contains<packed_transaction::prunable_data_type::partial>() ) {
       if( index >= data.get<packed_transaction::prunable_data_type::partial>().context_free_segments.size() ) return -1;
 

--- a/libraries/chain/block_log.cpp
+++ b/libraries/chain/block_log.cpp
@@ -905,10 +905,7 @@ namespace eosio { namespace chain {
                                      if (it != ids.end()) {
                                         ptx.prune_all();
                                         // remove the found entry from ids
-                                        if (it != ids.end() - 1) {
-                                           *it = ids.back();
-                                        }
-                                        ids.resize(ids.size() - 1);
+                                        ids.erase(it);
                                         return true;
                                      }
                                      return false;

--- a/libraries/chain/block_log.cpp
+++ b/libraries/chain/block_log.cpp
@@ -883,7 +883,7 @@ namespace eosio { namespace chain {
       }));
    }
    
-   size_t block_log::prune_transactions(uint32_t block_num, const std::vector<transaction_id_type>& ids) {
+   size_t block_log::prune_transactions(uint32_t block_num, std::vector<transaction_id_type>& ids) {
       try {
          EOS_ASSERT( my->version >= pruned_transaction_version, block_log_exception,
                      "The block log version ${version} does not support transaction pruning.", ("version", my->version) );
@@ -899,11 +899,21 @@ namespace eosio { namespace chain {
          EOS_ASSERT(entry.block_num() == block_num, block_log_exception,
                      "Wrong block was read from block log.");
 
-         auto pruner =
-             overloaded{[](transaction_id_type&) { return false; },
-                        [&ids](packed_transaction& ptx) {
-                           return std::find(ids.begin(), ids.end(), ptx.id()) != ids.end() && (ptx.prune_all(), true);
-                        }};
+         auto pruner = overloaded{[](transaction_id_type&) { return false; },
+                                  [&ids](packed_transaction& ptx) {
+                                     auto it = std::find(ids.begin(), ids.end(), ptx.id());
+                                     if (it != ids.end()) {
+                                        ptx.prune_all();
+                                        // remove the found entry from ids
+                                        if (it != ids.end() - 1) {
+                                           *it = ids.back();
+                                        }
+                                        ids.resize(ids.size() - 1);
+                                        return true;
+                                     }
+                                     return false;
+                                  }};
+
          size_t num_trx_pruned = 0;
          for (auto& trx : entry.transactions) {
             num_trx_pruned += trx.trx.visit(pruner);
@@ -1444,5 +1454,9 @@ namespace eosio { namespace chain {
          if (n == td.last_block)
             break;
       }
+   }
+
+   bool block_log::exists(const fc::path& data_dir) {
+      return fc::exists(data_dir / "blocks.log") && fc::exists(data_dir / "blocks.index");
    }
 }} /// eosio::chain

--- a/libraries/chain/include/eosio/chain/block_log.hpp
+++ b/libraries/chain/include/eosio/chain/block_log.hpp
@@ -56,10 +56,14 @@ namespace eosio { namespace chain {
          const signed_block_ptr&        head() const;
          uint32_t                       first_block_num() const;
 
+         static bool exists(const fc::path& data_dir);
          /**
+          *  @param ids[in,out] The list of transaction ids to be pruned. After the member function returns,
+          *                     it would be modified to contain the list of transaction ids that do not
+          *                     exists in the specified block.
           *  @returns The number of transactions been pruned
           **/
-         size_t prune_transactions(uint32_t block_num, const vector<transaction_id_type>& ids);
+         size_t prune_transactions(uint32_t block_num, vector<transaction_id_type>& ids);
 
          static const uint64_t npos = std::numeric_limits<uint64_t>::max();
 

--- a/libraries/chain/include/eosio/chain/exceptions.hpp
+++ b/libraries/chain/include/eosio/chain/exceptions.hpp
@@ -161,7 +161,7 @@ namespace eosio { namespace chain {
     *   |- resource_limit_exception
     *   |- mongo_db_exception
     *   |- contract_api_exception
-    *   |- history_state_exception
+    *   |- state_history_exception
     */
 
     FC_DECLARE_DERIVED_EXCEPTION( chain_type_exception, chain_exception,
@@ -659,6 +659,6 @@ namespace eosio { namespace chain {
                                     3270003, "Context free data pruned (invalid block)" )
  
    FC_DECLARE_DERIVED_EXCEPTION( state_history_exception,    chain_exception,
-                                 3280000, "History state exception" )
+                                 3280000, "State history exception" )
 
 } } // eosio::chain

--- a/libraries/chain/include/eosio/chain/exceptions.hpp
+++ b/libraries/chain/include/eosio/chain/exceptions.hpp
@@ -161,6 +161,7 @@ namespace eosio { namespace chain {
     *   |- resource_limit_exception
     *   |- mongo_db_exception
     *   |- contract_api_exception
+    *   |- history_state_exception
     */
 
     FC_DECLARE_DERIVED_EXCEPTION( chain_type_exception, chain_exception,
@@ -656,5 +657,8 @@ namespace eosio { namespace chain {
                                     3270002, "Protocol feature exception (invalid block)" )
       FC_DECLARE_DERIVED_EXCEPTION( pruned_context_free_data_bad_block_exception, objective_block_validation_exception,
                                     3270003, "Context free data pruned (invalid block)" )
+ 
+   FC_DECLARE_DERIVED_EXCEPTION( state_history_exception,    chain_exception,
+                                 3280000, "History state exception" )
 
 } } // eosio::chain

--- a/libraries/chain/include/eosio/chain/transaction.hpp
+++ b/libraries/chain/include/eosio/chain/transaction.hpp
@@ -225,11 +225,6 @@ namespace eosio { namespace chain {
             digest_type                     prunable_digest;
          };
 
-         struct signatures_only {
-            std::vector<signature_type>     signatures;
-            digest_type                     context_free_mroot;
-         };
-
          using segment_type = fc::static_variant<digest_type, bytes>;
 
          struct partial {
@@ -250,7 +245,6 @@ namespace eosio { namespace chain {
 
          using prunable_data_t = fc::static_variant< full_legacy,
                                                      none,
-                                                     signatures_only,
                                                      partial,
                                                      full >;
 
@@ -339,7 +333,6 @@ FC_REFLECT( eosio::chain::packed_transaction_v0, (signatures)(compression)(packe
 FC_REFLECT( eosio::chain::packed_transaction, (compression)(prunable_data)(packed_trx) )
 FC_REFLECT( eosio::chain::packed_transaction::prunable_data_type, (prunable_data));
 FC_REFLECT( eosio::chain::packed_transaction::prunable_data_type::none, (prunable_digest))
-FC_REFLECT( eosio::chain::packed_transaction::prunable_data_type::signatures_only, (signatures)( context_free_mroot))
 FC_REFLECT( eosio::chain::packed_transaction::prunable_data_type::partial, (signatures)( context_free_segments))
 FC_REFLECT( eosio::chain::packed_transaction::prunable_data_type::full, (signatures)( context_free_segments))
 // @ignore context_free_segments

--- a/libraries/chain/include/eosio/chain/transaction.hpp
+++ b/libraries/chain/include/eosio/chain/transaction.hpp
@@ -246,7 +246,6 @@ namespace eosio { namespace chain {
             std::vector<signature_type>     signatures;
             bytes                           packed_context_free_data;
             vector<bytes>                   context_free_segments;
-            void unpack_context_free_data(packed_transaction_v0::compression_type compression);
          };
 
          using prunable_data_t = fc::static_variant< full_legacy,

--- a/libraries/chain/include/eosio/chain/transaction.hpp
+++ b/libraries/chain/include/eosio/chain/transaction.hpp
@@ -246,6 +246,7 @@ namespace eosio { namespace chain {
             std::vector<signature_type>     signatures;
             bytes                           packed_context_free_data;
             vector<bytes>                   context_free_segments;
+            void unpack_context_free_data(packed_transaction_v0::compression_type compression);
          };
 
          using prunable_data_t = fc::static_variant< full_legacy,

--- a/libraries/chain/transaction.cpp
+++ b/libraries/chain/transaction.cpp
@@ -407,7 +407,10 @@ static digest_type prunable_digest(const packed_transaction::prunable_data_type:
 }
 
 static digest_type prunable_digest(const packed_transaction::prunable_data_type::full& obj) {
-   EOS_THROW(tx_prune_exception, "unimplemented");
+   digest_type::encoder prunable;
+   fc::raw::pack( prunable, obj.signatures );
+   fc::raw::pack( prunable, obj.context_free_segments );
+   return prunable.result();
 }
 
 static digest_type prunable_digest(const packed_transaction::prunable_data_type::full_legacy& obj) {
@@ -649,9 +652,5 @@ void packed_transaction::reflector_init()
       legacy.context_free_segments = unpack_context_free_data( legacy.packed_context_free_data, compression );
    }
    estimated_size = calculate_estimated_size();
-}
-
-void packed_transaction::prunable_data_type::full_legacy::unpack_context_free_data(packed_transaction_v0::compression_type compression) {
-   context_free_segments = chain::unpack_context_free_data(packed_context_free_data, compression);
 }
 } } // eosio::chain

--- a/libraries/chain/transaction.cpp
+++ b/libraries/chain/transaction.cpp
@@ -651,4 +651,7 @@ void packed_transaction::reflector_init()
    estimated_size = calculate_estimated_size();
 }
 
+void packed_transaction::prunable_data_type::full_legacy::unpack_context_free_data(packed_transaction_v0::compression_type compression) {
+   context_free_segments = chain::unpack_context_free_data(packed_context_free_data, compression);
+}
 } } // eosio::chain

--- a/libraries/state_history/CMakeLists.txt
+++ b/libraries/state_history/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library( state_history
              abi.cpp
              compression.cpp
              create_deltas.cpp
+             log.cpp
              trace_converter.cpp
              ${HEADERS}
            )

--- a/libraries/state_history/include/eosio/state_history/log.hpp
+++ b/libraries/state_history/include/eosio/state_history/log.hpp
@@ -129,12 +129,21 @@ class state_history_traces_log : public state_history_log {
 
    fc::optional<chain::bytes> get_log_entry(block_num_type block_num);
 
-   void store_traces(const chainbase::database& db, const chain::block_state_ptr& block_state);
+   void store(const chainbase::database& db, const chain::block_state_ptr& block_state);
 
    /**
     *  @param[in,out] ids The ids to been pruned and returns the ids not found in the specified block
     **/
    void prune_transactions(block_num_type block_num, std::vector<chain::transaction_id_type>& ids);
+};
+
+class state_history_chain_state_log : public state_history_log {
+ public:
+   state_history_chain_state_log(fc::path state_history_dir);
+   
+   fc::optional<chain::bytes> get_log_entry(block_num_type block_num);
+
+   void store(const chainbase::database& db, const chain::block_state_ptr& block_state);
 };
 
 } // namespace eosio

--- a/libraries/state_history/include/eosio/state_history/log.hpp
+++ b/libraries/state_history/include/eosio/state_history/log.hpp
@@ -9,6 +9,7 @@
 #include <eosio/chain/types.hpp>
 #include <fc/io/cfile.hpp>
 #include <fc/log/logger.hpp>
+#include <eosio/state_history/trace_converter.hpp>
 
 namespace eosio {
 
@@ -31,8 +32,8 @@ namespace eosio {
 inline uint64_t       ship_magic(uint32_t version) { return N(ship).to_uint64_t() | version; }
 inline bool           is_ship(uint64_t magic) { return (magic & 0xffff'ffff'0000'0000) == N(ship).to_uint64_t(); }
 inline uint32_t       get_ship_version(uint64_t magic) { return magic; }
-inline bool           is_ship_supported_version(uint64_t magic) { return get_ship_version(magic) == 0; }
-static const uint32_t ship_current_version = 0;
+inline bool           is_ship_supported_version(uint64_t magic) { return get_ship_version(magic) <= 1; }
+static const uint32_t ship_current_version = 1;
 
 struct state_history_log_header {
    uint64_t             magic        = ship_magic(ship_current_version);
@@ -53,244 +54,88 @@ class state_history_log {
    uint32_t             _begin_block = 0;
    uint32_t             _end_block   = 0;
    chain::block_id_type last_block_id;
-
+   uint32_t             version = ship_current_version;
  public:
-   state_history_log(const char* const name, std::string log_filename, std::string index_filename)
-       : name(name)
-       , log_filename(std::move(log_filename))
-       , index_filename(std::move(index_filename)) {
-      open_log();
-      open_index();
-   }
+   // The type aliases below help to make it obvious about the meanings of member function return values.
+   using block_num_type     = uint32_t;
+   using version_type       = uint32_t;
+   using file_position_type = uint64_t;
 
-   uint32_t begin_block() const { return _begin_block; }
-   uint32_t end_block() const { return _end_block; }
+   state_history_log(const char* const name, std::string log_filename, std::string index_filename);
 
-   void read_header(state_history_log_header& header, bool assert_version = true) {
-      char bytes[state_history_log_header_serial_size];
-      log.read(bytes, sizeof(bytes));
-      fc::datastream<const char*> ds(bytes, sizeof(bytes));
-      fc::raw::unpack(ds, header);
-      EOS_ASSERT(!ds.remaining(), chain::plugin_exception, "state_history_log_header_serial_size mismatch");
-      if (assert_version)
-         EOS_ASSERT(is_ship(header.magic) && is_ship_supported_version(header.magic), chain::plugin_exception,
-                    "corrupt ${name}.log (0)", ("name", name));
-   }
+   block_num_type begin_block() const { return _begin_block; }
+   block_num_type end_block() const { return _end_block; }
 
-   void write_header(const state_history_log_header& header) {
-      char                  bytes[state_history_log_header_serial_size];
-      fc::datastream<char*> ds(bytes, sizeof(bytes));
-      fc::raw::pack(ds, header);
-      EOS_ASSERT(!ds.remaining(), chain::plugin_exception, "state_history_log_header_serial_size mismatch");
-      log.write(bytes, sizeof(bytes));
-   }
+   void read_header(state_history_log_header& header, bool assert_version = true);
+   void write_header(const state_history_log_header& header);
 
    template <typename F>
    void write_entry(const state_history_log_header& header, const chain::block_id_type& prev_id, F write_payload) {
-      auto block_num = chain::block_header::num_from_id(header.block_id);
-      EOS_ASSERT(_begin_block == _end_block || block_num <= _end_block, chain::plugin_exception,
-                 "missed a block in ${name}.log", ("name", name));
-
-      if (_begin_block != _end_block && block_num > _begin_block) {
-         if (block_num == _end_block) {
-            EOS_ASSERT(prev_id == last_block_id, chain::plugin_exception, "missed a fork change in ${name}.log",
-                       ("name", name));
-         } else {
-            state_history_log_header prev;
-            get_entry(block_num - 1, prev);
-            EOS_ASSERT(prev_id == prev.block_id, chain::plugin_exception, "missed a fork change in ${name}.log",
-                       ("name", name));
-         }
-      }
-
-      if (block_num < _end_block)
-         truncate(block_num);
-      log.seek_end(0);
-      uint64_t pos = log.tellp();
-      write_header(header);
+      auto [pos, block_num] = write_entry_header(header, prev_id);
       write_payload(log);
-      uint64_t end = log.tellp();
-      EOS_ASSERT(end == pos + state_history_log_header_serial_size + header.payload_size, chain::plugin_exception,
-                 "wrote payload with incorrect size to ${name}.log", ("name", name));
-      log.write((char*)&pos, sizeof(pos));
-
-      index.seek_end(0);
-      index.write((char*)&pos, sizeof(pos));
-      if (_begin_block == _end_block)
-         _begin_block = block_num;
-      _end_block    = block_num + 1;
-      last_block_id = header.block_id;
+      write_entry_position(header, pos, block_num);
    }
 
-   // returns cfile positioned at payload
-   fc::cfile& get_entry(uint32_t block_num, state_history_log_header& header) {
-      EOS_ASSERT(block_num >= _begin_block && block_num < _end_block, chain::plugin_exception,
-                 "read non-existing block in ${name}.log", ("name", name));
-      log.seek(get_pos(block_num));
-      read_header(header);
-      return log;
+   /// @returns cfile positioned at payload
+   fc::cfile&           get_entry_header(block_num_type block_num, state_history_log_header& header);
+   chain::block_id_type get_block_id(block_num_type block_num);
+
+   /**
+    * @returns the entry payload and its version if existed
+    **/
+   fc::optional<std::pair<chain::bytes, version_type>> get_entry(block_num_type block_num);
+
+   template <typename Converter>
+   fc::optional<chain::bytes> get_entry(uint32_t block_num, Converter conv) {
+      auto entry = this->get_entry(block_num);
+      if (entry)
+         return conv(entry->first, entry->second);
+      return {};
    }
 
-   chain::block_id_type get_block_id(uint32_t block_num) {
-      state_history_log_header header;
-      get_entry(block_num, header);
-      return header.block_id;
-   }
-
+ protected:
+   fc::cfile& get_log() { return log; }
  private:
-   bool get_last_block(uint64_t size) {
-      state_history_log_header header;
-      uint64_t                 suffix;
-      log.seek(size - sizeof(suffix));
-      log.read((char*)&suffix, sizeof(suffix));
-      if (suffix > size || suffix + state_history_log_header_serial_size > size) {
-         elog("corrupt ${name}.log (2)", ("name", name));
-         return false;
-      }
-      log.seek(suffix);
-      read_header(header, false);
-      if (!is_ship(header.magic) || !is_ship_supported_version(header.magic) ||
-          suffix + state_history_log_header_serial_size + header.payload_size + sizeof(suffix) != size) {
-         elog("corrupt ${name}.log (3)", ("name", name));
-         return false;
-      }
-      _end_block    = chain::block_header::num_from_id(header.block_id) + 1;
-      last_block_id = header.block_id;
-      if (_begin_block >= _end_block) {
-         elog("corrupt ${name}.log (4)", ("name", name));
-         return false;
-      }
-      return true;
-   }
+   bool               get_last_block(uint64_t size);
+   void               recover_blocks(uint64_t size);
+   void               open_log();
+   void               open_index();
+   file_position_type get_pos(block_num_type block_num);
+   void               truncate(block_num_type block_num);
 
-   void recover_blocks(uint64_t size) {
-      ilog("recover ${name}.log", ("name", name));
-      uint64_t pos       = 0;
-      uint32_t num_found = 0;
-      while (true) {
-         state_history_log_header header;
-         if (pos + state_history_log_header_serial_size > size)
-            break;
-         log.seek(pos);
-         read_header(header, false);
-         uint64_t suffix;
-         if (!is_ship(header.magic) || !is_ship_supported_version(header.magic) || header.payload_size > size ||
-             pos + state_history_log_header_serial_size + header.payload_size + sizeof(suffix) > size) {
-            EOS_ASSERT(!is_ship(header.magic) || is_ship_supported_version(header.magic), chain::plugin_exception,
-                       "${name}.log has an unsupported version", ("name", name));
-            break;
-         }
-         log.seek(pos + state_history_log_header_serial_size + header.payload_size);
-         log.read((char*)&suffix, sizeof(suffix));
-         if (suffix != pos)
-            break;
-         pos = pos + state_history_log_header_serial_size + header.payload_size + sizeof(suffix);
-         if (!(++num_found % 10000)) {
-            printf("%10u blocks found, log pos=%12llu\r", (unsigned)num_found, (unsigned long long)pos);
-            fflush(stdout);
-         }
-      }
-      log.flush();
-      boost::filesystem::resize_file(log_filename, pos);
-      log.flush();
-      EOS_ASSERT(get_last_block(pos), chain::plugin_exception, "recover ${name}.log failed", ("name", name));
-   }
-
-   void open_log() {
-      log.set_file_path(log_filename);
-      log.open("a+b"); // std::ios_base::binary | std::ios_base::in | std::ios_base::out | std::ios_base::app
-      log.seek_end(0);
-      uint64_t size = log.tellp();
-      if (size >= state_history_log_header_serial_size) {
-         state_history_log_header header;
-         log.seek(0);
-         read_header(header, false);
-         EOS_ASSERT(is_ship(header.magic) && is_ship_supported_version(header.magic) &&
-                        state_history_log_header_serial_size + header.payload_size + sizeof(uint64_t) <= size,
-                    chain::plugin_exception, "corrupt ${name}.log (1)", ("name", name));
-         _begin_block  = chain::block_header::num_from_id(header.block_id);
-         last_block_id = header.block_id;
-         if (!get_last_block(size))
-            recover_blocks(size);
-         ilog("${name}.log has blocks ${b}-${e}", ("name", name)("b", _begin_block)("e", _end_block - 1));
-      } else {
-         EOS_ASSERT(!size, chain::plugin_exception, "corrupt ${name}.log (5)", ("name", name));
-         ilog("${name}.log is empty", ("name", name));
-      }
-   }
-
-   void open_index() {
-      index.set_file_path(index_filename);
-      index.open("a+b"); // std::ios_base::binary | std::ios_base::in | std::ios_base::out | std::ios_base::app
-      index.seek_end(0);
-      if (index.tellp() == (static_cast<int>(_end_block) - _begin_block) * sizeof(uint64_t))
-         return;
-      ilog("Regenerate ${name}.index", ("name", name));
-      index.close();
-      index.open("w+b"); // std::ios_base::binary | std::ios_base::in | std::ios_base::out | std::ios_base::trunc
-
-      log.seek_end(0);
-      uint64_t size      = log.tellp();
-      uint64_t pos       = 0;
-      uint32_t num_found = 0;
-      while (pos < size) {
-         state_history_log_header header;
-         EOS_ASSERT(pos + state_history_log_header_serial_size <= size, chain::plugin_exception,
-                    "corrupt ${name}.log (6)", ("name", name));
-         log.seek(pos);
-         read_header(header, false);
-         uint64_t suffix_pos = pos + state_history_log_header_serial_size + header.payload_size;
-         uint64_t suffix;
-         EOS_ASSERT(is_ship(header.magic) && is_ship_supported_version(header.magic) &&
-                        suffix_pos + sizeof(suffix) <= size,
-                    chain::plugin_exception, "corrupt ${name}.log (7)", ("name", name));
-         log.seek(suffix_pos);
-         log.read((char*)&suffix, sizeof(suffix));
-         // ilog("block ${b} at ${pos}-${end} suffix=${suffix} file_size=${fs}",
-         //      ("b", header.block_num)("pos", pos)("end", suffix_pos + sizeof(suffix))("suffix", suffix)("fs", size));
-         EOS_ASSERT(suffix == pos, chain::plugin_exception, "corrupt ${name}.log (8)", ("name", name));
-
-         index.write((char*)&pos, sizeof(pos));
-         pos = suffix_pos + sizeof(suffix);
-         if (!(++num_found % 10000)) {
-            printf("%10u blocks found, log pos=%12llu\r", (unsigned)num_found, (unsigned long long)pos);
-            fflush(stdout);
-         }
-      }
-   }
-
-   uint64_t get_pos(uint32_t block_num) {
-      uint64_t pos;
-      index.seek((block_num - _begin_block) * sizeof(pos));
-      index.read((char*)&pos, sizeof(pos));
-      return pos;
-   }
-
-   void truncate(uint32_t block_num) {
-      log.flush();
-      index.flush();
-      uint64_t num_removed = 0;
-      if (block_num <= _begin_block) {
-         num_removed = _end_block - _begin_block;
-         log.seek(0);
-         index.seek(0);
-         boost::filesystem::resize_file(log_filename, 0);
-         boost::filesystem::resize_file(index_filename, 0);
-         _begin_block = _end_block = 0;
-      } else {
-         num_removed  = _end_block - block_num;
-         uint64_t pos = get_pos(block_num);
-         log.seek(0);
-         index.seek(0);
-         boost::filesystem::resize_file(log_filename, pos);
-         boost::filesystem::resize_file(index_filename, (block_num - _begin_block) * sizeof(uint64_t));
-         _end_block = block_num;
-      }
-      log.flush();
-      index.flush();
-      ilog("fork or replay: removed ${n} blocks from ${name}.log", ("n", num_removed)("name", name));
-   }
+   /**
+    *  @returns the file position of the written entry and its block num
+    **/
+   std::pair<file_position_type, block_num_type> write_entry_header(const state_history_log_header& header,
+                                                                    const chain::block_id_type&     prev_id);
+   void write_entry_position(const state_history_log_header& header, file_position_type pos, block_num_type block_num);
 }; // state_history_log
+
+class state_history_traces_log : public state_history_log {
+   state_history::trace_converter trace_convert;
+
+ public:
+   using compression_type            = chain::packed_transaction::prunable_data_type::compression_type;
+   bool             trace_debug_mode = false;
+   compression_type compression      = compression_type::none;
+
+   state_history_traces_log(fc::path state_history_dir);
+
+   static bool exists(fc::path state_history_dir);
+
+   void add_transaction(const chain::transaction_trace_ptr& trace, const chain::packed_transaction_ptr& transaction) {
+      trace_convert.add_transaction(trace, transaction);
+   }
+
+   fc::optional<chain::bytes> get_log_entry(block_num_type block_num);
+
+   void store_traces(const chainbase::database& db, const chain::block_state_ptr& block_state);
+
+   /**
+    *  @param[in,out] ids The ids to been pruned and returns the ids not found in the specified block
+    **/
+   void prune_traces(block_num_type block_num, std::vector<chain::transaction_id_type>& ids);
+};
 
 } // namespace eosio
 

--- a/libraries/state_history/include/eosio/state_history/log.hpp
+++ b/libraries/state_history/include/eosio/state_history/log.hpp
@@ -117,7 +117,6 @@ class state_history_traces_log : public state_history_log {
  public:
    using compression_type            = chain::packed_transaction::prunable_data_type::compression_type;
    bool             trace_debug_mode = false;
-   compression_type compression      = compression_type::none;
 
    state_history_traces_log(fc::path state_history_dir);
 

--- a/libraries/state_history/include/eosio/state_history/log.hpp
+++ b/libraries/state_history/include/eosio/state_history/log.hpp
@@ -134,7 +134,7 @@ class state_history_traces_log : public state_history_log {
    /**
     *  @param[in,out] ids The ids to been pruned and returns the ids not found in the specified block
     **/
-   void prune_traces(block_num_type block_num, std::vector<chain::transaction_id_type>& ids);
+   void prune_transactions(block_num_type block_num, std::vector<chain::transaction_id_type>& ids);
 };
 
 } // namespace eosio

--- a/libraries/state_history/include/eosio/state_history/serialization.hpp
+++ b/libraries/state_history/include/eosio/state_history/serialization.hpp
@@ -43,8 +43,8 @@ history_context_wrapper<std::decay_t<P>, std::decay_t<T>> make_history_context_w
 
 struct trace_receipt_context {
    uint8_t  failed_status = eosio::chain::transaction_receipt_header::hard_fail;
-   bool     debug_mode;
-   uint32_t version;
+   bool     debug_mode    = false;
+   uint32_t version       = 0;
 };
 
 namespace fc {

--- a/libraries/state_history/include/eosio/state_history/trace_converter.hpp
+++ b/libraries/state_history/include/eosio/state_history/trace_converter.hpp
@@ -2,7 +2,6 @@
 
 #include <eosio/chain/block_state.hpp>
 #include <eosio/state_history/types.hpp>
-#include <eosio/chain/abi_serializer.hpp>
 
 namespace eosio {
 namespace state_history {

--- a/libraries/state_history/include/eosio/state_history/trace_converter.hpp
+++ b/libraries/state_history/include/eosio/state_history/trace_converter.hpp
@@ -2,6 +2,7 @@
 
 #include <eosio/chain/block_state.hpp>
 #include <eosio/state_history/types.hpp>
+#include <eosio/chain/abi_serializer.hpp>
 
 namespace eosio {
 namespace state_history {
@@ -9,13 +10,31 @@ namespace state_history {
 using chain::block_state_ptr;
 using chain::transaction_id_type;
 using chain::packed_transaction_ptr;
+using compression_type = chain::packed_transaction::prunable_data_type::compression_type;
 
 struct trace_converter {
    std::map<transaction_id_type, augmented_transaction_trace> cached_traces;
    fc::optional<augmented_transaction_trace>                  onblock_trace;
-
+   
    void  add_transaction(const transaction_trace_ptr& trace, const packed_transaction_ptr& transaction);
-   bytes pack(const chainbase::database& db, bool trace_debug_mode, const block_state_ptr& block_state);
+
+   bytes pack(const chainbase::database& db, bool trace_debug_mode, const block_state_ptr& block_state,
+              uint32_t version, compression_type compression);
+   static bytes to_traces_bin_v0(const bytes& entry_payload, uint32_t version); 
+
+   /**
+    * Prune the signatures and context free data in a v1 log entry payload
+    * 
+    * @param[in] entry_payload        The entry_payload 
+    * @param[in] version              The version of the entry
+    * @param[in, out] ids             The list of transaction ids to be pruned. After the member function returns, 
+    *                                 it would be modified to contain the list of transaction ids that do not exists
+    *                                 in the log entry.
+    * 
+   * @returns The serialized prunable_data section
+    **/
+   static bytes prune_traces(const bytes& entry_payload, uint32_t version, std::vector<transaction_id_type>& ids);
+
 };
 
 } // namespace state_history

--- a/libraries/state_history/include/eosio/state_history/trace_converter.hpp
+++ b/libraries/state_history/include/eosio/state_history/trace_converter.hpp
@@ -27,7 +27,7 @@ struct trace_converter {
     * @param[in] entry_payload        The entry_payload 
     * @param[in] version              The version of the entry
     * @param[in, out] ids             The list of transaction ids to be pruned. After the member function returns, 
-    *                                 it would be modified to contain the list of transaction ids that do not exists
+    *                                 it would be modified to contain the list of transaction ids that do not exist
     *                                 in the log entry.
     * 
    * @returns The serialized prunable_data section

--- a/libraries/state_history/include/eosio/state_history/trace_converter.hpp
+++ b/libraries/state_history/include/eosio/state_history/trace_converter.hpp
@@ -18,21 +18,21 @@ struct trace_converter {
    void  add_transaction(const transaction_trace_ptr& trace, const packed_transaction_ptr& transaction);
 
    bytes pack(const chainbase::database& db, bool trace_debug_mode, const block_state_ptr& block_state,
-              uint32_t version, compression_type compression);
+              uint32_t version);
    static bytes to_traces_bin_v0(const bytes& entry_payload, uint32_t version); 
 
    /**
-    * Prune the signatures and context free data in a v1 log entry payload
+    * Prune the signatures and context free data in a v1 log entry payload for the specified transactions.
     * 
-    * @param[in] entry_payload        The entry_payload 
+    * @param[in,out] entry_payload    The entry_payload.                            
     * @param[in] version              The version of the entry
     * @param[in, out] ids             The list of transaction ids to be pruned. After the member function returns, 
     *                                 it would be modified to contain the list of transaction ids that do not exist
     *                                 in the log entry.
     * 
-   * @returns The serialized prunable_data section
+   * @returns The pair of offsets within entry_payload where data has been modified.
     **/
-   static bytes prune_traces(const bytes& entry_payload, uint32_t version, std::vector<transaction_id_type>& ids);
+   static std::pair<uint64_t, uint64_t> prune_traces(bytes& entry_payload, uint32_t version, std::vector<transaction_id_type>& ids);
 
 };
 

--- a/libraries/state_history/log.cpp
+++ b/libraries/state_history/log.cpp
@@ -317,7 +317,8 @@ state_history_chain_state_log::state_history_chain_state_log(fc::path state_hist
                         (state_history_dir / "chain_state_history.index").string()) {}
 
 fc::optional<chain::bytes> state_history_chain_state_log::get_log_entry(block_num_type block_num) {
-   this->get_entry(block_num, [](const chain::bytes& data, uint32_t) { return state_history::zlib_decompress(data); });
+   return this->get_entry(block_num,
+                          [](const chain::bytes& data, uint32_t) { return state_history::zlib_decompress(data); });
 }
 
 void state_history_chain_state_log::store(const chainbase::database& db, const chain::block_state_ptr& block_state) {

--- a/libraries/state_history/log.cpp
+++ b/libraries/state_history/log.cpp
@@ -1,0 +1,312 @@
+#include <eosio/state_history/log.hpp>
+#include <eosio/state_history/trace_converter.hpp>
+
+namespace eosio {
+
+state_history_log::state_history_log(const char* const name, std::string log_filename, std::string index_filename)
+    : name(name)
+    , log_filename(std::move(log_filename))
+    , index_filename(std::move(index_filename)) {
+   open_log();
+   open_index();
+}
+
+void state_history_log::read_header(state_history_log_header& header, bool assert_version) {
+   char bytes[state_history_log_header_serial_size];
+   log.read(bytes, sizeof(bytes));
+   fc::datastream<const char*> ds(bytes, sizeof(bytes));
+   fc::raw::unpack(ds, header);
+   EOS_ASSERT(!ds.remaining(), chain::state_history_exception, "state_history_log_header_serial_size mismatch");
+   version = get_ship_version(header.magic);
+   if (assert_version)
+      EOS_ASSERT(is_ship(header.magic) && is_ship_supported_version(header.magic), chain::state_history_exception,
+                 "corrupt ${name}.log (0)", ("name", name));
+}
+
+void state_history_log::write_header(const state_history_log_header& header) {
+   char                  bytes[state_history_log_header_serial_size];
+   fc::datastream<char*> ds(bytes, sizeof(bytes));
+   fc::raw::pack(ds, header);
+   EOS_ASSERT(!ds.remaining(), chain::state_history_exception, "state_history_log_header_serial_size mismatch");
+   log.write(bytes, sizeof(bytes));
+}
+
+// returns cfile positioned at payload
+fc::cfile& state_history_log::get_entry_header(state_history_log::block_num_type block_num,
+                                               state_history_log_header&         header) {
+   EOS_ASSERT(block_num >= _begin_block && block_num < _end_block, chain::state_history_exception,
+              "read non-existing block in ${name}.log", ("name", name));
+   log.seek(get_pos(block_num));
+   read_header(header);
+   return log;
+}
+
+chain::block_id_type state_history_log::get_block_id(state_history_log::block_num_type block_num) {
+   state_history_log_header header;
+   get_entry_header(block_num, header);
+   return header.block_id;
+}
+
+bool state_history_log::get_last_block(uint64_t size) {
+   state_history_log_header header;
+   uint64_t                 suffix;
+   log.seek(size - sizeof(suffix));
+   log.read((char*)&suffix, sizeof(suffix));
+   if (suffix > size || suffix + state_history_log_header_serial_size > size) {
+      elog("corrupt ${name}.log (2)", ("name", name));
+      return false;
+   }
+   log.seek(suffix);
+   read_header(header, false);
+   if (!is_ship(header.magic) || !is_ship_supported_version(header.magic) ||
+       suffix + state_history_log_header_serial_size + header.payload_size + sizeof(suffix) != size) {
+      elog("corrupt ${name}.log (3)", ("name", name));
+      return false;
+   }
+   _end_block    = chain::block_header::num_from_id(header.block_id) + 1;
+   last_block_id = header.block_id;
+   if (_begin_block >= _end_block) {
+      elog("corrupt ${name}.log (4)", ("name", name));
+      return false;
+   }
+   return true;
+}
+
+void state_history_log::recover_blocks(uint64_t size) {
+   ilog("recover ${name}.log", ("name", name));
+   uint64_t pos       = 0;
+   uint32_t num_found = 0;
+   while (true) {
+      state_history_log_header header;
+      if (pos + state_history_log_header_serial_size > size)
+         break;
+      log.seek(pos);
+      read_header(header, false);
+      uint64_t suffix;
+      if (!is_ship(header.magic) || !is_ship_supported_version(header.magic) || header.payload_size > size ||
+          pos + state_history_log_header_serial_size + header.payload_size + sizeof(suffix) > size) {
+         EOS_ASSERT(!is_ship(header.magic) || is_ship_supported_version(header.magic), chain::state_history_exception,
+                    "${name}.log has an unsupported version", ("name", name));
+         break;
+      }
+      log.seek(pos + state_history_log_header_serial_size + header.payload_size);
+      log.read((char*)&suffix, sizeof(suffix));
+      if (suffix != pos)
+         break;
+      pos = pos + state_history_log_header_serial_size + header.payload_size + sizeof(suffix);
+      if (!(++num_found % 10000)) {
+         printf("%10u blocks found, log pos=%12llu\r", (unsigned)num_found, (unsigned long long)pos);
+         fflush(stdout);
+      }
+   }
+   log.flush();
+   boost::filesystem::resize_file(log_filename, pos);
+   log.flush();
+   EOS_ASSERT(get_last_block(pos), chain::state_history_exception, "recover ${name}.log failed", ("name", name));
+}
+
+void state_history_log::open_log() {
+   log.set_file_path(log_filename);
+   log.open("a+b"); // std::ios_base::binary | std::ios_base::in | std::ios_base::out | std::ios_base::app
+   log.seek_end(0);
+   uint64_t size = log.tellp();
+   if (size >= state_history_log_header_serial_size) {
+      state_history_log_header header;
+      log.seek(0);
+      read_header(header, false);
+      EOS_ASSERT(is_ship(header.magic) && is_ship_supported_version(header.magic) &&
+                     state_history_log_header_serial_size + header.payload_size + sizeof(uint64_t) <= size,
+                 chain::state_history_exception, "corrupt ${name}.log (1)", ("name", name));
+      _begin_block  = chain::block_header::num_from_id(header.block_id);
+      last_block_id = header.block_id;
+      if (!get_last_block(size))
+         recover_blocks(size);
+      ilog("${name}.log has blocks ${b}-${e}", ("name", name)("b", _begin_block)("e", _end_block - 1));
+   } else {
+      EOS_ASSERT(!size, chain::state_history_exception, "corrupt ${name}.log (5)", ("name", name));
+      ilog("${name}.log is empty", ("name", name));
+   }
+}
+
+void state_history_log::open_index() {
+   index.set_file_path(index_filename);
+   index.open("a+b"); // std::ios_base::binary | std::ios_base::in | std::ios_base::out | std::ios_base::app
+   index.seek_end(0);
+   if (index.tellp() == (static_cast<int>(_end_block) - _begin_block) * sizeof(uint64_t))
+      return;
+   ilog("Regenerate ${name}.index", ("name", name));
+   index.close();
+   index.open("w+b"); // std::ios_base::binary | std::ios_base::in | std::ios_base::out | std::ios_base::trunc
+
+   log.seek_end(0);
+   uint64_t size      = log.tellp();
+   uint64_t pos       = 0;
+   uint32_t num_found = 0;
+   while (pos < size) {
+      state_history_log_header header;
+      EOS_ASSERT(pos + state_history_log_header_serial_size <= size, chain::state_history_exception,
+                 "corrupt ${name}.log (6)", ("name", name));
+      log.seek(pos);
+      read_header(header, false);
+      uint64_t suffix_pos = pos + state_history_log_header_serial_size + header.payload_size;
+      uint64_t suffix;
+      EOS_ASSERT(is_ship(header.magic) && is_ship_supported_version(header.magic) &&
+                     suffix_pos + sizeof(suffix) <= size,
+                 chain::state_history_exception, "corrupt ${name}.log (7)", ("name", name));
+      log.seek(suffix_pos);
+      log.read((char*)&suffix, sizeof(suffix));
+      // ilog("block ${b} at ${pos}-${end} suffix=${suffix} file_size=${fs}",
+      //      ("b", header.block_num)("pos", pos)("end", suffix_pos + sizeof(suffix))("suffix", suffix)("fs", size));
+      EOS_ASSERT(suffix == pos, chain::state_history_exception, "corrupt ${name}.log (8)", ("name", name));
+
+      index.write((char*)&pos, sizeof(pos));
+      pos = suffix_pos + sizeof(suffix);
+      if (!(++num_found % 10000)) {
+         printf("%10u blocks found, log pos=%12llu\r", (unsigned)num_found, (unsigned long long)pos);
+         fflush(stdout);
+      }
+   }
+}
+
+state_history_log::file_position_type state_history_log::get_pos(state_history_log::block_num_type block_num) {
+   uint64_t pos;
+   index.seek((block_num - _begin_block) * sizeof(pos));
+   index.read((char*)&pos, sizeof(pos));
+   return pos;
+}
+
+void state_history_log::truncate(state_history_log::block_num_type block_num) {
+   log.flush();
+   index.flush();
+   uint64_t num_removed = 0;
+   if (block_num <= _begin_block) {
+      num_removed = _end_block - _begin_block;
+      log.seek(0);
+      index.seek(0);
+      boost::filesystem::resize_file(log_filename, 0);
+      boost::filesystem::resize_file(index_filename, 0);
+      _begin_block = _end_block = 0;
+   } else {
+      num_removed  = _end_block - block_num;
+      uint64_t pos = get_pos(block_num);
+      log.seek(0);
+      index.seek(0);
+      boost::filesystem::resize_file(log_filename, pos);
+      boost::filesystem::resize_file(index_filename, (block_num - _begin_block) * sizeof(uint64_t));
+      _end_block = block_num;
+   }
+   log.flush();
+   index.flush();
+   ilog("fork or replay: removed ${n} blocks from ${name}.log", ("n", num_removed)("name", name));
+}
+
+std::pair<state_history_log::file_position_type, state_history_log::block_num_type>
+state_history_log::write_entry_header(const state_history_log_header& header, const chain::block_id_type& prev_id) {
+   auto block_num = chain::block_header::num_from_id(header.block_id);
+   EOS_ASSERT(_begin_block == _end_block || block_num <= _end_block, chain::state_history_exception,
+              "missed a block in ${name}.log", ("name", name));
+
+   if (_begin_block != _end_block && block_num > _begin_block) {
+      if (block_num == _end_block) {
+         EOS_ASSERT(prev_id == last_block_id, chain::state_history_exception, "missed a fork change in ${name}.log",
+                    ("name", name));
+      } else {
+         state_history_log_header prev;
+         get_entry_header(block_num - 1, prev);
+         EOS_ASSERT(prev_id == prev.block_id, chain::state_history_exception, "missed a fork change in ${name}.log",
+                    ("name", name));
+      }
+   }
+
+   if (block_num < _end_block)
+      truncate(block_num);
+   log.seek_end(0);
+   uint64_t pos = log.tellp();
+   write_header(header);
+   return std::make_pair(pos, block_num);
+}
+
+void state_history_log::write_entry_position(const state_history_log_header&       header,
+                                             state_history_log::file_position_type pos,
+                                             state_history_log::block_num_type     block_num) {
+   uint64_t end = log.tellp();
+   EOS_ASSERT(end == pos + state_history_log_header_serial_size + header.payload_size, chain::state_history_exception,
+              "wrote payload with incorrect size to ${name}.log", ("name", name));
+   log.write((char*)&pos, sizeof(pos));
+
+   index.seek_end(0);
+   index.write((char*)&pos, sizeof(pos));
+   if (_begin_block == _end_block)
+      _begin_block = block_num;
+   _end_block    = block_num + 1;
+   last_block_id = header.block_id;
+}
+
+fc::optional<std::pair<chain::bytes, state_history_log::version_type>>
+state_history_log::get_entry(state_history_log::block_num_type block_num) {
+   if (block_num < begin_block() || block_num >= end_block())
+      return {};
+   state_history_log_header header;
+   auto&                    stream = get_entry_header(block_num, header);
+   uint32_t                 s;
+   stream.read((char*)&s, sizeof(s));
+   chain::bytes data(s);
+   if (s)
+      stream.read(data.data(), s);
+   return std::make_pair(data, get_ship_version(header.magic));
+}
+
+state_history_traces_log::state_history_traces_log(fc::path state_history_dir)
+    : state_history_log("trace_history", (state_history_dir / "trace_history.log").string(),
+                        (state_history_dir / "trace_history.index").string()) {}
+
+fc::optional<chain::bytes> state_history_traces_log::get_log_entry(block_num_type block_num) {
+   return this->get_entry(block_num, [](const chain::bytes& data, uint32_t version) {
+      return state_history::trace_converter::to_traces_bin_v0(data, version);
+   });
+}
+
+void state_history_traces_log::prune_traces(state_history_log::block_num_type        block_num,
+                                            std::vector<chain::transaction_id_type>& ids) {
+   auto entry_result = get_entry(block_num);
+   EOS_ASSERT(entry_result, chain::state_history_exception, "nonexistant block num ${block_num}",
+              ("block_num", block_num));
+
+   auto pos = get_log().tellp();
+
+   auto [entry_payload, version] = *entry_result;
+   auto pruned_section           = state_history::trace_converter::prune_traces(entry_payload, version, ids);
+   auto bytes_to_write = pruned_section.size();
+
+   if (bytes_to_write > 0) {
+      // the log object is in append mode, which cannot be used to update written content,
+      // we need to open the file in the update mode
+
+      fc::cfile update_log;
+      update_log.set_file_path(get_log().get_file_path());
+      update_log.open(fc::cfile::update_rw_mode);
+      update_log.seek(pos - bytes_to_write);
+      update_log.write(pruned_section.data(), bytes_to_write);
+   }
+}
+
+void state_history_traces_log::store_traces(const chainbase::database& db, const chain::block_state_ptr& block_state) {
+
+   auto traces_bin = trace_convert.pack(db, trace_debug_mode, block_state, ship_current_version, compression);
+
+   state_history_log_header header{.magic        = ship_magic(ship_current_version),
+                                   .block_id     = block_state->id,
+                                   .payload_size = sizeof(uint32_t) + traces_bin.size()};
+   this->write_entry(header, block_state->block->previous, [&](auto& stream) {
+      uint32_t s = (uint32_t)traces_bin.size();
+      stream.write((char*)&s, sizeof(s));
+      if (!traces_bin.empty())
+         stream.write(traces_bin.data(), traces_bin.size());
+   });
+}
+
+bool state_history_traces_log::exists(fc::path state_history_dir) {
+   return fc::exists(state_history_dir / "trace_history.log") && fc::exists(state_history_dir / "trace_history.index");
+}
+
+} // namespace eosio

--- a/libraries/state_history/log.cpp
+++ b/libraries/state_history/log.cpp
@@ -266,7 +266,7 @@ fc::optional<chain::bytes> state_history_traces_log::get_log_entry(block_num_typ
    });
 }
 
-void state_history_traces_log::prune_traces(state_history_log::block_num_type        block_num,
+void state_history_traces_log::prune_transactions(state_history_log::block_num_type        block_num,
                                             std::vector<chain::transaction_id_type>& ids) {
    auto entry_result = get_entry(block_num);
    EOS_ASSERT(entry_result, chain::state_history_exception, "nonexistant block num ${block_num}",

--- a/libraries/state_history/log.cpp
+++ b/libraries/state_history/log.cpp
@@ -267,7 +267,7 @@ fc::optional<chain::bytes> state_history_traces_log::get_log_entry(block_num_typ
 }
 
 void state_history_traces_log::prune_transactions(state_history_log::block_num_type        block_num,
-                                            std::vector<chain::transaction_id_type>& ids) {
+                                                  std::vector<chain::transaction_id_type>& ids) {
    auto entry_result = get_entry(block_num);
    EOS_ASSERT(entry_result, chain::state_history_exception, "nonexistant block num ${block_num}",
               ("block_num", block_num));
@@ -276,7 +276,7 @@ void state_history_traces_log::prune_transactions(state_history_log::block_num_t
 
    auto [entry_payload, version] = *entry_result;
    auto pruned_section           = state_history::trace_converter::prune_traces(entry_payload, version, ids);
-   auto bytes_to_write = pruned_section.size();
+   auto bytes_to_write           = pruned_section.size();
 
    if (bytes_to_write > 0) {
       // the log object is in append mode, which cannot be used to update written content,

--- a/libraries/state_history/log.cpp
+++ b/libraries/state_history/log.cpp
@@ -107,11 +107,7 @@ void state_history_log::recover_blocks(uint64_t size) {
 
 void state_history_log::open_log() {
    log.set_file_path(log_filename);
-   if (!fc::exists(log_filename)) {
-      log.open("a+b");
-      log.close();
-   }
-   log.open("rb+"); // we need to use "rb+" mode; otherwise, transaction pruning changes on disk won't be available for reading
+   log.open("a+b"); // std::ios_base::binary | std::ios_base::in | std::ios_base::out | std::ios_base::app
    log.seek_end(0);
    uint64_t size = log.tellp();
    if (size >= state_history_log_header_serial_size) {
@@ -276,16 +272,21 @@ void state_history_traces_log::prune_transactions(state_history_log::block_num_t
    EOS_ASSERT(entry_result, chain::state_history_exception, "nonexistant block num ${block_num}",
               ("block_num", block_num));
 
-   auto& log = get_log();
-   auto  pos = log.tellp();
+   auto pos = get_log().tellp();
 
    auto [entry_payload, version] = *entry_result;
    auto pruned_section           = state_history::trace_converter::prune_traces(entry_payload, version, ids);
    auto bytes_to_write = pruned_section.size();
 
    if (bytes_to_write > 0) {
-      log.seek(pos - bytes_to_write);
-      log.write(pruned_section.data(), bytes_to_write);
+      // the log object is in append mode, which cannot be used to update written content,
+      // we need to open the file in the update mode
+
+      fc::cfile update_log;
+      update_log.set_file_path(get_log().get_file_path());
+      update_log.open(fc::cfile::update_rw_mode);
+      update_log.seek(pos - bytes_to_write);
+      update_log.write(pruned_section.data(), bytes_to_write);
    }
 }
 

--- a/libraries/state_history/trace_converter.cpp
+++ b/libraries/state_history/trace_converter.cpp
@@ -281,7 +281,7 @@ bytes trace_converter::prune_traces(const bytes& entry_payload, uint32_t version
          // the incoming trace matches the one of ids to be pruned
          state_history::pack(write_strm, incoming_prunable.prune_all(), compression);
          modified = true;
-         ids.erase(it);
+         ids.erase(itr);
       } else {
          // the incoming trace should not be pruned
          auto bytes_read = read_strm.tellp() - last_read_pos; 

--- a/libraries/state_history/trace_converter.cpp
+++ b/libraries/state_history/trace_converter.cpp
@@ -192,7 +192,7 @@ struct restore_partial {
       ptrx.context_free_data = std::move(data.context_free_segments);
    }
    void operator()(prunable_data_type::none& data) const {}
-   void operator()(prunable_data_type::partial& data) const { ptrx.signatures = std::move(data.signatures); }
+   void operator()(prunable_data_type::partial& data) const { EOS_ASSERT(false, state_history_exception, "Not implemented"); }
    void operator()(prunable_data_type::full& data) const {
       ptrx.signatures        = std::move(data.signatures);
       ptrx.context_free_data = std::move(data.context_free_segments);

--- a/libraries/state_history/trace_converter.cpp
+++ b/libraries/state_history/trace_converter.cpp
@@ -43,7 +43,7 @@ namespace {
 bytes decompress_buffer(const char* buffer, uint32_t len, compression_type compression) {
    bytes                     decompressed;
    bio::filtering_ostreambuf strm;
-   EOS_ASSERT(compression == compression_type::zlib, state_history_exception, "unspported compression format");
+   EOS_ASSERT(compression == compression_type::zlib, state_history_exception, "unsupported compression format");
    strm.push(bio::zlib_decompressor());
    strm.push(bio::back_inserter(decompressed));
    bio::write(strm, buffer, len);
@@ -103,9 +103,9 @@ void pack(fc::datastream<char*>& ds, const prunable_data_type&  data, compressio
    }
 }
 
-// each individual pruable data in a trasaction is packed as an optional prunable_data_type::full
+// each individual prunable data in a transaction is packed as an optional prunable_data_type::full
 // or an optional bytes to a compressed prunable_data_type::full
-size_t pack_pruable(bytes& buffer, const packed_transaction& trx,
+size_t pack_prunable(bytes& buffer, const packed_transaction& trx,
                   compression_type compression) {
 
    const auto& data = trx.get_prunable_data();
@@ -154,8 +154,9 @@ bytes pack_prunables(const std::vector<augmented_transaction_trace>& traces, com
 
    int size_with_paddings = 0;
    for_each_packed_transaction(
-       traces, [&](const chain::packed_transaction& pt) { size_with_paddings += pack_pruable(out, pt, compression); });
+       traces, [&](const chain::packed_transaction& pt) { size_with_paddings += pack_prunable(out, pt, compression); });
 
+   EOS_ASSERT(size_with_paddings >= out.size(), state_history_exception, "The estimated max size is small than the actual size");
    out.resize(size_with_paddings);
    return out;
 }

--- a/libraries/state_history/trace_converter.cpp
+++ b/libraries/state_history/trace_converter.cpp
@@ -281,12 +281,7 @@ bytes trace_converter::prune_traces(const bytes& entry_payload, uint32_t version
          // the incoming trace matches the one of ids to be pruned
          state_history::pack(write_strm, incoming_prunable.prune_all(), compression);
          modified = true;
-
-         // delete the found id from the ids vector
-         if (itr != ids.end() - 1) {
-            *itr = ids.back();
-         }
-         ids.resize(ids.size() - 1);
+         ids.erase(it);
       } else {
          // the incoming trace should not be pruned
          auto bytes_read = read_strm.tellp() - last_read_pos; 

--- a/libraries/state_history/trace_converter.cpp
+++ b/libraries/state_history/trace_converter.cpp
@@ -1,11 +1,19 @@
+#include <boost/iostreams/device/back_inserter.hpp>
+#include <boost/iostreams/filter/zlib.hpp>
+#include <boost/iostreams/filtering_streambuf.hpp>
+#include <eosio/state_history/compression.hpp>
 #include <eosio/state_history/serialization.hpp>
 #include <eosio/state_history/trace_converter.hpp>
 
+extern const char* state_history_plugin_abi;
+
+namespace bio = boost::iostreams;
 namespace eosio {
 namespace state_history {
 
 using eosio::chain::packed_transaction;
-using eosio::chain::plugin_exception;
+using eosio::chain::state_history_exception;
+using prunable_data_type = packed_transaction::prunable_data_type;
 
 bool is_onblock(const transaction_trace_ptr& p) {
    if (p->action_traces.size() != 1)
@@ -30,25 +38,273 @@ void trace_converter::add_transaction(const transaction_trace_ptr& trace, const 
    }
 }
 
-bytes trace_converter::pack(const chainbase::database& db, bool trace_debug_mode, const block_state_ptr& block_state) {
+namespace {
+
+bytes decompress_buffer(const char* buffer, uint32_t len, compression_type compression) {
+   bytes                     decompressed;
+   bio::filtering_ostreambuf strm;
+   EOS_ASSERT(compression == compression_type::zlib, state_history_exception, "unspported compression format");
+   strm.push(bio::zlib_decompressor());
+   strm.push(bio::back_inserter(decompressed));
+   bio::write(strm, buffer, len);
+   bio::close(strm);
+   return decompressed;
+}
+
+std::vector<augmented_transaction_trace> prepare_traces(trace_converter&       converter,
+                                                        const block_state_ptr& block_state) {
    std::vector<augmented_transaction_trace> traces;
-   if (onblock_trace)
-      traces.push_back(*onblock_trace);
+   if (converter.onblock_trace)
+      traces.push_back(*converter.onblock_trace);
    for (auto& r : block_state->block->transactions) {
       transaction_id_type id;
       if (r.trx.contains<transaction_id_type>())
          id = r.trx.get<transaction_id_type>();
       else
          id = r.trx.get<packed_transaction>().id();
-      auto it = cached_traces.find(id);
-      EOS_ASSERT(it != cached_traces.end() && it->second.trace->receipt, plugin_exception,
+      auto it = converter.cached_traces.find(id);
+      EOS_ASSERT(it != converter.cached_traces.end() && it->second.trace->receipt, state_history_exception,
                  "missing trace for transaction ${id}", ("id", id));
       traces.push_back(it->second);
    }
-   cached_traces.clear();
-   onblock_trace.reset();
+   converter.cached_traces.clear();
+   converter.onblock_trace.reset();
+   return traces;
+}
 
-   return fc::raw::pack(make_history_context_wrapper(db, trace_debug_mode, traces));
+template <typename Lambda>
+void for_each_packed_transaction(const eosio::state_history::augmented_transaction_trace& obj, const Lambda& lambda) {
+   auto& trace = *obj.trace;
+   if (trace.failed_dtrx_trace) {
+      for_each_packed_transaction(
+          eosio::state_history::augmented_transaction_trace{trace.failed_dtrx_trace, obj.packed_trx}, lambda);
+   }
+   bool include_packed_trx = obj.packed_trx && !trace.failed_dtrx_trace;
+   if (include_packed_trx) {
+      lambda(*obj.packed_trx);
+   }
+}
+
+template <typename Lambda>
+void for_each_packed_transaction(const std::vector<eosio::state_history::augmented_transaction_trace>& traces,
+                                 const Lambda&                                                         lambda) {
+   for (const auto& v : traces) {
+      for_each_packed_transaction(v, lambda);
+   }
+}
+
+void pack(fc::datastream<char*>& ds, const prunable_data_type&  data, compression_type compression) {
+   if (compression == compression_type::none) {
+      fc::raw::pack(ds, data);
+   }
+   else if (compression == compression_type::zlib) {
+      bytes uncompressed = fc::raw::pack(data);
+      fc::raw::pack(ds, zlib_compress_bytes(uncompressed));
+   }
+}
+
+void unpack(fc::datastream<const char*>& ds, prunable_data_type& data, compression_type compression) {
+   if (compression == compression_type::none) {
+      fc::raw::unpack(ds, data);
+   }
+   else if (compression == compression_type::zlib) {
+      bytes compressed;
+      fc::raw::unpack(ds, compressed);
+      bytes uncompressed = zlib_decompress(compressed);
+      fc::datastream<const char*> uncompressed_ds(uncompressed.data(), uncompressed.size());
+      fc::raw::unpack(uncompressed_ds, data);
+   }
+}
+
+
+// each individual pruable data in a trasaction is packed as an optional prunable_data_type::full
+// or an optional bytes to a compressed prunable_data_type::full
+size_t pack_pruable(bytes& buffer, const packed_transaction& trx,
+                  compression_type compression) {
+
+   const auto& data = trx.get_prunable_data();
+
+   int max_size = data.maximum_pruned_pack_size(compression);
+   if (data.prunable_data.contains<prunable_data_type::full_legacy>()) {
+      max_size += sizeof(uint8_t);
+   }
+   uint64_t start_buffer_position = buffer.size();
+   buffer.resize(buffer.size() + max_size);
+   fc::datastream<char*> ds(buffer.data() + start_buffer_position, max_size);
+   pack(ds, data, compression);
+   
+   if (data.prunable_data.contains<prunable_data_type::full_legacy>()) {
+      fc::raw::pack(ds, static_cast<uint8_t>(trx.get_compression()));
+   }
+   buffer.resize(start_buffer_position + ds.tellp());
+   return max_size;
+}
+
+
+void unpack_prunable(const char* read_buffer, fc::datastream<const char*>& ds, prunable_data_type& data,
+                     compression_type compression) {
+
+   unpack(ds, data, compression);
+   if (data.prunable_data.contains<prunable_data_type::full_legacy>()) {
+      uint8_t local_comp;
+      fc::raw::unpack(ds, local_comp);
+      auto& full_legacy = data.prunable_data.get<prunable_data_type::full_legacy>();
+      full_legacy.unpack_context_free_data(static_cast<chain::packed_transaction_v0::compression_type>(local_comp));
+   }
+}
+
+bytes pack_prunables(const std::vector<augmented_transaction_trace>& traces, compression_type compression) {
+
+   std::vector<char> out;
+   out.reserve(1024);
+
+   int size_with_paddings = 0;
+   for_each_packed_transaction(
+       traces, [&](const chain::packed_transaction& pt) { size_with_paddings += pack_pruable(out, pt, compression); });
+
+   out.resize(size_with_paddings);
+   return out;
+}
+
+std::pair<std::vector<transaction_trace>, compression_type>
+traces_from_v1_entry_payload(const char* read_buffer, fc::datastream<const char*>& ds) {
+   uint8_t compr;
+   fc::raw::unpack(ds, compr);
+   fc::unsigned_int len;
+   fc::raw::unpack(ds, len);
+   EOS_ASSERT(ds.remaining() >= static_cast<size_t>(len), fc::out_of_range_exception, "read datastream over by ${v}",
+              ("v", ds.remaining() - len));
+
+   auto unprunable_section = decompress_buffer(read_buffer + ds.tellp(), len, compression_type::zlib);
+   ds.skip(len);
+
+   std::vector<transaction_trace> traces;
+   fc::datastream<const char*>    traces_ds(unprunable_section.data(), unprunable_section.size());
+   fc::raw::unpack(traces_ds, traces);
+   return std::make_pair(traces, static_cast<compression_type>(compr));
+}
+
+template <typename Visitor>
+void do_visit_trace(const char* read_buffer, fc::datastream<const char*>& strm, transaction_trace& trace,
+                    compression_type compression, Visitor&& visitor) {
+   auto& trace_v0 = trace.get<transaction_trace_v0>();
+   if (trace_v0.failed_dtrx_trace.size()) {
+      // failed_dtrx_trace have at most one element because it is encoded as an optional
+      do_visit_trace(read_buffer, strm, trace_v0.failed_dtrx_trace[0].recurse, compression, visitor);
+   }
+   if (trace_v0.partial) {
+      prunable_data_type prunable;
+      unpack_prunable(read_buffer, strm, prunable, compression);
+      visitor(trace_v0, prunable);
+   }
+}
+} // namespace
+
+bytes trace_converter::pack(const chainbase::database& db, bool trace_debug_mode, const block_state_ptr& block_state,
+                            uint32_t version, compression_type compression) {
+
+   auto traces     = prepare_traces(*this, block_state);
+   auto unprunable = zlib_compress_bytes(fc::raw::pack(make_history_context_wrapper(
+       db, trace_receipt_context{.debug_mode = trace_debug_mode, .version = version}, traces)));
+
+   if (version == 0) {
+      return unprunable;
+   } else {
+      // In version 1 of ShiP traces log disk format, it log entry consists of 3 parts.
+      //  1. a unit8_t compression tag to indicate the compression level of prunables
+      //  2. an zlib compressed unprunable section contains the serialization of the vector of traces excluding
+      //     the prunable_data data (i.e. signatures and context free data)
+      //  3. a prunable section contains the serialization of the vector of optional (possibly compressed)
+      //     prunable_data
+
+      auto                   prunables = pack_prunables(traces, compression);
+      fc::datastream<size_t> unprunable_size_strm;
+      fc::raw::pack(unprunable_size_strm, unprunable);
+      uint8_t compression_tag = static_cast<uint8_t>(compression);
+      bytes   buffer(sizeof(compression_tag) + unprunable_size_strm.tellp() + prunables.size());
+
+      fc::datastream<char*> strm(buffer.data(), buffer.size());
+      fc::raw::pack(strm, compression_tag);
+      fc::raw::pack(strm, unprunable);
+      strm.write(prunables.data(), prunables.size());
+      return buffer;
+   }
+}
+
+struct restore_partial {
+   partial_transaction_v0& ptrx;
+   void operator()(prunable_data_type::full_legacy& data) const {
+      ptrx.signatures        = std::move(data.signatures);
+      ptrx.context_free_data = std::move(data.context_free_segments);
+   }
+   void operator()(prunable_data_type::none& data) const {}
+   void operator()(prunable_data_type::signatures_only& data) const {
+      ptrx.signatures        = std::move(data.signatures);
+   }
+   void operator()(prunable_data_type::partial& data) const  {
+      ptrx.signatures        = std::move(data.signatures);
+   }
+   void operator()(prunable_data_type::full& data) const {
+      ptrx.signatures        = std::move(data.signatures);
+      ptrx.context_free_data = std::move(data.context_free_segments);
+   }
+};
+
+bytes trace_converter::to_traces_bin_v0(const bytes& entry_payload, uint32_t version) {
+   if (version == 0)
+      return zlib_decompress(entry_payload);
+   else {
+      fc::datastream<const char*> strm(entry_payload.data(), entry_payload.size());
+
+      auto [traces, compression] = traces_from_v1_entry_payload(entry_payload.data(), strm);
+      for (auto& trace : traces) {
+         do_visit_trace(entry_payload.data(), strm, trace, compression,
+                        [](transaction_trace_v0& trace, prunable_data_type& prunable_data) {
+                           auto& ptrx             = trace.partial->get<partial_transaction_v0>();
+                           prunable_data.prunable_data.visit(restore_partial{ptrx});
+                        });
+      }
+
+      return fc::raw::pack(traces);
+   }
+}
+
+bytes trace_converter::prune_traces(const bytes& entry_payload, uint32_t version, std::vector<transaction_id_type>& ids) {
+   EOS_ASSERT(version > 0, state_history_exception, "state history log version 0 does not support trace pruning");
+   fc::datastream<const char*> read_strm(entry_payload.data(), entry_payload.size());
+
+   auto [traces, compression] = traces_from_v1_entry_payload(entry_payload.data(), read_strm);
+   uint64_t last_read_pos     = read_strm.tellp();
+   uint64_t change_offset     = entry_payload.size();
+   bool     modified          = false;
+
+   bytes write_buffer(entry_payload.size() - last_read_pos);
+   fc::datastream<char*> write_strm(write_buffer.data(), write_buffer.size());
+
+   auto prune_trace = [&, compression=compression](transaction_trace_v0& trace, auto& incoming_prunable) {
+      auto itr = std::find(ids.begin(), ids.end(), trace.id);
+      if (itr != ids.end()) {
+         // the incoming trace matches the one of ids to be pruned
+         state_history::pack(write_strm, incoming_prunable.prune_all(), compression);
+         modified = true;
+
+         // delete the found id from the ids vector
+         if (itr != ids.end() - 1) {
+            *itr = ids.back();
+         }
+         ids.resize(ids.size() - 1);
+      } else {
+         // the incoming trace should not be pruned
+         auto bytes_read = read_strm.tellp() - last_read_pos; 
+         write_strm.write(entry_payload.data() + last_read_pos, bytes_read);    
+      }
+      last_read_pos = read_strm.tellp();
+   };
+
+   for (auto& trace : traces) {
+      do_visit_trace(entry_payload.data(), read_strm, trace, compression, prune_trace);
+   }
+   return modified? write_buffer : bytes{};
 }
 
 } // namespace state_history

--- a/programs/eosio-blocklog/CMakeLists.txt
+++ b/programs/eosio-blocklog/CMakeLists.txt
@@ -8,7 +8,7 @@ target_include_directories(eosio-blocklog PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
 
 target_link_libraries( eosio-blocklog
         PRIVATE appbase
-        PRIVATE eosio_chain fc ${CMAKE_DL_LIBS} ${PLATFORM_SPECIFIC_LIBS} )
+        PRIVATE eosio_chain fc state_history ${CMAKE_DL_LIBS} ${PLATFORM_SPECIFIC_LIBS} )
 
 copy_bin( eosio-blocklog )
 install( TARGETS

--- a/programs/eosio-blocklog/main.cpp
+++ b/programs/eosio-blocklog/main.cpp
@@ -321,10 +321,10 @@ int main(int argc, char** argv) {
          return 0;
       }
       if (blog.prune_transactions) {
-         const auto  blocks_dir        = vmap.at("blocks-dir").as<bfs::path>();
-         const auto  state_history_dir = vmap.at("state-history-dir").as<bfs::path>();
-         const auto  block_num         = vmap.at("block-num").as<uint32_t>();
-         const auto  ids               = vmap.at("transaction").as<std::vector<string>>();
+         const auto  blocks_dir        = vmap["blocks-dir"].as<bfs::path>();
+         const auto  state_history_dir = vmap["state-history-dir"].as<bfs::path>();
+         const auto  block_num         = vmap["block-num"].as<uint32_t>();
+         const auto  ids               = vmap.count("transaction") ? vmap["transaction"].as<std::vector<string>>() : std::vector<string>{};
          
          report_time                 rt("prune transactions");
          int ret = prune_transactions(blocks_dir, state_history_dir, block_num, {ids.begin(), ids.end()});

--- a/programs/eosio-blocklog/main.cpp
+++ b/programs/eosio-blocklog/main.cpp
@@ -4,6 +4,8 @@
 #include <eosio/chain/config.hpp>
 #include <eosio/chain/reversible_block_object.hpp>
 
+#include <eosio/state_history/log.hpp>
+
 #include <fc/io/json.hpp>
 #include <fc/filesystem.hpp>
 #include <fc/variant.hpp>
@@ -47,7 +49,8 @@ struct blocklog {
    bool                             make_index = false;
    bool                             trim_log = false;
    bool                             smoke_test = false;
-   bool                             help = false;
+   bool                             prune_transactions = false;
+   bool                             help               = false;
 };
 
 struct report_time {
@@ -171,6 +174,8 @@ void blocklog::set_program_options(options_description& cli)
    cli.add_options()
          ("blocks-dir", bpo::value<bfs::path>()->default_value("blocks"),
           "the location of the blocks directory (absolute path or relative to the current directory)")
+         ("state-history-dir", bpo::value<bfs::path>()->default_value("state-history"),
+           "the location of the state-history directory (absolute path or relative to application data dir)")
          ("output-file,o", bpo::value<bfs::path>(),
           "the file to write the output to (absolute or relative path).  If not specified then output is to stdout.")
          ("first,f", bpo::value<uint32_t>(&first_block)->default_value(0),
@@ -187,6 +192,10 @@ void blocklog::set_program_options(options_description& cli)
           "Trim blocks.log and blocks.index. Must give 'blocks-dir' and 'first and/or 'last'.")
          ("smoke-test", bpo::bool_switch(&smoke_test)->default_value(false),
           "Quick test that blocks.log and blocks.index are well formed and agree with each other.")
+         ("block-num", bpo::value<uint32_t>()->default_value(0), "The block number which contains the transactions to be pruned")
+         ("transaction,t", bpo::value<std::vector<std::string> >()->multitoken(), "The transaction id to be pruned")
+         ("prune-transactions", bpo::bool_switch(&prune_transactions)->default_value(false),
+          "Prune the context free data and signatures from specified transactions of specified block-num.")
          ("help,h", bpo::bool_switch(&help)->default_value(false), "Print this help message and exit.")
          ;
 }
@@ -230,6 +239,37 @@ void smoke_test(bfs::path block_dir) {
    cout << "\nSmoke test of blocks.log and blocks.index in directory " << block_dir << '\n';
    block_log::smoke_test(block_dir, 0);
    cout << "\nno problems found\n"; // if get here there were no exceptions
+}
+
+template <typename Log>
+int prune_transactions(const char* type, bfs::path dir, uint32_t block_num,
+                       std::vector<transaction_id_type> unpruned_ids) {
+   using namespace std;
+   if (Log::exists(dir)) {
+      Log log(dir);
+      log.prune_transactions(block_num, unpruned_ids);
+      if (unpruned_ids.size()) {
+         cerr << "block " << block_num << " in " << type << " does not contain the following transactions: ";
+         copy(unpruned_ids.begin(), unpruned_ids.end(), ostream_iterator<string>(cerr, " "));
+         cerr << "\n";
+      }
+   } else {
+      cerr << "No " << type << " is found in " << dir.native() << "\n";
+   }
+   return unpruned_ids.size();
+}
+
+int prune_transactions(bfs::path block_dir, bfs::path state_history_dir, uint32_t block_num,
+                       const std::vector<transaction_id_type>& ids) {
+
+   if (block_num == 0 || ids.size() == 0) {
+      std::cerr << "prune-transaction does nothing unless specify block-num and transaction\n";
+      return -1;
+   }
+
+   using eosio::state_history_traces_log;
+   return prune_transactions<block_log>("block log", block_dir, block_num, ids) +
+          prune_transactions<state_history_traces_log>("state history traces log", state_history_dir, block_num, ids);
 }
 
 int main(int argc, char** argv) {
@@ -279,6 +319,17 @@ int main(int argc, char** argv) {
          fc::logger::get(DEFAULT_LOGGER).set_log_level(log_level);
          rt.report();
          return 0;
+      }
+      if (blog.prune_transactions) {
+         const auto  blocks_dir        = vmap.at("blocks-dir").as<bfs::path>();
+         const auto  state_history_dir = vmap.at("state-history-dir").as<bfs::path>();
+         const auto  block_num         = vmap.at("block-num").as<uint32_t>();
+         const auto  ids               = vmap.at("transaction").as<std::vector<string>>();
+         
+         report_time                 rt("prune transactions");
+         int ret = prune_transactions(blocks_dir, state_history_dir, block_num, {ids.begin(), ids.end()});
+         rt.report();
+         return ret;
       }
       //else print blocks.log as JSON
       blog.initialize(vmap);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -50,6 +50,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/ship_test.py ${CMAKE_CURRENT_BINARY_D
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/ship_client.js ${CMAKE_CURRENT_BINARY_DIR}/ship_client.js COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/nodeos_high_transaction_test.py ${CMAKE_CURRENT_BINARY_DIR}/nodeos_high_transaction_test.py COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/light_validation_sync_test.py ${CMAKE_CURRENT_BINARY_DIR}/light_validation_sync_test.py COPYONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/eosio_blocklog_prune_test.py ${CMAKE_CURRENT_BINARY_DIR}/eosio_blocklog_prune_test.py COPYONLY)
 
 #To run plugin_test with all log from blockchain displayed, put --verbose after --, i.e. plugin_test -- --verbose
 add_test(NAME plugin_test COMMAND plugin_test --report_level=detailed --color_output)

--- a/tests/Cluster.py
+++ b/tests/Cluster.py
@@ -1639,9 +1639,9 @@ class Cluster(object):
 
         self.printBlockLog()
 
-    def getBlockLog(self, nodeExtension, blockLogAction=BlockLogAction.return_blocks, outputFile=None, first=None, last=None, throwException=False, silentErrors=False, exitOnError=False):
-        blockLogDir=Utils.getNodeDataDir(nodeExtension, "blocks")
-        return Utils.getBlockLog(blockLogDir, blockLogAction=blockLogAction, outputFile=outputFile, first=first, last=last,  throwException=throwException, silentErrors=silentErrors, exitOnError=exitOnError)
+    def getBlockLog(self, nodeExtension, blockLogAction=BlockLogAction.return_blocks, outputFile=None, first=None, last=None, extraArgs="", throwException=False, silentErrors=False, exitOnError=False):
+        nodeDataDir=Utils.getNodeDataDir(nodeExtension)
+        return Utils.getBlockLog(nodeDataDir, blockLogAction=blockLogAction, outputFile=outputFile, first=first, last=last, extraArgs=extraArgs, throwException=throwException, silentErrors=silentErrors, exitOnError=exitOnError)
 
     def printBlockLog(self):
         blockLogBios=self.getBlockLog("bios")

--- a/tests/eosio_blocklog_prune_test.py
+++ b/tests/eosio_blocklog_prune_test.py
@@ -10,6 +10,7 @@ from TestHelper import TestHelper
 from TestHelper import AppArgs
 from testUtils import BlockLogAction
 import json
+import sys
 
 ###############################################################
 # eosio_blocklog_prune_test.py
@@ -103,14 +104,22 @@ try:
     trans = validationNode.processCleosCmd(cmd, cmd, silentErrors=False)
     assert trans, "Failed to get the transaction with context free data from the light validation node"
 
+
+    # prune the transaction with block-num=trans["block_num"], id=cfTrxId
     cluster.getBlockLog(1, blockLogAction=BlockLogAction.prune_transactions, extraArgs=" --block-num {} --transaction {}".format(trans["block_num"], cfTrxId), exitOnError=True)
 
     trans = validationNode.processCleosCmd(cmd, cmd, silentErrors=False)
     assert trans, "Failed to get the transaction with context free data from the light validation node"
+    # check whether the transaction has been pruned based on the tag of prunable_data, if the tag is 1, when it's prunable_data_t::none
     assert trans["trx"]["receipt"]["trx"][1]["prunable_data"]["prunable_data"][0] == 1, "the the transaction with context free data has not been pruned"
 
-
-    # output = cluster.getBlockLog(1, blockLogAction=BlockLogAction.prune_transactions, extraArgs=" --block-num {} --transaction {}".format(cfTrxBlockNum-1, cfTrxId))
+    # try to prune the transaction where it doesn't belong
+    try:
+        cluster.getBlockLog(1, blockLogAction=BlockLogAction.prune_transactions, extraArgs=" --block-num {} --transaction {}".format(cfTrxBlockNum - 1, cfTrxId), throwException=True, silentErrors=True)
+    except:
+        ex = sys.exc_info()[0]
+        msg=ex.output.decode("utf-8")
+        assert "does not contain the following transactions: " + cfTrxId in msg, "The transaction id is not displayed in the console when it cannot be found"
 
     testSuccessful = True
 finally:

--- a/tests/eosio_blocklog_prune_test.py
+++ b/tests/eosio_blocklog_prune_test.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+
+from testUtils import Account
+from testUtils import Utils
+from Cluster import Cluster
+from WalletMgr import WalletMgr
+from Node import Node
+from Node import ReturnType
+from TestHelper import TestHelper
+from TestHelper import AppArgs
+from testUtils import BlockLogAction
+import json
+
+###############################################################
+# eosio_blocklog_prune_test.py
+#
+# Test eosio-blocklog prune-transaction 
+# 
+# This test creates a producer node and a verification node. 
+# The verification node is configured with state history plugin.
+# A transaction with context free data is pushed to the producer node.
+# Afterwards, it uses eosio-blocklog to prune the transaction with context free
+# data and check if the context free data in the block log has actually been pruned. 
+# Notice that there's no verification on whether the pruning on the 
+# state history traces log has actually been pruned. We rely on the 
+# unittests/state_history_tests.cpp to perform this test. 
+#
+###############################################################
+
+# Parse command line arguments
+args = TestHelper.parse_args({"-v","--clean-run","--dump-error-details","--leave-running","--keep-logs"})
+Utils.Debug = args.v
+killAll=args.clean_run
+dumpErrorDetails=args.dump_error_details
+dontKill=args.leave_running
+killEosInstances=not dontKill
+killWallet=not dontKill
+keepLogs=args.keep_logs
+
+walletMgr=WalletMgr(True)
+cluster=Cluster(walletd=True)
+cluster.setWalletMgr(walletMgr)
+
+testSuccessful = False
+try:
+    TestHelper.printSystemInfo("BEGIN")
+    cluster.killall(allInstances=killAll)
+    cluster.cleanup()
+
+    assert cluster.launch(
+        pnodes=1,
+        prodCount=1,
+        totalProducers=1,
+        totalNodes=2,
+        useBiosBootFile=False,
+        loadSystemContract=False,
+        specificExtraNodeosArgs={
+            1:"--plugin eosio::state_history_plugin --trace-history --disable-replay-opts --sync-fetch-span 200 --plugin eosio::net_api_plugin "})
+
+    producerNode = cluster.getNode(0)
+    validationNode = cluster.getNode(1)
+
+    # Create a transaction to create an account
+    Utils.Print("create a new account payloadless from the producer node")
+    payloadlessAcc = Account("payloadless")
+    payloadlessAcc.ownerPublicKey = "EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV"
+    payloadlessAcc.activePublicKey = "EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV"
+    producerNode.createAccount(payloadlessAcc, cluster.eosioAccount)
+
+
+    contractDir="unittests/test-contracts/payloadless"
+    wasmFile="payloadless.wasm"
+    abiFile="payloadless.abi"
+    Utils.Print("Publish payloadless contract")
+    trans = producerNode.publishContract(payloadlessAcc, contractDir, wasmFile, abiFile, waitForTransBlock=True)
+
+    trx = {
+        "actions": [{"account": "payloadless", "name": "doit", "authorization": [{
+          "actor": "payloadless", "permission": "active"}], "data": ""}],
+        "context_free_actions": [{"account": "payloadless", "name": "doit", "data": ""}],
+        "context_free_data": ["a1b2c3", "1a2b3c"],
+    } 
+
+    cmd = "push transaction '{}' -p payloadless".format(json.dumps(trx))
+    trans = producerNode.processCleosCmd(cmd, cmd, silentErrors=False)
+    assert trans, "Failed to push transaction with context free data"
+    
+    cfTrxBlockNum = int(trans["processed"]["block_num"])
+    cfTrxId = trans["transaction_id"]
+
+    # Wait until the block where create account is executed to become irreversible 
+    def isBlockNumIrr():
+        return validationNode.getIrreversibleBlockNum() >= cfTrxBlockNum
+    Utils.waitForBool(isBlockNumIrr, timeout=30, sleepTime=0.1)
+    
+    Utils.Print("verify the account payloadless from validation node")
+    cmd = "get account -j payloadless"
+    trans = validationNode.processCleosCmd(cmd, cmd, silentErrors=False)
+    assert trans["account_name"], "Failed to get the account payloadless"
+
+    Utils.Print("verify the context free transaction from validation node")
+    cmd = "get transaction " + cfTrxId
+    trans = validationNode.processCleosCmd(cmd, cmd, silentErrors=False)
+    assert trans, "Failed to get the transaction with context free data from the light validation node"
+
+    cluster.getBlockLog(1, blockLogAction=BlockLogAction.prune_transactions, extraArgs=" --block-num {} --transaction {}".format(trans["block_num"], cfTrxId), exitOnError=True)
+
+    trans = validationNode.processCleosCmd(cmd, cmd, silentErrors=False)
+    assert trans, "Failed to get the transaction with context free data from the light validation node"
+    assert trans["trx"]["receipt"]["trx"][1]["prunable_data"]["prunable_data"][0] == 1, "the the transaction with context free data has not been pruned"
+
+
+    # output = cluster.getBlockLog(1, blockLogAction=BlockLogAction.prune_transactions, extraArgs=" --block-num {} --transaction {}".format(cfTrxBlockNum-1, cfTrxId))
+
+    testSuccessful = True
+finally:
+    TestHelper.shutdown(cluster, walletMgr, testSuccessful, killEosInstances, killWallet, keepLogs, killAll, dumpErrorDetails)
+
+exitCode = 0 if testSuccessful else 1
+exit(exitCode)

--- a/tests/eosio_blocklog_prune_test.py
+++ b/tests/eosio_blocklog_prune_test.py
@@ -110,7 +110,7 @@ try:
 
     trans = validationNode.processCleosCmd(cmd, cmd, silentErrors=False)
     assert trans, "Failed to get the transaction with context free data from the light validation node"
-    # check whether the transaction has been pruned based on the tag of prunable_data, if the tag is 1, when it's prunable_data_t::none
+    # check whether the transaction has been pruned based on the tag of prunable_data, if the tag is 1, then it's a prunable_data_t::none
     assert trans["trx"]["receipt"]["trx"][1]["prunable_data"]["prunable_data"][0] == 1, "the the transaction with context free data has not been pruned"
 
     # try to prune the transaction where it doesn't belong

--- a/tests/testUtils.py
+++ b/tests/testUtils.py
@@ -269,13 +269,13 @@ class Utils:
             raise
 
     @staticmethod
-    def runCmdReturnStr(cmd, trace=False):
+    def runCmdReturnStr(cmd, trace=False, silentErrors=False):
         cmdArr=shlex.split(cmd)
-        return Utils.runCmdArrReturnStr(cmdArr)
+        return Utils.runCmdArrReturnStr(cmdArr, trace=trace, silentErrors=silentErrors)
 
     @staticmethod
-    def runCmdArrReturnStr(cmdArr, trace=False):
-        retStr=Utils.checkOutput(cmdArr)
+    def runCmdArrReturnStr(cmdArr, trace=False, silentErrors=False):
+        retStr=Utils.checkOutput(cmdArr,ignoreError=silentErrors)
         if trace: Utils.Print ("RAW > %s" % (retStr))
         return retStr
 
@@ -358,7 +358,7 @@ class Utils:
             if returnType==ReturnType.json:
                 rtn=Utils.runCmdReturnJson(cmd, silentErrors=silentErrors)
             else:
-                rtn=Utils.runCmdReturnStr(cmd)
+                rtn=Utils.runCmdReturnStr(cmd, silentErrors=silentErrors)
         except subprocess.CalledProcessError as ex:
             if throwException:
                 raise

--- a/tests/testUtils.py
+++ b/tests/testUtils.py
@@ -47,6 +47,7 @@ addEnum(BlockLogAction, "make_index")
 addEnum(BlockLogAction, "trim")
 addEnum(BlockLogAction, "smoke_test")
 addEnum(BlockLogAction, "return_blocks")
+addEnum(BlockLogAction, "prune_transactions")
 
 ###########################################################################################
 class Utils:
@@ -327,11 +328,12 @@ class Utils:
         return "pgrep %s %s" % (pgrepOpts, serverName)
 
     @staticmethod
-    def getBlockLog(blockLogLocation, blockLogAction=BlockLogAction.return_blocks, outputFile=None, first=None, last=None, throwException=False, silentErrors=False, exitOnError=False):
+    def getBlockLog(nodeDataDir, blockLogAction=BlockLogAction.return_blocks, outputFile=None, first=None, last=None, extraArgs="", throwException=False, silentErrors=False, exitOnError=False):
+        blockLogLocation = os.path.join(nodeDataDir, "blocks")
         assert(isinstance(blockLogLocation, str))
         outputFileStr=" --output-file %s " % (outputFile) if outputFile is not None else ""
         firstStr=" --first %s " % (first) if first is not None else ""
-        lastStr=" --last %s " % (last) if last is not None else ""
+        lastStr = " --last %s " % (last) if last is not None else ""
 
         blockLogActionStr=None
         returnType=ReturnType.raw
@@ -343,11 +345,13 @@ class Utils:
         elif blockLogAction==BlockLogAction.trim:
             blockLogActionStr=" --trim "
         elif blockLogAction==BlockLogAction.smoke_test:
-            blockLogActionStr=" --smoke-test "
+            blockLogActionStr = " --smoke-test "
+        elif blockLogAction == BlockLogAction.prune_transactions:
+            blockLogActionStr = " --state-history-dir {}/state-history --prune-transactions ".format(nodeDataDir)
         else:
             unhandledEnumType(blockLogAction)
 
-        cmd="%s --blocks-dir %s --as-json-array %s%s%s%s" % (Utils.EosBlockLogPath, blockLogLocation, outputFileStr, firstStr, lastStr, blockLogActionStr)
+        cmd="%s --blocks-dir %s --as-json-array %s%s%s%s %s" % (Utils.EosBlockLogPath, blockLogLocation, outputFileStr, firstStr, lastStr, blockLogActionStr, extraArgs)
         if Utils.Debug: Utils.Print("cmd: %s" % (cmd))
         rtn=None
         try:

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -38,7 +38,7 @@ add_custom_command(
 file(GLOB UNIT_TESTS "*.cpp") # find all unit test suites
 add_executable( unit_test ${UNIT_TESTS} protocol_feature_digest_tests.cpp) # build unit tests as one executable
 
-target_link_libraries( unit_test eosio_chain_wrap chainbase eosio_testing fc appbase ${PLATFORM_SPECIFIC_LIBS} )
+target_link_libraries( unit_test eosio_chain_wrap chainbase eosio_testing fc appbase state_history ${PLATFORM_SPECIFIC_LIBS} )
 
 target_compile_options(unit_test PUBLIC -DDISABLE_EOSLIB_SERIALIZE)
 target_include_directories( unit_test PUBLIC

--- a/unittests/restart_chain_tests.cpp
+++ b/unittests/restart_chain_tests.cpp
@@ -248,6 +248,11 @@ BOOST_AUTO_TEST_CASE(test_trim_blocklog_front) {
    bfs::copy(blocks_dir / "blocks.index", temp1.path / "blocks.index");
    BOOST_REQUIRE_NO_THROW(block_log::trim_blocklog_front(temp1.path, temp2.path, 10));
    BOOST_REQUIRE_NO_THROW(block_log::smoke_test(temp1.path, 1));
+
+   block_log old_log(blocks_dir);
+   block_log new_log(temp1.path);
+   BOOST_CHECK(new_log.first_block_num() == 10);
+   BOOST_CHECK(new_log.head()->block_num() == old_log.head()->block_num());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/unittests/restart_chain_tests.cpp
+++ b/unittests/restart_chain_tests.cpp
@@ -266,7 +266,8 @@ BOOST_FIXTURE_TEST_CASE(test_light_validation_restart_from_block_log, light_vali
 BOOST_FIXTURE_TEST_CASE(test_light_validation_restart_from_block_log_with_pruned_trx, light_validation_restart_from_block_log_test_fixture) {
    const auto& blocks_dir = chain.get_config().blocks_dir;
    block_log blog(blocks_dir);
-   BOOST_CHECK(blog.prune_transactions(trace->block_num, std::vector<transaction_id_type>{trace->id}) == 1);
+   std::vector<transaction_id_type> ids{trace->id};
+   BOOST_CHECK(blog.prune_transactions(trace->block_num, ids) == 1);
    BOOST_REQUIRE_NO_THROW(block_log::repair_log(blocks_dir));
 }
 

--- a/unittests/restart_chain_tests.cpp
+++ b/unittests/restart_chain_tests.cpp
@@ -11,6 +11,7 @@
 #include <contracts.hpp>
 #include <snapshots.hpp>
 #include <boost/iostreams/device/mapped_file.hpp>
+#include "test_cfd_transaction.hpp"
 
 using namespace eosio;
 using namespace testing;
@@ -28,30 +29,6 @@ void remove_existing_states(controller::config& config) {
    remove_all(state_path);
    fc::create_directories(state_path);
 }
-
-struct dummy_action {
-   static eosio::chain::name get_name() { return N(dummyaction); }
-   static eosio::chain::name get_account() { return N(testapi); }
-
-   char     a; // 1
-   uint64_t b; // 8
-   int32_t  c; // 4
-};
-
-struct cf_action {
-   static eosio::chain::name get_name() { return N(cfaction); }
-   static eosio::chain::name get_account() { return N(testapi); }
-
-   uint32_t payload = 100;
-   uint32_t cfd_idx = 0; // context free data index
-};
-
-FC_REFLECT(dummy_action, (a)(b)(c))
-FC_REFLECT(cf_action, (payload)(cfd_idx))
-
-#define DUMMY_ACTION_DEFAULT_A 0x45
-#define DUMMY_ACTION_DEFAULT_B 0xab11cd1244556677
-#define DUMMY_ACTION_DEFAULT_C 0x7451ae12
 
 class replay_tester : public base_tester {
  public:
@@ -119,26 +96,9 @@ struct light_validation_restart_from_block_log_test_fixture {
    eosio::chain::transaction_trace_ptr trace;
    light_validation_restart_from_block_log_test_fixture()
        : chain(setup_policy::full) {
-      chain.create_account(N(testapi));
-      chain.create_account(N(dummy));
-      chain.produce_block();
-      chain.set_code(N(testapi), contracts::test_api_wasm());
-      chain.produce_block();
 
-      cf_action          cfa;
-      signed_transaction trx;
-      action             act({}, cfa);
-      trx.context_free_actions.push_back(act);
-      trx.context_free_data.emplace_back(fc::raw::pack<uint32_t>(100)); // verify payload matches context free data
-      trx.context_free_data.emplace_back(fc::raw::pack<uint32_t>(200));
-      // add a normal action along with cfa
-      dummy_action da = {DUMMY_ACTION_DEFAULT_A, DUMMY_ACTION_DEFAULT_B, DUMMY_ACTION_DEFAULT_C};
-      action       act1(vector<permission_level>{{N(testapi), config::active_name}}, da);
-      trx.actions.push_back(act1);
-      chain.set_transaction_headers(trx);
-      // run normal passing case
-      auto sigs  = trx.sign(chain.get_private_key(N(testapi), "active"), chain.control->get_chain_id());
-      trace = chain.push_transaction(trx);
+      deploy_test_api(chain);
+      trace = push_test_cfd_transaction(chain);
       chain.produce_blocks(10);
 
       BOOST_REQUIRE(trace->receipt);
@@ -253,7 +213,7 @@ BOOST_FIXTURE_TEST_CASE(test_restart_from_block_log, restart_from_block_log_test
    BOOST_REQUIRE_NO_THROW(block_log::smoke_test(chain.get_config().blocks_dir, 1));
 }
 
-BOOST_FIXTURE_TEST_CASE(test_restart_from_trimed_block_log, restart_from_block_log_test_fixture) {
+BOOST_FIXTURE_TEST_CASE(test_restart_from_trimmed_block_log, restart_from_block_log_test_fixture) {
    auto& config = chain.get_config();
    auto blocks_path = config.blocks_dir;
    remove_all(blocks_path/"reversible");
@@ -268,6 +228,7 @@ BOOST_FIXTURE_TEST_CASE(test_light_validation_restart_from_block_log_with_pruned
    block_log blog(blocks_dir);
    std::vector<transaction_id_type> ids{trace->id};
    BOOST_CHECK(blog.prune_transactions(trace->block_num, ids) == 1);
+   BOOST_CHECK(ids.empty());
    BOOST_REQUIRE_NO_THROW(block_log::repair_log(blocks_dir));
 }
 
@@ -280,15 +241,13 @@ BOOST_AUTO_TEST_CASE(test_trim_blocklog_front) {
    namespace bfs = boost::filesystem;
 
    auto  blocks_dir = chain.get_config().blocks_dir;
-   auto  temp1   = bfs::unique_path();
-   boost::filesystem::create_directory(temp1);
-   bfs::copy(blocks_dir / "blocks.log", temp1 / "blocks.log");
-   bfs::copy(blocks_dir / "blocks.index", temp1 / "blocks.index");
-   auto temp2 = bfs::unique_path();
-   BOOST_REQUIRE_NO_THROW(block_log::trim_blocklog_front(temp1, temp2, 10));
-   BOOST_REQUIRE_NO_THROW(block_log::smoke_test(temp1, 1));
-   bfs::remove_all(temp1);
-   bfs::remove_all(temp2);
+
+   scoped_temp_path temp1, temp2;
+   boost::filesystem::create_directory(temp1.path);
+   bfs::copy(blocks_dir / "blocks.log", temp1.path / "blocks.log");
+   bfs::copy(blocks_dir / "blocks.index", temp1.path / "blocks.index");
+   BOOST_REQUIRE_NO_THROW(block_log::trim_blocklog_front(temp1.path, temp2.path, 10));
+   BOOST_REQUIRE_NO_THROW(block_log::smoke_test(temp1.path, 1));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/unittests/state_history_tests.cpp
+++ b/unittests/state_history_tests.cpp
@@ -1,0 +1,203 @@
+#include <boost/test/unit_test.hpp>
+#include <contracts.hpp>
+#include <eosio/state_history/log.hpp>
+#include <eosio/testing/tester.hpp>
+#include <fc/io/json.hpp>
+
+#include <boost/iostreams/device/back_inserter.hpp>
+#include <boost/iostreams/filter/zlib.hpp>
+#include <boost/iostreams/filtering_stream.hpp>
+#include <boost/filesystem.hpp>
+
+using namespace eosio;
+using namespace testing;
+using namespace chain;
+
+struct dummy_action {
+   static eosio::chain::name get_name() { return N(dummyaction); }
+   static eosio::chain::name get_account() { return N(testapi); }
+
+   char     a; // 1
+   uint64_t b; // 8
+   int32_t  c; // 4
+};
+
+struct cf_action {
+   static eosio::chain::name get_name() { return N(cfaction); }
+   static eosio::chain::name get_account() { return N(testapi); }
+
+   uint32_t payload = 100;
+   uint32_t cfd_idx = 0; // context free data index
+};
+
+FC_REFLECT(dummy_action, (a)(b)(c))
+FC_REFLECT(cf_action, (payload)(cfd_idx))
+
+#define DUMMY_ACTION_DEFAULT_A 0x45
+#define DUMMY_ACTION_DEFAULT_B 0xab11cd1244556677
+#define DUMMY_ACTION_DEFAULT_C 0x7451ae12
+
+std::vector<chain::signed_block_ptr> deploy_test_api(eosio::testing::tester& chain) {
+   std::vector<chain::signed_block_ptr> result;
+   chain.create_account(N(testapi));
+   chain.create_account(N(dummy));
+   result.push_back(chain.produce_block());
+   chain.set_code(N(testapi), contracts::test_api_wasm());
+   result.push_back(chain.produce_block());
+   return result;
+}
+
+eosio::chain::transaction_trace_ptr push_test_cfd_transaction(eosio::testing::tester& chain) {
+   cf_action          cfa;
+   signed_transaction trx;
+   action             act({}, cfa);
+   trx.context_free_actions.push_back(act);
+   trx.context_free_data.emplace_back(fc::raw::pack<uint32_t>(100));
+   trx.context_free_data.emplace_back(fc::raw::pack<uint32_t>(200));
+   // add a normal action along with cfa
+   dummy_action da = {DUMMY_ACTION_DEFAULT_A, DUMMY_ACTION_DEFAULT_B, DUMMY_ACTION_DEFAULT_C};
+   action       act1(vector<permission_level>{{N(testapi), config::active_name}}, da);
+   trx.actions.push_back(act1);
+   chain.set_transaction_headers(trx);
+   // run normal passing case
+   auto sigs = trx.sign(chain.get_private_key(N(testapi), "active"), chain.control->get_chain_id());
+   return chain.push_transaction(trx);
+}
+
+state_history::partial_transaction_v0 get_partial_from_traces_bin(const bytes&               traces_bin,
+                                                                  const transaction_id_type& id) {
+   fc::datastream<const char*>                   strm(traces_bin.data(), traces_bin.size());
+   std::vector<state_history::transaction_trace> traces;
+   fc::raw::unpack(strm, traces);
+
+   auto cfd_trace_itr = std::find_if(traces.begin(), traces.end(), [id](const state_history::transaction_trace& v) {
+      return v.get<state_history::transaction_trace_v0>().id == id;
+   });
+
+   // make sure the trace with cfd can be found
+   BOOST_REQUIRE(cfd_trace_itr != traces.end());
+   BOOST_REQUIRE(cfd_trace_itr->contains<state_history::transaction_trace_v0>());
+   auto trace_v0 = cfd_trace_itr->get<state_history::transaction_trace_v0>();
+   BOOST_REQUIRE(trace_v0.partial);
+   BOOST_REQUIRE(trace_v0.partial->contains<state_history::partial_transaction_v0>());
+   return trace_v0.partial->get<state_history::partial_transaction_v0>();
+}
+
+struct scoped_temp_path {
+   boost::filesystem::path path;
+   scoped_temp_path() { path = boost::filesystem::unique_path(); }
+   ~scoped_temp_path() {
+      boost::filesystem::remove_all(path);
+   }
+};
+
+struct trace_converter_test_fixture {
+   packed_transaction::prunable_data_type::compression_type compression;
+
+   void start() {
+      tester chain;
+
+      state_history::trace_converter converter_v0, converter_v1;
+      std::map<uint32_t, bytes>      on_disk_log_entries_v0;
+      std::map<uint32_t, bytes>      on_disk_log_entries_v1;
+
+      chain.control->applied_transaction.connect(
+          [&](std::tuple<const transaction_trace_ptr&, const packed_transaction_ptr&> t) {
+             converter_v0.add_transaction(std::get<0>(t), std::get<1>(t));
+             converter_v1.add_transaction(std::get<0>(t), std::get<1>(t));
+          });
+
+      chain.control->accepted_block.connect([&](const block_state_ptr& bs) {
+         on_disk_log_entries_v0[bs->block_num] = converter_v0.pack(chain.control->db(), true, bs, 0, compression);
+         on_disk_log_entries_v1[bs->block_num] = converter_v1.pack(chain.control->db(), true, bs, 1, compression);
+      });
+
+      deploy_test_api(chain);
+      auto cfd_trace    = push_test_cfd_transaction(chain);
+      chain.produce_blocks(10);
+
+      BOOST_CHECK(on_disk_log_entries_v0.size());
+      BOOST_CHECK(on_disk_log_entries_v1.size());
+
+      // make sure v0 and v1 are identifical when transform to traces bin
+      BOOST_CHECK(std::equal(on_disk_log_entries_v0.begin(), on_disk_log_entries_v0.end(),
+                             on_disk_log_entries_v1.begin(), [&](const auto& entry_v0, const auto& entry_v1) {
+                                return state_history::trace_converter::to_traces_bin_v0(entry_v0.second, 0) ==
+                                       state_history::trace_converter::to_traces_bin_v0(entry_v1.second, 1);
+                             }));
+
+      // Now deserialize the on disk trace log and make sure that the cfd exists
+      auto& cfd_entry_v1 = on_disk_log_entries_v1[cfd_trace->block_num];
+      auto  partial =
+          get_partial_from_traces_bin(state_history::trace_converter::to_traces_bin_v0(cfd_entry_v1, 1), cfd_trace->id);
+      BOOST_REQUIRE(partial.context_free_data.size());
+      BOOST_REQUIRE(partial.signatures.size());
+
+      // prune the cfd for the block
+      std::vector<transaction_id_type> ids{cfd_trace->id};
+      auto                             pruned = state_history::trace_converter::prune_traces(cfd_entry_v1, 1, ids);
+      BOOST_CHECK(pruned.size() < cfd_entry_v1.size());
+      BOOST_CHECK(ids.size() == 0);
+
+      std::copy(pruned.begin(), pruned.end(), cfd_entry_v1.end() - pruned.size());
+
+      // read the pruned trace and make sure the signature/cfd are empty
+      auto pruned_partial = get_partial_from_traces_bin(state_history::trace_converter::to_traces_bin_v0(cfd_entry_v1, 1),
+                                                  cfd_trace->id);
+      BOOST_CHECK(pruned_partial.context_free_data.size() == 0);
+      BOOST_CHECK(pruned_partial.signatures.size() == 0);
+   }
+};
+
+BOOST_AUTO_TEST_SUITE(test_state_history)
+
+BOOST_FIXTURE_TEST_CASE(test_trace_converter_test_no_compression, trace_converter_test_fixture) {
+   compression = packed_transaction::prunable_data_type::compression_type::none;
+   start();
+}
+
+// BOOST_FIXTURE_TEST_CASE(test_trace_converter_test_zlib_compression, trace_converter_test_fixture) {
+//    compression = packed_transaction::prunable_data_type::compression_type::zlib;
+//    start();
+// }
+
+BOOST_AUTO_TEST_CASE(test_trace_log) {
+      tester chain;
+
+      scoped_temp_path state_history_dir;
+      fc::create_directories(state_history_dir.path);
+      state_history_traces_log log(state_history_dir.path);
+
+      chain.control->applied_transaction.connect(
+          [&](std::tuple<const transaction_trace_ptr&, const packed_transaction_ptr&> t) {
+             log.add_transaction(std::get<0>(t), std::get<1>(t));
+          });
+
+      chain.control->accepted_block.connect(
+          [&](const block_state_ptr& bs) { log.store_traces(chain.control->db(), bs); });
+
+
+      deploy_test_api(chain);
+      auto cfd_trace    = push_test_cfd_transaction(chain);
+      chain.produce_blocks(10);
+
+      auto traces_bin = log.get_log_entry(cfd_trace->block_num);
+      BOOST_REQUIRE(traces_bin);
+
+      auto partial = get_partial_from_traces_bin(*traces_bin, cfd_trace->id);
+      BOOST_REQUIRE(partial.context_free_data.size());
+      BOOST_REQUIRE(partial.signatures.size());
+
+      std::vector<transaction_id_type> ids{cfd_trace->id};
+      log.prune_traces(cfd_trace->block_num, ids);
+      BOOST_REQUIRE(ids.empty());
+
+      auto pruned_traces_bin = log.get_log_entry(cfd_trace->block_num);
+      BOOST_REQUIRE(pruned_traces_bin);
+
+      auto pruned_partial = get_partial_from_traces_bin(*pruned_traces_bin, cfd_trace->id);
+      BOOST_CHECK(pruned_partial.context_free_data.empty());
+      BOOST_CHECK(pruned_partial.signatures.empty());
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/unittests/state_history_tests.cpp
+++ b/unittests/state_history_tests.cpp
@@ -99,11 +99,6 @@ BOOST_FIXTURE_TEST_CASE(test_trace_converter_test_no_compression, trace_converte
    start();
 }
 
-// BOOST_FIXTURE_TEST_CASE(test_trace_converter_test_zlib_compression, trace_converter_test_fixture) {
-//    compression = packed_transaction::prunable_data_type::compression_type::zlib;
-//    start();
-// }
-
 BOOST_AUTO_TEST_CASE(test_trace_log) {
    namespace bfs = boost::filesystem;
    tester chain;

--- a/unittests/state_history_tests.cpp
+++ b/unittests/state_history_tests.cpp
@@ -4,16 +4,15 @@
 #include <eosio/testing/tester.hpp>
 #include <fc/io/json.hpp>
 
+#include "test_cfd_transaction.hpp"
+#include <boost/filesystem.hpp>
 #include <boost/iostreams/device/back_inserter.hpp>
 #include <boost/iostreams/filter/zlib.hpp>
 #include <boost/iostreams/filtering_stream.hpp>
-#include <boost/filesystem.hpp>
-#include "test_cfd_transaction.hpp"
 
 using namespace eosio;
 using namespace testing;
 using namespace chain;
-
 
 state_history::partial_transaction_v0 get_partial_from_traces_bin(const bytes&               traces_bin,
                                                                   const transaction_id_type& id) {
@@ -34,69 +33,59 @@ state_history::partial_transaction_v0 get_partial_from_traces_bin(const bytes&  
    return trace_v0.partial->get<state_history::partial_transaction_v0>();
 }
 
-struct trace_converter_test_fixture {
-   packed_transaction::prunable_data_type::compression_type compression;
-
-   void start() {
-      tester chain;
-
-      state_history::trace_converter converter_v0, converter_v1;
-      std::map<uint32_t, bytes>      on_disk_log_entries_v0;
-      std::map<uint32_t, bytes>      on_disk_log_entries_v1;
-
-      chain.control->applied_transaction.connect(
-          [&](std::tuple<const transaction_trace_ptr&, const packed_transaction_ptr&> t) {
-             converter_v0.add_transaction(std::get<0>(t), std::get<1>(t));
-             converter_v1.add_transaction(std::get<0>(t), std::get<1>(t));
-          });
-
-      chain.control->accepted_block.connect([&](const block_state_ptr& bs) {
-         on_disk_log_entries_v0[bs->block_num] = converter_v0.pack(chain.control->db(), true, bs, 0, compression);
-         on_disk_log_entries_v1[bs->block_num] = converter_v1.pack(chain.control->db(), true, bs, 1, compression);
-      });
-
-      deploy_test_api(chain);
-      auto cfd_trace    = push_test_cfd_transaction(chain);
-      chain.produce_blocks(10);
-
-      BOOST_CHECK(on_disk_log_entries_v0.size());
-      BOOST_CHECK(on_disk_log_entries_v1.size());
-
-      // make sure v0 and v1 are identifical when transform to traces bin
-      BOOST_CHECK(std::equal(on_disk_log_entries_v0.begin(), on_disk_log_entries_v0.end(),
-                             on_disk_log_entries_v1.begin(), [&](const auto& entry_v0, const auto& entry_v1) {
-                                return state_history::trace_converter::to_traces_bin_v0(entry_v0.second, 0) ==
-                                       state_history::trace_converter::to_traces_bin_v0(entry_v1.second, 1);
-                             }));
-
-      // Now deserialize the on disk trace log and make sure that the cfd exists
-      auto& cfd_entry_v1 = on_disk_log_entries_v1[cfd_trace->block_num];
-      auto  partial =
-          get_partial_from_traces_bin(state_history::trace_converter::to_traces_bin_v0(cfd_entry_v1, 1), cfd_trace->id);
-      BOOST_REQUIRE(partial.context_free_data.size());
-      BOOST_REQUIRE(partial.signatures.size());
-
-      // prune the cfd for the block
-      std::vector<transaction_id_type> ids{cfd_trace->id};
-      auto                             pruned = state_history::trace_converter::prune_traces(cfd_entry_v1, 1, ids);
-      BOOST_CHECK(pruned.size() < cfd_entry_v1.size());
-      BOOST_CHECK(ids.size() == 0);
-
-      std::copy(pruned.begin(), pruned.end(), cfd_entry_v1.end() - pruned.size());
-
-      // read the pruned trace and make sure the signature/cfd are empty
-      auto pruned_partial = get_partial_from_traces_bin(state_history::trace_converter::to_traces_bin_v0(cfd_entry_v1, 1),
-                                                  cfd_trace->id);
-      BOOST_CHECK(pruned_partial.context_free_data.size() == 0);
-      BOOST_CHECK(pruned_partial.signatures.size() == 0);
-   }
-};
-
 BOOST_AUTO_TEST_SUITE(test_state_history)
 
-BOOST_FIXTURE_TEST_CASE(test_trace_converter_test_no_compression, trace_converter_test_fixture) {
-   compression = packed_transaction::prunable_data_type::compression_type::none;
-   start();
+BOOST_AUTO_TEST_CASE(test_trace_converter_test) {
+
+   tester chain;
+
+   state_history::trace_converter converter_v0, converter_v1;
+   std::map<uint32_t, bytes>      on_disk_log_entries_v0;
+   std::map<uint32_t, bytes>      on_disk_log_entries_v1;
+
+   chain.control->applied_transaction.connect(
+       [&](std::tuple<const transaction_trace_ptr&, const packed_transaction_ptr&> t) {
+          converter_v0.add_transaction(std::get<0>(t), std::get<1>(t));
+          converter_v1.add_transaction(std::get<0>(t), std::get<1>(t));
+       });
+
+   chain.control->accepted_block.connect([&](const block_state_ptr& bs) {
+      on_disk_log_entries_v0[bs->block_num] = converter_v0.pack(chain.control->db(), true, bs, 0);
+      on_disk_log_entries_v1[bs->block_num] = converter_v1.pack(chain.control->db(), true, bs, 1);
+   });
+
+   deploy_test_api(chain);
+   auto cfd_trace = push_test_cfd_transaction(chain);
+   chain.produce_blocks(1);
+
+   BOOST_CHECK(on_disk_log_entries_v0.size());
+   BOOST_CHECK(on_disk_log_entries_v1.size());
+
+   // make sure v0 and v1 are identifical when transform to traces bin
+   BOOST_CHECK(std::equal(on_disk_log_entries_v0.begin(), on_disk_log_entries_v0.end(), on_disk_log_entries_v1.begin(),
+                          [&](const auto& entry_v0, const auto& entry_v1) {
+                             return state_history::trace_converter::to_traces_bin_v0(entry_v0.second, 0) ==
+                                    state_history::trace_converter::to_traces_bin_v0(entry_v1.second, 1);
+                          }));
+
+   // Now deserialize the on disk trace log and make sure that the cfd exists
+   auto& cfd_entry_v1 = on_disk_log_entries_v1.at(cfd_trace->block_num);
+   auto  partial =
+       get_partial_from_traces_bin(state_history::trace_converter::to_traces_bin_v0(cfd_entry_v1, 1), cfd_trace->id);
+   BOOST_REQUIRE(partial.context_free_data.size());
+   BOOST_REQUIRE(partial.signatures.size());
+
+   // prune the cfd for the block
+   std::vector<transaction_id_type> ids{cfd_trace->id};
+   auto                             offsets = state_history::trace_converter::prune_traces(cfd_entry_v1, 1, ids);
+   BOOST_CHECK(offsets.first > 0 && offsets.second > 0);
+   BOOST_CHECK(ids.size() == 0);
+
+   // read the pruned trace and make sure the signature/cfd are empty
+   auto pruned_partial =
+       get_partial_from_traces_bin(state_history::trace_converter::to_traces_bin_v0(cfd_entry_v1, 1), cfd_trace->id);
+   BOOST_CHECK(pruned_partial.context_free_data.size() == 0);
+   BOOST_CHECK(pruned_partial.signatures.size() == 0);
 }
 
 BOOST_AUTO_TEST_CASE(test_trace_log) {
@@ -118,6 +107,9 @@ BOOST_AUTO_TEST_CASE(test_trace_log) {
    auto cfd_trace = push_test_cfd_transaction(chain);
    chain.produce_blocks(10);
 
+   packed_transaction::prunable_data_type prunable;
+   auto                                   x = prunable.prune_all();
+
    auto traces_bin = log.get_log_entry(cfd_trace->block_num);
    BOOST_REQUIRE(traces_bin);
 
@@ -132,7 +124,7 @@ BOOST_AUTO_TEST_CASE(test_trace_log) {
    // we assume the nodeos has to be stopped while running, it can only be read
    // correctly with restart
    state_history_traces_log new_log(state_history_dir.path);
-   auto pruned_traces_bin = new_log.get_log_entry(cfd_trace->block_num);
+   auto                     pruned_traces_bin = new_log.get_log_entry(cfd_trace->block_num);
    BOOST_REQUIRE(pruned_traces_bin);
 
    auto pruned_partial = get_partial_from_traces_bin(*pruned_traces_bin, cfd_trace->id);

--- a/unittests/state_history_tests.cpp
+++ b/unittests/state_history_tests.cpp
@@ -8,61 +8,12 @@
 #include <boost/iostreams/filter/zlib.hpp>
 #include <boost/iostreams/filtering_stream.hpp>
 #include <boost/filesystem.hpp>
+#include "test_cfd_transaction.hpp"
 
 using namespace eosio;
 using namespace testing;
 using namespace chain;
 
-struct dummy_action {
-   static eosio::chain::name get_name() { return N(dummyaction); }
-   static eosio::chain::name get_account() { return N(testapi); }
-
-   char     a; // 1
-   uint64_t b; // 8
-   int32_t  c; // 4
-};
-
-struct cf_action {
-   static eosio::chain::name get_name() { return N(cfaction); }
-   static eosio::chain::name get_account() { return N(testapi); }
-
-   uint32_t payload = 100;
-   uint32_t cfd_idx = 0; // context free data index
-};
-
-FC_REFLECT(dummy_action, (a)(b)(c))
-FC_REFLECT(cf_action, (payload)(cfd_idx))
-
-#define DUMMY_ACTION_DEFAULT_A 0x45
-#define DUMMY_ACTION_DEFAULT_B 0xab11cd1244556677
-#define DUMMY_ACTION_DEFAULT_C 0x7451ae12
-
-std::vector<chain::signed_block_ptr> deploy_test_api(eosio::testing::tester& chain) {
-   std::vector<chain::signed_block_ptr> result;
-   chain.create_account(N(testapi));
-   chain.create_account(N(dummy));
-   result.push_back(chain.produce_block());
-   chain.set_code(N(testapi), contracts::test_api_wasm());
-   result.push_back(chain.produce_block());
-   return result;
-}
-
-eosio::chain::transaction_trace_ptr push_test_cfd_transaction(eosio::testing::tester& chain) {
-   cf_action          cfa;
-   signed_transaction trx;
-   action             act({}, cfa);
-   trx.context_free_actions.push_back(act);
-   trx.context_free_data.emplace_back(fc::raw::pack<uint32_t>(100));
-   trx.context_free_data.emplace_back(fc::raw::pack<uint32_t>(200));
-   // add a normal action along with cfa
-   dummy_action da = {DUMMY_ACTION_DEFAULT_A, DUMMY_ACTION_DEFAULT_B, DUMMY_ACTION_DEFAULT_C};
-   action       act1(vector<permission_level>{{N(testapi), config::active_name}}, da);
-   trx.actions.push_back(act1);
-   chain.set_transaction_headers(trx);
-   // run normal passing case
-   auto sigs = trx.sign(chain.get_private_key(N(testapi), "active"), chain.control->get_chain_id());
-   return chain.push_transaction(trx);
-}
 
 state_history::partial_transaction_v0 get_partial_from_traces_bin(const bytes&               traces_bin,
                                                                   const transaction_id_type& id) {
@@ -82,19 +33,6 @@ state_history::partial_transaction_v0 get_partial_from_traces_bin(const bytes&  
    BOOST_REQUIRE(trace_v0.partial->contains<state_history::partial_transaction_v0>());
    return trace_v0.partial->get<state_history::partial_transaction_v0>();
 }
-
-struct scoped_temp_path {
-   boost::filesystem::path path;
-   scoped_temp_path() {
-      path = boost::filesystem::unique_path();
-      if (boost::unit_test::framework::master_test_suite().argc >= 2) {
-         path += boost::unit_test::framework::master_test_suite().argv[1];
-      }
-   }
-   ~scoped_temp_path() {
-      boost::filesystem::remove_all(path);
-   }
-};
 
 struct trace_converter_test_fixture {
    packed_transaction::prunable_data_type::compression_type compression;

--- a/unittests/state_history_tests.cpp
+++ b/unittests/state_history_tests.cpp
@@ -117,7 +117,7 @@ BOOST_AUTO_TEST_CASE(test_trace_log) {
           log.add_transaction(std::get<0>(t), std::get<1>(t));
        });
 
-   chain.control->accepted_block.connect([&](const block_state_ptr& bs) { log.store_traces(chain.control->db(), bs); });
+   chain.control->accepted_block.connect([&](const block_state_ptr& bs) { log.store(chain.control->db(), bs); });
 
    deploy_test_api(chain);
    auto cfd_trace = push_test_cfd_transaction(chain);

--- a/unittests/state_history_tests.cpp
+++ b/unittests/state_history_tests.cpp
@@ -196,7 +196,10 @@ BOOST_AUTO_TEST_CASE(test_trace_log) {
    log.prune_transactions(cfd_trace->block_num, ids);
    BOOST_REQUIRE(ids.empty());
 
-   auto pruned_traces_bin = log.get_log_entry(cfd_trace->block_num);
+   // we assume the nodeos has to be stopped while running, it can only be read
+   // correctly with restart
+   state_history_traces_log new_log(state_history_dir.path);
+   auto pruned_traces_bin = new_log.get_log_entry(cfd_trace->block_num);
    BOOST_REQUIRE(pruned_traces_bin);
 
    auto pruned_partial = get_partial_from_traces_bin(*pruned_traces_bin, cfd_trace->id);

--- a/unittests/test_cfd_transaction.cpp
+++ b/unittests/test_cfd_transaction.cpp
@@ -1,0 +1,54 @@
+#include "test_cfd_transaction.hpp"
+#include <contracts.hpp>
+
+struct dummy_action {
+   static eosio::chain::name get_name() { return N(dummyaction); }
+   static eosio::chain::name get_account() { return N(testapi); }
+
+   char     a; // 1
+   uint64_t b; // 8
+   int32_t  c; // 4
+};
+
+struct cf_action {
+   static eosio::chain::name get_name() { return N(cfaction); }
+   static eosio::chain::name get_account() { return N(testapi); }
+
+   uint32_t payload = 100;
+   uint32_t cfd_idx = 0; // context free data index
+};
+
+FC_REFLECT(dummy_action, (a)(b)(c))
+FC_REFLECT(cf_action, (payload)(cfd_idx))
+
+#define DUMMY_ACTION_DEFAULT_A 0x45
+#define DUMMY_ACTION_DEFAULT_B 0xab11cd1244556677
+#define DUMMY_ACTION_DEFAULT_C 0x7451ae12
+
+std::vector<eosio::chain::signed_block_ptr> deploy_test_api(eosio::testing::tester& chain) {
+   std::vector<eosio::chain::signed_block_ptr> result;
+   chain.create_account(N(testapi));
+   chain.create_account(N(dummy));
+   result.push_back(chain.produce_block());
+   chain.set_code(N(testapi), eosio::testing::contracts::test_api_wasm());
+   result.push_back(chain.produce_block());
+   return result;
+}
+
+eosio::chain::transaction_trace_ptr push_test_cfd_transaction(eosio::testing::tester& chain) {
+   cf_action                        cfa;
+   eosio::chain::signed_transaction trx;
+   eosio::chain::action             act({}, cfa);
+   trx.context_free_actions.push_back(act);
+   trx.context_free_data.emplace_back(fc::raw::pack<uint32_t>(100));
+   trx.context_free_data.emplace_back(fc::raw::pack<uint32_t>(200));
+   // add a normal action along with cfa
+   dummy_action         da = {DUMMY_ACTION_DEFAULT_A, DUMMY_ACTION_DEFAULT_B, DUMMY_ACTION_DEFAULT_C};
+   eosio::chain::action act1(
+       std::vector<eosio::chain::permission_level>{{N(testapi), eosio::chain::config::active_name}}, da);
+   trx.actions.push_back(act1);
+   chain.set_transaction_headers(trx);
+   // run normal passing case
+   auto sigs = trx.sign(chain.get_private_key(N(testapi), "active"), chain.control->get_chain_id());
+   return chain.push_transaction(trx);
+}

--- a/unittests/test_cfd_transaction.hpp
+++ b/unittests/test_cfd_transaction.hpp
@@ -1,0 +1,18 @@
+#pragma once
+#include <eosio/testing/tester.hpp>
+
+std::vector<eosio::chain::signed_block_ptr> deploy_test_api(eosio::testing::tester& chain);
+eosio::chain::transaction_trace_ptr push_test_cfd_transaction(eosio::testing::tester& chain);
+
+struct scoped_temp_path {
+   boost::filesystem::path path;
+   scoped_temp_path() {
+      path = boost::filesystem::unique_path();
+      if (boost::unit_test::framework::master_test_suite().argc >= 2) {
+         path += boost::unit_test::framework::master_test_suite().argv[1];
+      }
+   }
+   ~scoped_temp_path() {
+      boost::filesystem::remove_all(path);
+   }
+};


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
This PR changes the on disk format for state history plugin traces log and increment the SHiP version to 1. It enables the pruning of the context free data and signatures in transactions.

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
