### PR TITLE
Fix onblock trace tracking - 2.0

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1520,6 +1520,8 @@ struct controller_impl {
    {
       EOS_ASSERT( !pending, block_validate_exception, "pending block already exists" );
 
+      emit( self.block_start, head->block_num + 1 );
+
       auto guard_pending = fc::make_scoped_exit([this, head_block_num=head->block_num](){
          protocol_features.popped_blocks_to( head_block_num );
          pending.reset();

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -299,6 +299,7 @@ namespace eosio { namespace chain {
 
          static fc::optional<uint64_t> convert_exception_to_error_code( const fc::exception& e );
 
+         signal<void(uint32_t)>                        block_start; // block_num
          signal<void(const signed_block_ptr&)>         pre_accepted_block;
          signal<void(const block_state_ptr&)>          accepted_block_header;
          signal<void(const block_state_ptr&)>          accepted_block;

--- a/libraries/chain/include/eosio/chain/trace.hpp
+++ b/libraries/chain/include/eosio/chain/trace.hpp
@@ -64,6 +64,21 @@ namespace eosio { namespace chain {
       std::exception_ptr                         except_ptr;
    };
 
+   /**
+    * Deduce if transaction_trace is the trace of an onblock system transaction
+    */
+   inline bool is_onblock( const transaction_trace& tt ) {
+      if (tt.action_traces.empty())
+         return false;
+      const auto& act = tt.action_traces[0].act;
+      if (act.account != eosio::chain::config::system_account_name || act.name != N(onblock) ||
+          act.authorization.size() != 1)
+         return false;
+      const auto& auth = act.authorization[0];
+      return auth.actor == eosio::chain::config::system_account_name &&
+             auth.permission == eosio::chain::config::active_name;
+   }
+
 } }  /// namespace eosio::chain
 
 FC_REFLECT( eosio::chain::account_delta,

--- a/plugins/state_history_plugin/state_history_plugin.cpp
+++ b/plugins/state_history_plugin/state_history_plugin.cpp
@@ -411,21 +411,9 @@ struct state_history_plugin_impl : std::enable_shared_from_this<state_history_pl
       });
    }
 
-   static bool is_onblock(const transaction_trace_ptr& p) {
-      if (p->action_traces.empty())
-         return false;
-      auto& act = p->action_traces[0].act;
-      if (act.account != eosio::chain::config::system_account_name || act.name != N(onblock) ||
-          act.authorization.size() != 1)
-         return false;
-      auto& auth = act.authorization[0];
-      return auth.actor == eosio::chain::config::system_account_name &&
-             auth.permission == eosio::chain::config::active_name;
-   }
-
    void on_applied_transaction(const transaction_trace_ptr& p, const signed_transaction& t) {
       if (p->receipt && trace_log) {
-         if (is_onblock(p))
+         if (chain::is_onblock(*p))
             onblock_trace.emplace(p, t);
          else if (p->failed_dtrx_trace)
             cached_traces[p->failed_dtrx_trace->id] = augmented_transaction_trace{p, t};

--- a/plugins/state_history_plugin/state_history_plugin.cpp
+++ b/plugins/state_history_plugin/state_history_plugin.cpp
@@ -447,6 +447,15 @@ struct state_history_plugin_impl : std::enable_shared_from_this<state_history_pl
       }
    }
 
+   void on_block_start(uint32_t block_num) {
+      clear_caches();
+   }
+
+   void clear_caches() {
+      cached_traces.clear();
+      onblock_trace.reset();
+   }
+
    void store_traces(const block_state_ptr& block_state) {
       if (!trace_log)
          return;
@@ -464,8 +473,7 @@ struct state_history_plugin_impl : std::enable_shared_from_this<state_history_pl
                     "missing trace for transaction ${id}", ("id", id));
          traces.push_back(it->second);
       }
-      cached_traces.clear();
-      onblock_trace.reset();
+      clear_caches();
 
       auto& db         = chain_plug->chain().db();
       auto  traces_bin = zlib_compress_bytes(fc::raw::pack(make_history_context_wrapper(db, trace_debug_mode, traces)));

--- a/plugins/trace_api_plugin/include/eosio/trace_api/chain_extraction.hpp
+++ b/plugins/trace_api_plugin/include/eosio/trace_api/chain_extraction.hpp
@@ -40,6 +40,11 @@ public:
       on_irreversible_block( bsp );
    }
 
+   /// connect to chain controller block_start signal
+   void signal_block_start( uint32_t block_num ) {
+      on_block_start( block_num );
+   }
+
 private:
 
    void on_applied_transaction(const chain::transaction_trace_ptr& trace, const chain::signed_transaction& t) {
@@ -64,6 +69,11 @@ private:
 
    void on_irreversible_block( const chain::block_state_ptr& block_state ) {
       store_lib( block_state );
+   }
+
+   void on_block_start( uint32_t block_num ) {
+      cached_traces.clear();
+      onblock_trace.reset();
    }
 
    void store_block_trace( const chain::block_state_ptr& block_state ) {

--- a/plugins/trace_api_plugin/include/eosio/trace_api/chain_extraction.hpp
+++ b/plugins/trace_api_plugin/include/eosio/trace_api/chain_extraction.hpp
@@ -86,8 +86,7 @@ private:
 
          std::vector<transaction_trace_v1>& traces = bt.transactions_v1;
          traces.reserve( block_state->block->transactions.size() + 1 );
-         // verify block_num of onblock_trace because last block could have been aborted & new block have no onblock
-         if( onblock_trace && onblock_trace->trace->block_num == block_state->block_num )
+         if( onblock_trace )
             traces.emplace_back( to_transaction_trace_v1( *onblock_trace ));
          for( const auto& r : block_state->block->transactions ) {
             transaction_id_type id;

--- a/plugins/trace_api_plugin/include/eosio/trace_api/chain_extraction.hpp
+++ b/plugins/trace_api_plugin/include/eosio/trace_api/chain_extraction.hpp
@@ -72,6 +72,10 @@ private:
    }
 
    void on_block_start( uint32_t block_num ) {
+      clear_caches();
+   }
+
+   void clear_caches() {
       cached_traces.clear();
       onblock_trace.reset();
    }
@@ -97,8 +101,7 @@ private:
                traces.emplace_back( to_transaction_trace_v1( it->second ));
             }
          }
-         cached_traces.clear();
-         onblock_trace.reset();
+         clear_caches();
 
          store.append( std::move( bt ) );
 

--- a/plugins/trace_api_plugin/trace_api_plugin.cpp
+++ b/plugins/trace_api_plugin/trace_api_plugin.cpp
@@ -316,6 +316,13 @@ struct trace_api_plugin_impl {
             });
          }));
 
+      block_start_connection.emplace(
+            chain.block_start.connect([this](uint32_t block_num) {
+               emit_killer([&](){
+                  extraction->signal_block_start(block_num);
+               });
+            }));
+
       accepted_block_connection.emplace(
          chain.accepted_block.connect([this](const chain::block_state_ptr& p) {
             emit_killer([&](){
@@ -346,6 +353,7 @@ struct trace_api_plugin_impl {
    std::shared_ptr<chain_extraction_t> extraction;
 
    fc::optional<scoped_connection>                            applied_transaction_connection;
+   fc::optional<scoped_connection>                            block_start_connection;
    fc::optional<scoped_connection>                            accepted_block_connection;
    fc::optional<scoped_connection>                            irreversible_block_connection;
 };


### PR DESCRIPTION
## Change Description

- Fix issue identified with current scheme for capturing `onblock` transaction traces. See https://github.com/EOSIO/eos/pull/9135#discussion_r432711431 & https://github.com/EOSIO/eos/pull/9135#discussion_r433423912
  - The previous scheme would report an `onblock` trace for the case where a block is aborted with a valid `onblock` followed by a non-aborted block with an invalid `onblock`.
- Added new controller signal `block_start` for plugins to use to know when a new block starts.
- Added an `is_onblock` to `trace.hpp` so this code does not have to be duplicated across various plugins.
- 2.0.x version of #9169 

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
