### PR TITLE
EPE-306 fix

### DIFF
--- a/libraries/chain/include/eosio/chain/kv_chainbase_objects.hpp
+++ b/libraries/chain/include/eosio/chain/kv_chainbase_objects.hpp
@@ -34,9 +34,11 @@ namespace eosio { namespace chain {
 namespace config {
    template<>
    struct billable_size<kv_object> {
-      static constexpr uint64_t overhead = overhead_per_row_per_index_ram_bytes * 2;
-      static constexpr uint64_t serialized_kv_object_size = sizeof(kv_object) - 2*sizeof(shared_blob) + (8 + 4) * 2; ///< 8 for vector data 4 for vector size
-      static constexpr uint64_t value = serialized_kv_object_size + overhead; 
+      // NOTICE: Do not change any of the constants defined here; otherwise it would cause backward concensus compatibility problem.
+      static constexpr uint64_t overhead                     = overhead_per_row_per_index_ram_bytes * 2;
+      static constexpr uint64_t serialized_shared_blob_size  = 8 + 4; // 8 for vector data 4 for vector size
+      static constexpr uint64_t serialized_kv_object_size_exclude_shared_blobs = 32; // derived from sizeof(id_type) + 3* sizeof(name)
+      static constexpr uint64_t value = serialized_kv_object_size_exclude_shared_blobs + serialized_shared_blob_size * 2 + overhead; 
    };
 } // namespace config
 


### PR DESCRIPTION
## Change Description
Avoid using sizeof() for billable_size to prevent consensus problem.

## Change Type
**Select ONE**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [x] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [ ] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the relase notes. Please include a description of the change for inclusion in the release notes.-->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
