### PR TITLE
[2.0.x] epe-37 fixed test-contracts build

### DIFF
--- a/unittests/test-contracts/get_sender_test/get_sender_test.hpp
+++ b/unittests/test-contracts/get_sender_test/get_sender_test.hpp
@@ -2,21 +2,6 @@
 
 #include <eosio/eosio.hpp>
 
-namespace eosio {
-   namespace internal_use_do_not_use {
-      extern "C" {
-         __attribute__((eosio_wasm_import))
-         uint64_t get_sender();
-      }
-   }
-}
-
-namespace eosio {
-   name get_sender() {
-      return name( internal_use_do_not_use::get_sender() );
-   }
-}
-
 class [[eosio::contract]] get_sender_test : public eosio::contract {
 public:
    using eosio::contract::contract;

--- a/unittests/test-contracts/snapshot_test/CMakeLists.txt
+++ b/unittests/test-contracts/snapshot_test/CMakeLists.txt
@@ -1,4 +1,7 @@
-if( EOSIO_COMPILE_TEST_CONTRACTS )
+if( EOSIO_COMPILE_TEST_CONTRACTS AND 0 )
+   # This contract should not be rebuilt, because the saved snapshots in
+   # unittests/snapshots/ contain a copy of the current version of the contract
+   # and snapshot_tests requires it to be identical.
    add_contract( snapshot_test snapshot_test snapshot_test.cpp )
 else()
    configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/snapshot_test.wasm ${CMAKE_CURRENT_BINARY_DIR}/snapshot_test.wasm COPYONLY )

--- a/unittests/test-contracts/test_api/test_action.cpp
+++ b/unittests/test-contracts/test_api/test_action.cpp
@@ -1,14 +1,32 @@
-#include <eosiolib/action.hpp>
-#include <eosiolib/chain.h>
-#include <eosiolib/crypto.h>
-#include <eosiolib/datastream.hpp>
-#include <eosiolib/db.h>
-#include <eosiolib/eosio.hpp>
-#include <eosiolib/print.hpp>
-#include <eosiolib/privileged.h>
-#include <eosiolib/transaction.hpp>
+#include <eosiolib/contracts/eosio/action.hpp>
+#include <eosiolib/capi/eosio/chain.h>
+#include <eosiolib/capi/eosio/crypto.h>
+#include <eosiolib/core/eosio/datastream.hpp>
+#include <eosiolib/capi/eosio/db.h>
+#include <eosiolib/contracts/eosio/eosio.hpp>
+#include <eosiolib/core/eosio/print.hpp>
+#include <eosiolib/capi/eosio/privileged.h>
+#include <eosiolib/contracts/eosio/transaction.hpp>
 
 #include "test_api.hpp"
+
+extern "C" {
+    __attribute__((eosio_wasm_import))
+    void set_action_return_value(const char*, size_t);
+
+    __attribute__((eosio_wasm_import))
+    void  eosio_assert( uint32_t test, const char* msg );
+
+    __attribute__((eosio_wasm_import))
+    void  eosio_assert_code( uint32_t test, uint64_t code );
+
+    __attribute__((eosio_wasm_import))
+    uint64_t  current_time();
+
+    __attribute__((eosio_wasm_import))
+    int get_action( uint32_t type, uint32_t index, char* buff, size_t size );
+
+}
 
 using namespace eosio;
 
@@ -56,7 +74,7 @@ void test_action::test_dummy_action() {
 
    if ( dum13.b == 200 ) {
       // attempt to access context free only api
-      get_context_free_data( 0, nullptr, 0 );
+      eosio::get_context_free_data( 0, nullptr, 0 );
       eosio_assert( false, "get_context_free_data() not allowed in non-context free action" );
    } else {
       eosio_assert( dum13.a == DUMMY_ACTION_DEFAULT_A, "dum13.a == DUMMY_ACTION_DEFAULT_A" );
@@ -79,10 +97,10 @@ void test_action::test_cf_action() {
    cf_action cfa = act.data_as<cf_action>();
    if ( cfa.payload == 100 ) {
       // verify read of get_context_free_data, also verifies system api access
-      int size = get_context_free_data( cfa.cfd_idx, nullptr, 0 );
+      int size = eosio::get_context_free_data( cfa.cfd_idx, nullptr, 0 );
       eosio_assert( size > 0, "size determination failed" );
       std::vector<char> cfd( static_cast<size_t>(size) );
-      size = get_context_free_data( cfa.cfd_idx, &cfd[0], static_cast<size_t>(size) );
+      size = eosio::get_context_free_data( cfa.cfd_idx, &cfd[0], static_cast<size_t>(size) );
       eosio_assert(static_cast<size_t>(size) == cfd.size(), "get_context_free_data failed" );
       uint32_t v = eosio::unpack<uint32_t>( &cfd[0], cfd.size() );
       eosio_assert( v == cfa.payload, "invalid value" );
@@ -100,7 +118,7 @@ void test_action::test_cf_action() {
       uint32_t i = 42;
       memccpy( &v, &i, sizeof(i), sizeof(i) );
       // verify transaction api access
-      eosio_assert(transaction_size() > 0, "transaction_size failed");
+      eosio_assert(eosio::transaction_size() > 0, "transaction_size failed");
       // verify softfloat api access
       float f1 = 1.0f, f2 = 2.0f;
       float f3 = f1 + f2;
@@ -137,20 +155,18 @@ void test_action::test_cf_action() {
    } else if ( cfa.payload == 206 ) {
       eosio::require_auth("test"_n);
       eosio_assert( false, "authorization_api should not be allowed" );
-   } else if ( cfa.payload == 207 ) {
-      now();
-      eosio_assert( false, "system_api should not be allowed" );
-   } else if ( cfa.payload == 208 ) {
+   } else if ( cfa.payload == 207 || cfa.payload == 208 ) {
+      // 207 is obsolete as now() is removed from system.h
       current_time();
       eosio_assert( false, "system_api should not be allowed" );
    } else if ( cfa.payload == 209 ) {
       publication_time();
       eosio_assert( false, "system_api should not be allowed" );
    } else if ( cfa.payload == 210 ) {
-      send_inline( (char*)"hello", 6 );
+      eosio::internal_use_do_not_use::send_inline( (char*)"hello", 6 );
       eosio_assert( false, "transaction_api should not be allowed" );
    } else if ( cfa.payload == 211 ) {
-      send_deferred( "testapi"_n.value, "testapi"_n.value, "hello", 6, 0 );
+      eosio::send_deferred( "testapi"_n.value, "testapi"_n, "hello", 6, 0 );
       eosio_assert( false, "transaction_api should not be allowed" );
    }
 
@@ -181,7 +197,7 @@ void test_action::require_notice_tests( uint64_t receiver, uint64_t code, uint64
 }
 
 void test_action::require_auth() {
-   prints("require_auth");
+   print("require_auth");
    eosio::require_auth("acc3"_n);
    eosio::require_auth("acc4"_n);
 }
@@ -207,7 +223,9 @@ void test_action::test_publication_time() {
    uint64_t pub_time = 0;
    uint32_t total = read_action_data( &pub_time, sizeof(uint64_t) );
    eosio_assert( total == sizeof(uint64_t), "total == sizeof(uint64_t)" );
-   eosio_assert( pub_time == publication_time(), "pub_time == publication_time()" );
+   time_point msec{ microseconds{static_cast<int64_t>(pub_time)}};
+   eosio_assert( msec == publication_time(), "pub_time == publication_time()" );
+
 }
 
 void test_action::test_current_receiver( uint64_t receiver, uint64_t code, uint64_t action ) {
@@ -234,7 +252,7 @@ void test_action::test_assert_code() {
 
 void test_action::test_ram_billing_in_notify( uint64_t receiver, uint64_t code, uint64_t action ) {
    uint128_t tmp = 0;
-   uint32_t total = read_action_data( &tmp, sizeof(uint128_t) );
+   uint32_t total = eosio::read_action_data( &tmp, sizeof(uint128_t) );
    eosio_assert( total == sizeof(uint128_t), "total == sizeof(uint128_t)" );
 
    uint64_t to_notify = tmp >> 64;

--- a/unittests/test-contracts/test_api/test_action.cpp
+++ b/unittests/test-contracts/test_api/test_action.cpp
@@ -1,32 +1,11 @@
-#include <eosiolib/contracts/eosio/action.hpp>
-#include <eosiolib/capi/eosio/chain.h>
-#include <eosiolib/capi/eosio/crypto.h>
-#include <eosiolib/core/eosio/datastream.hpp>
-#include <eosiolib/capi/eosio/db.h>
-#include <eosiolib/contracts/eosio/eosio.hpp>
-#include <eosiolib/core/eosio/print.hpp>
-#include <eosiolib/capi/eosio/privileged.h>
-#include <eosiolib/contracts/eosio/transaction.hpp>
+#include <eosio/action.hpp>
+#include <eosio/crypto.hpp>
+#include <eosio/datastream.hpp>
+#include <eosio/eosio.hpp>
+#include <eosio/print.hpp>
+#include <eosio/transaction.hpp>
 
 #include "test_api.hpp"
-
-extern "C" {
-    __attribute__((eosio_wasm_import))
-    void set_action_return_value(const char*, size_t);
-
-    __attribute__((eosio_wasm_import))
-    void  eosio_assert( uint32_t test, const char* msg );
-
-    __attribute__((eosio_wasm_import))
-    void  eosio_assert_code( uint32_t test, uint64_t code );
-
-    __attribute__((eosio_wasm_import))
-    uint64_t  current_time();
-
-    __attribute__((eosio_wasm_import))
-    int get_action( uint32_t type, uint32_t index, char* buff, size_t size );
-
-}
 
 using namespace eosio;
 
@@ -106,10 +85,9 @@ void test_action::test_cf_action() {
       eosio_assert( v == cfa.payload, "invalid value" );
 
       // verify crypto api access
-      capi_checksum256 hash;
       char test[] = "test";
-      sha256( test, sizeof(test), &hash );
-      assert_sha256( test, sizeof(test), &hash );
+      auto hash = sha256( test, sizeof(test) );
+      eosio::assert_sha256( test, sizeof(test), hash );
       // verify action api access
       action_data_size();
       // verify console api access

--- a/unittests/test-contracts/test_api/test_api.cpp
+++ b/unittests/test-contracts/test_api/test_api.cpp
@@ -1,5 +1,5 @@
-#include <eosiolib/eosio.hpp>
-#include <eosiolib/transaction.hpp>
+#include <eosiolib/contracts/eosio/eosio.hpp>
+#include <eosiolib/contracts/eosio/transaction.hpp>
 
 #include "test_api.hpp"
 

--- a/unittests/test-contracts/test_api/test_api.cpp
+++ b/unittests/test-contracts/test_api/test_api.cpp
@@ -1,5 +1,5 @@
-#include <eosiolib/contracts/eosio/eosio.hpp>
-#include <eosiolib/contracts/eosio/transaction.hpp>
+#include <eosio/eosio.hpp>
+#include <eosio/transaction.hpp>
 
 #include "test_api.hpp"
 

--- a/unittests/test-contracts/test_api/test_api.hpp
+++ b/unittests/test-contracts/test_api/test_api.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <string>
-
+#include "../capi/eosio/types.h"
 #include "test_api_common.hpp"
 
 namespace eosio { class transaction; }
@@ -25,6 +25,50 @@ namespace eosio { class transaction; }
    if( error_action == name{WASM_TEST_ACTION(CALLED_CLASS_STR, CALLED_METHOD_STR)} ) { \
    HANDLER_CLASS::HANDLER_METHOD(error_trx); \
    return; \
+}
+
+extern "C" {
+    __attribute__((eosio_wasm_import))
+    void set_action_return_value(const char*, size_t);
+
+    __attribute__((eosio_wasm_import))
+    void  eosio_assert( uint32_t test, const char* msg );
+
+    __attribute__((eosio_wasm_import))
+    void  eosio_assert_code( uint32_t test, uint64_t code );
+
+    __attribute__((eosio_wasm_import))
+    uint64_t  current_time();
+
+    __attribute__((eosio_wasm_import))
+    int get_action( uint32_t type, uint32_t index, char* buff, size_t size );
+
+    //db.h
+    __attribute__((eosio_wasm_import))
+    int32_t db_store_i64(uint64_t scope, capi_name table, capi_name payer, uint64_t id,  const void* data, uint32_t len);
+
+    __attribute__((eosio_wasm_import))
+    int32_t db_find_i64(capi_name code, uint64_t scope, capi_name table, uint64_t id);
+
+    __attribute__((eosio_wasm_import))
+    int32_t db_idx64_store(uint64_t scope, capi_name table, capi_name payer, uint64_t id, const uint64_t* secondary);
+
+    __attribute__((eosio_wasm_import))
+    void db_remove_i64(int32_t iterator);
+
+    __attribute__((eosio_wasm_import))
+    int32_t db_lowerbound_i64(capi_name code, uint64_t scope, capi_name table, uint64_t id);
+
+    __attribute__((eosio_wasm_import))
+    void db_update_i64(int32_t iterator, capi_name payer, const void* data, uint32_t len);
+
+    //privilege.h
+    __attribute__((eosio_wasm_import))
+    bool is_privileged( capi_name account );
+
+    // chain.h
+    __attribute__((eosio_wasm_import))
+    uint32_t get_active_producers( capi_name* producers, uint32_t datalen );
 }
 
 struct test_types {

--- a/unittests/test-contracts/test_api/test_api_common.hpp
+++ b/unittests/test-contracts/test_api/test_api_common.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <eosiolib/serialize.hpp>
-
+#include <eosiolib/core/eosio/serialize.hpp>
 
 static constexpr unsigned int DJBH( const char* cp )
 {

--- a/unittests/test-contracts/test_api/test_api_common.hpp
+++ b/unittests/test-contracts/test_api/test_api_common.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <eosiolib/core/eosio/serialize.hpp>
+#include <eosio/serialize.hpp>
 
 static constexpr unsigned int DJBH( const char* cp )
 {

--- a/unittests/test-contracts/test_api/test_chain.cpp
+++ b/unittests/test-contracts/test_api/test_chain.cpp
@@ -1,6 +1,6 @@
-#include <eosiolib/action.h>
-#include <eosiolib/chain.h>
-#include <eosiolib/eosio.hpp>
+#include <eosiolib/contracts/eosio/action.hpp>
+#include <eosiolib/capi/eosio/chain.h>
+#include <eosiolib/contracts/eosio/eosio.hpp>
 
 #include "test_api.hpp"
 

--- a/unittests/test-contracts/test_api/test_chain.cpp
+++ b/unittests/test-contracts/test_api/test_chain.cpp
@@ -1,6 +1,5 @@
-#include <eosiolib/contracts/eosio/action.hpp>
-#include <eosiolib/capi/eosio/chain.h>
-#include <eosiolib/contracts/eosio/eosio.hpp>
+#include <eosio/action.hpp>
+#include <eosio/eosio.hpp>
 
 #include "test_api.hpp"
 

--- a/unittests/test-contracts/test_api/test_checktime.cpp
+++ b/unittests/test-contracts/test_api/test_checktime.cpp
@@ -1,8 +1,8 @@
 #include <vector>
 
-#include <eosiolib/crypto.h>
-#include <eosiolib/eosio.hpp>
-#include <eosiolib/print.h>
+#include <eosiolib/capi/eosio/crypto.h>
+#include <eosiolib/contracts/eosio/eosio.hpp>
+#include <eosiolib/core/eosio/print.hpp>
 
 #include "test_api.hpp"
 

--- a/unittests/test-contracts/test_api/test_checktime.cpp
+++ b/unittests/test-contracts/test_api/test_checktime.cpp
@@ -1,10 +1,11 @@
 #include <vector>
 
-#include <eosiolib/capi/eosio/crypto.h>
-#include <eosiolib/contracts/eosio/eosio.hpp>
-#include <eosiolib/core/eosio/print.hpp>
+#include <eosio/crypto.hpp>
+#include <eosio/eosio.hpp>
+#include <eosio/print.hpp>
 
 #include "test_api.hpp"
+using namespace eosio;
 
 void test_checktime::checktime_pass() {
    int p = 0;
@@ -31,48 +32,44 @@ constexpr size_t size = 20000000;
 
 void test_checktime::checktime_sha1_failure() {
    char* ptr = new char[size];
-   capi_checksum160 res;
-   sha1( ptr, size, &res );
+   auto res = sha1( ptr, size );
 }
 
 void test_checktime::checktime_assert_sha1_failure() {
    char* ptr = new char[size];
-   capi_checksum160 res;
-   assert_sha1( ptr, size, &res );
+   checksum160 res;
+   assert_sha1( ptr, size, res );
 }
 
 void test_checktime::checktime_sha256_failure() {
    char* ptr = new char[size];
-   capi_checksum256 res;
-   sha256( ptr, size, &res );
+   auto res = sha256( ptr, size );
 }
 
 void test_checktime::checktime_assert_sha256_failure() {
    char* ptr = new char[size];
-   capi_checksum256 res;
-   assert_sha256( ptr, size, &res );
+   checksum256 res;
+   assert_sha256( ptr, size, res );
 }
 
 void test_checktime::checktime_sha512_failure() {
    char* ptr = new char[size];
-   capi_checksum512 res;
-   sha512( ptr, size, &res );
+   auto res = sha512( ptr, size );
 }
 
 void test_checktime::checktime_assert_sha512_failure() {
    char* ptr = new char[size];
-   capi_checksum512 res;
-   assert_sha512( ptr, size, &res );
+   checksum512 res;
+   assert_sha512( ptr, size, res );
 }
 
 void test_checktime::checktime_ripemd160_failure() {
    char* ptr = new char[size];
-   capi_checksum160 res;
-   ripemd160( ptr, size, &res );
+   auto res = ripemd160( ptr, size );
 }
 
 void test_checktime::checktime_assert_ripemd160_failure() {
    char* ptr = new char[size];
-   capi_checksum160 res;
-   assert_ripemd160( ptr, size, &res );
+   checksum160 res;
+   assert_ripemd160( ptr, size, res );
 }

--- a/unittests/test-contracts/test_api/test_crypto.cpp
+++ b/unittests/test-contracts/test_api/test_crypto.cpp
@@ -1,6 +1,6 @@
-#include <eosiolib/core/eosio/crypto.hpp>
-#include <eosiolib/contracts/eosio/eosio.hpp>
-#include <eosiolib/core/eosio/print.hpp>
+#include <eosio/crypto.hpp>
+#include <eosio/eosio.hpp>
+#include <eosio/print.hpp>
 
 #include "test_api.hpp"
 
@@ -179,6 +179,9 @@ extern "C" {
       }
       return true;
    }
+
+   __attribute__((eosio_wasm_import))
+   int recover_key( const capi_checksum256* digest, const char* sig, size_t siglen, char* pub, size_t publen );
 }
 
 struct sig_hash_key_header {
@@ -195,20 +198,38 @@ struct sig_hash_key_header {
    }
 };
 
+
+using namespace eosio;
+
 void test_crypto::test_recover_key_assert_true() {
    char buffer[action_data_size()];
    read_action_data( buffer, action_data_size() );
    auto sh = (const sig_hash_key_header*)buffer;
 
-   assert_recover_key( &sh->hash, sh->sig_base(), sh->sig_len, sh->pk_base(), sh->pk_len );
+   checksum256 digest(sh->hash.hash);
+   ecc_signature ecc_sig = eosio::unpack<ecc_signature>(&sh->sig_base()[1], sh->sig_len);
+   signature sig(std::in_place_index<0>, ecc_sig);
+
+   ecc_public_key ecc_pubkey = eosio::unpack<ecc_public_key>(&sh->pk_base()[1], sh->pk_len);
+   public_key pubkey(std::in_place_index<0>, ecc_pubkey);
+
+   assert_recover_key( sh->hash.hash, sig, pubkey );
 }
+
 
 void test_crypto::test_recover_key_assert_false() {
    char buffer[action_data_size()];
    read_action_data( buffer, action_data_size() );
    auto sh = (const sig_hash_key_header*)buffer;
 
-   assert_recover_key( &sh->hash, sh->sig_base(), sh->sig_len, sh->pk_base(), sh->pk_len );
+   checksum256 digest(sh->hash.hash);
+   ecc_signature ecc_sig = eosio::unpack<ecc_signature>(&sh->sig_base()[1], sh->sig_len);
+   signature sig(std::in_place_index<0>, ecc_sig);
+
+   ecc_public_key ecc_pubkey;
+   public_key pubkey(std::in_place_index<0>, ecc_pubkey);
+
+   assert_recover_key( sh->hash.hash, sig, pubkey );
    eosio_assert( false, "should have thrown an error" );
 }
 
@@ -217,12 +238,16 @@ void test_crypto::test_recover_key() {
    read_action_data( buffer, action_data_size() );
    auto sh = (const sig_hash_key_header*)buffer;
 
-   char recovered[sh->pk_len];
-   auto result = recover_key( &sh->hash, sh->sig_base(), sh->sig_len, recovered, sh->pk_len );
-   eosio_assert(result == sh->pk_len, "public key does not match");
+   checksum256 digest(sh->hash.hash);
+   ecc_signature ecc_sig = eosio::unpack<ecc_signature>(&sh->sig_base()[1], sh->sig_len);
+   signature sig(std::in_place_index<0>, ecc_sig);
+
+   auto pubkey = recover_key( digest, sig );
+   auto ecc_pubkey = std::get<0>(pubkey);
+   eosio_assert(ecc_pubkey.size() == sh->pk_len - 1, "public key does not match");
    for ( uint32_t i=0; i < sh->pk_len; i++ )
-      if ( recovered[i] != sh->pk_base()[i] )
-         eosio_assert( false, "public key does not match" );
+     if ( ecc_pubkey[i] != sh->pk_base()[i+1] )
+        eosio_assert( false, "public key does not match" );
 }
 
 void test_crypto::test_recover_key_partial() {
@@ -232,7 +257,8 @@ void test_crypto::test_recover_key_partial() {
 
    auto recover_size = std::max<uint32_t>(sh->pk_len / 2, 33);
    char recovered[recover_size];
-   auto result = recover_key( &sh->hash, sh->sig_base(), sh->sig_len, recovered, recover_size );
+   // testing capi recover_key. There is no equivalent C++ recover_key function for this test.
+   auto result = ::recover_key( &sh->hash, sh->sig_base(), sh->sig_len, recovered, recover_size );
    eosio_assert(result == sh->pk_len, "recoverable key is not as long as provided key");
    for ( uint32_t i=0; i < recover_size; i++ )
       if ( recovered[i] != sh->pk_base()[i] )
@@ -240,203 +266,177 @@ void test_crypto::test_recover_key_partial() {
 }
 
 void test_crypto::test_sha1() {
-   unsigned char tmp[20];
+   auto tmp = eosio::sha1( test1, my_strlen(test1) ).extract_as_byte_array();
+   my_memcmp((void *)test1_ok_1, tmp.data(), tmp.size());
+   eosio_assert(  my_memcmp((void *)test1_ok_1, tmp.data(), tmp.size()), "sha1 test1" );
 
-   ::sha1( test1, my_strlen(test1), (capi_checksum160*)tmp );
-   eosio_assert(  my_memcmp((void *)test1_ok_1, &tmp, sizeof(tmp)), "sha1 test1" );
+   tmp = eosio::sha1( test3, my_strlen(test3) ).extract_as_byte_array();
+   eosio_assert( my_memcmp((void *)test3_ok_1, tmp.data(), tmp.size()), "sha1 test3" );
 
-   ::sha1( test3, my_strlen(test3), (capi_checksum160*)tmp );
-   eosio_assert( my_memcmp((void *)test3_ok_1, &tmp, sizeof(tmp)), "sha1 test3" );
+   tmp = eosio::sha1( test4, my_strlen(test4) ).extract_as_byte_array();
+   eosio_assert( my_memcmp((void *)test4_ok_1, tmp.data(), tmp.size()), "sha1 test4" );
 
-   ::sha1( test4, my_strlen(test4), (capi_checksum160*)tmp );
-   eosio_assert( my_memcmp((void *)test4_ok_1, &tmp, sizeof(tmp)), "sha1 test4" );
-
-   ::sha1( test5, my_strlen(test5), (capi_checksum160*)tmp );
-   eosio_assert( my_memcmp((void *)test5_ok_1, &tmp, sizeof(tmp)), "sha1 test5" );
+   tmp = eosio::sha1( test5, my_strlen(test5) ).extract_as_byte_array();
+   eosio_assert( my_memcmp((void *)test5_ok_1, tmp.data(), tmp.size()), "sha1 test5" );
 }
 
 void test_crypto::test_sha256() {
-   unsigned char tmp[32];
+   auto tmp = eosio::sha256( test1, my_strlen(test1) ).extract_as_byte_array();
+   eosio_assert( my_memcmp((void *)test1_ok_256, tmp.data(), tmp.size()), "sha256 test1" );
 
-   ::sha256( test1, my_strlen(test1), (capi_checksum256*)tmp);
-   eosio_assert( my_memcmp((void *)test1_ok_256, &tmp, sizeof(tmp)), "sha256 test1" );
+   tmp = eosio::sha256( test3, my_strlen(test3) ).extract_as_byte_array();
+   eosio_assert( my_memcmp((void *)test3_ok_256, tmp.data(), tmp.size()), "sha256 test3" );
 
-   ::sha256( test3, my_strlen(test3), (capi_checksum256*)tmp);
-   eosio_assert( my_memcmp((void *)test3_ok_256, &tmp, sizeof(tmp)), "sha256 test3" );
+   tmp = eosio::sha256( test4, my_strlen(test4)).extract_as_byte_array();
+   eosio_assert( my_memcmp((void *)test4_ok_256, tmp.data(), tmp.size()), "sha256 test4" );
 
-   ::sha256( test4, my_strlen(test4), (capi_checksum256*)tmp);
-   eosio_assert( my_memcmp((void *)test4_ok_256, &tmp, sizeof(tmp)), "sha256 test4" );
-
-   ::sha256( test5, my_strlen(test5), (capi_checksum256*)tmp);
-   eosio_assert( my_memcmp((void *)test5_ok_256, &tmp, sizeof(tmp)), "sha256 test5" );
+   tmp = eosio::sha256( test5, my_strlen(test5)).extract_as_byte_array();
+   eosio_assert( my_memcmp((void *)test5_ok_256, tmp.data(), tmp.size()), "sha256 test5" );
 }
 
 void test_crypto::test_sha512() {
-   unsigned char tmp[64];
+   auto tmp = eosio::sha512( test1, my_strlen(test1) ).extract_as_byte_array();
+   eosio_assert( my_memcmp((void *)test1_ok_512, tmp.data(), tmp.size()), "sha512 test1" );
 
-   ::sha512( test1, my_strlen(test1), (capi_checksum512*)tmp );
-   eosio_assert( my_memcmp((void *)test1_ok_512, &tmp, sizeof(tmp)), "sha512 test1" );
+   tmp = eosio::sha512( test3, my_strlen(test3) ).extract_as_byte_array();
+   eosio_assert( my_memcmp((void *)test3_ok_512, tmp.data(), tmp.size()), "sha512 test3" );
 
-   ::sha512( test3, my_strlen(test3), (capi_checksum512*)tmp );
-   eosio_assert( my_memcmp((void *)test3_ok_512, &tmp, sizeof(tmp)), "sha512 test3" );
+   tmp = eosio::sha512( test4, my_strlen(test4) ).extract_as_byte_array();
+   eosio_assert( my_memcmp((void *)test4_ok_512, tmp.data(), tmp.size()), "sha512 test4" );
 
-   ::sha512( test4, my_strlen(test4), (capi_checksum512*)tmp );
-   eosio_assert( my_memcmp((void *)test4_ok_512, &tmp, sizeof(tmp)), "sha512 test4" );
-
-   ::sha512( test5, my_strlen(test5), (capi_checksum512*)tmp );
-   eosio_assert( my_memcmp((void *)test5_ok_512, &tmp, sizeof(tmp)), "sha512 test5" );
+   tmp = eosio::sha512( test5, my_strlen(test5) ).extract_as_byte_array();
+   eosio_assert( my_memcmp((void *)test5_ok_512, tmp.data(), tmp.size()), "sha512 test5" );
 }
 
 void test_crypto::test_ripemd160() {
-   unsigned char tmp[20];
+   auto tmp = ripemd160( test1, my_strlen(test1) ).extract_as_byte_array();
+   eosio_assert( my_memcmp((void *)test1_ok_ripe, tmp.data(), tmp.size()), "ripemd160 test1" );
 
-   ::ripemd160( test1, my_strlen(test1), (capi_checksum160*)tmp );
-   eosio_assert( my_memcmp((void *)test1_ok_ripe, &tmp, sizeof(tmp)), "ripemd160 test1" );
+   tmp = ripemd160( test3, my_strlen(test3) ).extract_as_byte_array();
+   eosio_assert( my_memcmp((void *)test3_ok_ripe, tmp.data(), tmp.size()), "ripemd160 test3" );
 
-   ::ripemd160( test3, my_strlen(test3), (capi_checksum160*)tmp );
-   eosio_assert( my_memcmp((void *)test3_ok_ripe, &tmp, sizeof(tmp)), "ripemd160 test3" );
+   tmp = ripemd160( test4, my_strlen(test4) ).extract_as_byte_array();
+   eosio_assert( my_memcmp((void *)test4_ok_ripe, tmp.data(), tmp.size()), "ripemd160 test4" );
 
-   ::ripemd160( test4, my_strlen(test4), (capi_checksum160*)tmp );
-   eosio_assert( my_memcmp((void *)test4_ok_ripe, &tmp, sizeof(tmp)), "ripemd160 test4" );
-
-   ::ripemd160( test5, my_strlen(test5), (capi_checksum160*)tmp );
-   eosio_assert( my_memcmp((void *)test5_ok_ripe, &tmp, sizeof(tmp)), "ripemd160 test5" );
+   tmp = ripemd160( test5, my_strlen(test5) ).extract_as_byte_array();
+   eosio_assert( my_memcmp((void *)test5_ok_ripe, tmp.data(), tmp.size()), "ripemd160 test5" );
 }
 
 void test_crypto::sha256_null() {
-   unsigned char tmp[32];
-   ::sha256( nullptr, 100, (capi_checksum256*)tmp);
+   auto tmp = sha256( nullptr, 100 );
    eosio_assert( false, "should've thrown an error" );
 }
 
 void test_crypto::sha1_no_data() {
-   unsigned char tmp[20];
-   ::sha1( test2, my_strlen(test2), (capi_checksum160*)tmp );
-   eosio_assert( my_memcmp((void *)test2_ok_1, &tmp, sizeof(tmp)), "sha1 test2" );
+   auto tmp = sha1( test2, my_strlen(test2) ).extract_as_byte_array();
+   eosio_assert( my_memcmp((void *)test2_ok_1, tmp.data(), tmp.size()), "sha1 test2" );
 }
 
 void test_crypto::sha256_no_data() {
-   unsigned char tmp[32];
-   ::sha256( test2, my_strlen(test2), (capi_checksum256*)tmp );
-   eosio_assert( my_memcmp((void *)test2_ok_256, &tmp, sizeof(tmp)), "sha256 test2" );
+   auto tmp = sha256( test2, my_strlen(test2) ).extract_as_byte_array();
+   eosio_assert( my_memcmp((void *)test2_ok_256, tmp.data(), tmp.size()), "sha256 test2" );
 }
 
 void test_crypto::sha512_no_data() {
-   unsigned char tmp[64];
-   ::sha512( test2, my_strlen(test2), (capi_checksum512*)tmp );
-   eosio_assert( my_memcmp((void *)test2_ok_512, &tmp, sizeof(tmp)), "sha512 test2" );
+   auto tmp = sha512( test2, my_strlen(test2) ).extract_as_byte_array();
+   eosio_assert( my_memcmp((void *)test2_ok_512, tmp.data(), tmp.size()), "sha512 test2" );
 }
 
 void test_crypto::ripemd160_no_data() {
-   unsigned char tmp[20];
-   ::ripemd160( test2, my_strlen(test2), (capi_checksum160*)tmp );
-   eosio_assert( my_memcmp((void *)test2_ok_ripe, &tmp, sizeof(tmp)), "ripemd160 test2" );
+   auto tmp = ripemd160( test2, my_strlen(test2) ).extract_as_byte_array();
+   eosio_assert( my_memcmp((void *)test2_ok_ripe, tmp.data(), tmp.size()), "ripemd160 test2" );
 }
 
 
 void test_crypto::assert_sha256_false() {
-   unsigned char tmp[32];
-
-   ::sha256( test1, my_strlen(test1), (capi_checksum256*)tmp );
-   tmp[0] ^= (uint64_t)(-1);
+   auto tmp = sha256( test1, my_strlen(test1) );
+   tmp.data()[0] ^= (uint64_t)(-1);
    assert_sha256( test1, my_strlen(test1), tmp );
 
    eosio_assert( false, "should have failed" );
 }
 
 void test_crypto::assert_sha256_true() {
-   unsigned char tmp[32];
-   
-   ::sha256( test1, my_strlen(test1), (capi_checksum256*)tmp );
+   auto tmp = sha256( test1, my_strlen(test1) ).extract_as_byte_array();
    assert_sha256( test1, my_strlen(test1), tmp );
-   
-   ::sha256( test3, my_strlen(test3), (capi_checksum256*)tmp );
+
+   tmp = sha256( test3, my_strlen(test3) ).extract_as_byte_array();
    assert_sha256( test3, my_strlen(test3), tmp );
-   
-   ::sha256( test4, my_strlen(test4), (capi_checksum256*)tmp );
+
+   tmp = sha256( test4, my_strlen(test4) ).extract_as_byte_array();
    assert_sha256( test4, my_strlen(test4), tmp );
-   
-   ::sha256( test5, my_strlen(test5), (capi_checksum256*)tmp );
+
+   tmp = sha256( test5, my_strlen(test5) ).extract_as_byte_array();
    assert_sha256( test5, my_strlen(test5), tmp );
 }
 
 void test_crypto::assert_sha1_false() {
-   unsigned char tmp[20];
+   auto tmp = sha1( test1, my_strlen(test1) );
+   tmp.data()[0] ^= (uint64_t)(-1);
 
-   ::sha1( test1, my_strlen(test1), (capi_checksum160*)tmp );
-   tmp[0] ^= (uint64_t)(-1);
    assert_sha1( test1, my_strlen(test1), tmp );
-   
+
    eosio_assert( false, "should have failed" );
 }
 
 
 void test_crypto::assert_sha1_true() {
-   unsigned char tmp[20];
-
-   ::sha1( test1, my_strlen(test1), (capi_checksum160*)tmp );
+   auto tmp = sha1( test1, my_strlen(test1) );
    assert_sha1( test1, my_strlen(test1), tmp );
 
-   ::sha1( test3, my_strlen(test3), (capi_checksum160*)tmp );
+   tmp = sha1( test3, my_strlen(test3) );
    assert_sha1( test3, my_strlen(test3), tmp );
 
-   ::sha1( test4, my_strlen(test4), (capi_checksum160*)tmp);
+   tmp = sha1( test4, my_strlen(test4));
    assert_sha1( test4, my_strlen(test4), tmp );
 
-   ::sha1( test5, my_strlen(test5), (capi_checksum160*)tmp);
+   tmp = sha1( test5, my_strlen(test5));
    assert_sha1( test5, my_strlen(test5), tmp );
 }
 
 void test_crypto::assert_sha512_false() { 
-   unsigned char tmp[64];
-
-   ::sha512( test1, my_strlen(test1), (capi_checksum512*)tmp);
-   tmp[0] ^= (uint64_t)(-1);
+   auto tmp = sha512( test1, my_strlen(test1));
+   tmp.data()[0] ^= (uint64_t)(-1);
    assert_sha512( test1, my_strlen(test1), tmp );
-   
+
    eosio_assert(false, "should have failed");
 }
 
 
 void test_crypto::assert_sha512_true() {
-   unsigned char tmp[64];
-
-   ::sha512( test1, my_strlen(test1), (capi_checksum512*)tmp);
+   auto tmp = sha512( test1, my_strlen(test1));
    assert_sha512( test1, my_strlen(test1), tmp );
 
-   ::sha512( test3, my_strlen(test3), (capi_checksum512*)tmp);
-   assert_sha512( test3, my_strlen(test3), tmp );
+   tmp = sha512( test3, my_strlen(test3) );
+   assert_sha512( test3, my_strlen(test3) , tmp );
 
-   ::sha512( test4, my_strlen(test4), (capi_checksum512*)tmp);
+   tmp = sha512( test4, my_strlen(test4) );
    assert_sha512( test4, my_strlen(test4), tmp );
 
-   ::sha512( test5, my_strlen(test5), (capi_checksum512*)tmp);
+   tmp = sha512( test5, my_strlen(test5) );
    assert_sha512( test5, my_strlen(test5), tmp );
 }
 
 void test_crypto::assert_ripemd160_false() {
-   unsigned char tmp[20];
-
-   ::ripemd160( test1, my_strlen(test1), (capi_checksum160*)tmp);
-   tmp[0] ^= (uint64_t)(-1);
+   auto tmp = ripemd160( test1, my_strlen(test1));
+   tmp.data()[0] ^= (uint64_t)(-1);
    assert_ripemd160( test1, my_strlen(test1), tmp );
-   
+
    eosio_assert( false, "should have failed" );
 }
 
 
 void test_crypto::assert_ripemd160_true() {
-   unsigned char tmp[20];
-
-   ::ripemd160( test1, my_strlen(test1), (capi_checksum160*)tmp);
+   auto tmp = ripemd160( test1, my_strlen(test1) );
    assert_ripemd160( test1, my_strlen(test1), tmp );
 
-   ::ripemd160( test3, my_strlen(test3), (capi_checksum160*)tmp);
+   tmp = ripemd160( test3, my_strlen(test3) );
    assert_ripemd160( test3, my_strlen(test3), tmp );
 
-   ::ripemd160( test4, my_strlen(test4), (capi_checksum160*)tmp);
+   tmp = ripemd160( test4, my_strlen(test4) );
    assert_ripemd160( test4, my_strlen(test4), tmp );
 
-   ::ripemd160( test5, my_strlen(test5), (capi_checksum160*)tmp);
+   tmp = ripemd160( test5, my_strlen(test5) );
    assert_ripemd160( test5, my_strlen(test5), tmp );
 }
+

--- a/unittests/test-contracts/test_api/test_crypto.cpp
+++ b/unittests/test-contracts/test_api/test_crypto.cpp
@@ -1,6 +1,6 @@
-#include <eosiolib/crypto.h>
-#include <eosiolib/eosio.hpp>
-#include <eosiolib/print.hpp>
+#include <eosiolib/core/eosio/crypto.hpp>
+#include <eosiolib/contracts/eosio/eosio.hpp>
+#include <eosiolib/core/eosio/print.hpp>
 
 #include "test_api.hpp"
 

--- a/unittests/test-contracts/test_api/test_datastream.cpp
+++ b/unittests/test-contracts/test_api/test_datastream.cpp
@@ -1,7 +1,7 @@
 #include <cmath>
 
-#include <eosiolib/eosio.hpp>
-#include <eosiolib/datastream.hpp>
+#include <eosiolib/contracts/eosio/eosio.hpp>
+#include <eosiolib/core/eosio/datastream.hpp>
 
 #include "test_api.hpp"
 

--- a/unittests/test-contracts/test_api/test_datastream.cpp
+++ b/unittests/test-contracts/test_api/test_datastream.cpp
@@ -1,7 +1,7 @@
 #include <cmath>
 
-#include <eosiolib/contracts/eosio/eosio.hpp>
-#include <eosiolib/core/eosio/datastream.hpp>
+#include <eosio/eosio.hpp>
+#include <eosio/datastream.hpp>
 
 #include "test_api.hpp"
 

--- a/unittests/test-contracts/test_api/test_permission.cpp
+++ b/unittests/test-contracts/test_api/test_permission.cpp
@@ -1,11 +1,11 @@
 #include <limits>
 
-#include <eosiolib/action.hpp>
-#include <eosiolib/db.h>
-#include <eosiolib/eosio.hpp>
-#include <eosiolib/permission.h>
-#include <eosiolib/print.hpp>
-#include <eosiolib/serialize.hpp>
+#include <eosiolib/contracts/eosio/action.hpp>
+#include <eosiolib/capi/eosio/db.h>
+#include <eosiolib/contracts/eosio/eosio.hpp>
+#include <eosiolib/contracts/eosio/permission.hpp>
+#include <eosiolib/core/eosio/print.hpp>
+#include <eosiolib/core/eosio/serialize.hpp>
 
 #include "test_api.hpp"
 
@@ -27,11 +27,11 @@ void test_permission::check_authorization( uint64_t receiver, uint64_t code, uin
    auto self = receiver;
    auto params = unpack_action_data<check_auth_msg>();
    auto packed_pubkeys = pack(params.pubkeys);
-   int64_t res64 = ::check_permission_authorization( params.account.value,
-                                                     params.permission.value,
+   int64_t res64 = eosio::check_permission_authorization( params.account,
+                                                     params.permission,
                                                      packed_pubkeys.data(), packed_pubkeys.size(),
                                                      (const char*)0,        0,
-                                                     static_cast<uint64_t>( std::numeric_limits<int64_t>::max() )
+                                                     microseconds{ std::numeric_limits<int64_t>::max() }
                                                    );
 
    auto itr = db_lowerbound_i64( self, self, self, 1 );
@@ -57,7 +57,8 @@ void test_permission::test_permission_last_used( uint64_t /* receiver */, uint64
 
    auto params = unpack_action_data<test_permission_last_used_msg>();
 
-   eosio_assert( get_permission_last_used(params.account.value, params.permission.value) == params.last_used_time, "unexpected last used permission time" );
+   time_point msec{ microseconds{params.last_used_time}};
+   eosio_assert( eosio::get_permission_last_used(params.account, params.permission) == msec, "unexpected last used permission time" );
 }
 
 void test_permission::test_account_creation_time( uint64_t /* receiver */, uint64_t code, uint64_t action ) {
@@ -67,5 +68,6 @@ void test_permission::test_account_creation_time( uint64_t /* receiver */, uint6
 
    auto params = unpack_action_data<test_permission_last_used_msg>();
 
-   eosio_assert( get_account_creation_time(params.account.value) == params.last_used_time, "unexpected account creation time" );
+   time_point msec{ microseconds{params.last_used_time}};
+   eosio_assert( eosio::get_account_creation_time(params.account) == msec, "unexpected account creation time" );
 }

--- a/unittests/test-contracts/test_api/test_permission.cpp
+++ b/unittests/test-contracts/test_api/test_permission.cpp
@@ -1,11 +1,10 @@
 #include <limits>
 
-#include <eosiolib/contracts/eosio/action.hpp>
-#include <eosiolib/capi/eosio/db.h>
-#include <eosiolib/contracts/eosio/eosio.hpp>
-#include <eosiolib/contracts/eosio/permission.hpp>
-#include <eosiolib/core/eosio/print.hpp>
-#include <eosiolib/core/eosio/serialize.hpp>
+#include <eosio/action.hpp>
+#include <eosio/eosio.hpp>
+#include <eosio/permission.hpp>
+#include <eosio/print.hpp>
+#include <eosio/serialize.hpp>
 
 #include "test_api.hpp"
 

--- a/unittests/test-contracts/test_api/test_print.cpp
+++ b/unittests/test-contracts/test_api/test_print.cpp
@@ -1,6 +1,9 @@
-#include <eosiolib/eosio.hpp>
+ #include <eosiolib/contracts/eosio/eosio.hpp>
+ #include <eosiolib/core/eosio/print.hpp>
 
 #include "test_api.hpp"
+
+using namespace eosio::internal_use_do_not_use;
 
 void test_print::test_prints_l() {
   char ab[] = { 'a', 'b' };

--- a/unittests/test-contracts/test_api/test_print.cpp
+++ b/unittests/test-contracts/test_api/test_print.cpp
@@ -1,5 +1,5 @@
- #include <eosiolib/contracts/eosio/eosio.hpp>
- #include <eosiolib/core/eosio/print.hpp>
+ #include <eosio/eosio.hpp>
+ #include <eosio/print.hpp>
 
 #include "test_api.hpp"
 

--- a/unittests/test-contracts/test_api/test_transaction.cpp
+++ b/unittests/test-contracts/test_api/test_transaction.cpp
@@ -1,6 +1,6 @@
-#include <eosiolib/action.hpp>
-#include <eosiolib/crypto.h>
-#include <eosiolib/transaction.hpp>
+#include <eosiolib/contracts/eosio/action.hpp>
+#include <eosiolib/capi/eosio/crypto.h>
+#include <eosiolib/contracts/eosio/transaction.hpp>
 
 #include "test_api.hpp"
 
@@ -105,7 +105,7 @@ void test_transaction::send_action_large() {
 void test_transaction::send_action_recurse() {
    using namespace eosio;
    char buffer[1024];
-   read_action_data( buffer, 1024 );
+   eosio::read_action_data( buffer, 1024 );
 
    test_action_action<"testapi"_n.value, WASM_TEST_ACTION( "test_transaction", "send_action_recurse" )> test_action;
    copy_data( buffer, 1024, test_action.data );
@@ -132,23 +132,23 @@ void test_transaction::send_action_inline_fail() {
 void test_transaction::test_tapos_block_prefix() {
    using namespace eosio;
    int tbp;
-   read_action_data( (char*)&tbp, sizeof(int) );
-   eosio_assert( tbp == tapos_block_prefix(), "tapos_block_prefix does not match" );
+   eosio::read_action_data( (char*)&tbp, sizeof(int) );
+   eosio_assert( tbp == eosio::tapos_block_prefix(), "tapos_block_prefix does not match" );
 }
 
 void test_transaction::test_tapos_block_num() {
    using namespace eosio;
    int tbn;
-   read_action_data( (char*)&tbn, sizeof(int) );
-   eosio_assert( tbn == tapos_block_num(), "tapos_block_num does not match" );
+   eosio::read_action_data( (char*)&tbn, sizeof(int) );
+   eosio_assert( tbn == eosio::tapos_block_num(), "tapos_block_num does not match" );
 }
 
 void test_transaction::test_read_transaction() {
    using namespace eosio;
    checksum256 h;
-   auto size = transaction_size();
+   auto size = eosio::transaction_size();
    char buf[size];
-   uint32_t read = read_transaction( buf, size );
+   uint32_t read = eosio::read_transaction( buf, size );
    eosio_assert( size == read, "read_transaction failed");
    h = eosio::sha256(buf, read);
    print(h);
@@ -157,9 +157,9 @@ void test_transaction::test_read_transaction() {
 void test_transaction::test_transaction_size() {
    using namespace eosio;
    uint32_t trans_size = 0;
-   read_action_data( (char*)&trans_size, sizeof(uint32_t) );
-   print( "size: ", transaction_size() );
-   eosio_assert( trans_size == transaction_size(), "transaction size does not match" );
+   eosio::read_action_data( (char*)&trans_size, sizeof(uint32_t) );
+   print( "size: ", eosio::transaction_size() );
+   eosio_assert( trans_size == eosio::transaction_size(), "transaction size does not match" );
 }
 
 void test_transaction::send_transaction(uint64_t receiver, uint64_t, uint64_t) {
@@ -179,7 +179,7 @@ void test_transaction::send_transaction(uint64_t receiver, uint64_t, uint64_t) {
 void test_transaction::send_action_sender( uint64_t receiver, uint64_t, uint64_t ) {
    using namespace eosio;
    uint64_t cur_send;
-   read_action_data( &cur_send, sizeof(name) );
+   eosio::read_action_data( &cur_send, sizeof(name) );
 
    auto trx = transaction();
    std::vector<permission_level> permissions = { {"testapi"_n, "active"_n} };
@@ -269,7 +269,7 @@ void test_transaction::send_deferred_transaction_replace( uint64_t receiver, uin
 void test_transaction::send_deferred_tx_with_dtt_action() {
    using namespace eosio;
    dtt_action dtt_act;
-   read_action_data( &dtt_act, action_data_size() );
+   eosio::read_action_data( &dtt_act, eosio::action_data_size() );
 
    action deferred_act;
    deferred_act.account = name{dtt_act.deferred_account};
@@ -285,13 +285,13 @@ void test_transaction::send_deferred_tx_with_dtt_action() {
 
 void test_transaction::cancel_deferred_transaction_success() {
    using namespace eosio;
-   auto r = cancel_deferred( 0xffffffffffffffff ); //use the same id (0) as in send_deferred_transaction
+   auto r = eosio::cancel_deferred( 0xffffffffffffffff ); //use the same id (0) as in send_deferred_transaction
    eosio_assert( (bool)r, "transaction was not found" );
 }
 
 void test_transaction::cancel_deferred_transaction_not_found() {
    using namespace eosio;
-   auto r = cancel_deferred( 0xffffffffffffffff ); //use the same id (0) as in send_deferred_transaction
+   auto r = eosio::cancel_deferred( 0xffffffffffffffff ); //use the same id (0) as in send_deferred_transaction
    eosio_assert( !r, "transaction was canceled, whild should not be found" );
 }
 
@@ -315,7 +315,7 @@ void test_transaction::stateful_api() {
 
 void test_transaction::context_free_api() {
    char buf[128] = {0};
-   get_context_free_data( 0, buf, sizeof(buf) );
+   eosio::get_context_free_data( 0, buf, sizeof(buf) );
 }
 
 void test_transaction::repeat_deferred_transaction( uint64_t receiver, uint64_t code, uint64_t action ) {
@@ -326,7 +326,7 @@ void test_transaction::repeat_deferred_transaction( uint64_t receiver, uint64_t 
    uint32_t payload = unpack_action_data<uint32_t>();
    print("repeat_deferred_transaction called: payload = ", payload);
 
-   bool res = cancel_deferred( sender_id );
+   bool res = eosio::cancel_deferred( sender_id );
 
    print("\nrepeat_deferred_transaction cancelled trx with sender_id = ", sender_id, ", result is ", res);
 

--- a/unittests/test-contracts/test_api/test_transaction.cpp
+++ b/unittests/test-contracts/test_api/test_transaction.cpp
@@ -1,6 +1,6 @@
-#include <eosiolib/contracts/eosio/action.hpp>
-#include <eosiolib/capi/eosio/crypto.h>
-#include <eosiolib/contracts/eosio/transaction.hpp>
+#include <eosio/action.hpp>
+#include <eosio/crypto.hpp>
+#include <eosio/transaction.hpp>
 
 #include "test_api.hpp"
 

--- a/unittests/test-contracts/test_api/test_types.cpp
+++ b/unittests/test-contracts/test_api/test_types.cpp
@@ -1,4 +1,4 @@
-#include <eosiolib/eosio.hpp>
+#include <eosiolib/contracts/eosio/eosio.hpp>
 
 #include "test_api.hpp"
 

--- a/unittests/test-contracts/test_api/test_types.cpp
+++ b/unittests/test-contracts/test_api/test_types.cpp
@@ -1,4 +1,4 @@
-#include <eosiolib/contracts/eosio/eosio.hpp>
+#include <eosio/eosio.hpp>
 
 #include "test_api.hpp"
 


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->
Since the removal of those deprecated headers in eosio.cdt v1.7.x,  it is not possible to build EOSIO with -DEOSIO_COMPILE_TEST_CONTRACTS=true with an installed version of eosio.cdt of 1.7.x or later. 
https://blockone.atlassian.net/browse/EPE-37
## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
#1. Changed include path from eosiolib/* to eosiolib/capi/, eosiolib/core/, eosiolib/contracts/*.
#2. Added namespace if call to a function is ambiguous
#3. Handled function arguments changes.

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
