### PR TITLE
Add unity build support for some targets

### DIFF
--- a/.cicd/build.sh
+++ b/.cicd/build.sh
@@ -2,7 +2,7 @@
 set -eo pipefail
 . ./.cicd/helpers/general.sh
 mkdir -p $BUILD_DIR
-CMAKE_EXTRAS="-DCMAKE_BUILD_TYPE='Release' -DENABLE_MULTIVERSION_PROTOCOL_TEST=true"
+CMAKE_EXTRAS="-DCMAKE_BUILD_TYPE='Release' -DENABLE_MULTIVERSION_PROTOCOL_TEST=true -DENABLE_UNITY_BUILD=ON"
 if [[ "$(uname)" == 'Darwin' && $FORCE_LINUX != true ]]; then
     # You can't use chained commands in execute
     if [[ "$GITHUB_ACTIONS" == 'true' ]]; then

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,12 @@ if ("${CMAKE_GENERATOR}" STREQUAL "Ninja")
    add_compile_options(-fdiagnostics-color=always)
 endif()
 
-set(CMAKE_EXPORT_COMPILE_COMMANDS "ON")
+if (ENABLE_UNITY_BUILD)
+  set(CMAKE_EXPORT_COMPILE_COMMANDS "OFF")
+else()
+  set(CMAKE_EXPORT_COMPILE_COMMANDS "ON")
+endif()
+
 set(BUILD_DOXYGEN FALSE CACHE BOOL "Build doxygen documentation on every make")
 set(ENABLE_MULTIVERSION_PROTOCOL_TEST FALSE CACHE BOOL "Enable nodeos multiversion protocol test")
 

--- a/libraries/chain/CMakeLists.txt
+++ b/libraries/chain/CMakeLists.txt
@@ -140,6 +140,10 @@ target_include_directories( eosio_chain
 add_library(eosio_chain_wrap INTERFACE )
 target_link_libraries(eosio_chain_wrap INTERFACE eosio_chain)
 
+if(ENABLE_UNITY_BUILD)
+   set_target_properties(eosio_chain PROPERTIES UNITY_BUILD TRUE)
+endif() 
+
 if("eos-vm-oc" IN_LIST EOSIO_WASM_RUNTIMES)
    target_link_libraries(eosio_chain_wrap INTERFACE "-Wl,-wrap=main")
 endif()

--- a/libraries/chainbase/CMakeLists.txt
+++ b/libraries/chainbase/CMakeLists.txt
@@ -67,6 +67,10 @@ add_library( chainbase src/chainbase.cpp src/pinnable_mapped_file.cpp ${HEADERS}
 target_link_libraries( chainbase Boost::filesystem ${PLATFORM_LIBRARIES} )
 target_include_directories( chainbase PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" )
 
+if(ENABLE_UNITY_BUILD)
+   set_target_properties(chainbase PROPERTIES UNITY_BUILD TRUE)
+endif() 
+
 if(WIN32)
    target_link_libraries( chainbase ws2_32 mswsock )
 endif()

--- a/libraries/fc/CMakeLists.txt
+++ b/libraries/fc/CMakeLists.txt
@@ -123,6 +123,11 @@ list(APPEND sources ${fc_headers})
 
 setup_library( fc SOURCES ${sources} LIBRARY_TYPE STATIC DONT_INSTALL_LIBRARY )
 
+if(ENABLE_UNITY_BUILD)
+   set_target_properties(fc PROPERTIES UNITY_BUILD TRUE)
+endif() 
+
+
 function(detect_thread_name)
   include(CheckSymbolExists)
   list(APPEND CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)

--- a/libraries/fc/src/crypto/elliptic_secp256k1.cpp
+++ b/libraries/fc/src/crypto/elliptic_secp256k1.cpp
@@ -63,10 +63,11 @@ namespace fc { namespace ecc {
     }
 
     static const public_key_data empty_pub;
-    static const private_key_secret empty_priv;
+    
 
     fc::sha512 private_key::get_shared_secret( const public_key& other )const
     {
+      static const private_key_secret empty_priv;
       FC_ASSERT( my->_key != empty_priv );
       FC_ASSERT( other.my->_key != empty_pub );
       public_key_data pub(other.my->_key);

--- a/libraries/fc/src/crypto/private_key.cpp
+++ b/libraries/fc/src/crypto/private_key.cpp
@@ -88,7 +88,7 @@ namespace fc { namespace crypto {
       return Data(fc::variant(key_bytes).as<typename Data::data_type>());
    }
 
-   static private_key::storage_type parse_base58(const string& base58str)
+   static private_key::storage_type priv_parse_base58(const string& base58str)
    {
       const auto pivot = base58str.find('_');
 
@@ -108,7 +108,7 @@ namespace fc { namespace crypto {
    }
 
    private_key::private_key(const std::string& base58str)
-   :_storage(parse_base58(base58str))
+   :_storage(priv_parse_base58(base58str))
    {}
 
    std::string private_key::to_string(const fc::yield_function_t& yield) const
@@ -118,7 +118,7 @@ namespace fc { namespace crypto {
       if (which == 0) {
          using default_type = storage_type::template type_at<0>;
          return to_wif(_storage.template get<default_type>(), yield);
-      }
+      }      
 
       auto data_str = _storage.visit(base58str_visitor<storage_type, config::private_key_prefix>(yield));
       return std::string(config::private_key_base_prefix) + "_" + data_str;

--- a/libraries/fc/src/crypto/private_key.cpp
+++ b/libraries/fc/src/crypto/private_key.cpp
@@ -118,7 +118,7 @@ namespace fc { namespace crypto {
       if (which == 0) {
          using default_type = storage_type::template type_at<0>;
          return to_wif(_storage.template get<default_type>(), yield);
-      }      
+      }
 
       auto data_str = _storage.visit(base58str_visitor<storage_type, config::private_key_prefix>(yield));
       return std::string(config::private_key_base_prefix) + "_" + data_str;

--- a/libraries/fc/src/crypto/signature.cpp
+++ b/libraries/fc/src/crypto/signature.cpp
@@ -16,7 +16,7 @@ namespace fc { namespace crypto {
       }
    };
 
-   static signature::storage_type parse_base58(const std::string& base58str)
+   static signature::storage_type sig_parse_base58(const std::string& base58str)
    { try {
       constexpr auto prefix = config::signature_base_prefix;
 
@@ -32,7 +32,7 @@ namespace fc { namespace crypto {
    } FC_RETHROW_EXCEPTIONS( warn, "error parsing signature", ("str", base58str ) ) }
 
    signature::signature(const std::string& base58str)
-      :_storage(parse_base58(base58str))
+      :_storage(sig_parse_base58(base58str))
    {}
 
    int signature::which() const {

--- a/libraries/rodeos/CMakeLists.txt
+++ b/libraries/rodeos/CMakeLists.txt
@@ -14,3 +14,7 @@ target_link_libraries( rodeos_lib
 target_include_directories( rodeos_lib
                             PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include"
                           )
+
+if(ENABLE_UNITY_BUILD)
+   set_target_properties(rodeos_lib PROPERTIES UNITY_BUILD TRUE)
+endif() 

--- a/libraries/rodeos/include/b1/rodeos/rodeos.hpp
+++ b/libraries/rodeos/include/b1/rodeos/rodeos.hpp
@@ -1,3 +1,4 @@
+#pragma once
 #include <b1/chain_kv/chain_kv.hpp>
 #include <b1/rodeos/filter.hpp>
 #include <b1/rodeos/wasm_ql.hpp>

--- a/libraries/state_history/CMakeLists.txt
+++ b/libraries/state_history/CMakeLists.txt
@@ -16,3 +16,7 @@ target_link_libraries( state_history
 target_include_directories( state_history
                             PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include"
                           )
+
+if(ENABLE_UNITY_BUILD)
+   set_target_properties(state_history PROPERTIES UNITY_BUILD TRUE)
+endif() 

--- a/libraries/state_history/trace_converter.cpp
+++ b/libraries/state_history/trace_converter.cpp
@@ -5,7 +5,7 @@
 #include <eosio/state_history/compression.hpp>
 #include <eosio/state_history/serialization.hpp>
 #include <eosio/state_history/trace_converter.hpp>
-extern const char* state_history_plugin_abi;
+extern const char* const state_history_plugin_abi;
 
 namespace bio = boost::iostreams;
 namespace eosio {


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
This PR add support to enable cmake unity build for certain targets. Enabling unity build can significantly improve the build time for the project. However, it's not possible enable it globally with CMAKE_UNITY_BUILD because some of the libraries/submodules requires modification to make it work. This PR uses ENABLE_UNITY_BUILD flag to enable unity build for the targets don't have problem with it. 



## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
