### PR TITLE
Bugfix for uninitialized variable in cleos - 2.0

### DIFF
--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -2573,7 +2573,7 @@ int main( int argc, char** argv ) {
    // get account
    string accountName;
    string coresym;
-   bool print_json;
+   bool print_json = false;
    auto getAccount = get->add_subcommand("account", localized("Retrieve an account from the blockchain"), false);
    getAccount->add_option("name", accountName, localized("The name of the account to retrieve"))->required();
    getAccount->add_option("core-symbol", coresym, localized("The expected core symbol of the chain you are querying"));

--- a/tests/nodeos_run_test.py
+++ b/tests/nodeos_run_test.py
@@ -650,7 +650,7 @@ try:
         rawAccount=node.getEosAccount(defproduceraAccount.name, exitOnError=True, returnType=ReturnType.raw)
         coreLiquidBalance=account['core_liquid_balance']
         match=re.search(r'\bliquid:\s*%s\s' % (coreLiquidBalance), rawAccount, re.MULTILINE | re.DOTALL)
-        assert match is not None, "did not find the core liquid balance (\"liquid:\") of %d in \"%s\"" % (coreLiquidBalance, rawAccount)
+        assert match is not None, "did not find the core liquid balance (\"liquid:\") of {} in \"{}\"".format(coreLiquidBalance, rawAccount)
 
     Print("Get head block num.")
     currentBlockNum=node.getHeadBlockNum()


### PR DESCRIPTION
This is the 2.0 counterpart of https://github.com/EOSIO/eos/pull/9012

## Change Description

This commit fixes a bug that caused cleos to ignore the `-j` switch in the `get account` command.

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
