### PR TITLE
Fix for connection cycle not being in sync with test startup.

### DIFF
--- a/tests/eosio_blocklog_prune_test.py
+++ b/tests/eosio_blocklog_prune_test.py
@@ -156,7 +156,8 @@ try:
     #
     # Check lightValidationNode keeping sync while the full fullValidationNode stop syncing after the cfd block
     #
-    lightValidationNode.waitForBlock(cfTrxBlockNum, blockType=BlockType.lib, timeout=WaitSpec.calculate(), errorContext="ligtValidationNode did not advance")
+    timeForNodesToWorkOutReconnect=30 + 10    # 30 is reconnect cycle since all nodes are restarting and giving time for a little churn
+    lightValidationNode.waitForBlock(cfTrxBlockNum, blockType=BlockType.lib, timeout=WaitSpec.calculate(leeway=timeForNodesToWorkOutReconnect), errorContext="ligtValidationNode did not advance")
     assert lightValidationNode.waitForHeadToAdvance(), "the light validation node stops syncing"
 
     fullValidationNode.waitForBlock(cfTrxBlockNum-1, blockType=BlockType.lib, timeout=WaitSpec.calculate(), errorContext="fullValidationNode LIB did not advance")

--- a/tests/eosio_blocklog_prune_test.py
+++ b/tests/eosio_blocklog_prune_test.py
@@ -157,7 +157,7 @@ try:
     # Check lightValidationNode keeping sync while the full fullValidationNode stop syncing after the cfd block
     #
     timeForNodesToWorkOutReconnect=30 + 10    # 30 is reconnect cycle since all nodes are restarting and giving time for a little churn
-    lightValidationNode.waitForBlock(cfTrxBlockNum, blockType=BlockType.lib, timeout=WaitSpec.calculate(leeway=timeForNodesToWorkOutReconnect), errorContext="ligtValidationNode did not advance")
+    lightValidationNode.waitForBlock(cfTrxBlockNum, blockType=BlockType.lib, timeout=WaitSpec.calculate(leeway=timeForNodesToWorkOutReconnect), errorContext="lightValidationNode did not advance")
     assert lightValidationNode.waitForHeadToAdvance(), "the light validation node stops syncing"
 
     fullValidationNode.waitForBlock(cfTrxBlockNum-1, blockType=BlockType.lib, timeout=WaitSpec.calculate(), errorContext="fullValidationNode LIB did not advance")


### PR DESCRIPTION
## Change Description
Test restarts several nodes at the same time, which occasionally leads to connection cycle being delayed to the next pass, which is 30 seconds later, so test was failing.  Added extra time to wait for lib to start moving. 

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
