### PR TITLE
Fix uninitialized struct members used as CLI flags - develop

### DIFF
--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -802,8 +802,8 @@ struct set_account_permission_subcommand {
    string permission;
    string authority_json_or_file;
    string parent;
-   bool add_code;
-   bool remove_code;
+   bool add_code = false;
+   bool remove_code = false;
 
    set_account_permission_subcommand(CLI::App* accountCmd) {
       auto permissions = accountCmd->add_subcommand("permission", localized("Set parameters dealing with account permissions"));
@@ -1088,8 +1088,8 @@ struct create_account_subcommand {
    uint32_t buy_ram_bytes_in_kbytes = 0;
    uint32_t buy_ram_bytes = 0;
    string buy_ram_eos;
-   bool transfer;
-   bool simple;
+   bool transfer = false;
+   bool simple = false;
 
    create_account_subcommand(CLI::App* actionRoot, bool s) : simple(s) {
       auto createAccount = actionRoot->add_subcommand(


### PR DESCRIPTION
## Change Description

This commit initializes uninitialized struct members used as CLI11 flags. Previously, only the local uninitialized variables were fixed, and struct fields were consciously omitted.

Fixes #9058

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
