### PR TITLE
add help text to wasm-runtime - 2.0.x

### DIFF
--- a/libraries/chain/include/eosio/chain/wasm_interface.hpp
+++ b/libraries/chain/include/eosio/chain/wasm_interface.hpp
@@ -82,6 +82,18 @@ namespace eosio { namespace chain {
             eos_vm_oc
          };
 
+         inline static const std::vector<std::string> vm_strings = {
+            "wabt",
+            "eos-vm",
+            "eos-vm-jit",
+            "eos-vm-oc"
+         };
+
+         //return string description of vm_type
+         static std::string vm_type_string(vm_type vmtype) {
+            return vm_strings[static_cast<int>(vmtype)];
+         }
+
          wasm_interface(vm_type vm, bool eosvmoc_tierup, const chainbase::database& d, const boost::filesystem::path data_dir, const eosvmoc::config& eosvmoc_config);
          ~wasm_interface();
 

--- a/libraries/chain/include/eosio/chain/wasm_interface.hpp
+++ b/libraries/chain/include/eosio/chain/wasm_interface.hpp
@@ -82,16 +82,18 @@ namespace eosio { namespace chain {
             eos_vm_oc
          };
 
-         inline static const std::vector<std::string> vm_strings = {
-            "wabt",
-            "eos-vm",
-            "eos-vm-jit",
-            "eos-vm-oc"
-         };
-
          //return string description of vm_type
          static std::string vm_type_string(vm_type vmtype) {
-            return vm_strings[static_cast<int>(vmtype)];
+             switch (vmtype) {
+             case vm_type::eos_vm:
+                return "eos-vm";
+             case vm_type::eos_vm_jit:
+                return "eos-vm-jit";
+             case vm_type::eos_vm_oc:
+                return "eos-vm-oc";
+             default:
+                return "wabt";
+             }
          }
 
          wasm_interface(vm_type vm, bool eosvmoc_tierup, const chainbase::database& d, const boost::filesystem::path data_dir, const eosvmoc::config& eosvmoc_config);

--- a/libraries/chain/wasm_interface.cpp
+++ b/libraries/chain/wasm_interface.cpp
@@ -2079,16 +2079,21 @@ REGISTER_INJECTED_INTRINSICS(softfloat_api,
 std::istream& operator>>(std::istream& in, wasm_interface::vm_type& runtime) {
    std::string s;
    in >> s;
-   if (s == "wabt")
-      runtime = eosio::chain::wasm_interface::vm_type::wabt;
-   else if (s == "eos-vm")
-      runtime = eosio::chain::wasm_interface::vm_type::eos_vm;
-   else if (s == "eos-vm-jit")
-      runtime = eosio::chain::wasm_interface::vm_type::eos_vm_jit;
-   else if (s == "eos-vm-oc")
-      runtime = eosio::chain::wasm_interface::vm_type::eos_vm_oc;
-   else
+
+   bool found = false;
+   for (int i = 0; i < wasm_interface::vm_strings.size(); ++i)
+   {
+      auto vmtype = static_cast<wasm_interface::vm_type>(i);
+      if (s == wasm_interface::vm_type_string(vmtype)) {
+         runtime = vmtype;
+         found = true;
+         break;
+      }
+   }
+
+   if (!found) {
       in.setstate(std::ios_base::failbit);
+   }
    return in;
 }
 

--- a/libraries/chain/wasm_interface.cpp
+++ b/libraries/chain/wasm_interface.cpp
@@ -2079,21 +2079,16 @@ REGISTER_INJECTED_INTRINSICS(softfloat_api,
 std::istream& operator>>(std::istream& in, wasm_interface::vm_type& runtime) {
    std::string s;
    in >> s;
-
-   bool found = false;
-   for (int i = 0; i < wasm_interface::vm_strings.size(); ++i)
-   {
-      auto vmtype = static_cast<wasm_interface::vm_type>(i);
-      if (s == wasm_interface::vm_type_string(vmtype)) {
-         runtime = vmtype;
-         found = true;
-         break;
-      }
-   }
-
-   if (!found) {
+   if (s == "wabt")
+      runtime = eosio::chain::wasm_interface::vm_type::wabt;
+   else if (s == "eos-vm")
+      runtime = eosio::chain::wasm_interface::vm_type::eos_vm;
+   else if (s == "eos-vm-jit")
+      runtime = eosio::chain::wasm_interface::vm_type::eos_vm_jit;
+   else if (s == "eos-vm-oc")
+      runtime = eosio::chain::wasm_interface::vm_type::eos_vm_oc;
+   else
       in.setstate(std::ios_base::failbit);
-   }
    return in;
 }
 

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -189,12 +189,35 @@ chain_plugin::chain_plugin()
    app().register_config_type<eosio::chain::db_read_mode>();
    app().register_config_type<eosio::chain::validation_mode>();
    app().register_config_type<chainbase::pinnable_mapped_file::map_mode>();
+   app().register_config_type<eosio::chain::wasm_interface::vm_type>();
 }
 
 chain_plugin::~chain_plugin(){}
 
 void chain_plugin::set_program_options(options_description& cli, options_description& cfg)
 {
+   // build wasm_runtime help text
+   std::string wasm_runtime_opt = "Override default WASM runtime (";
+   std::string wasm_runtime_desc;
+   std::string delim;
+#ifdef EOSIO_EOS_VM_JIT_RUNTIME_ENABLED
+   wasm_runtime_opt += " \"eos-vm-jit\"";
+   wasm_runtime_desc += "\"eos-vm-jit\" : A WebAssembly runtime that compiles WebAssembly code to native x86 code prior to execution.\n";
+   delim = ", ";
+#endif
+
+#ifdef EOSIO_EOS_VM_RUNTIME_ENABLED
+   wasm_runtime_opt += delim + "\"eos-vm\"";
+   wasm_runtime_desc += "\"eos-vm\" : A WebAssembly interpreter.\n";
+   delim = ", ";
+#endif
+
+#ifdef EOSIO_EOS_VM_OC_DEVELOPER
+   wasm_runtime_opt += delim + "\"eos-vm-oc\"";
+   wasm_runtime_desc += "\"eos-vm-oc\" : Unsupported. Instead, use one of the other runtimes along with the option enable-eos-vm-oc.\n";
+#endif
+   wasm_runtime_opt += ")\n" + wasm_runtime_desc;
+
    cfg.add_options()
          ("blocks-dir", bpo::value<bfs::path>()->default_value("blocks"),
           "the location of the blocks directory (absolute path or relative to application data dir)")
@@ -209,7 +232,8 @@ void chain_plugin::set_program_options(options_description& cli, options_descrip
                EOS_ASSERT(false, plugin_exception, "");
             }
 #endif
-         }), "Override default WASM runtime")
+         })->default_value(eosio::chain::wasm_interface::vm_type::eos_vm_jit, "eos-vm-jit"), wasm_runtime_opt.c_str()
+         )
          ("abi-serializer-max-time-ms", bpo::value<uint32_t>()->default_value(config::default_abi_serializer_max_time_us / 1000),
           "Override default maximum ABI serialization time allowed in ms")
          ("chain-state-db-size-mb", bpo::value<uint64_t>()->default_value(config::default_state_size / (1024  * 1024)), "Maximum size (in MiB) of the chain state database")

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -200,16 +200,19 @@ void chain_plugin::set_program_options(options_description& cli, options_descrip
    std::string wasm_runtime_opt = "Override default WASM runtime (";
    std::string wasm_runtime_desc;
    std::string delim;
-#ifdef EOSIO_EOS_VM_JIT_RUNTIME_ENABLED
-   wasm_runtime_opt += " \"eos-vm-jit\"";
-   wasm_runtime_desc += "\"eos-vm-jit\" : A WebAssembly runtime that compiles WebAssembly code to native x86 code prior to execution.\n";
+
+   wasm_runtime_opt += " \"wabt\"";
+   wasm_runtime_desc += "\"wabt\" : The WebAssembly Binary Toolkit.\n";
    delim = ", ";
+
+#ifdef EOSIO_EOS_VM_JIT_RUNTIME_ENABLED
+   wasm_runtime_opt += delim + " \"eos-vm-jit\"";
+   wasm_runtime_desc += "\"eos-vm-jit\" : A WebAssembly runtime that compiles WebAssembly code to native x86 code prior to execution.\n";
 #endif
 
 #ifdef EOSIO_EOS_VM_RUNTIME_ENABLED
    wasm_runtime_opt += delim + "\"eos-vm\"";
    wasm_runtime_desc += "\"eos-vm\" : A WebAssembly interpreter.\n";
-   delim = ", ";
 #endif
 
 #ifdef EOSIO_EOS_VM_OC_DEVELOPER
@@ -217,6 +220,8 @@ void chain_plugin::set_program_options(options_description& cli, options_descrip
    wasm_runtime_desc += "\"eos-vm-oc\" : Unsupported. Instead, use one of the other runtimes along with the option enable-eos-vm-oc.\n";
 #endif
    wasm_runtime_opt += ")\n" + wasm_runtime_desc;
+
+   std::string default_wasm_runtime_str= eosio::chain::wasm_interface::vm_type_string(eosio::chain::config::default_wasm_runtime);
 
    cfg.add_options()
          ("blocks-dir", bpo::value<bfs::path>()->default_value("blocks"),
@@ -232,7 +237,7 @@ void chain_plugin::set_program_options(options_description& cli, options_descrip
                EOS_ASSERT(false, plugin_exception, "");
             }
 #endif
-         })->default_value(eosio::chain::wasm_interface::vm_type::eos_vm_jit, "eos-vm-jit"), wasm_runtime_opt.c_str()
+         })->default_value(eosio::chain::config::default_wasm_runtime, default_wasm_runtime_str), wasm_runtime_opt.c_str()
          )
          ("abi-serializer-max-time-ms", bpo::value<uint32_t>()->default_value(config::default_abi_serializer_max_time_us / 1000),
           "Override default maximum ABI serialization time allowed in ms")


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->
Created PR for release/2.0.x from  PR(develop)
https://github.com/EOSIO/eos/pull/9020

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
nodeos --help

Old help text
--wasm-runtime runtime Override default WASM runtime

New help text
--wasm-runtime runtime (=wabt)        Override default WASM runtime ( "wabt",
                                          "eos-vm-jit", "eos-vm"[, "eos-vm-oc"])
                                        "wabt" : The WebAssembly Binary 
                                        Toolkit.
                                        "eos-vm-jit" : A WebAssembly runtime 
                                        that compiles WebAssembly code to 
                                        native x86 code prior to execution.
                                        "eos-vm" : A WebAssembly interpreter."eos-vm-oc" : Unsupported. Instead, use one of the other runtimes along with the option enable-eos-vm-oc

*Note: The text for "eos-vm-oc" only appears in help text when EOSIO_EOS_VM_DEVELOPER is defnend.

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
