### PR TITLE
Exit on rodeos filter wasm error

### DIFF
--- a/libraries/rodeos/rodeos.cpp
+++ b/libraries/rodeos/rodeos.cpp
@@ -245,14 +245,24 @@ void rodeos_filter::process(rodeos_db_snapshot& snapshot, const ship_protocol::g
    backend->initialize(&cb);
    try {
       (*backend)(cb, "env", "apply", uint64_t(0), uint64_t(0), uint64_t(0));
+
+      if (!filter_state->console.empty())
+         ilog("filter ${n} console output: <<<\n${c}>>>", ("n", name.to_string())("c", filter_state->console));
    } catch (...) {
+      try {
+         throw;
+      } catch( const std::exception& e ) {
+         elog( "std::exception processing filter wasm: ${e}", ("e", e.what()) );
+      } catch( const fc::exception& e ) {
+         elog( "fc::exception processing filter wasm: ${e}", ("e", e.to_detail_string()) );
+      } catch( ... ) {
+         elog( "unknown exception processing filter wasm" );
+      }
       if (!filter_state->console.empty())
          ilog("filter ${n} console output before exception: <<<\n${c}>>>",
               ("n", name.to_string())("c", filter_state->console));
       throw;
    }
-   if (!filter_state->console.empty())
-      ilog("filter ${n} console output: <<<\n${c}>>>", ("n", name.to_string())("c", filter_state->console));
 }
 
 rodeos_query_handler::rodeos_query_handler(std::shared_ptr<rodeos_db_partition>         partition,

--- a/programs/rodeos/ship_client.hpp
+++ b/programs/rodeos/ship_client.hpp
@@ -199,8 +199,6 @@ struct connection : std::enable_shared_from_this<connection> {
       if (callbacks)
          callbacks->closed(retry);
       callbacks.reset();
-      if (!retry)
-         appbase::app().quit();
    }
 }; // connection
 

--- a/programs/rodeos/ship_client.hpp
+++ b/programs/rodeos/ship_client.hpp
@@ -199,6 +199,8 @@ struct connection : std::enable_shared_from_this<connection> {
       if (callbacks)
          callbacks->closed(retry);
       callbacks.reset();
+      if (!retry)
+         appbase::app().quit();
    }
 }; // connection
 


### PR DESCRIPTION
## Change Description

- Report filter wasm exceptions as errors so it is clear exception is from the filter wasm.
- Add option `clone-exit-on-filter-wasm-error` to `cloner_plugin` which is part of `rodeos` defaults to false. If enabled, it will shutdown rodeos on error.

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [x] Documentation Additions

- New rodeos option `clone-exit-on-filter-wasm-error` - `Shutdown application if filter wasm throws an exception`
