### PR TITLE
change witness_plugin to by default sign blocks of any age

### DIFF
--- a/plugins/witness_plugin/witness_plugin.cpp
+++ b/plugins/witness_plugin/witness_plugin.cpp
@@ -6,7 +6,7 @@ static appbase::abstract_plugin& _witness_plugin = app().register_plugin<witness
 
 struct witness_plugin_impl {
    signature_provider_plugin::signature_provider_type signature_provider;
-   unsigned staleness_limit = 600;
+   std::optional<unsigned> staleness_limit;
 
    struct callback_entry {
       witness_plugin::witness_callback_func func;
@@ -32,9 +32,9 @@ void witness_plugin::set_program_options(options_description& cli, options_descr
                   my->signature_provider = provider;
                }),
                app().get_plugin<signature_provider_plugin>().signature_provider_help_text())
-         ("witness-staleness-limit", boost::program_options::value<unsigned>()->default_value(my->staleness_limit)->notifier([this](const unsigned& v) {
+         ("witness-staleness-limit", boost::program_options::value<unsigned>()->notifier([this](const unsigned& v) {
                   my->staleness_limit = v;
-               }), "Blocks older than this many seconds are not signed by the witness plugin")
+               }), "When set, blocks older than this many seconds are not signed by the witness plugin")
          ;
 }
 
@@ -52,7 +52,7 @@ void witness_plugin::plugin_startup() {
 
 
    app().get_plugin<chain_plugin>().chain().irreversible_block.connect([&](const chain::block_state_ptr& bsp) {
-      if(bsp->block->timestamp.to_time_point() < fc::time_point::now() - fc::seconds(my->staleness_limit))
+      if(my->staleness_limit && bsp->block->timestamp.to_time_point() < fc::time_point::now() - fc::seconds(*my->staleness_limit))
          return;
 
       std::list<std::pair<std::reference_wrapper<witness_plugin::witness_callback_func>, std::shared_ptr<wrapped_shared_ptr_base>>> locks;


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->
## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
witness_plugin's previous default was to only sign blocks timestamped within 10 minutes of its wall clock. I think this might be a nasty trap. If BP(s) out run a witness_plugin node by over 10 minutes, when that witness_plugin node catches up there will be some blocks that it won't sign. In the case that a quorum of witnesses fall behind the BP(s) by 10 minutes, that quorum will never sign to the threshold needed to take action based on that quorum.

Change the default to always sign any block regardless of the block's age.

## Change Type
**Select ONE**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [ ] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [x] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the relase notes. Please include a description of the change for inclusion in the release notes.-->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
