### PR TITLE
add get(char) to fc::cfile; allowing fc::cfile to be used as a datastream

### DIFF
--- a/libraries/fc/include/fc/io/cfile.hpp
+++ b/libraries/fc/include/fc/io/cfile.hpp
@@ -84,6 +84,10 @@ public:
       }
    }
 
+   void get(char& c) {
+      read(&c, 1);
+   }
+
    void write( const char* d, size_t n ) {
       size_t result = fwrite( d, 1, n, _file.get() );
       if( result != n ) {


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
Before this PR I could do something like

```c++
         fc::cfile file;
         file.set_file_path(amqp_data_file);
         file.open("wb");
         fc::raw::pack(file, message_deque);
```
But to do

```c++
         fc::cfile file;
         file.set_file_path(amqp_data_file);
         file.open("rb");
         fc::raw::unpack(file, message_deque);
```
I need get(char) implemented on `fc::cfile`.

This seems pretty neat and useful.

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
