### PR TITLE
fix the issue caused by \r in cleos warnings and infos

### DIFF
--- a/libraries/fc/src/log/console_appender.cpp
+++ b/libraries/fc/src/log/console_appender.cpp
@@ -1,4 +1,4 @@
-%s/^M$//#include <fc/log/console_appender.hpp>
+#include <fc/log/console_appender.hpp>
 #include <fc/log/log_message.hpp>
 #include <fc/string.hpp>
 #include <fc/variant.hpp>
@@ -121,7 +121,7 @@ namespace fc {
                line += "<7>";
                break;
          }
-      }^M
+      }
 
       line += fixed_size(  5, context.get_log_level().to_string() ); line += ' ';
       // use now() instead of context.get_timestamp() because log_message construction can include user provided long running calls

--- a/libraries/fc/src/log/console_appender.cpp
+++ b/libraries/fc/src/log/console_appender.cpp
@@ -1,4 +1,4 @@
-#include <fc/log/console_appender.hpp>
+%s/^M$//#include <fc/log/console_appender.hpp>
 #include <fc/log/log_message.hpp>
 #include <fc/string.hpp>
 #include <fc/variant.hpp>
@@ -105,6 +105,7 @@ namespace fc {
 
       std::string line;
       line.reserve( 256 );
+      line += "[ ";
       if(my->use_syslog_header) {
          switch(m.get_context().get_log_level()) {
             case log_level::error:
@@ -120,7 +121,8 @@ namespace fc {
                line += "<7>";
                break;
          }
-      }
+      }^M
+
       line += fixed_size(  5, context.get_log_level().to_string() ); line += ' ';
       // use now() instead of context.get_timestamp() because log_message construction can include user provided long running calls
       line += string( time_point::now() ); line += ' ';
@@ -138,8 +140,11 @@ namespace fc {
          if( me[p] == ':' ) ++p;
          line += fixed_size( 20, context.get_method().substr( p, 20 ) ); line += ' ';
       }
+
       line += "] ";
-      line += fc::format_string( m.get_format(), m.get_data() );
+      std::string message = fc::format_string( m.get_format(), m.get_data() );
+      message.erase( std::remove(message.begin(), message.end(), '\r'), message.end() );
+      line += message;
 
       print( line, my->lc[context.get_log_level()] );
 

--- a/libraries/fc/src/log/console_appender.cpp
+++ b/libraries/fc/src/log/console_appender.cpp
@@ -105,7 +105,6 @@ namespace fc {
 
       std::string line;
       line.reserve( 256 );
-      line += "[ ";
       if(my->use_syslog_header) {
          switch(m.get_context().get_log_level()) {
             case log_level::error:

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -590,7 +590,7 @@ void print_result( const fc::variant& result ) { try {
             for( const auto& a : actions ) {
                print_action_tree( a );
             }
-            wlog( "\rwarning: transaction executed locally, but may not be confirmed by the network yet" );
+            wlog( "\r\nwarning: transaction executed locally, but may not be confirmed by the network yet" );
          }
       } else {
          cerr << fc::json::to_pretty_string( result ) << endl;

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -590,6 +590,7 @@ void print_result( const fc::variant& result ) { try {
             for( const auto& a : actions ) {
                print_action_tree( a );
             }
+            wlog( "\rwarning: transaction executed locally, but may not be confirmed by the network yet" );
          }
       } else {
          cerr << fc::json::to_pretty_string( result ) << endl;

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -590,7 +590,6 @@ void print_result( const fc::variant& result ) { try {
             for( const auto& a : actions ) {
                print_action_tree( a );
             }
-            wlog( "\rwarning: transaction executed locally, but may not be confirmed by the network yet" );
          }
       } else {
          cerr << fc::json::to_pretty_string( result ) << endl;


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->
## Change Description
The character '\r' causes issues for the string concatenation. The characters before '\r' are overwritten. This change removes all '\r' in the message before the it is appended.
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->


## Change Type
**Select ONE**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [x] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [ ] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the relase notes. Please include a description of the change for inclusion in the release notes.-->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
