### PR TITLE
Better error handling for push/send_transaction - develop

### DIFF
--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -66,7 +66,6 @@ namespace {
    [api_handle](string, string body, url_response_callback cb) mutable { \
           api_handle.validate(); \
           try { \
-             if (body.empty()) body = "{}"; \
              auto params = parse_params<api_namespace::call_name ## _params>(body);\
              fc::variant result( api_handle.call_name( std::move(params) ) ); \
              cb(http_response_code, std::move(result)); \

--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -31,6 +31,19 @@ struct async_result_visitor : public fc::visitor<fc::variant> {
    }
 };
 
+namespace {
+   template<typename T>
+   T parse_params(const std::string& body) {
+     if (body.empty()) {
+       return {};
+     }
+
+     try {
+       return fc::json::from_string(body).as<T>();
+     } EOS_RETHROW_EXCEPTIONS(chain::invalid_http_request, "Unable to parse valid input from ${body}", ("body", body));
+   }
+}
+
 #define CALL(api_name, api_handle, api_namespace, call_name, http_response_code) \
 {std::string("/v1/" #api_name "/" #call_name), \
    [api_handle](string, string body, url_response_callback cb) mutable { \
@@ -38,6 +51,20 @@ struct async_result_visitor : public fc::visitor<fc::variant> {
           try { \
              if (body.empty()) body = "{}"; \
              fc::variant result( api_handle.call_name(fc::json::from_string(body).as<api_namespace::call_name ## _params>()) ); \
+             cb(http_response_code, std::move(result)); \
+          } catch (...) { \
+             http_plugin::handle_exception(#api_name, #call_name, body, cb); \
+          } \
+       }}
+
+#define CALL_WITH_400(api_name, api_handle, api_namespace, call_name, http_response_code) \
+{std::string("/v1/" #api_name "/" #call_name), \
+   [api_handle](string, string body, url_response_callback cb) mutable { \
+          api_handle.validate(); \
+          try { \
+             if (body.empty()) body = "{}"; \
+             auto params = parse_params<api_namespace::call_name ## _params>(body);\
+             fc::variant result( api_handle.call_name( std::move(params) ) ); \
              cb(http_response_code, std::move(result)); \
           } catch (...) { \
              http_plugin::handle_exception(#api_name, #call_name, body, cb); \
@@ -68,6 +95,8 @@ struct async_result_visitor : public fc::visitor<fc::variant> {
 #define CHAIN_RW_CALL(call_name, http_response_code) CALL(chain, rw_api, chain_apis::read_write, call_name, http_response_code)
 #define CHAIN_RO_CALL_ASYNC(call_name, call_result, http_response_code) CALL_ASYNC(chain, ro_api, chain_apis::read_only, call_name, call_result, http_response_code)
 #define CHAIN_RW_CALL_ASYNC(call_name, call_result, http_response_code) CALL_ASYNC(chain, rw_api, chain_apis::read_write, call_name, call_result, http_response_code)
+
+#define CHAIN_RO_CALL_WITH_400(call_name, http_response_code) CALL_WITH_400(chain, ro_api, chain_apis::read_only, call_name, http_response_code)
 
 void chain_api_plugin::plugin_startup() {
    ilog( "starting chain_api_plugin" );
@@ -107,6 +136,12 @@ void chain_api_plugin::plugin_startup() {
       CHAIN_RW_CALL_ASYNC(push_transactions, chain_apis::read_write::push_transactions_results, 202),
       CHAIN_RW_CALL_ASYNC(send_transaction, chain_apis::read_write::send_transaction_results, 202)
    });
+
+//   if (chain.account_queries_enabled()) {
+//      _http_plugin.add_api({
+//         CHAIN_RO_CALL_WITH_400(get_accounts_by_authorizers, 200),
+//      });
+//   }
 }
 
 void chain_api_plugin::plugin_shutdown() {}

--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -35,7 +35,7 @@ namespace {
    template<typename T>
    T parse_params(const std::string& body) {
       if (body.empty()) {
-         return {};
+         EOS_THROW(chain::invalid_http_request, "A Request body is required");
       }
 
       try {

--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -34,13 +34,17 @@ struct async_result_visitor : public fc::visitor<fc::variant> {
 namespace {
    template<typename T>
    T parse_params(const std::string& body) {
-     if (body.empty()) {
-       return {};
-     }
+      if (body.empty()) {
+         return {};
+      }
 
-     try {
-       return fc::json::from_string(body).as<T>();
-     } EOS_RETHROW_EXCEPTIONS(chain::invalid_http_request, "Unable to parse valid input from ${body}", ("body", body));
+      try {
+        try {
+           return fc::json::from_string(body).as<T>();
+        } catch (const chain::chain_exception& e) { // EOS_RETHROW_EXCEPTIONS does not re-type these so, re-code it
+          throw fc::exception(e);
+        }
+      } EOS_RETHROW_EXCEPTIONS(chain::invalid_http_request, "Unable to parse valid input from POST body");
    }
 }
 

--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -144,12 +144,6 @@ void chain_api_plugin::plugin_startup() {
       CHAIN_RW_CALL_ASYNC(push_transactions, chain_apis::read_write::push_transactions_results, 202),
       CHAIN_RW_CALL_ASYNC(send_transaction, chain_apis::read_write::send_transaction_results, 202)
    });
-
-//   if (chain.account_queries_enabled()) {
-//      _http_plugin.add_api({
-//         CHAIN_RO_CALL_WITH_400(get_accounts_by_authorizers, 200),
-//      });
-//   }
 }
 
 void chain_api_plugin::plugin_shutdown() {}

--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -79,18 +79,23 @@ namespace {
    [api_handle](string, string body, url_response_callback cb) mutable { \
       if (body.empty()) body = "{}"; \
       api_handle.validate(); \
-      api_handle.call_name(fc::json::from_string(body).as<api_namespace::call_name ## _params>(),\
-         [cb, body](const fc::static_variant<fc::exception_ptr, call_result>& result){\
-            if (result.contains<fc::exception_ptr>()) {\
-               try {\
-                  result.get<fc::exception_ptr>()->dynamic_rethrow_exception();\
-               } catch (...) {\
-                  http_plugin::handle_exception(#api_name, #call_name, body, cb);\
+      try { \
+         auto params = parse_params<api_namespace::call_name ## _params>(body);\
+         api_handle.call_name( std::move(params),\
+            [cb, body](const fc::static_variant<fc::exception_ptr, call_result>& result){\
+               if (result.contains<fc::exception_ptr>()) {\
+                  try {\
+                     result.get<fc::exception_ptr>()->dynamic_rethrow_exception();\
+                  } catch (...) {\
+                     http_plugin::handle_exception(#api_name, #call_name, body, cb);\
+                  }\
+               } else {\
+                  cb(http_response_code, result.visit(async_result_visitor()));\
                }\
-            } else {\
-               cb(http_response_code, result.visit(async_result_visitor()));\
-            }\
-         });\
+            });\
+      } catch (...) { \
+         http_plugin::handle_exception(#api_name, #call_name, body, cb); \
+      } \
    }\
 }
 

--- a/plugins/http_plugin/http_plugin.cpp
+++ b/plugins/http_plugin/http_plugin.cpp
@@ -906,6 +906,9 @@ namespace eosio {
          } catch (chain::unknown_block_exception& e) {
             error_results results{400, "Unknown Block", error_results::error_info(e, verbose_http_errors)};
             cb( 400, fc::variant( results ));
+         } catch (chain::invalid_http_request& e) {
+            error_results results{400, "Invalid Request", error_results::error_info(e, verbose_http_errors)};
+            cb( 400, fc::variant( results ));
          } catch (chain::unsatisfied_authorization& e) {
             error_results results{401, "UnAuthorized", error_results::error_info(e, verbose_http_errors)};
             cb( 401, fc::variant( results ));


### PR DESCRIPTION
## Change Description

- Add better error handling for arguments to `push_block`, `push_transaction`, `push_transactions`, `send_transaction`.
- Return 400 on error, see https://github.com/EOSIO/eos/pull/8899 for discussion on returned error code.

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
