### PR TITLE
Support unity build for unittests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,12 +51,6 @@ if ("${CMAKE_GENERATOR}" STREQUAL "Ninja")
    add_compile_options(-fdiagnostics-color=always)
 endif()
 
-if (ENABLE_UNITY_BUILD)
-  set(CMAKE_EXPORT_COMPILE_COMMANDS "OFF")
-else()
-  set(CMAKE_EXPORT_COMPILE_COMMANDS "ON")
-endif()
-
 set(BUILD_DOXYGEN FALSE CACHE BOOL "Build doxygen documentation on every make")
 set(ENABLE_MULTIVERSION_PROTOCOL_TEST FALSE CACHE BOOL "Enable nodeos multiversion protocol test")
 
@@ -185,6 +179,15 @@ option(DISABLE_WASM_SPEC_TESTS "disable building of wasm spec unit tests" OFF)
 
 if (NOT DISABLE_WASM_SPEC_TESTS)
 add_subdirectory( eosio-wasm-spec-tests/generated-tests )
+endif()
+
+
+if (ENABLE_UNITY_BUILD)
+  set(CMAKE_EXPORT_COMPILE_COMMANDS "OFF")
+  set_target_properties(eosio_chain chainbase fc rodeos_lib state_history unit_test wasm_spec_test trace_api_plugin
+                        PROPERTIES UNITY_BUILD TRUE)
+else()
+  set(CMAKE_EXPORT_COMPILE_COMMANDS "ON")
 endif()
 
 install_directory_permissions(DIRECTORY ${CMAKE_INSTALL_FULL_SYSCONFDIR}/eosio)

--- a/libraries/chain/CMakeLists.txt
+++ b/libraries/chain/CMakeLists.txt
@@ -140,10 +140,6 @@ target_include_directories( eosio_chain
 add_library(eosio_chain_wrap INTERFACE )
 target_link_libraries(eosio_chain_wrap INTERFACE eosio_chain)
 
-if(ENABLE_UNITY_BUILD)
-   set_target_properties(eosio_chain PROPERTIES UNITY_BUILD TRUE)
-endif() 
-
 if("eos-vm-oc" IN_LIST EOSIO_WASM_RUNTIMES)
    target_link_libraries(eosio_chain_wrap INTERFACE "-Wl,-wrap=main")
 endif()

--- a/libraries/chain/include/eosio/chain/authority_checker.hpp
+++ b/libraries/chain/include/eosio/chain/authority_checker.hpp
@@ -210,7 +210,7 @@ namespace detail {
 
             template<typename KeyWeight, typename = std::enable_if_t<detail::is_any_of_v<KeyWeight, shared_key_weight, key_weight>>>
             uint32_t operator()(const KeyWeight& permission) {
-               auto itr = boost::find( checker.provided_keys, permission.key );
+               auto itr = boost::range::find( checker.provided_keys, permission.key );
                if( itr != checker.provided_keys.end() ) {
                   checker._used_keys[itr - checker.provided_keys.begin()] = true;
                   total_weight += permission.weight;

--- a/libraries/chainbase/CMakeLists.txt
+++ b/libraries/chainbase/CMakeLists.txt
@@ -67,10 +67,6 @@ add_library( chainbase src/chainbase.cpp src/pinnable_mapped_file.cpp ${HEADERS}
 target_link_libraries( chainbase Boost::filesystem ${PLATFORM_LIBRARIES} )
 target_include_directories( chainbase PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" )
 
-if(ENABLE_UNITY_BUILD)
-   set_target_properties(chainbase PROPERTIES UNITY_BUILD TRUE)
-endif() 
-
 if(WIN32)
    target_link_libraries( chainbase ws2_32 mswsock )
 endif()

--- a/libraries/fc/CMakeLists.txt
+++ b/libraries/fc/CMakeLists.txt
@@ -124,7 +124,6 @@ list(APPEND sources ${fc_headers})
 setup_library( fc SOURCES ${sources} LIBRARY_TYPE STATIC DONT_INSTALL_LIBRARY )
 
 if(ENABLE_UNITY_BUILD)
-   set_target_properties(fc PROPERTIES UNITY_BUILD TRUE)
    set_source_files_properties(src/io/json.cpp 
                                PROPERTIES SKIP_UNITY_BUILD_INCLUSION TRUE)
 endif() 

--- a/libraries/fc/CMakeLists.txt
+++ b/libraries/fc/CMakeLists.txt
@@ -72,8 +72,7 @@ set( fc_sources
      src/log/log_message.cpp
      src/log/logger.cpp
      src/log/appender.cpp
-     src/log/console_appender.cpp
-     src/log/gelf_appender.cpp
+     src/log/console_appender.cpp    
      src/log/dmlog_appender.cpp
      src/log/logger_config.cpp
      src/crypto/_digest_common.cpp
@@ -111,6 +110,7 @@ set( fc_sources
      src/network/http/http_client.cpp
      src/compress/smaz.cpp
      src/compress/zlib.cpp
+     src/log/gelf_appender.cpp
      )
 
 file( GLOB_RECURSE fc_headers ${CMAKE_CURRENT_SOURCE_DIR} *.hpp *.h )
@@ -125,6 +125,8 @@ setup_library( fc SOURCES ${sources} LIBRARY_TYPE STATIC DONT_INSTALL_LIBRARY )
 
 if(ENABLE_UNITY_BUILD)
    set_target_properties(fc PROPERTIES UNITY_BUILD TRUE)
+   set_source_files_properties(src/io/json.cpp 
+                               PROPERTIES SKIP_UNITY_BUILD_INCLUSION TRUE)
 endif() 
 
 

--- a/libraries/rodeos/CMakeLists.txt
+++ b/libraries/rodeos/CMakeLists.txt
@@ -14,7 +14,3 @@ target_link_libraries( rodeos_lib
 target_include_directories( rodeos_lib
                             PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include"
                           )
-
-if(ENABLE_UNITY_BUILD)
-   set_target_properties(rodeos_lib PROPERTIES UNITY_BUILD TRUE)
-endif() 

--- a/libraries/state_history/CMakeLists.txt
+++ b/libraries/state_history/CMakeLists.txt
@@ -16,7 +16,3 @@ target_link_libraries( state_history
 target_include_directories( state_history
                             PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include"
                           )
-
-if(ENABLE_UNITY_BUILD)
-   set_target_properties(state_history PROPERTIES UNITY_BUILD TRUE)
-endif() 

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -54,10 +54,6 @@ target_include_directories( unit_test PUBLIC
                             ${CMAKE_CURRENT_BINARY_DIR}/include
                             ${CMAKE_SOURCE_DIR}/plugins/http_plugin/include )
 
-if (ENABLE_UNITY_BUILD)
-  set_target_properties(unit_test PROPERTIES UNITY_BUILD TRUE)
-endif(ENABLE_UNITY_BUILD)
-
 ### MARK TEST SUITES FOR EXECUTION ###
 add_test(NAME protocol_feature_digest_unit_test COMMAND unit_test --run_test=protocol_feature_digest_tests --report_level=detailed --color_output --catch_system_errors=no)
 set(ctest_tests "protocol_feature_digest_tests")

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -54,6 +54,10 @@ target_include_directories( unit_test PUBLIC
                             ${CMAKE_CURRENT_BINARY_DIR}/include
                             ${CMAKE_SOURCE_DIR}/plugins/http_plugin/include )
 
+if (ENABLE_UNITY_BUILD)
+  set_target_properties(unit_test PROPERTIES UNITY_BUILD TRUE)
+endif(ENABLE_UNITY_BUILD)
+
 ### MARK TEST SUITES FOR EXECUTION ###
 add_test(NAME protocol_feature_digest_unit_test COMMAND unit_test --run_test=protocol_feature_digest_tests --report_level=detailed --color_output --catch_system_errors=no)
 set(ctest_tests "protocol_feature_digest_tests")

--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -31,6 +31,7 @@
 #include <Runtime/Runtime.h>
 
 #include <contracts.hpp>
+#include "test_cfd_transaction.hpp"
 
 #define DUMMY_ACTION_DEFAULT_A 0x45
 #define DUMMY_ACTION_DEFAULT_B 0xab11cd1244556677
@@ -49,33 +50,8 @@ static constexpr unsigned long long WASM_TEST_ACTION(const char* cls, const char
   return static_cast<unsigned long long>(DJBH(cls)) << 32 | static_cast<unsigned long long>(DJBH(method));
 }
 
-struct dummy_action {
-   static eosio::chain::name get_name() {
-      return N(dummyaction);
-   }
-   static eosio::chain::name get_account() {
-      return N(testapi);
-   }
-
-  char a; //1
-  uint64_t b; //8
-  int32_t  c; //4
-};
-
 struct u128_action {
   unsigned __int128  values[3]; //16*3
-};
-
-struct cf_action {
-   static eosio::chain::name get_name() {
-      return N(cfaction);
-   }
-   static eosio::chain::name get_account() {
-      return N(testapi);
-   }
-
-   uint32_t       payload = 100;
-   uint32_t       cfd_idx = 0; // context free data index
 };
 
 // Deferred Transaction Trigger Action
@@ -101,9 +77,7 @@ struct invalid_access_action {
    bool store;
 };
 
-FC_REFLECT( dummy_action, (a)(b)(c) )
 FC_REFLECT( u128_action, (values) )
-FC_REFLECT( cf_action, (payload)(cfd_idx) )
 FC_REFLECT( dtt_action, (payer)(deferred_account)(deferred_action)(permission_name)(delay_sec) )
 FC_REFLECT( invalid_access_action, (code)(val)(index)(store) )
 

--- a/unittests/payloadless_tests.cpp
+++ b/unittests/payloadless_tests.cpp
@@ -51,7 +51,7 @@ BOOST_FIXTURE_TEST_CASE( test_abi_serializer, payloadless_tester ) {
    set_code( N(payloadless), contracts::payloadless_wasm() );
    set_abi( N(payloadless), contracts::payloadless_abi().data() );
 
-   variant pretty_trx = fc::mutable_variant_object()
+   fc::variant pretty_trx = fc::mutable_variant_object()
       ("actions", fc::variants({
          fc::mutable_variant_object()
             ("account", name(N(payloadless)))

--- a/unittests/special_accounts_tests.cpp
+++ b/unittests/special_accounts_tests.cpp
@@ -31,12 +31,12 @@ BOOST_FIXTURE_TEST_CASE(accounts_exists, tester)
 
       auto nobody = chain1_db.find<account_object, by_name>(config::null_account_name);
       BOOST_CHECK(nobody != nullptr);
-      const auto& nobody_active_authority = chain1_db.get<permission_object, by_owner>(boost::make_tuple(config::null_account_name, config::active_name));
+      const auto& nobody_active_authority = chain1_db.get<permission_object, eosio::chain::by_owner>(boost::make_tuple(config::null_account_name, config::active_name));
       BOOST_CHECK_EQUAL(nobody_active_authority.auth.threshold, 1u);
       BOOST_CHECK_EQUAL(nobody_active_authority.auth.accounts.size(), 0u);
       BOOST_CHECK_EQUAL(nobody_active_authority.auth.keys.size(), 0u);
 
-      const auto& nobody_owner_authority = chain1_db.get<permission_object, by_owner>(boost::make_tuple(config::null_account_name, config::owner_name));
+      const auto& nobody_owner_authority = chain1_db.get<permission_object, eosio::chain::by_owner>(boost::make_tuple(config::null_account_name, config::owner_name));
       BOOST_CHECK_EQUAL(nobody_owner_authority.auth.threshold, 1u);
       BOOST_CHECK_EQUAL(nobody_owner_authority.auth.accounts.size(), 0u);
       BOOST_CHECK_EQUAL(nobody_owner_authority.auth.keys.size(), 0u);

--- a/unittests/test_cfd_transaction.cpp
+++ b/unittests/test_cfd_transaction.cpp
@@ -1,29 +1,7 @@
 #include "test_cfd_transaction.hpp"
 #include <contracts.hpp>
 
-struct dummy_action {
-   static eosio::chain::name get_name() { return N(dummyaction); }
-   static eosio::chain::name get_account() { return N(testapi); }
 
-   char     a; // 1
-   uint64_t b; // 8
-   int32_t  c; // 4
-};
-
-struct cf_action {
-   static eosio::chain::name get_name() { return N(cfaction); }
-   static eosio::chain::name get_account() { return N(testapi); }
-
-   uint32_t payload = 100;
-   uint32_t cfd_idx = 0; // context free data index
-};
-
-FC_REFLECT(dummy_action, (a)(b)(c))
-FC_REFLECT(cf_action, (payload)(cfd_idx))
-
-#define DUMMY_ACTION_DEFAULT_A 0x45
-#define DUMMY_ACTION_DEFAULT_B 0xab11cd1244556677
-#define DUMMY_ACTION_DEFAULT_C 0x7451ae12
 
 std::vector<eosio::chain::signed_block_ptr> deploy_test_api(eosio::testing::tester& chain) {
    std::vector<eosio::chain::signed_block_ptr> result;

--- a/unittests/test_cfd_transaction.hpp
+++ b/unittests/test_cfd_transaction.hpp
@@ -1,6 +1,30 @@
 #pragma once
 #include <eosio/testing/tester.hpp>
 
+struct dummy_action {
+   static eosio::chain::name get_name() { return N(dummyaction); }
+   static eosio::chain::name get_account() { return N(testapi); }
+
+   char     a; // 1
+   uint64_t b; // 8
+   int32_t  c; // 4
+};
+
+struct cf_action {
+   static eosio::chain::name get_name() { return N(cfaction); }
+   static eosio::chain::name get_account() { return N(testapi); }
+
+   uint32_t payload = 100;
+   uint32_t cfd_idx = 0; // context free data index
+};
+
+FC_REFLECT(dummy_action, (a)(b)(c))
+FC_REFLECT(cf_action, (payload)(cfd_idx))
+
+#define DUMMY_ACTION_DEFAULT_A 0x45
+#define DUMMY_ACTION_DEFAULT_B 0xab11cd1244556677
+#define DUMMY_ACTION_DEFAULT_C 0x7451ae12
+
 std::vector<eosio::chain::signed_block_ptr> deploy_test_api(eosio::testing::tester& chain);
 eosio::chain::transaction_trace_ptr push_test_cfd_transaction(eosio::testing::tester& chain);
 

--- a/unittests/wasm_config_tests.cpp
+++ b/unittests/wasm_config_tests.cpp
@@ -52,9 +52,7 @@ struct wasm_config_tester : TESTER {
    }
    chain::abi_serializer bios_abi_ser;
 };
-struct old_wasm_tester : tester {
-   old_wasm_tester() : tester{setup_policy::old_wasm_parser} {}
-};
+
 
 std::string make_locals_wasm(int n_params, int n_locals, int n_stack)
 {
@@ -78,6 +76,10 @@ std::string make_locals_wasm(int n_params, int n_locals, int n_stack)
 }
 
 BOOST_AUTO_TEST_SUITE(wasm_config_tests)
+
+struct old_wasm_tester : tester {
+   old_wasm_tester() : tester{setup_policy::old_wasm_parser} {}
+};
 
 BOOST_DATA_TEST_CASE_F(wasm_config_tester, max_mutable_global_bytes, data::make({ 4096, 8192 , 16384 }) * data::make({0, 1}), n_globals, oversize) {
    produce_block();

--- a/unittests/wasm_tests.cpp
+++ b/unittests/wasm_tests.cpp
@@ -67,16 +67,14 @@ struct provereset {
    }
 };
 
-namespace {
+FC_REFLECT_EMPTY(provereset);
+
+BOOST_AUTO_TEST_SUITE(wasm_tests)
+
 #warning Change this back to using TESTER
 struct old_wasm_tester : tester {
    old_wasm_tester() : tester{setup_policy::old_wasm_parser} {}
 };
-}
-
-FC_REFLECT_EMPTY(provereset);
-
-BOOST_AUTO_TEST_SUITE(wasm_tests)
 
 /**
  * Prove that action reading and assertions are working
@@ -180,14 +178,14 @@ BOOST_FIXTURE_TEST_CASE( abi_from_variant, TESTER ) try {
    set_abi(N(asserter), contracts::asserter_abi().data());
    produce_blocks(1);
 
-   auto resolver = [&,this]( const account_name& name ) -> optional<abi_serializer> {
+   auto resolver = [&,this]( const account_name& name ) -> fc::optional<abi_serializer> {
       try {
          const auto& accnt  = this->control->db().get<account_object,by_name>( name );
          abi_def abi;
          if (abi_serializer::to_abi(accnt.abi, abi)) {
             return abi_serializer(abi, abi_serializer::create_yield_function( abi_serializer_max_time ));
          }
-         return optional<abi_serializer>();
+         return fc::optional<abi_serializer>();
       } FC_RETHROW_EXCEPTIONS(error, "Failed to find or parse ABI for ${name}", ("name", name))
    };
 


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->
## Change Description
This PR enable unity build for unittests and fix some ODR violations when CMAKE_UNITY_BUILD_BATCH_SIZE is set to non-default value 
## Change Type
**Select ONE**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [ ] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [ ] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the relase notes. Please include a description of the change for inclusion in the release notes.-->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
