### PR TITLE
Use new block_start signal for clearing onblock cached value

### DIFF
--- a/plugins/amqp_compressed_proof_plugin/include/eosio/amqp_compressed_proof_plugin/amqp_compressed_proof_plugin.hpp
+++ b/plugins/amqp_compressed_proof_plugin/include/eosio/amqp_compressed_proof_plugin/amqp_compressed_proof_plugin.hpp
@@ -19,6 +19,7 @@ public:
    void on_applied_transaction(const chain::transaction_trace_ptr& trace);
    void on_accepted_block(const chain::block_state_ptr& p);
    void on_irreversible_block(const chain::block_state_ptr& bsp, const chain::controller& controller);
+   void on_block_start(uint32_t block_num);
 
    using action_filter_func = std::function<bool(const chain::action& a)>;
    using merkle_proof_result_func = std::function<void(std::vector<char>&&)>;


### PR DESCRIPTION
## Change Description

- Update to use new scheme for tracking `onblock`

## Change Type
**Select ONE**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [ ] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [x] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the relase notes. Please include a description of the change for inclusion in the release notes.-->


## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
