### PR TITLE
std::promise use

### DIFF
--- a/libraries/amqp/reliable_amqp_publisher.cpp
+++ b/libraries/amqp/reliable_amqp_publisher.cpp
@@ -104,10 +104,11 @@ reliable_amqp_publisher_impl::~reliable_amqp_publisher_impl() {
 
    //drain any remaining items on user submitted queue
    std::promise<void> shutdown_promise;
+   auto shutdown_future = shutdown_promise.get_future();
    boost::asio::post(user_submitted_work_strand, [&]() {
       shutdown_promise.set_value();
    });
-   shutdown_promise.get_future().wait();
+   shutdown_future.wait();
 
    ctx.stop();
    thread.join();

--- a/libraries/chain/platform_timer_asio_fallback.cpp
+++ b/libraries/chain/platform_timer_asio_fallback.cpp
@@ -28,6 +28,7 @@ platform_timer::platform_timer() {
 
    if(refcount++ == 0) {
       std::promise<void> p;
+      auto f = p.get_future();
       checktime_thread = std::thread([&p]() {
          fc::set_os_thread_name("checktime");
          checktime_ios = std::make_unique<boost::asio::io_service>();
@@ -36,7 +37,7 @@ platform_timer::platform_timer() {
 
          checktime_ios->run();
       });
-      p.get_future().get();
+      f.get();
    }
 
    my->timer = std::make_unique<boost::asio::high_resolution_timer>(*checktime_ios);
@@ -64,11 +65,12 @@ void platform_timer::start(fc::time_point tp) {
    else {
 #if 0
       std::promise<void> p;
+      auto f = p.get_future();
       checktime_ios->post([&p,this]() {
          expired = 0;
          p.set_value();
       });
-      p.get_future().get();
+      f.get();
 #endif
       expired = 0;
       my->timer->expires_after(std::chrono::microseconds((int)x.count()));


### PR DESCRIPTION
## Change Description

- Get future before promise use to avoid race on `set_value` & `get_future`

## Change Type
**Select ONE**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [x] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [ ] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the relase notes. Please include a description of the change for inclusion in the release notes.-->


## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
