### PR TITLE
Fixed relaunch calls that still passed in nodeId.

### DIFF
--- a/tests/Cluster.py
+++ b/tests/Cluster.py
@@ -1431,7 +1431,7 @@ class Cluster(object):
         newChain= False if self.__chainSyncStrategy.name in [Utils.SyncHardReplayTag, Utils.SyncNoneTag] else True
         for i in range(0, len(self.nodes)):
             node=self.nodes[i]
-            if node.killed and not node.relaunch(chainArg, newChain=newChain, cachePopen=cachePopen):
+            if node.killed and not node.relaunch(chainArg=chainArg, newChain=newChain, cachePopen=cachePopen):
                 return False
 
         return True

--- a/tests/nodeos_irreversible_mode_test.py
+++ b/tests/nodeos_irreversible_mode_test.py
@@ -349,7 +349,7 @@ try:
          backupBlksDir(nodeIdOfNodeToTest)
 
          # Relaunch in irreversible mode and create the snapshot
-         relaunchNode(nodeToTest, nodeIdOfNodeToTest, chainArg=" --read-mode irreversible")
+         relaunchNode(nodeToTest, chainArg=" --read-mode irreversible")
          confirmHeadLibAndForkDbHeadOfIrrMode(nodeToTest)
          nodeToTest.createSnapshot()
          nodeToTest.kill(signal.SIGTERM)

--- a/tests/nodeos_short_fork_take_over_test.py
+++ b/tests/nodeos_short_fork_take_over_test.py
@@ -339,12 +339,12 @@ try:
         Utils.errorExit("Expected the node 1 to have shutdown.")
 
     Print("Relaunching the non-producing bridge node to connect the node 0 (defproducera, defproducerb)")
-    if not nonProdNode.relaunch(nonProdNode.nodeNum, None):
+    if not nonProdNode.relaunch():
         errorExit("Failure - (non-production) node %d should have restarted" % (nonProdNode.nodeNum))
 
     Print("Relaunch node 1 (defproducerc) and let it connect to brigde node that already synced up with node 0")
     time.sleep(10)
-    if not node1.relaunch(nodeId=1, chainArg=" --enable-stale-production "):
+    if not node1.relaunch(chainArg=" --enable-stale-production "):
         errorExit("Failure - (non-production) node 1 should have restarted")
 
     Print("Waiting to allow forks to resolve")

--- a/tests/nodeos_under_min_avail_ram.py
+++ b/tests/nodeos_under_min_avail_ram.py
@@ -199,7 +199,7 @@ try:
         if not enabledStaleProduction:
             addSwapFlags["--enable-stale-production"]=""   # just enable stale production for the first node
             enabledStaleProduction=True
-        if not nodes[nodeIndex].relaunch(nodeIndex, "", newChain=False, addSwapFlags=addSwapFlags):
+        if not nodes[nodeIndex].relaunch(newChain=False, addSwapFlags=addSwapFlags):
             Utils.cmdError("Failed to restart node0 with new capacity %s" % (maxRAMValue))
             errorExit("Failure - Node should have restarted")
         addSwapFlags={}
@@ -262,7 +262,7 @@ try:
     maxRAMValue=currentMinimumMaxRAM+5
     currentMinimumMaxRAM=maxRAMValue
     addSwapFlags[maxRAMFlag]=str(maxRAMValue)
-    if not nodes[len(nodes)-1].relaunch(nodeIndex, "", newChain=False, addSwapFlags=addSwapFlags):
+    if not nodes[len(nodes)-1].relaunch(newChain=False, addSwapFlags=addSwapFlags):
         Utils.cmdError("Failed to restart node %d with new capacity %s" % (numNodes-1, maxRAMValue))
         errorExit("Failure - Node should have restarted")
     addSwapFlags={}


### PR DESCRIPTION
## Change Description
#9175 did some cleanup of having to pass in nodeId to Node methods, and some existing calls that passed it in to relaunch missed removing it.

## Change Type
**Select ONE**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [ ] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [ ] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the relase notes. Please include a description of the change for inclusion in the release notes.-->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
