### PR TITLE
RFC: replace openssl dep with submoduled boringssl

### DIFF
--- a/.cicd/build.sh
+++ b/.cicd/build.sh
@@ -39,7 +39,7 @@ else # Linux
         CMAKE_EXTRAS="$CMAKE_EXTRAS -DCMAKE_CXX_COMPILER='clang++-7' -DCMAKE_C_COMPILER='clang-7' -DLLVM_DIR='/usr/lib/llvm-7/lib/cmake/llvm'"
     fi
     if [[ "$IMAGE_TAG" == centos* ]]; then
-        PRE_COMMANDS="$PRE_COMMANDS && source /opt/rh/rh-python36/enable"
+        PRE_COMMANDS="$PRE_COMMANDS && source /opt/rh/rh-python36/enable && source /opt/rh/go-toolset-7/enable"
     fi
     BUILD_COMMANDS="cmake $CMAKE_EXTRAS .. && make -j$JOBS"
     # Docker Commands

--- a/.cicd/platforms/pinned/amazon_linux-2-pinned.dockerfile
+++ b/.cicd/platforms/pinned/amazon_linux-2-pinned.dockerfile
@@ -5,7 +5,7 @@ RUN yum update -y && \
     yum install -y which git sudo procps-ng util-linux autoconf automake \
     libtool make bzip2 bzip2-devel openssl-devel gmp-devel libstdc++ libcurl-devel \
     libusbx-devel python3 python3-devel python-devel libedit-devel doxygen \
-    graphviz patch gcc gcc-c++ vim-common jq
+    graphviz patch gcc gcc-c++ vim-common jq golang
 # build cmake
 RUN curl -LO https://github.com/Kitware/CMake/releases/download/v3.16.2/cmake-3.16.2.tar.gz && \
     tar -xzf cmake-3.16.2.tar.gz && \

--- a/.cicd/platforms/pinned/centos-7.7-pinned.dockerfile
+++ b/.cicd/platforms/pinned/centos-7.7-pinned.dockerfile
@@ -8,7 +8,7 @@ RUN yum update -y && \
     yum --enablerepo=extras install -y which git autoconf automake libtool make bzip2 doxygen \
     graphviz bzip2-devel openssl-devel gmp-devel ocaml \
     python python-devel rh-python36 file libusbx-devel \
-    libcurl-devel patch vim-common jq
+    libcurl-devel patch vim-common jq go-toolset-7
 # build cmake
 RUN curl -LO https://github.com/Kitware/CMake/releases/download/v3.16.2/cmake-3.16.2.tar.gz && \
     tar -xzf cmake-3.16.2.tar.gz && \

--- a/.cicd/platforms/pinned/macos-10.15-pinned.sh
+++ b/.cicd/platforms/pinned/macos-10.15-pinned.sh
@@ -3,7 +3,7 @@ set -eo pipefail
 VERSION=1
 export SDKROOT="$(xcrun --sdk macosx --show-sdk-path)"
 brew update
-brew install git cmake python libtool libusb graphviz automake wget gmp pkgconfig doxygen openssl jq || :
+brew install git cmake python libtool libusb graphviz automake wget gmp pkgconfig doxygen jq go || :
 # install clang from source
 git clone --single-branch --branch llvmorg-10.0.0 https://github.com/llvm/llvm-project clang10
 mkdir clang10/build

--- a/.cicd/platforms/pinned/ubuntu-16.04-pinned.dockerfile
+++ b/.cicd/platforms/pinned/ubuntu-16.04-pinned.dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential git automake \
     libbz2-dev libssl-dev doxygen graphviz libgmp3-dev autotools-dev \
     python2.7 python2.7-dev python3 python3-dev autoconf libtool curl zlib1g-dev \
-    sudo ruby libusb-1.0-0-dev libcurl4-gnutls-dev pkg-config apt-transport-https vim-common jq
+    sudo ruby libusb-1.0-0-dev libcurl4-gnutls-dev pkg-config apt-transport-https vim-common jq golang
 # build cmake
 RUN curl -LO https://github.com/Kitware/CMake/releases/download/v3.16.2/cmake-3.16.2.tar.gz && \
     tar -xzf cmake-3.16.2.tar.gz && \

--- a/.cicd/platforms/pinned/ubuntu-18.04-pinned.dockerfile
+++ b/.cicd/platforms/pinned/ubuntu-18.04-pinned.dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && \
     autotools-dev python2.7 python2.7-dev python3 \
     python3-dev python-configparser python-requests python-pip \
     autoconf libtool g++ gcc curl zlib1g-dev sudo ruby libusb-1.0-0-dev \
-    libcurl4-gnutls-dev pkg-config patch vim-common jq
+    libcurl4-gnutls-dev pkg-config patch vim-common jq golang
 # build cmake
 RUN curl -LO https://github.com/Kitware/CMake/releases/download/v3.16.2/cmake-3.16.2.tar.gz && \
     tar -xzf cmake-3.16.2.tar.gz && \

--- a/.cicd/platforms/unpinned/ubuntu-18.04-unpinned.dockerfile
+++ b/.cicd/platforms/unpinned/ubuntu-18.04-unpinned.dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && \
     bzip2 automake libbz2-dev libssl-dev doxygen graphviz libgmp3-dev \
     autotools-dev python2.7 python2.7-dev python3 python3-dev \
     autoconf libtool curl zlib1g-dev sudo ruby libusb-1.0-0-dev \
-    libcurl4-gnutls-dev pkg-config patch llvm-7-dev clang-7 vim-common jq
+    libcurl4-gnutls-dev pkg-config patch llvm-7-dev clang-7 vim-common jq golang
 # build cmake
 RUN curl -LO https://github.com/Kitware/CMake/releases/download/v3.16.2/cmake-3.16.2.tar.gz && \
     tar -xzf cmake-3.16.2.tar.gz && \


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
It might come as somewhat as a surprise given how pervasive openssl is, but it has given us some grief over time:
* eosio still has some gnarly code to support openssl 1.0. Even though openssl 1.0 is EoL by upstream, it’s still in use on Centos7, a supported platform of ours
* There has been fallout in macos builds due to some homebrew naming switcharoo around openssl vs openssl@1.0 vs openssl@1.1
* A copy/paste of OPENSSL_ROOT_DIR and friends across many of our cmake files, sometimes incorrectly
* macos build issues have been encountered even as of the last month due to the above two, which can manifest itself in weird ways like using openssl’s headers but trying to link to macos’ “openssl” (which isn’t openssl, but rather libressl)
* A recurring concern in security audits is the practice of dynamically linking to system provided code to perform r1 ECDSA signatures. While it’s clear the random-k in openssl is well designed and adequate, the concern is that it may change out from under us without knowledge. Maybe due to a repeat of the Debian issue long ago, for example.
* Linking dynamically causes some additional downstream packaging grief:
    + binaries still need openssl installed locally; preventing a “standalone” binary
    + unsigned dylibs, such as the openssl dylib provided by homebrew, interfere with a hardened macos build because no unsigned dylibs can be used there

Some of the issues above could be resolved by simply static linking to openssl. This PR explores an alternative of including boringssl as a git submodule and linking to it. Unfortunately, this is not without its own problems, which makes such a migration not a clear win.

* static linking to openssl or boringssl means that if there is a vulnerability, we must update and release eosio with the fixed library ASAP. This is probably of most concern with cleos & nodeos HTTPS support where something like heartbleed, for example, would affect these tools.
* ripemd160 is under the decrepit directory, but still seems to work fine
* boringssl lacks SHA3 support which we want eventually. That said, we were already unable to lean on openssl here because of our openssl 1.0 support (1.0 lacks SHA3).
* go is required for building boringssl. This is very unfortunate, but I’ve updated the cicd pinned dockerfiles to illustrate on our supported platforms that is easy to get. Plus, I consider a build dep (go) not as "bad" as a runtime dep (openssl)
* boringssl’s SHA256 performance is poor compared to openssl. This is due to the AVX2 and SHA paths being disabled in boringssl. SHA256 hashing shows up in nodeos profiling fairly visibly so this does matter for us. We could either
    + eat the performance difference
    + contribute back to boringssl re-enabling the existing AVX2 & SHA paths. My impression is that Google would welcome such contribution given correct implementation
    + Use our own internal implementation of SHA256 (based off existing openssl code or such). This gives us some additional flexibility like the ability to add an AVX512 implementation which will be fastest for current shipping Intel server and HEDT parts.

This draft PR is in no way complete (ex: further code reduction needs to be performed in the k1 mixed/openssl impl, as k1 curves are not supported via boringssl). It is provided as a working example with tests passing to gather feedback.

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
