### PR TITLE
Fix setting of keosd-provider-timeout

### DIFF
--- a/plugins/signature_provider_plugin/include/eosio/signature_provider_plugin/signature_provider_plugin.hpp
+++ b/plugins/signature_provider_plugin/include/eosio/signature_provider_plugin/signature_provider_plugin.hpp
@@ -15,7 +15,7 @@ public:
    APPBASE_PLUGIN_REQUIRES((http_client_plugin))
    virtual void set_program_options(options_description&, options_description& cfg) override;
 
-   void plugin_initialize(const variables_map& options) {}
+   void plugin_initialize(const variables_map& options);
    void plugin_startup() {}
    void plugin_shutdown() {}
 

--- a/plugins/signature_provider_plugin/signature_provider_plugin.cpp
+++ b/plugins/signature_provider_plugin/signature_provider_plugin.cpp
@@ -65,9 +65,7 @@ signature_provider_plugin::~signature_provider_plugin(){}
 
 void signature_provider_plugin::set_program_options(options_description&, options_description& cfg) {
    cfg.add_options()
-         ("keosd-provider-timeout", boost::program_options::value<int32_t>()->default_value(5)->notifier([this](auto to){
-            my->_keosd_provider_timeout_us = fc::milliseconds(to);
-         }),
+         ("keosd-provider-timeout", boost::program_options::value<int32_t>()->default_value(5),
           "Limits the maximum time (in milliseconds) that is allowed for sending requests to a keosd provider for signing")
          ;
 }
@@ -85,6 +83,10 @@ const char* const signature_provider_plugin::signature_provider_help_text() cons
 #endif
           ;
 
+}
+
+void signature_provider_plugin::plugin_initialize(const variables_map& options) {
+   my->_keosd_provider_timeout_us = fc::milliseconds( options.at("keosd-provider-timeout").as<int32_t>() );
 }
 
 std::pair<chain::public_key_type,signature_provider_plugin::signature_provider_type>


### PR DESCRIPTION
## Change Description

- On Ubuntu & Boost 1.70 (no idea if this is isolated to this platform)
- The `keosd-provider-timeout` config option notifier was getting called after `make_keosd_signature_provider` so the lambda was capturing the unset value of _keosd_provider_timeout_us (0) setting a deadline of `now` so that `keosd` always timed out.

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
