### PR TITLE
rodeos: retry on bind failure

### DIFF
--- a/programs/rodeos/wasm_ql_http.cpp
+++ b/programs/rodeos/wasm_ql_http.cpp
@@ -507,6 +507,7 @@ class listener : public std::enable_shared_from_this<listener> {
       }
 
       // Bind to the server address
+      acceptor.set_option(net::socket_base::reuse_address(true));
       acceptor.bind(endpoint, ec);
       if (ec) {
          fail(ec, "bind");

--- a/programs/rodeos/wasm_ql_plugin.cpp
+++ b/programs/rodeos/wasm_ql_plugin.cpp
@@ -44,12 +44,12 @@ struct wasm_ql_plugin_impl : std::enable_shared_from_this<wasm_ql_plugin_impl> {
                FC_LOG_AND_RETHROW()
             } catch (...) {
                elog("shutting down");
-               app().shutdown();
+               app().quit();
             }
          });
       } else {
          elog("hit --wql-retries limit; shutting down");
-         app().shutdown();
+         app().quit();
       }
    }
 

--- a/programs/rodeos/wasm_ql_plugin.cpp
+++ b/programs/rodeos/wasm_ql_plugin.cpp
@@ -17,14 +17,45 @@ namespace b1 {
 
 struct wasm_ql_plugin_impl : std::enable_shared_from_this<wasm_ql_plugin_impl> {
    bool                                         stopping     = false;
+   uint32_t                                     max_retries  = 0xffff'ffff;
+   uint32_t                                     retried      = 0;
    std::shared_ptr<const wasm_ql::http_config>  http_config  = {};
    std::shared_ptr<const wasm_ql::shared_state> shared_state = {};
    std::shared_ptr<wasm_ql::http_server>        http_server  = {};
+   boost::asio::deadline_timer                  timer;
 
-   void start_http() { http_server = wasm_ql::http_server::create(http_config, shared_state); }
+   wasm_ql_plugin_impl() : timer(app().get_io_service()) {}
+
+   void start_http() {
+      http_server = wasm_ql::http_server::create(http_config, shared_state);
+      if (!http_server)
+         schedule_retry();
+   }
+
+   void schedule_retry() {
+      if (retried++ < max_retries) {
+         timer.expires_from_now(boost::posix_time::seconds(1));
+         timer.async_wait([this](auto&) {
+            ilog("retry...");
+            try {
+               try {
+                  start_http();
+               }
+               FC_LOG_AND_RETHROW()
+            } catch (...) {
+               elog("shutting down");
+               app().shutdown();
+            }
+         });
+      } else {
+         elog("hit --wql-retries limit; shutting down");
+         app().shutdown();
+      }
+   }
 
    void shutdown() {
       stopping = true;
+      timer.cancel();
       if (http_server)
          http_server->stop();
    }
@@ -43,6 +74,9 @@ void wasm_ql_plugin::set_program_options(options_description& cli, options_descr
    auto op = cfg.add_options();
    op("wql-threads", bpo::value<int>()->default_value(8), "Number of threads to process requests");
    op("wql-listen", bpo::value<std::string>()->default_value("127.0.0.1:8880"), "Endpoint to listen on");
+   op("wql-retries", bpo::value<uint32_t>()->default_value(0xffff'ffff),
+      "Number of times to retry binding to --wql-listen. Each retry is approx 1 second apart. Set to 0 to prevent "
+      "retries.");
    op("wql-allow-origin", bpo::value<std::string>(), "Access-Control-Allow-Origin header. Use \"*\" to allow any.");
    op("wql-contract-dir", bpo::value<std::string>(),
       "Directory to fetch contracts from. These override contracts on the chain. (default: disabled)");
@@ -65,6 +99,7 @@ void wasm_ql_plugin::plugin_initialize(const variables_map& options) {
       my->http_config   = http_config;
       my->shared_state  = shared_state;
 
+      my->max_retries                = options.at("wql-retries").as<uint32_t>();
       http_config->num_threads       = options.at("wql-threads").as<int>();
       http_config->port              = ip_port.substr(ip_port.find(':') + 1, ip_port.size());
       http_config->address           = ip_port.substr(0, ip_port.find(':'));


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->
## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->


## Change Type
**Select ONE**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [ ] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [x] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the relase notes. Please include a description of the change for inclusion in the release notes.-->

Sometimes when rodeos starts up, the OS fails the socket bind saying the port is already in use. The OS then allows it after some unknown amount of time. We've seen this behavior on OSX after killing (gracefully) the process then restarting it. We've also seen this behavior when starting containers on k8s.

rodeos now automatically retries the bind, waiting ~1s between each try. A new option, `--wql-retries` limits the number of retries (0 = no retrying, default = no limit). rodeos shuts down if it hits the retry limit.

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
