### PR TITLE
add separate logging for state history plugin

### DIFF
--- a/plugins/state_history_plugin/include/eosio/state_history_plugin/state_history_plugin.hpp
+++ b/plugins/state_history_plugin/include/eosio/state_history_plugin/state_history_plugin.hpp
@@ -27,6 +27,8 @@ class state_history_plugin : public plugin<state_history_plugin> {
    void plugin_startup();
    void plugin_shutdown();
 
+   void handle_sighup() override;
+
  private:
    state_history_ptr my;
 };

--- a/plugins/state_history_plugin/state_history_plugin.cpp
+++ b/plugins/state_history_plugin/state_history_plugin.cpp
@@ -24,16 +24,19 @@ using boost::signals2::scoped_connection;
 
 static appbase::abstract_plugin& _state_history_plugin = app().register_plugin<state_history_plugin>();
 
+const std::string logger_name("state_history");
+fc::logger _log;
+
 template <typename F>
 auto catch_and_log(F f) {
    try {
       return f();
    } catch (const fc::exception& e) {
-      elog("${e}", ("e", e.to_detail_string()));
+      fc_elog(_log, "${e}", ("e", e.to_detail_string()));
    } catch (const std::exception& e) {
-      elog("${e}", ("e", e.what()));
+      fc_elog(_log, "${e}", ("e", e.what()));
    } catch (...) {
-      elog("unknown exception");
+      fc_elog(_log, "unknown exception");
    }
 }
 
@@ -82,7 +85,7 @@ struct state_history_plugin_impl : std::enable_shared_from_this<state_history_pl
           : plugin(std::move(plugin)) {}
 
       void start(tcp::socket socket) {
-         ilog("incoming connection");
+         fc_ilog(_log, "incoming connection");
          socket_stream = std::make_unique<ws::stream<tcp::socket>>(std::move(socket));
          socket_stream->binary(true);
          socket_stream->next_layer().set_option(boost::asio::ip::tcp::no_delay(true));
@@ -144,6 +147,7 @@ struct state_history_plugin_impl : std::enable_shared_from_this<state_history_pl
 
       using result_type = void;
       void operator()(get_status_request_v0&) {
+         fc_ilog(_log, "got get_status_request_v0");
          auto&                chain = plugin->chain_plug->chain();
          get_status_result_v0 result;
          result.head              = {chain.head_block_num(), chain.head_block_id()};
@@ -157,25 +161,37 @@ struct state_history_plugin_impl : std::enable_shared_from_this<state_history_pl
             result.chain_state_begin_block = plugin->chain_state_log->begin_block();
             result.chain_state_end_block   = plugin->chain_state_log->end_block();
          }
+         fc_ilog(_log, "pushing get_status_result_v0 to send queue");
          send(std::move(result));
       }
 
       void operator()(get_blocks_request_v0& req) {
+         fc_ilog(_log, "received get_blocks_request_v0 = ${req}", ("req",req) );
          for (auto& cp : req.have_positions) {
             if (req.start_block_num <= cp.block_num)
                continue;
             auto id = plugin->get_block_id(cp.block_num);
             if (!id || *id != cp.block_id)
                req.start_block_num = std::min(req.start_block_num, cp.block_num);
+
+            if (!id) {
+               fc_dlog(_log, "block ${block_num} is not available", ("block_num", cp.block_num));
+            } else if (*id != cp.block_id) {
+               fc_dlog(_log, "the id for block ${block_num} in block request have_positions does not match the existing", ("block_num", cp.block_num));
+            }         
          }
          req.have_positions.clear();
+         fc_dlog(_log, "  get_blocks_request_v0 start_block_num set to ${num}", ("num", req.start_block_num));
          current_request = req;
          send_update(true);
       }
 
       void operator()(get_blocks_ack_request_v0& req) {
-         if (!current_request)
+         fc_ilog(_log, "received get_blocks_ack_request_v0 = ${req}", ("req",req));
+         if (!current_request) {
+            fc_dlog(_log, " no current get_blocks_request_v0, discarding the get_blocks_ack_request_v0");
             return;
+         }
          current_request->max_messages_in_flight += req.num_messages;
          send_update();
       }
@@ -207,6 +223,8 @@ struct state_history_plugin_impl : std::enable_shared_from_this<state_history_pl
             }
             ++current_request->start_block_num;
          }
+         fc_ilog(_log, "pushing result {\"head\":{\"block_num\":${head}},\"last_irreversible\":{\"block_num\":${last_irr}},\"this_block\":{\"block_num\":${this_block}}} to send queue", 
+               ("head", result.head.block_num) ("last_irr", result.last_irreversible.block_num)("this_block", result.this_block->block_num));
          send(std::move(result));
          --current_request->max_messages_in_flight;
          need_to_send_update = current_request->start_block_num <= current &&
@@ -239,13 +257,13 @@ struct state_history_plugin_impl : std::enable_shared_from_this<state_history_pl
          try {
             f();
          } catch (const fc::exception& e) {
-            elog("${e}", ("e", e.to_detail_string()));
+            fc_elog(_log, "${e}", ("e", e.to_detail_string()));
             close();
          } catch (const std::exception& e) {
-            elog("${e}", ("e", e.what()));
+            fc_elog(_log,"${e}", ("e", e.what()));
             close();
          } catch (...) {
-            elog("unknown exception");
+            fc_elog(_log, "unknown exception");
             close();
          }
       }
@@ -263,10 +281,10 @@ struct state_history_plugin_impl : std::enable_shared_from_this<state_history_pl
 
       void on_fail(boost::system::error_code ec, const char* what) {
          try {
-            elog("${w}: ${m}", ("w", what)("m", ec.message()));
+            fc_elog(_log,"${w}: ${m}", ("w", what)("m", ec.message()));
             close();
          } catch (...) {
-            elog("uncaught exception on close");
+            fc_elog(_log,"uncaught exception on close");
          }
       }
 
@@ -287,7 +305,7 @@ struct state_history_plugin_impl : std::enable_shared_from_this<state_history_pl
       auto check_ec = [&](const char* what) {
          if (!ec)
             return;
-         elog("${w}: ${m}", ("w", what)("m", ec.message()));
+         fc_elog(_log,"${w}: ${m}", ("w", what)("m", ec.message()));
          EOS_ASSERT(false, plugin_exception, "unable to open listen socket");
       };
 
@@ -402,7 +420,7 @@ void state_history_plugin::plugin_initialize(const variables_map& options) {
       idump((ip_port)(host)(port));
 
       if (options.at("delete-state-history").as<bool>()) {
-         ilog("Deleting state history");
+         fc_ilog(_log, "Deleting state history");
          boost::filesystem::remove_all(state_history_dir);
       }
       boost::filesystem::create_directories(state_history_dir);
@@ -428,7 +446,10 @@ void state_history_plugin::plugin_initialize(const variables_map& options) {
    FC_LOG_AND_RETHROW()
 } // state_history_plugin::plugin_initialize
 
-void state_history_plugin::plugin_startup() { my->listen(); }
+void state_history_plugin::plugin_startup() { 
+   handle_sighup(); // setup logging
+   my->listen(); 
+}
 
 void state_history_plugin::plugin_shutdown() {
    my->applied_transaction_connection.reset();
@@ -437,6 +458,10 @@ void state_history_plugin::plugin_shutdown() {
    while (!my->sessions.empty())
       my->sessions.begin()->second->close();
    my->stopping = true;
+}
+
+void state_history_plugin::handle_sighup() {
+   fc::logger::update( logger_name, _log );
 }
 
 } // namespace eosio

--- a/tests/rodeos_test.py
+++ b/tests/rodeos_test.py
@@ -40,13 +40,61 @@ dontKill=args.leave_running
 killEosInstances=not dontKill
 killWallet=not dontKill
 keepLogs=args.keep_logs
-stateHistoryEndpoint="127.0.0.1:8080"
+stateHistoryEndpoint = "127.0.0.1:8080"
+
+loggingFile="logging.json"
+
+
+logging="""{
+  "includes": [],
+  "appenders": [{
+      "name": "stderr",
+      "type": "console",
+      "args": {
+        "stream": "std_error",
+        "level_colors": [{
+            "level": "debug",
+            "color": "green"
+          },{
+            "level": "warn",
+            "color": "brown"
+          },{
+            "level": "error",
+            "color": "red"
+          }
+        ]
+      },
+      "enabled": true
+    }
+  ],
+  "loggers": [{
+      "name": "default",
+      "level": "debug",
+      "enabled": true,
+      "additivity": false,
+      "appenders": [
+        "stderr"
+      ]
+    },{
+      "name": "state_history",
+      "level": "debug",
+      "enabled": true,
+      "additivity": false,
+      "appenders": [
+        "stderr"
+      ]
+    }
+  ]
+}"""
 
 walletMgr=WalletMgr(True)
 cluster=Cluster(walletd=True)
 cluster.setWalletMgr(walletMgr)
 
 testSuccessful = False
+
+with open(loggingFile, "w") as textFile:
+        print(logging,file=textFile)
 
 class Rodeos:
     def __init__(self, stateHistoryEndpoint, filterName, filterWasm):
@@ -107,7 +155,7 @@ try:
         loadSystemContract=False,
         specificExtraNodeosArgs={
             0: ("--plugin eosio::state_history_plugin --trace-history --chain-state-history --disable-replay-opts " 
-                "--state-history-endpoint {} --plugin eosio::net_api_plugin --wasm-runtime eos-vm-jit").format(stateHistoryEndpoint)})
+                "--state-history-endpoint {} --plugin eosio::net_api_plugin --wasm-runtime eos-vm-jit -l logging.json").format(stateHistoryEndpoint)})
 
     producerNodeIndex = 0
     producerNode = cluster.getNode(producerNodeIndex)


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->
## Change Description

This PR support add a separate logger to the state history plugin and add some additional logging messages for receiving requests and sending replies. 

Also 
## Change Type
**Select ONE**
- [x] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [ ] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [ ] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the relase notes. Please include a description of the change for inclusion in the release notes.-->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [x] Documentation Additions

A new logger "state_history" should be added to Nodes Logging/Logger section.