### PR TITLE
[develop]  added eosio-blocklog options to take last good blocks

### DIFF
--- a/libraries/chain/include/eosio/chain/block_log.hpp
+++ b/libraries/chain/include/eosio/chain/block_log.hpp
@@ -34,7 +34,14 @@ namespace eosio { namespace chain {
 
    class block_log {
       public:
-         block_log(const fc::path& data_dir);
+         /**
+          * Constructor
+          * @param data_dir Directory of blocks.log and blocks.index files
+          * @param fix_index flag to indicate to fix blocks.index. By default it fixes the blocks.index
+          *                  For corrupted files, we need to disable the fixing index here.
+          */
+         block_log(const fc::path& data_dir, bool fix_index = true);
+
          block_log(block_log&& other) = default;
          ~block_log();
          
@@ -42,13 +49,25 @@ namespace eosio { namespace chain {
 
          void reset( const genesis_state& gs, const signed_block_ptr& genesis_block, packed_transaction::cf_compression_type segment_compression);
          void reset( const chain_id_type& chain_id, uint32_t first_block_num );
-         
+
          block_id_type    read_block_id_by_num(uint32_t block_num)const;
 
          std::unique_ptr<signed_block>   read_signed_block_by_num(uint32_t block_num) const;
 
          const signed_block_ptr&        head() const;
          uint32_t                       first_block_num() const;
+
+         /**
+          * fix blocks.log and/or blocks.index files if they have incomplete block at the end of file
+          * @param block_dir  Directory of blocks.log and blocks.index files
+          */
+         void fix_corrupted_file(const fc::path& block_dir);
+
+         /**
+          *
+          * @return
+          */
+         void check_files();
 
          static bool exists(const fc::path& data_dir);
          /**

--- a/programs/eosio-blocklog/main.cpp
+++ b/programs/eosio-blocklog/main.cpp
@@ -318,6 +318,11 @@ int main(int argc, char** argv) {
       }
       if (blog.fix_corrupted_file) {
          fix_corrupted_file(vmap.at("blocks-dir").as<bfs::path>());
+         update_index(vmap.at("blocks-dir").as<bfs::path>());
+         return 0;
+      }
+      if (blog.update_index) {
+         update_index(vmap.at("blocks-dir").as<bfs::path>());
          return 0;
       }
       if (blog.check_files) {
@@ -357,10 +362,6 @@ int main(int argc, char** argv) {
          block_log::construct_index(block_file.generic_string(), out_file.generic_string());
          fc::logger::get(DEFAULT_LOGGER).set_log_level(log_level);
          rt.report();
-         return 0;
-      }
-      if (blog.update_index) {
-         update_index(vmap.at("blocks-dir").as<bfs::path>());
          return 0;
       }
       if (blog.prune_transactions) {

--- a/tests/block_log_util_test.py
+++ b/tests/block_log_util_test.py
@@ -228,8 +228,7 @@ try:
 
     # fix-corrupted-file
     output=cluster.getBlockLog(0, blockLogAction=BlockLogAction.fix_corrupted_file)
-    fixedBlockIndexFileSize = os.path.getsize(blockIndexFileName)
-    assert fixedBlockIndexFileSize == blockIndexFileSize, "blocks.index not fixed properly\n"
+    output=cluster.getBlockLog(0, blockLogAction=BlockLogAction.update_index)
 
     # check_files
     output=cluster.getBlockLog(0, blockLogAction=BlockLogAction.check_files)

--- a/tests/block_log_util_test.py
+++ b/tests/block_log_util_test.py
@@ -263,9 +263,6 @@ try:
     # fix-corrupted-file
     output=cluster.getBlockLog(0, blockLogAction=BlockLogAction.fix_corrupted_file)
 
-    # update-index
-    output=cluster.getBlockLog(0, blockLogAction=BlockLogAction.update_index)
-
     # check_files
     output=cluster.getBlockLog(0, blockLogAction=BlockLogAction.check_files)
     expectedStr="no problems found"

--- a/tests/block_log_util_test.py
+++ b/tests/block_log_util_test.py
@@ -229,12 +229,7 @@ try:
     # fix-corrupted-file
     output=cluster.getBlockLog(0, blockLogAction=BlockLogAction.fix_corrupted_file)
     fixedBlockIndexFileSize = os.path.getsize(blockIndexFileName)
-    assert fixedBlockIndexFileSize == blockIndexFileSize - 16, "blocks.index not fixed properly\n"
-
-    # update-index
-    output=cluster.getBlockLog(0, blockLogAction=BlockLogAction.update_index)
-    updatedBlockIndexFileSize = os.path.getsize(blockIndexFileName)
-    assert updatedBlockIndexFileSize == blockIndexFileSize, "blocks.index not updated properly\n"
+    assert fixedBlockIndexFileSize == blockIndexFileSize, "blocks.index not fixed properly\n"
 
     # check_files
     output=cluster.getBlockLog(0, blockLogAction=BlockLogAction.check_files)

--- a/tests/testUtils.py
+++ b/tests/testUtils.py
@@ -49,6 +49,9 @@ addEnum(BlockLogAction, "trim")
 addEnum(BlockLogAction, "smoke_test")
 addEnum(BlockLogAction, "return_blocks")
 addEnum(BlockLogAction, "prune_transactions")
+addEnum(BlockLogAction, "update_index")
+addEnum(BlockLogAction, "check_files")
+addEnum(BlockLogAction, "fix_corrupted_file")
 
 ###########################################################################################
 
@@ -422,6 +425,12 @@ class Utils:
             returnType=ReturnType.json
         elif blockLogAction==BlockLogAction.make_index:
             blockLogActionStr=" --make-index "
+        elif blockLogAction==BlockLogAction.update_index:
+            blockLogActionStr=" --update-index "
+        elif blockLogAction==BlockLogAction.check_files:
+            blockLogActionStr=" --check-files "
+        elif blockLogAction==BlockLogAction.fix_corrupted_file:
+            blockLogActionStr=" --fix-corrupted-file "
         elif blockLogAction==BlockLogAction.trim:
             blockLogActionStr=" --trim "
         elif blockLogAction==BlockLogAction.smoke_test:


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->
## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
eosio-blocklog --trim-blocklog allows you to take a block.log + block.index and repair it to a usable situation.  You need to know what is a good block to repair to.  If you choose a block in the future, it fails.

New options:
~/contracts/eos/build/programs/eosio-blocklog> ./eosio-blocklog --help
  --check-files               Check  blocks.index and blocks.log. 
                                        Must give 'blocks-dir'.
  --update-index           Update blocks.index with the best 
                                        effort to avoid creating a new index 
                                        file. Must give 'blocks-dir'. Give 
                                        'output-file' relative to current 
                                        directory or absolute path (default is 
                                        <blocks-dir>/blocks.index).
  --fix-corrupted-file     fix the corrupted end of blocks.log and
                                        blocks.index files by trimming the 
                                        incomplete block. Must give 
                                        'blocks-dir'.


Example)
~/tmp/blocks> ls -al
-rw-r--r--  1 jongho.kim staff  128 Jun  9 13:52 blocks.index
-rw-r--r--  1 jongho.kim staff 3198 Jun  9 13:47 blocks.log
drwxr-xr-x  3 jongho.kim staff   96 Jun  9 13:47 reversible

// truncate blocks.log
~/tmp/blocks> truncate -s 3000 blocks.log
~/tmp/blocks> ls -al
-rw-r--r--  1 jongho.kim staff  128 Jun  9 13:52 blocks.index
-rw-r--r--  1 jongho.kim staff 3000 Jun  9 14:27 blocks.log
drwxr-xr-x  3 jongho.kim staff   96 Jun  9 13:47 reversible


// smoke-test crashes because of the corrupted file
~/contracts/eos/build/programs/eosio-blocklog> ./eosio-blocklog --blocks-dir ~/tmp/blocks --smoke-test 

Smoke test of blocks.log and blocks.index in directory "/Users/jongho.kim/tmp/blocks"
zsh: segmentation fault  ./eosio-blocklog --blocks-dir ~/tmp/blocks --smoke-test
~/contracts/eos/build/programs/eosio-blocklog> 


// check-file got the assertion
~/contracts/eos/build/programs/eosio-blocklog> ./eosio-blocklog --blocks-dir ~/tmp/blocks --check-files
Check blocks.index and blocks.log in "/Users/jongho.kim/tmp/blocks"
info  2020-06-09T18:29:08.512 thread-0  block_log.cpp:673             check_corrupted_bloc ]  blocks.index file looks good with size of 128 bytes.
info  2020-06-09T18:29:08.513 thread-0  block_log.cpp:754             check_corrupted_bloc ] Found incomplete 186 bytes in blocks.log file
error 2020-06-09T18:29:08.513 thread-0  main.cpp:381                  main                 ] 3190000 block_log_exception: Block log exception
corrupted blocks.log/blocks.index.
    {}
    thread-0  block_log.cpp:598 check_files


// fix-corrupted-file fixed the blocks.log 
~/contracts/eos/build/programs/eosio-blocklog> ./eosio-blocklog --blocks-dir ~/tmp/blocks --fix-corrupted-file
Fix corrupted blocks.log and blocks.index files in "/Users/jongho.kim/tmp/blocks"
info  2020-06-09T18:30:02.781 thread-0  block_log.cpp:673             check_corrupted_bloc ]  blocks.index file looks good with size of 128 bytes.
info  2020-06-09T18:30:02.781 thread-0  block_log.cpp:754             check_corrupted_bloc ] Found incomplete 186 bytes in blocks.log file
info  2020-06-09T18:30:02.781 thread-0  block_log.cpp:758             check_corrupted_bloc ] Fixed blocks.log file by trimming 186 bytes.

no problems found


// check-file still asserts because of blocks.index not updated
~/contracts/eos/build/programs/eosio-blocklog> ./eosio-blocklog --blocks-dir ~/tmp/blocks --check-files       

Check blocks.index and blocks.log in "/Users/jongho.kim/tmp/blocks"
info  2020-06-09T18:30:38.378 thread-0  block_log.cpp:673             check_corrupted_bloc ]  blocks.index file looks good with size of 128 bytes.
info  2020-06-09T18:30:38.378 thread-0  block_log.cpp:747             check_corrupted_bloc ] blocks.log file looks good with size of 2814 bytes.
info  2020-06-09T18:30:38.378 thread-0  block_log.cpp:658             check_corrupted_file ] No corrupted block or index found!
info  2020-06-09T18:30:38.378 thread-0  block_log.cpp:608             check_files          ] blocks.log file /Users/jongho.kim/tmp/blocks/blocks.log has 14 blocks
info  2020-06-09T18:30:38.378 thread-0  block_log.cpp:609             check_files          ] blocks.index file /Users/jongho.kim/tmp/blocks/blocks.index has 16 blocks
error 2020-06-09T18:30:38.378 thread-0  main.cpp:381                  main                 ] 3190000 block_log_exception: Block log exception
Need to update index...
    {}
    thread-0  block_log.cpp:633 check_files


// smoke-test failed, too.
~/contracts/eos/build/programs/eosio-blocklog> ./eosio-blocklog --blocks-dir ~/tmp/blocks --smoke-test        

Smoke test of blocks.log and blocks.index in directory "/Users/jongho.kim/tmp/blocks"
error 2020-06-09T18:31:35.742 thread-0  main.cpp:381                  main                 ] 3190000 block_log_exception: Block log exception
/Users/jongho.kim/tmp/blocks/blocks.log says it has 14 blocks which disagrees with 16 indicated by /Users/jongho.kim/tmp/blocks/blocks.index
    {"block_file_name":"/Users/jongho.kim/tmp/blocks/blocks.log","log_num_blocks":14,"index_num_blocks":16,"index_file_name":"/Users/jongho.kim/tmp/blocks/blocks.index"}
    thread-0  block_log.cpp:456 block_log_archive


// update-index 
~/contracts/eos/build/programs/eosio-blocklog> ./eosio-blocklog --blocks-dir ~/tmp/blocks --update-index      

Update blocks.index to blocks.log in "/Users/jongho.kim/tmp/blocks"
info  2020-06-09T18:32:21.662 thread-0  block_log.cpp:539             fix_index_file       ] Log is nonempty
info  2020-06-09T18:32:21.663 thread-0  block_log.cpp:546             fix_index_file       ] Index is nonempty
info  2020-06-09T18:32:21.663 thread-0  block_log.cpp:554             fix_index_file       ] The last block positions from blocks.log and blocks.index are different, Reconstructing index...
info  2020-06-09T18:32:21.663 thread-0  block_log.cpp:557             fix_index_file       ] Need to update index file

no problems found


// check-files ok
~/contracts/eos/build/programs/eosio-blocklog> ./eosio-blocklog --blocks-dir ~/tmp/blocks --check-files 

Check blocks.index and blocks.log in "/Users/jongho.kim/tmp/blocks"
info  2020-06-09T18:32:26.275 thread-0  block_log.cpp:673             check_corrupted_bloc ]  blocks.index file looks good with size of 112 bytes.
info  2020-06-09T18:32:26.275 thread-0  block_log.cpp:747             check_corrupted_bloc ] blocks.log file looks good with size of 2814 bytes.
info  2020-06-09T18:32:26.275 thread-0  block_log.cpp:658             check_corrupted_file ] No corrupted block or index found!
info  2020-06-09T18:32:26.275 thread-0  block_log.cpp:608             check_files          ] blocks.log file /Users/jongho.kim/tmp/blocks/blocks.log has 14 blocks
info  2020-06-09T18:32:26.275 thread-0  block_log.cpp:609             check_files          ] blocks.index file /Users/jongho.kim/tmp/blocks/blocks.index has 14 blocks
info  2020-06-09T18:32:26.275 thread-0  block_log.cpp:635             check_files          ] Index is up-to-date

no problems found

// smoke-test ok
~/contracts/eos/build/programs/eosio-blocklog> ./eosio-blocklog --blocks-dir ~/tmp/blocks --smoke-test  

Smoke test of blocks.log and blocks.index in directory "/Users/jongho.kim/tmp/blocks"
info  2020-06-09T18:32:28.436 thread-0  block_log.cpp:1225            smoke_test           ] blocks.log and blocks.index agree on number of blocks

no problems found


// 2 blocks truncated 
~/tmp/blocks> ls -al
-rw-r--r--  1 jongho.kim staff  112 Jun  9 14:32 blocks.index
-rw-r--r--  1 jongho.kim staff 2814 Jun  9 14:30 blocks.log






## Change Type
**Select ONE**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [ ] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [ ] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the relase notes. Please include a description of the change for inclusion in the release notes.-->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
