### PR TITLE
Fixed failing nodeos_run_test when core symbol is not SYS - develop

### DIFF
--- a/tests/Cluster.py
+++ b/tests/Cluster.py
@@ -983,6 +983,7 @@ class Cluster(object):
         if Utils.Debug: Utils.Print("cmd: %s" % (cmd))
         env = {
             "BIOS_CONTRACT_PATH": "unittests/contracts/old_versions/v1.6.0-rc3/eosio.bios",
+            "BIOS_CURRENCY_SYMBOL": CORE_SYMBOL,
             "FEATURE_DIGESTS": ""
         }
         if PFSetupPolicy.hasPreactivateFeature(pfSetupPolicy):

--- a/tests/core_symbol.py
+++ b/tests/core_symbol.py
@@ -1,1 +1,0 @@
-CORE_SYMBOL='SYS'


### PR DESCRIPTION
## Change Description

`nodeos_run_test` was failing if core symbol is redefined

- `develop` version of #8975 

Thanks @cc32d9 

 
## Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
