### PR TITLE
refactor yubihsm: drop curl & pkgconfig build deps; libusb runtime dep

### DIFF
--- a/.cicd/platforms/pinned/amazon_linux-2-pinned.dockerfile
+++ b/.cicd/platforms/pinned/amazon_linux-2-pinned.dockerfile
@@ -3,7 +3,7 @@ ENV VERSION 1
 # install dependencies.
 RUN yum update -y && \
     yum install -y which git sudo procps-ng util-linux autoconf automake \
-    libtool make bzip2 bzip2-devel openssl-devel gmp-devel libstdc++ libcurl-devel \
+    libtool make bzip2 bzip2-devel openssl-devel gmp-devel libstdc++ \
     libusbx-devel python3 python3-devel python-devel libedit-devel doxygen \
     graphviz patch gcc gcc-c++ vim-common jq
 # build cmake

--- a/.cicd/platforms/pinned/centos-7.7-pinned.dockerfile
+++ b/.cicd/platforms/pinned/centos-7.7-pinned.dockerfile
@@ -8,7 +8,7 @@ RUN yum update -y && \
     yum --enablerepo=extras install -y which git autoconf automake libtool make bzip2 doxygen \
     graphviz bzip2-devel openssl-devel gmp-devel ocaml \
     python python-devel rh-python36 file libusbx-devel \
-    libcurl-devel patch vim-common jq
+    patch vim-common jq
 # build cmake
 RUN curl -LO https://github.com/Kitware/CMake/releases/download/v3.16.2/cmake-3.16.2.tar.gz && \
     tar -xzf cmake-3.16.2.tar.gz && \

--- a/.cicd/platforms/pinned/macos-10.14-pinned.sh
+++ b/.cicd/platforms/pinned/macos-10.14-pinned.sh
@@ -2,7 +2,7 @@
 set -eo pipefail
 VERSION=1
 brew update
-brew install git cmake python libtool libusb graphviz automake wget gmp pkgconfig doxygen openssl@1.1 jq || :
+brew install git cmake python libtool libusb graphviz automake wget gmp doxygen openssl@1.1 jq || :
 # install clang from source
 git clone --single-branch --branch llvmorg-10.0.0 https://github.com/llvm/llvm-project clang10
 mkdir clang10/build

--- a/.cicd/platforms/pinned/macos-10.15-pinned.sh
+++ b/.cicd/platforms/pinned/macos-10.15-pinned.sh
@@ -3,7 +3,7 @@ set -eo pipefail
 VERSION=1
 export SDKROOT="$(xcrun --sdk macosx --show-sdk-path)"
 brew update
-brew install git cmake python libtool libusb graphviz automake wget gmp pkgconfig doxygen openssl jq || :
+brew install git cmake python libtool libusb graphviz automake wget gmp doxygen openssl jq || :
 # install clang from source
 git clone --single-branch --branch llvmorg-10.0.0 https://github.com/llvm/llvm-project clang10
 mkdir clang10/build

--- a/.cicd/platforms/pinned/ubuntu-16.04-pinned.dockerfile
+++ b/.cicd/platforms/pinned/ubuntu-16.04-pinned.dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential git automake \
     libbz2-dev libssl-dev doxygen graphviz libgmp3-dev autotools-dev \
     python2.7 python2.7-dev python3 python3-dev autoconf libtool curl zlib1g-dev \
-    sudo ruby libusb-1.0-0-dev libcurl4-gnutls-dev pkg-config apt-transport-https vim-common jq
+    sudo ruby libusb-1.0-0-dev build-essential apt-transport-https vim-common jq
 # build cmake
 RUN curl -LO https://github.com/Kitware/CMake/releases/download/v3.16.2/cmake-3.16.2.tar.gz && \
     tar -xzf cmake-3.16.2.tar.gz && \

--- a/.cicd/platforms/pinned/ubuntu-18.04-pinned.dockerfile
+++ b/.cicd/platforms/pinned/ubuntu-18.04-pinned.dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && \
     autotools-dev python2.7 python2.7-dev python3 \
     python3-dev python-configparser python-requests python-pip \
     autoconf libtool g++ gcc curl zlib1g-dev sudo ruby libusb-1.0-0-dev \
-    libcurl4-gnutls-dev pkg-config patch vim-common jq
+    build-essential  patch vim-common jq
 # build cmake
 RUN curl -LO https://github.com/Kitware/CMake/releases/download/v3.16.2/cmake-3.16.2.tar.gz && \
     tar -xzf cmake-3.16.2.tar.gz && \

--- a/.cicd/platforms/unpinned/amazon_linux-2-unpinned.dockerfile
+++ b/.cicd/platforms/unpinned/amazon_linux-2-unpinned.dockerfile
@@ -3,7 +3,7 @@ ENV VERSION 1
 # install dependencies.
 RUN yum update -y && \
     yum install -y which git sudo procps-ng util-linux autoconf automake \
-    libtool make bzip2 bzip2-devel openssl-devel gmp-devel libstdc++ libcurl-devel \
+    libtool make bzip2 bzip2-devel openssl-devel gmp-devel libstdc++ \
     libusbx-devel python3 python3-devel python-devel libedit-devel doxygen \
     graphviz clang patch llvm-devel llvm-static vim-common jq
 # build cmake

--- a/.cicd/platforms/unpinned/centos-7.7-unpinned.dockerfile
+++ b/.cicd/platforms/unpinned/centos-7.7-unpinned.dockerfile
@@ -8,7 +8,7 @@ RUN yum update -y && \
     yum --enablerepo=extras install -y which git autoconf automake libtool make bzip2 doxygen \
     graphviz bzip2-devel openssl-devel gmp-devel ocaml \
     python python-devel rh-python36 file libusbx-devel \
-    libcurl-devel patch vim-common jq llvm-toolset-7.0-llvm-devel llvm-toolset-7.0-llvm-static
+    patch vim-common jq llvm-toolset-7.0-llvm-devel llvm-toolset-7.0-llvm-static
 # build cmake
 RUN curl -LO https://github.com/Kitware/CMake/releases/download/v3.16.2/cmake-3.16.2.tar.gz && \
     tar -xzf cmake-3.16.2.tar.gz && \

--- a/.cicd/platforms/unpinned/macos-10.14-unpinned.sh
+++ b/.cicd/platforms/unpinned/macos-10.14-unpinned.sh
@@ -2,6 +2,6 @@
 set -eo pipefail
 VERSION=1
 brew update
-brew install git cmake python libtool libusb graphviz automake wget gmp pkgconfig doxygen openssl@1.1 jq boost || :
+brew install git cmake python libtool libusb graphviz automake wget gmp doxygen openssl@1.1 jq boost || :
 # install nvm for ship_test
 cd ~ && brew install nvm && mkdir -p ~/.nvm && echo "export NVM_DIR=$HOME/.nvm" >> ~/.bash_profile && echo 'source $(brew --prefix nvm)/nvm.sh' >> ~/.bash_profile && cat ~/.bash_profile && source ~/.bash_profile && echo $NVM_DIR && nvm install --lts=dubnium

--- a/.cicd/platforms/unpinned/macos-10.15-unpinned.sh
+++ b/.cicd/platforms/unpinned/macos-10.15-unpinned.sh
@@ -3,6 +3,6 @@ set -eo pipefail
 VERSION=1
 export SDKROOT="$(xcrun --sdk macosx --show-sdk-path)"
 brew update
-brew install git cmake python libtool libusb graphviz automake wget gmp pkgconfig doxygen openssl jq boost || :
+brew install git cmake python libtool libusb graphviz automake wget gmp doxygen openssl jq boost || :
 # install nvm for ship_test
 cd ~ && brew install nvm && mkdir -p ~/.nvm && echo "export NVM_DIR=$HOME/.nvm" >> ~/.bash_profile && echo 'source $(brew --prefix nvm)/nvm.sh' >> ~/.bash_profile && cat ~/.bash_profile && source ~/.bash_profile && echo $NVM_DIR && nvm install --lts=dubnium

--- a/.cicd/platforms/unpinned/ubuntu-18.04-unpinned.dockerfile
+++ b/.cicd/platforms/unpinned/ubuntu-18.04-unpinned.dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && \
     bzip2 automake libbz2-dev libssl-dev doxygen graphviz libgmp3-dev \
     autotools-dev python2.7 python2.7-dev python3 python3-dev \
     autoconf libtool curl zlib1g-dev sudo ruby libusb-1.0-0-dev \
-    libcurl4-gnutls-dev pkg-config patch llvm-7-dev clang-7 vim-common jq
+    build-essential patch llvm-7-dev clang-7 vim-common jq
 # build cmake
 RUN curl -LO https://github.com/Kitware/CMake/releases/download/v3.16.2/cmake-3.16.2.tar.gz && \
     tar -xzf cmake-3.16.2.tar.gz && \

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "libraries/softfloat"]
 	path = libraries/softfloat
 	url = https://github.com/eosio/berkeley-softfloat-3
-[submodule "libraries/yubihsm"]
-	path = libraries/yubihsm
-	url = https://github.com/Yubico/yubihsm-shell
 [submodule "libraries/eos-vm"]
 	path = libraries/eos-vm
 	url = https://github.com/eosio/eos-vm
@@ -25,3 +22,6 @@
 [submodule "libraries/amqp-cpp"]
 	path = libraries/amqp-cpp
 	url = https://github.com/CopernicaMarketingSoftware/AMQP-CPP
+[submodule "libraries/yubihsm/upstream"]
+	path = libraries/yubihsm/upstream
+	url = https://github.com/Yubico/yubihsm-shell/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,7 +214,7 @@ configure_file(${CMAKE_SOURCE_DIR}/libraries/fc/include/fc/crypto/webauthn_json/
                ${CMAKE_BINARY_DIR}/licenses/eosio/LICENSE.rapidjson COPYONLY)
 configure_file(${CMAKE_SOURCE_DIR}/libraries/fc/src/network/LICENSE.go
                ${CMAKE_BINARY_DIR}/licenses/eosio/LICENSE.go COPYONLY)
-configure_file(${CMAKE_SOURCE_DIR}/libraries/yubihsm/LICENSE
+configure_file(${CMAKE_SOURCE_DIR}/libraries/yubihsm/upstream/LICENSE
                ${CMAKE_BINARY_DIR}/licenses/eosio/LICENSE.yubihsm COPYONLY)
 configure_file(${CMAKE_SOURCE_DIR}/libraries/eos-vm/LICENSE
                ${CMAKE_BINARY_DIR}/licenses/eosio/LICENSE.eos-vm COPYONLY)
@@ -231,7 +231,7 @@ install(FILES libraries/wasm-jit/LICENSE DESTINATION ${CMAKE_INSTALL_FULL_DATARO
 install(FILES libraries/fc/secp256k1/upstream/COPYING DESTINATION ${CMAKE_INSTALL_FULL_DATAROOTDIR}/licenses/eosio/ RENAME LICENSE.secp256k1 COMPONENT base)
 install(FILES libraries/fc/include/fc/crypto/webauthn_json/license.txt DESTINATION ${CMAKE_INSTALL_FULL_DATAROOTDIR}/licenses/eosio/ RENAME LICENSE.rapidjson COMPONENT base)
 install(FILES libraries/fc/src/network/LICENSE.go DESTINATION ${CMAKE_INSTALL_FULL_DATAROOTDIR}/licenses/eosio/ COMPONENT base)
-install(FILES libraries/yubihsm/LICENSE DESTINATION ${CMAKE_INSTALL_FULL_DATAROOTDIR}/licenses/eosio/ RENAME LICENSE.yubihsm COMPONENT base)
+install(FILES libraries/yubihsm/upstream/LICENSE DESTINATION ${CMAKE_INSTALL_FULL_DATAROOTDIR}/licenses/eosio/ RENAME LICENSE.yubihsm COMPONENT base)
 install(FILES libraries/eos-vm/LICENSE DESTINATION ${CMAKE_INSTALL_FULL_DATAROOTDIR}/licenses/eosio/ RENAME LICENSE.eos-vm COMPONENT base)
 install(FILES libraries/rocksdb/LICENSE.Apache DESTINATION ${CMAKE_INSTALL_FULL_DATAROOTDIR}/licenses/eosio/ RENAME LICENSE.rocksdb COMPONENT base)
 install(FILES libraries/rocksdb/LICENSE.leveldb DESTINATION ${CMAKE_INSTALL_FULL_DATAROOTDIR}/licenses/eosio/ RENAME LICENSE.leveldb COMPONENT base)

--- a/libraries/CMakeLists.txt
+++ b/libraries/CMakeLists.txt
@@ -30,13 +30,7 @@ if(eos-vm IN_LIST EOSIO_WASM_RUNTIMES OR eos-vm-jit IN_LIST EOSIO_WASM_RUNTIMES)
 add_subdirectory( eos-vm )
 endif()
 
-set(ENABLE_STATIC ON)
-set(CMAKE_MACOSX_RPATH OFF)
-set(BUILD_ONLY_LIB ON CACHE BOOL "Library only build")
-message(STATUS "Starting yubihsm configuration...")
 add_subdirectory( yubihsm EXCLUDE_FROM_ALL )
-set_target_properties(yubihsm_static PROPERTIES COMPILE_OPTIONS "-fno-lto")
-message(STATUS "yubihsm configuration complete")
 
 get_property(_CTEST_CUSTOM_TESTS_IGNORE GLOBAL PROPERTY CTEST_CUSTOM_TESTS_IGNORE)
 set_property(GLOBAL PROPERTY CTEST_CUSTOM_TESTS_IGNORE

--- a/libraries/yubihsm/CMakeLists.txt
+++ b/libraries/yubihsm/CMakeLists.txt
@@ -1,0 +1,36 @@
+add_library(yubihsm upstream/aes_cmac/aes.c
+                    upstream/aes_cmac/aes_cmac.c
+                    upstream/common/hash.c
+                    upstream/common/pkcs5.c
+                    upstream/common/rand.c
+                    upstream/lib/error.c
+                    upstream/lib/lib_util.c
+                    upstream/lib/yubihsm.c)
+
+if(WIN32)
+   target_sources(yubihsm upstream/lib/yubihsm_winhttp.c
+                          upstream/lib/yubihsm_usb.c
+                          upstream/lib/yubihsm_winusb.c)
+   find_package(OpenSSL REQUIRED)
+   target_link_libraries(yubihsm winusb ws2_32 winhttp setupapi OpenSSL::Crypto)
+   target_compile_definitions(yubihsm PRIVATE -DVERSION="yubihsmwallet")
+else()
+   target_sources(yubihsm PRIVATE yubihsm_beast.cpp)
+
+   if(NOT LIBUSB_1_INCLUDE_DIR)
+      find_path(LIBUSB_1_INCLUDE_DIR NAMES libusb.h PATH_SUFFIXES libusb-1.0)
+   endif()
+
+   if(LIBUSB_1_INCLUDE_DIR)
+      target_sources(yubihsm PRIVATE upstream/lib/yubihsm_usb.c yubihsm_dyn_libusb.cpp)
+      target_include_directories(yubihsm PRIVATE "${LIBUSB_1_INCLUDE_DIR}")
+   else()
+      message(WARNING "libusb 1.0 not found, direct USB support for yubihsm disabled")
+      target_sources(yubihsm PRIVATE yubihsm_nousb.c)
+   endif()
+
+   target_link_libraries(yubihsm PRIVATE fc)
+endif()
+
+target_compile_definitions(yubihsm PRIVATE -DSTATIC)
+target_include_directories(yubihsm PUBLIC upstream/lib)

--- a/libraries/yubihsm/yubihsm_beast.cpp
+++ b/libraries/yubihsm/yubihsm_beast.cpp
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2015-2018 Yubico AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <string.h>
+
+#include <arpa/inet.h>
+
+extern "C" {
+#include "yubihsm.h"
+#include "internal.h"
+#include "debug_lib.h"
+}
+
+#include <boost/beast.hpp>
+#include <boost/asio.hpp>
+
+#undef D
+#include <fc/network/url.hpp>
+
+struct state {
+  boost::asio::io_context io_context;
+  boost::asio::ip::tcp::socket socket{io_context};
+  int timeout;
+  std::string host;
+  std::string port;
+  std::string hostport;
+  std::string api_path;
+};
+
+static void backend_set_verbosity(uint8_t verbosity, FILE *output) {}
+
+static yh_rc backend_init(uint8_t verbosity, FILE *output) {
+  return YHR_SUCCESS;
+}
+
+static yh_backend *backend_create() {
+  state *s = new (std::nothrow) state;
+  if(!s)
+    return s;
+  boost::asio::socket_base::keep_alive ka(true);
+  boost::system::error_code ec;
+  s->socket.set_option(ka, ec);
+  if(!ec) {
+    delete s;
+    return NULL;
+  }
+  return (yh_backend*)s;
+}
+
+static yh_rc do_connect(state *const s) {
+  s->io_context.restart();
+
+  boost::asio::ip::tcp::resolver resolver(s->io_context);
+  boost::system::error_code final_ec = boost::asio::error::would_block;
+  resolver.async_resolve(s->host, s->port, [&final_ec,&socket=s->socket](auto ec, auto results) {
+    if(ec) {
+      final_ec = ec;
+      return;
+    }
+    boost::asio::async_connect(socket, results, [&final_ec](auto ec, auto endpoint) {
+      final_ec = ec;
+    });
+  });
+
+  s->io_context.run_for(std::chrono::seconds(s->timeout));
+
+  if(final_ec) {
+    s->socket.close();
+    return YHR_CONNECTOR_NOT_FOUND;
+  }
+
+  return YHR_SUCCESS;
+}
+
+static yh_rc backend_connect(yh_connector *connector, int timeout) {
+  state *s = reinterpret_cast<state*>(connector->connection);
+  s->timeout = timeout ?: INT_MAX;
+
+  std::string path;
+
+  try {
+    fc::url hsmurl(connector->status_url);
+    if(hsmurl.proto() != "http" || !hsmurl.host() || !hsmurl.path())
+      return YHR_CONNECTOR_NOT_FOUND;
+    s->host = *hsmurl.host();
+    s->port = hsmurl.port() ? std::to_string(*hsmurl.port()) : "80";
+    std::stringstream ss;
+    ss << s->host << ":" << s->port;
+    s->hostport = ss.str();
+    path = hsmurl.path()->string();
+
+    fc::url apiurl(connector->api_url);
+    if(apiurl.proto() != "http" || !apiurl.host() || !apiurl.path() || apiurl.host() != hsmurl.host())
+      return YHR_CONNECTOR_NOT_FOUND;
+    s->api_path = apiurl.path()->string();
+  }
+  catch(...) {
+    return YHR_CONNECTOR_NOT_FOUND;
+  }
+
+  if(yh_rc yrc = do_connect(s))
+    return yrc;
+
+  boost::beast::http::request<boost::beast::http::string_body> req{boost::beast::http::verb::get, path, 11};
+  req.set(boost::beast::http::field::host, s->hostport);
+  req.set(boost::beast::http::field::user_agent, "yubihsm_wallet");
+
+  boost::system::error_code ec;
+
+  boost::beast::http::write(s->socket, req, ec);
+  if(ec) {
+    s->socket.close();
+    return YHR_CONNECTOR_NOT_FOUND;
+  }
+
+  boost::beast::flat_buffer buffer;
+  boost::beast::http::response<boost::beast::http::buffer_body> res;
+  char buff[256];
+  res.body().data = buff;
+  res.body().size = sizeof(buff);
+  res.body().more = false;
+
+  boost::beast::http::read(s->socket, buffer, res, ec);
+  if(ec || res.result() != boost::beast::http::status::ok) {
+    s->socket.close();
+    return YHR_CONNECTOR_NOT_FOUND;
+  }
+
+  return YHR_SUCCESS;
+}
+
+static void backend_disconnect(yh_backend *connection) {
+  boost::system::error_code ec;
+  connection->socket.close(ec);
+  delete connection;
+}
+
+static yh_rc backend_send_msg(yh_backend *connection, Msg *msg, Msg *response) {
+  boost::system::error_code ec;
+
+  boost::beast::http::request<boost::beast::http::buffer_body> req{boost::beast::http::verb::post, connection->api_path, 11};
+  req.set(boost::beast::http::field::host, connection->hostport);
+  req.set(boost::beast::http::field::content_type, "application/octet-stream");
+  req.body().data = msg->raw;
+  req.body().size = msg->st.len + 3;
+  req.body().more = false;
+  auto orig_body = req.body();
+  req.prepare_payload();
+
+  msg->st.len = htons(msg->st.len);
+
+  auto cleanup_and_return_on_error = [&connection, &msg, &response]() {
+    boost::system::error_code ec;
+    connection->socket.close(ec);
+    msg->st.len = ntohs(msg->st.len);
+    response->st.len = 0;
+    return YHR_CONNECTION_ERROR;
+  };
+
+  boost::beast::http::write(connection->socket, req, ec);
+  if(ec) {
+    //try reconnecting once
+    if(yh_rc yrc = do_connect(connection))
+      return yrc;
+    req.body() = orig_body;
+    boost::beast::http::write(connection->socket, req, ec);
+    if(ec)
+      return cleanup_and_return_on_error();
+  }
+
+  boost::beast::flat_buffer buffer;
+  boost::beast::http::response<boost::beast::http::buffer_body> res;
+  res.body().data = response->raw;
+  res.body().size = sizeof(response->raw);
+  res.body().more = false;
+  boost::beast::http::read(connection->socket, buffer, res, ec);
+  if(ec || res.result() != boost::beast::http::status::ok)
+    return cleanup_and_return_on_error();
+
+  size_t transferred = (uint8_t*)res.body().data - response->raw;
+
+  if(transferred < 3)
+    return YHR_WRONG_LENGTH;
+  response->st.len = ntohs(response->st.len);
+  if(transferred - 3 != response->st.len)
+    return YHR_WRONG_LENGTH;
+
+  return YHR_SUCCESS;
+}
+
+static void backend_cleanup(void) {}
+
+static yh_rc backend_option(yh_backend *connection, yh_connector_option opt,
+                            const void *val) {
+  return YHR_CONNECTOR_ERROR;
+}
+
+static struct backend_functions f = {backend_init,     backend_create,
+                                     backend_connect,  backend_disconnect,
+                                     backend_send_msg, backend_cleanup,
+                                     backend_option,   backend_set_verbosity};
+
+#ifdef STATIC
+struct backend_functions *http_backend_functions(void) {
+#else
+struct backend_functions *backend_functions(void) {
+#endif
+  return &f;
+}

--- a/libraries/yubihsm/yubihsm_dyn_libusb.cpp
+++ b/libraries/yubihsm/yubihsm_dyn_libusb.cpp
@@ -1,0 +1,260 @@
+/*
+ * Copyright 2015-2018 Yubico AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <fc/log/logger.hpp>
+
+extern "C" {
+#include <libusb.h>
+
+#include <string.h>
+#include <dlfcn.h>
+
+#include "yubihsm.h"
+#include "internal.h"
+#include "yubihsm_usb.h"
+#include "debug_lib.h"
+}
+
+struct libusb_api {
+  struct func_ptr {
+     explicit func_ptr(void* ptr) : _ptr(ptr) {}
+     template <typename T> operator T*() const {
+        return reinterpret_cast<T*>(_ptr);
+      }
+     void* _ptr;
+  };
+
+  struct libusb_shlib {
+    libusb_shlib() {
+      const char* lib_name =
+#if defined( __APPLE__ )
+        "libusb-1.0.dylib";
+#else
+        "libusb-1.0.so";
+#endif
+      _good = _handle = dlopen(lib_name, RTLD_NOW);
+      if(!_good)
+        elog("Failed to load libusb: %{e}", ("e", dlerror()));
+    }
+    ~libusb_shlib() {
+      dlclose(_handle);
+    }
+
+    func_ptr operator[](const char* import_name) {
+      if(!_good)
+        return func_ptr(NULL);
+      dlerror();
+      void* ret = dlsym(_handle, import_name);
+      char* error;
+      if((error = dlerror())) {
+        elog("Failed to load import ${i} from libusb: ${e}", ("i", import_name)("e", error));
+        _good = false;
+      }
+      return func_ptr(ret);
+    }
+
+    void* _handle;
+    bool _good = false;
+  };
+  libusb_shlib _shlib;
+  bool good = _shlib._good;
+   
+
+#define LOAD_IMPORT(n) decltype(n)* n = _shlib[#n];
+  LOAD_IMPORT(libusb_release_interface)
+  LOAD_IMPORT(libusb_close)
+  LOAD_IMPORT(libusb_exit)
+  LOAD_IMPORT(libusb_init)
+  LOAD_IMPORT(libusb_get_device_list)
+  LOAD_IMPORT(libusb_get_device_descriptor)
+  LOAD_IMPORT(libusb_get_string_descriptor_ascii)
+  LOAD_IMPORT(libusb_claim_interface)
+  LOAD_IMPORT(libusb_free_device_list)
+  LOAD_IMPORT(libusb_bulk_transfer)
+  LOAD_IMPORT(libusb_error_name)
+  LOAD_IMPORT(libusb_open)
+};
+
+struct state {
+  libusb_context *ctx;
+  libusb_device_handle *handle;
+  libusb_api *api;
+  unsigned long serial;
+};
+
+extern "C" {
+
+void usb_set_serial(yh_backend *state, unsigned long serial) {
+  state->serial = serial;
+}
+
+void usb_close(yh_backend *state) {
+  if (state && state->handle) {
+    state->api->libusb_release_interface(state->handle, 0);
+    state->api->libusb_close(state->handle);
+    state->handle = NULL;
+  }
+}
+
+void usb_destroy(yh_backend **state) {
+  if (state && *state) {
+    usb_close(*state);
+    if ((*state)->ctx) {
+      (*state)->api->libusb_exit((*state)->ctx);
+      (*state)->ctx = NULL;
+    }
+    delete (*state)->api;
+    free(*state);
+    *state = NULL;
+  }
+}
+
+yh_backend *backend_create(void) {
+  yh_backend *backend = (yh_backend*)calloc(1, sizeof(yh_backend));
+  if (backend) {
+    backend->api = new libusb_api();
+    if(backend->api->good == false) {
+      delete backend->api;
+      free(backend);
+      return NULL;
+    }
+    backend->api->libusb_init(&backend->ctx);
+  }
+  return backend;
+}
+
+bool usb_open_device(yh_backend *backend) {
+  libusb_device **list;
+  libusb_device_handle *h = NULL;
+  ssize_t cnt = backend->api->libusb_get_device_list(backend->ctx, &list);
+
+  if (backend->handle) {
+    usb_close(backend);
+  }
+
+  if (cnt < 0) {
+    DBG_ERR("Failed to get device list: %s", backend->api->libusb_error_name((libusb_error)cnt));
+    return false;
+  }
+
+  for (ssize_t i = 0; i < cnt; i++) {
+    struct libusb_device_descriptor desc;
+    int ret = backend->api->libusb_get_device_descriptor(list[i], &desc);
+    if (ret != 0) {
+      DBG_INFO("Failed to get descriptor for device %zd: %s", i,
+               backend->api->libusb_error_name((libusb_error)ret));
+      continue;
+    }
+    if (desc.idVendor == YH_VID && desc.idProduct == YH_PID) {
+      ret = backend->api->libusb_open(list[i], &h);
+      if (ret != 0 || h == NULL) {
+        DBG_INFO("Failed to open device for index %zd: %s", i,
+                 backend->api->libusb_error_name((libusb_error)ret));
+        continue;
+      }
+      if (backend->serial != 0) {
+        unsigned char data[16] = {0};
+
+        ret = backend->api->libusb_get_string_descriptor_ascii(h, desc.iSerialNumber, data,
+                                                 sizeof(data));
+
+        unsigned long devSerial = strtoul((char *) data, NULL, 10);
+
+        if (devSerial != backend->serial) {
+          DBG_INFO("Device %zd has serial %lu, not matching searched %lu", i,
+                   devSerial, backend->serial);
+          goto next;
+        }
+      }
+
+      ret = backend->api->libusb_claim_interface(h, 0);
+      if (ret != 0) {
+        DBG_ERR("Failed to claim interface: %s of device %zd",
+                backend->api->libusb_error_name((libusb_error)ret), i);
+        goto next;
+      }
+
+      break;
+    next:
+      backend->api->libusb_close(h);
+      h = NULL;
+    }
+  }
+
+  backend->api->libusb_free_device_list(list, 1);
+  backend->handle = h;
+  if (h) {
+    // we set up a dummy read with a 1ms timeout here. The reason for doing this
+    // is that there might be data left in th e device buffers from earlier
+    // transactions, this should flush it.
+    unsigned char buf[YH_MSG_BUF_SIZE];
+    int transferred = 0;
+    if (backend->api->libusb_bulk_transfer(h, 0x81, buf, sizeof(buf), &transferred, 1) == 0) {
+      DBG_INFO("%d bytes of stale data read from device", transferred);
+    }
+    return true;
+  } else {
+    return false;
+  }
+}
+
+int usb_write(yh_backend *state, unsigned char *buf, long unsigned len) {
+  int transferred = 0;
+  if (state->handle == NULL) {
+    DBG_ERR("Handle is not connected");
+    return 0;
+  }
+  /* TODO: does this need to loop and transmit several times? */
+  int ret =
+    state->api->libusb_bulk_transfer(state->handle, 0x01, buf, len, &transferred, 0);
+  DBG_INFO("Write of %lu %d, err %d", len, transferred, ret);
+  if (ret != 0 || transferred != (int) len) {
+    DBG_ERR("Transferred did not match len of write %d-%lu", transferred, len);
+    return 0;
+  }
+  if (len % 64 == 0) {
+    /* this writes the ZLP */
+    ret = state->api->libusb_bulk_transfer(state->handle, 0x01, buf, 0, &transferred, 0);
+    if (ret != 0) {
+      return 0;
+    }
+  }
+  return 1;
+}
+
+int usb_read(yh_backend *state, unsigned char *buf, unsigned long *len) {
+  int transferred = 0;
+  int ret;
+
+  if (state->handle == NULL) {
+    DBG_ERR("Handle is not connected");
+    return 0;
+  }
+
+  DBG_INFO("Doing usb read");
+
+  /* TODO: does this need to loop for all data?*/
+  ret = state->api->libusb_bulk_transfer(state->handle, 0x81, buf, *len, &transferred, 0);
+  if (ret != 0) {
+    DBG_ERR("Failed usb_read with ret: %d", ret);
+    return 0;
+  }
+  DBG_INFO("Read, transfer %d", transferred);
+  *len = transferred;
+  return 1;
+}
+
+}

--- a/libraries/yubihsm/yubihsm_nousb.c
+++ b/libraries/yubihsm/yubihsm_nousb.c
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2015-2018 Yubico AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdint.h>
+#include <string.h>
+
+#include "yubihsm.h"
+#include "internal.h"
+
+static void backend_set_verbosity(uint8_t verbosity, FILE *output) {}
+
+static yh_rc backend_init(uint8_t verbosity, FILE *output) {
+  return YHR_CONNECTION_ERROR;
+}
+
+yh_backend *backend_create(void) {
+  return NULL;
+}
+
+static yh_rc backend_connect(yh_connector *connector, int timeout) {
+  return YHR_CONNECTION_ERROR;
+}
+
+static void backend_disconnect(yh_backend *connection) {}
+
+static yh_rc backend_send_msg(yh_backend *connection, Msg *msg, Msg *response) {
+   return YHR_CONNECTION_ERROR;
+}
+
+static void backend_cleanup(void) {}
+
+static yh_rc backend_option(yh_backend *connection, yh_connector_option opt,
+                            const void *val) {
+   return YHR_CONNECTION_ERROR;
+}
+
+static struct backend_functions f = {backend_init,     backend_create,
+                                     backend_connect,  backend_disconnect,
+                                     backend_send_msg, backend_cleanup,
+                                     backend_option,   backend_set_verbosity};
+
+#ifdef STATIC
+struct backend_functions *usb_backend_functions(void) {
+#else
+struct backend_functions *backend_functions(void) {
+#endif
+  return &f;
+}

--- a/plugins/wallet_plugin/CMakeLists.txt
+++ b/plugins/wallet_plugin/CMakeLists.txt
@@ -18,12 +18,9 @@ add_library( wallet_plugin
              yubihsm_wallet.cpp
              ${HEADERS} )
 
-target_link_libraries( wallet_plugin yubihsm_static eosio_chain appbase ${security_framework} ${corefoundation_framework} ${localauthentication_framework} ${cocoa_framework})
+target_link_libraries( wallet_plugin yubihsm eosio_chain appbase ${security_framework} ${corefoundation_framework} ${localauthentication_framework} ${cocoa_framework})
 target_include_directories( wallet_plugin PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" )
 
 if(APPLE)
    target_link_libraries( wallet_plugin se-helpers )
 endif()
-
-#sadly old cmake 2.8 support in yubihsm cmake prevents usage of target_include_directories there
-target_include_directories( wallet_plugin PRIVATE "${CMAKE_SOURCE_DIR}/libraries/yubihsm/lib" )

--- a/scripts/eosio_build_amazonlinux2_deps
+++ b/scripts/eosio_build_amazonlinux2_deps
@@ -11,7 +11,6 @@ bzip2-devel,rpm -qa
 openssl-devel,rpm -qa
 gmp-devel,rpm -qa
 libstdc++,rpm -qa
-libcurl-devel,rpm -qa
 libusbx-devel,rpm -qa
 python3,rpm -qa
 python3-devel,rpm -qa

--- a/scripts/eosio_build_centos7_deps
+++ b/scripts/eosio_build_centos7_deps
@@ -16,7 +16,6 @@ rh-python36,rpm -qa
 gettext-devel,rpm -qa
 file,rpm -qa
 libusbx-devel,rpm -qa
-libcurl-devel,rpm -qa
 patch,rpm -qa
 llvm-toolset-7.0-llvm-devel,rpm -qa
 llvm-toolset-7.0-llvm-static,rpm -qa

--- a/scripts/eosio_build_darwin_deps
+++ b/scripts/eosio_build_darwin_deps
@@ -4,7 +4,6 @@ libtool,/usr/local/bin/glibtool
 automake,/usr/local/bin/automake
 wget,/usr/local/bin/wget
 gmp,/usr/local/opt/gmp/include/gmpxx.h
-pkgconfig,/usr/local/bin/pkg-config
 python,/usr/local/opt/python3
 doxygen,/usr/local/bin/doxygen
 libusb,/usr/local/lib/libusb-1.0.0.dylib

--- a/scripts/eosio_build_ubuntu_deps
+++ b/scripts/eosio_build_ubuntu_deps
@@ -19,6 +19,5 @@ zlib1g-dev,dpkg -s
 sudo,dpkg -s
 ruby,dpkg -s
 libusb-1.0-0-dev,dpkg -s
-libcurl4-gnutls-dev,dpkg -s
-pkg-config,dpkg -s
+build-essential,dpkg -s
 patch,dpkg -s


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
In 1.7 libyubihsm was integrated in to eosio's keosd making it significantly easier to use compared to tracking down a shared lib and placing it in the correct location. This also meant building eosio required a few new dependencies like pkgconfig, libusb, and libcurl. But these are very common packages so no problems, right?

Unfortunately yes, there has been some grief. For example, there was recently some pkgconfig+libcurl issues with our macos builds due to something in homebrew going awry. The way libyubihsm pulls in OpenSSL forces dynamic linking of it thus causing problems with macos hardened builds. libusb is LGPL which means if we ever wanted a "standalone" binary we couldn't static link libusb.

This PR resolves these issues and reduces the build and runtime depencies of eosio.

* **pkgconfig**: no longer used. Instead, typical cmake constructs are used to find dependencies
* **libcurl**: no longer used. the http code has been completely refactored to use boost beast instead of libcurl
* **libusb**: Now optional at build time. If it's not found at build time a warning message is displayed via cmake and libyubihsm is built without usb support. If it is found at build time, USB support is enabled but eosio will not link to libusb. Instead, at runtime, a `dlopen()` is performed on libusb and it's used that way. This allows, for example, a standalone binary that doesn't balk at the absence of libusb on startup.

I constructed the changes such that upstream's repo can still be used without a fork. This means upstream's CMakeLists.txt is completely ignored and "reimplemented" locally. I realize there are advantages and disadvantages to this approach but it seemed the best fit to me.

I've removed libcurl and pkgconfig from cicd & script dependency installs. But for Ubuntu I needed to replace it with `build-essential` (which we probably should have been installing anyways).

Leaving as draft until I decide what to do about lack of unit testing. At a point ready for feedback though.

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
