### PR TITLE
Stop Nodeos or issue warning if both state history plugin and history plugin are enabled

### DIFF
--- a/libraries/appbase/include/appbase/application.hpp
+++ b/libraries/appbase/include/appbase/application.hpp
@@ -156,6 +156,18 @@ namespace appbase {
             return *ptr;
          }
 
+         template<typename Plugin>
+         bool is_plugin_initialized()const {
+            string name = boost::core::demangle(typeid(Plugin).name());
+            for ( const auto& plugin: initialized_plugins ) {
+               if ( plugin->name() == name ) {
+                  return true;
+               }
+            }
+
+            return false;
+         }
+
          /**
           * Fetch a reference to the method declared by the passed in type.  This will construct the method
           * on first access.  This allows loose and deferred binding between plugins

--- a/plugins/state_history_plugin/CMakeLists.txt
+++ b/plugins/state_history_plugin/CMakeLists.txt
@@ -4,4 +4,4 @@ add_library( state_history_plugin
              ${HEADERS} )
 
 target_link_libraries( state_history_plugin state_history chain_plugin eosio_chain appbase )
-target_include_directories( state_history_plugin PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" )
+target_include_directories( state_history_plugin PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" "${CMAKE_SOURCE_DIR}/plugins/history_plugin/include" )

--- a/plugins/state_history_plugin/state_history_plugin.cpp
+++ b/plugins/state_history_plugin/state_history_plugin.cpp
@@ -3,6 +3,7 @@
 #include <eosio/state_history/log.hpp>
 #include <eosio/state_history/serialization.hpp>
 #include <eosio/state_history_plugin/state_history_plugin.hpp>
+#include <eosio/history_plugin/history_plugin.hpp>
 
 #include <boost/asio/bind_executor.hpp>
 #include <boost/asio/ip/host_name.hpp>
@@ -42,6 +43,7 @@ struct state_history_plugin_impl : std::enable_shared_from_this<state_history_pl
    fc::optional<state_history_traces_log>                     trace_log;
    fc::optional<state_history_chain_state_log>                chain_state_log;
    bool                                                       stopping = false;
+   bool                                                       allow_legacy_history_plugin = false;
    fc::optional<scoped_connection>                            applied_transaction_connection;
    fc::optional<scoped_connection>                            block_start_connection;
    fc::optional<scoped_connection>                            accepted_block_connection;
@@ -278,6 +280,16 @@ struct state_history_plugin_impl : std::enable_shared_from_this<state_history_pl
    std::map<session*, std::shared_ptr<session>> sessions;
 
    void listen() {
+      if ( app().is_plugin_initialized<history_plugin>() ) {
+         wlog( "Legacy history plugin is running; this will cause random crashes." );
+         if ( allow_legacy_history_plugin ) {
+            wlog( "With state-history-allow-legacy-history-plugin set, proceed at your own risk" );
+         } else {
+            wlog( "With state-history-allow-legacy-history-plugin not set, shutting down." );
+            appbase::app().quit();
+         }
+      }
+
       boost::system::error_code ec;
 
       auto address  = boost::asio::ip::make_address(endpoint_address);
@@ -366,6 +378,8 @@ void state_history_plugin::set_program_options(options_description& cli, options
            "enable debug mode for trace history");
    options("context-free-data-compression", bpo::value<string>()->default_value("zlib"), 
            "compression mode for context free data in transaction traces. Supported options are \"zlib\" and \"none\"");
+   options("state-history-allow-legacy-history-plugin", bpo::bool_switch()->default_value(false),
+           "allow legacy history plugin to run at the same time. Caution: it will cause random crashes");
 }
 
 void state_history_plugin::plugin_initialize(const variables_map& options) {
@@ -424,6 +438,10 @@ void state_history_plugin::plugin_initialize(const variables_map& options) {
 
       if (options.at("chain-state-history").as<bool>())
          my->chain_state_log.emplace(state_history_dir);
+      
+      if (options.at("state-history-allow-legacy-history-plugin").as<bool>()) {
+         my->allow_legacy_history_plugin = true;
+      }
    }
    FC_LOG_AND_RETHROW()
 } // state_history_plugin::plugin_initialize

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -57,6 +57,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/plugin_http_api_test.py ${CMAKE_CURRE
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/resource_monitor_plugin_test.py ${CMAKE_CURRENT_BINARY_DIR}/resource_monitor_plugin_test.py COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/rodeos_test.py ${CMAKE_CURRENT_BINARY_DIR}/rodeos_test.py COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/test_filter.wasm ${CMAKE_CURRENT_BINARY_DIR}/test_filter.wasm COPYONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/state_history_history_test.py ${CMAKE_CURRENT_BINARY_DIR}/state_history_history_test.py COPYONLY)
 
 #To run plugin_test with all log from blockchain displayed, put --verbose after --, i.e. plugin_test -- --verbose
 add_test(NAME plugin_test COMMAND plugin_test --report_level=detailed --color_output)
@@ -176,6 +177,9 @@ add_subdirectory(se_tests)
 
 add_test(NAME resource_monitor_plugin_test COMMAND tests/resource_monitor_plugin_test.py WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 set_property(TEST resource_monitor_plugin_test PROPERTY LABELS long_running_tests)
+
+add_test(NAME state_history_history_test COMMAND tests/state_history_history_test.py -v --clean-run --dump-error-detail WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+set_property(TEST state_history_history_test PROPERTY LABELS long_running_tests)
 
 if(ENABLE_COVERAGE_TESTING)
 

--- a/tests/state_history_history_test.py
+++ b/tests/state_history_history_test.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+
+from testUtils import Utils
+from Cluster import Cluster
+from TestHelper import TestHelper
+
+import random
+import subprocess
+import signal
+import os
+import shutil
+import re
+
+Print=Utils.Print
+errorExit=Utils.errorExit
+
+stagingDir="staging"
+dataDir=stagingDir+"/data"
+stderrFile=dataDir + "/stderr.txt"
+
+testNum=0
+
+def cleanDirectories():
+    os.path.exists(stagingDir) and shutil.rmtree(stagingDir)
+
+def prepareDirectories():
+    # Prepare own directories so we don't depend on others to make sure
+    # tests are repeatable
+    cleanDirectories()
+    os.makedirs(stagingDir)
+    os.makedirs(dataDir)
+
+def runNodeos(extraNodeosArgs, myTimeout):
+    """Startup nodeos, wait for timeout (before forced shutdown) and collect output."""
+    if debug: Print("Launching nodeos process.")
+    cmd="programs/nodeos/nodeos -e -p eosio --plugin eosio::chain_api_plugin --plugin eosio::state_history_plugin --disable-replay-opts --data-dir " + dataDir + " "
+
+    cmd=cmd + extraNodeosArgs;
+    if debug: Print("cmd: %s" % (cmd))
+    with open(stderrFile, 'w') as serr:
+        proc=subprocess.Popen(cmd.split(), stdout=subprocess.PIPE, stderr=serr)
+
+        try:
+            proc.communicate(timeout=myTimeout)
+        except (subprocess.TimeoutExpired) as _:
+            if debug: Print("Timed out\n")
+            proc.send_signal(signal.SIGKILL)
+
+def isMsgInStderrFile(msg):
+    msgFound=False
+    with open(stderrFile) as errFile:
+        for line in errFile:
+            if msg in line:
+                msgFound=True
+                break
+    return msgFound
+
+def testCommon(title, extraNodeosArgs, expectedMsgs):
+    global testNum
+    testNum+=1
+    Print("Test %d: %s" % (testNum, title))
+
+    prepareDirectories()
+
+    timeout=120  # Leave sufficient time such nodeos can start up fully in any platforms
+    runNodeos(extraNodeosArgs, timeout)
+
+    for msg in expectedMsgs:
+        if not isMsgInStderrFile(msg):
+            errorExit ("Log should have contained \"%s\"" % (expectedMsgs))
+
+def testAll():
+    # State hisory plugin only. nodeos should run normally, producing blocks
+    testCommon("state history plugin only", "", ["Produced block"])
+    
+    # Both state history plugin and history plugin enabled with
+    # state-history-allow-legacy-history set. Nodeos would keep running
+    testCommon("Both plugins enabled with state-history-allow-legacy-history flag", "--plugin eosio::history_plugin --state-history-allow-legacy-history-plugin", ["Legacy history plugin is running; this will cause random crashes", "With state-history-allow-legacy-history-plugin set, proceed at your own risk", "Produced block"])
+    
+    # Both state history plugin and history plugin enabled without
+    # state-history-allow-legacy-history set. Nodeos aborts.
+    testCommon("Both plugins enabled without state-history-allow-legacy-history flag", "--plugin eosio::history_plugin", ["Legacy history plugin is running; this will cause random crashes", "With state-history-allow-legacy-history-plugin not set, shutting down", "nodeos successfully exiting"])
+
+args = TestHelper.parse_args({"--keep-logs","--dump-error-details","-v","--leave-running","--clean-run"})
+debug=args.v
+pnodes=1
+topo="mesh"
+delay=1
+chainSyncStrategyStr=Utils.SyncResyncTag
+total_nodes = pnodes
+killCount=1
+killSignal=Utils.SigKillTag
+
+killEosInstances= not args.leave_running
+dumpErrorDetails=args.dump_error_details
+keepLogs=args.keep_logs
+killAll=args.clean_run
+
+seed=1
+Utils.Debug=debug
+testSuccessful=False
+
+cluster=Cluster(walletd=True)
+
+try:
+    TestHelper.printSystemInfo("BEGIN")
+
+    cluster.setChainStrategy(chainSyncStrategyStr)
+
+    cluster.killall(allInstances=killAll)
+    cluster.cleanup()
+
+    if cluster.launch(pnodes=pnodes, totalNodes=total_nodes, topo=topo,delay=delay, dontBootstrap=True) is False:
+        errorExit("Failed to stand up eos cluster.")
+    cluster.killall(allInstances=killAll)
+
+    testAll()
+
+    testSuccessful=True
+finally:
+    if debug: Print("Cleanup in finally block.")
+    cleanDirectories()
+    TestHelper.shutdown(cluster, None, testSuccessful, killEosInstances, False, keepLogs, killAll, dumpErrorDetails)
+
+if debug: Print("Exiting test, exit value 0.")
+exit(0)


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->
## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
This PR resolves Jira https://blockone.atlassian.net/browse/EPE-135 (https://github.com/EOSIO/eos/issues/9176).
When both state history plugin and history plugin are enabled,
if `state-history-allow-legacy-history-plugin` option is set, a warning is issued but *Nodeos* is let to continue; if `state-history-allow-legacy-history-plugin` option is not set, *Nodeos* will gracefully shut down with a message.

## Change Type
**Select ONE**
- [X] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [ ] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [ ] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the relase notes. Please include a description of the change for inclusion in the release notes.-->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [X] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
A new configuration option `state-history-allow-legacy-history-plugin`  is added to state history plugin. When both state history plugin and history plugin are enabled,
if `state-history-allow-legacy-history-plugin` is set, a warning is issued but *Nodeos* is let to continue; if it is is not set, *Nodeos* will gracefully shut down.
