### PR TITLE
bump eosio minimum gcc version to gcc9; update centos7 build scripts

### DIFF
--- a/.cicd/build.sh
+++ b/.cicd/build.sh
@@ -33,7 +33,7 @@ else # Linux
     if [[ "$IMAGE_TAG" == 'amazon_linux-2-unpinned' ]]; then
         CMAKE_EXTRAS="$CMAKE_EXTRAS -DCMAKE_CXX_COMPILER='clang++' -DCMAKE_C_COMPILER='clang'"
     elif [[ "$IMAGE_TAG" == 'centos-7.7-unpinned' ]]; then
-        PRE_COMMANDS="$PRE_COMMANDS && source /opt/rh/devtoolset-8/enable"
+        PRE_COMMANDS="$PRE_COMMANDS && source /opt/rh/devtoolset-9/enable"
         CMAKE_EXTRAS="$CMAKE_EXTRAS -DLLVM_DIR='/opt/rh/llvm-toolset-7.0/root/usr/lib64/cmake/llvm'"
     elif [[ "$IMAGE_TAG" == 'ubuntu-18.04-unpinned' ]]; then
         CMAKE_EXTRAS="$CMAKE_EXTRAS -DCMAKE_CXX_COMPILER='clang++-7' -DCMAKE_C_COMPILER='clang-7' -DLLVM_DIR='/usr/lib/llvm-7/lib/cmake/llvm'"

--- a/.cicd/platforms/pinned/centos-7.7-pinned.dockerfile
+++ b/.cicd/platforms/pinned/centos-7.7-pinned.dockerfile
@@ -18,9 +18,12 @@ RUN curl -LO https://github.com/Kitware/CMake/releases/download/v3.16.2/cmake-3.
     make -j$(nproc) && \
     make install && \
     rm -rf cmake-3.16.2.tar.gz cmake-3.16.2
+COPY ./scripts/clang-devtoolset9-support.patch /tmp/clang-devtoolset9-support.patch
 # build clang10
 RUN git clone --single-branch --branch llvmorg-10.0.0 https://github.com/llvm/llvm-project clang10 && \
-    mkdir /clang10/build && cd /clang10/build && \
+    cd /clang10 && \
+    patch -p1 < /tmp/clang-devtoolset9-support.patch && \
+    mkdir build && cd build && \
     source /opt/rh/devtoolset-9/enable && \
     source /opt/rh/rh-python36/enable && \
     cmake -G 'Unix Makefiles' -DCMAKE_INSTALL_PREFIX='/usr/local' -DLLVM_ENABLE_PROJECTS='lld;polly;clang;clang-tools-extra;libcxx;libcxxabi;libunwind;compiler-rt' -DLLVM_BUILD_LLVM_DYLIB=ON -DLLVM_ENABLE_RTTI=ON -DLLVM_INCLUDE_DOCS=OFF -DLLVM_TARGETS_TO_BUILD=host -DCMAKE_BUILD_TYPE=Release ../llvm && \

--- a/.cicd/platforms/pinned/centos-7.7-pinned.dockerfile
+++ b/.cicd/platforms/pinned/centos-7.7-pinned.dockerfile
@@ -4,7 +4,7 @@ ENV VERSION 1
 RUN yum update -y && \
     yum install -y epel-release && \
     yum --enablerepo=extras install -y centos-release-scl && \
-    yum --enablerepo=extras install -y devtoolset-8 && \
+    yum --enablerepo=extras install -y devtoolset-9 && \
     yum --enablerepo=extras install -y which git autoconf automake libtool make bzip2 doxygen \
     graphviz bzip2-devel openssl-devel gmp-devel ocaml libicu-devel \
     python python-devel rh-python36 file libusbx-devel \
@@ -13,7 +13,7 @@ RUN yum update -y && \
 RUN curl -LO https://github.com/Kitware/CMake/releases/download/v3.16.2/cmake-3.16.2.tar.gz && \
     tar -xzf cmake-3.16.2.tar.gz && \
     cd cmake-3.16.2 && \
-    source /opt/rh/devtoolset-8/enable && \
+    source /opt/rh/devtoolset-9/enable && \
     ./bootstrap --prefix=/usr/local && \
     make -j$(nproc) && \
     make install && \
@@ -21,7 +21,7 @@ RUN curl -LO https://github.com/Kitware/CMake/releases/download/v3.16.2/cmake-3.
 # build clang10
 RUN git clone --single-branch --branch llvmorg-10.0.0 https://github.com/llvm/llvm-project clang10 && \
     mkdir /clang10/build && cd /clang10/build && \
-    source /opt/rh/devtoolset-8/enable && \
+    source /opt/rh/devtoolset-9/enable && \
     source /opt/rh/rh-python36/enable && \
     cmake -G 'Unix Makefiles' -DCMAKE_INSTALL_PREFIX='/usr/local' -DLLVM_ENABLE_PROJECTS='lld;polly;clang;clang-tools-extra;libcxx;libcxxabi;libunwind;compiler-rt' -DLLVM_BUILD_LLVM_DYLIB=ON -DLLVM_ENABLE_RTTI=ON -DLLVM_INCLUDE_DOCS=OFF -DLLVM_TARGETS_TO_BUILD=host -DCMAKE_BUILD_TYPE=Release ../llvm && \
     make -j $(nproc) && \

--- a/.cicd/platforms/unpinned/centos-7.7-unpinned.dockerfile
+++ b/.cicd/platforms/unpinned/centos-7.7-unpinned.dockerfile
@@ -4,7 +4,7 @@ ENV VERSION 1
 RUN yum update -y && \
     yum install -y epel-release && \
     yum --enablerepo=extras install -y centos-release-scl && \
-    yum --enablerepo=extras install -y devtoolset-8 && \
+    yum --enablerepo=extras install -y devtoolset-9 && \
     yum --enablerepo=extras install -y which git autoconf automake libtool make bzip2 doxygen \
     graphviz bzip2-devel openssl-devel gmp-devel ocaml libicu-devel \
     python python-devel rh-python36 file libusbx-devel \
@@ -13,14 +13,14 @@ RUN yum update -y && \
 RUN curl -LO https://github.com/Kitware/CMake/releases/download/v3.16.2/cmake-3.16.2.tar.gz && \
     tar -xzf cmake-3.16.2.tar.gz && \
     cd cmake-3.16.2 && \
-    source /opt/rh/devtoolset-8/enable && \
+    source /opt/rh/devtoolset-9/enable && \
     ./bootstrap --prefix=/usr/local && \
     make -j$(nproc) && \
     make install && \
     rm -rf cmake-3.16.2.tar.gz cmake-3.16.2
 # build boost
 RUN curl -LO https://dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.tar.bz2 && \
-    source /opt/rh/devtoolset-8/enable && \
+    source /opt/rh/devtoolset-9/enable && \
     source /opt/rh/rh-python36/enable && \
     tar -xjf boost_1_71_0.tar.bz2 && \
     cd boost_1_71_0 && \
@@ -34,7 +34,7 @@ RUN curl -LO https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-amazon-3.6.3.
     rm -f mongodb-linux-x86_64-amazon-3.6.3.tgz
 # build mongodb c driver
 RUN curl -LO https://github.com/mongodb/mongo-c-driver/releases/download/1.13.0/mongo-c-driver-1.13.0.tar.gz && \
-    source /opt/rh/devtoolset-8/enable && \
+    source /opt/rh/devtoolset-9/enable && \
     source /opt/rh/rh-python36/enable && \
     tar -xzf mongo-c-driver-1.13.0.tar.gz && \
     cd mongo-c-driver-1.13.0 && \
@@ -47,7 +47,7 @@ RUN curl -LO https://github.com/mongodb/mongo-c-driver/releases/download/1.13.0/
     rm -rf mongo-c-driver-1.13.0.tar.gz /mongo-c-driver-1.13.0
 # build mongodb cxx driver
 RUN curl -L https://github.com/mongodb/mongo-cxx-driver/archive/r3.4.0.tar.gz -o mongo-cxx-driver-r3.4.0.tar.gz && \
-    source /opt/rh/devtoolset-8/enable && \
+    source /opt/rh/devtoolset-9/enable && \
     source /opt/rh/rh-python36/enable && \
     tar -xzf mongo-cxx-driver-r3.4.0.tar.gz && \
     cd mongo-cxx-driver-r3.4.0 && \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,8 +36,8 @@ set( KEY_STORE_EXECUTABLE_NAME keosd )
 
 # http://stackoverflow.com/a/18369825
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-    if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.0)
-        message(FATAL_ERROR "GCC version must be at least 7.0!")
+    if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9.0)
+        message(FATAL_ERROR "GCC version must be at least 9.0!")
     endif()
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
     if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0)

--- a/docs/00_install/01_build-from-source/02_manual-build/03_platforms/centos-7.7.md
+++ b/docs/00_install/01_build-from-source/02_manual-build/03_platforms/centos-7.7.md
@@ -40,7 +40,7 @@ These commands install the EOSIO software dependencies. Make sure to [Download
 yum update -y && \
     yum install -y epel-release && \
     yum --enablerepo=extras install -y centos-release-scl && \
-    yum --enablerepo=extras install -y devtoolset-8 && \
+    yum --enablerepo=extras install -y devtoolset-9 && \
     yum --enablerepo=extras install -y which git autoconf automake libtool make bzip2 doxygen \
     graphviz bzip2-devel openssl-devel gmp-devel ocaml libicu-devel \
     python python-devel rh-python36 file libusbx-devel \
@@ -48,7 +48,7 @@ yum update -y && \
 # build cmake
 export PATH=$EOSIO_INSTALL_LOCATION/bin:$PATH
 cd $EOSIO_INSTALL_LOCATION && curl -LO https://cmake.org/files/v3.13/cmake-3.13.2.tar.gz && \
-    source /opt/rh/devtoolset-8/enable && \
+    source /opt/rh/devtoolset-9/enable && \
     tar -xzf cmake-3.13.2.tar.gz && \
     cd cmake-3.13.2 && \
     ./bootstrap --prefix=$EOSIO_INSTALL_LOCATION && \
@@ -59,7 +59,7 @@ cd $EOSIO_INSTALL_LOCATION && curl -LO https://cmake.org/files/v3.13/cmake-3.13.
 cp -f $EOSIO_LOCATION/scripts/clang-devtoolset8-support.patch /tmp/clang-devtoolset8-support.patch
 # build boost
 cd $EOSIO_INSTALL_LOCATION && curl -LO https://dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.tar.bz2 && \
-    source /opt/rh/devtoolset-8/enable && \
+    source /opt/rh/devtoolset-9/enable && \
     tar -xjf boost_1_71_0.tar.bz2 && \
     cd boost_1_71_0 && \
     ./bootstrap.sh --prefix=$EOSIO_INSTALL_LOCATION && \
@@ -72,7 +72,7 @@ cd $EOSIO_INSTALL_LOCATION && curl -LO https://fastdl.mongodb.org/linux/mongodb-
     rm -rf $EOSIO_INSTALL_LOCATION/mongodb-linux-x86_64-amazon-3.6.3
 # build mongodb c driver
 cd $EOSIO_INSTALL_LOCATION && curl -LO https://github.com/mongodb/mongo-c-driver/releases/download/1.13.0/mongo-c-driver-1.13.0.tar.gz && \
-    source /opt/rh/devtoolset-8/enable && \
+    source /opt/rh/devtoolset-9/enable && \
     tar -xzf mongo-c-driver-1.13.0.tar.gz && cd mongo-c-driver-1.13.0 && \
     mkdir -p build && cd build && \
     cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$EOSIO_INSTALL_LOCATION -DENABLE_BSON=ON -DENABLE_SSL=OPENSSL -DENABLE_AUTOMATIC_INIT_AND_CLEANUP=OFF -DENABLE_STATIC=ON -DENABLE_ICU=OFF -DENABLE_SNAPPY=OFF .. && \
@@ -81,7 +81,7 @@ cd $EOSIO_INSTALL_LOCATION && curl -LO https://github.com/mongodb/mongo-c-driver
     rm -rf $EOSIO_INSTALL_LOCATION/mongo-c-driver-1.13.0.tar.gz $EOSIO_INSTALL_LOCATION/mongo-c-driver-1.13.0
 # build mongodb cxx driver
 cd $EOSIO_INSTALL_LOCATION && curl -L https://github.com/mongodb/mongo-cxx-driver/archive/r3.4.0.tar.gz -o mongo-cxx-driver-r3.4.0.tar.gz && \
-    source /opt/rh/devtoolset-8/enable && \
+    source /opt/rh/devtoolset-9/enable && \
     tar -xzf mongo-cxx-driver-r3.4.0.tar.gz && cd mongo-cxx-driver-r3.4.0 && \
     sed -i 's/\"maxAwaitTimeMS\", count/\"maxAwaitTimeMS\", static_cast<int64_t>(count)/' src/mongocxx/options/change_stream.cpp && \
     sed -i 's/add_subdirectory(test)//' src/mongocxx/CMakeLists.txt src/bsoncxx/CMakeLists.txt && \
@@ -101,7 +101,7 @@ These commands build the EOSIO software on the specified OS. Make sure to [Insta
 ```sh
 export EOSIO_BUILD_LOCATION=$EOSIO_LOCATION/build
 mkdir -p $EOSIO_BUILD_LOCATION
-cd $EOSIO_BUILD_LOCATION && source /opt/rh/devtoolset-8/enable && cmake -DCMAKE_BUILD_TYPE='Release' -DLLVM_DIR='/opt/rh/llvm-toolset-7.0/root/usr/lib64/cmake/llvm' -DCMAKE_INSTALL_PREFIX=$EOSIO_INSTALL_LOCATION -DBUILD_MONGO_DB_PLUGIN=true $EOSIO_LOCATION
+cd $EOSIO_BUILD_LOCATION && source /opt/rh/devtoolset-9/enable && cmake -DCMAKE_BUILD_TYPE='Release' -DLLVM_DIR='/opt/rh/llvm-toolset-7.0/root/usr/lib64/cmake/llvm' -DCMAKE_INSTALL_PREFIX=$EOSIO_INSTALL_LOCATION -DBUILD_MONGO_DB_PLUGIN=true $EOSIO_LOCATION
 cd $EOSIO_BUILD_LOCATION && make -j$(nproc)
 ```
 

--- a/scripts/clang-devtoolset9-support.patch
+++ b/scripts/clang-devtoolset9-support.patch
@@ -1,0 +1,12 @@
+diff --git a/clang/lib/Driver/ToolChains/Gnu.cpp b/clang/lib/Driver/ToolChains/Gnu.cpp
+index da197e47662..151ddb7a5be 100644
+--- a/clang/lib/Driver/ToolChains/Gnu.cpp
++++ b/clang/lib/Driver/ToolChains/Gnu.cpp
+@@ -1975,6 +1975,7 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
+   // Non-Solaris is much simpler - most systems just go with "/usr".
+   if (SysRoot.empty() && TargetTriple.getOS() == llvm::Triple::Linux) {
+     // Yet, still look for RHEL devtoolsets.
++    Prefixes.push_back("/opt/rh/devtoolset-9/root/usr");
+     Prefixes.push_back("/opt/rh/devtoolset-8/root/usr");
+     Prefixes.push_back("/opt/rh/devtoolset-7/root/usr");
+     Prefixes.push_back("/opt/rh/devtoolset-6/root/usr");

--- a/scripts/eosio_build_centos.sh
+++ b/scripts/eosio_build_centos.sh
@@ -12,14 +12,14 @@ echo "Disk space available: ${DISK_AVAIL}G"
 
 echo ""
 
-# Repo necessary for rh-python3, devtoolset-8 and llvm-toolset-7.0
+# Repo necessary for rh-python3, devtoolset-9 and llvm-toolset-7.0
 ensure-scl
 # GCC8 for Centos / Needed for CMAKE install even if we're pinning
 ensure-devtoolset
-if [[ -d /opt/rh/devtoolset-8 ]]; then
-	echo "${COLOR_CYAN}[Enabling Centos devtoolset-8 (so we can use GCC 8)]${COLOR_NC}"
-	execute-always source /opt/rh/devtoolset-8/enable
-	echo " - ${COLOR_GREEN}Centos devtoolset-8 successfully enabled!${COLOR_NC}"
+if [[ -d /opt/rh/devtoolset-9 ]]; then
+	echo "${COLOR_CYAN}[Enabling Centos devtoolset-9 (so we can use GCC 9)]${COLOR_NC}"
+	execute-always source /opt/rh/devtoolset-9/enable
+	echo " - ${COLOR_GREEN}Centos devtoolset-9 successfully enabled!${COLOR_NC}"
 fi
 # Ensure packages exist
 ensure-yum-packages "${REPO_ROOT}/scripts/eosio_build_centos7_deps"

--- a/scripts/helpers/eosio.sh
+++ b/scripts/helpers/eosio.sh
@@ -294,6 +294,7 @@ function build-clang() {
             && rm -rf clang10 \
             && git clone --single-branch --branch $PINNED_COMPILER_BRANCH https://github.com/llvm/llvm-project clang10 \
             && cd clang10 \
+            && patch -p1 < \"$REPO_ROOT/scripts/clang-devtoolset9-support.patch\" \
             && mkdir build && cd build \
             && ${CMAKE} -G 'Unix Makefiles' -DCMAKE_INSTALL_PREFIX='${CLANG_ROOT}' -DLLVM_ENABLE_PROJECTS='lld;polly;clang;clang-tools-extra;libcxx;libcxxabi;libunwind;compiler-rt' -DLLVM_BUILD_LLVM_DYLIB=ON -DLLVM_ENABLE_RTTI=ON -DLLVM_INCLUDE_DOCS=OFF -DLLVM_TARGETS_TO_BUILD=host -DCMAKE_BUILD_TYPE=Release ../llvm \
             && make -j${JOBS} \

--- a/scripts/helpers/eosio.sh
+++ b/scripts/helpers/eosio.sh
@@ -180,20 +180,8 @@ function ensure-compiler() {
                 fi
             fi
         else
-            ## Check for c++ version 7 or higher
-            [[ $( $(which $CXX) -dumpversion | cut -d '.' -f 1 ) -lt 7 ]] && export NO_CPP17=true
-            if [[ $NO_CPP17 == false ]]; then # https://github.com/EOSIO/eos/issues/7402
-                while true; do
-                    echo "${COLOR_YELLOW}WARNING: Your GCC compiler ($CXX) is less performant than clang (https://github.com/EOSIO/eos/issues/7402). We suggest running the build script with -P or install your own clang and try again.${COLOR_NC}"
-                    [[ $NONINTERACTIVE == false ]] && printf "${COLOR_YELLOW}Do you wish to proceed anyway? (y/n)?${COLOR_NC}" && read -p " " PROCEED
-                    case $PROCEED in
-                        "" ) echo "What would you like to do?";;
-                        0 | true | [Yy]* ) break;;
-                        1 | false | [Nn]* ) exit 1;;
-                        * ) echo "Please type 'y' for yes or 'n' for no.";;
-                    esac
-                done
-            fi
+            ## Check for c++ version 9 or higher
+            [[ $( $(which $CXX) -dumpversion | cut -d '.' -f 1 ) -lt 9 ]] && export NO_CPP17=true
         fi
     fi
     if $NO_CPP17; then

--- a/scripts/helpers/general.sh
+++ b/scripts/helpers/general.sh
@@ -146,16 +146,16 @@ function ensure-scl() {
 }
 
 function ensure-devtoolset() {
-    echo "${COLOR_CYAN}[Ensuring installation of devtoolset-8]${COLOR_NC}"
-    DEVTOOLSET=$( rpm -qa | grep -E 'devtoolset-8-[0-9].*' || true )
+    echo "${COLOR_CYAN}[Ensuring installation of devtoolset-9]${COLOR_NC}"
+    DEVTOOLSET=$( rpm -qa | grep -E 'devtoolset-9-[0-9].*' || true )
     if [[ -z "${DEVTOOLSET}" ]]; then
         while true; do
             [[ $NONINTERACTIVE == false ]] && printf "${COLOR_YELLOW}Not Found: Do you wish to install it? (y/n)?${COLOR_NC}" && read -p " " PROCEED
             echo ""
             case $PROCEED in
                 "" ) echo "What would you like to do?";;
-                0 | true | [Yy]* ) install-package devtoolset-8; break;;
-                1 | false | [Nn]* ) echo " - User aborted installation of devtoolset-8."; break;;
+                0 | true | [Yy]* ) install-package devtoolset-9; break;;
+                1 | false | [Nn]* ) echo " - User aborted installation of devtoolset-9."; break;;
                 * ) echo "Please type 'y' for yes or 'n' for no.";;
             esac
         done


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
gcc 7 is failing to build eosio due to due constexpr confusion in new intrinsic wrappers. gcc8 is failing to build eosio due to.. something.. in kv-database-fix-alias. Require gcc 9+ now, and update centos 7 build scripts accordingly.

Also remove the scary warning about gcc in the build scripts. The performance delta is no longer much an issue due to removal of wabt.

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
