### PR TITLE
Add support for specifying a logging.json to keosd

### DIFF
--- a/programs/keosd/main.cpp
+++ b/programs/keosd/main.cpp
@@ -16,6 +16,46 @@
 using namespace appbase;
 using namespace eosio;
 
+void configure_logging(const bfs::path& config_path) {
+   try {
+      try {
+         fc::configure_logging(config_path);
+      } catch (...) {
+         elog("Error reloading logging.json");
+         throw;
+      }
+   } catch (const fc::exception& e) { //
+      elog("${e}", ("e", e.to_detail_string()));
+   } catch (const boost::exception& e) {
+      elog("${e}", ("e", boost::diagnostic_information(e)));
+   } catch (const std::exception& e) { //
+      elog("${e}", ("e", e.what()));
+   } catch (...) {
+      // empty
+   }
+}
+
+void logging_conf_handler() {
+   auto config_path = app().get_logging_conf();
+   if (fc::exists(config_path)) {
+      ilog("Received HUP.  Reloading logging configuration from ${p}.", ("p", config_path.string()));
+   } else {
+      ilog("Received HUP.  No log config found at ${p}, setting to default.", ("p", config_path.string()));
+   }
+   configure_logging(config_path);
+   fc::log_config::initialize_appenders(app().get_io_service());
+}
+
+void initialize_logging() {
+   auto config_path = app().get_logging_conf();
+   if (fc::exists(config_path))
+      fc::configure_logging(config_path); // intentionally allowing exceptions to escape
+   fc::log_config::initialize_appenders(app().get_io_service());
+
+   app().set_sighup_callback(logging_conf_handler);
+}
+
+
 bfs::path determine_home_directory()
 {
    bfs::path home;
@@ -52,6 +92,7 @@ int main(int argc, char** argv)
          }
          return -1;
       }
+      initialize_logging();
       auto& http = app().get_plugin<http_plugin>();
       http.add_handler("/v1/" + keosd::config::key_store_executable_name + "/stop", [&a=app()](string, string, url_response_callback cb) { cb(200, fc::variant(fc::variant_object())); a.quit(); } );
       app().startup();


### PR DESCRIPTION
## Change Description

- Apparently changing the logging of `keosd` to `debug` level to see more info on fc exceptions was not possible.
- Added support for specifying a logging.json
  - `./keosd --logconf /home/heifnerk/ext/eosio/bin/logging.json`

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
