### PR TITLE
Read transaction consensus fix

### DIFF
--- a/libraries/chain/webassembly/cf_transaction.cpp
+++ b/libraries/chain/webassembly/cf_transaction.cpp
@@ -6,24 +6,35 @@ namespace eosio { namespace chain { namespace webassembly {
       if( data.size() == 0 ) return transaction_size();
 
       const packed_transaction& packed_trx = context.trx_context.packed_trx;
-      const bytes& trx =
-            packed_trx.get_compression() == packed_transaction::compression_type::none ?
-               packed_trx.get_packed_transaction() :
-               fc::raw::pack( static_cast<const transaction&>( packed_trx.get_transaction() ) );
-
+      bytes trx = fc::raw::pack( static_cast<const transaction&>( packed_trx.get_transaction() ) );
       size_t copy_size = std::min( static_cast<size_t>(data.size()), trx.size() );
       std::memcpy( data.data(), trx.data(), copy_size );
 
       return copy_size;
+//      if( data.size() == 0 ) return transaction_size();
+//
+//      const packed_transaction& packed_trx = context.trx_context.packed_trx;
+//      const bytes& trx =
+//            packed_trx.get_compression() == packed_transaction::compression_type::none ?
+//               packed_trx.get_packed_transaction() :
+//               fc::raw::pack( static_cast<const transaction&>( packed_trx.get_transaction() ) );
+//
+//      size_t copy_size = std::min( static_cast<size_t>(data.size()), trx.size() );
+//      std::memcpy( data.data(), trx.data(), copy_size );
+//
+//      return copy_size;
    }
 
    int32_t interface::transaction_size() const {
       const packed_transaction& packed_trx = context.trx_context.packed_trx;
-      if( packed_trx.get_compression() == packed_transaction::compression_type::none) {
-         return packed_trx.get_packed_transaction().size();
-      } else {
-         return fc::raw::pack_size( static_cast<const transaction&>( packed_trx.get_transaction() ) );
-      }
+      return fc::raw::pack_size( static_cast<const transaction&>( packed_trx.get_transaction() ) );
+
+//      const packed_transaction& packed_trx = context.trx_context.packed_trx;
+//      if( packed_trx.get_compression() == packed_transaction::compression_type::none) {
+//         return packed_trx.get_packed_transaction().size();
+//      } else {
+//         return fc::raw::pack_size( static_cast<const transaction&>( packed_trx.get_transaction() ) );
+//      }
    }
 
    int32_t interface::expiration() const {

--- a/libraries/chain/webassembly/cf_transaction.cpp
+++ b/libraries/chain/webassembly/cf_transaction.cpp
@@ -5,36 +5,19 @@ namespace eosio { namespace chain { namespace webassembly {
    int32_t interface::read_transaction( legacy_span<char> data ) const {
       if( data.size() == 0 ) return transaction_size();
 
+      // always pack the transaction here as exact pack format is part of consensus
+      // and an alternative packed format could be stored in get_packed_transaction()
       const packed_transaction& packed_trx = context.trx_context.packed_trx;
       bytes trx = fc::raw::pack( static_cast<const transaction&>( packed_trx.get_transaction() ) );
       size_t copy_size = std::min( static_cast<size_t>(data.size()), trx.size() );
       std::memcpy( data.data(), trx.data(), copy_size );
 
       return copy_size;
-//      if( data.size() == 0 ) return transaction_size();
-//
-//      const packed_transaction& packed_trx = context.trx_context.packed_trx;
-//      const bytes& trx =
-//            packed_trx.get_compression() == packed_transaction::compression_type::none ?
-//               packed_trx.get_packed_transaction() :
-//               fc::raw::pack( static_cast<const transaction&>( packed_trx.get_transaction() ) );
-//
-//      size_t copy_size = std::min( static_cast<size_t>(data.size()), trx.size() );
-//      std::memcpy( data.data(), trx.data(), copy_size );
-//
-//      return copy_size;
    }
 
    int32_t interface::transaction_size() const {
       const packed_transaction& packed_trx = context.trx_context.packed_trx;
       return fc::raw::pack_size( static_cast<const transaction&>( packed_trx.get_transaction() ) );
-
-//      const packed_transaction& packed_trx = context.trx_context.packed_trx;
-//      if( packed_trx.get_compression() == packed_transaction::compression_type::none) {
-//         return packed_trx.get_packed_transaction().size();
-//      } else {
-//         return fc::raw::pack_size( static_cast<const transaction&>( packed_trx.get_transaction() ) );
-//      }
    }
 
    int32_t interface::expiration() const {

--- a/unittests/misc_tests.cpp
+++ b/unittests/misc_tests.cpp
@@ -813,6 +813,19 @@ BOOST_AUTO_TEST_CASE(transaction_test) { try {
    BOOST_CHECK_EQUAL(1u, keys.size());
    BOOST_CHECK_EQUAL(public_key, *keys.begin());
 
+   // verify packed_transaction creation from packed data
+   auto packed = fc::raw::pack( static_cast<const transaction&>(pkt5.get_transaction()) );
+   packed_transaction_v0 pkt7( packed, *pkt6.get_signatures(), pkt6.to_packed_transaction_v0()->get_packed_context_free_data(),
+                               packed_transaction_v0::compression_type::none );
+   BOOST_CHECK_EQUAL(pkt.get_transaction().id(), pkt7.get_transaction().id());
+
+   packed.push_back('8'); packed.push_back('8'); // extra ignored
+   packed_transaction_v0 pkt8( packed, *pkt6.get_signatures(), pkt6.to_packed_transaction_v0()->get_packed_context_free_data(),
+                               packed_transaction_v0::compression_type::none );
+   BOOST_CHECK_EQUAL(pkt.get_transaction().id(), pkt8.get_transaction().id());
+   BOOST_CHECK( packed != fc::raw::pack( static_cast<const transaction&>(pkt8.get_transaction()) ));
+   BOOST_CHECK( packed == pkt8.get_packed_transaction() ); // extra maintained
+
 } FC_LOG_AND_RETHROW() }
 
 


### PR DESCRIPTION
## Change Description

Always pack the transaction in read_transaction as exact pack format is part of consensus and an alternative packed format could be stored in get_packed_transaction()

## Change Type
**Select ONE**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [x] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [ ] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the relase notes. Please include a description of the change for inclusion in the release notes.-->


## Consensus Changes
- [x] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
