### PR TITLE
Update example logging.json - 2.0

### DIFF
--- a/programs/nodeos/logging.json
+++ b/programs/nodeos/logging.json
@@ -57,7 +57,7 @@
       ]
     },{
       "name": "net_plugin_impl",
-      "level": "debug",
+      "level": "info",
       "enabled": true,
       "additivity": false,
       "appenders": [
@@ -84,7 +84,16 @@
       ]
     },{
       "name": "transaction_tracing",
-      "level": "info",
+      "level": "debug",
+      "enabled": true,
+      "additivity": false,
+      "appenders": [
+        "stderr",
+        "net"
+      ]
+    },{
+      "name": "trace_api",
+      "level": "debug",
       "enabled": true,
       "additivity": false,
       "appenders": [


### PR DESCRIPTION
## Change Description

- Add `"trace_api"` to example `logging.json`
- Set `"transaction_tracing"` to `debug` since that is the only level used currently for that logger
- Change `"net_plugin_impl"` to `info` since `debug` is a lot of output.

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [x] Documentation Additions
- See #8993 
