### PR TITLE
SHIP's onblock test should consider trxs with one or more actions - 2.0 backport

### DIFF
--- a/plugins/state_history_plugin/state_history_plugin.cpp
+++ b/plugins/state_history_plugin/state_history_plugin.cpp
@@ -411,7 +411,7 @@ struct state_history_plugin_impl : std::enable_shared_from_this<state_history_pl
    }
 
    static bool is_onblock(const transaction_trace_ptr& p) {
-      if (p->action_traces.size() != 1)
+      if (p->action_traces.empty())
          return false;
       auto& act = p->action_traces[0].act;
       if (act.account != eosio::chain::config::system_account_name || act.name != N(onblock) ||


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
This defect was originally spotted here https://github.com/EOSIO/eos/pull/8750#discussion_r417622287 but AFAIK this fix should be in 2.0.x too

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
