### PR TITLE
Remove fc::uint128_t typedef

### DIFF
--- a/libraries/chain/eosio_contract.cpp
+++ b/libraries/chain/eosio_contract.cpp
@@ -25,7 +25,7 @@ namespace eosio { namespace chain {
 
 
 uint128_t transaction_id_to_sender_id( const transaction_id_type& tid ) {
-   fc::uint128_t _id(tid._hash[3], tid._hash[2]);
+   fc::uint128 _id(tid._hash[3], tid._hash[2]);
    return (unsigned __int128)_id;
 }
 

--- a/libraries/chain/webassembly/compiler_builtins.cpp
+++ b/libraries/chain/webassembly/compiler_builtins.cpp
@@ -8,7 +8,7 @@
 namespace eosio { namespace chain { namespace webassembly {
 
    void interface::__ashlti3(legacy_ptr<__int128> ret, uint64_t low, uint64_t high, uint32_t shift) const {
-      fc::uint128_t i(high, low);
+      fc::uint128 i(high, low);
       i <<= shift;
       *ret = (unsigned __int128)i;
    }
@@ -22,13 +22,13 @@ namespace eosio { namespace chain { namespace webassembly {
    }
 
    void interface::__lshlti3(legacy_ptr<__int128> ret, uint64_t low, uint64_t high, uint32_t shift) const {
-      fc::uint128_t i(high, low);
+      fc::uint128 i(high, low);
       i <<= shift;
       *ret = (unsigned __int128)i;
    }
 
    void interface::__lshrti3(legacy_ptr<__int128> ret, uint64_t low, uint64_t high, uint32_t shift) const {
-      fc::uint128_t i(high, low);
+      fc::uint128 i(high, low);
       i >>= shift;
       *ret = (unsigned __int128)i;
    }
@@ -204,12 +204,12 @@ namespace eosio { namespace chain { namespace webassembly {
       *ret = ui64_to_f128( a );
    }
    double interface::__floattidf( uint64_t l, uint64_t h ) const {
-      fc::uint128_t v(h, l);
+      fc::uint128 v(h, l);
       unsigned __int128 val = (unsigned __int128)v;
       return ___floattidf( *(__int128*)&val );
    }
    double interface::__floatuntidf( uint64_t l, uint64_t h ) const {
-      fc::uint128_t v(h, l);
+      fc::uint128 v(h, l);
       return ___floatuntidf( (unsigned __int128)v );
    }
 

--- a/libraries/chain/webassembly/console.cpp
+++ b/libraries/chain/webassembly/console.cpp
@@ -50,7 +50,7 @@ namespace eosio { namespace chain { namespace webassembly {
 			else
 				val_magnitude = static_cast<unsigned __int128>(*val);
 
-			fc::uint128_t v(val_magnitude>>64, static_cast<uint64_t>(val_magnitude) );
+			fc::uint128 v(val_magnitude>>64, static_cast<uint64_t>(val_magnitude) );
 
 			string s;
 			if( is_negative ) {
@@ -65,7 +65,7 @@ namespace eosio { namespace chain { namespace webassembly {
    void interface::printui128(legacy_ptr<const unsigned __int128> val) {
 		predicated_print(context,
       [&]() {
-			fc::uint128_t v(*val>>64, static_cast<uint64_t>(*val) );
+			fc::uint128 v(*val>>64, static_cast<uint64_t>(*val) );
 			context.console_append(fc::variant(v).get_string());
       });
    }

--- a/libraries/fc/include/fc/io/raw.hpp
+++ b/libraries/fc/include/fc/io/raw.hpp
@@ -27,11 +27,12 @@ namespace fc {
     namespace bip = boost::interprocess;
     using shared_string = bip::basic_string< char, std::char_traits< char >, bip::allocator<char, bip::managed_mapped_file::segment_manager> >;
 
-    using namespace boost::multiprecision;
     template<size_t Size>
-    using UInt = number<cpp_int_backend<Size, Size, unsigned_magnitude, unchecked, void> >;
+    using UInt = boost::multiprecision::number<
+          boost::multiprecision::cpp_int_backend<Size, Size, boost::multiprecision::unsigned_magnitude, boost::multiprecision::unchecked, void> >;
     template<size_t Size>
-    using Int = number<cpp_int_backend<Size, Size, signed_magnitude, unchecked, void> >;
+    using Int = boost::multiprecision::number<
+          boost::multiprecision::cpp_int_backend<Size, Size, boost::multiprecision::signed_magnitude, boost::multiprecision::unchecked, void> >;
     template<typename Stream> void pack( Stream& s, const UInt<256>& n );
     template<typename Stream> void unpack( Stream& s,  UInt<256>& n );
     template<typename Stream> void pack( Stream& s, const Int<256>& n );

--- a/libraries/fc/include/fc/uint128.hpp
+++ b/libraries/fc/include/fc/uint128.hpp
@@ -122,9 +122,7 @@ namespace fc
       uint64_t lo;
   };
   static_assert( sizeof(uint128) == 2*sizeof(uint64_t), "validate packing assumptions" );
-
-  typedef uint128 uint128_t;
-
+  
   class variant;
 
   void to_variant( const uint128& var,  variant& vo );
@@ -155,7 +153,7 @@ namespace std
     };
 }
 
-FC_REFLECT( fc::uint128_t, (hi)(lo) )
+FC_REFLECT( fc::uint128, (hi)(lo) )
 
 #ifdef _MSC_VER
   #pragma warning (pop)

--- a/libraries/fc/include/fc/variant.hpp
+++ b/libraries/fc/include/fc/variant.hpp
@@ -53,11 +53,12 @@ namespace fc
    template<typename T, typename... Args> void to_variant( const boost::multi_index_container<T,Args...>& s, variant& v );
    template<typename T, typename... Args> void from_variant( const variant& v, boost::multi_index_container<T,Args...>& s );
 
-   using namespace boost::multiprecision;
    template<size_t Size>
-   using UInt = number<cpp_int_backend<Size, Size, unsigned_magnitude, unchecked, void> >;
+   using UInt = boost::multiprecision::number<
+         boost::multiprecision::cpp_int_backend<Size, Size, boost::multiprecision::unsigned_magnitude, boost::multiprecision::unchecked, void> >;
    template<size_t Size>
-   using Int = number<cpp_int_backend<Size, Size, signed_magnitude, unchecked, void> >;
+   using Int = boost::multiprecision::number<
+         boost::multiprecision::cpp_int_backend<Size, Size, boost::multiprecision::signed_magnitude, boost::multiprecision::unchecked, void> >;
 
    void to_variant( const UInt<8>& n, variant& v );
    void from_variant( const variant& v, UInt<8>& n );

--- a/libraries/fc/src/uint128.cpp
+++ b/libraries/fc/src/uint128.cpp
@@ -331,7 +331,7 @@ namespace fc
        uint64_t y[4];    // final result
        y[0] = sl;
 
-       uint128_t acc = sh;
+       uint128 acc = sh;
        acc += ql;
        acc += rl;
        y[1] = acc.lo;

--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -156,7 +156,7 @@ string U64Str(uint64_t i)
 
 string U128Str(unsigned __int128 i)
 {
-   return fc::variant(fc::uint128_t(i)).get_string();
+   return fc::variant(fc::uint128(i)).get_string();
 }
 
 template <typename T>


### PR DESCRIPTION
## Change Description

Removed `fc::uint128_t` typedef to avoid confusion with `eosio::chain::config::uint128_t` typedef.
- `fc::uint128_t` was `fc::uint128` class
- `eosio::chain::config::uint128_t` is `__uint128_t`

Removed `using namespace boost::multiprecision` to avoid pulling in `boost::multiprecision::uint128_t` which we also use.

## Change Type
**Select ONE**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [ ] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [x] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the relase notes. Please include a description of the change for inclusion in the release notes.-->

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
