### PR TITLE
Prevent an older version of g++ to build eosio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,8 +40,8 @@ set( KEY_STORE_EXECUTABLE_NAME keosd )
 
 # http://stackoverflow.com/a/18369825
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-    if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.0)
-        message(FATAL_ERROR "GCC version must be at least 7.0!")
+    if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 8.0)
+        message(FATAL_ERROR "GCC version must be at least 8.0!")
     endif()
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
     if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0)


### PR DESCRIPTION
## Change Description
Updating the CMakeLists.txt to prevent older g++ versions to build eosio.

## Change Type
**Select ONE**
- [ ] Documentation
- [ ] Stability bug fix
- [X] Other
- [ ] Other - special case


## Consensus Changes
- [ ] Consensus Changes


## API Changes
- [ ] API Changes


## Documentation Additions
- [ ] Documentation Additions