### PR TITLE
Fix onblock handling in trace_api_plugin - 2.0

### DIFF
--- a/plugins/trace_api_plugin/include/eosio/trace_api/chain_extraction.hpp
+++ b/plugins/trace_api_plugin/include/eosio/trace_api/chain_extraction.hpp
@@ -42,7 +42,7 @@ public:
 
 private:
    static bool is_onblock(const chain::transaction_trace_ptr& p) {
-      if (p->action_traces.size() != 1)
+      if (p->action_traces.empty())
          return false;
       const auto& act = p->action_traces[0].act;
       if (act.account != eosio::chain::config::system_account_name || act.name != N(onblock) ||
@@ -61,7 +61,7 @@ private:
          return;
       }
       if( is_onblock( trace )) {
-         onblock_trace.emplace( trace );
+         onblock_trace.emplace( cache_trace{trace, static_cast<const chain::transaction_header&>(t), t.signatures} );
       } else if( trace->failed_dtrx_trace ) {
          cached_traces[trace->failed_dtrx_trace->id] = {trace, static_cast<const chain::transaction_header&>(t), t.signatures};
       } else {
@@ -84,7 +84,7 @@ private:
          std::vector<transaction_trace_v1>& traces = bt.transactions_v1;
          traces.reserve( block_state->block->transactions.size() + 1 );
          if( onblock_trace )
-            traces.emplace_back( to_transaction_trace_v1( {*onblock_trace} ));
+            traces.emplace_back( to_transaction_trace_v1( *onblock_trace ));
          for( const auto& r : block_state->block->transactions ) {
             transaction_id_type id;
             if( r.trx.contains<transaction_id_type>()) {
@@ -119,7 +119,7 @@ private:
    StoreProvider                                                store;
    exception_handler                                            except_handler;
    std::map<transaction_id_type, cache_trace>                   cached_traces;
-   fc::optional<chain::transaction_trace_ptr>                   onblock_trace;
+   fc::optional<cache_trace>                                    onblock_trace;
 
 };
 


### PR DESCRIPTION
## Change Description

- New additions to reported traces in #9047 did not account for `onblock`
- Fixes a crash on startup for `--plugin eosio::trace_api_plugin -e`

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
