### PR TITLE
Fix onblock handling in trace_api_plugin - develop

### DIFF
--- a/plugins/trace_api_plugin/include/eosio/trace_api/chain_extraction.hpp
+++ b/plugins/trace_api_plugin/include/eosio/trace_api/chain_extraction.hpp
@@ -84,7 +84,7 @@ private:
          std::vector<transaction_trace_v1>& traces = bt.transactions_v1;
          traces.reserve( block_state->block->transactions.size() + 1 );
          if( onblock_trace )
-            traces.emplace_back( to_transaction_trace_v1( {*onblock_trace} ));
+            traces.emplace_back( to_transaction_trace_v1( *onblock_trace ));
          for( const auto& r : block_state->block->transactions ) {
             transaction_id_type id;
             if( r.trx.contains<transaction_id_type>()) {

--- a/plugins/trace_api_plugin/include/eosio/trace_api/chain_extraction.hpp
+++ b/plugins/trace_api_plugin/include/eosio/trace_api/chain_extraction.hpp
@@ -61,7 +61,7 @@ private:
          return;
       }
       if( is_onblock( trace )) {
-         onblock_trace.emplace( trace );
+         onblock_trace.emplace( cache_trace{trace, t} );
       } else if( trace->failed_dtrx_trace ) {
          cached_traces[trace->failed_dtrx_trace->id] = {trace, t};
       } else {
@@ -119,7 +119,7 @@ private:
    StoreProvider                                                store;
    exception_handler                                            except_handler;
    std::map<transaction_id_type, cache_trace>                   cached_traces;
-   fc::optional<chain::transaction_trace_ptr>                   onblock_trace;
+   fc::optional<cache_trace>                                    onblock_trace;
 
 };
 


### PR DESCRIPTION
## Change Description

- New additions to reported traces in #9047 did not account for `onblock`
- Fixes a crash on startup for `--plugin eosio::trace_api_plugin -e`
- Release 2.0.x version #9127 

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
