### PR TITLE
call boost program option notifiers before plugin initialize

### DIFF
--- a/libraries/appbase/application.cpp
+++ b/libraries/appbase/application.cpp
@@ -340,6 +340,13 @@ bool application::initialize_impl(int argc, char** argv, vector<abstract_plugin*
       std::cerr << "         removing these items." << std::endl;
    }
 
+   try {
+      bpo::notify(options);
+   } catch(...) {
+      std::cerr << "Failed to notify plugins of options\n";
+      return false;
+   }
+
    if(options.count("plugin") > 0)
    {
       auto plugins = options.at("plugin").as<std::vector<std::string>>();
@@ -355,8 +362,6 @@ bool application::initialize_impl(int argc, char** argv, vector<abstract_plugin*
       for (auto plugin : autostart_plugins)
          if (plugin != nullptr && plugin->get_state() == abstract_plugin::registered)
             plugin->initialize(options);
-
-      bpo::notify(options);
    } catch (...) {
       std::cerr << "Failed to initialize\n";
       return false;

--- a/libraries/appbase/application.cpp
+++ b/libraries/appbase/application.cpp
@@ -343,8 +343,8 @@ bool application::initialize_impl(int argc, char** argv, vector<abstract_plugin*
    try {
       bpo::notify(options);
    } catch(...) {
-      std::cerr << "Failed to notify plugins of options\n";
-      return false;
+      std::cerr << "APPBASE: Failed to notify plugins of options\n";
+      throw;
    }
 
    if(options.count("plugin") > 0)


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->
## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
This PR changes boost program option notifiers to fire before plugin initialization instead of after initialization but before startup. Current behavior has bitten me an embarrassing number of times and I’m not immediately sure of any drawback moving the notifiers earlier given our typical plugin pattern.

Using notifiers, IMO, cleans up option handling. For example, without using the notifiers our typical pattern is something like

```c++
struct my_plugin_impl {
   std::string server_address;
}

void my_plugin::set_program_options(options_description&, options_description& cfg) {
   cfg.add_options()("https-server-address", bpo::value<string>(), "set the address");
}

void my_plugin::plugin_initialize(const variables_map& options) {
   if( options.count( "https-server-address" )
     my->server_address = options.at("https-server-address").as<string>();
   if(my->server_address.size())
      dothedew();
   //...
```

But using the notifiers it can be more like
```c++
struct my_plugin_impl {
   std::string server_address;
}

void my_plugin::set_program_options(options_description&, options_description& cfg) {
   cfg.add_options()("https-server-address", bpo::value<string>()->notifier([this](const string& a) {
      my->server_address = a;
   }), "set the address");
}

void my_plugin::plugin_initialize(const variables_map& options) {
   if(my->server_address.size())
      dothedew();
   //...
```
In particular notice that the `https-server-address` string doesn't have to be copy pastaed around, and that there is no need for the `options.at("https-server-address").as<string>();` mouthful.

But the code above won't work today because the notifiers are fired _after_ plugin_initialize() (before startup()). This PR moves the notifiers to occur before plugin_initialize() allowing plugin_initialize() to make use of values set in notifiers.


## Change Type
**Select ONE**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [ ] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [X] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the relase notes. Please include a description of the change for inclusion in the release notes.-->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
