### PR TITLE
Ship delay error fix

### DIFF
--- a/scripts/serial-test.sh
+++ b/scripts/serial-test.sh
@@ -48,6 +48,7 @@ else # run specific serial test
         else
             echo "$TEST PASSED"
         fi
+        grep "produced the following blocks late" ctest-output.log
         echo "Done running $TEST."
     else
         echo "+++ $([[ "$BUILDKITE" == 'true' ]] && echo ':no_entry: ')ERROR: No tests matching \"$TEST\" registered with ctest! Exiting..."

--- a/tests/Cluster.py
+++ b/tests/Cluster.py
@@ -119,6 +119,7 @@ class Cluster(object):
         self.useBiosBootFile=False
         self.filesToCleanup=[]
         self.alternateVersionLabels=Cluster.__defaultAlternateVersionLabels()
+        self.biosNode = None
 
 
     def setChainStrategy(self, chainSyncStrategy=Utils.SyncReplayTag):
@@ -496,7 +497,8 @@ class Cluster(object):
     def initializeNodes(self, defproduceraPrvtKey=None, defproducerbPrvtKey=None, onlyBios=False):
         port=Cluster.__BiosPort if onlyBios else self.port
         host=Cluster.__BiosHost if onlyBios else self.host
-        node=Node(host, port, walletMgr=self.walletMgr)
+        nodeNum="bios" if onlyBios else 0
+        node=Node(host, port, nodeNum, walletMgr=self.walletMgr)
         if Utils.Debug: Utils.Print("Node: %s", str(node))
 
         node.checkPulse(exitOnError=True)
@@ -535,11 +537,12 @@ class Cluster(object):
         for n in nArr:
             port=n["port"]
             host=n["host"]
-            node=Node(host, port, walletMgr=self.walletMgr)
+            node=Node(host, port, nodeId=len(nodes), walletMgr=self.walletMgr)
             if Utils.Debug: Utils.Print("Node:", node)
 
             node.checkPulse(exitOnError=True)
             nodes.append(node)
+
 
         self.nodes=nodes
         return True
@@ -707,7 +710,17 @@ class Cluster(object):
         return self.nodes[nodeId]
 
     def getNodes(self):
-        return self.nodes
+        nodes = []
+        if hasattr(self, "nodes") and self.nodes is not None:
+            nodes += self.nodes
+        return nodes
+
+    def getAllNodes(self):
+        nodes = []
+        if self.biosNode is not None:
+            nodes.append(self.biosNode)
+        nodes += self.getNodes()
+        return nodes
 
     def launchUnstarted(self, numToLaunch=1, cachePopen=False):
         assert(isinstance(numToLaunch, int))
@@ -716,7 +729,7 @@ class Cluster(object):
         del self.unstartedNodes[:numToLaunch]
         for node in launchList:
             # the node number is indexed off of the started nodes list
-            node.launchUnstarted(len(self.nodes), cachePopen=cachePopen)
+            node.launchUnstarted(cachePopen=cachePopen)
             self.nodes.append(node)
 
     # Spread funds across accounts with transactions spread through cluster nodes.
@@ -1380,7 +1393,7 @@ class Cluster(object):
         if m is None:
             Utils.Print("ERROR: Failed to find %s pid. Pattern %s" % (Utils.EosServerName, pattern))
             return None
-        instance=Node(self.host, self.port + nodeNum, pid=int(m.group(1)), cmd=m.group(2), walletMgr=self.walletMgr)
+        instance=Node(self.host, self.port + nodeNum, nodeNum, pid=int(m.group(1)), cmd=m.group(2), walletMgr=self.walletMgr)
         if Utils.Debug: Utils.Print("Node>", instance)
         return instance
 
@@ -1393,7 +1406,7 @@ class Cluster(object):
             Utils.Print("ERROR: Failed to find %s pid. Pattern %s" % (Utils.EosServerName, pattern))
             return None
         else:
-            return Node(Cluster.__BiosHost, Cluster.__BiosPort, pid=int(m.group(1)), cmd=m.group(2), walletMgr=self.walletMgr)
+            return Node(Cluster.__BiosHost, Cluster.__BiosPort, "bios", pid=int(m.group(1)), cmd=m.group(2), walletMgr=self.walletMgr)
 
     # Kills a percentange of Eos instances starting from the tail and update eosInstanceInfos state
     def killSomeEosInstances(self, killCount, killSignalStr=Utils.SigKillTag):
@@ -1421,7 +1434,7 @@ class Cluster(object):
         newChain= False if self.__chainSyncStrategy.name in [Utils.SyncHardReplayTag, Utils.SyncNoneTag] else True
         for i in range(0, len(self.nodes)):
             node=self.nodes[i]
-            if node.killed and not node.relaunch(i, chainArg, newChain=newChain, cachePopen=cachePopen):
+            if node.killed and not node.relaunch(chainArg, newChain=newChain, cachePopen=cachePopen):
                 return False
 
         return True
@@ -1571,8 +1584,7 @@ class Cluster(object):
         with open(startFile, 'r') as file:
             cmd=file.read()
             Utils.Print("unstarted local node cmd: %s" % (cmd))
-        p=re.compile(r'^\s*(\w+)\s*=\s*([^\s](?:.*[^\s])?)\s*$')
-        instance=Node(self.host, port=self.port+nodeId, pid=None, cmd=cmd, walletMgr=self.walletMgr)
+        instance=Node(self.host, port=self.port+nodeId, nodeId=nodeId, pid=None, cmd=cmd, walletMgr=self.walletMgr)
         if Utils.Debug: Utils.Print("Unstarted Node>", instance)
         return instance
 

--- a/tests/Cluster.py
+++ b/tests/Cluster.py
@@ -1449,23 +1449,11 @@ class Cluster(object):
         else:
             Utils.Print("File %s not found." % (fileName))
 
-    @staticmethod
-    def __findFiles(path):
-        files=[]
-        it=os.scandir(path)
-        for entry in it:
-            if entry.is_file(follow_symlinks=False):
-                match=re.match("stderr\..+\.txt", entry.name)
-                if match:
-                    files.append(os.path.join(path, entry.name))
-        files.sort()
-        return files
-
     def dumpErrorDetails(self):
         fileName=Utils.getNodeConfigDir("bios", "config.ini")
         Cluster.dumpErrorDetailImpl(fileName)
         path=Utils.getNodeDataDir("bios")
-        fileNames=Cluster.__findFiles(path)
+        fileNames=Node.findFiles(path)
         for fileName in fileNames:
             Cluster.dumpErrorDetailImpl(fileName)
 
@@ -1476,7 +1464,7 @@ class Cluster(object):
             fileName=os.path.join(configLocation, "genesis.json")
             Cluster.dumpErrorDetailImpl(fileName)
             path=Utils.getNodeDataDir(i)
-            fileNames=Cluster.__findFiles(path)
+            fileNames=Node.findFiles(path)
             for fileName in fileNames:
                 Cluster.dumpErrorDetailImpl(fileName)
 
@@ -1596,14 +1584,12 @@ class Cluster(object):
         return infos
 
     def reportStatus(self):
-        if hasattr(self, "biosNode") and self.biosNode is not None:
-            self.biosNode.reportStatus()
-        if hasattr(self, "nodes"):
-            for node in self.nodes:
-                try:
-                    node.reportStatus()
-                except:
-                    Utils.Print("No reportStatus")
+        nodes = self.getAllNodes()
+        for node in nodes:
+            try:
+                node.reportStatus()
+            except:
+                Utils.Print("No reportStatus for nodeId: %s" % (node.nodeId))
 
     def getBlockLog(self, nodeExtension, blockLogAction=BlockLogAction.return_blocks, outputFile=None, first=None, last=None, extraArgs="", throwException=False, silentErrors=False, exitOnError=False):
         nodeDataDir=Utils.getNodeDataDir(nodeExtension)

--- a/tests/Cluster.py
+++ b/tests/Cluster.py
@@ -94,7 +94,7 @@ class Cluster(object):
         defproducerbPrvtKey: Defproducerb account private key
         """
         self.accounts={}
-        self.nodes={}
+        self.nodes=[]
         self.unstartedNodes=[]
         self.localCluster=localCluster
         self.wallet=None
@@ -710,10 +710,7 @@ class Cluster(object):
         return self.nodes[nodeId]
 
     def getNodes(self):
-        nodes = []
-        if hasattr(self, "nodes") and self.nodes is not None:
-            nodes += self.nodes
-        return nodes
+        return self.nodes[:]
 
     def getAllNodes(self):
         nodes = []
@@ -1453,7 +1450,7 @@ class Cluster(object):
         fileName=Utils.getNodeConfigDir("bios", "config.ini")
         Cluster.dumpErrorDetailImpl(fileName)
         path=Utils.getNodeDataDir("bios")
-        fileNames=Node.findFiles(path)
+        fileNames=Node.findStderrFiles(path)
         for fileName in fileNames:
             Cluster.dumpErrorDetailImpl(fileName)
 
@@ -1464,7 +1461,7 @@ class Cluster(object):
             fileName=os.path.join(configLocation, "genesis.json")
             Cluster.dumpErrorDetailImpl(fileName)
             path=Utils.getNodeDataDir(i)
-            fileNames=Node.findFiles(path)
+            fileNames=Node.findStderrFiles(path)
             for fileName in fileNames:
                 Cluster.dumpErrorDetailImpl(fileName)
 

--- a/tests/Node.py
+++ b/tests/Node.py
@@ -1547,11 +1547,11 @@ class Node(object):
 
                         if specificBlockNum is not None:
                             return blockAnalysis
-                    elif specificBlockNum is not None:
-                        blockAnalysis[specificBlockNum] = { "slot": None, "prod": None}
-                        return
 
                     if readLine:
                         line = f.readline()
+
+        if specificBlockNum is not None and specificBlockNum not in blockAnalysis:
+            blockAnalysis[specificBlockNum] = { "slot": None, "prod": None}
 
         return blockAnalysis

--- a/tests/Node.py
+++ b/tests/Node.py
@@ -1539,8 +1539,7 @@ class Node(object):
                         prodTime = datetime.strptime(prodTimeStr, Utils.TimeFmt)
                         slotTime = datetime.strptime(slotTimeStr, Utils.TimeFmt)
                         delta = prodTime - slotTime
-                        millisecondsPerSecond=1000
-                        limit = timedelta(seconds=thresholdMs/millisecondsPerSecond)
+                        limit = timedelta(milliseconds=thresholdMs)
                         if delta > limit:
                             if blockNum in blockAnalysis:
                                 Utils.errorExit("Found repeat production of the same block num: %d in one of the stderr files in: %s" % (blockNum, dataDir))

--- a/tests/Node.py
+++ b/tests/Node.py
@@ -1548,7 +1548,7 @@ class Node(object):
                         if specificBlockNum is not None:
                             return blockAnalysis
                     elif specificBlockNum is not None:
-                        blockAnalysis[blockNum] = { "slot": None, "prod": None}
+                        blockAnalysis[specificBlockNum] = { "slot": None, "prod": None}
                         return
 
                     if readLine:

--- a/tests/Node.py
+++ b/tests/Node.py
@@ -1489,7 +1489,7 @@ class Node(object):
         return self.processCurlCmd("producer", "create_snapshot", json.dumps(param))
 
     @staticmethod
-    def findFiles(path):
+    def findStderrFiles(path):
         files=[]
         it=os.scandir(path)
         for entry in it:
@@ -1502,7 +1502,7 @@ class Node(object):
 
     def analyzeProduction(self, specificBlockNum=None, thresholdMs=500):
         dataDir=Utils.getNodeDataDir(self.nodeId)
-        files=Node.findFiles(dataDir)
+        files=Node.findStderrFiles(dataDir)
         blockAnalysis={}
         anyBlockStr=r'[0-9]+'
         initialTimestamp=r'\s+([0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3})\s'

--- a/tests/Node.py
+++ b/tests/Node.py
@@ -1487,3 +1487,15 @@ class Node(object):
     def createSnapshot(self):
         param = { }
         return self.processCurlCmd("producer", "create_snapshot", json.dumps(param))
+
+    @staticmethod
+    def findFiles(path):
+        files=[]
+        it=os.scandir(path)
+        for entry in it:
+            if entry.is_file(follow_symlinks=False):
+                match=re.match("stderr\..+\.txt", entry.name)
+                if match:
+                    files.append(os.path.join(path, entry.name))
+        files.sort()
+        return files

--- a/tests/TestHelper.py
+++ b/tests/TestHelper.py
@@ -153,10 +153,10 @@ class TestHelper(object):
         else:
             Utils.Print("Test failed.")
 
-        def reportProductionAnalysis():
+        def reportProductionAnalysis(thresholdMs):
             Utils.Print(Utils.FileDivider)
             for node in cluster.getAllNodes():
-                missedBlocks=node.analyzeProduction(thresholdMs=0)
+                missedBlocks=node.analyzeProduction(thresholdMs=thresholdMs)
                 if len(missedBlocks) > 0:
                     Utils.Print("NodeId: %s produced the following blocks late: %s" % (node.nodeId, missedBlocks))
 
@@ -165,11 +165,11 @@ class TestHelper(object):
             Utils.Print(Utils.FileDivider)
             psOut = Cluster.pgrepEosServers(timeout=60)
             Utils.Print("pgrep output:\n%s" % (psOut))
-            reportProductionAnalysis()
+            reportProductionAnalysis(thresholdMs=0)
             Utils.Print("== Errors see above ==")
         elif dumpErrorDetails:
             # for now report these to know how many blocks we are missing production windows for
-            reportProductionAnalysis()
+            reportProductionAnalysis(thresholdMs=200)
 
         if killEosInstances:
             Utils.Print("Shut down the cluster.")

--- a/tests/TestHelper.py
+++ b/tests/TestHelper.py
@@ -152,12 +152,24 @@ class TestHelper(object):
             Utils.Print("Test succeeded.")
         else:
             Utils.Print("Test failed.")
+
+        def reportProductionAnalysis():
+            Utils.Print(Utils.FileDivider)
+            for node in cluster.getAllNodes():
+                missedBlocks=node.analyzeProduction(thresholdMs=0)
+                if len(missedBlocks) > 0:
+                    Utils.Print("NodeId: %s produced the following blocks late: %s" % (node.nodeId, missedBlocks))
+
         if not testSuccessful and dumpErrorDetails:
             cluster.reportStatus()
             Utils.Print(Utils.FileDivider)
-            psOut=Cluster.pgrepEosServers(timeout=60)
+            psOut = Cluster.pgrepEosServers(timeout=60)
             Utils.Print("pgrep output:\n%s" % (psOut))
+            reportProductionAnalysis()
             Utils.Print("== Errors see above ==")
+        elif dumpErrorDetails:
+            # for now report these to know how many blocks we are missing production windows for
+            reportProductionAnalysis()
 
         if killEosInstances:
             Utils.Print("Shut down the cluster.")

--- a/tests/block_log_util_test.py
+++ b/tests/block_log_util_test.py
@@ -156,7 +156,7 @@ try:
 
     # relaunch the node with the truncated block log and ensure it catches back up with the producers
     current_head_block_num = node1.getInfo()["head_block_num"]
-    cluster.getNode(2).relaunch(2, cachePopen=True)
+    cluster.getNode(2).relaunch(cachePopen=True)
     assert cluster.getNode(2).waitForBlock(current_head_block_num, timeout=60, reportInterval=15)
 
     # ensure it continues to advance
@@ -186,7 +186,7 @@ try:
     # relaunch the node with the truncated block log and ensure it catches back up with the producers
     current_head_block_num = node1.getInfo()["head_block_num"]
     assert current_head_block_num >= info["head_block_num"]
-    cluster.getNode(2).relaunch(2, cachePopen=True)
+    cluster.getNode(2).relaunch(cachePopen=True)
     assert cluster.getNode(2).waitForBlock(current_head_block_num, timeout=60, reportInterval=15)
 
     # ensure it continues to advance

--- a/tests/eosio_blocklog_prune_test.py
+++ b/tests/eosio_blocklog_prune_test.py
@@ -127,7 +127,7 @@ try:
     #
     #  restart the producer node with pruned cfd
     #
-    isRelaunchSuccess = producerNode.relaunch(producerNodeIndex)
+    isRelaunchSuccess = producerNode.relaunch()
     assert isRelaunchSuccess, "Fail to relaunch full producer node"
 
     #
@@ -147,10 +147,10 @@ try:
     #
     #  restart both full and light validation node
     #
-    isRelaunchSuccess = fullValidationNode.relaunch(fullValidationNodeIndex)
+    isRelaunchSuccess = fullValidationNode.relaunch()
     assert isRelaunchSuccess, "Fail to relaunch full verification node"
 
-    isRelaunchSuccess = lightValidationNode.relaunch(lightValidationNodeIndex)
+    isRelaunchSuccess = lightValidationNode.relaunch()
     assert isRelaunchSuccess, "Fail to relaunch light verification node"
 
     #

--- a/tests/nodeos_chainbase_allocation_test.py
+++ b/tests/nodeos_chainbase_allocation_test.py
@@ -102,7 +102,7 @@ try:
 
     # Restart irr node and ensure the snapshot is still identical
     irrNode.kill(signal.SIGTERM)
-    isRelaunchSuccess = irrNode.relaunch(irrNodeId, "", timeout=5, cachePopen=True)
+    isRelaunchSuccess = irrNode.relaunch(timeout=5, cachePopen=True)
     assert isRelaunchSuccess, "Fail to relaunch"
     res = irrNode.createSnapshot()
     afterShutdownSnapshotPath = res["snapshot_name"]

--- a/tests/nodeos_forked_chain_test.py
+++ b/tests/nodeos_forked_chain_test.py
@@ -478,7 +478,7 @@ try:
 
     Print("Relaunching the non-producing bridge node to connect the producing nodes again")
 
-    if not nonProdNode.relaunch(nonProdNode.nodeNum, None):
+    if not nonProdNode.relaunch():
         errorExit("Failure - (non-production) node %d should have restarted" % (nonProdNode.nodeNum))
 
 

--- a/tests/nodeos_irreversible_mode_test.py
+++ b/tests/nodeos_irreversible_mode_test.py
@@ -138,8 +138,8 @@ def confirmHeadLibAndForkDbHeadOfSpecMode(nodeToTest, headLibAndForkDbHeadBefore
       assert forkDbHead == forkDbHeadBeforeSwitchMode, \
          "Fork db head ({}) should be equal to fork db head before switch mode ({}) ".format(forkDbHead, forkDbHeadBeforeSwitchMode)
 
-def relaunchNode(node: Node, nodeId, chainArg="", addSwapFlags=None, relaunchAssertMessage="Fail to relaunch"):
-   isRelaunchSuccess = node.relaunch(nodeId, chainArg=chainArg, addSwapFlags=addSwapFlags, timeout=relaunchTimeout, cachePopen=True)
+def relaunchNode(node: Node, chainArg="", addSwapFlags=None, relaunchAssertMessage="Fail to relaunch"):
+   isRelaunchSuccess = node.relaunch(chainArg=chainArg, addSwapFlags=addSwapFlags, timeout=relaunchTimeout, cachePopen=True)
    time.sleep(1) # Give a second to replay or resync if needed
    assert isRelaunchSuccess, relaunchAssertMessage
    return isRelaunchSuccess
@@ -174,7 +174,7 @@ try:
 
    def startProdNode():
       if producingNode.killed:
-         relaunchNode(producingNode, producingNodeId)
+         relaunchNode(producingNode)
 
    # Give some time for it to produce, so lib is advancing
    waitForBlksProducedAndLibAdvanced()
@@ -193,7 +193,7 @@ try:
          # Relaunch killed node so it can be used for the test
          nodeToTest = cluster.getNode(nodeIdOfNodeToTest)
          Utils.Print("Re-launch node #{} to excute test scenario: {}".format(nodeIdOfNodeToTest, runTestScenario.__name__))
-         relaunchNode(nodeToTest, nodeIdOfNodeToTest, relaunchAssertMessage="Fail to relaunch before running test scenario")
+         relaunchNode(nodeToTest, relaunchAssertMessage="Fail to relaunch before running test scenario")
 
          # Run test scenario
          runTestScenario(nodeIdOfNodeToTest, nodeToTest)
@@ -216,7 +216,7 @@ try:
 
       # Kill node and replay in irreversible mode
       nodeToTest.kill(signal.SIGTERM)
-      relaunchNode(nodeToTest, nodeIdOfNodeToTest, chainArg=" --read-mode irreversible --replay")
+      relaunchNode(nodeToTest, chainArg=" --read-mode irreversible --replay")
 
       # Confirm state
       confirmHeadLibAndForkDbHeadOfIrrMode(nodeToTest, headLibAndForkDbHeadBeforeSwitchMode)
@@ -230,7 +230,7 @@ try:
       # Shut down node, remove reversible blks and relaunch
       nodeToTest.kill(signal.SIGTERM)
       removeReversibleBlks(nodeIdOfNodeToTest)
-      relaunchNode(nodeToTest, nodeIdOfNodeToTest, chainArg=" --read-mode irreversible --replay")
+      relaunchNode(nodeToTest, chainArg=" --read-mode irreversible --replay")
 
       # Ensure the node condition is as expected after relaunch
       confirmHeadLibAndForkDbHeadOfIrrMode(nodeToTest, headLibAndForkDbHeadBeforeSwitchMode)
@@ -243,7 +243,7 @@ try:
 
       # Kill and relaunch in irreversible mode
       nodeToTest.kill(signal.SIGTERM)
-      relaunchNode(nodeToTest, nodeIdOfNodeToTest, chainArg=" --read-mode irreversible")
+      relaunchNode(nodeToTest, chainArg=" --read-mode irreversible")
 
       # Ensure the node condition is as expected after relaunch
       confirmHeadLibAndForkDbHeadOfIrrMode(nodeToTest, headLibAndForkDbHeadBeforeSwitchMode)
@@ -256,7 +256,7 @@ try:
 
       # Kill and relaunch in speculative mode
       nodeToTest.kill(signal.SIGTERM)
-      relaunchNode(nodeToTest, nodeIdOfNodeToTest, addSwapFlags={"--read-mode": "speculative"})
+      relaunchNode(nodeToTest, addSwapFlags={"--read-mode": "speculative"})
 
       # Ensure the node condition is as expected after relaunch
       confirmHeadLibAndForkDbHeadOfSpecMode(nodeToTest, headLibAndForkDbHeadBeforeSwitchMode)
@@ -272,7 +272,7 @@ try:
          # Kill and relaunch in irreversible mode
          nodeToTest.kill(signal.SIGTERM)
          waitForBlksProducedAndLibAdvanced() # Wait for some blks to be produced and lib advance
-         relaunchNode(nodeToTest, nodeIdOfNodeToTest, chainArg=" --read-mode irreversible")
+         relaunchNode(nodeToTest, chainArg=" --read-mode irreversible")
 
          # Ensure the node condition is as expected after relaunch
          ensureHeadLibAndForkDbHeadIsAdvancing(nodeToTest)
@@ -291,7 +291,7 @@ try:
          # Kill and relaunch in irreversible mode
          nodeToTest.kill(signal.SIGTERM)
          waitForBlksProducedAndLibAdvanced() # Wait for some blks to be produced and lib advance)
-         relaunchNode(nodeToTest, nodeIdOfNodeToTest, addSwapFlags={"--read-mode": "speculative"})
+         relaunchNode(nodeToTest, addSwapFlags={"--read-mode": "speculative"})
 
          # Ensure the node condition is as expected after relaunch
          ensureHeadLibAndForkDbHeadIsAdvancing(nodeToTest)
@@ -309,7 +309,7 @@ try:
          # Kill node and replay in irreversible mode
          nodeToTest.kill(signal.SIGTERM)
          waitForBlksProducedAndLibAdvanced() # Wait
-         relaunchNode(nodeToTest, nodeIdOfNodeToTest, chainArg=" --read-mode irreversible --replay")
+         relaunchNode(nodeToTest, chainArg=" --read-mode irreversible --replay")
 
          # Ensure the node condition is as expected after relaunch
          ensureHeadLibAndForkDbHeadIsAdvancing(nodeToTest)
@@ -329,7 +329,7 @@ try:
          nodeToTest.kill(signal.SIGTERM)
          removeReversibleBlks(nodeIdOfNodeToTest)
          waitForBlksProducedAndLibAdvanced() # Wait
-         relaunchNode(nodeToTest, nodeIdOfNodeToTest, chainArg=" --read-mode irreversible --replay")
+         relaunchNode(nodeToTest, chainArg=" --read-mode irreversible --replay")
 
          # Ensure the node condition is as expected after relaunch
          ensureHeadLibAndForkDbHeadIsAdvancing(nodeToTest)
@@ -357,7 +357,7 @@ try:
          # Start from clean data dir, recover back up blocks, and then relaunch with irreversible snapshot
          removeState(nodeIdOfNodeToTest)
          recoverBackedupBlksDir(nodeIdOfNodeToTest) # this function will delete the existing blocks dir first
-         relaunchNode(nodeToTest, nodeIdOfNodeToTest, chainArg=" --snapshot {}".format(getLatestSnapshot(nodeIdOfNodeToTest)), addSwapFlags={"--read-mode": "speculative"})
+         relaunchNode(nodeToTest, chainArg=" --snapshot {}".format(getLatestSnapshot(nodeIdOfNodeToTest)), addSwapFlags={"--read-mode": "speculative"})
          confirmHeadLibAndForkDbHeadOfSpecMode(nodeToTest)
          # Ensure it automatically replays "reversible blocks", i.e. head lib and fork db should be the same
          headLibAndForkDbHeadAfterRelaunch = getHeadLibAndForkDbHead(nodeToTest)
@@ -376,7 +376,7 @@ try:
          # Relaunch the node again (using the same snapshot)
          # This time ensure it automatically replays both "irreversible blocks" and "reversible blocks", i.e. the end result should be the same as before shutdown
          removeState(nodeIdOfNodeToTest)
-         relaunchNode(nodeToTest, nodeIdOfNodeToTest)
+         relaunchNode(nodeToTest)
          headLibAndForkDbHeadAfterRelaunch = getHeadLibAndForkDbHead(nodeToTest)
          assert headLibAndForkDbHeadBeforeShutdown == headLibAndForkDbHeadAfterRelaunch, \
             "Head, Lib, and Fork Db after relaunch is different {} vs {}".format(headLibAndForkDbHeadBeforeShutdown, headLibAndForkDbHeadAfterRelaunch)

--- a/tests/nodeos_multiple_version_protocol_feature_test.py
+++ b/tests/nodeos_multiple_version_protocol_feature_test.py
@@ -191,11 +191,11 @@ try:
     portableRevBlkPath = os.path.join(Utils.getNodeDataDir(oldNodeId), "rev_blk_portable_format")
     oldNode.kill(signal.SIGTERM)
     # Note, for the following relaunch, these will fail to relaunch immediately (expected behavior of export/import), so the chainArg will not replace the old cmd
-    oldNode.relaunch(oldNodeId, chainArg="--export-reversible-blocks {}".format(portableRevBlkPath), timeout=1)
-    oldNode.relaunch(oldNodeId, chainArg="--import-reversible-blocks {}".format(portableRevBlkPath), timeout=1, nodeosPath="programs/nodeos/nodeos")
+    oldNode.relaunch(chainArg="--export-reversible-blocks {}".format(portableRevBlkPath), timeout=1)
+    oldNode.relaunch(chainArg="--import-reversible-blocks {}".format(portableRevBlkPath), timeout=1, nodeosPath="programs/nodeos/nodeos")
     os.remove(portableRevBlkPath)
 
-    restartNode(oldNode, oldNodeId, chainArg="--replay", nodeosPath="programs/nodeos/nodeos")
+    restartNode(oldNode, chainArg="--replay", nodeosPath="programs/nodeos/nodeos")
     time.sleep(2) # Give some time to replay
 
     assert areNodesInSync(allNodes), "All nodes should be in sync"

--- a/tests/nodeos_multiple_version_protocol_feature_test.py
+++ b/tests/nodeos_multiple_version_protocol_feature_test.py
@@ -36,10 +36,10 @@ walletMgr=WalletMgr(True)
 cluster=Cluster(walletd=True)
 cluster.setWalletMgr(walletMgr)
 
-def restartNode(node: Node, nodeId, chainArg=None, addSwapFlags=None, nodeosPath=None):
+def restartNode(node: Node, chainArg=None, addSwapFlags=None, nodeosPath=None):
     if not node.killed:
         node.kill(signal.SIGTERM)
-    isRelaunchSuccess = node.relaunch(nodeId, chainArg, addSwapFlags=addSwapFlags,
+    isRelaunchSuccess = node.relaunch(chainArg, addSwapFlags=addSwapFlags,
                                       timeout=5, cachePopen=True, nodeosPath=nodeosPath)
     assert isRelaunchSuccess, "Fail to relaunch"
 
@@ -61,7 +61,7 @@ def waitUntilBeginningOfProdTurn(node, producerName, timeout=30, sleepTime=0.4):
 def waitForOneRound():
     time.sleep(24) # We have 4 producers for this test
 
-def setValidityOfActTimeSubjRestriction(node, nodeId, codename, valid):
+def setValidityOfActTimeSubjRestriction(node, codename, valid):
     invalidActTimeSubjRestriction = {
         "earliest_allowed_activation_time": "2030-01-01T00:00:00.000",
     }
@@ -69,8 +69,8 @@ def setValidityOfActTimeSubjRestriction(node, nodeId, codename, valid):
         "earliest_allowed_activation_time": "1970-01-01T00:00:00.000",
     }
     actTimeSubjRestriction = validActTimeSubjRestriction if valid else invalidActTimeSubjRestriction
-    node.modifyBuiltinPFSubjRestrictions(nodeId, codename, actTimeSubjRestriction)
-    restartNode(node, nodeId)
+    node.modifyBuiltinPFSubjRestrictions(codename, actTimeSubjRestriction)
+    restartNode(node)
 
 def waitUntilBlockBecomeIrr(node, blockNum, timeout=60):
     def hasBlockBecomeIrr():
@@ -142,8 +142,8 @@ try:
     # Therefore, 1st node will be out of sync with 2nd, 3rd, and 4th node
     # After a round has passed though, 1st node will realize he's in minority fork and then join the other nodes
     # Hence, the PREACTIVATE_FEATURE that was previously activated will be dropped and all of the nodes should be in sync
-    setValidityOfActTimeSubjRestriction(newNodes[1], newNodeIds[1], "PREACTIVATE_FEATURE", False)
-    setValidityOfActTimeSubjRestriction(newNodes[2], newNodeIds[2], "PREACTIVATE_FEATURE", False)
+    setValidityOfActTimeSubjRestriction(newNodes[1], "PREACTIVATE_FEATURE", False)
+    setValidityOfActTimeSubjRestriction(newNodes[2], "PREACTIVATE_FEATURE", False)
 
     waitUntilBeginningOfProdTurn(newNodes[0], "defproducera")
     newNodes[0].activatePreactivateFeature()
@@ -163,8 +163,8 @@ try:
     # They will be in sync and their LIB will advance since they control > 2/3 of the producers
     # Also the LIB should be able to advance past the block that contains PREACTIVATE_FEATURE
     # However, the 4th node will be out of sync with them, and its LIB will stuck
-    setValidityOfActTimeSubjRestriction(newNodes[1], newNodeIds[1], "PREACTIVATE_FEATURE", True)
-    setValidityOfActTimeSubjRestriction(newNodes[2], newNodeIds[2], "PREACTIVATE_FEATURE", True)
+    setValidityOfActTimeSubjRestriction(newNodes[1], "PREACTIVATE_FEATURE", True)
+    setValidityOfActTimeSubjRestriction(newNodes[2], "PREACTIVATE_FEATURE", True)
 
     waitUntilBeginningOfProdTurn(newNodes[0], "defproducera")
     libBeforePreactivation = newNodes[0].getIrreversibleBlockNum()

--- a/tests/nodeos_protocol_feature_test.py
+++ b/tests/nodeos_protocol_feature_test.py
@@ -30,10 +30,10 @@ keepLogs=args.keep_logs
 
 # The following test case will test the Protocol Feature JSON reader of the blockchain
 
-def restartNode(node: Node, nodeId, chainArg=None, addSwapFlags=None):
+def restartNode(node: Node, chainArg=None, addSwapFlags=None):
     if not node.killed:
         node.kill(signal.SIGTERM)
-    isRelaunchSuccess = node.relaunch(nodeId, chainArg, addSwapFlags=addSwapFlags, timeout=5, cachePopen=True)
+    isRelaunchSuccess = node.relaunch(chainArg, addSwapFlags=addSwapFlags, timeout=5, cachePopen=True)
     assert isRelaunchSuccess, "Fail to relaunch"
 
 walletMgr=WalletMgr(True)
@@ -56,8 +56,8 @@ try:
         "preactivation_required": True,
         "enabled": False
     }
-    biosNode.modifyBuiltinPFSubjRestrictions("bios", "PREACTIVATE_FEATURE", newSubjectiveRestrictions)
-    restartNode(biosNode, "bios")
+    biosNode.modifyBuiltinPFSubjRestrictions("PREACTIVATE_FEATURE", newSubjectiveRestrictions)
+    restartNode(biosNode)
 
     supportedProtocolFeatureDict = biosNode.getSupportedProtocolFeatureDict()
     preactivateFeatureSubjectiveRestrictions = supportedProtocolFeatureDict["PREACTIVATE_FEATURE"]["subjective_restrictions"]

--- a/tests/nodeos_startup_catchup.py
+++ b/tests/nodeos_startup_catchup.py
@@ -168,7 +168,7 @@ try:
         catchupNode.interruptAndVerifyExitStatus(60)
 
         Print("Restart catchup node")
-        catchupNode.relaunch(catchupNodeNum, cachePopen=True)
+        catchupNode.relaunch(cachePopen=True)
         waitForNodeStarted(catchupNode)
         lastCatchupLibNum=lib(catchupNode)
 

--- a/tests/ship_test.py
+++ b/tests/ship_test.py
@@ -179,8 +179,7 @@ try:
                     limit = timedelta(seconds=0.500)
                     if delta >= limit:
                         actualProducerTimeStr=None
-                        nodes = cluster.getAllNodes()
-                        nodes.remove(shipNodeNum)
+                        nodes = [node for node in cluster.getAllNodes() if node.nodeId != shipNodeNum]
                         for node in nodes:
                             threshold=-500   # set negative to guarantee the block analysis gets returned
                             blockAnalysis = node.analyzeProduction(specificBlockNum=blockNum, thresholdMs=threshold)

--- a/tests/ship_test.py
+++ b/tests/ship_test.py
@@ -203,26 +203,6 @@ try:
 finally:
     TestHelper.shutdown(cluster, walletMgr, testSuccessful=testSuccessful, killEosInstances=killEosInstances, killWallet=killWallet, keepLogs=keepLogs, cleanRun=killAll, dumpErrorDetails=dumpErrorDetails)
     if shipTempDir is not None:
-        if dumpErrorDetails and not testSuccessful:
-            def printTruncatedFile(filename, maxLines):
-                Print(Utils.FileDivider)
-                with open(filename, "r") as f:
-                    Print("Contents of %s" % (filename))
-                    line = f.readline()
-                    lineCount = 0
-                    while line and lineCount < maxLines:
-                        Print(line)
-                        lineCount += 1
-                        line = f.readline()
-                    if line:
-                        Print("...       CONTENT TRUNCATED AT %d lines" % (maxLines))
-
-            for index in range(0, args.num_clients):
-                # error file should not contain much content, so if there are lots of lines it is likely useless
-                printTruncatedFile("%s%d.err" % (shipClientFilePrefix, i), maxLines=1000)
-                # output file should have lots of output, but if user passes in a huge number of requests, these could go on forever
-                printTruncatedFile("%s%d.out" % (shipClientFilePrefix, i), maxLines=20000)
-
         if testSuccessful and not keepLogs:
             shutil.rmtree(shipTempDir, ignore_errors=True)
 


### PR DESCRIPTION
## Change Description
Added Node methods to analyze production delays, added reporting these at the end of tests, and changed ship_test to only identify as an error when a block is reported as received in the ship node significantly later than when it would have been produced in the producing node (it originally assumed that it was produced at the slot time, which resulted in VM hiccups delaying block production and triggering this error). Also added storing nodeId in the Node so it would not need to be passed in to so many methods.

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
