### PR TITLE
GCC 8.3 on CentOS 7 compiler workaround - 2.0

### DIFF
--- a/plugins/chain_plugin/account_query_db.cpp
+++ b/plugins/chain_plugin/account_query_db.cpp
@@ -164,7 +164,8 @@ namespace eosio::chain_apis {
 
          // for each key, add this permission info's non-owning reference to the bimap for keys
          for (const auto& k: po.auth.keys) {
-            key_bimap.insert(key_bimap_t::value_type {{(chain::public_key_type)k.key, k.weight}, pi});
+            chain::public_key_type key = k.key;
+            key_bimap.insert(key_bimap_t::value_type {{std::move(key), k.weight}, pi});
          }
       }
 


### PR DESCRIPTION
## Change Description

- Workaround a GCC 8.3 issue with conversion.
- EPE-105 

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
