### PR TITLE
amqp_compressed_proof_plugin: Send compressed action merkle proofs over AMQP

### DIFF
--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -20,6 +20,7 @@ add_subdirectory(login_plugin)
 add_subdirectory(test_control_plugin)
 add_subdirectory(test_control_api_plugin)
 add_subdirectory(amqp_witness_plugin)
+add_subdirectory(amqp_compressed_proof_plugin)
 
 # Forward variables to top level so packaging picks them up
 set(CPACK_DEBIAN_PACKAGE_DEPENDS ${CPACK_DEBIAN_PACKAGE_DEPENDS} PARENT_SCOPE)

--- a/plugins/amqp_compressed_proof_plugin/CMakeLists.txt
+++ b/plugins/amqp_compressed_proof_plugin/CMakeLists.txt
@@ -1,0 +1,7 @@
+file(GLOB HEADERS "include/eosio/amqp_compressed_proof_plugin/*.hpp")
+add_library( amqp_compressed_proof_plugin
+             amqp_compressed_proof_plugin.cpp
+             ${HEADERS} )
+
+target_link_libraries( amqp_compressed_proof_plugin appbase fc chain_plugin reliable_amqp_publisher )
+target_include_directories( amqp_compressed_proof_plugin PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" )

--- a/plugins/amqp_compressed_proof_plugin/amqp_compressed_proof_plugin.cpp
+++ b/plugins/amqp_compressed_proof_plugin/amqp_compressed_proof_plugin.cpp
@@ -1,0 +1,397 @@
+#include <eosio/amqp_compressed_proof_plugin/amqp_compressed_proof_plugin.hpp>
+
+#include <eosio/chain/protocol_feature_manager.hpp>
+#include <eosio/chain/exceptions.hpp>
+
+#include <eosio/reliable_amqp_publisher/reliable_amqp_publisher.hpp>
+
+#include <boost/multi_index_container.hpp>
+#include <boost/multi_index/key.hpp>
+#include <boost/multi_index/ordered_index.hpp>
+#include <boost/multi_index/hashed_index.hpp>
+#include <boost/algorithm/string/predicate.hpp>
+#include <boost/algorithm/string.hpp>
+
+#include <fc/io/cfile.hpp>
+
+//using boost::multi_index_container;
+using namespace boost::multi_index;
+using namespace std::string_literals;
+
+namespace eosio {
+static appbase::abstract_plugin& _amqp_compressed_proof_plugin = app().register_plugin<amqp_compressed_proof_plugin>();
+
+struct action_entry {
+   chain::action         action;
+   std::vector<char>     return_value;
+   chain::action_receipt action_receipt;
+
+   action_entry() = default;
+
+   action_entry(const chain::action_trace& atrace) :
+     action(atrace.act), return_value(atrace.return_value), action_receipt(*atrace.receipt) {}
+
+   bool operator<(const action_entry& other) const {
+      return action_receipt.global_sequence < other.action_receipt.global_sequence;
+   }
+};
+
+struct combine_nodes{};
+using merkle_cmd = fc::static_variant<chain::digest_type, action_entry, combine_nodes>;
+
+struct merkle_creator_node {
+   chain::checksum_type  hash;
+   std::list<merkle_cmd> cmd_stream;
+};
+
+class merkle_cmd_creator {
+public:
+   void add_noninterested_action(const action_entry& ae) {
+      handle_input_action(merkle_creator_node{chain::digest_type::hash(ae.action_receipt)});
+   }
+
+   void add_interested_action(const action_entry& ae) {
+      handle_input_action(merkle_creator_node{chain::digest_type::hash(ae.action_receipt), {ae}});
+   }
+
+   std::vector<char> generate_serialized_proof(bool arv_activated) {
+      if(!first_input_pair && curent_level.empty())
+         return std::vector<char>();
+      if(first_input_pair && curent_level.empty())
+         return fc::raw::pack<bool, std::list<merkle_cmd>>((bool)arv_activated, first_input_pair->cmd_stream);
+
+
+      if(first_input_pair) {
+         merkle_creator_node even_pair{first_input_pair->hash};
+         curent_level.emplace_back(combine(*first_input_pair, even_pair));
+      }
+
+      while(curent_level.size() > 1) {
+         if(curent_level.size() % 2)
+            curent_level.emplace_back(merkle_creator_node{curent_level.back().hash});
+         for(unsigned int i = 0; i < curent_level.size(); i+=2)
+            curent_level[i/2] = combine(curent_level[i], curent_level[i+1]);
+         curent_level.resize(curent_level.size()/2);
+      }
+
+      return fc::raw::pack<bool, std::list<merkle_cmd>>((bool)arv_activated, curent_level[0].cmd_stream);
+   }
+
+private:
+   void handle_input_action(merkle_creator_node input) {
+      if(!first_input_pair) {
+         first_input_pair = input;
+         return;
+      }
+
+      curent_level.emplace_back(combine(*first_input_pair, input));
+      first_input_pair.reset();
+   }
+
+   merkle_creator_node combine(merkle_creator_node& left, merkle_creator_node& right) {
+      chain::digest_type::encoder digest_enc;
+      fc::raw::pack(digest_enc, chain::make_canonical_left(left.hash), chain::make_canonical_right(right.hash));
+
+      merkle_creator_node new_node = {digest_enc.result()};
+
+      if(left.cmd_stream.empty() && right.cmd_stream.empty()) {
+         //do nothing, this is an uninteresting part of the tree
+      }
+      else if(left.cmd_stream.empty()) {
+         new_node.cmd_stream.emplace_front(left.hash);
+         new_node.cmd_stream.splice(new_node.cmd_stream.end(), right.cmd_stream);
+         new_node.cmd_stream.emplace_back(combine_nodes());
+      }
+      else if(right.cmd_stream.empty()) {
+         new_node.cmd_stream.splice(new_node.cmd_stream.end(), left.cmd_stream);
+         new_node.cmd_stream.emplace_back(right.hash);
+         new_node.cmd_stream.emplace_back(combine_nodes());
+      }
+      else {
+         new_node.cmd_stream.splice(new_node.cmd_stream.end(), left.cmd_stream);
+         new_node.cmd_stream.splice(new_node.cmd_stream.end(), right.cmd_stream);
+         new_node.cmd_stream.emplace_back(combine_nodes());
+      }
+
+      return new_node;
+   }
+
+   std::optional<merkle_creator_node> first_input_pair;
+   std::vector<merkle_creator_node>   curent_level;
+};
+
+struct compressed_proof_generator_impl {
+   struct reversible_action_entries {
+      chain::block_num_type  block_num;
+      chain::block_id_type   block_id;
+      std::set<action_entry> action_entries;
+   };
+
+   struct by_block_id;
+   struct by_block_num;
+
+   typedef multi_index_container<
+      reversible_action_entries,
+      indexed_by<
+         hashed_unique<tag<by_block_id>,   key<&reversible_action_entries::block_id>, std::hash<fc::sha256>>,
+         ordered_unique<tag<by_block_num>, key<&reversible_action_entries::block_num>>
+      >
+   > reversible_action_entries_index_type;
+   reversible_action_entries_index_type reversible_action_entries_index;
+
+   static bool is_onblock(const chain::transaction_trace_ptr& p) {
+      if (p->action_traces.size() != 1)
+         return false;
+      auto& act = p->action_traces[0].act;
+      if (act.account != eosio::chain::config::system_account_name || act.name != N(onblock) ||
+          act.authorization.size() != 1)
+         return false;
+      auto& auth = act.authorization[0];
+      return auth.actor == eosio::chain::config::system_account_name &&
+             auth.permission == eosio::chain::config::active_name;
+   }
+
+   std::map<transaction_id_type, chain::transaction_trace_ptr> cached_traces;
+   std::optional<chain::transaction_trace_ptr>                 onblock_trace;
+   std::vector<std::pair<compressed_proof_generator::action_filter_func,
+                         compressed_proof_generator::merkle_proof_result_func>>  callbacks;
+
+   fc::optional<boost::filesystem::path> reversible_path;
+};
+
+using generator_impl = compressed_proof_generator_impl;
+
+compressed_proof_generator::compressed_proof_generator() : my(new compressed_proof_generator_impl) {}
+
+compressed_proof_generator::compressed_proof_generator(const boost::filesystem::path& p) : my(new compressed_proof_generator_impl) {
+   my->reversible_path = p;
+
+   if(boost::filesystem::exists(*my->reversible_path)) {
+      try {
+         fc::datastream<fc::cfile> file;
+         file.set_file_path(*my->reversible_path);
+         file.open("rb");
+         fc::unsigned_int count;
+         fc::raw::unpack(file, count);
+         while(count.value--) {
+            compressed_proof_generator_impl::reversible_action_entries entry;
+            fc::raw::unpack(file, entry);
+            my->reversible_action_entries_index.emplace(entry);
+         }
+      } FC_RETHROW_EXCEPTIONS(error, "Failed to load compressed merkle generator reversible state file ${f}", ("f", (fc::path)*my->reversible_path));
+   }
+   else {
+      try {
+         boost::filesystem::ofstream s(*my->reversible_path);
+      } FC_RETHROW_EXCEPTIONS(error, "Unable to create compressed merkle generator reversible state file ${f}", ("f", (fc::path)*my->reversible_path));
+   }
+   boost::system::error_code ec;
+   boost::filesystem::remove(*my->reversible_path, ec);
+}
+
+compressed_proof_generator::~compressed_proof_generator() {
+   if(my->reversible_path) {
+      try {
+         fc::unsigned_int num = my->reversible_action_entries_index.size();
+         fc::datastream<fc::cfile> file;
+         file.set_file_path(*my->reversible_path);
+         file.open("wb");
+         fc::raw::pack(file, num);
+         for(const auto& v : my->reversible_action_entries_index)
+            fc::raw::pack(file, v);
+      } FC_LOG_AND_DROP();
+   }
+}
+
+void compressed_proof_generator::on_applied_transaction(const chain::transaction_trace_ptr& trace) {
+   if(!trace->receipt)
+      return;
+   //only executed & delayed transaction traces would make it in to action_mroot
+   if(trace->receipt->status != chain::transaction_receipt::status_enum::executed &&
+      trace->receipt->status != chain::transaction_receipt::status_enum::delayed)
+      return;
+
+   if(my->is_onblock(trace))
+      my->onblock_trace.emplace(trace);
+   else
+      my->cached_traces[trace->id] = trace;
+}
+
+void compressed_proof_generator::on_accepted_block(const chain::block_state_ptr& bsp) {
+   std::set<action_entry> action_entries_this_block;
+
+   if(my->onblock_trace)
+      action_entries_this_block.emplace((*my->onblock_trace)->action_traces.front());
+   for(const chain::transaction_receipt& r : bsp->block->transactions) {
+      transaction_id_type id;
+      if(r.trx.contains<chain::transaction_id_type>())
+         id = r.trx.get<chain::transaction_id_type>();
+      else
+         id = r.trx.get<chain::packed_transaction>().id();
+      auto it = my->cached_traces.find(id);
+      EOS_ASSERT(it != my->cached_traces.end(), chain::misc_exception, "missing trace for transaction ${id}", ("id", id));
+      for(const chain::action_trace& at : it->second->action_traces)
+         action_entries_this_block.emplace(at);
+   }
+   my->cached_traces.clear();
+   my->onblock_trace.reset();
+
+   my->reversible_action_entries_index.emplace(generator_impl::reversible_action_entries{bsp->block_num, bsp->id, std::move(action_entries_this_block)});
+}
+
+void compressed_proof_generator::on_irreversible_block(const chain::block_state_ptr& bsp, const chain::controller& controller) {
+   if(const auto it = my->reversible_action_entries_index.find(bsp->id); it != my->reversible_action_entries_index.end()) {
+      const std::set<action_entry>& action_entries = it->action_entries;
+
+      const chain::digest_type arv_dig = *controller.get_protocol_feature_manager().get_builtin_digest(chain::builtin_protocol_feature_t::action_return_value);
+      const auto& protocol_features_this_block = bsp->activated_protocol_features->protocol_features;
+      bool action_return_value_active_this_block = protocol_features_this_block.find(arv_dig) != protocol_features_this_block.end();
+
+      for(const auto& cb : my->callbacks) {
+         merkle_cmd_creator cc;
+         bool any_interested = false;
+         for(const action_entry& ae : action_entries) {
+            if(cb.first(ae.action)) {
+               cc.add_interested_action(ae);
+               any_interested = true;
+            }
+            else
+               cc.add_noninterested_action(ae);
+         }
+
+         if(any_interested)
+            cb.second(cc.generate_serialized_proof(action_return_value_active_this_block));
+      }
+   }
+
+   my->reversible_action_entries_index.get<generator_impl::by_block_num>().erase(
+           my->reversible_action_entries_index.get<generator_impl::by_block_num>().begin(),
+           my->reversible_action_entries_index.get<generator_impl::by_block_num>().upper_bound(bsp->block_num)
+   );
+}
+
+void compressed_proof_generator::add_result_callback(action_filter_func&& filter, merkle_proof_result_func&& result) {
+   my->callbacks.emplace_back(std::make_pair(filter, result));
+}
+
+struct amqp_compressed_proof_plugin_impl {
+   bool delete_data = false;
+
+   std::map<std::string, compressed_proof_generator> proof_generators;
+   std::list<reliable_amqp_publisher>                publishers;
+};
+
+amqp_compressed_proof_plugin::amqp_compressed_proof_plugin():my(new amqp_compressed_proof_plugin_impl()){}
+amqp_compressed_proof_plugin::~amqp_compressed_proof_plugin() = default;
+
+void amqp_compressed_proof_plugin::set_program_options(options_description& cli, options_description& cfg) {
+   cfg.add_options()
+         ("compressed-proof", bpo::value<std::vector<std::string>>()->composing(),
+          "Define a filter, AMQP server, and exchange to publish compressed proofs to. May be specified multiple times. "
+          "Must be in the form of:\n"
+          "  <name>=<filter>=<server>=<exchange>\n"
+          "Where:\n"
+          "   <name>     \tis a unique name identifying this proof; used for persistent filenames\n"
+          "   <filter>   \tis a comma separated list of account names to filter actions on\n"
+          "   <server>   \tis the AMQP server URI\n"
+          "   <exchange> \tis the AMQP exchange to publish to\n"
+          )
+         ;
+
+   cli.add_options()
+         ("compressed-proof-delete", bpo::bool_switch(&my->delete_data),
+          "Delete all compressed proof data files for unconfirmed messages and blocks");
+}
+
+void amqp_compressed_proof_plugin::plugin_initialize(const variables_map& options) {
+   try {
+      boost::filesystem::path dir = app().data_dir() / "amqp";
+      boost::system::error_code ec;
+      boost::filesystem::create_directories(dir, ec);
+
+      const std::string file_prefix = "cproof";
+
+      chain::controller& controller = app().get_plugin<chain_plugin>().chain();
+
+      for(const auto& p : boost::filesystem::directory_iterator(dir)) {
+         if(boost::starts_with(p.path().filename().generic_string(), file_prefix))
+            boost::filesystem::remove(p.path(), ec);
+      }
+
+      if(options.count("compressed-proof")) {
+         const std::vector<std::string>& descs = options.at("compressed-proof").as<std::vector<std::string>>();
+         for(const std::string& desc : descs) {
+            std::vector<std::string> tokens;
+            boost::split(tokens, desc, boost::is_any_of("="));
+            EOS_ASSERT(tokens.size() >= 4, chain::plugin_config_exception, "Did not find 4 tokens in compressed-proof option \"${o}\"", ("o", desc));
+
+            std::string& name = tokens[0];
+            EOS_ASSERT(name.size(), chain::plugin_config_exception, "Cannot have empty name for compressed-proof \"${o}\"", ("o", desc));
+            EOS_ASSERT(my->proof_generators.find(name) == my->proof_generators.end(),
+                       chain::plugin_config_exception, "Name \"${n}\" used for more than one compressed-proof", ("n", name));
+            std::vector<std::string> filtered_receivers;
+            boost::split(filtered_receivers, tokens[1], boost::is_any_of(","));
+            EOS_ASSERT(filtered_receivers.size(), chain::plugin_config_exception, "Cannot have empty filter list for compressed-proof");
+
+            boost::filesystem::path amqp_unconfimed_file   = dir / (file_prefix + "-unconfirmed-"s + name + ".bin"s);
+            boost::filesystem::path reversible_blocks_file = dir / (file_prefix + "-reversible-"s + name + ".bin"s);
+
+            compressed_proof_generator& generator = my->proof_generators.emplace(std::piecewise_construct,
+                                                                                 std::forward_as_tuple(name),
+                                                                                 std::forward_as_tuple(reversible_blocks_file)).first->second;
+            reliable_amqp_publisher& publisher = my->publishers.emplace_back(tokens[2], tokens[3], amqp_unconfimed_file);
+
+            controller.irreversible_block.connect([&generator,&controller](const chain::block_state_ptr& bsp) {
+               generator.on_irreversible_block(bsp, controller);
+            });
+            controller.applied_transaction.connect([&generator](std::tuple<const chain::transaction_trace_ptr&, const chain::packed_transaction_ptr&> t) {
+               generator.on_applied_transaction(std::get<0>(t));
+            });
+            controller.accepted_block.connect([&generator](const chain::block_state_ptr& p) {
+               generator.on_accepted_block(p);
+            });
+
+            std::set<chain::name> filter_on_names;
+            for(const std::string& name_string : filtered_receivers)
+               filter_on_names.emplace(name_string);
+
+            generator.add_result_callback(
+               [filter_on_names](const chain::action& act) {
+                  return filter_on_names.find(act.account) != filter_on_names.end();
+               },
+               [&publisher](std::vector<char>&& serialized_proof) {
+                  publisher.publish_message(std::move(serialized_proof));
+               }
+            );
+         }
+      }
+   }
+   FC_LOG_AND_RETHROW()
+}
+
+void amqp_compressed_proof_plugin::plugin_startup() {}
+
+void amqp_compressed_proof_plugin::plugin_shutdown() {}
+
+}
+
+namespace fc {
+template<typename T>
+inline T& operator<<(T& ds, const std::list<eosio::merkle_cmd>& mcl) {
+   fc::raw::pack(ds, unsigned_int((uint32_t)mcl.size()) );
+   for(const eosio::merkle_cmd& mc : mcl)
+      fc::raw::pack(ds, mc);
+   return ds;
+}
+template<typename T>
+inline T& operator<<(T& ds, const std::set<eosio::action_entry>& aes) {
+   fc::raw::pack(ds, unsigned_int((uint32_t)aes.size()) );
+   for(const eosio::action_entry& ae : aes)
+      fc::raw::pack(ds, ae);
+   return ds;
+}
+}
+
+FC_REFLECT(eosio::combine_nodes, );
+FC_REFLECT(eosio::action_entry, (action)(return_value)(action_receipt));
+FC_REFLECT(eosio::compressed_proof_generator_impl::reversible_action_entries, (block_num)(block_id)(action_entries));

--- a/plugins/amqp_compressed_proof_plugin/amqp_compressed_proof_plugin.cpp
+++ b/plugins/amqp_compressed_proof_plugin/amqp_compressed_proof_plugin.cpp
@@ -181,9 +181,8 @@ compressed_proof_generator::compressed_proof_generator(const boost::filesystem::
       } FC_RETHROW_EXCEPTIONS(error, "Failed to load compressed merkle generator reversible state file ${f}", ("f", (fc::path)*my->reversible_path));
    }
    else {
-      try {
-         boost::filesystem::ofstream s(*my->reversible_path);
-      } FC_RETHROW_EXCEPTIONS(error, "Unable to create compressed merkle generator reversible state file ${f}", ("f", (fc::path)*my->reversible_path));
+      boost::filesystem::ofstream s(*my->reversible_path);
+      EOS_ASSERT(s.good(), chain::plugin_config_exception, "Unable to create compressed merkle generator reversible state file ${f}", ("f", (fc::path)*my->reversible_path));
    }
    boost::system::error_code ec;
    boost::filesystem::remove(*my->reversible_path, ec);

--- a/plugins/amqp_compressed_proof_plugin/amqp_compressed_proof_plugin.cpp
+++ b/plugins/amqp_compressed_proof_plugin/amqp_compressed_proof_plugin.cpp
@@ -348,7 +348,7 @@ void amqp_compressed_proof_plugin::plugin_initialize(const variables_map& option
             EOS_ASSERT(filtered_receivers.size(), chain::plugin_config_exception, "Cannot have empty filter list for compressed-proof");
 
             const boost::filesystem::path amqp_unconfimed_file   = dir / (file_prefix + "-unconfirmed-"s + name + ".bin"s);
-            reliable_amqp_publisher& publisher = my->publishers.emplace_back(tokens[2], tokens[3], amqp_unconfimed_file);
+            reliable_amqp_publisher& publisher = my->publishers.emplace_back(tokens[2], tokens[3], "", amqp_unconfimed_file, "eosio.node.compressed_proof_v0");
 
             std::set<chain::name> filter_on_names;
             for(const std::string& name_string : filtered_receivers)

--- a/plugins/amqp_compressed_proof_plugin/amqp_compressed_proof_plugin.cpp
+++ b/plugins/amqp_compressed_proof_plugin/amqp_compressed_proof_plugin.cpp
@@ -53,11 +53,11 @@ public:
       handle_input_action(merkle_creator_node{chain::digest_type::hash(ae.action_receipt), {ae}});
    }
 
-   std::vector<char> generate_serialized_proof(bool arv_activated) {
+   std::vector<char> generate_serialized_proof(const bool arv_activated) {
       if(!first_input_pair && curent_level.empty())
          return std::vector<char>();
       if(first_input_pair && curent_level.empty())
-         return fc::raw::pack<bool, std::list<merkle_cmd>>((bool)arv_activated, first_input_pair->cmd_stream);
+         return fc::raw::pack((const bool)arv_activated, first_input_pair->cmd_stream);
 
 
       if(first_input_pair) {
@@ -246,7 +246,7 @@ void compressed_proof_generator::on_irreversible_block(const chain::block_state_
 
       const chain::digest_type arv_dig = *controller.get_protocol_feature_manager().get_builtin_digest(chain::builtin_protocol_feature_t::action_return_value);
       const auto& protocol_features_this_block = bsp->activated_protocol_features->protocol_features;
-      bool action_return_value_active_this_block = protocol_features_this_block.find(arv_dig) != protocol_features_this_block.end();
+      const bool action_return_value_active_this_block = protocol_features_this_block.find(arv_dig) != protocol_features_this_block.end();
 
       for(const auto& cb : my->callbacks) {
          merkle_cmd_creator cc;

--- a/plugins/amqp_compressed_proof_plugin/amqp_compressed_proof_plugin.cpp
+++ b/plugins/amqp_compressed_proof_plugin/amqp_compressed_proof_plugin.cpp
@@ -219,8 +219,11 @@ void compressed_proof_generator::on_applied_transaction(const chain::transaction
 void compressed_proof_generator::on_accepted_block(const chain::block_state_ptr& bsp) {
    std::set<action_entry> action_entries_this_block;
 
-   if(my->onblock_trace)
-      action_entries_this_block.emplace((*my->onblock_trace)->action_traces.front());
+   // verify block_num of onblock_trace because last block could have been aborted & new block have no onblock
+   if(my->onblock_trace && (*my->onblock_trace)->block_num == bsp->block_num) {
+      for(const chain::action_trace& at : (*my->onblock_trace)->action_traces)
+         action_entries_this_block.emplace(at);
+   }
    for(const chain::transaction_receipt& r : bsp->block->transactions) {
       transaction_id_type id;
       if(r.trx.contains<chain::transaction_id_type>())

--- a/plugins/amqp_compressed_proof_plugin/amqp_compressed_proof_plugin.cpp
+++ b/plugins/amqp_compressed_proof_plugin/amqp_compressed_proof_plugin.cpp
@@ -352,7 +352,7 @@ void amqp_compressed_proof_plugin::plugin_initialize(const variables_map& option
                   return filter_on_names.find(act.account) != filter_on_names.end();
                },
                [&publisher](std::vector<char>&& serialized_proof) {
-                  publisher.publish_message(std::move(serialized_proof));
+                  publisher.publish_message_raw(std::move(serialized_proof));
                }
             ));
          }

--- a/plugins/amqp_compressed_proof_plugin/amqp_compressed_proof_plugin.cpp
+++ b/plugins/amqp_compressed_proof_plugin/amqp_compressed_proof_plugin.cpp
@@ -219,8 +219,8 @@ void compressed_proof_generator::on_applied_transaction(const chain::transaction
 void compressed_proof_generator::on_accepted_block(const chain::block_state_ptr& bsp) {
    std::set<action_entry> action_entries_this_block;
 
-   // verify block id of onblock_trace because last block could have been aborted & new block have no onblock
-   if(my->onblock_trace && (*my->onblock_trace)->id == bsp->id) {
+   // verify block_num of onblock_trace because last block could have been aborted & new block have no onblock
+   if(my->onblock_trace && (*my->onblock_trace)->block_num == bsp->block_num) {
       for(const chain::action_trace& at : (*my->onblock_trace)->action_traces)
          action_entries_this_block.emplace(at);
    }

--- a/plugins/amqp_compressed_proof_plugin/amqp_compressed_proof_plugin.cpp
+++ b/plugins/amqp_compressed_proof_plugin/amqp_compressed_proof_plugin.cpp
@@ -14,7 +14,6 @@
 
 #include <fc/io/cfile.hpp>
 
-//using boost::multi_index_container;
 using namespace boost::multi_index;
 using namespace std::string_literals;
 

--- a/plugins/amqp_compressed_proof_plugin/amqp_compressed_proof_plugin.cpp
+++ b/plugins/amqp_compressed_proof_plugin/amqp_compressed_proof_plugin.cpp
@@ -219,8 +219,8 @@ void compressed_proof_generator::on_applied_transaction(const chain::transaction
 void compressed_proof_generator::on_accepted_block(const chain::block_state_ptr& bsp) {
    std::set<action_entry> action_entries_this_block;
 
-   // verify block_num of onblock_trace because last block could have been aborted & new block have no onblock
-   if(my->onblock_trace && (*my->onblock_trace)->block_num == bsp->block_num) {
+   // verify block id of onblock_trace because last block could have been aborted & new block have no onblock
+   if(my->onblock_trace && (*my->onblock_trace)->id == bsp->id) {
       for(const chain::action_trace& at : (*my->onblock_trace)->action_traces)
          action_entries_this_block.emplace(at);
    }

--- a/plugins/amqp_compressed_proof_plugin/amqp_compressed_proof_plugin.cpp
+++ b/plugins/amqp_compressed_proof_plugin/amqp_compressed_proof_plugin.cpp
@@ -65,7 +65,7 @@ public:
          curent_level.resize(curent_level.size()/2);
       }
 
-      return fc::raw::pack<bool, std::list<merkle_cmd>>((bool)arv_activated, curent_level[0].cmd_stream);
+      return fc::raw::pack((const bool)arv_activated, curent_level[0].cmd_stream);
    }
 
 private:

--- a/plugins/amqp_compressed_proof_plugin/amqp_compressed_proof_plugin.cpp
+++ b/plugins/amqp_compressed_proof_plugin/amqp_compressed_proof_plugin.cpp
@@ -119,24 +119,17 @@ struct compressed_proof_generator_impl {
    > reversible_action_entries_index_type;
    reversible_action_entries_index_type reversible_action_entries_index;
 
-   static bool is_onblock(const chain::transaction_trace_ptr& p) {
-      if(p->action_traces.empty())
-         return false;
-      auto& act = p->action_traces[0].act;
-      if(act.account != eosio::chain::config::system_account_name || act.name != N(onblock) ||
-          act.authorization.size() != 1)
-         return false;
-      auto& auth = act.authorization[0];
-      return auth.actor == eosio::chain::config::system_account_name &&
-             auth.permission == eosio::chain::config::active_name;
-   }
-
    std::map<transaction_id_type, chain::transaction_trace_ptr> cached_traces;
    std::optional<chain::transaction_trace_ptr>                 onblock_trace;
    std::vector<std::pair<compressed_proof_generator::action_filter_func,
                          compressed_proof_generator::merkle_proof_result_func>>  callbacks;
 
    fc::optional<boost::filesystem::path> reversible_path;
+
+   void clear_caches() {
+      cached_traces.clear();
+      onblock_trace.reset();
+   }
 };
 
 using generator_impl = compressed_proof_generator_impl;
@@ -190,7 +183,7 @@ void compressed_proof_generator::on_applied_transaction(const chain::transaction
       trace->receipt->status != chain::transaction_receipt::status_enum::delayed)
       return;
 
-   if(my->is_onblock(trace))
+   if(chain::is_onblock(*trace))
       my->onblock_trace.emplace(trace);
    else
       my->cached_traces[trace->id] = trace;
@@ -199,8 +192,7 @@ void compressed_proof_generator::on_applied_transaction(const chain::transaction
 void compressed_proof_generator::on_accepted_block(const chain::block_state_ptr& bsp) {
    std::set<action_entry> action_entries_this_block;
 
-   // verify block_num of onblock_trace because last block could have been aborted & new block have no onblock
-   if(my->onblock_trace && (*my->onblock_trace)->block_num == bsp->block_num) {
+   if(my->onblock_trace) {
       for(const chain::action_trace& at : (*my->onblock_trace)->action_traces)
          action_entries_this_block.emplace(at);
    }
@@ -215,8 +207,7 @@ void compressed_proof_generator::on_accepted_block(const chain::block_state_ptr&
       for(const chain::action_trace& at : it->second->action_traces)
          action_entries_this_block.emplace(at);
    }
-   my->cached_traces.clear();
-   my->onblock_trace.reset();
+   my->clear_caches();
 
    my->reversible_action_entries_index.emplace(generator_impl::reversible_action_entries{bsp->block_num, bsp->id, std::move(action_entries_this_block)});
 }
@@ -250,6 +241,10 @@ void compressed_proof_generator::on_irreversible_block(const chain::block_state_
            my->reversible_action_entries_index.get<generator_impl::by_block_num>().begin(),
            my->reversible_action_entries_index.get<generator_impl::by_block_num>().upper_bound(bsp->block_num)
    );
+}
+
+void compressed_proof_generator::on_block_start(uint32_t block_num) {
+   my->clear_caches();
 }
 
 void compressed_proof_generator::add_result_callback(action_filter_func&& filter, merkle_proof_result_func&& result) {
@@ -308,6 +303,9 @@ void amqp_compressed_proof_plugin::plugin_initialize(const variables_map& option
       });
       controller.accepted_block.connect([&generator=*my->proof_generator](const chain::block_state_ptr& p) {
          generator.on_accepted_block(p);
+      });
+      controller.block_start.connect([&generator=*my->proof_generator](uint32_t block_num) {
+         generator.on_block_start(block_num);
       });
 
       if(options.count("compressed-proof")) {

--- a/plugins/amqp_compressed_proof_plugin/amqp_compressed_proof_plugin.cpp
+++ b/plugins/amqp_compressed_proof_plugin/amqp_compressed_proof_plugin.cpp
@@ -140,10 +140,10 @@ struct compressed_proof_generator_impl {
    reversible_action_entries_index_type reversible_action_entries_index;
 
    static bool is_onblock(const chain::transaction_trace_ptr& p) {
-      if (p->action_traces.size() != 1)
+      if(p->action_traces.empty())
          return false;
       auto& act = p->action_traces[0].act;
-      if (act.account != eosio::chain::config::system_account_name || act.name != N(onblock) ||
+      if(act.account != eosio::chain::config::system_account_name || act.name != N(onblock) ||
           act.authorization.size() != 1)
          return false;
       auto& auth = act.authorization[0];

--- a/plugins/amqp_compressed_proof_plugin/include/eosio/amqp_compressed_proof_plugin/amqp_compressed_proof_plugin.hpp
+++ b/plugins/amqp_compressed_proof_plugin/include/eosio/amqp_compressed_proof_plugin/amqp_compressed_proof_plugin.hpp
@@ -1,0 +1,46 @@
+#pragma once
+#include <appbase/application.hpp>
+
+#include <eosio/chain_plugin/chain_plugin.hpp>
+
+namespace eosio {
+
+using namespace appbase;
+
+class compressed_proof_generator {
+public:
+   compressed_proof_generator();
+   compressed_proof_generator(const boost::filesystem::path& reversible_path);
+   ~compressed_proof_generator();
+
+   compressed_proof_generator(const compressed_proof_generator&) = delete;
+   compressed_proof_generator& operator=(const compressed_proof_generator&) = delete;
+
+   void on_applied_transaction(const chain::transaction_trace_ptr& trace);
+   void on_accepted_block(const chain::block_state_ptr& p);
+   void on_irreversible_block(const chain::block_state_ptr& bsp, const chain::controller& controller);
+
+   using action_filter_func = std::function<bool(const chain::action& a)>;
+   using merkle_proof_result_func = std::function<void(std::vector<char>&&)>;
+   void add_result_callback(action_filter_func&& filter, merkle_proof_result_func&& result);
+private:
+   std::unique_ptr<struct compressed_proof_generator_impl> my;
+};
+
+class amqp_compressed_proof_plugin : public appbase::plugin<amqp_compressed_proof_plugin> {
+public:
+   amqp_compressed_proof_plugin();
+   virtual ~amqp_compressed_proof_plugin();
+
+   APPBASE_PLUGIN_REQUIRES((chain_plugin))
+   virtual void set_program_options(options_description&, options_description& cfg) override;
+
+   void plugin_initialize(const variables_map& options);
+   void plugin_startup();
+   void plugin_shutdown();
+
+private:
+   std::unique_ptr<struct amqp_compressed_proof_plugin_impl> my;
+};
+
+}

--- a/plugins/amqp_compressed_proof_plugin/include/eosio/amqp_compressed_proof_plugin/amqp_compressed_proof_plugin.hpp
+++ b/plugins/amqp_compressed_proof_plugin/include/eosio/amqp_compressed_proof_plugin/amqp_compressed_proof_plugin.hpp
@@ -9,16 +9,17 @@ using namespace appbase;
 
 class compressed_proof_generator {
 public:
-   compressed_proof_generator(chain::controller& controller);
-   compressed_proof_generator(chain::controller& controller, const boost::filesystem::path& reversible_path);
+   using action_filter_func = std::function<bool(const chain::action& a)>;
+   using merkle_proof_result_func = std::function<void(std::vector<char>&&)>;
+   using result_callback_funcs = std::pair<action_filter_func, merkle_proof_result_func>;
+
+   compressed_proof_generator(chain::controller& controller, std::vector<result_callback_funcs>&& callbacks);
+   compressed_proof_generator(chain::controller& controller, std::vector<result_callback_funcs>&& callbacks, const boost::filesystem::path& reversible_path);
    ~compressed_proof_generator();
 
    compressed_proof_generator(const compressed_proof_generator&) = delete;
    compressed_proof_generator& operator=(const compressed_proof_generator&) = delete;
 
-   using action_filter_func = std::function<bool(const chain::action& a)>;
-   using merkle_proof_result_func = std::function<void(std::vector<char>&&)>;
-   void add_result_callback(action_filter_func&& filter, merkle_proof_result_func&& result);
 private:
    std::unique_ptr<struct compressed_proof_generator_impl> my;
 };

--- a/plugins/amqp_compressed_proof_plugin/include/eosio/amqp_compressed_proof_plugin/amqp_compressed_proof_plugin.hpp
+++ b/plugins/amqp_compressed_proof_plugin/include/eosio/amqp_compressed_proof_plugin/amqp_compressed_proof_plugin.hpp
@@ -9,17 +9,12 @@ using namespace appbase;
 
 class compressed_proof_generator {
 public:
-   compressed_proof_generator();
-   compressed_proof_generator(const boost::filesystem::path& reversible_path);
+   compressed_proof_generator(chain::controller& controller);
+   compressed_proof_generator(chain::controller& controller, const boost::filesystem::path& reversible_path);
    ~compressed_proof_generator();
 
    compressed_proof_generator(const compressed_proof_generator&) = delete;
    compressed_proof_generator& operator=(const compressed_proof_generator&) = delete;
-
-   void on_applied_transaction(const chain::transaction_trace_ptr& trace);
-   void on_accepted_block(const chain::block_state_ptr& p);
-   void on_irreversible_block(const chain::block_state_ptr& bsp, const chain::controller& controller);
-   void on_block_start(uint32_t block_num);
 
    using action_filter_func = std::function<bool(const chain::action& a)>;
    using merkle_proof_result_func = std::function<void(std::vector<char>&&)>;

--- a/plugins/amqp_compressed_proof_plugin/include/eosio/amqp_compressed_proof_plugin/amqp_compressed_proof_plugin.hpp
+++ b/plugins/amqp_compressed_proof_plugin/include/eosio/amqp_compressed_proof_plugin/amqp_compressed_proof_plugin.hpp
@@ -19,6 +19,7 @@ public:
    void on_applied_transaction(const chain::transaction_trace_ptr& trace);
    void on_accepted_block(const chain::block_state_ptr& p);
    void on_irreversible_block(const chain::block_state_ptr& bsp, const chain::controller& controller);
+   void on_block_start(uint32_t block_num);
 
    using action_filter_func = std::function<bool(const chain::action& a)>;
    using merkle_proof_result_func = std::function<void(std::vector<char>&&)>;

--- a/programs/nodeos/CMakeLists.txt
+++ b/programs/nodeos/CMakeLists.txt
@@ -58,6 +58,7 @@ target_link_libraries( ${NODE_EXECUTABLE_NAME}
         PRIVATE -Wl,${whole_archive_flag} test_control_plugin        -Wl,${no_whole_archive_flag}
         PRIVATE -Wl,${whole_archive_flag} test_control_api_plugin    -Wl,${no_whole_archive_flag}
         PRIVATE -Wl,${whole_archive_flag} amqp_witness_plugin        -Wl,${no_whole_archive_flag}
+        PRIVATE -Wl,${whole_archive_flag} amqp_compressed_proof_plugin -Wl,${no_whole_archive_flag}
         PRIVATE -Wl,${build_id_flag}
         PRIVATE chain_plugin http_plugin producer_plugin http_client_plugin
         PRIVATE eosio_chain_wrap fc ${CMAKE_DL_LIBS} ${PLATFORM_SPECIFIC_LIBS} )

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -42,7 +42,7 @@ add_custom_command(
 file(GLOB UNIT_TESTS "*.cpp") # find all unit test suites
 add_executable( unit_test ${UNIT_TESTS} protocol_feature_digest_tests.cpp) # build unit tests as one executable
 
-target_link_libraries( unit_test eosio_chain_wrap chainbase eosio_testing fc appbase state_history abieos ${PLATFORM_SPECIFIC_LIBS} )
+target_link_libraries( unit_test eosio_chain_wrap chainbase eosio_testing fc appbase state_history abieos amqp_compressed_proof_plugin ${PLATFORM_SPECIFIC_LIBS} )
 
 target_compile_options(unit_test PUBLIC -DDISABLE_EOSLIB_SERIALIZE)
 target_include_directories( unit_test PUBLIC

--- a/unittests/compressed_merkle_tests.cpp
+++ b/unittests/compressed_merkle_tests.cpp
@@ -1,0 +1,210 @@
+#include <eosio/amqp_compressed_proof_plugin/amqp_compressed_proof_plugin.hpp>
+#include <eosio/testing/tester.hpp>
+
+#include <boost/test/data/test_case.hpp>
+
+#include "compressed_proof_validator.hpp"
+
+using namespace eosio;
+using namespace eosio::chain;
+using namespace eosio::testing;
+using namespace fc;
+
+static const char fail_everything_wast[] = R"=====(
+(module
+ (export "apply" (func $apply))
+ (func $apply (param $0 i64) (param $1 i64) (param $2 i64)
+  (unreachable)
+ )
+)
+)=====";
+
+static const char test_account_abi[] = R"=====(
+{
+   "version": "eosio::abi/1.0",
+   "types": [],
+   "structs": [{"name":"dothedew", "base": "", "fields": [{"name":"nonce", "type":"uint32"}]}],
+   "actions": [{"name":"dothedew", "type": "dothedew", "ricardian_contract":""}],
+   "tables": [],
+   "ricardian_clauses": [],
+   "variants": [],
+   "action_results": []
+}
+)=====";
+
+static auto wire_signals_to_generator(compressed_proof_generator& generator, controller& ctrl) {
+   std::vector<boost::signals2::scoped_connection> conns;
+   conns.emplace_back(ctrl.irreversible_block.connect([&](const block_state_ptr& bsp) {
+      generator.on_irreversible_block(bsp, ctrl);
+   }));
+   conns.emplace_back(ctrl.applied_transaction.connect([&](std::tuple<const transaction_trace_ptr&, const packed_transaction_ptr&> t) {
+      generator.on_applied_transaction(std::get<0>(t));
+   }));
+   conns.emplace_back(ctrl.accepted_block.connect([&](const block_state_ptr& p) {
+      generator.on_accepted_block(p);
+   }));
+   return conns;
+}
+
+BOOST_AUTO_TEST_SUITE(test_compressed_proof)
+
+BOOST_AUTO_TEST_CASE(test_proof_no_actions) try {
+   tester chain(setup_policy::none);
+   //I want to very precisely control the exact actions in the block; disable onblock
+   chain.set_code(N(eosio), fail_everything_wast);
+   chain.produce_block();
+
+   compressed_proof_generator proof_generator;
+   auto signal_connections = wire_signals_to_generator(proof_generator, *chain.control);
+
+   proof_generator.add_result_callback([&](const auto&){return true;}, [&](auto&& x) {
+      //no actions means no callback should ever be fired
+      BOOST_FAIL("Callback should not be called");
+   });
+
+   chain.produce_blocks(2);
+} FC_LOG_AND_RETHROW()
+
+//This test will create 1 to n actions in a block. For each of n, it will then test all permutations of
+// interested vs non-interested actions. That is, when n is 1, there will be 1 action in a block which
+// will be tested as an interested action, and then tested as a non-interested action. When n is 2, there
+// will be 4 total combinations tried, etc
+BOOST_DATA_TEST_CASE(test_proof_actions, boost::unit_test::data::xrange(1u, 10u), n_actions) try {
+   tester chain(setup_policy::none);
+   chain.create_accounts({N(interested), N(nointerested)});
+   chain.set_abi(N(interested), test_account_abi);
+   chain.set_abi(N(nointerested), test_account_abi);
+   chain.produce_block();
+   //this test wants to very precisely control the exact actions in the block; disable onblock
+   chain.set_code(N(eosio), fail_everything_wast);
+   chain.produce_block();
+
+   compressed_proof_generator proof_generator;
+   auto signal_connections = wire_signals_to_generator(proof_generator, *chain.control);
+
+   bool expecting_callback = false;
+   fc::sha256 computed_action_mroot;
+
+   proof_generator.add_result_callback(
+      [&](const chain::action& act){
+         return act.account == N(interested);
+      },
+      [&](std::vector<char>&& serialized_compressed_proof) {
+         BOOST_CHECK(expecting_callback);
+         computed_action_mroot = validate_compressed_merkle_proof(serialized_compressed_proof, [](uint64_t receiver) {
+            BOOST_CHECK(name(receiver) == N(interested));
+         });
+      }
+   );
+
+   unsigned nonce = 0;
+   for(unsigned action_mask = 0; action_mask < 1<<n_actions; action_mask++) {
+      for(unsigned action_bit = 0; action_bit < n_actions; ++action_bit) {
+         bool push_interested = action_mask&1<<action_bit;
+
+         if(push_interested)
+            chain.push_action(N(interested), N(dothedew), N(interested), fc::mutable_variant_object()("nonce", nonce++));
+         else
+            chain.push_action(N(nointerested), N(dothedew), N(nointerested), fc::mutable_variant_object()("nonce", nonce++));
+      }
+
+      expecting_callback = false;
+      fc::sha256 expected_action_mroot = chain.produce_block()->action_mroot;
+      expecting_callback = action_mask; //when action_mask is 0, no interested action pushed meaning no callback called
+      chain.produce_block();
+
+      if(expecting_callback)
+         BOOST_CHECK(expected_action_mroot == computed_action_mroot);
+   }
+
+} FC_LOG_AND_RETHROW()
+
+BOOST_AUTO_TEST_CASE(test_proof_arv_activation) try {
+   tester chain(setup_policy::none);
+   compressed_proof_generator proof_generator;
+   auto signal_connections = wire_signals_to_generator(proof_generator, *chain.control);
+
+   fc::sha256 computed_action_mroot;
+
+   proof_generator.add_result_callback(
+      [&](const chain::action& act){
+         return true;
+      },
+      [&](std::vector<char>&& serialized_compressed_proof) {
+         computed_action_mroot = validate_compressed_merkle_proof(serialized_compressed_proof, [](uint64_t receiver) {});
+      }
+   );
+
+   std::optional<sha256> reversible_action_mroot;
+   auto produce_and_check = [&]() {
+      sha256 new_mroot = chain.produce_block()->action_mroot;
+      if(reversible_action_mroot)
+         BOOST_CHECK(*reversible_action_mroot == computed_action_mroot);
+      reversible_action_mroot = new_mroot;
+   };
+   chain.execute_setup_policy(setup_policy::preactivate_feature_and_new_bios);
+
+   chain.create_account(N(interested));
+   chain.set_abi(N(interested), test_account_abi);
+   produce_and_check();
+   produce_and_check();
+
+   //activate ARV
+   const auto& pfm = chain.control->get_protocol_feature_manager();
+   auto d = pfm.get_builtin_digest(builtin_protocol_feature_t::action_return_value);
+   chain.preactivate_protocol_features({*d});
+
+   //put something else in the same block too
+   chain.push_action(N(interested), N(dothedew), N(interested), fc::mutable_variant_object()("nonce", 0));
+
+   produce_and_check();
+   produce_and_check();
+
+   //another post activation test
+   chain.push_action(N(interested), N(dothedew), N(interested), fc::mutable_variant_object()("nonce", 0));
+
+   produce_and_check();
+   produce_and_check();
+} FC_LOG_AND_RETHROW()
+
+BOOST_AUTO_TEST_CASE(test_proof_presist_reversible) try {
+   tester chain(setup_policy::none);
+   fc::temp_file tempfile;
+
+   unsigned blocks_seen = 0;
+
+   {
+      compressed_proof_generator proof_generator(tempfile.path());
+      auto signal_connections = wire_signals_to_generator(proof_generator, *chain.control);
+      proof_generator.add_result_callback(
+         [&](const chain::action& act){
+            return true;
+         },
+         [&](std::vector<char>&& serialized_compressed_proof) {
+            blocks_seen++;
+         }
+      );
+
+      chain.produce_blocks(5); //make 4 irreversible blocks; calling result callback 4 times
+   }
+
+   {
+      compressed_proof_generator proof_generator(tempfile.path());
+      auto signal_connections = wire_signals_to_generator(proof_generator, *chain.control);
+      proof_generator.add_result_callback(
+         [&](const chain::action& act){
+            return true;
+         },
+         [&](std::vector<char>&& serialized_compressed_proof) {
+            blocks_seen++;
+         }
+      );
+      chain.produce_block(); //makes one more irreversible block
+   }
+
+   //so should have seen 5 blocks from callback
+   BOOST_CHECK(blocks_seen == 5);
+} FC_LOG_AND_RETHROW()
+
+BOOST_AUTO_TEST_SUITE_END()
+

--- a/unittests/compressed_merkle_tests.cpp
+++ b/unittests/compressed_merkle_tests.cpp
@@ -182,6 +182,7 @@ BOOST_AUTO_TEST_CASE(test_proof_arv_activation) try {
    produce_and_check();
 } FC_LOG_AND_RETHROW()
 
+//This test isn't as interesting now that reversibility is completely handled by db mode, keeping it around anyways
 BOOST_AUTO_TEST_CASE(test_proof_presist_reversible) try {
    tester base_chain(setup_policy::none);
    base_chain.produce_blocks(10);
@@ -195,8 +196,6 @@ BOOST_AUTO_TEST_CASE(test_proof_presist_reversible) try {
    };
 
    tester chain(setup_policy::none, chain::db_read_mode::IRREVERSIBLE);
-   fc::temp_file tempfile;
-
    unsigned blocks_seen = 0;
 
    {
@@ -207,7 +206,7 @@ BOOST_AUTO_TEST_CASE(test_proof_presist_reversible) try {
          [&](std::vector<char>&& serialized_compressed_proof) {
             blocks_seen++;
          }
-      )}, tempfile.path());
+      )});
 
       push_blocks(base_chain, chain, 6); //make 4 irreversible blocks (2, 3, 4, 5); calling result callback 4 times
    }
@@ -220,7 +219,7 @@ BOOST_AUTO_TEST_CASE(test_proof_presist_reversible) try {
          [&](std::vector<char>&& serialized_compressed_proof) {
             blocks_seen++;
          }
-      )}, tempfile.path());
+      )});
 
       push_blocks(base_chain, chain, 7); //makes one more irreversible block
    }

--- a/unittests/compressed_proof_validator.cpp
+++ b/unittests/compressed_proof_validator.cpp
@@ -1,0 +1,158 @@
+#include "compressed_proof_validator.hpp"
+
+#include <eosio/from_bin.hpp>
+#include <eosio/ship_protocol.hpp>
+
+#include <openssl/sha.h>
+
+namespace eosio {
+
+namespace proof_validator {
+
+using sha256 = std::array<uint8_t, 32>;
+
+//no copy sha256 input
+struct sha256_input {
+   constexpr size_t size() const { return sizeof(sha256); };
+
+   const sha256& get() const {
+      return *reinterpret_cast<const sha256*>(pos);
+   }
+
+   const char* pos;
+};
+
+template <typename S>
+void from_bin(sha256_input& sha, S& stream) {
+   sha.pos = stream.pos;
+   return stream.skip(sha.size());
+}
+
+struct stream_range_capture {
+   const char* start = nullptr;
+   const char* end = nullptr;
+
+   size_t size() const {
+      check(start && end, "called stream_range_capture.size() without start and end");
+      return end-start;
+   }
+};
+
+template <typename S>
+void from_bin(stream_range_capture& range, S& stream) {
+   check(!range.start || !range.end, "stream_range_capture called too many times");
+   if(range.start == nullptr)
+      range.start = stream.pos;
+   else
+      range.end = stream.pos;
+}
+
+//used instead of ship_protocol::action so that the action base range can be easily capture
+struct action {
+   eosio::name                                  account       = {};
+   eosio::name                                  name          = {};
+   std::vector<ship_protocol::permission_level> authorization = {};
+   eosio::input_stream                          data          = {};
+
+   stream_range_capture action_base_range;
+};
+EOSIO_REFLECT(action, action_base_range, account, name, authorization, action_base_range, data);
+
+//used instead of ship_protocol::action_receipt for efficient act_digest input
+struct action_receipt {
+   name                                              receiver        = {};
+   sha256_input                                      act_digest      = {};
+   uint64_t                                          global_sequence = {};
+   uint64_t                                          recv_sequence   = {};
+   std::vector<ship_protocol::account_auth_sequence> auth_sequence   = {};
+   varuint32                                         code_sequence   = {};
+   varuint32                                         abi_sequence    = {};
+};
+EOSIO_REFLECT(action_receipt, receiver, act_digest, global_sequence, recv_sequence, auth_sequence, code_sequence, abi_sequence)
+
+struct action_entry {
+   proof_validator::action         action;
+   eosio::input_stream             return_value;
+   proof_validator::action_receipt action_receipt;
+
+   stream_range_capture action_range;
+   stream_range_capture action_receipt_range;
+};
+EOSIO_REFLECT(action_entry, action_range, action, action_range, return_value, action_receipt_range, action_receipt, action_receipt_range);
+
+struct combine {};
+EOSIO_REFLECT(combine);
+
+using merkle_cmd_t = std::variant<sha256_input, action_entry, combine>;
+
+static sha256 action_hash_pre_rv(const action_entry& input) {
+   sha256 ret;
+   SHA256((const unsigned char*)input.action_range.start, input.action_range.size(), ret.data());
+   return ret;
+}
+
+static sha256 action_hash_post_rv(const action_entry& input) {
+   sha256 hashpair[2];
+   SHA256((const unsigned char*)input.action.action_base_range.start, input.action.action_base_range.size(), hashpair[0].data());
+   SHA256((const unsigned char*)input.action.action_base_range.end, input.return_value.end - input.action.action_base_range.end, hashpair[1].data());
+   SHA256(hashpair->data(), sizeof(hashpair), hashpair[0].data());
+   return hashpair[0];
+}
+
+static sha256 validate_single_action(bool return_value_active, const action_entry& input, std::function<void(uint64_t)> on_action_receiver) {
+   const sha256 action_hash = return_value_active ? action_hash_post_rv(input) : action_hash_pre_rv(input);
+
+   check(input.action_receipt.act_digest.get() == action_hash, "action digest in action receipt does not match computed action digest");
+
+   //For a real validation application, you would do something more "interesting" here. In this example code,
+   // just make a call out to a function with the receiver as a uint64_t so that it can be validated. Anything more
+   // advanced is tricky with abieos vs fc/chain together.
+   on_action_receiver(input.action_receipt.receiver.value);
+
+   sha256 ret;
+   SHA256((const unsigned char*)input.action_receipt_range.start, input.action_receipt_range.size(), ret.data());
+   return ret;
+}
+
+}
+
+using namespace proof_validator;
+
+fc::sha256 validate_compressed_merkle_proof(const std::vector<char>& input, std::function<void(uint64_t)> on_action_receiver) {
+   input_stream is(input);
+   bool arv_activated;
+   unsigned_int num_cmds;
+   from_bin(arv_activated, is);
+   from_bin(num_cmds, is);
+
+   //Used stack size will be the same as the merkle tree depth. So something like 24 is vastly overkill
+   // because you're not going to have 2^24 actions in a block any time soon.
+   const unsigned merkle_stack_size = 24;
+   sha256* merkle_stack = (sha256*)alloca(sizeof(sha256)*merkle_stack_size);
+   unsigned merkle_stack_top = 0;
+
+   merkle_cmd_t cmd;
+   while(num_cmds.value--) {
+      from_bin(cmd, is);
+
+      if(const action_entry* act_input = std::get_if<action_entry>(&cmd)) {
+         check(merkle_stack_top != merkle_stack_size, "merkle stack is full");
+         merkle_stack[merkle_stack_top++] = validate_single_action(arv_activated, *act_input, on_action_receiver);
+      }
+      else if(const sha256_input* hash_input = std::get_if<sha256_input>(&cmd)) {
+         check(merkle_stack_top != merkle_stack_size, "merkle stack is full");
+         merkle_stack[merkle_stack_top++] = hash_input->get();
+      }
+      else if(std::holds_alternative<combine>(cmd)) {
+         check(merkle_stack_top >= 2, "merkle stack combine operator found when stack size less than 2");
+         merkle_stack[merkle_stack_top-2][0] &= 0x7fu;
+         merkle_stack[merkle_stack_top-1][0] |= 0x80u;
+         SHA256(merkle_stack[merkle_stack_top-2].data(), sizeof(sha256)*2, merkle_stack[merkle_stack_top-2].data());
+         merkle_stack_top--;
+      }
+   }
+
+   return fc::sha256((const char*)merkle_stack[0].data(), sizeof(sha256));
+}
+
+}

--- a/unittests/compressed_proof_validator.hpp
+++ b/unittests/compressed_proof_validator.hpp
@@ -1,0 +1,7 @@
+#include <fc/crypto/sha256.hpp>
+
+namespace eosio {
+
+fc::sha256 validate_compressed_merkle_proof(const std::vector<char>& input, std::function<void(uint64_t)> on_action_receiver);
+
+}


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
The amqp_compressed_proof_plugin creates “compressed” action merkle proofs over a list of filtered action receivers and their actions once they become irreversible. The proofs are compressed in that they contain as few leafs of the merkle tree as necessary to match the filtered actions with the action_mroot. Additionally, the input stream is constructed in a manner that attempts to be efficient in validation within a smart contract — hashing can be done with minimal copying and working through the proof requires very little temporary memory.

Configuration of the plugin is a mouthful to say the least. amqp_compressed_proof_plugin can generate multiple proofs per block sending them to different AMQP servers and/or exchanges. This is desirable if different actions need to be handled by different downstream consumers on the message bus. But there is no easy way in appbase’s configuration system to define a “group” other then a repeating string parsed in a particular manner. That is what `compressed-proof` option is here, a repeating string with 4 fields describing a single proof to be created and sent in the form of

`NAME=FILTER=SERVER=EXCHANGE`

Where,
* **NAME**: A unique name for this proof. Used for naming the persistence files created for this publisher. I elected to make this manually configurable instead of auto-generated so that users could tweak the exchange, filter list, or server without losing the persistent unconfirmed AMQP queue that goes with each entry.
* **FILTER**: A comma separated list of receivers to include in the proof.
* **SERVER**: URI for the AMQP server
* **EXCHANGE**: exchange name to publish to

An example valid configuration may be, for example
```
# pusblish all actions on eosio and eosio.token to the exchange named 'wheelhouse' on the local amqp server
compressed-proof = proof1=eosio,eosio.token=amqp://=wheelhouse
# Additionally publish actions on eosio via another exchange named 'stack'
compressed-proof = justSendEOSIOHere=eosio=amqp://=stack
```

Parts of the implementation refer to a “command stream” when generating or parsing the proof. This terminology comes about because the serialized data structure is effectively three commands that operate a stack. After the final input from the command stream, the stack should have a single entry that is the same as the action_mroot.

At the front of the serialized proof is a boolean indicating if the proof needs to be computed with action return value semantics or not. I believe there may be a desire to include the block header as well. Downstream components consuming the proof may want to generate additional EOSIO transactions based on the actions in the proof. Block header will be required in that use case for tapos fields. I’m not really sure how to handle this yet… maybe the block header should simply be slapped on the front too.

There may also be a desire to increase the filter granularity by filtering on action name.

Typically you would combine this plugin with #9122: downstream consumers will only operate on the compressed action merkle proof if other witnesses have attested to the action_mroot being correct.

As part of the unit tests, a validator that can parse the compressed command stream is implemented via abieos as an example of a reasonably efficient implementation that could work in a smart contract.

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
