### PR TITLE
Avoid legacy for set_action_return_value intrinsic

### DIFF
--- a/libraries/chain/include/eosio/chain/webassembly/common.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/common.hpp
@@ -24,6 +24,8 @@ namespace eosio { namespace chain {
 
    inline static constexpr auto eosio_injected_module_name = EOSIO_INJECTED_MODULE_NAME;
 
+   template <typename T, std::size_t Extent = eosio::vm::dynamic_extent>
+   using span = eosio::vm::span<T, Extent>;
 
    template <typename T, std::size_t Align = alignof(T)>
    using legacy_ptr = eosio::vm::argument_proxy<T*, Align>;

--- a/libraries/chain/include/eosio/chain/webassembly/interface.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/interface.hpp
@@ -268,12 +268,12 @@ namespace eosio { namespace chain { namespace webassembly {
          int32_t read_action_data(legacy_span<char>) const;
          int32_t action_data_size() const;
          name current_receiver() const;
-         void set_action_return_value(legacy_span<const char>);
+         void set_action_return_value(span<const char>);
 
          REGISTER_LEGACY_CF_HOST_FUNCTION(read_action_data);
          REGISTER_CF_HOST_FUNCTION(action_data_size);
          REGISTER_CF_HOST_FUNCTION(current_receiver);
-         REGISTER_LEGACY_HOST_FUNCTION(set_action_return_value);
+         REGISTER_HOST_FUNCTION(set_action_return_value);
 
          // console api
          void prints(null_terminated_ptr);

--- a/libraries/chain/include/eosio/chain/webassembly/preconditions.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/preconditions.hpp
@@ -129,7 +129,7 @@ namespace eosio { namespace chain { namespace webassembly {
                eosio::vm::invoke_on<false, eosio::vm::invoke_on_all_t>([&](auto&& narg, auto&&... nrest) {
                   using nested_arg_t = std::decay_t<decltype(arg)>;
                   if constexpr (eosio::vm::is_span_type_v<nested_arg_t> || vm::is_argument_proxy_type_v<arg_t>)
-                      EOS_ASSERT(!is_aliasing(to_span(arg), to_span(narg)), wasm_exception, "pointers not allowed to alias");
+                      EOS_ASSERT(!is_aliasing(detail::to_span(arg), detail::to_span(narg)), wasm_exception, "pointers not allowed to alias");
                }, rest...);
             }
          })));

--- a/libraries/chain/webassembly/action.cpp
+++ b/libraries/chain/webassembly/action.cpp
@@ -19,7 +19,7 @@ namespace eosio { namespace chain { namespace webassembly {
       return context.get_receiver();
    }
 
-   void interface::set_action_return_value( legacy_span<const char> packed_blob ) {
+   void interface::set_action_return_value( span<const char> packed_blob ) {
       context.action_return_value.assign( packed_blob.data(), packed_blob.data() + packed_blob.size() );
    }
 }}} // ns eosio::chain::webassembly


### PR DESCRIPTION
## Change Description

The `set_action_return_value` intrinsic is made available in a protocol feature that has not yet been released. So we are not forced to mark it as a legacy intrinsic and use `legacy_span`. This PR changes the `set_action_return_value` to use a `vm::span` instead.

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions

