### PR TITLE
add help text for --wasm-runtime

### DIFF
--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -201,7 +201,8 @@ void chain_plugin::set_program_options(options_description& cli, options_descrip
          ("protocol-features-dir", bpo::value<bfs::path>()->default_value("protocol_features"),
           "the location of the protocol_features directory (absolute path or relative to application config dir)")
          ("checkpoint", bpo::value<vector<string>>()->composing(), "Pairs of [BLOCK_NUM,BLOCK_ID] that should be enforced as checkpoints.")
-         ("wasm-runtime", bpo::value<eosio::chain::wasm_interface::vm_type>()->value_name("runtime")->notifier([](const auto& vm){
+         ("wasm-runtime", bpo::value<eosio::chain::wasm_interface::vm_type>()->default_value(eosio::chain::wasm_interface::vm_type::wabt,
+            "wabt")->value_name("runtime")->notifier([](const auto& vm){
 #ifndef EOSIO_EOS_VM_OC_DEVELOPER
             //throwing an exception here (like EOS_ASSERT) is just gobbled up with a "Failed to initialize" error :(
             if(vm == wasm_interface::vm_type::eos_vm_oc) {
@@ -209,7 +210,12 @@ void chain_plugin::set_program_options(options_description& cli, options_descrip
                EOS_ASSERT(false, plugin_exception, "");
             }
 #endif
-         }), "Override default WASM runtime")
+         }), "Override default WASM runtime(\"wabt\", \"eos-vm\", \"eos-vm-jit\", \"eos-vm-oc\").\n"
+         "\"wabt\" : runtime from the WebAssembly Binary Toolkit.\n"
+         "\"eos-vm\" : runtime lets developers perform step-through debugging of C++ smart contracts.\n"
+         "\"eos-vm-jit\" : runtime rapidly compiles smart contracts in an easy to reference binary file for WASMs.\n"
+         "\"eos-vm-oc\" : runtime creates an optimized version of the file for fast reference."
+         )
          ("abi-serializer-max-time-ms", bpo::value<uint32_t>()->default_value(config::default_abi_serializer_max_time_us / 1000),
           "Override default maximum ABI serialization time allowed in ms")
          ("chain-state-db-size-mb", bpo::value<uint64_t>()->default_value(config::default_state_size / (1024  * 1024)), "Maximum size (in MiB) of the chain state database")

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -211,10 +211,12 @@ void chain_plugin::set_program_options(options_description& cli, options_descrip
             }
 #endif
          }), "Override default WASM runtime(\"wabt\", \"eos-vm\", \"eos-vm-jit\", \"eos-vm-oc\").\n"
-         "\"wabt\" : runtime from the WebAssembly Binary Toolkit.\n"
-         "\"eos-vm\" : runtime lets developers perform step-through debugging of C++ smart contracts.\n"
-         "\"eos-vm-jit\" : runtime rapidly compiles smart contracts in an easy to reference binary file for WASMs.\n"
-         "\"eos-vm-oc\" : runtime creates an optimized version of the file for fast reference."
+         "\"wabt\" : default runtime, the WebAssembly Binary Toolkit.\n"
+         "\"eos-vm\" : A WebAssembly interpreter providing extremely fast parsing/loading,"
+		 " and deterministic and efficient time bound execution with debugging support.\n"
+         "\"eos-vm-jit\" : A WebAssembly compiler that takes WASM and generates native code on the fly.\n"
+         "\"eos-vm-oc\" :  A specialized compiler framework (LLVM) that leverages a multipass compilation architecture."
+		 "The resulting native code from the Optimized Compiler is often an order of magnitude faster thatn others.\n"
          )
          ("abi-serializer-max-time-ms", bpo::value<uint32_t>()->default_value(config::default_abi_serializer_max_time_us / 1000),
           "Override default maximum ABI serialization time allowed in ms")


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->
#8945 fixed the issue of Help text for --wasm-runtime does not show available options
## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
Added available options from eosio::chain::wasm_interface::vm_type.
Got string values from  std::istream operator >>() in wasm_interface.cpp.

changed output : 
 Before:
 --wasm-runtime runtime                Override default WASM runtime
After:
  --wasm-runtime runtime (=wabt)        Override default WASM runtime("wabt", 
                                                                   "eos-vm", "eos-vm-jit", "eos-vm-oc").
                                                                   "wabt" : default runtime, the 
                                                                   WebAssembly Binary Toolkit.
                                                                  "eos-vm" : A WebAssembly interpreter 
                                                                  providing extremely fast 
                                                                  parsing/loading, and deterministic and 
                                                                  efficient time bound execution with 
                                                                 debugging support.
                                                                 "eos-vm-jit" : A WebAssembly compiler 
                                                                 that takes WASM and generates native 
                                                                 code on the fly.
                                                                "eos-vm-oc" :  A specialized compiler 
                                                                framework (LLVM) that leverages a 
                                                                multipass compilation architecture.The 
                                                               resulting native code from the 
                                                               Optimized Compiler is often an order of
                                                               magnitude faster thatn others.
 
## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
