### PR TITLE
Use `signed_block_v0` binary format for SHiP

### DIFF
--- a/plugins/state_history_plugin/state_history_plugin.cpp
+++ b/plugins/state_history_plugin/state_history_plugin.cpp
@@ -54,8 +54,11 @@ struct state_history_plugin_impl : std::enable_shared_from_this<state_history_pl
       } catch (...) {
          return;
       }
-      if (p)
-         result = fc::raw::pack(*p);
+      if (p) {
+         auto v0 = p->to_signed_block_v0();
+         if (v0)
+            result = fc::raw::pack(*v0);
+      }
    }
 
    fc::optional<chain::block_id_type> get_block_id(uint32_t block_num) {


### PR DESCRIPTION
## Change Description

- SHiP (state_history_plugin) protocol currently depends on `signed_block_v0` format for signed block binary data.
- Instead of reverting https://github.com/EOSIO/eos/pull/9067 convert to `signed_block_v0` for now.
- Addition of `get_blocks_request_v1` to add `signed_block` support to SHiP will be added in a future PR.

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
