### PR TITLE
Support Triggering a Build that Runs ALL Tests in One Build

### DIFF
--- a/.cicd/generate-pipeline.sh
+++ b/.cicd/generate-pipeline.sh
@@ -81,6 +81,7 @@ if [[ ! $BUILDKITE_PIPELINE_SLUG =~ 'lrt' ]] && [[ $BUILDKITE_BRANCH =~ ^release
 fi
 # run LRTs synchronously when running full test suite
 if [[ "$RUN_ALL_TESTS" == 'true' && "$SKIP_LONG_RUNNING_TESTS" != 'true' ]]; then
+    export BUILD_SOURCE="--build \$BUILDKITE_BUILD_ID"
     export SKIP_LONG_RUNNING_TESTS='false'
     export TRIGGER_JOB='false'
 fi


### PR DESCRIPTION
## Change Description
After merging [pull request 8969](https://github.com/EOSIO/eos/pull/8969), I created the [eosio-full-test-suite](https://buildkite.com/EOSIO/eosio-full-test-suite) pipeline to trigger a synchronous build on the `eosio` and `eosio-build-unpinned` pipelines simultaneously, each with `RUN_ALL_TESTS` set to `true`. Where the current pipelines only run some tests when certain conditions are met, this new pipeline Blockchain requested allows engineers to override those conditions to run ALL tests on suspect code with just one click.   
   
This pull request adjust some logic that is only encountered during builds that were triggered by other builds.  
  
### Tested Working
Some builds show the pipeline step generation and then were cancelled so as not to waste agents, while other builds show pipeline step generation and passing tests.
- Normal Builds -- Cancelled after step generation
  - [Build 21649](https://buildkite.com/EOSIO/eosio/builds/21649) -- pinned
  - [Build 1589](https://buildkite.com/EOSIO/eosio-build-unpinned/builds/1589) -- unpinned
- Triggering [Build 5](https://buildkite.com/EOSIO/eosio-full-test-suite/builds/5) -- `RUN_ALL_TESTS='true'`
  - Triggered [Build 21650](https://buildkite.com/EOSIO/eosio/builds/21650) -- pinned
  - Triggered [Build 1590](https://buildkite.com/EOSIO/eosio-build-unpinned/builds/1590) -- unpinned
  
### See Also
- Support Running ALL Tests in One Build
  - [Pull request 8961](https://github.com/EOSIO/eos/pull/8961) -- `eos:develop`
  - [Pull request 8968](https://github.com/EOSIO/eos/pull/8968) -- `eos:release/2.0.x`
  - [Pull request 8969](https://github.com/EOSIO/eos/pull/8969) -- `eos:release/1.8.x`
- Support Triggering a Build that Runs ALL Tests in One Build
  - [Pull request 9001](https://github.com/EOSIO/eos/pull/9001) -- `eos:develop`
  - [Pull request 9002](https://github.com/EOSIO/eos/pull/9002) -- `eos:release/2.0.x`
  - [Pull request 9003](https://github.com/EOSIO/eos/pull/9003) -- `eos:release/1.8.x`

## Consensus Changes
- [ ] Consensus Changes
None.

## API Changes
- [ ] API Changes
None.

## Documentation Additions
- [ ] Documentation Additions
None.