### PR TITLE
distinguish old and new table_delta in state history plugin

### DIFF
--- a/plugins/state_history_plugin/include/eosio/state_history_plugin/state_history_plugin.hpp
+++ b/plugins/state_history_plugin/include/eosio/state_history_plugin/state_history_plugin.hpp
@@ -68,7 +68,7 @@ struct augmented_transaction_trace {
 struct table_delta {
    fc::unsigned_int                                                       struct_version = 0;
    std::string                                                            name{};
-   history_serial_big_vector_wrapper<std::vector<std::pair<bool, bytes>>> rows{};
+   history_serial_big_vector_wrapper<std::vector<std::pair<uint8_t, bytes>>> rows{};
 };
 
 struct block_position {

--- a/plugins/state_history_plugin/state_history_plugin.cpp
+++ b/plugins/state_history_plugin/state_history_plugin.cpp
@@ -502,7 +502,7 @@ struct state_history_plugin_impl : std::enable_shared_from_this<state_history_pl
             auto& delta = deltas.back();
             delta.name  = name;
             for (auto& row : index.indices())
-               delta.rows.obj.emplace_back(true, pack_row(row));
+               delta.rows.obj.emplace_back(2, pack_row(row));
          } else {
             if (index.stack().empty())
                return;
@@ -515,13 +515,13 @@ struct state_history_plugin_impl : std::enable_shared_from_this<state_history_pl
             for (auto& old : undo.old_values) {
                auto& row = index.get(old.first);
                if (include_delta(old.second, row))
-                  delta.rows.obj.emplace_back(true, pack_row(row));
+                  delta.rows.obj.emplace_back(1, pack_row(row));
             }
             for (auto& old : undo.removed_values)
-               delta.rows.obj.emplace_back(false, pack_row(old.second));
+               delta.rows.obj.emplace_back(0, pack_row(old.second));
             for (auto id : undo.new_ids) {
                auto& row = index.get(id);
-               delta.rows.obj.emplace_back(true, pack_row(row));
+               delta.rows.obj.emplace_back(2, pack_row(row));
             }
          }
       };


### PR DESCRIPTION
replace bool with uint8_t to distinguish old and new table_delta in state history plugin: 0=removed; 1=old; 2=new