### PR TITLE
Prune data integration test fix

### DIFF
--- a/tests/Cluster.py
+++ b/tests/Cluster.py
@@ -427,7 +427,7 @@ class Cluster(object):
             self.unstartedNodes=self.discoverUnstartedLocalNodes(unstartedNodes, totalNodes)
 
         biosNode=self.discoverBiosNode(timeout=Utils.systemWaitTimeout)
-        if not biosNode or not Utils.waitForBool(biosNode.checkPulse, Utils.systemWaitTimeout):
+        if not biosNode or not Utils.waitForTruth(biosNode.checkPulse, Utils.systemWaitTimeout):
             Utils.Print("ERROR: Bios node doesn't appear to be running...")
             return False
 
@@ -589,7 +589,7 @@ class Cluster(object):
 
         printCount=0
         lam = lambda: doNodesHaveBlockNum(self.nodes, targetBlockNum, blockType, printCount)
-        ret=Utils.waitForBool(lam, timeout)
+        ret=Utils.waitForTruth(lam, timeout)
         return ret
 
     @staticmethod
@@ -1181,7 +1181,7 @@ class Cluster(object):
 
             # wait for block production handover (essentially a block produced by anyone but eosio).
             lam = lambda: biosNode.getInfo(exitOnError=True)["head_block_producer"] != "eosio"
-            ret=Utils.waitForBool(lam)
+            ret=Utils.waitForTruth(lam)
             if not ret:
                 Utils.Print("ERROR: Block production handover failed.")
                 return None
@@ -1338,7 +1338,7 @@ class Cluster(object):
                 return None
             return None
 
-        return Utils.waitForObj(myFunc, timeout)
+        return Utils.waitForTruth(myFunc, timeout)
 
     @staticmethod
     def pgrepEosServerPattern(nodeInstance):

--- a/tests/Node.py
+++ b/tests/Node.py
@@ -484,7 +484,7 @@ class Node(object):
         ret=Utils.waitForTruth(lam, timeout)
         return ret
 
-    def waitForNextBlock(self, timeout=WaitSpec.default, blockType=BlockType.head):
+    def waitForNextBlock(self, timeout=WaitSpec.default(), blockType=BlockType.head):
         num=self.getBlockNum(blockType=blockType)
         if isinstance(timeout, WaitSpec):
             timeout = timeout.seconds(num, num+1)
@@ -492,7 +492,7 @@ class Node(object):
         ret=Utils.waitForTruth(lam, timeout)
         return ret
 
-    def waitForBlock(self, blockNum, timeout=WaitSpec.default, blockType=BlockType.head, reportInterval=None, errorContext=None):
+    def waitForBlock(self, blockNum, timeout=WaitSpec.default(), blockType=BlockType.head, reportInterval=None, errorContext=None):
         currentBlockNum=self.getBlockNum(blockType=blockType)
         currentTime=time.time()
         if isinstance(timeout, WaitSpec):
@@ -550,7 +550,7 @@ class Node(object):
         assert ret is not None or errorContext is None, Utils.errorExit("%s." % (errorContext))
         return ret
 
-    def waitForIrreversibleBlock(self, blockNum, timeout=WaitSpec.default, blockType=BlockType.head):
+    def waitForIrreversibleBlock(self, blockNum, timeout=WaitSpec.default(), blockType=BlockType.head):
         return self.waitForBlock(blockNum, timeout=timeout, blockType=blockType)
 
     # Trasfer funds. Returns "transfer" json return object

--- a/tests/Node.py
+++ b/tests/Node.py
@@ -803,8 +803,10 @@ class Node(object):
             return (False, msg)
 
     # returns tuple with indication if transaction was successfully sent and either the transaction or else the exception output
-    def pushTransaction(self, trans, opts="--skip-sign", silentErrors=False):
+    def pushTransaction(self, trans, opts="--skip-sign", silentErrors=False, permissions=None):
         assert(isinstance(trans, dict))
+        if isinstance(permissions, str):
+            permissions=[permissions]
         cmd="%s %s push transaction -j" % (Utils.EosClientPath, self.eosClientArgs())
         cmdArr=cmd.split()
         transStr = json.dumps(trans, separators=(',', ':'))
@@ -812,6 +814,11 @@ class Node(object):
         cmdArr.append(transStr)
         if opts is not None:
             cmdArr += opts.split()
+        if permissions is not None:
+            for permission in permissions:
+                cmdArr.append("-p")
+                cmdArr.append(permission)
+
         s=" ".join(cmdArr)
         if Utils.Debug: Utils.Print("cmd: %s" % (cmdArr))
         start=time.perf_counter()

--- a/tests/Node.py
+++ b/tests/Node.py
@@ -474,14 +474,14 @@ class Node(object):
         """Wait for trans id to be finalized."""
         assert(isinstance(transId, str))
         lam = lambda: self.isTransInAnyBlock(transId)
-        ret=Utils.waitForBool(lam, timeout)
+        ret=Utils.waitForTruth(lam, timeout)
         return ret
 
     def waitForTransFinalization(self, transId, timeout=None):
         """Wait for trans id to be finalized."""
         assert(isinstance(transId, str))
         lam = lambda: self.isTransFinalized(transId)
-        ret=Utils.waitForBool(lam, timeout)
+        ret=Utils.waitForTruth(lam, timeout)
         return ret
 
     def waitForNextBlock(self, timeout=Timeout.default, blockType=BlockType.head):
@@ -489,7 +489,7 @@ class Node(object):
         if isinstance(timeout, Timeout):
             timeout = timeout.seconds(num, num+1)
         lam = lambda: self.getHeadBlockNum() > num
-        ret=Utils.waitForBool(lam, timeout)
+        ret=Utils.waitForTruth(lam, timeout)
         return ret
 
     def waitForBlock(self, blockNum, timeout=None, blockType=BlockType.head, reportInterval=None, errorContext=None):
@@ -546,7 +546,7 @@ class Node(object):
         with RequireBlockNum(self, blockNum) as lam:
 
             reporter = WaitReporter(self, reportInterval) if reportInterval is not None else None
-            ret=Utils.waitForBool(lam, timeout, reporter=reporter)
+            ret=Utils.waitForTruth(lam, timeout, reporter=reporter)
 
         assert ret is not None or errorContext is None, Utils.errorExit("%s." % (errorContext))
         return ret
@@ -1125,7 +1125,7 @@ class Node(object):
                 return True
             return False
 
-        if not Utils.waitForBool(myFunc):
+        if not Utils.waitForTruth(myFunc):
             Utils.Print("ERROR: Failed to validate node shutdown.")
             return False
 
@@ -1288,9 +1288,10 @@ class Node(object):
                     return False
 
         if "terminate-at-block" not in cmd:
-            isAlive=Utils.waitForBool(isNodeAlive, timeout, sleepTime=1)
+            isAlive=Utils.waitForTruth(isNodeAlive, timeout, sleepTime=1)
         else:
-            isAlive=Utils.waitForBoolWithArg(didNodeExitGracefully, self.popenProc, timeout, sleepTime=1)
+            lam=DidProcessExitGracefully(self.popenProc, timeout)
+            isAlive=Utils.waitForTruth(lam, timeout, sleepTime=1)
         if isAlive:
             Utils.Print("Node relaunch was successful.")
         else:
@@ -1405,13 +1406,13 @@ class Node(object):
         currentHead = self.getHeadBlockNum()
         def isHeadAdvancing():
             return self.getHeadBlockNum() > currentHead
-        return Utils.waitForBool(isHeadAdvancing, timeout)
+        return Utils.waitForTruth(isHeadAdvancing, timeout)
 
     def waitForLibToAdvance(self, timeout=30):
         currentLib = self.getIrreversibleBlockNum()
         def isLibAdvancing():
             return self.getIrreversibleBlockNum() > currentLib
-        return Utils.waitForBool(isLibAdvancing, timeout)
+        return Utils.waitForTruth(isLibAdvancing, timeout)
 
     # Require producer_api_plugin
     def activatePreactivateFeature(self):

--- a/tests/Node.py
+++ b/tests/Node.py
@@ -15,6 +15,7 @@ from testUtils import EnumType
 from testUtils import addEnum
 from testUtils import unhandledEnumType
 from testUtils import ReturnType
+from testUtils import Timeout
 
 class BlockType(EnumType):
     pass
@@ -483,13 +484,21 @@ class Node(object):
         ret=Utils.waitForBool(lam, timeout)
         return ret
 
-    def waitForNextBlock(self, timeout=None, blockType=BlockType.head):
+    def waitForNextBlock(self, timeout=Timeout.default, blockType=BlockType.head):
         num=self.getBlockNum(blockType=blockType)
+        if isinstance(timeout, Timeout):
+            timeout = timeout.seconds(num, num+1)
         lam = lambda: self.getHeadBlockNum() > num
         ret=Utils.waitForBool(lam, timeout)
         return ret
 
     def waitForBlock(self, blockNum, timeout=None, blockType=BlockType.head, reportInterval=None, errorContext=None):
+#    def waitForBlock(self, blockNum, timeout=Timeout.default, blockType=BlockType.head, reportInterval=None, errorContext=None):
+        currentBlockNum=self.getBlockNum(blockType=blockType)
+        currentTime=time.time()
+        if isinstance(timeout, Timeout):
+            timeout.convert(currentBlockNum, blockNum)
+
         blockDesc = "head" if blockType == BlockType.head else "LIB"
         count = 0
 
@@ -542,7 +551,7 @@ class Node(object):
         assert ret is not None or errorContext is None, Utils.errorExit("%s." % (errorContext))
         return ret
 
-    def waitForIrreversibleBlock(self, blockNum, timeout=None, blockType=BlockType.head):
+    def waitForIrreversibleBlock(self, blockNum, timeout=Timeout.default, blockType=BlockType.head):
         return self.waitForBlock(blockNum, timeout=timeout, blockType=blockType)
 
     # Trasfer funds. Returns "transfer" json return object

--- a/tests/eosio_blocklog_prune_test.py
+++ b/tests/eosio_blocklog_prune_test.py
@@ -101,7 +101,7 @@ try:
     cfTrxId = trans["transaction_id"]
 
     # Wait until the block where create account is executed to become irreversible
-    producerNode.waitForBlock(cfTrxBlockNum, blockType=BlockType.lib, timeout=WaitSpec.calculate, errorContext="producerNode LIB did not advance")
+    producerNode.waitForBlock(cfTrxBlockNum, blockType=BlockType.lib, timeout=WaitSpec.calculate(), errorContext="producerNode LIB did not advance")
 
     Utils.Print("verify the account payloadless from producer node")
     trans = producerNode.getEosAccount("payloadless")
@@ -138,7 +138,7 @@ try:
     # check whether the transaction has been pruned based on the tag of prunable_data, if the tag is 1, then it's a prunable_data_t::none
     assert trans["trx"]["receipt"]["trx"][1]["prunable_data"]["prunable_data"][0] == 1, "the the transaction with context free data has not been pruned"
 
-    producerNode.waitForBlock(cfTrxBlockNum, blockType=BlockType.lib, timeout=WaitSpec.calculate, errorContext="producerNode LIB did not advance")
+    producerNode.waitForBlock(cfTrxBlockNum, blockType=BlockType.lib, timeout=WaitSpec.calculate(), errorContext="producerNode LIB did not advance")
     assert producerNode.waitForHeadToAdvance(), "the producer node stops producing"
 
     # kill the producer with un-pruned cfd
@@ -156,12 +156,12 @@ try:
     #
     # Check lightValidationNode keeping sync while the full fullValidationNode stop syncing after the cfd block
     #
-    lightValidationNode.waitForBlock(cfTrxBlockNum, blockType=BlockType.lib, timeout=WaitSpec.calculate, errorContext="ligtValidationNode did not advance")
+    lightValidationNode.waitForBlock(cfTrxBlockNum, blockType=BlockType.lib, timeout=WaitSpec.calculate(), errorContext="ligtValidationNode did not advance")
     assert lightValidationNode.waitForHeadToAdvance(), "the light validation node stops syncing"
 
-    fullValidationNode.waitForBlock(cfTrxBlockNum-1, blockType=BlockType.lib, timeout=WaitSpec.calculate, errorContext="fullValidationNode LIB did not advance")
+    fullValidationNode.waitForBlock(cfTrxBlockNum-1, blockType=BlockType.lib, timeout=WaitSpec.calculate(), errorContext="fullValidationNode LIB did not advance")
     assert not fullValidationNode.waitForHeadToAdvance(), "the full validation node is still syncing"
-    
+
     testSuccessful = True
 finally:
     TestHelper.shutdown(cluster, walletMgr, testSuccessful, killEosInstances, killWallet, keepLogs, killAll, dumpErrorDetails)

--- a/tests/eosio_blocklog_prune_test.py
+++ b/tests/eosio_blocklog_prune_test.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 from testUtils import Account
+from testUtils import Timeout
 from testUtils import Utils
 from Cluster import Cluster
 from WalletMgr import WalletMgr

--- a/tests/eosio_blocklog_prune_test.py
+++ b/tests/eosio_blocklog_prune_test.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 from testUtils import Account
-from testUtils import Timeout
+from testUtils import WaitSpec
 from testUtils import Utils
 from Cluster import Cluster
 from WalletMgr import WalletMgr
@@ -101,7 +101,7 @@ try:
     cfTrxId = trans["transaction_id"]
 
     # Wait until the block where create account is executed to become irreversible
-    producerNode.waitForBlock(cfTrxBlockNum, blockType=BlockType.lib, timeout=Timeout.calculate, errorContext="producerNode LIB did not advance")
+    producerNode.waitForBlock(cfTrxBlockNum, blockType=BlockType.lib, timeout=WaitSpec.calculate, errorContext="producerNode LIB did not advance")
 
     Utils.Print("verify the account payloadless from producer node")
     trans = producerNode.getEosAccount("payloadless")
@@ -138,7 +138,7 @@ try:
     # check whether the transaction has been pruned based on the tag of prunable_data, if the tag is 1, then it's a prunable_data_t::none
     assert trans["trx"]["receipt"]["trx"][1]["prunable_data"]["prunable_data"][0] == 1, "the the transaction with context free data has not been pruned"
 
-    producerNode.waitForBlock(cfTrxBlockNum, blockType=BlockType.lib, timeout=Timeout.calculate, errorContext="producerNode LIB did not advance")
+    producerNode.waitForBlock(cfTrxBlockNum, blockType=BlockType.lib, timeout=WaitSpec.calculate, errorContext="producerNode LIB did not advance")
     assert producerNode.waitForHeadToAdvance(), "the producer node stops producing"
 
     # kill the producer with un-pruned cfd
@@ -156,10 +156,10 @@ try:
     #
     # Check lightValidationNode keeping sync while the full fullValidationNode stop syncing after the cfd block
     #
-    lightValidationNode.waitForBlock(cfTrxBlockNum, blockType=BlockType.lib, timeout=Timeout.calculate, errorContext="ligtValidationNode did not advance")
+    lightValidationNode.waitForBlock(cfTrxBlockNum, blockType=BlockType.lib, timeout=WaitSpec.calculate, errorContext="ligtValidationNode did not advance")
     assert lightValidationNode.waitForHeadToAdvance(), "the light validation node stops syncing"
 
-    fullValidationNode.waitForBlock(cfTrxBlockNum-1, blockType=BlockType.lib, timeout=Timeout.calculate, errorContext="fullValidationNode LIB did not advance")
+    fullValidationNode.waitForBlock(cfTrxBlockNum-1, blockType=BlockType.lib, timeout=WaitSpec.calculate, errorContext="fullValidationNode LIB did not advance")
     assert not fullValidationNode.waitForHeadToAdvance(), "the full validation node is still syncing"
     
     testSuccessful = True

--- a/tests/light_validation_sync_test.py
+++ b/tests/light_validation_sync_test.py
@@ -86,7 +86,7 @@ try:
     # Wait until the block where create account is executed to become irreversible 
     def isBlockNumIrr():
         return validationNode.getIrreversibleBlockNum() >= cfTrxBlockNum
-    Utils.waitForBool(isBlockNumIrr, timeout=30, sleepTime=0.1)
+    Utils.waitForTruth(isBlockNumIrr, timeout=30, sleepTime=0.1)
     
     Utils.Print("verify the account payloadless from validation node")
     cmd = "get account -j payloadless"

--- a/tests/nodeos_chainbase_allocation_test.py
+++ b/tests/nodeos_chainbase_allocation_test.py
@@ -88,7 +88,7 @@ try:
     # Wait until the block where set prods is executed become irreversible so the producer schedule
     def isSetProdsBlockNumIrr():
             return producerNode.getIrreversibleBlockNum() >= setProdsBlockNum
-    Utils.waitForBool(isSetProdsBlockNumIrr, timeout=30, sleepTime=0.1)
+    Utils.waitForTruth(isSetProdsBlockNumIrr, timeout=30, sleepTime=0.1)
     # Once it is irreversible, immediately pause the producer so the promoted producer schedule is not cleared
     producerNode.processCurlCmd("producer", "pause", "")
 

--- a/tests/nodeos_multiple_version_protocol_feature_test.py
+++ b/tests/nodeos_multiple_version_protocol_feature_test.py
@@ -56,7 +56,7 @@ def waitUntilBeginningOfProdTurn(node, producerName, timeout=30, sleepTime=0.4):
         res =  node.getBlock(headBlockNum)["producer"] == producerName and \
                node.getBlock(headBlockNum-1)["producer"] != producerName
         return res
-    Utils.waitForBool(isDesiredProdTurn, timeout, sleepTime)
+    Utils.waitForTruth(isDesiredProdTurn, timeout, sleepTime)
 
 def waitForOneRound():
     time.sleep(24) # We have 4 producers for this test
@@ -75,7 +75,7 @@ def setValidityOfActTimeSubjRestriction(node, nodeId, codename, valid):
 def waitUntilBlockBecomeIrr(node, blockNum, timeout=60):
     def hasBlockBecomeIrr():
         return node.getIrreversibleBlockNum() >= blockNum
-    return Utils.waitForBool(hasBlockBecomeIrr, timeout)
+    return Utils.waitForTruth(hasBlockBecomeIrr, timeout)
 
 # List to contain the test result message
 testSuccessful = False

--- a/tests/ship_client.js
+++ b/tests/ship_client.js
@@ -100,9 +100,10 @@ class Connection {
         }
         console.log('{ \"get_status_result_v0\":');
         response["resp_num"] = this.numRequests;
-        var currentTime = Date.now();
-        response["resp_time"] = (currentTime - this.startTime) / 1000;
-        var timeSinceBlockNumChange = (currentTime - this.blockNumChangeTime) / 1000;
+        var currentTime = Date();
+        var currentTimeSec = currentTime.getTime()
+        response["resp_time"] = (currentTimeSec - this.startTime) / 1000;
+        var timeSinceBlockNumChange = (currentTimeSec - this.blockNumChangeTime) / 1000;
         response["time_since_block_num_change"] = timeSinceBlockNumChange;
         var blockNum = response["head"]["block_num"]
         if (blockNum != this.blockNum) {
@@ -111,11 +112,11 @@ class Connection {
                 this.max["time"] = timeSinceBlockNumChange;
                 this.max["blockNum"] = blockNum;
             }
-            this.blockNumChangeTime = currentTime;
+            this.blockNumChangeTime = currentTimeSec;
         }
-        response["time_since_last_block"] = (currentTime - this.lastResponseTime) / 1000;
+        response["time_since_last_block"] = (currentTimeSec - this.lastResponseTime) / 1000;
         response["current_time"] = currentTime.toISOString()
-        this.lastResponseTime = currentTime;
+        this.lastResponseTime = currentTimeSec;
         console.log(JSON.stringify(response, null, 4));
         console.log('}');
         if (this.numRequests < 0) { // request forever
@@ -136,7 +137,7 @@ class Connection {
             status["last_block_num"] = blockNum;
             status["abi_rcv_delta_time"] = (this.abiTime - this.createTime)/1000;
             status["req_rcv_delta_time"] = (this.startTime - this.createTime)/1000;
-            status["done_delta_time"] = (currentTime - this.createTime)/1000;
+            status["done_delta_time"] = (currentTimeSec - this.createTime)/1000;
 
             console.error(JSON.stringify(status, null, 4));
             console.error(']');

--- a/tests/ship_client.js
+++ b/tests/ship_client.js
@@ -114,6 +114,7 @@ class Connection {
             this.blockNumChangeTime = currentTime;
         }
         response["time_since_last_block"] = (currentTime - this.lastResponseTime) / 1000;
+        response["current_time"] = currentTime.toISOString()
         this.lastResponseTime = currentTime;
         console.log(JSON.stringify(response, null, 4));
         console.log('}');

--- a/tests/ship_client.js
+++ b/tests/ship_client.js
@@ -100,7 +100,7 @@ class Connection {
         }
         console.log('{ \"get_status_result_v0\":');
         response["resp_num"] = this.numRequests;
-        var currentTime = Date();
+        var currentTime = new Date();
         var currentTimeSec = currentTime.getTime()
         response["resp_time"] = (currentTimeSec - this.startTime) / 1000;
         var timeSinceBlockNumChange = (currentTimeSec - this.blockNumChangeTime) / 1000;

--- a/tests/testUtils.py
+++ b/tests/testUtils.py
@@ -275,7 +275,7 @@ class Utils:
         Utils.Print(msg)
 
     @staticmethod
-    def waitForObj(lam, timeout=None, sleepTime=3, reporter=None):
+    def waitForTruth(lam, timeout=None, sleepTime=3, reporter=None):
         if timeout is None:
             timeout=Timeout.default
         if isinstance(timeout, Timeout):
@@ -285,11 +285,14 @@ class Utils:
         currentTime=time.time()
         endTime=currentTime+timeout
         needsNewLine=False
+        failReturnVal=None
         try:
             while endTime > currentTime:
                 ret=lam()
-                if ret is not None:
+                if ret:
                     return ret
+                # save this to return the not Truth state for the passed in method
+                failReturnVal=ret
                 remaining = endTime - currentTime
                 if sleepTime > remaining:
                     sleepTime = remaining
@@ -308,21 +311,8 @@ class Utils:
             if needsNewLine:
                 Utils.Print()
 
-        return None
+        return failReturnVal
 
-    @staticmethod
-    def waitForBool(lam, timeout=None, sleepTime=3, reporter=None):
-        if isinstance(timeout, Timeout):
-            sleepTime = timeout.sleepTime(sleepTime)
-        myLam = lambda: True if lam() else None
-        ret=Utils.waitForObj(myLam, timeout, sleepTime, reporter=reporter)
-        return False if ret is None else ret
-
-    @staticmethod
-    def waitForBoolWithArg(lam, arg, timeout=None, sleepTime=3, reporter=None):
-        myLam = lambda: True if lam(arg, timeout) else None
-        ret=Utils.waitForObj(myLam, timeout, sleepTime, reporter=reporter)
-        return False if ret is None else ret
 
     @staticmethod
     def filterJsonObjectOrArray(data):

--- a/tests/testUtils.py
+++ b/tests/testUtils.py
@@ -54,13 +54,13 @@ addEnum(BlockLogAction, "prune_transactions")
 
 class WaitSpec:
 
-    def __init__(self, value, leeway=10):
+    def __init__(self, value, leeway=None):
         self.toCalculate = True if value == -1 else False
         if value is not None:
             assert isinstance(value, (int))
             assert value >= -1
         self.value = value
-        self.leeway = leeway
+        self.leeway = leeway if leeway is not None else WaitSpec.default_leeway
 
     def __str__(self):
         append = "[calculated based on block production]" if self.toCalculate else ""
@@ -93,10 +93,16 @@ class WaitSpec:
         retVal = self.value if self.value is not None else WaitSpec.default_seconds
         return retVal
 
-    default_seconds = 60
+    @staticmethod
+    def calculate(leeway=None):
+        return WaitSpec(value=-1, leeway=leeway)
 
-setattr(WaitSpec, "default", WaitSpec(None))
-setattr(WaitSpec, "calculate", WaitSpec(-1))
+    @staticmethod
+    def default(leeway=None):
+        return WaitSpec(value=None, leeway=leeway)
+
+    default_seconds = 60
+    default_leeway = 10
 
 ###########################################################################################
 

--- a/tests/testUtils.py
+++ b/tests/testUtils.py
@@ -273,7 +273,7 @@ class Utils:
     @staticmethod
     def waitForTruth(lam, timeout=None, sleepTime=3, reporter=None):
         if timeout is None:
-            timeout=WaitSpec.default
+            timeout=WaitSpec.default()
         if isinstance(timeout, WaitSpec):
             timeout = timeout.asSeconds()
 

--- a/tests/testUtils.py
+++ b/tests/testUtils.py
@@ -89,7 +89,8 @@ class WaitSpec:
 
     def asSeconds(self):
         assert self.value != -1, "Called method with WaitSpec for calculating the appropriate timeout (WaitSpec.convert)," +\
-                                 " but convert method was never called."
+                                 " but convert method was never called. This means that either one of the methods the WaitSpec" +\
+                                 " is passed to needs to call convert, or else WaitSpec.calculate(...) should not have been passed."
         retVal = self.value if self.value is not None else WaitSpec.default_seconds
         return retVal
 

--- a/tests/testUtils.py
+++ b/tests/testUtils.py
@@ -83,7 +83,12 @@ class Timeout:
 
         timeout = self.leeway if self.leeway is not None else 10
         if (endBlockNum > startBlockNum):
-            timeout += (endBlockNum - startBlockNum + 1) / 2
+            # calculation is performing worst case (irreversible block progression) which at worst will waste 5 seconds
+            blocksPerWindow = 12
+            blockWindowsToWait = (endBlockNum - startBlockNum + blocksPerWindow - 1) / blocksPerWindow
+            secondsPerWindow = blocksPerWindow / 2
+            timeout += blockWindowsToWait * secondsPerWindow
+
         self.value = timeout
         if self.sleep_interval is None:
             self.sleep_interval = max(timeout / 10, 1)

--- a/tests/testUtils.py
+++ b/tests/testUtils.py
@@ -88,7 +88,7 @@ class WaitSpec:
         self.value = timeout
 
     def asSeconds(self):
-        assert self.value != -1, "Called method with WaitSpec for calculating the appropriate timeout (WaitSpec.calculate)," +\
+        assert self.value != -1, "Called method with WaitSpec for calculating the appropriate timeout (WaitSpec.convert)," +\
                                  " but convert method was never called."
         retVal = self.value if self.value is not None else WaitSpec.default_seconds
         return retVal


### PR DESCRIPTION
## Change Description
The eosio_blocklog_prune_test test was not sufficiently waiting long enough for the nodes to advance their irreversible blocks, so the timeout was changed to calculate how many block time slots needed to occur.  Also cleaned up test to use helper methods on Node and added better reporting for when tests identify that the head/lib is not advancing.

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
