### PR TITLE
amqp_witness_plugin: sign blocks as non-producer and publish over AMQP

### DIFF
--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -19,6 +19,7 @@ add_subdirectory(db_size_api_plugin)
 add_subdirectory(login_plugin)
 add_subdirectory(test_control_plugin)
 add_subdirectory(test_control_api_plugin)
+add_subdirectory(amqp_witness_plugin)
 
 # Forward variables to top level so packaging picks them up
 set(CPACK_DEBIAN_PACKAGE_DEPENDS ${CPACK_DEBIAN_PACKAGE_DEPENDS} PARENT_SCOPE)

--- a/plugins/amqp_witness_plugin/CMakeLists.txt
+++ b/plugins/amqp_witness_plugin/CMakeLists.txt
@@ -1,0 +1,7 @@
+file(GLOB HEADERS "include/eosio/amqp_witness_plugin/*.hpp")
+add_library( amqp_witness_plugin
+             amqp_witness_plugin.cpp
+             ${HEADERS} )
+
+target_link_libraries( amqp_witness_plugin appbase fc signature_provider_plugin chain_plugin amqpcpp reliable_amqp_publisher)
+target_include_directories( amqp_witness_plugin PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" )

--- a/plugins/amqp_witness_plugin/amqp_witness_plugin.cpp
+++ b/plugins/amqp_witness_plugin/amqp_witness_plugin.cpp
@@ -23,7 +23,7 @@ struct amqp_witness_plugin_impl {
    std::unique_ptr<reliable_amqp_publisher> rqueue;
 
    struct amqp_witness_msg {
-      bool is_sig_digest;
+      bool is_sig_digest = false;
       chain::digest_type digest;
       chain::signature_type sig;
    };

--- a/plugins/amqp_witness_plugin/amqp_witness_plugin.cpp
+++ b/plugins/amqp_witness_plugin/amqp_witness_plugin.cpp
@@ -1,0 +1,122 @@
+#include <eosio/amqp_witness_plugin/amqp_witness_plugin.hpp>
+#include <eosio/chain/types.hpp>
+
+#include <eosio/reliable_amqp_publisher/reliable_amqp_publisher.hpp>
+
+namespace eosio {
+static appbase::abstract_plugin& _amqp_witness_plugin = app().register_plugin<amqp_witness_plugin>();
+
+struct amqp_witness_plugin_impl {
+   enum class witness_signature_over {
+      action_mroot,
+      sig_digest
+   };
+
+   signature_provider_plugin::signature_provider_type signature_provider;
+   unsigned staleness_limit;
+   std::string amqp_server;
+   std::string exchange;
+   witness_signature_over witness_signature_type;
+   bool delete_previous = false;
+
+   std::unique_ptr<reliable_amqp_publisher> rqueue;
+
+   struct amqp_witness_msg {
+      bool is_sig_digest;
+      chain::digest_type digest;
+      chain::signature_type sig;
+   };
+};
+
+std::ostream& operator<<(std::ostream& os, const amqp_witness_plugin_impl::witness_signature_over wso) {
+   if(wso == amqp_witness_plugin_impl::witness_signature_over::action_mroot)
+      os << "action_mroot";
+   else
+      os << "sig_digest";
+   return os;
+}
+
+std::istream& operator>>(std::istream& is, amqp_witness_plugin_impl::witness_signature_over& wso) {
+   std::string s;
+   is >> s;
+   if (s == "action_mroot")
+      wso = amqp_witness_plugin_impl::witness_signature_over::action_mroot;
+   else if (s == "sig_digest")
+      wso = amqp_witness_plugin_impl::witness_signature_over::sig_digest;
+   else
+      is.setstate(std::ios_base::failbit);
+   return is;
+}
+
+amqp_witness_plugin::amqp_witness_plugin() : my(new amqp_witness_plugin_impl()) {
+   app().register_config_type<amqp_witness_plugin_impl::witness_signature_over>();
+}
+
+void amqp_witness_plugin::set_program_options(options_description& cli, options_description& cfg) {
+   auto default_priv_key = eosio::chain::private_key_type::regenerate<fc::ecc::private_key_shim>(fc::sha256::hash(std::string("witness")));
+
+   cfg.add_options()
+         ("witness-signature-provider", boost::program_options::value<string>()->default_value(
+               default_priv_key.get_public_key().to_string() + "=KEY:" + default_priv_key.to_string()),
+               app().get_plugin<signature_provider_plugin>().signature_provider_help_text())
+         ("witness-staleness-limit", boost::program_options::value<unsigned>()->default_value(600)->notifier([this](const unsigned& v) {
+                  my->staleness_limit = v;
+               }), "Blocks older than this many seconds are not signed by the witness plugin")
+         ("witness-amqp-server", boost::program_options::value<string>()->default_value("amqp://")->notifier([this](const string& v) {
+                  my->amqp_server = v;
+               }), "AMQP server to send witness signatures in form of amqp://user:password@host:port/vhost")
+         ("witness-amqp-exchange", boost::program_options::value<string>()->default_value("witness_signatures")->notifier([this](const string& v) {
+                  my->exchange = v;
+               }), "Existing AMQP exchange to send witness signature messages to")
+         ("witness-signature-type", boost::program_options::value<amqp_witness_plugin_impl::witness_signature_over>()
+                                    ->default_value(amqp_witness_plugin_impl::witness_signature_over::action_mroot)->value_name("action_mroot/block_id")
+                                    ->notifier([this](const amqp_witness_plugin_impl::witness_signature_over& v) {
+                  my->witness_signature_type = v;
+               }), "What the witness signature should sign:\n"
+                   "\"action_mroot\": signs the action_mroot of a block\n"
+                   "\"block_id\": signs the block id of a block\n"
+                   "Appropriate value is application specific. e.g. a light validator may need block_id, but simply validating actions in blocks only needs action_mroot."
+               )
+         ;
+
+   cli.add_options()
+         ("witness-delete-unsent", boost::program_options::bool_switch(&my->delete_previous), "Delete unsent witness signature messages retained from previous connections");
+}
+
+void amqp_witness_plugin::plugin_initialize(const variables_map& options) {
+   try {
+      const auto& [pubkey, provider] = app().get_plugin<signature_provider_plugin>().signature_provider_for_specification(options["witness-signature-provider"].as<std::string>());
+      my->signature_provider = provider;
+   }
+   FC_LOG_AND_RETHROW()
+}
+
+void amqp_witness_plugin::plugin_startup() {
+   const boost::filesystem::path witness_data_file_path = appbase::app().data_dir() / "amqp" / "witness.bin";
+
+   if(boost::filesystem::exists(witness_data_file_path) && my->delete_previous)
+      boost::filesystem::remove(witness_data_file_path);
+
+   my->rqueue = std::make_unique<reliable_amqp_publisher>(my->amqp_server, my->exchange, witness_data_file_path);
+
+   app().get_plugin<chain_plugin>().chain().irreversible_block.connect([&](const chain::block_state_ptr& bsp) {
+      if(bsp->block->timestamp.to_time_point() < fc::time_point::now() - fc::seconds(my->staleness_limit))
+         return;
+
+      my->rqueue->post_on_io_context([this, bsp]() {
+         amqp_witness_plugin_impl::amqp_witness_msg msg = {
+            .is_sig_digest = my->witness_signature_type == amqp_witness_plugin_impl::witness_signature_over::sig_digest,
+            .digest = msg.is_sig_digest ? bsp->sig_digest() : bsp->header.action_mroot,
+            .sig = my->signature_provider(msg.digest)
+         };
+
+         my->rqueue->publish_message(msg);
+      });
+   });
+}
+
+void amqp_witness_plugin::plugin_shutdown() {}
+
+}
+
+FC_REFLECT(eosio::amqp_witness_plugin_impl::amqp_witness_msg, (is_sig_digest)(digest)(sig));

--- a/plugins/amqp_witness_plugin/include/eosio/amqp_witness_plugin/amqp_witness_plugin.hpp
+++ b/plugins/amqp_witness_plugin/include/eosio/amqp_witness_plugin/amqp_witness_plugin.hpp
@@ -1,0 +1,28 @@
+#pragma once
+#include <appbase/application.hpp>
+#include <eosio/signature_provider_plugin/signature_provider_plugin.hpp>
+#include <eosio/chain_plugin/chain_plugin.hpp>
+
+namespace eosio {
+
+using namespace appbase;
+
+/**
+ *  This is a template plugin, intended to serve as a starting point for making new plugins
+ */
+class amqp_witness_plugin : public appbase::plugin<amqp_witness_plugin> {
+public:
+   amqp_witness_plugin();
+
+   APPBASE_PLUGIN_REQUIRES((signature_provider_plugin)(chain_plugin))
+   virtual void set_program_options(options_description& cli, options_description& cfg) override;
+
+   void plugin_initialize(const variables_map& options);
+   void plugin_startup();
+   void plugin_shutdown();
+
+private:
+   std::unique_ptr<struct amqp_witness_plugin_impl> my;
+};
+
+}

--- a/programs/nodeos/CMakeLists.txt
+++ b/programs/nodeos/CMakeLists.txt
@@ -57,6 +57,7 @@ target_link_libraries( ${NODE_EXECUTABLE_NAME}
         PRIVATE -Wl,${whole_archive_flag} producer_api_plugin        -Wl,${no_whole_archive_flag}
         PRIVATE -Wl,${whole_archive_flag} test_control_plugin        -Wl,${no_whole_archive_flag}
         PRIVATE -Wl,${whole_archive_flag} test_control_api_plugin    -Wl,${no_whole_archive_flag}
+        PRIVATE -Wl,${whole_archive_flag} amqp_witness_plugin        -Wl,${no_whole_archive_flag}
         PRIVATE -Wl,${build_id_flag}
         PRIVATE chain_plugin http_plugin producer_plugin http_client_plugin
         PRIVATE eosio_chain_wrap fc ${CMAKE_DL_LIBS} ${PLATFORM_SPECIFIC_LIBS} )


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
A _witness_ is, conceptually, a node that signs a block attesting that the entire contents of the block are valid. A producer is a witness. This plugin extends the concept to a non-producing node. When the plugin is activated irreversible blocks are signed and those signatures are published to an AMQP exchange.

An AMQP server and existing exchange must be specified. The plugin is able to use any existing signature provider: a soft key specified in the config, keosd, or a Secure Enclave key. Blocks older than a specified age will not be signed -- useful for sync or replay.

Either the block’s signature digest or simply its action merkle root is reported in the message and what is signed. I believe this is appropriate to identify the block for both applications considered. A stateful application, like a light validator, will know the block signature digest it is seeking witness signatures for. A stateless application, like an application that is only inspecting action receipts, only wishes to know that the action receipt merkle proof for a block satisfies a merkle root that a witness has signed.

This plugin communicates to the AMQP server via the reliable_amqp_publisher for increased publishing reliability.

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [X] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
Yes big time; a new plugin and the start of more AMQP support throughout nodeos.