### PR TITLE
Fix timedelta and strftime usage - 2.0

### DIFF
--- a/tests/nodeos_forked_chain_test.py
+++ b/tests/nodeos_forked_chain_test.py
@@ -2,6 +2,7 @@
 
 from testUtils import Utils
 from datetime import datetime
+from datetime import timedelta
 import time
 from Cluster import Cluster
 import json
@@ -329,12 +330,12 @@ try:
             slotTime=0.5
             slotsDiff=int(timediff.total_seconds() / slotTime)
             if slotsDiff != 1:
-                slotTimeDelta=datetime.timedelta(slotTime)
+                slotTimeDelta=timedelta(slotTime)
                 first=lastTimestamp + slotTimeDelta
-                missed=datetime.strftime(first, Utils.TimeFmt)
+                missed=first.strftime(Utils.TimeFmt)
                 if slotsDiff > 2:
                     last=timestamp - slotTimeDelta
-                    missed+= " thru " + datetime.strftime(last, Utils.TimeFmt)
+                    missed+= " thru " + last.strftime(Utils.TimeFmt)
                 missedSlotAfter.append("%d (%s)" % (blockNum-1, missed))
             lastTimestamp=timestamp
 


### PR DESCRIPTION
## Change Description
In error handling code, timedelta didn't need an import preface and strtime is a class method on datetime.
#9057 port to release/2.0.x


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
