### PR TITLE
Track Source Files Excluded from Code Coverage Reports

### DIFF
--- a/pipeline.jsonc
+++ b/pipeline.jsonc
@@ -1,4 +1,22 @@
 {
+    "eosio-code-coverage":
+    {
+        "exclude": [ // ignore coverage reports from source filenames matching these PCREs
+            "^/build/",
+            "^/coverage/",
+            "^/.git/",
+            "^/libraries/eos-vm/",
+            "^/libraries/fc/",
+            "^/libraries/wabt/",
+            "^/libraries/wasm-jit/",
+            "^/node_modules/",
+            "^/unittests/"
+        ],
+        "expect": [ // expect coverage reports from source filenames matching these PCREs
+            "[.]c(pp)?([.]in)?$",
+            "[.]h(pp)?([.]in)?$"
+        ]
+    },
     "eosio-docker-builds":
     {
         "environment":

--- a/pipeline.jsonc
+++ b/pipeline.jsonc
@@ -35,14 +35,6 @@
             "170=v1.7.0"
         ]
     },
-    "eosio-replay-tests":
-    {
-        "environment":
-        {
-            "SKIP_PRE_V180": "true",
-            "SKIP_V180": "false"
-        }
-    },
     "eosio-resume-from-state":
     {
         "test":

--- a/pipeline.jsonc
+++ b/pipeline.jsonc
@@ -21,7 +21,7 @@
     {
         "environment":
         {
-            "BUILDER_TAG": "v1.8.0"
+            "BUILDER_TAG": "v1.8.14"
         }
     },
     "eos-multiversion-tests":

--- a/pipeline.jsonc
+++ b/pipeline.jsonc
@@ -1,4 +1,11 @@
 {
+    "eosio-docker-builds":
+    {
+        "environment":
+        {
+            "BUILDER_TAG": "v1.8.0"
+        }
+    },
     "eos-multiversion-tests":
     {
         "environment":
@@ -9,21 +16,6 @@
         [
             "170=v1.7.0"
         ]
-    },
-    "eosio-docker-builds":
-    {
-        "environment":
-        {
-            "BUILDER_TAG": "v1.8.0"
-        }
-    },
-    "eosio-sync-tests":
-    {
-        "environment":
-        {
-            "SKIP_PRE_V180": "true",
-            "SKIP_V180": "false"
-        }
     },
     "eosio-replay-tests":
     {
@@ -44,5 +36,13 @@
                 "tag": "v1.8.7"
             }
         ]
+    },
+    "eosio-sync-tests":
+    {
+        "environment":
+        {
+            "SKIP_PRE_V180": "true",
+            "SKIP_V180": "false"
+        }
     }
 }

--- a/pipeline.jsonc
+++ b/pipeline.jsonc
@@ -21,7 +21,7 @@
     {
         "environment":
         {
-            "BUILDER_TAG": "v1.8.14"
+            "BUILDER_TAG": "v1.8.0"
         }
     },
     "eos-multiversion-tests":

--- a/pipeline.jsonc
+++ b/pipeline.jsonc
@@ -46,13 +46,5 @@
                 "tag": "v1.8.7"
             }
         ]
-    },
-    "eosio-sync-tests":
-    {
-        "environment":
-        {
-            "SKIP_PRE_V180": "true",
-            "SKIP_V180": "false"
-        }
     }
 }


### PR DESCRIPTION
## Change Description
From [AUTO-117](https://blockone.atlassian.net/browse/AUTO-117), Blockchain wishes to collect metrics on what source files are not being reported upon by the code coverage reports. The new metrics collection code references the `pipeline.jsonc` file to determine which files it should expect coverage reports from, and which files it should ignore in the coverage report. This pull request creates initial versions of these declarations, and also updates some other `pipeline.jsonc` entries.

### Schema
This script looks for a `pipeline.jsonc` file in the root of the repo in which it is running, filters by pipeline slug, then automagically imports two properties, if they are present:
```jsonc
{
    "eosio-code-coverage":
    {
        "exclude": [ // ignore coverage reports from source filenames matching these PCREs
            "^/build/",
            "^/coverage/",
            "^/.git/",
            "^/libraries/eos-vm/",
            "^/libraries/fc/",
            "^/libraries/wabt/",
            "^/libraries/wasm-jit/",
            "^/node_modules/",
            "^/unittests/"
        ],
        "expect": [ // expect coverage reports from source filenames matching these PCREs
            "[.]c(pp)?([.]in)?$",
            "[.]h(pp)?([.]in)?$"
        ]
    }
}
```
The script will still work if this file or either one of these properties are missing.

### See Also
- [AUTO-117](https://blockone.atlassian.net/browse/AUTO-117) - Coverage report for code coverage report
- auto-events-subscribers [pull request 409](https://github.com/EOSIO/auto-events-subscribers/pull/409) - Track Source Files Excluded from Code Coverage Reports
- eos-buildkite-pipelines [pull request 110](https://github.com/EOSIO/eos-buildkite-pipelines/pull/110) - Track Source Files Excluded from Code Coverage Reports
- eos
  - [Pull Request 9308](https://github.com/EOSIO/eos/pull/9308) - `eos:develop`
  - [Pull Request 9311](https://github.com/EOSIO/eos/pull/9311) - `eos:release/2.0.x`
  - [Pull Request 9312](https://github.com/EOSIO/eos/pull/9312) - `eos:release/1.8.x`
- [Code Coverage Dashboard](https://app.datadoghq.com/dashboard/82q-upb-mph/eosio-code-coverage)

## Change Type
**Select ONE**
- [ ] Documentation
- [ ] Stability bug fix
- [x] Other

CI
- [ ] Other - special case

## Consensus Changes
- [ ] Consensus Changes

None.

## API Changes
- [ ] API Changes

None.

## Documentation Additions
- [ ] Documentation Additions

None.