### PR TITLE
Rodeos streamer exchanges

### DIFF
--- a/programs/rodeos/streamer_plugin.cpp
+++ b/programs/rodeos/streamer_plugin.cpp
@@ -29,9 +29,9 @@ streamer_plugin::~streamer_plugin() {}
 void streamer_plugin::set_program_options(options_description& cli, options_description& cfg) {
    auto op = cfg.add_options();
    op("stream-rabbits", bpo::value<std::vector<string>>()->composing(),
-      "RabbitMQ Streams to queues if any; Format: amqp://USER:PASSWORD@ADDRESS:PORT/QUEUE[/STREAMER_ROUTE, ...]");
+      "RabbitMQ Streams to queues if any; Format: amqp://USER:PASSWORD@ADDRESS:PORT/QUEUE[/STREAMING_ROUTE, ...]");
    op("stream-rabbits-exchange", bpo::value<std::vector<string>>()->composing(),
-      "RabbitMQ Streams to exchanges if any; Format: amqp://USER:PASSWORD@ADDRESS:PORT/EXCHANGE[::EXCHANGE_TYPE]");
+      "RabbitMQ Streams to exchanges if any; Format: amqp://USER:PASSWORD@ADDRESS:PORT/EXCHANGE[::EXCHANGE_TYPE][/STREAMING_ROUTE, ...]");
    op("stream-loggers", bpo::value<std::vector<string>>()->composing(),
       "Logger Streams if any; Format: [routing_keys, ...]");
 }
@@ -45,7 +45,7 @@ void streamer_plugin::plugin_initialize(const variables_map& options) {
 
       if (options.count("stream-rabbits")) {
          auto rabbits = options.at("stream-rabbits").as<std::vector<std::string>>();
-         initialize_rabbits(app().get_io_service(), my->streams, rabbits);
+         initialize_rabbits_queue(app().get_io_service(), my->streams, rabbits);
       }
 
       if (options.count("stream-rabbits-exchange")) {

--- a/programs/rodeos/streamer_plugin.cpp
+++ b/programs/rodeos/streamer_plugin.cpp
@@ -31,7 +31,7 @@ void streamer_plugin::set_program_options(options_description& cli, options_desc
    op("stream-rabbits", bpo::value<std::vector<string>>()->composing(),
       "RabbitMQ Streams to queues if any; Format: amqp://USER:PASSWORD@ADDRESS:PORT/QUEUE[/ROUTING_KEYS, ...]");
    op("stream-rabbits-exchange", bpo::value<std::vector<string>>()->composing(),
-      "RabbitMQ Streams to exchanges if any; Format: amqp://USER:PASSWORD@ADDRESS:PORT/EXCHANGE[/ROUTING_KEYS, ...]");
+      "RabbitMQ Streams to exchanges if any; Format: amqp://USER:PASSWORD@ADDRESS:PORT/EXCHANGE[::EXCHANGE_TYPE]");
    op("stream-loggers", bpo::value<std::vector<string>>()->composing(),
       "Logger Streams if any; Format: [routing_keys, ...]");
 }
@@ -50,7 +50,7 @@ void streamer_plugin::plugin_initialize(const variables_map& options) {
 
       if (options.count("stream-rabbits-exchange")) {
          auto rabbits = options.at("stream-rabbits-exchange").as<std::vector<std::string>>();
-         initialize_rabbits(app().get_io_service(), my->streams, rabbits, true);
+         initialize_rabbits_exchange(app().get_io_service(), my->streams, rabbits);
       }
 
       ilog("initialized streams: ${streams}", ("streams", my->streams.size()));

--- a/programs/rodeos/streamer_plugin.cpp
+++ b/programs/rodeos/streamer_plugin.cpp
@@ -29,7 +29,7 @@ streamer_plugin::~streamer_plugin() {}
 void streamer_plugin::set_program_options(options_description& cli, options_description& cfg) {
    auto op = cfg.add_options();
    op("stream-rabbits", bpo::value<std::vector<string>>()->composing(),
-      "RabbitMQ Streams to queues if any; Format: amqp://USER:PASSWORD@ADDRESS:PORT/QUEUE[/ROUTING_KEYS, ...]");
+      "RabbitMQ Streams to queues if any; Format: amqp://USER:PASSWORD@ADDRESS:PORT/QUEUE[/STREAMER_ROUTE, ...]");
    op("stream-rabbits-exchange", bpo::value<std::vector<string>>()->composing(),
       "RabbitMQ Streams to exchanges if any; Format: amqp://USER:PASSWORD@ADDRESS:PORT/EXCHANGE[::EXCHANGE_TYPE]");
    op("stream-loggers", bpo::value<std::vector<string>>()->composing(),

--- a/programs/rodeos/streams/logger.hpp
+++ b/programs/rodeos/streams/logger.hpp
@@ -15,7 +15,7 @@ class logger : public stream_handler {
 
    const std::vector<eosio::name>& get_routes() const override { return routes_; }
 
-   void publish(const char* data, uint64_t data_size, const std::string& routing_key) override {
+   void publish(const char* data, uint64_t data_size, const eosio::name& routing_key) override {
       ilog("logger stream [${data_size}] >> ${data}", ("data", data)("data_size", data_size));
    }
 };

--- a/programs/rodeos/streams/logger.hpp
+++ b/programs/rodeos/streams/logger.hpp
@@ -15,7 +15,7 @@ class logger : public stream_handler {
 
    const std::vector<eosio::name>& get_routes() const override { return routes_; }
 
-   void publish(const char* data, uint64_t data_size) override {
+   void publish(const char* data, uint64_t data_size, const std::string& route) override {
       ilog("logger stream [${data_size}] >> ${data}", ("data", data)("data_size", data_size));
    }
 };

--- a/programs/rodeos/streams/logger.hpp
+++ b/programs/rodeos/streams/logger.hpp
@@ -22,9 +22,9 @@ class logger : public stream_handler {
 
 inline void initialize_loggers(std::vector<std::unique_ptr<stream_handler>>& streams,
                                const std::vector<std::string>&               loggers) {
-   for (const auto& routings : loggers) {
-      std::vector<eosio::name> routing_keys = extract_routes(routings);
-      logger                   logger_streamer{ std::move(routing_keys) };
+   for (const auto& routes_str : loggers) {
+      std::vector<eosio::name> routes = extract_routes(routes_str);
+      logger                   logger_streamer{ std::move(routes) };
       streams.emplace_back(std::make_unique<logger>(std::move(logger_streamer)));
    }
 }

--- a/programs/rodeos/streams/logger.hpp
+++ b/programs/rodeos/streams/logger.hpp
@@ -15,7 +15,7 @@ class logger : public stream_handler {
 
    const std::vector<eosio::name>& get_routes() const override { return routes_; }
 
-   void publish(const char* data, uint64_t data_size, const std::string& route) override {
+   void publish(const char* data, uint64_t data_size, const std::string& routing_key) override {
       ilog("logger stream [${data_size}] >> ${data}", ("data", data)("data_size", data_size));
    }
 };

--- a/programs/rodeos/streams/logger.hpp
+++ b/programs/rodeos/streams/logger.hpp
@@ -23,7 +23,7 @@ class logger : public stream_handler {
 inline void initialize_loggers(std::vector<std::unique_ptr<stream_handler>>& streams,
                                const std::vector<std::string>&               loggers) {
    for (const auto& routings : loggers) {
-      std::vector<eosio::name> routing_keys = extract_routings(routings);
+      std::vector<eosio::name> routing_keys = extract_routes(routings);
       logger                   logger_streamer{ std::move(routing_keys) };
       streams.emplace_back(std::make_unique<logger>(std::move(logger_streamer)));
    }

--- a/programs/rodeos/streams/rabbitmq.hpp
+++ b/programs/rodeos/streams/rabbitmq.hpp
@@ -120,7 +120,6 @@ inline void initialize_rabbits(boost::asio::io_service&                      io_
       }
 
       std::string queue_name = "stream.default";
-
       if (pos != std::string::npos) {
          queue_name = rabbit.substr(pos + 1, rabbit.length());
          rabbit.erase(pos, rabbit.length());
@@ -129,7 +128,6 @@ inline void initialize_rabbits(boost::asio::io_service&                      io_
       std::string address = "amqp://" + rabbit;
       rabbitmq rmq{ io_service, std::move(routings), std::move(address), std::move(queue_name) };
       streams.emplace_back(std::make_unique<rabbitmq>(std::move(rmq)));
-
    }
 }
 

--- a/programs/rodeos/streams/rabbitmq.hpp
+++ b/programs/rodeos/streams/rabbitmq.hpp
@@ -32,7 +32,7 @@ class rabbitmq : public stream_handler {
    }
 
    rabbitmq(boost::asio::io_service& io_service, std::vector<eosio::name> routes, std::string address, std::string exchange_name, std::string exchange_type)
-       : exchangeName_(std::move(exchange_name), routes_(std::move(routes)) {
+       : exchangeName_(std::move(exchange_name)), routes_(std::move(routes)) {
       AMQP::Address amqp_address(address);
       ilog("Connecting to RabbitMQ address ${a} - Exchange: ${e}...", ("a", std::string(amqp_address))("e", exchangeName_));
 

--- a/programs/rodeos/streams/rabbitmq.hpp
+++ b/programs/rodeos/streams/rabbitmq.hpp
@@ -43,11 +43,11 @@ class rabbitmq : public stream_handler {
 
    const std::vector<eosio::name>& get_routes() const override { return routes_; }
 
-   void publish(const char* data, uint64_t data_size, const std::string& route) override {
+   void publish(const char* data, uint64_t data_size, const std::string& routing_key) override {
       if (DEFAULT_EXCHANGE == exchangeName_) {
          channel_->publish(exchangeName_, queueName_, data, data_size, 0);
       } else {
-         channel_->publish(exchangeName_, route, data, data_size, 0);
+         channel_->publish(exchangeName_, routing_key, data, data_size, 0);
       }
    }
 
@@ -77,8 +77,8 @@ class rabbitmq : public stream_handler {
          case "fanout"  :
             type = AMQP::fanout;
             break;
-         case "topic"  :
-            type = AMQP::topic;
+         case "direct"  :
+            type = AMQP::direct;
             break;
       }
 

--- a/programs/rodeos/streams/rabbitmq.hpp
+++ b/programs/rodeos/streams/rabbitmq.hpp
@@ -25,9 +25,9 @@ class rabbitmq : public stream_handler {
       AMQP::Address amqp_address(address);
       ilog("Connecting to RabbitMQ address ${a} - Queue: ${q}...", ("a", std::string(amqp_address))("q", queueName_));
 
-      init(io_service, amqp_address)
+      init(io_service, amqp_address);
 
-      exchangeName_ = DEFAULT_EXCHANGE
+      exchangeName_ = DEFAULT_EXCHANGE;
       declare_queue();
    }
 
@@ -36,7 +36,7 @@ class rabbitmq : public stream_handler {
       AMQP::Address amqp_address(address);
       ilog("Connecting to RabbitMQ address ${a} - Exchange: ${e}...", ("a", std::string(amqp_address))("e", exchangeName_));
 
-      init(io_service, amqp_address)
+      init(io_service, amqp_address);
 
       declare_exchange(exchange_type);
    }
@@ -49,7 +49,6 @@ class rabbitmq : public stream_handler {
       } else {
          channel_->publish(exchangeName_, route, data, data_size, 0);
       }
-
    }
 
  private:
@@ -120,7 +119,7 @@ inline void initialize_rabbits(boost::asio::io_service&                      io_
          rabbit.erase(pos_router, rabbit.length());
       }
 
-      std::string queue_name = "stream.default"
+      std::string queue_name = "stream.default";
 
       if (pos != std::string::npos) {
          queue_name = rabbit.substr(pos + 1, rabbit.length());
@@ -149,7 +148,7 @@ inline void initialize_rabbits(boost::asio::io_service&                      io_
             rabbit.erase(pos_router, rabbit.length());
          }
 
-         std::string exchange_name = ""
+         std::string exchange_name = "";
          if (pos != std::string::npos) {
             exchange_name = rabbit.substr(pos + 1, rabbit.length());
             rabbit.erase(pos, rabbit.length());

--- a/programs/rodeos/streams/rabbitmq.hpp
+++ b/programs/rodeos/streams/rabbitmq.hpp
@@ -25,9 +25,12 @@ class rabbitmq : public stream_handler {
       AMQP::Address amqp_address(address);
       ilog("Connecting to RabbitMQ address ${a} - Queue: ${q}...", ("a", std::string(amqp_address))("q", queueName_));
 
-      init(io_service, amqp_address);
+      init(io_service, std::move(amqp_address));
 
       exchangeName_ = DEFAULT_EXCHANGE;
+
+      ilog("RabbitMQ Connected Successfully!\n Exchange ${e}",
+           ("e", exchangeName_));
       declare_queue();
    }
 
@@ -36,7 +39,7 @@ class rabbitmq : public stream_handler {
       AMQP::Address amqp_address(address);
       ilog("Connecting to RabbitMQ address ${a} - Exchange: ${e}...", ("a", std::string(amqp_address))("e", exchangeName_));
 
-      init(io_service, amqp_address);
+      init(io_service, std::move(amqp_address));
 
       declare_exchange(exchange_type);
    }
@@ -54,7 +57,7 @@ class rabbitmq : public stream_handler {
  private:
    inline static const std::string DEFAULT_EXCHANGE = "";
 
-   void init(boost::asio::io_service& io_service, AMQP::Address& amqp_address) {
+   void init(boost::asio::io_service& io_service, AMQP::Address amqp_address) {
       handler_    = std::make_shared<rabbitmq_handler>(io_service);
       connection_ = std::make_shared<AMQP::TcpConnection>(handler_.get(), amqp_address);
       channel_    = std::make_shared<AMQP::TcpChannel>(connection_.get());

--- a/programs/rodeos/streams/rabbitmq.hpp
+++ b/programs/rodeos/streams/rabbitmq.hpp
@@ -148,7 +148,7 @@ inline void initialize_rabbits_exchange(boost::asio::io_service&                
 
       std::string exchange_type = "";
       if (has_exchange_type) {
-         exchange_type = rabbit.substr(pos_exchange_type + 1, rabbit.length());
+         exchange_type = rabbit.substr(pos_exchange_type + 2, rabbit.length());
          rabbit.erase(pos_exchange_type, rabbit.length());
       }
 

--- a/programs/rodeos/streams/rabbitmq.hpp
+++ b/programs/rodeos/streams/rabbitmq.hpp
@@ -54,7 +54,7 @@ class rabbitmq : public stream_handler {
  private:
    inline static const string DEFAULT_EXCHANGE = "";
 
-   void init(boost::asio::io_service& io_service, AMQP::Address amqp_address) {
+   void init(boost::asio::io_service& io_service, AMQP::Address& amqp_address) {
       handler_    = std::make_shared<rabbitmq_handler>(io_service);
       connection_ = std::make_shared<AMQP::TcpConnection>(handler_.get(), amqp_address);
       channel_    = std::make_shared<AMQP::TcpChannel>(connection_.get());
@@ -71,7 +71,7 @@ class rabbitmq : public stream_handler {
       });
    }
 
-   void declare_exchange(std::string exchange_type) {
+   void declare_exchange(std::string& exchange_type) {
       auto type = AMQP::direct;
       switch(exchange_type) {
          case "fanout"  :

--- a/programs/rodeos/streams/rabbitmq.hpp
+++ b/programs/rodeos/streams/rabbitmq.hpp
@@ -29,8 +29,6 @@ class rabbitmq : public stream_handler {
 
       exchangeName_ = DEFAULT_EXCHANGE;
 
-      ilog("RabbitMQ Connected Successfully!\n Exchange ${e}",
-           ("e", exchangeName_));
       declare_queue();
    }
 

--- a/programs/rodeos/streams/rabbitmq.hpp
+++ b/programs/rodeos/streams/rabbitmq.hpp
@@ -105,13 +105,13 @@ inline std::vector<eosio::name> extract_rabbit_routes(std::string& rabbit, size_
    size_t pos_router = rabbit.find_last_of("/");
    bool   has_router = pos_router != pos;
 
-   std::vector<eosio::name> routings = {};
+   std::vector<eosio::name> routes = {};
    if (has_router) {
-      routings = extract_routes(rabbit.substr(pos_router + 1, rabbit.length()));
+      routes = extract_routes(rabbit.substr(pos_router + 1, rabbit.length()));
       rabbit.erase(pos_router, rabbit.length());
    }
 
-   return routings;
+   return routes;
 }
 
 inline void initialize_rabbits_queue(boost::asio::io_service&                      io_service,
@@ -144,8 +144,8 @@ inline void initialize_rabbits_exchange(boost::asio::io_service&                
 
       auto routes = extract_rabbit_routes(rabbit, pos);
 
-      size_t pos_exchange_type = rabbit.find_last_of("::");
-      bool   has_exchange_type = pos_exchange_type != pos;
+      size_t pos_exchange_type = rabbit.find("::");
+      bool   has_exchange_type = pos_exchange_type != std::string::npos;
 
       std::string exchange_type = "";
       if (has_exchange_type) {

--- a/programs/rodeos/streams/rabbitmq.hpp
+++ b/programs/rodeos/streams/rabbitmq.hpp
@@ -75,8 +75,6 @@ class rabbitmq : public stream_handler {
       auto type = AMQP::direct;
       if (exchange_type == "fanout") {
          type = AMQP::fanout;
-      } else if (exchange_type == "direct") {
-         type = AMQP::direct;
       }
 
       auto& exchange = channel_->declareExchange(exchangeName_, type);

--- a/programs/rodeos/streams/rabbitmq.hpp
+++ b/programs/rodeos/streams/rabbitmq.hpp
@@ -121,7 +121,7 @@ inline void initialize_rabbits_queue(boost::asio::io_service&                   
       rabbit            = rabbit.substr(7, rabbit.length());
       size_t pos        = rabbit.find("/");
 
-      auto routings = extract_rabbit_routes(rabbit, pos);
+      auto routes = extract_rabbit_routes(rabbit, pos);
 
       std::string queue_name = "stream.default";
       if (pos != std::string::npos) {
@@ -130,7 +130,7 @@ inline void initialize_rabbits_queue(boost::asio::io_service&                   
       }
 
       std::string address = "amqp://" + rabbit;
-      rabbitmq rmq{ io_service, std::move(routings), std::move(address), std::move(queue_name) };
+      rabbitmq rmq{ io_service, std::move(routes), std::move(address), std::move(queue_name) };
       streams.emplace_back(std::make_unique<rabbitmq>(std::move(rmq)));
    }
 }
@@ -142,7 +142,7 @@ inline void initialize_rabbits_exchange(boost::asio::io_service&                
       rabbit            = rabbit.substr(7, rabbit.length());
       size_t pos        = rabbit.find("/");
 
-      auto routings = extract_rabbit_routes(rabbit, pos);
+      auto routes = extract_rabbit_routes(rabbit, pos);
 
       size_t pos_exchange_type = rabbit.find_last_of("::");
       bool   has_exchange_type = pos_exchange_type != pos;
@@ -160,7 +160,7 @@ inline void initialize_rabbits_exchange(boost::asio::io_service&                
       }
 
       std::string address = "amqp://" + rabbit;
-      rabbitmq rmq{ io_service, std::move(routings), std::move(address), std::move(exchange_name), std::move(exchange_type) };
+      rabbitmq rmq{ io_service, std::move(routes), std::move(address), std::move(exchange_name), std::move(exchange_type) };
       streams.emplace_back(std::make_unique<rabbitmq>(std::move(rmq)));
    }
 }

--- a/programs/rodeos/streams/stream.hpp
+++ b/programs/rodeos/streams/stream.hpp
@@ -25,26 +25,26 @@ class stream_handler {
    }
 };
 
-inline std::vector<eosio::name> extract_routings(const std::string& routings_str) {
-   std::vector<eosio::name> routing_keys{};
+inline std::vector<eosio::name> extract_routes(const std::string& routes_str) {
+   std::vector<eosio::name> stream_routes{};
    bool star = false;
-   std::string routings = routings_str;
+   std::string routings = routes_str;
    while (routings.size() > 0) {
       size_t      pos          = routings.find(",");
       size_t      route_length = pos == std::string::npos ? routings.length() : pos;
       std::string route        = routings.substr(0, pos);
       ilog("extracting route ${route}", ("route", route));
       if (route != "*") {
-         routing_keys.emplace_back(eosio::name(route));
+         stream_routes.emplace_back(eosio::name(route));
       } else {
          star = true;
       }
       routings.erase(0, route_length + 1);
    }
-   if (star && !routing_keys.empty()) {
-      throw std::runtime_error(std::string("Invalid routings '") + routings_str + "'");
+   if (star && !stream_routes.empty()) {
+      throw std::runtime_error(std::string("Invalid routings '") + routes_str + "'");
    }
-   return routing_keys;
+   return stream_routes;
 }
 
 } // namespace b1

--- a/programs/rodeos/streams/stream.hpp
+++ b/programs/rodeos/streams/stream.hpp
@@ -8,7 +8,7 @@ class stream_handler {
  public:
    virtual ~stream_handler() {}
    virtual const std::vector<eosio::name>& get_routes() const = 0;
-   virtual void publish(const char* data, uint64_t data_size) = 0;
+   virtual void publish(const char* data, uint64_t data_size, const std::string& route) = 0;
 
    bool check_route(const eosio::name& stream_route) {
       if (get_routes().size() == 0) {

--- a/programs/rodeos/streams/stream.hpp
+++ b/programs/rodeos/streams/stream.hpp
@@ -42,7 +42,7 @@ inline std::vector<eosio::name> extract_routes(const std::string& routes_str) {
       routings.erase(0, route_length + 1);
    }
    if (star && !stream_routes.empty()) {
-      throw std::runtime_error(std::string("Invalid routings '") + routes_str + "'");
+      throw std::runtime_error(std::string("Invalid routes '") + routes_str + "'");
    }
    return stream_routes;
 }

--- a/programs/rodeos/streams/stream.hpp
+++ b/programs/rodeos/streams/stream.hpp
@@ -8,7 +8,7 @@ class stream_handler {
  public:
    virtual ~stream_handler() {}
    virtual const std::vector<eosio::name>& get_routes() const = 0;
-   virtual void publish(const char* data, uint64_t data_size, const std::string& route) = 0;
+   virtual void publish(const char* data, uint64_t data_size, const std::string& routing_key) = 0;
 
    bool check_route(const eosio::name& stream_route) {
       if (get_routes().size() == 0) {

--- a/programs/rodeos/streams/stream.hpp
+++ b/programs/rodeos/streams/stream.hpp
@@ -26,7 +26,7 @@ class stream_handler {
 };
 
 inline std::vector<eosio::name> extract_routes(const std::string& routes_str) {
-   std::vector<eosio::name> stream_routes{};
+   std::vector<eosio::name> streaming_routes{};
    bool star = false;
    std::string routings = routes_str;
    while (routings.size() > 0) {
@@ -35,16 +35,16 @@ inline std::vector<eosio::name> extract_routes(const std::string& routes_str) {
       std::string route        = routings.substr(0, pos);
       ilog("extracting route ${route}", ("route", route));
       if (route != "*") {
-         stream_routes.emplace_back(eosio::name(route));
+         streaming_routes.emplace_back(eosio::name(route));
       } else {
          star = true;
       }
       routings.erase(0, route_length + 1);
    }
-   if (star && !stream_routes.empty()) {
+   if (star && !streaming_routes.empty()) {
       throw std::runtime_error(std::string("Invalid routes '") + routes_str + "'");
    }
-   return stream_routes;
+   return streaming_routes;
 }
 
 } // namespace b1

--- a/programs/rodeos/streams/stream.hpp
+++ b/programs/rodeos/streams/stream.hpp
@@ -8,7 +8,7 @@ class stream_handler {
  public:
    virtual ~stream_handler() {}
    virtual const std::vector<eosio::name>& get_routes() const = 0;
-   virtual void publish(const char* data, uint64_t data_size, const std::string& routing_key) = 0;
+   virtual void publish(const char* data, uint64_t data_size, const eosio::name& routing_key) = 0;
 
    bool check_route(const eosio::name& stream_route) {
       if (get_routes().size() == 0) {


### PR DESCRIPTION
## Change Description
This builds on #9029

This adds the non breaking changes in the Streamer plugin to create RabbitMQ exchanges, versus the current implementation which only allows directly pushing to RabbitMQ queues. An additional parameter was added to the streamer interface for the `publish` function:  `routing_key`. 

Also renamed the use of the internal `routing_keys` to a more appropriate `stream_routes` as to not confuse this with the RabbitMQ term routing keys. 


## Consensus Changes
- [ ] Consensus Changes


## API Changes
- [ ] API Changes


## Documentation Additions
- [x] Documentation Additions

### `--stream-rabbits-exchange amqp://guest:guest@localhost:5672/myexchange::direct,mystreamingroute`
Adds a RabbitMQ exchange streamer.

- you can declare multiple rabbitmq exchange connections
- the template is always `amqp://USER:PASSWORD@HOST:PORT/EXCHANGE_NAME[::EXCHANGE_TYPE][/STREAMING_ROUTE1,STREAMING_ROUTE2]`
    - `amqp://` prefix is fixed
    - `USER` is the rabbitmq user
    - `PASSWORD` is the rabbitmq password
    - `HOST` is the address of rabbitmq host
    - `PORT` is the rabbitmq's port
    - `EXCHANGE_NAME` is the name of the exchange that you want to publish the messages
    - `::EXCHANGE_TYPE` is the type of exchange you want to create. By default a `direct` exchange is created. Currently only `direct` and `fanout` are supported.
    - `/STREAMING_ROUTE1,STREAMING_ROUTE2` is a set of streaming routes that you want to determine which exchanges to push messages to.  
        - `direct` exchanges: the default is empty, which means it will publish all messages to all exchanges and pass along the routing key specified in the message. This is useful if you have specified a `direct` exchange where the binding key of the queue to the exchanges specifies which routing keys it cares about therefore filtering at the exchange level via RabbitMQ routing keys.
        - `fanout` exchanges: you can separate routes by commas to specify multiple streaming routes. This is useful if you have specified multiple `fanout` exchanges for each of your event types and want to forward messages to only certain exchanges therefore filtering prior to publishing a message to an exchange.