### PR TITLE
Fix onblock trace tracking - develop

### DIFF
--- a/libraries/chain/include/eosio/chain/trace.hpp
+++ b/libraries/chain/include/eosio/chain/trace.hpp
@@ -66,6 +66,21 @@ namespace eosio { namespace chain {
       std::exception_ptr                         except_ptr;
    };
 
+   /**
+    * Deduce if transaction_trace is the trace of an onblock system transaction
+    */
+   inline bool is_onblock( const transaction_trace& tt ) {
+      if (tt.action_traces.empty())
+         return false;
+      const auto& act = tt.action_traces[0].act;
+      if (act.account != eosio::chain::config::system_account_name || act.name != N(onblock) ||
+          act.authorization.size() != 1)
+         return false;
+      const auto& auth = act.authorization[0];
+      return auth.actor == eosio::chain::config::system_account_name &&
+             auth.permission == eosio::chain::config::active_name;
+   }
+
    #define STORAGE_EVENT_ID( FORMAT, ... ) \
       fc::format_string( FORMAT, fc::mutable_variant_object()__VA_ARGS__ )
 

--- a/plugins/trace_api_plugin/include/eosio/trace_api/chain_extraction.hpp
+++ b/plugins/trace_api_plugin/include/eosio/trace_api/chain_extraction.hpp
@@ -41,18 +41,6 @@ public:
    }
 
 private:
-   static bool is_onblock(const chain::transaction_trace_ptr& p) {
-      if (p->action_traces.empty())
-         return false;
-      const auto& act = p->action_traces[0].act;
-      if (act.account != eosio::chain::config::system_account_name || act.name != N(onblock) ||
-          act.authorization.size() != 1)
-         return false;
-      const auto& auth = act.authorization[0];
-      return auth.actor == eosio::chain::config::system_account_name &&
-             auth.permission == eosio::chain::config::active_name;
-   }
-
    void on_applied_transaction(const chain::transaction_trace_ptr& trace, const chain::packed_transaction_ptr& t) {
       if( !trace->receipt ) return;
       // include only executed transactions; soft_fail included so that onerror (and any inlines via onerror) are included
@@ -60,7 +48,7 @@ private:
           trace->receipt->status != chain::transaction_receipt_header::soft_fail)) {
          return;
       }
-      if( is_onblock( trace )) {
+      if( chain::is_onblock( *trace )) {
          onblock_trace.emplace( cache_trace{trace, t} );
       } else if( trace->failed_dtrx_trace ) {
          cached_traces[trace->failed_dtrx_trace->id] = {trace, t};
@@ -83,7 +71,8 @@ private:
 
          std::vector<transaction_trace_v1>& traces = bt.transactions_v1;
          traces.reserve( block_state->block->transactions.size() + 1 );
-         if( onblock_trace )
+         // verify block_num of onblock_trace because last block could have been aborted & new block have no onblock
+         if( onblock_trace && onblock_trace->trace->block_num == block_state->block_num )
             traces.emplace_back( to_transaction_trace_v1( *onblock_trace ));
          for( const auto& r : block_state->block->transactions ) {
             transaction_id_type id;


### PR DESCRIPTION
## Change Description

- Fix issue identified with current scheme for capturing `onblock` transaction traces. See https://github.com/EOSIO/eos/pull/9135#discussion_r432711431 & https://github.com/EOSIO/eos/pull/9135#discussion_r433423912
  - The previous scheme would report an `onblock` trace for the case where a block is aborted with a valid `onblock` followed by a non-aborted block with an invalid `onblock`.
- Added an `is_onblock` to `trace.hpp` so this code does not have to be duplicated across various plugins.

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
