### PR TITLE
Using default logger in amqp_trx_plugin

### DIFF
--- a/programs/eosio-launcher/main.cpp
+++ b/programs/eosio-launcher/main.cpp
@@ -1189,12 +1189,6 @@ launcher_def::write_logging_config_file(tn_node_def &node) {
   if( gelf_enabled ) ta.appenders.push_back( "net" );
   log_config.loggers.emplace_back( ta );
 
-  fc::logger_config at( "amqp_trx" );
-  at.level = fc::log_level::debug;
-  at.appenders.push_back( "stderr" );
-  if( gelf_enabled ) at.appenders.push_back( "net" );
-  log_config.loggers.emplace_back( at );
-
   auto str = fc::json::to_pretty_string( log_config, fc::time_point::maximum(), fc::json::output_formatting::stringify_large_ints_and_doubles );
   cfg.write( str.c_str(), str.size() );
   cfg.close();

--- a/programs/nodeos/logging.json
+++ b/programs/nodeos/logging.json
@@ -100,15 +100,6 @@
         "stderr",
         "net"
       ]
-    },{
-      "name": "amqp_trx",
-      "level": "debug",
-      "enabled": true,
-      "additivity": false,
-      "appenders": [
-        "stderr",
-        "net"
-      ]
     }
   ]
 }


### PR DESCRIPTION
## Change Description

- The new `amqp_trx` logger is no longer used as the `amqp_trx_plugin` & `amqp_trace_plugin` use the default logger.

## Change Type
**Select ONE**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [ ] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [x] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the relase notes. Please include a description of the change for inclusion in the release notes.-->


## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
