### PR TITLE
Improve parsing of RabbitMQ-related command line arguments in rodeos - develop

### DIFF
--- a/programs/rodeos/CMakeLists.txt
+++ b/programs/rodeos/CMakeLists.txt
@@ -40,6 +40,8 @@ target_link_libraries( ${RODEOS_EXECUTABLE_NAME}
         PRIVATE appbase version
         PRIVATE rodeos_lib fc amqpcpp ${CMAKE_DL_LIBS} ${PLATFORM_SPECIFIC_LIBS})
 
+add_subdirectory(tests)
+
 copy_bin( ${RODEOS_EXECUTABLE_NAME} )
 install( TARGETS
    ${RODEOS_EXECUTABLE_NAME} RUNTIME DESTINATION ${CMAKE_INSTALL_FULL_BINDIR} COMPONENT base

--- a/programs/rodeos/streams/rabbitmq.hpp
+++ b/programs/rodeos/streams/rabbitmq.hpp
@@ -81,7 +81,8 @@ class rabbitmq : public stream_handler {
       }
 
       auto& exchange = channel_->declareExchange(exchangeName_, type);
-      exchange.onSuccess([this]() { ilog("RabbitMQ Connected Successfully!\n Exchange ${e}", ("e", exchangeName_)); });
+      exchange.onSuccess(
+            [en = exchangeName_]() { ilog("RabbitMQ Connected Successfully!\n Exchange ${e}", ("e", en)); });
       exchange.onError([](const char* error_message) {
          throw std::runtime_error("RabbitMQ Exchange error: " + std::string(error_message));
       });

--- a/programs/rodeos/streams/rabbitmq.hpp
+++ b/programs/rodeos/streams/rabbitmq.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "stream.hpp"
 #include "amqpcpp.h"
 #include "amqpcpp/libboostasio.h"
 #include "amqpcpp/linux_tcp.h"
+#include "stream.hpp"
 #include <fc/log/logger.hpp>
 #include <memory>
 
@@ -20,24 +20,24 @@ class rabbitmq : public stream_handler {
    std::vector<eosio::name>             routes_;
 
  public:
-   rabbitmq(boost::asio::io_service& io_service, std::vector<eosio::name> routes, std::string address, std::string queue_name)
+   rabbitmq(boost::asio::io_service& io_service, std::vector<eosio::name>&& routes, const AMQP::Address& address,
+            std::string&& queue_name)
        : queueName_(std::move(queue_name)), routes_(std::move(routes)) {
-      AMQP::Address amqp_address(address);
-      ilog("Connecting to RabbitMQ address ${a} - Queue: ${q}...", ("a", std::string(amqp_address))("q", queueName_));
+      ilog("Connecting to RabbitMQ address ${a} - Queue: ${q}...", ("a", std::string(address))("q", queueName_));
 
-      init(io_service, std::move(amqp_address));
+      init(io_service, address);
 
       exchangeName_ = DEFAULT_EXCHANGE;
 
       declare_queue();
    }
 
-   rabbitmq(boost::asio::io_service& io_service, std::vector<eosio::name> routes, std::string address, std::string exchange_name, std::string exchange_type)
+   rabbitmq(boost::asio::io_service& io_service, std::vector<eosio::name>&& routes, const AMQP::Address& address,
+            std::string&& exchange_name, const std::string& exchange_type)
        : exchangeName_(std::move(exchange_name)), routes_(std::move(routes)) {
-      AMQP::Address amqp_address(address);
-      ilog("Connecting to RabbitMQ address ${a} - Exchange: ${e}...", ("a", std::string(amqp_address))("e", exchangeName_));
+      ilog("Connecting to RabbitMQ address ${a} - Exchange: ${e}...", ("a", std::string(address))("e", exchangeName_));
 
-      init(io_service, std::move(amqp_address));
+      init(io_service, address);
 
       declare_exchange(exchange_type);
    }
@@ -55,9 +55,9 @@ class rabbitmq : public stream_handler {
  private:
    inline static const std::string DEFAULT_EXCHANGE = "";
 
-   void init(boost::asio::io_service& io_service, AMQP::Address amqp_address) {
+   void init(boost::asio::io_service& io_service, const AMQP::Address& address) {
       handler_    = std::make_shared<rabbitmq_handler>(io_service);
-      connection_ = std::make_shared<AMQP::TcpConnection>(handler_.get(), amqp_address);
+      connection_ = std::make_shared<AMQP::TcpConnection>(handler_.get(), address);
       channel_    = std::make_shared<AMQP::TcpChannel>(connection_.get());
    }
 
@@ -72,17 +72,18 @@ class rabbitmq : public stream_handler {
       });
    }
 
-   void declare_exchange(std::string& exchange_type) {
+   void declare_exchange(const std::string& exchange_type) {
       auto type = AMQP::direct;
       if (exchange_type == "fanout") {
          type = AMQP::fanout;
+      } else if (exchange_type == "topic") {
+         type = AMQP::topic;
+      } else {
+         throw std::runtime_error("Unsupported RabbitMQ exchange type: " + exchange_type);
       }
 
       auto& exchange = channel_->declareExchange(exchangeName_, type);
-      exchange.onSuccess([this]() {
-         ilog("RabbitMQ Connected Successfully!\n Exchange ${e}",
-              ("e", exchangeName_));
-      });
+      exchange.onSuccess([this]() { ilog("RabbitMQ Connected Successfully!\n Exchange ${e}", ("e", exchangeName_)); });
       exchange.onError([](const char* error_message) {
          throw std::runtime_error("RabbitMQ Exchange error: " + std::string(error_message));
       });
@@ -100,37 +101,78 @@ class rabbitmq_handler : public AMQP::LibBoostAsioHandler {
    uint16_t onNegotiate(AMQP::TcpConnection* connection, uint16_t interval) { return 0; }
 };
 
-inline std::vector<eosio::name> extract_rabbit_routes(std::string& rabbit, size_t& pos) {
-   size_t pos_router = rabbit.find_last_of("/");
-   bool   has_router = pos_router != pos;
-
-   std::vector<eosio::name> routes = {};
-   if (has_router) {
-      routes = extract_routes(rabbit.substr(pos_router + 1, rabbit.length()));
-      rabbit.erase(pos_router, rabbit.length());
+// Parse the specified argument of a '--stream-rabbits'
+// or '--stream-rabbits-exchange' option and split it into:
+//
+// - RabbitMQ address, returned as an instance of AMQP::Address;
+// - (optional) queue name or exchange specification, saved to
+//   the output argument 'queue_name_or_exchange_spec';
+// - (optional) RabbitMQ routes, saved to the output argument 'routes'.
+//
+// Because all of the above fields use slashes as separators, the following
+// precedence rules are applied when parsing:
+//
+// Input                   Output
+// ------------------      ----------------------------------------
+// amqp://a                host='a' vhost='' queue='' routes=[]
+// amqp://a/b              host='a' vhost='' queue='b' routes=[]
+// amqp://a/b/c            host='a' vhost='' queue='b' routes='c'.split(',')
+// amqp://a/b/c/d          host='a' vhost='b' queue='c' routes='d'.split(',')
+//
+// To specify a vhost without specifying a queue name or routes, omit
+// the queue name and use an asterisk or an empty string for the routes,
+// like so:
+//
+//    amqp://host/vhost//*
+//    amqp:///vhost//*
+//
+inline AMQP::Address parse_rabbitmq_address(const std::string& cmdline_arg, std::string& queue_name_or_exchange_spec,
+                                            std::vector<eosio::name>& routes) {
+   // AMQP address starts with "amqp://" or "amqps://".
+   const auto double_slash_pos = cmdline_arg.find("//");
+   if (double_slash_pos == std::string::npos) {
+      // Invalid RabbitMQ address - AMQP::Address constructor
+      // will throw an exception.
+      return AMQP::Address(cmdline_arg);
    }
 
-   return routes;
+   const auto first_slash_pos = cmdline_arg.find('/', double_slash_pos + 2);
+   if (first_slash_pos == std::string::npos) {
+      return AMQP::Address(cmdline_arg);
+   }
+
+   const auto second_slash_pos = cmdline_arg.find('/', first_slash_pos + 1);
+   if (second_slash_pos == std::string::npos) {
+      queue_name_or_exchange_spec = cmdline_arg.substr(first_slash_pos + 1);
+      return AMQP::Address(cmdline_arg.substr(0, first_slash_pos));
+   }
+
+   const auto third_slash_pos = cmdline_arg.find('/', second_slash_pos + 1);
+   if (third_slash_pos == std::string::npos) {
+      queue_name_or_exchange_spec = cmdline_arg.substr(first_slash_pos + 1, second_slash_pos - (first_slash_pos + 1));
+      routes                      = extract_routes(cmdline_arg.substr(second_slash_pos + 1));
+      return AMQP::Address(cmdline_arg.substr(0, first_slash_pos));
+   }
+
+   queue_name_or_exchange_spec = cmdline_arg.substr(second_slash_pos + 1, third_slash_pos - (second_slash_pos + 1));
+   routes                      = extract_routes(cmdline_arg.substr(third_slash_pos + 1));
+   return AMQP::Address(cmdline_arg.substr(0, second_slash_pos));
 }
 
 inline void initialize_rabbits_queue(boost::asio::io_service&                      io_service,
-                               std::vector<std::unique_ptr<stream_handler>>& streams,
-                               const std::vector<std::string>&               rabbits) {
-   for (std::string rabbit : rabbits) {
-      rabbit            = rabbit.substr(7, rabbit.length());
-      size_t pos        = rabbit.find("/");
+                                     std::vector<std::unique_ptr<stream_handler>>& streams,
+                                     const std::vector<std::string>&               rabbits) {
+   for (const std::string& rabbit : rabbits) {
+      std::string              queue_name;
+      std::vector<eosio::name> routes;
 
-      auto routes = extract_rabbit_routes(rabbit, pos);
+      AMQP::Address address = parse_rabbitmq_address(rabbit, queue_name, routes);
 
-      std::string queue_name = "stream.default";
-      if (pos != std::string::npos) {
-         queue_name = rabbit.substr(pos + 1, rabbit.length());
-         rabbit.erase(pos, rabbit.length());
+      if (queue_name.empty()) {
+         queue_name = "stream.default";
       }
 
-      std::string address = "amqp://" + rabbit;
-      rabbitmq rmq{ io_service, std::move(routes), std::move(address), std::move(queue_name) };
-      streams.emplace_back(std::make_unique<rabbitmq>(std::move(rmq)));
+      streams.emplace_back(std::make_unique<rabbitmq>(io_service, std::move(routes), address, std::move(queue_name)));
    }
 }
 
@@ -138,29 +180,21 @@ inline void initialize_rabbits_exchange(boost::asio::io_service&                
                                         std::vector<std::unique_ptr<stream_handler>>& streams,
                                         const std::vector<std::string>&               rabbits) {
    for (std::string rabbit : rabbits) {
-      rabbit            = rabbit.substr(7, rabbit.length());
-      size_t pos        = rabbit.find("/");
+      std::string              exchange;
+      std::vector<eosio::name> routes;
 
-      auto routes = extract_rabbit_routes(rabbit, pos);
+      AMQP::Address address = parse_rabbitmq_address(rabbit, exchange, routes);
 
-      size_t pos_exchange_type = rabbit.find("::");
-      bool   has_exchange_type = pos_exchange_type != std::string::npos;
+      std::string exchange_type;
 
-      std::string exchange_type = "";
-      if (has_exchange_type) {
-         exchange_type = rabbit.substr(pos_exchange_type + 2, rabbit.length());
-         rabbit.erase(pos_exchange_type, rabbit.length());
+      const auto double_column_pos = exchange.find("::");
+      if (double_column_pos != std::string::npos) {
+         exchange_type = exchange.substr(double_column_pos + 2);
+         exchange.erase(double_column_pos);
       }
 
-      std::string exchange_name = "";
-      if (pos != std::string::npos) {
-         exchange_name = rabbit.substr(pos + 1, rabbit.length());
-         rabbit.erase(pos, rabbit.length());
-      }
-
-      std::string address = "amqp://" + rabbit;
-      rabbitmq rmq{ io_service, std::move(routes), std::move(address), std::move(exchange_name), std::move(exchange_type) };
-      streams.emplace_back(std::make_unique<rabbitmq>(std::move(rmq)));
+      streams.emplace_back(
+            std::make_unique<rabbitmq>(io_service, std::move(routes), address, std::move(exchange), exchange_type));
    }
 }
 

--- a/programs/rodeos/streams/rabbitmq.hpp
+++ b/programs/rodeos/streams/rabbitmq.hpp
@@ -76,9 +76,7 @@ class rabbitmq : public stream_handler {
       auto type = AMQP::direct;
       if (exchange_type == "fanout") {
          type = AMQP::fanout;
-      } else if (exchange_type == "topic") {
-         type = AMQP::topic;
-      } else {
+      } else if (exchange_type != "direct") {
          throw std::runtime_error("Unsupported RabbitMQ exchange type: " + exchange_type);
       }
 

--- a/programs/rodeos/streams/rabbitmq.hpp
+++ b/programs/rodeos/streams/rabbitmq.hpp
@@ -20,8 +20,8 @@ class rabbitmq : public stream_handler {
    std::vector<eosio::name>             routes_;
 
  public:
-   rabbitmq(boost::asio::io_service& io_service, std::vector<eosio::name>&& routes, const AMQP::Address& address,
-            std::string&& queue_name)
+   rabbitmq(boost::asio::io_service& io_service, std::vector<eosio::name> routes, const AMQP::Address& address,
+            std::string queue_name)
        : queueName_(std::move(queue_name)), routes_(std::move(routes)) {
       ilog("Connecting to RabbitMQ address ${a} - Queue: ${q}...", ("a", std::string(address))("q", queueName_));
 
@@ -32,8 +32,8 @@ class rabbitmq : public stream_handler {
       declare_queue();
    }
 
-   rabbitmq(boost::asio::io_service& io_service, std::vector<eosio::name>&& routes, const AMQP::Address& address,
-            std::string&& exchange_name, const std::string& exchange_type)
+   rabbitmq(boost::asio::io_service& io_service, std::vector<eosio::name> routes, const AMQP::Address& address,
+            std::string exchange_name, std::string exchange_type)
        : exchangeName_(std::move(exchange_name)), routes_(std::move(routes)) {
       ilog("Connecting to RabbitMQ address ${a} - Exchange: ${e}...", ("a", std::string(address))("e", exchangeName_));
 
@@ -191,8 +191,8 @@ inline void initialize_rabbits_exchange(boost::asio::io_service&                
          exchange.erase(double_column_pos);
       }
 
-      streams.emplace_back(
-            std::make_unique<rabbitmq>(io_service, std::move(routes), address, std::move(exchange), exchange_type));
+      streams.emplace_back(std::make_unique<rabbitmq>(io_service, std::move(routes), address, std::move(exchange),
+                                                      std::move(exchange_type)));
    }
 }
 

--- a/programs/rodeos/tests/CMakeLists.txt
+++ b/programs/rodeos/tests/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_executable(test_rodeos_cli test_rodeos_cli.cpp)
+target_link_libraries(test_rodeos_cli
+    PRIVATE rodeos_lib fc amqpcpp ${CMAKE_DL_LIBS} ${PLATFORM_SPECIFIC_LIBS}
+    PRIVATE Boost::unit_test_framework
+)
+
+add_test(NAME test_rodeos_cli
+    COMMAND libraries/rodeos/tests/test_rodeos_cli
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+)

--- a/programs/rodeos/tests/CMakeLists.txt
+++ b/programs/rodeos/tests/CMakeLists.txt
@@ -5,6 +5,6 @@ target_link_libraries(test_rodeos_cli
 )
 
 add_test(NAME test_rodeos_cli
-    COMMAND libraries/rodeos/tests/test_rodeos_cli
+    COMMAND programs/rodeos/tests/test_rodeos_cli
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
 )

--- a/programs/rodeos/tests/test_rodeos_cli.cpp
+++ b/programs/rodeos/tests/test_rodeos_cli.cpp
@@ -1,0 +1,47 @@
+#include "../streams/rabbitmq.hpp"
+
+#define BOOST_TEST_MAIN
+#include <boost/test/unit_test.hpp>
+
+using namespace eosio::literals;
+
+static void parse_and_check(const std::string& cmdline_arg, const std::string& expected_address,
+                            const std::string& expected_queue_name, const std::vector<eosio::name>& expected_routes) {
+   std::string              queue_name;
+   std::vector<eosio::name> routes;
+
+   auto amqp_address = b1::parse_rabbitmq_address(cmdline_arg, queue_name, routes);
+
+   BOOST_TEST(std::string(amqp_address) == expected_address);
+   BOOST_TEST(queue_name == expected_queue_name);
+   BOOST_TEST(routes == expected_routes);
+}
+
+BOOST_AUTO_TEST_CASE(rabbitmq_address_parsing) {
+   // No slashes
+   parse_and_check("amqp://user:pass@host", "amqp://user:pass@host/", "", {});
+
+   // One slash (/queue)
+   parse_and_check("amqp://user:pass@host/", "amqp://user:pass@host/", "", {});
+   parse_and_check("amqp://user:pass@host:1000/queue", "amqp://user:pass@host:1000/", "queue", {});
+
+   // Two slashes (/queue/routes)
+   parse_and_check("amqp://user:pass@host//", "amqp://user:pass@host/", "", {});
+   parse_and_check("amqp://user:pass@host//r1,r2", "amqp://user:pass@host/", "", { "r1"_n, "r2"_n });
+   parse_and_check("amqp://user:pass@host/queue/", "amqp://user:pass@host/", "queue", {});
+   parse_and_check("amqp://user:pass@host/queue/*", "amqp://user:pass@host/", "queue", {});
+   parse_and_check("amqp://user:pass@host/queue/r1", "amqp://user:pass@host/", "queue", { "r1"_n });
+   parse_and_check("amqp://user:pass@host/queue/r1,r2", "amqp://user:pass@host/", "queue", { "r1"_n, "r2"_n });
+
+   // Three slashes (/vhost/queue/routes)
+   parse_and_check("amqps://user:pass@host/vhost/queue/*", "amqps://user:pass@host:5671/vhost", "queue", {});
+   parse_and_check("amqps://user:pass@host/vhost//*", "amqps://user:pass@host:5671/vhost", "", {});
+
+   // Check that amqp-cpp detects invalid AMQP addresses.
+   std::string              queue_name;
+   std::vector<eosio::name> routes;
+
+   BOOST_CHECK_EXCEPTION(
+         b1::parse_rabbitmq_address("user:pass@host", queue_name, routes), std::runtime_error,
+         [](const auto& e) { return std::strstr(e.what(), "AMQP address should start with") != nullptr; });
+}


### PR DESCRIPTION
## Change Description

This commit tightens up parsing of RabbitMQ-related command line arguments (it simplifies the code, improves readability, and adds a comment and a unit test).

## Change Type

- [x] Stability bug fix

On Linux, specifying `--stream-rabbits-exchange` crashes rodeos with SEGFAULT. On macOS, it was observed that the log contained "RabbitMQ Connected Successfully! Exchange п��". Apparently, there's a read access of deleted memory in the onSuccess lambda. It can no longer be reproduced after this commit. If this commit doesn't fix the Linux bus error, I'll investigate it separately.

## Consensus Changes

- [ ] Consensus Changes

## API Changes

- [ ] API Changes

## Documentation Additions

- [x] Documentation Additions

A comment to `parse_rabbitmq_address` in `rabbitmq.hpp` expands a little bit on the format of the argument of the rodeos options `--stream-rabbits` and `--stream-rabbits-exchange`.
