### PR TITLE
fix build test-contracts

### DIFF
--- a/unittests/test-contracts/get_sender_test/get_sender_test.hpp
+++ b/unittests/test-contracts/get_sender_test/get_sender_test.hpp
@@ -2,21 +2,6 @@
 
 #include <eosio/eosio.hpp>
 
-namespace eosio {
-   namespace internal_use_do_not_use {
-      extern "C" {
-         __attribute__((eosio_wasm_import))
-         uint64_t get_sender();
-      }
-   }
-}
-
-namespace eosio {
-   name get_sender() {
-      return name( internal_use_do_not_use::get_sender() );
-   }
-}
-
 class [[eosio::contract]] get_sender_test : public eosio::contract {
 public:
    using eosio::contract::contract;

--- a/unittests/test-contracts/kv_bios/kv_bios.cpp
+++ b/unittests/test-contracts/kv_bios/kv_bios.cpp
@@ -5,10 +5,8 @@
 extern "C" __attribute__((eosio_wasm_import)) void set_resource_limit(int64_t, int64_t, int64_t);
 extern "C" __attribute__((eosio_wasm_import)) uint32_t get_kv_parameters_packed(uint64_t db, void* params, uint32_t size, uint32_t max_version);
 extern "C" __attribute__((eosio_wasm_import)) void set_kv_parameters_packed(uint64_t db, const void* params, uint32_t size);
-#ifdef USE_EOSIO_CDT_1.7.X
 extern "C" __attribute__((eosio_wasm_import)) uint32_t read_action_data( void* msg, uint32_t len );
 extern "C" __attribute__((eosio_wasm_import))    uint32_t action_data_size();
-#endif
 using namespace eosio;
 
 // Manages resources used by the kv-store

--- a/unittests/test-contracts/kv_bios/kv_bios.cpp
+++ b/unittests/test-contracts/kv_bios/kv_bios.cpp
@@ -5,8 +5,11 @@
 extern "C" __attribute__((eosio_wasm_import)) void set_resource_limit(int64_t, int64_t, int64_t);
 extern "C" __attribute__((eosio_wasm_import)) uint32_t get_kv_parameters_packed(uint64_t db, void* params, uint32_t size, uint32_t max_version);
 extern "C" __attribute__((eosio_wasm_import)) void set_kv_parameters_packed(uint64_t db, const void* params, uint32_t size);
+#ifdef USE_EOSIO_CDT_1.7.x
 extern "C" __attribute__((eosio_wasm_import)) uint32_t read_action_data( void* msg, uint32_t len );
 extern "C" __attribute__((eosio_wasm_import))    uint32_t action_data_size();
+#endif
+
 using namespace eosio;
 
 // Manages resources used by the kv-store

--- a/unittests/test-contracts/kv_bios/kv_bios.cpp
+++ b/unittests/test-contracts/kv_bios/kv_bios.cpp
@@ -5,6 +5,8 @@
 extern "C" __attribute__((eosio_wasm_import)) void set_resource_limit(int64_t, int64_t, int64_t);
 extern "C" __attribute__((eosio_wasm_import)) uint32_t get_kv_parameters_packed(uint64_t db, void* params, uint32_t size, uint32_t max_version);
 extern "C" __attribute__((eosio_wasm_import)) void set_kv_parameters_packed(uint64_t db, const void* params, uint32_t size);
+extern "C" __attribute__((eosio_wasm_import)) uint32_t read_action_data( void* msg, uint32_t len );
+extern "C" __attribute__((eosio_wasm_import))    uint32_t action_data_size();
 
 using namespace eosio;
 

--- a/unittests/test-contracts/kv_bios/kv_bios.cpp
+++ b/unittests/test-contracts/kv_bios/kv_bios.cpp
@@ -5,9 +5,10 @@
 extern "C" __attribute__((eosio_wasm_import)) void set_resource_limit(int64_t, int64_t, int64_t);
 extern "C" __attribute__((eosio_wasm_import)) uint32_t get_kv_parameters_packed(uint64_t db, void* params, uint32_t size, uint32_t max_version);
 extern "C" __attribute__((eosio_wasm_import)) void set_kv_parameters_packed(uint64_t db, const void* params, uint32_t size);
+#ifdef USE_EOSIO_CDT_1.7.X
 extern "C" __attribute__((eosio_wasm_import)) uint32_t read_action_data( void* msg, uint32_t len );
 extern "C" __attribute__((eosio_wasm_import))    uint32_t action_data_size();
-
+#endif
 using namespace eosio;
 
 // Manages resources used by the kv-store

--- a/unittests/test-contracts/test_api/test_action.cpp
+++ b/unittests/test-contracts/test_api/test_action.cpp
@@ -1,18 +1,32 @@
-#include <eosiolib/action.hpp>
-#include <eosiolib/chain.h>
-#include <eosiolib/crypto.h>
-#include <eosiolib/datastream.hpp>
-#include <eosiolib/db.h>
-#include <eosiolib/eosio.hpp>
-#include <eosiolib/print.hpp>
-#include <eosiolib/privileged.h>
-#include <eosiolib/transaction.hpp>
+#include <eosiolib/contracts/eosio/action.hpp>
+#include <eosiolib/capi/eosio/chain.h>
+#include <eosiolib/capi/eosio/crypto.h>
+#include <eosiolib/core/eosio/datastream.hpp>
+#include <eosiolib/capi/eosio/db.h>
+#include <eosiolib/contracts/eosio/eosio.hpp>
+#include <eosiolib/core/eosio/print.hpp>
+#include <eosiolib/capi/eosio/privileged.h>
+#include <eosiolib/contracts/eosio/transaction.hpp>
+
 
 #include "test_api.hpp"
 
 extern "C" {
-  __attribute__((eosio_wasm_import))
-  void set_action_return_value(const char*, size_t);
+    __attribute__((eosio_wasm_import))
+    void set_action_return_value(const char*, size_t);
+
+    __attribute__((eosio_wasm_import))
+    void  eosio_assert( uint32_t test, const char* msg );
+
+    __attribute__((eosio_wasm_import))
+    void  eosio_assert_code( uint32_t test, uint64_t code );
+
+    __attribute__((eosio_wasm_import))
+    uint64_t  current_time();
+
+    __attribute__((eosio_wasm_import))
+    int get_action( uint32_t type, uint32_t index, char* buff, size_t size );
+
 }
 
 using namespace eosio;
@@ -61,7 +75,7 @@ void test_action::test_dummy_action() {
 
    if ( dum13.b == 200 ) {
       // attempt to access context free only api
-      get_context_free_data( 0, nullptr, 0 );
+      eosio::get_context_free_data( 0, nullptr, 0 );
       eosio_assert( false, "get_context_free_data() not allowed in non-context free action" );
    } else {
       eosio_assert( dum13.a == DUMMY_ACTION_DEFAULT_A, "dum13.a == DUMMY_ACTION_DEFAULT_A" );
@@ -84,10 +98,10 @@ void test_action::test_cf_action() {
    cf_action cfa = act.data_as<cf_action>();
    if ( cfa.payload == 100 ) {
       // verify read of get_context_free_data, also verifies system api access
-      int size = get_context_free_data( cfa.cfd_idx, nullptr, 0 );
-      eosio_assert( size > 0, "size determination failed" );
+      int size = eosio::get_context_free_data( cfa.cfd_idx, nullptr, 0 );
+      check( size > 0, "size determination failed" );
       std::vector<char> cfd( static_cast<size_t>(size) );
-      size = get_context_free_data( cfa.cfd_idx, &cfd[0], static_cast<size_t>(size) );
+      size = eosio::get_context_free_data( cfa.cfd_idx, &cfd[0], static_cast<size_t>(size) );
       eosio_assert(static_cast<size_t>(size) == cfd.size(), "get_context_free_data failed" );
       uint32_t v = eosio::unpack<uint32_t>( &cfd[0], cfd.size() );
       eosio_assert( v == cfa.payload, "invalid value" );
@@ -105,7 +119,7 @@ void test_action::test_cf_action() {
       uint32_t i = 42;
       memccpy( &v, &i, sizeof(i), sizeof(i) );
       // verify transaction api access
-      eosio_assert(transaction_size() > 0, "transaction_size failed");
+      eosio_assert(eosio::transaction_size() > 0, "transaction_size failed");
       // verify softfloat api access
       float f1 = 1.0f, f2 = 2.0f;
       float f3 = f1 + f2;
@@ -143,7 +157,7 @@ void test_action::test_cf_action() {
       eosio::require_auth("test"_n);
       eosio_assert( false, "authorization_api should not be allowed" );
    } else if ( cfa.payload == 207 ) {
-      now();
+      // now();
       eosio_assert( false, "system_api should not be allowed" );
    } else if ( cfa.payload == 208 ) {
       current_time();
@@ -152,10 +166,10 @@ void test_action::test_cf_action() {
       publication_time();
       eosio_assert( false, "system_api should not be allowed" );
    } else if ( cfa.payload == 210 ) {
-      send_inline( (char*)"hello", 6 );
+      eosio::internal_use_do_not_use::send_inline( (char*)"hello", 6 );
       eosio_assert( false, "transaction_api should not be allowed" );
    } else if ( cfa.payload == 211 ) {
-      send_deferred( "testapi"_n.value, "testapi"_n.value, "hello", 6, 0 );
+      eosio::send_deferred( "testapi"_n.value, "testapi"_n, "hello", 6, 0 );
       eosio_assert( false, "transaction_api should not be allowed" );
    } else if ( cfa.payload == 212 ) {
       set_action_return_value("hi", 2);
@@ -189,7 +203,7 @@ void test_action::require_notice_tests( uint64_t receiver, uint64_t code, uint64
 }
 
 void test_action::require_auth() {
-   prints("require_auth");
+   print("require_auth");
    eosio::require_auth("acc3"_n);
    eosio::require_auth("acc4"_n);
 }
@@ -215,7 +229,9 @@ void test_action::test_publication_time() {
    uint64_t pub_time = 0;
    uint32_t total = read_action_data( &pub_time, sizeof(uint64_t) );
    eosio_assert( total == sizeof(uint64_t), "total == sizeof(uint64_t)" );
-   eosio_assert( pub_time == publication_time(), "pub_time == publication_time()" );
+   time_point msec{ microseconds{static_cast<int64_t>(pub_time)}};
+   eosio_assert( msec == publication_time(), "pub_time == publication_time()" );
+
 }
 
 void test_action::test_current_receiver( uint64_t receiver, uint64_t code, uint64_t action ) {
@@ -242,8 +258,8 @@ void test_action::test_assert_code() {
 
 void test_action::test_ram_billing_in_notify( uint64_t receiver, uint64_t code, uint64_t action ) {
    uint128_t tmp = 0;
-   uint32_t total = read_action_data( &tmp, sizeof(uint128_t) );
-   eosio_assert( total == sizeof(uint128_t), "total == sizeof(uint128_t)" );
+   uint32_t total = eosio::read_action_data( &tmp, sizeof(uint128_t) );
+   check( total == sizeof(uint128_t), "total == sizeof(uint128_t)" );
 
    uint64_t to_notify = tmp >> 64;
    uint64_t payer = tmp & 0xFFFFFFFFFFFFFFFFULL;

--- a/unittests/test-contracts/test_api/test_action.cpp
+++ b/unittests/test-contracts/test_api/test_action.cpp
@@ -156,10 +156,8 @@ void test_action::test_cf_action() {
    } else if ( cfa.payload == 206 ) {
       eosio::require_auth("test"_n);
       eosio_assert( false, "authorization_api should not be allowed" );
-   } else if ( cfa.payload == 207 ) {
-      // now();
-      eosio_assert( false, "system_api should not be allowed" );
-   } else if ( cfa.payload == 208 ) {
+   } else if ( cfa.payload == 207 || cfa.payload == 208 ) {
+      // 207 is obsolete as now() is removed from system.h
       current_time();
       eosio_assert( false, "system_api should not be allowed" );
    } else if ( cfa.payload == 209 ) {

--- a/unittests/test-contracts/test_api/test_action.cpp
+++ b/unittests/test-contracts/test_api/test_action.cpp
@@ -99,7 +99,7 @@ void test_action::test_cf_action() {
    if ( cfa.payload == 100 ) {
       // verify read of get_context_free_data, also verifies system api access
       int size = eosio::get_context_free_data( cfa.cfd_idx, nullptr, 0 );
-      check( size > 0, "size determination failed" );
+      eosio_assert( size > 0, "size determination failed" );
       std::vector<char> cfd( static_cast<size_t>(size) );
       size = eosio::get_context_free_data( cfa.cfd_idx, &cfd[0], static_cast<size_t>(size) );
       eosio_assert(static_cast<size_t>(size) == cfd.size(), "get_context_free_data failed" );
@@ -259,7 +259,7 @@ void test_action::test_assert_code() {
 void test_action::test_ram_billing_in_notify( uint64_t receiver, uint64_t code, uint64_t action ) {
    uint128_t tmp = 0;
    uint32_t total = eosio::read_action_data( &tmp, sizeof(uint128_t) );
-   check( total == sizeof(uint128_t), "total == sizeof(uint128_t)" );
+   eosio_assert( total == sizeof(uint128_t), "total == sizeof(uint128_t)" );
 
    uint64_t to_notify = tmp >> 64;
    uint64_t payer = tmp & 0xFFFFFFFFFFFFFFFFULL;

--- a/unittests/test-contracts/test_api/test_api.cpp
+++ b/unittests/test-contracts/test_api/test_api.cpp
@@ -1,5 +1,5 @@
-#include <eosiolib/eosio.hpp>
-#include <eosiolib/transaction.hpp>
+#include <eosiolib/contracts/eosio/eosio.hpp>
+#include <eosiolib/contracts/eosio/transaction.hpp>
 
 #include "test_api.hpp"
 

--- a/unittests/test-contracts/test_api/test_api_common.hpp
+++ b/unittests/test-contracts/test_api/test_api_common.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <eosiolib/serialize.hpp>
-
+#include <eosiolib/core/eosio/serialize.hpp>
 
 static constexpr unsigned int DJBH( const char* cp )
 {

--- a/unittests/test-contracts/test_api/test_chain.cpp
+++ b/unittests/test-contracts/test_api/test_chain.cpp
@@ -1,6 +1,6 @@
-#include <eosiolib/action.h>
-#include <eosiolib/chain.h>
-#include <eosiolib/eosio.hpp>
+#include <eosiolib/contracts/eosio/action.hpp>
+#include <eosiolib/capi/eosio/chain.h>
+#include <eosiolib/contracts/eosio/eosio.hpp>
 
 #include "test_api.hpp"
 

--- a/unittests/test-contracts/test_api/test_checktime.cpp
+++ b/unittests/test-contracts/test_api/test_checktime.cpp
@@ -1,8 +1,8 @@
 #include <vector>
 
-#include <eosiolib/crypto.h>
-#include <eosiolib/eosio.hpp>
-#include <eosiolib/print.h>
+#include <eosiolib/capi/eosio/crypto.h>
+#include <eosiolib/contracts/eosio/eosio.hpp>
+#include <eosiolib/core/eosio/print.hpp>
 
 #include "test_api.hpp"
 

--- a/unittests/test-contracts/test_api/test_crypto.cpp
+++ b/unittests/test-contracts/test_api/test_crypto.cpp
@@ -1,6 +1,6 @@
-#include <eosiolib/crypto.h>
-#include <eosiolib/eosio.hpp>
-#include <eosiolib/print.hpp>
+#include <eosiolib/core/eosio/crypto.hpp>
+#include <eosiolib/contracts/eosio/eosio.hpp>
+#include <eosiolib/core/eosio/print.hpp>
 
 #include "test_api.hpp"
 

--- a/unittests/test-contracts/test_api/test_datastream.cpp
+++ b/unittests/test-contracts/test_api/test_datastream.cpp
@@ -1,7 +1,7 @@
 #include <cmath>
 
-#include <eosiolib/eosio.hpp>
-#include <eosiolib/datastream.hpp>
+#include <eosiolib/contracts/eosio/eosio.hpp>
+#include <eosiolib/core/eosio/datastream.hpp>
 
 #include "test_api.hpp"
 

--- a/unittests/test-contracts/test_api/test_permission.cpp
+++ b/unittests/test-contracts/test_api/test_permission.cpp
@@ -1,11 +1,11 @@
 #include <limits>
 
-#include <eosiolib/action.hpp>
-#include <eosiolib/db.h>
-#include <eosiolib/eosio.hpp>
-#include <eosiolib/permission.h>
-#include <eosiolib/print.hpp>
-#include <eosiolib/serialize.hpp>
+#include <eosiolib/contracts/eosio/action.hpp>
+#include <eosiolib/capi/eosio/db.h>
+#include <eosiolib/contracts/eosio/eosio.hpp>
+#include <eosiolib/contracts/eosio/permission.hpp>
+#include <eosiolib/core/eosio/print.hpp>
+#include <eosiolib/core/eosio/serialize.hpp>
 
 #include "test_api.hpp"
 
@@ -27,11 +27,11 @@ void test_permission::check_authorization( uint64_t receiver, uint64_t code, uin
    auto self = receiver;
    auto params = unpack_action_data<check_auth_msg>();
    auto packed_pubkeys = pack(params.pubkeys);
-   int64_t res64 = ::check_permission_authorization( params.account.value,
-                                                     params.permission.value,
+   int64_t res64 = eosio::check_permission_authorization( params.account,
+                                                     params.permission,
                                                      packed_pubkeys.data(), packed_pubkeys.size(),
                                                      (const char*)0,        0,
-                                                     static_cast<uint64_t>( std::numeric_limits<int64_t>::max() )
+                                                     microseconds{ std::numeric_limits<int64_t>::max() }
                                                    );
 
    auto itr = db_lowerbound_i64( self, self, self, 1 );
@@ -57,7 +57,8 @@ void test_permission::test_permission_last_used( uint64_t /* receiver */, uint64
 
    auto params = unpack_action_data<test_permission_last_used_msg>();
 
-   eosio_assert( get_permission_last_used(params.account.value, params.permission.value) == params.last_used_time, "unexpected last used permission time" );
+   time_point msec{ microseconds{params.last_used_time}};
+   eosio_assert( eosio::get_permission_last_used(params.account, params.permission) == msec, "unexpected last used permission time" );
 }
 
 void test_permission::test_account_creation_time( uint64_t /* receiver */, uint64_t code, uint64_t action ) {
@@ -67,5 +68,6 @@ void test_permission::test_account_creation_time( uint64_t /* receiver */, uint6
 
    auto params = unpack_action_data<test_permission_last_used_msg>();
 
-   eosio_assert( get_account_creation_time(params.account.value) == params.last_used_time, "unexpected account creation time" );
+   time_point msec{ microseconds{params.last_used_time}};
+   eosio_assert( eosio::get_account_creation_time(params.account) == msec, "unexpected account creation time" );
 }

--- a/unittests/test-contracts/test_api/test_print.cpp
+++ b/unittests/test-contracts/test_api/test_print.cpp
@@ -1,6 +1,9 @@
-#include <eosiolib/eosio.hpp>
+#include <eosiolib/contracts/eosio/eosio.hpp>
+#include <eosiolib/core/eosio/print.hpp>
 
 #include "test_api.hpp"
+
+using namespace eosio::internal_use_do_not_use;
 
 void test_print::test_prints_l() {
   char ab[] = { 'a', 'b' };

--- a/unittests/test-contracts/test_api/test_transaction.cpp
+++ b/unittests/test-contracts/test_api/test_transaction.cpp
@@ -1,6 +1,6 @@
-#include <eosiolib/action.hpp>
-#include <eosiolib/crypto.h>
-#include <eosiolib/transaction.hpp>
+#include <eosiolib/contracts/eosio/action.hpp>
+#include <eosiolib/capi/eosio/crypto.h>
+#include <eosiolib/contracts/eosio/transaction.hpp>
 
 #include "test_api.hpp"
 
@@ -105,7 +105,7 @@ void test_transaction::send_action_large() {
 void test_transaction::send_action_recurse() {
    using namespace eosio;
    char buffer[1024];
-   read_action_data( buffer, 1024 );
+   eosio::read_action_data( buffer, 1024 );
 
    test_action_action<"testapi"_n.value, WASM_TEST_ACTION( "test_transaction", "send_action_recurse" )> test_action;
    copy_data( buffer, 1024, test_action.data );
@@ -132,23 +132,23 @@ void test_transaction::send_action_inline_fail() {
 void test_transaction::test_tapos_block_prefix() {
    using namespace eosio;
    int tbp;
-   read_action_data( (char*)&tbp, sizeof(int) );
-   eosio_assert( tbp == tapos_block_prefix(), "tapos_block_prefix does not match" );
+   eosio::read_action_data( (char*)&tbp, sizeof(int) );
+   eosio_assert( tbp == eosio::tapos_block_prefix(), "tapos_block_prefix does not match" );
 }
 
 void test_transaction::test_tapos_block_num() {
    using namespace eosio;
    int tbn;
-   read_action_data( (char*)&tbn, sizeof(int) );
-   eosio_assert( tbn == tapos_block_num(), "tapos_block_num does not match" );
+   eosio::read_action_data( (char*)&tbn, sizeof(int) );
+   eosio_assert( tbn == eosio::tapos_block_num(), "tapos_block_num does not match" );
 }
 
 void test_transaction::test_read_transaction() {
    using namespace eosio;
    checksum256 h;
-   auto size = transaction_size();
+   auto size = eosio::transaction_size();
    char buf[size];
-   uint32_t read = read_transaction( buf, size );
+   uint32_t read = eosio::read_transaction( buf, size );
    eosio_assert( size == read, "read_transaction failed");
    h = eosio::sha256(buf, read);
    print(h);
@@ -157,9 +157,9 @@ void test_transaction::test_read_transaction() {
 void test_transaction::test_transaction_size() {
    using namespace eosio;
    uint32_t trans_size = 0;
-   read_action_data( (char*)&trans_size, sizeof(uint32_t) );
-   print( "size: ", transaction_size() );
-   eosio_assert( trans_size == transaction_size(), "transaction size does not match" );
+   eosio::read_action_data( (char*)&trans_size, sizeof(uint32_t) );
+   print( "size: ", eosio::transaction_size() );
+   eosio_assert( trans_size == eosio::transaction_size(), "transaction size does not match" );
 }
 
 void test_transaction::send_transaction(uint64_t receiver, uint64_t, uint64_t) {
@@ -179,7 +179,7 @@ void test_transaction::send_transaction(uint64_t receiver, uint64_t, uint64_t) {
 void test_transaction::send_action_sender( uint64_t receiver, uint64_t, uint64_t ) {
    using namespace eosio;
    uint64_t cur_send;
-   read_action_data( &cur_send, sizeof(name) );
+   eosio::read_action_data( &cur_send, sizeof(name) );
 
    auto trx = transaction();
    std::vector<permission_level> permissions = { {"testapi"_n, "active"_n} };
@@ -269,7 +269,7 @@ void test_transaction::send_deferred_transaction_replace( uint64_t receiver, uin
 void test_transaction::send_deferred_tx_with_dtt_action() {
    using namespace eosio;
    dtt_action dtt_act;
-   read_action_data( &dtt_act, action_data_size() );
+   eosio::read_action_data( &dtt_act, eosio::action_data_size() );
 
    action deferred_act;
    deferred_act.account = name{dtt_act.deferred_account};
@@ -285,13 +285,13 @@ void test_transaction::send_deferred_tx_with_dtt_action() {
 
 void test_transaction::cancel_deferred_transaction_success() {
    using namespace eosio;
-   auto r = cancel_deferred( 0xffffffffffffffff ); //use the same id (0) as in send_deferred_transaction
+   auto r = eosio::cancel_deferred( 0xffffffffffffffff ); //use the same id (0) as in send_deferred_transaction
    eosio_assert( (bool)r, "transaction was not found" );
 }
 
 void test_transaction::cancel_deferred_transaction_not_found() {
    using namespace eosio;
-   auto r = cancel_deferred( 0xffffffffffffffff ); //use the same id (0) as in send_deferred_transaction
+   auto r = eosio::cancel_deferred( 0xffffffffffffffff ); //use the same id (0) as in send_deferred_transaction
    eosio_assert( !r, "transaction was canceled, whild should not be found" );
 }
 
@@ -315,7 +315,7 @@ void test_transaction::stateful_api() {
 
 void test_transaction::context_free_api() {
    char buf[128] = {0};
-   get_context_free_data( 0, buf, sizeof(buf) );
+   eosio::get_context_free_data( 0, buf, sizeof(buf) );
 }
 
 void test_transaction::repeat_deferred_transaction( uint64_t receiver, uint64_t code, uint64_t action ) {
@@ -326,7 +326,7 @@ void test_transaction::repeat_deferred_transaction( uint64_t receiver, uint64_t 
    uint32_t payload = unpack_action_data<uint32_t>();
    print("repeat_deferred_transaction called: payload = ", payload);
 
-   bool res = cancel_deferred( sender_id );
+   bool res = eosio::cancel_deferred( sender_id );
 
    print("\nrepeat_deferred_transaction cancelled trx with sender_id = ", sender_id, ", result is ", res);
 

--- a/unittests/test-contracts/test_api/test_types.cpp
+++ b/unittests/test-contracts/test_api/test_types.cpp
@@ -1,4 +1,4 @@
-#include <eosiolib/eosio.hpp>
+#include <eosiolib/contracts/eosio/eosio.hpp>
 
 #include "test_api.hpp"
 

--- a/unittests/test-contracts/wasm_config_bios/wasm_config_bios.cpp
+++ b/unittests/test-contracts/wasm_config_bios/wasm_config_bios.cpp
@@ -1,8 +1,10 @@
 #include <eosio/contract.hpp>
 
 extern "C" __attribute__((eosio_wasm_import)) void set_wasm_parameters_packed(const void*, std::size_t);
+#ifdef USE_EOSIO_CDT_1.7.X
 extern "C" __attribute__((eosio_wasm_import)) uint32_t read_action_data( void* msg, uint32_t len );
 extern "C" __attribute__((eosio_wasm_import))    uint32_t action_data_size();
+#endif
 
 struct wasm_config {
    std::uint32_t max_mutable_global_bytes;

--- a/unittests/test-contracts/wasm_config_bios/wasm_config_bios.cpp
+++ b/unittests/test-contracts/wasm_config_bios/wasm_config_bios.cpp
@@ -1,8 +1,10 @@
 #include <eosio/contract.hpp>
 
 extern "C" __attribute__((eosio_wasm_import)) void set_wasm_parameters_packed(const void*, std::size_t);
+#ifdef USE_EOSIO_CDT_1.7.x
 extern "C" __attribute__((eosio_wasm_import)) uint32_t read_action_data( void* msg, uint32_t len );
 extern "C" __attribute__((eosio_wasm_import))    uint32_t action_data_size();
+#endif
 
 struct wasm_config {
    std::uint32_t max_mutable_global_bytes;

--- a/unittests/test-contracts/wasm_config_bios/wasm_config_bios.cpp
+++ b/unittests/test-contracts/wasm_config_bios/wasm_config_bios.cpp
@@ -1,6 +1,8 @@
 #include <eosio/contract.hpp>
 
 extern "C" __attribute__((eosio_wasm_import)) void set_wasm_parameters_packed(const void*, std::size_t);
+extern "C" __attribute__((eosio_wasm_import)) uint32_t read_action_data( void* msg, uint32_t len );
+extern "C" __attribute__((eosio_wasm_import))    uint32_t action_data_size();
 
 struct wasm_config {
    std::uint32_t max_mutable_global_bytes;

--- a/unittests/test-contracts/wasm_config_bios/wasm_config_bios.cpp
+++ b/unittests/test-contracts/wasm_config_bios/wasm_config_bios.cpp
@@ -1,10 +1,8 @@
 #include <eosio/contract.hpp>
 
 extern "C" __attribute__((eosio_wasm_import)) void set_wasm_parameters_packed(const void*, std::size_t);
-#ifdef USE_EOSIO_CDT_1.7.X
 extern "C" __attribute__((eosio_wasm_import)) uint32_t read_action_data( void* msg, uint32_t len );
 extern "C" __attribute__((eosio_wasm_import))    uint32_t action_data_size();
-#endif
 
 struct wasm_config {
    std::uint32_t max_mutable_global_bytes;


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->
We removed those deprecated headers in eosio.cdt v1.7.x so now it is not possible to build EOSIO with -DEOSIO_COMPILE_TEST_CONTRACTS=true with an installed version of eosio.cdt of 1.7.x or later. Also, reevaluate all the test contracts to see if we are missing coverage or if we are over testing.
## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
#1. Changed include path from eosiolib/* to eosiolib/capi/*, eosiolib/core/*, eosiolib/contracts/*.
#2. Added namespace if call to a function is ambiguous
#3. Handled function arguments changes.

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->




## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
