### PR TITLE
For develop - Updated the priority of the APIs in producer_api_plugin and net_api_plugin to MEDIUM_HIGH

### DIFF
--- a/plugins/net_api_plugin/net_api_plugin.cpp
+++ b/plugins/net_api_plugin/net_api_plugin.cpp
@@ -59,7 +59,6 @@ void net_api_plugin::plugin_startup() {
    ilog("starting net_api_plugin");
    // lifetime of plugin is lifetime of application
    auto& net_mgr = app().get_plugin<net_plugin>();
-
    app().get_plugin<http_plugin>().add_api({
     //   CALL(net, net_mgr, set_timeout,
     //        INVOKE_V_R(net_mgr, set_timeout, int64_t), 200),
@@ -75,7 +74,7 @@ void net_api_plugin::plugin_startup() {
             INVOKE_R_V(net_mgr, connections), 201),
     //   CALL(net, net_mgr, open,
     //        INVOKE_V_R(net_mgr, open, std::string), 200),
-   }, appbase::priority::medium);
+   }, appbase::priority::medium_high);
 }
 
 void net_api_plugin::plugin_initialize(const variables_map& options) {

--- a/plugins/producer_api_plugin/producer_api_plugin.cpp
+++ b/plugins/producer_api_plugin/producer_api_plugin.cpp
@@ -124,7 +124,7 @@ void producer_api_plugin::plugin_startup() {
                                  producer_plugin::get_supported_protocol_features_params), 201),
        CALL(producer, producer, get_account_ram_corrections,
             INVOKE_R_R(producer, get_account_ram_corrections, producer_plugin::get_account_ram_corrections_params), 201),
-   }, appbase::priority::medium);
+   }, appbase::priority::medium_high);
 }
 
 void producer_api_plugin::plugin_initialize(const variables_map& options) {


### PR DESCRIPTION
Updated the priority of the APIs in producer_api_plugin and net_api_plugin to MEDIUM_HIGH
PR for release/2.0.x branch :- https://github.com/EOSIO/eos/pull/9035

Change Description
These apis should respond fast even if host is busy. Hence, the priority for it within net_api_plugin and producer_net_plugin needs to be updated.

Consensus Changes
NA

API Changes
Updates to net_api_plugin

Documentation Additions
Updated the priority of the APIs in producer_api_plugin and net_api_plugin to MEDIUM_HIGH as these apis should  respond fast even if host is busy. 