### PR TITLE
Fix onblock trace tracking - develop

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1601,6 +1601,8 @@ struct controller_impl {
          fc_dlog(*dm_logger, "START_BLOCK ${block_num}", ("block_num", head->block_num + 1));
       }
 
+      emit( self.block_start, head->block_num + 1 );
+
       auto guard_pending = fc::make_scoped_exit([this, head_block_num=head->block_num](){
          protocol_features.popped_blocks_to( head_block_num );
          pending.reset();

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -309,6 +309,7 @@ namespace eosio { namespace chain {
 
          static fc::optional<uint64_t> convert_exception_to_error_code( const fc::exception& e );
 
+         signal<void(uint32_t)>                        block_start; // block_num
          signal<void(const signed_block_ptr&)>         pre_accepted_block;
          signal<void(const block_state_ptr&)>          accepted_block_header;
          signal<void(const block_state_ptr&)>          accepted_block;

--- a/libraries/chain/include/eosio/chain/trace.hpp
+++ b/libraries/chain/include/eosio/chain/trace.hpp
@@ -66,6 +66,21 @@ namespace eosio { namespace chain {
       std::exception_ptr                         except_ptr;
    };
 
+   /**
+    * Deduce if transaction_trace is the trace of an onblock system transaction
+    */
+   inline bool is_onblock( const transaction_trace& tt ) {
+      if (tt.action_traces.empty())
+         return false;
+      const auto& act = tt.action_traces[0].act;
+      if (act.account != eosio::chain::config::system_account_name || act.name != N(onblock) ||
+          act.authorization.size() != 1)
+         return false;
+      const auto& auth = act.authorization[0];
+      return auth.actor == eosio::chain::config::system_account_name &&
+             auth.permission == eosio::chain::config::active_name;
+   }
+
    #define STORAGE_EVENT_ID( FORMAT, ... ) \
       fc::format_string( FORMAT, fc::mutable_variant_object()__VA_ARGS__ )
 

--- a/libraries/state_history/include/eosio/state_history/log.hpp
+++ b/libraries/state_history/include/eosio/state_history/log.hpp
@@ -126,6 +126,11 @@ class state_history_traces_log : public state_history_log {
       trace_convert.add_transaction(trace, transaction);
    }
 
+   void block_start(uint32_t block_num) {
+      trace_convert.cached_traces.clear();
+      trace_convert.onblock_trace.reset();
+   }
+
    fc::optional<chain::bytes> get_log_entry(block_num_type block_num);
 
    void store(const chainbase::database& db, const chain::block_state_ptr& block_state);

--- a/libraries/state_history/include/eosio/state_history/log.hpp
+++ b/libraries/state_history/include/eosio/state_history/log.hpp
@@ -127,8 +127,7 @@ class state_history_traces_log : public state_history_log {
    }
 
    void block_start(uint32_t block_num) {
-      trace_convert.cached_traces.clear();
-      trace_convert.onblock_trace.reset();
+      trace_convert.clear_cache();
    }
 
    fc::optional<chain::bytes> get_log_entry(block_num_type block_num);

--- a/libraries/state_history/include/eosio/state_history/trace_converter.hpp
+++ b/libraries/state_history/include/eosio/state_history/trace_converter.hpp
@@ -17,6 +17,8 @@ struct trace_converter {
    
    void  add_transaction(const transaction_trace_ptr& trace, const packed_transaction_ptr& transaction);
 
+   void clear_cache();
+
    bytes pack(const chainbase::database& db, bool trace_debug_mode, const block_state_ptr& block_state,
               uint32_t version);
    static bytes to_traces_bin_v0(const bytes& entry_payload, uint32_t version); 

--- a/libraries/state_history/trace_converter.cpp
+++ b/libraries/state_history/trace_converter.cpp
@@ -59,8 +59,7 @@ Object unpack_zlib_compressed(const char* buffer, fc::datastream<const char*>& d
 std::vector<augmented_transaction_trace> prepare_traces(trace_converter&       converter,
                                                         const block_state_ptr& block_state) {
    std::vector<augmented_transaction_trace> traces;
-   // verify block_num of onblock_trace because last block could have been aborted & new block have no onblock
-   if (converter.onblock_trace && converter.onblock_trace->trace->block_num == block_state->block_num)
+   if (converter.onblock_trace)
       traces.push_back(*converter.onblock_trace);
    for (auto& r : block_state->block->transactions) {
       transaction_id_type id;

--- a/libraries/state_history/trace_converter.cpp
+++ b/libraries/state_history/trace_converter.cpp
@@ -26,6 +26,11 @@ void trace_converter::add_transaction(const transaction_trace_ptr& trace, const 
    }
 }
 
+void trace_converter::clear_cache() {
+   cached_traces.clear();
+   onblock_trace.reset();
+}
+
 namespace {
 
 template <typename Object>
@@ -68,8 +73,7 @@ std::vector<augmented_transaction_trace> prepare_traces(trace_converter&       c
                  "missing trace for transaction ${id}", ("id", id));
       traces.push_back(it->second);
    }
-   converter.cached_traces.clear();
-   converter.onblock_trace.reset();
+   converter.clear_cache();
    return traces;
 }
 

--- a/plugins/state_history_plugin/state_history_plugin.cpp
+++ b/plugins/state_history_plugin/state_history_plugin.cpp
@@ -42,6 +42,7 @@ struct state_history_plugin_impl : std::enable_shared_from_this<state_history_pl
    fc::optional<state_history_chain_state_log>                chain_state_log;
    bool                                                       stopping = false;
    fc::optional<scoped_connection>                            applied_transaction_connection;
+   fc::optional<scoped_connection>                            block_start_connection;
    fc::optional<scoped_connection>                            accepted_block_connection;
    string                                                     endpoint_address = "0.0.0.0";
    uint16_t                                                   endpoint_port    = 8080;
@@ -345,6 +346,12 @@ struct state_history_plugin_impl : std::enable_shared_from_this<state_history_pl
          }
       }
    }
+
+   void on_block_start(uint32_t block_num) {
+      if (trace_log)
+         trace_log->block_start(block_num);
+   }
+
 };   // state_history_plugin_impl
 
 state_history_plugin::state_history_plugin()
@@ -380,6 +387,8 @@ void state_history_plugin::plugin_initialize(const variables_map& options) {
           }));
       my->accepted_block_connection.emplace(
           chain.accepted_block.connect([&](const block_state_ptr& p) { my->on_accepted_block(p); }));
+      my->block_start_connection.emplace(
+          chain.block_start.connect([&](uint32_t block_num) { my->on_block_start(block_num); }));
 
       auto                    dir_option = options.at("state-history-dir").as<bfs::path>();
       boost::filesystem::path state_history_dir;
@@ -418,6 +427,7 @@ void state_history_plugin::plugin_startup() { my->listen(); }
 void state_history_plugin::plugin_shutdown() {
    my->applied_transaction_connection.reset();
    my->accepted_block_connection.reset();
+   my->block_start_connection.reset();
    while (!my->sessions.empty())
       my->sessions.begin()->second->close();
    my->stopping = true;

--- a/plugins/trace_api_plugin/include/eosio/trace_api/chain_extraction.hpp
+++ b/plugins/trace_api_plugin/include/eosio/trace_api/chain_extraction.hpp
@@ -85,8 +85,7 @@ private:
 
          std::vector<transaction_trace_v1>& traces = bt.transactions_v1;
          traces.reserve( block_state->block->transactions.size() + 1 );
-         // verify block_num of onblock_trace because last block could have been aborted & new block have no onblock
-         if( onblock_trace && onblock_trace->trace->block_num == block_state->block_num )
+         if( onblock_trace )
             traces.emplace_back( to_transaction_trace_v1( *onblock_trace ));
          for( const auto& r : block_state->block->transactions ) {
             transaction_id_type id;

--- a/plugins/trace_api_plugin/include/eosio/trace_api/chain_extraction.hpp
+++ b/plugins/trace_api_plugin/include/eosio/trace_api/chain_extraction.hpp
@@ -40,6 +40,11 @@ public:
       on_irreversible_block( bsp );
    }
 
+   /// connect to chain controller block_start signal
+   void signal_block_start( uint32_t block_num ) {
+      on_block_start( block_num );
+   }
+
 private:
    void on_applied_transaction(const chain::transaction_trace_ptr& trace, const chain::packed_transaction_ptr& t) {
       if( !trace->receipt ) return;
@@ -63,6 +68,11 @@ private:
 
    void on_irreversible_block( const chain::block_state_ptr& block_state ) {
       store_lib( block_state );
+   }
+
+   void on_block_start( uint32_t block_num ) {
+      cached_traces.clear();
+      onblock_trace.reset();
    }
 
    void store_block_trace( const chain::block_state_ptr& block_state ) {

--- a/plugins/trace_api_plugin/include/eosio/trace_api/chain_extraction.hpp
+++ b/plugins/trace_api_plugin/include/eosio/trace_api/chain_extraction.hpp
@@ -41,18 +41,6 @@ public:
    }
 
 private:
-   static bool is_onblock(const chain::transaction_trace_ptr& p) {
-      if (p->action_traces.empty())
-         return false;
-      const auto& act = p->action_traces[0].act;
-      if (act.account != eosio::chain::config::system_account_name || act.name != N(onblock) ||
-          act.authorization.size() != 1)
-         return false;
-      const auto& auth = act.authorization[0];
-      return auth.actor == eosio::chain::config::system_account_name &&
-             auth.permission == eosio::chain::config::active_name;
-   }
-
    void on_applied_transaction(const chain::transaction_trace_ptr& trace, const chain::packed_transaction_ptr& t) {
       if( !trace->receipt ) return;
       // include only executed transactions; soft_fail included so that onerror (and any inlines via onerror) are included
@@ -60,7 +48,7 @@ private:
           trace->receipt->status != chain::transaction_receipt_header::soft_fail)) {
          return;
       }
-      if( is_onblock( trace )) {
+      if( chain::is_onblock( *trace )) {
          onblock_trace.emplace( cache_trace{trace, t} );
       } else if( trace->failed_dtrx_trace ) {
          cached_traces[trace->failed_dtrx_trace->id] = {trace, t};
@@ -83,7 +71,8 @@ private:
 
          std::vector<transaction_trace_v1>& traces = bt.transactions_v1;
          traces.reserve( block_state->block->transactions.size() + 1 );
-         if( onblock_trace )
+         // verify block_num of onblock_trace because last block could have been aborted & new block have no onblock
+         if( onblock_trace && onblock_trace->trace->block_num == block_state->block_num )
             traces.emplace_back( to_transaction_trace_v1( *onblock_trace ));
          for( const auto& r : block_state->block->transactions ) {
             transaction_id_type id;

--- a/plugins/trace_api_plugin/include/eosio/trace_api/chain_extraction.hpp
+++ b/plugins/trace_api_plugin/include/eosio/trace_api/chain_extraction.hpp
@@ -71,6 +71,10 @@ private:
    }
 
    void on_block_start( uint32_t block_num ) {
+      clear_caches();
+   }
+
+   void clear_caches() {
       cached_traces.clear();
       onblock_trace.reset();
    }
@@ -96,8 +100,7 @@ private:
                traces.emplace_back( to_transaction_trace_v1( it->second ));
             }
          }
-         cached_traces.clear();
-         onblock_trace.reset();
+         clear_caches();
 
          store.append( std::move( bt ) );
 

--- a/plugins/trace_api_plugin/trace_api_plugin.cpp
+++ b/plugins/trace_api_plugin/trace_api_plugin.cpp
@@ -316,6 +316,13 @@ struct trace_api_plugin_impl {
             });
          }));
 
+      block_start_connection.emplace(
+            chain.block_start.connect([this](uint32_t block_num) {
+               emit_killer([&](){
+                  extraction->signal_block_start(block_num);
+               });
+            }));
+
       accepted_block_connection.emplace(
          chain.accepted_block.connect([this](const chain::block_state_ptr& p) {
             emit_killer([&](){
@@ -346,6 +353,7 @@ struct trace_api_plugin_impl {
    std::shared_ptr<chain_extraction_t> extraction;
 
    fc::optional<scoped_connection>                            applied_transaction_connection;
+   fc::optional<scoped_connection>                            block_start_connection;
    fc::optional<scoped_connection>                            accepted_block_connection;
    fc::optional<scoped_connection>                            irreversible_block_connection;
 };

--- a/unittests/state_history_tests.cpp
+++ b/unittests/state_history_tests.cpp
@@ -54,6 +54,11 @@ BOOST_AUTO_TEST_CASE(test_trace_converter_test) {
       on_disk_log_entries_v1[bs->block_num] = converter_v1.pack(chain.control->db(), true, bs, 1);
    });
 
+   chain.control->block_start.connect([&](uint32_t block_num) {
+      converter_v0.clear_cache();
+      converter_v1.clear_cache();
+   });
+
    deploy_test_api(chain);
    auto cfd_trace = push_test_cfd_transaction(chain);
    chain.produce_blocks(1);
@@ -102,6 +107,7 @@ BOOST_AUTO_TEST_CASE(test_trace_log) {
        });
 
    chain.control->accepted_block.connect([&](const block_state_ptr& bs) { log.store(chain.control->db(), bs); });
+   chain.control->block_start.connect([&](uint32_t block_num) { log.block_start(block_num); } );
 
    deploy_test_api(chain);
    auto cfd_trace = push_test_cfd_transaction(chain);


### PR DESCRIPTION
## Change Description

- Fix issue identified with current scheme for capturing `onblock` transaction traces. See https://github.com/EOSIO/eos/pull/9135#discussion_r432711431 & https://github.com/EOSIO/eos/pull/9135#discussion_r433423912
  - The previous scheme would report an `onblock` trace for the case where a block is aborted with a valid `onblock` followed by a non-aborted block with an invalid `onblock`.
- Added new controller signal `block_start` for plugins to use to know when a new block starts.
- Added an `is_onblock` to `trace.hpp` so this code does not have to be duplicated across various plugins.
- `develop` version of #9170 


## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
