### PR TITLE
separate out signature provider from producer plugin

### DIFF
--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -10,7 +10,7 @@ add_subdirectory(history_plugin)
 add_subdirectory(history_api_plugin)
 add_subdirectory(state_history_plugin)
 add_subdirectory(trace_api_plugin)
-
+add_subdirectory(signature_provider_plugin)
 add_subdirectory(wallet_plugin)
 add_subdirectory(wallet_api_plugin)
 add_subdirectory(txn_test_gen_plugin)

--- a/plugins/producer_plugin/CMakeLists.txt
+++ b/plugins/producer_plugin/CMakeLists.txt
@@ -5,9 +5,6 @@ add_library( producer_plugin
              ${HEADERS}
            )
 
-target_link_libraries( producer_plugin chain_plugin http_client_plugin appbase eosio_chain )
-if(APPLE)
-   target_link_libraries( producer_plugin se-helpers )
-endif()
+target_link_libraries( producer_plugin chain_plugin signature_provider_plugin appbase eosio_chain )
 target_include_directories( producer_plugin
                             PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" "${CMAKE_CURRENT_SOURCE_DIR}/../chain_interface/include" )

--- a/plugins/producer_plugin/include/eosio/producer_plugin/producer_plugin.hpp
+++ b/plugins/producer_plugin/include/eosio/producer_plugin/producer_plugin.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <eosio/chain_plugin/chain_plugin.hpp>
-#include <eosio/http_client_plugin/http_client_plugin.hpp>
+#include <eosio/signature_provider_plugin/signature_provider_plugin.hpp>
 
 #include <appbase/application.hpp>
 
@@ -11,7 +11,7 @@ using boost::signals2::signal;
 
 class producer_plugin : public appbase::plugin<producer_plugin> {
 public:
-   APPBASE_PLUGIN_REQUIRES((chain_plugin)(http_client_plugin))
+   APPBASE_PLUGIN_REQUIRES((chain_plugin)(signature_provider_plugin))
 
    struct runtime_options {
       fc::optional<int32_t>   max_transaction_time;

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -720,7 +720,7 @@ void producer_plugin::plugin_initialize(const boost::program_options::variables_
       const std::vector<std::string> key_spec_pairs = options["signature-provider"].as<std::vector<std::string>>();
       for (const auto& key_spec_pair : key_spec_pairs) {
          try {
-            auto [pubkey, provider] = app().get_plugin<signature_provider_plugin>().signature_provider_for_specification(key_spec_pair);
+            const auto& [pubkey, provider] = app().get_plugin<signature_provider_plugin>().signature_provider_for_specification(key_spec_pair);
             my->_signature_providers[pubkey] = provider;
          } catch(secure_enclave_exception& e) {
             elog("Error with Secure Enclave signature provider: ${e}; ignoring ${val}", ("e", e.top_message())("val", key_spec_pair));

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -6,9 +6,6 @@
 #include <eosio/chain/transaction_object.hpp>
 #include <eosio/chain/thread_utils.hpp>
 #include <eosio/chain/unapplied_transaction_queue.hpp>
-#ifdef __APPLE__
-#include <eosio/se-helpers/se-helpers.hpp>
-#endif
 
 #include <fc/io/json.hpp>
 #include <fc/log/logger_config.hpp>
@@ -19,7 +16,6 @@
 
 #include <iostream>
 #include <algorithm>
-#include <boost/algorithm/string.hpp>
 #include <boost/range/adaptor/map.hpp>
 #include <boost/function_output_iterator.hpp>
 #include <boost/multi_index_container.hpp>
@@ -196,7 +192,7 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
       bool     _production_enabled                 = false;
       bool     _pause_production                   = false;
 
-      using signature_provider_type = std::function<chain::signature_type(chain::digest_type)>;
+      using signature_provider_type = signature_provider_plugin::signature_provider_type;
       std::map<chain::public_key_type, signature_provider_type> _signature_providers;
       std::set<chain::account_name>                             _producers;
       boost::asio::deadline_timer                               _timer;
@@ -214,7 +210,6 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
       uint32_t                                                  _max_block_net_usage_threshold_bytes = 0;
       int32_t                                                   _max_scheduled_transaction_time_per_block_ms = 0;
       fc::time_point                                            _irreversible_block_time;
-      fc::microseconds                                          _keosd_provider_timeout_us;
 
       std::vector<chain::digest_type>                           _protocol_features_to_activate;
       bool                                                      _protocol_features_signaled = false; // to mark whether it has been signaled in start_block
@@ -624,15 +619,7 @@ void producer_plugin::set_program_options(
          ("signature-provider", boost::program_options::value<vector<string>>()->composing()->multitoken()->default_value(
                {default_priv_key.get_public_key().to_string() + "=KEY:" + default_priv_key.to_string()},
                 default_priv_key.get_public_key().to_string() + "=KEY:" + default_priv_key.to_string()),
-          "Key=Value pairs in the form <public-key>=<provider-spec>\n"
-          "Where:\n"
-          "   <public-key>    \tis a string form of a vaild EOSIO public key\n\n"
-          "   <provider-spec> \tis a string in the form <provider-type>:<data>\n\n"
-          "   <provider-type> \tis KEY, or KEOSD\n\n"
-          "   KEY:<data>      \tis a string form of a valid EOSIO private key which maps to the provided public key\n\n"
-          "   KEOSD:<data>    \tis the URL where keosd is available and the approptiate wallet(s) are unlocked")
-         ("keosd-provider-timeout", boost::program_options::value<int32_t>()->default_value(5),
-          "Limits the maximum time (in milliseconds) that is allowed for sending blocks to a keosd provider for signing")
+               app().get_plugin<signature_provider_plugin>().signature_provider_help_text())
          ("greylist-account", boost::program_options::value<vector<string>>()->composing()->multitoken(),
           "account that can not access to extended CPU/NET virtual resources")
          ("greylist-limit", boost::program_options::value<uint32_t>()->default_value(1000),
@@ -699,54 +686,6 @@ if( options.count(op_name) ) { \
    } \
 }
 
-static producer_plugin_impl::signature_provider_type
-make_key_signature_provider(const private_key_type& key) {
-   return [key]( const chain::digest_type& digest ) {
-      return key.sign(digest);
-   };
-}
-
-#ifdef __APPLE__
-static producer_plugin_impl::signature_provider_type
-make_se_signature_provider(const public_key_type pubkey) {
-   EOS_ASSERT(secure_enclave::hardware_supports_secure_enclave(), secure_enclave_exception, "Secure Enclave not supported on this hardware");
-   EOS_ASSERT(secure_enclave::application_signed(), secure_enclave_exception, "Application is not signed, Secure Enclave use not supported");
-
-   std::set<secure_enclave::secure_enclave_key> allkeys = secure_enclave::get_all_keys();
-   for(const auto& se_key : secure_enclave::get_all_keys())
-      if(se_key.public_key() == pubkey)
-         return [se_key](const chain::digest_type& digest) {
-            return se_key.sign(digest);
-         };
-
-   EOS_THROW(secure_enclave_exception, "${k} configured for block signing not found in Secure Enclave", ("k", pubkey));
-}
-#endif
-
-static producer_plugin_impl::signature_provider_type
-make_keosd_signature_provider(const std::shared_ptr<producer_plugin_impl>& impl, const string& url_str, const public_key_type pubkey) {
-   fc::url keosd_url;
-   if(boost::algorithm::starts_with(url_str, "unix://"))
-      //send the entire string after unix:// to http_plugin. It'll auto-detect which part
-      // is the unix socket path, and which part is the url to hit on the server
-      keosd_url = fc::url("unix", url_str.substr(7), ostring(), ostring(), ostring(), ostring(), ovariant_object(), fc::optional<uint16_t>());
-   else
-      keosd_url = fc::url(url_str);
-   std::weak_ptr<producer_plugin_impl> weak_impl = impl;
-
-   return [weak_impl, keosd_url, pubkey]( const chain::digest_type& digest ) {
-      auto impl = weak_impl.lock();
-      if (impl) {
-         fc::variant params;
-         fc::to_variant(std::make_pair(digest, pubkey), params);
-         auto deadline = impl->_keosd_provider_timeout_us.count() >= 0 ? fc::time_point::now() + impl->_keosd_provider_timeout_us : fc::time_point::maximum();
-         return app().get_plugin<http_client_plugin>().get_client().post_sync(keosd_url, params, deadline).as<chain::signature_type>();
-      } else {
-         return signature_type();
-      }
-   };
-}
-
 void producer_plugin::plugin_initialize(const boost::program_options::variables_map& options)
 { try {
    my->chain_plug = app().find_plugin<chain_plugin>();
@@ -768,7 +707,7 @@ void producer_plugin::plugin_initialize(const boost::program_options::variables_
       {
          try {
             auto key_id_to_wif_pair = dejsonify<std::pair<public_key_type, private_key_type>>(key_id_to_wif_pair_string);
-            my->_signature_providers[key_id_to_wif_pair.first] = make_key_signature_provider(key_id_to_wif_pair.second);
+            my->_signature_providers[key_id_to_wif_pair.first] = app().get_plugin<signature_provider_plugin>().signature_provider_for_private_key(key_id_to_wif_pair.second);
             auto blanked_privkey = std::string(key_id_to_wif_pair.second.to_string().size(), '*' );
             wlog("\"private-key\" is DEPRECATED, use \"signature-provider=${pub}=KEY:${priv}\"", ("pub",key_id_to_wif_pair.first)("priv", blanked_privkey));
          } catch ( fc::exception& e ) {
@@ -781,28 +720,8 @@ void producer_plugin::plugin_initialize(const boost::program_options::variables_
       const std::vector<std::string> key_spec_pairs = options["signature-provider"].as<std::vector<std::string>>();
       for (const auto& key_spec_pair : key_spec_pairs) {
          try {
-            auto delim = key_spec_pair.find("=");
-            EOS_ASSERT(delim != std::string::npos, plugin_config_exception, "Missing \"=\" in the key spec pair");
-            auto pub_key_str = key_spec_pair.substr(0, delim);
-            auto spec_str = key_spec_pair.substr(delim + 1);
-
-            auto spec_delim = spec_str.find(":");
-            EOS_ASSERT(spec_delim != std::string::npos, plugin_config_exception, "Missing \":\" in the key spec pair");
-            auto spec_type_str = spec_str.substr(0, spec_delim);
-            auto spec_data = spec_str.substr(spec_delim + 1);
-
-            auto pubkey = public_key_type(pub_key_str);
-
-            if (spec_type_str == "KEY") {
-               my->_signature_providers[pubkey] = make_key_signature_provider(private_key_type(spec_data));
-            } else if (spec_type_str == "KEOSD") {
-               my->_signature_providers[pubkey] = make_keosd_signature_provider(my, spec_data, pubkey);
-            }
-#ifdef __APPLE__
-            else if (spec_type_str == "SE") {
-               my->_signature_providers[pubkey] = make_se_signature_provider(pubkey);
-            }
-#endif
+            auto [pubkey, provider] = app().get_plugin<signature_provider_plugin>().signature_provider_for_specification(key_spec_pair);
+            my->_signature_providers[pubkey] = provider;
          } catch(secure_enclave_exception& e) {
             elog("Error with Secure Enclave signature provider: ${e}; ignoring ${val}", ("e", e.top_message())("val", key_spec_pair));
          } catch (...) {
@@ -810,8 +729,6 @@ void producer_plugin::plugin_initialize(const boost::program_options::variables_
          }
       }
    }
-
-   my->_keosd_provider_timeout_us = fc::milliseconds(options.at("keosd-provider-timeout").as<int32_t>());
 
    my->_produce_time_offset_us = options.at("produce-time-offset-us").as<int32_t>();
    EOS_ASSERT( my->_produce_time_offset_us <= 0 && my->_produce_time_offset_us >= -config::block_interval_us, plugin_config_exception,

--- a/plugins/signature_provider_plugin/CMakeLists.txt
+++ b/plugins/signature_provider_plugin/CMakeLists.txt
@@ -1,0 +1,10 @@
+file(GLOB HEADERS "include/eosio/signature_provider_plugin/*.hpp")
+add_library( signature_provider_plugin
+             signature_provider_plugin.cpp
+             ${HEADERS} )
+
+target_link_libraries( signature_provider_plugin appbase fc http_client_plugin )
+target_include_directories( signature_provider_plugin PUBLIC include )
+if(APPLE)
+   target_link_libraries( signature_provider_plugin se-helpers )
+endif()

--- a/plugins/signature_provider_plugin/include/eosio/signature_provider_plugin/signature_provider_plugin.hpp
+++ b/plugins/signature_provider_plugin/include/eosio/signature_provider_plugin/signature_provider_plugin.hpp
@@ -1,0 +1,33 @@
+#pragma once
+#include <appbase/application.hpp>
+#include <eosio/http_client_plugin/http_client_plugin.hpp>
+#include <eosio/chain/types.hpp>
+
+namespace eosio {
+
+using namespace appbase;
+
+class signature_provider_plugin : public appbase::plugin<signature_provider_plugin> {
+public:
+   signature_provider_plugin();
+   virtual ~signature_provider_plugin();
+
+   APPBASE_PLUGIN_REQUIRES((http_client_plugin))
+   virtual void set_program_options(options_description&, options_description& cfg) override;
+
+   void plugin_initialize(const variables_map& options) {}
+   void plugin_startup() {}
+   void plugin_shutdown() {}
+
+   const char* const signature_provider_help_text() const;
+
+   using signature_provider_type = std::function<chain::signature_type(chain::digest_type)>;
+
+   std::pair<chain::public_key_type,signature_provider_type> signature_provider_for_specification(const std::string& spec) const;
+   signature_provider_type signature_provider_for_private_key(const chain::private_key_type priv) const;
+
+private:
+   std::unique_ptr<class signature_provider_plugin_impl> my;
+};
+
+}

--- a/plugins/signature_provider_plugin/signature_provider_plugin.cpp
+++ b/plugins/signature_provider_plugin/signature_provider_plugin.cpp
@@ -1,0 +1,123 @@
+#include <eosio/signature_provider_plugin/signature_provider_plugin.hpp>
+#include <eosio/chain/exceptions.hpp>
+
+#include <fc/time.hpp>
+#include <fc/network/url.hpp>
+
+#include <boost/algorithm/string.hpp>
+
+#ifdef __APPLE__
+#include <eosio/se-helpers/se-helpers.hpp>
+#endif
+
+namespace eosio {
+   static appbase::abstract_plugin& _signature_provider_plugin = app().register_plugin<signature_provider_plugin>();
+
+class signature_provider_plugin_impl {
+   public:
+      fc::microseconds  _keosd_provider_timeout_us;
+
+      signature_provider_plugin::signature_provider_type
+      make_key_signature_provider(const chain::private_key_type& key) const {
+         return [key]( const chain::digest_type& digest ) {
+            return key.sign(digest);
+         };
+      }
+
+#ifdef __APPLE__
+      signature_provider_plugin::signature_provider_type
+      make_se_signature_provider(const chain::public_key_type pubkey) const {
+         EOS_ASSERT(secure_enclave::hardware_supports_secure_enclave(), chain::secure_enclave_exception, "Secure Enclave not supported on this hardware");
+         EOS_ASSERT(secure_enclave::application_signed(), chain::secure_enclave_exception, "Application is not signed, Secure Enclave use not supported");
+
+         std::set<secure_enclave::secure_enclave_key> allkeys = secure_enclave::get_all_keys();
+         for(const auto& se_key : secure_enclave::get_all_keys())
+            if(se_key.public_key() == pubkey)
+               return [se_key](const chain::digest_type& digest) {
+                  return se_key.sign(digest);
+               };
+
+         EOS_THROW(chain::secure_enclave_exception, "${k} not found in Secure Enclave", ("k", pubkey));
+      }
+#endif
+
+      signature_provider_plugin::signature_provider_type
+      make_keosd_signature_provider(const string& url_str, const chain::public_key_type pubkey) const {
+         fc::url keosd_url;
+         if(boost::algorithm::starts_with(url_str, "unix://"))
+            //send the entire string after unix:// to http_plugin. It'll auto-detect which part
+            // is the unix socket path, and which part is the url to hit on the server
+            keosd_url = fc::url("unix", url_str.substr(7), fc::ostring(), fc::ostring(), fc::ostring(), fc::ostring(), fc::ovariant_object(), fc::optional<uint16_t>());
+         else
+            keosd_url = fc::url(url_str);
+
+         return [to=_keosd_provider_timeout_us, keosd_url, pubkey](const chain::digest_type& digest) {
+            fc::variant params;
+            fc::to_variant(std::make_pair(digest, pubkey), params);
+            auto deadline = to.count() >= 0 ? fc::time_point::now() + to : fc::time_point::maximum();
+            return app().get_plugin<http_client_plugin>().get_client().post_sync(keosd_url, params, deadline).as<chain::signature_type>();
+         };
+      }
+};
+
+signature_provider_plugin::signature_provider_plugin():my(new signature_provider_plugin_impl()){}
+signature_provider_plugin::~signature_provider_plugin(){}
+
+void signature_provider_plugin::set_program_options(options_description&, options_description& cfg) {
+   cfg.add_options()
+         ("keosd-provider-timeout", boost::program_options::value<int32_t>()->default_value(5)->notifier([this](auto to){
+            my->_keosd_provider_timeout_us = fc::milliseconds(to);
+         }),
+          "Limits the maximum time (in milliseconds) that is allowed for sending requests to a keosd provider for signing")
+         ;
+}
+
+const char* const signature_provider_plugin::signature_provider_help_text() const {
+   return "Key=Value pairs in the form <public-key>=<provider-spec>\n"
+          "Where:\n"
+          "   <public-key>    \tis a string form of a vaild EOSIO public key\n\n"
+          "   <provider-spec> \tis a string in the form <provider-type>:<data>\n\n"
+          "   <provider-type> \tis KEY, KEOSD, or SE\n\n"
+          "   KEY:<data>      \tis a string form of a valid EOSIO private key which maps to the provided public key\n\n"
+          "   KEOSD:<data>    \tis the URL where keosd is available and the approptiate wallet(s) are unlocked\n\n"
+#ifdef __APPLE__
+          "   SE:             \tindicates the key resides in Secure Enclave"
+#endif
+          ;
+
+}
+
+std::pair<chain::public_key_type,signature_provider_plugin::signature_provider_type>
+signature_provider_plugin::signature_provider_for_specification(const std::string& spec) const {
+   auto delim = spec.find("=");
+   EOS_ASSERT(delim != std::string::npos, chain::plugin_config_exception, "Missing \"=\" in the key spec pair");
+   auto pub_key_str = spec.substr(0, delim);
+   auto spec_str = spec.substr(delim + 1);
+
+   auto spec_delim = spec_str.find(":");
+   EOS_ASSERT(spec_delim != std::string::npos, chain::plugin_config_exception, "Missing \":\" in the key spec pair");
+   auto spec_type_str = spec_str.substr(0, spec_delim);
+   auto spec_data = spec_str.substr(spec_delim + 1);
+
+   auto pubkey = chain::public_key_type(pub_key_str);
+
+   if(spec_type_str == "KEY") {
+      chain::private_key_type priv(spec_data);
+      EOS_ASSERT(pubkey == priv.get_public_key(), chain::plugin_config_exception, "Private key does not match given public key for ${pub}", ("pub", pubkey));
+      return std::make_pair(pubkey, my->make_key_signature_provider(priv));
+   }
+   else if(spec_type_str == "KEOSD")
+      return std::make_pair(pubkey, my->make_keosd_signature_provider(spec_data, pubkey));
+#ifdef __APPLE__
+   else if(spec_type_str == "SE")
+      return std::make_pair(pubkey, my->make_se_signature_provider(pubkey));
+#endif
+   EOS_THROW(chain::plugin_config_exception, "Unsupported key provider type \"${t}\"", ("t", spec_type_str));
+}
+
+signature_provider_plugin::signature_provider_type
+signature_provider_plugin::signature_provider_for_private_key(const chain::private_key_type priv) const {
+   return my->make_key_signature_provider(priv);
+}
+
+}


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
Currently the only time nodeos needs to perform a signature is when signing a block. Thus defining keys and where to find the private key for those keys has been in producer plugin.

Going forward though, this will not be the only use case for signing in nodeos. For example, a witness needs to sign blocks as well.

Move the signature provider code out of producer plugin to its own plugin so that any plugin can leverage signing through a single impl.

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
