### PR TITLE
Use OptimizeUniversalStyleCompaction and delete manual flush

### DIFF
--- a/libraries/chain_kv/include/b1/chain_kv/chain_kv.hpp
+++ b/libraries/chain_kv/include/b1/chain_kv/chain_kv.hpp
@@ -135,6 +135,7 @@ struct database {
             std::optional<int> max_open_files = {}) {
 
       rocksdb::Options options;
+      options.OptimizeUniversalStyleCompaction();
       options.create_if_missing                    = create_if_missing;
       options.level_compaction_dynamic_level_bytes = true;
       options.bytes_per_sync                       = 1048576;

--- a/libraries/rodeos/rodeos.cpp
+++ b/libraries/rodeos/rodeos.cpp
@@ -127,8 +127,6 @@ void rodeos_db_snapshot::end_block(const get_blocks_result_base& result, bool fo
       first = head;
    if (write_now)
       end_write(write_now);
-   if (near)
-      db->flush(false, false);
 }
 
 void rodeos_db_snapshot::check_write(const ship_protocol::get_blocks_result_base& result) {


### PR DESCRIPTION
## Change Description

This commit is an attempt to resolve the problem with SSD thrashing caused by frequent RocksDB compaction, which in turn is caused by manual flushing on every block.

Applying `OptimizeUniversalStyleCompaction()` to RocksDB options seems to help.

## Change Type
**Select ONE**
- [ ] Documentation
- [ ] Stability bug fix
- [x] Other
- [ ] Other - special case
## Consensus Changes
- [ ] Consensus Changes
## API Changes
- [ ] API Changes
## Documentation Additions
- [ ] Documentation Additions