### PR TITLE
stop rocksdb's CMakeLists from force overriding CMAKE_INSTALL_PREFIX

### DIFF
--- a/libraries/CMakeLists.txt
+++ b/libraries/CMakeLists.txt
@@ -5,6 +5,9 @@ option(WITH_TOOLS CACHE OFF)            # rocksdb: don't build this
 option(WITH_BENCHMARK_TOOLS CACHE OFF)  # rocksdb: don't build this
 option(FAIL_ON_WARNINGS CACHE OFF)      # rocksdb: stop the madness: warnings change over time
 
+#on Linux, rocksdb will monkey with CMAKE_INSTALL_PREFIX is this is on
+set(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT OFF)
+
 add_subdirectory( fc )
 add_subdirectory( builtins )
 add_subdirectory( softfloat )


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
If rocksdb's CMakeLists.txt finds `CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT` set it will force the `CMAKE_INSTALL_PREFIX` cache value to `/usr`. This ends up creating some truly bizarre behavior where some files get installed to `/usr/local` but others `/usr`. Or files get installed to `/usr/local` but then something like `EosioTester.cmake` gets created thinking it should find libraries in `/usr`.

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
