### PR TITLE
relaxing the on_notify constraint to *

### DIFF
--- a/unittests/test-contracts/get_sender_test/get_sender_test.hpp
+++ b/unittests/test-contracts/get_sender_test/get_sender_test.hpp
@@ -16,9 +16,7 @@ public:
    [[eosio::action]]
    void notify( eosio::name to, eosio::name expected_sender, bool send_inline );
 
-   // eosio.cdt 1.6.1 has a problem with "*::notify" so hardcode to tester1 for now.
-   // TODO: Change it back to "*::notify" when the bug is fixed in eosio.cdt.
-   [[eosio::on_notify("tester1::notify")]]
+   [[eosio::on_notify("*::notify")]]
    void on_notify( eosio::name to, eosio::name expected_sender, bool send_inline );
 
 };


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->
## Change Description
-------------
**Replaced by https://github.com/EOSIO/eos/pull/9244**
-------------
I am relaxing the on_notify constraint back to * 

This issue was first reported against EOSIO.CDT 1.6.1 https://github.com/EOSIO/eosio.cdt/issues/497 and has been fixed since EOSOIO.CDT 1.6.2.

   // eosio.cdt 1.6.1 has a problem with "* ::notify" so hardcode to tester1 for now.
   // TODO: Change it back to "* ::notify" when the bug is fixed in eosio.cdt.
   [[eosio::on_notify("tester1::notify")]]

<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->


## Change Type
**Select ONE**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [ ] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [x] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the relase notes. Please include a description of the change for inclusion in the release notes.-->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
