### PR TITLE
Rocksdb composite key construction for db intrinsic primary and secondary keys

### DIFF
--- a/libraries/chain/CMakeLists.txt
+++ b/libraries/chain/CMakeLists.txt
@@ -125,6 +125,8 @@ add_library( eosio_chain
              kv_context.cpp
              kv_context_chainbase.cpp
              db_context_chainbase.cpp
+             db_context_rocksdb.cpp
+             db_key_value_format.cpp
              ${PLATFORM_TIMER_IMPL}
              ${HEADERS}
              )

--- a/libraries/chain/db_context_rocksdb.cpp
+++ b/libraries/chain/db_context_rocksdb.cpp
@@ -1,0 +1,285 @@
+#include <eosio/chain/apply_context.hpp>
+#include <eosio/chain/exceptions.hpp>
+#include <eosio/chain/db_context.hpp>
+
+namespace eosio { namespace chain {
+
+   struct db_context_rocksdb : db_context {
+      apply_context&               context;
+      const name                   receiver;
+
+      db_context_rocksdb(apply_context& context, name receiver)
+         : context{ context }, receiver{ receiver } {}
+
+      ~db_context_rocksdb() override {}
+
+      int32_t db_store_i64(uint64_t scope, uint64_t table, account_name payer, uint64_t id, const char* buffer , size_t buffer_size) override {
+         return -1;
+      }
+
+      void db_update_i64(int32_t itr, account_name payer, const char* buffer , size_t buffer_size) override {
+      }
+
+      void db_remove_i64(int32_t itr) override {
+      }
+
+      int32_t db_get_i64(int32_t itr, char* buffer , size_t buffer_size) override {
+         return -1;
+      }
+
+      int32_t db_next_i64(int32_t itr, uint64_t& primary) override {
+         return -1;
+      }
+
+      int32_t db_previous_i64(int32_t itr, uint64_t& primary) override {
+         return -1;
+      }
+
+      int32_t db_find_i64(uint64_t code, uint64_t scope, uint64_t table, uint64_t id) override {
+         return -1;
+      }
+
+      int32_t db_lowerbound_i64(uint64_t code, uint64_t scope, uint64_t table, uint64_t id) override {
+         return -1;
+      }
+
+      int32_t db_upperbound_i64(uint64_t code, uint64_t scope, uint64_t table, uint64_t id) override {
+         return -1;
+      }
+
+      int32_t db_end_i64(uint64_t code, uint64_t scope, uint64_t table) override {
+         return -1;
+      }
+
+      /**
+       * interface for uint64_t secondary
+       */
+      int32_t db_idx64_store(uint64_t scope, uint64_t table, account_name payer, uint64_t id,
+                                     const uint64_t& secondary) override {
+         return -1;
+      }
+
+      void db_idx64_update(int32_t iterator, account_name payer, const uint64_t& secondary) override {
+      }
+
+      void db_idx64_remove(int32_t iterator) override {
+      }
+
+      int32_t db_idx64_find_secondary(uint64_t code, uint64_t scope, uint64_t table, const uint64_t& secondary,
+                                      uint64_t& primary) override {
+         return -1;
+      }
+
+      int32_t db_idx64_find_primary(uint64_t code, uint64_t scope, uint64_t table, uint64_t& secondary,
+                                    uint64_t primary) override {
+         return -1;
+      }
+
+      int32_t db_idx64_lowerbound(uint64_t code, uint64_t scope, uint64_t table, uint64_t& secondary,
+                                  uint64_t& primary) override {
+         return -1;
+      }
+
+      int32_t db_idx64_upperbound(uint64_t code, uint64_t scope, uint64_t table, uint64_t& secondary,
+                                  uint64_t& primary) override {
+         return -1;
+      }
+
+      int32_t db_idx64_end(uint64_t code, uint64_t scope, uint64_t table) override {
+         return -1;
+      }
+
+      int32_t db_idx64_next(int32_t iterator, uint64_t& primary) override {
+         return -1;
+      }
+
+      int32_t db_idx64_previous(int32_t iterator, uint64_t& primary) override {
+         return -1;
+      }
+
+      /**
+       * interface for uint128_t secondary
+       */
+      int32_t db_idx128_store(uint64_t scope, uint64_t table, account_name payer, uint64_t id,
+                              const uint128_t& secondary) override {
+         return -1;
+      }
+
+      void db_idx128_update(int32_t iterator, account_name payer, const uint128_t& secondary) override {
+      }
+
+      void db_idx128_remove(int32_t iterator) override {
+      }
+
+      int32_t db_idx128_find_secondary(uint64_t code, uint64_t scope, uint64_t table, const uint128_t& secondary,
+                                       uint64_t& primary) override {
+         return -1;
+      }
+
+      int32_t db_idx128_find_primary(uint64_t code, uint64_t scope, uint64_t table, uint128_t& secondary,
+                                     uint64_t primary) override {
+         return -1;
+      }
+
+      int32_t db_idx128_lowerbound(uint64_t code, uint64_t scope, uint64_t table, uint128_t& secondary,
+                                   uint64_t& primary) override {
+         return -1;
+      }
+
+      int32_t db_idx128_upperbound(uint64_t code, uint64_t scope, uint64_t table, uint128_t& secondary,
+                                   uint64_t& primary) override {
+         return -1;
+      }
+
+      int32_t db_idx128_end(uint64_t code, uint64_t scope, uint64_t table) override {
+         return -1;
+      }
+
+      int32_t db_idx128_next(int32_t iterator, uint64_t& primary) override {
+         return -1;
+      }
+
+      int32_t db_idx128_previous(int32_t iterator, uint64_t& primary) override {
+         return -1;
+      }
+
+      /**
+       * interface for 256-bit interger secondary
+       */
+      int32_t db_idx256_store(uint64_t scope, uint64_t table, account_name payer, uint64_t id,
+                              const uint128_t* data) override {
+         return -1;
+      }
+
+      void db_idx256_update(int32_t iterator, account_name payer, const uint128_t* data) override {
+      }
+
+      void db_idx256_remove(int32_t iterator) override {
+      }
+
+      int32_t db_idx256_find_secondary(uint64_t code, uint64_t scope, uint64_t table, const uint128_t* data,
+                                       uint64_t& primary) override {
+         return -1;
+      }
+
+      int32_t db_idx256_find_primary(uint64_t code, uint64_t scope, uint64_t table, uint128_t* data,
+                                     uint64_t primary) override {
+         return -1;
+      }
+
+      int32_t db_idx256_lowerbound(uint64_t code, uint64_t scope, uint64_t table, uint128_t* data,
+                                   uint64_t& primary) override {
+         return -1;
+      }
+
+      int32_t db_idx256_upperbound(uint64_t code, uint64_t scope, uint64_t table, uint128_t* data,
+                                   uint64_t& primary) override {
+         return -1;
+      }
+
+      int32_t db_idx256_end(uint64_t code, uint64_t scope, uint64_t table) override {
+         return -1;
+      }
+
+      int32_t db_idx256_next(int32_t iterator, uint64_t& primary) override {
+         return -1;
+      }
+
+      int32_t db_idx256_previous(int32_t iterator, uint64_t& primary) override {
+         return -1;
+      }
+
+      /**
+       * interface for double secondary
+       */
+      int32_t db_idx_double_store(uint64_t scope, uint64_t table, account_name payer, uint64_t id,
+                                  const float64_t& secondary) override {
+         return -1;
+      }
+
+      void db_idx_double_update(int32_t iterator, account_name payer, const float64_t& secondary) override {
+      }
+
+      void db_idx_double_remove(int32_t iterator) override {
+      }
+
+      int32_t db_idx_double_find_secondary(uint64_t code, uint64_t scope, uint64_t table,
+                                           const float64_t& secondary, uint64_t& primary) override {
+         return -1;
+      }
+
+      int32_t db_idx_double_find_primary(uint64_t code, uint64_t scope, uint64_t table, float64_t& secondary,
+                                         uint64_t primary) override {
+         return -1;
+      }
+
+      int32_t db_idx_double_lowerbound(uint64_t code, uint64_t scope, uint64_t table, float64_t& secondary,
+                                       uint64_t& primary) override {
+         return -1;
+      }
+
+      int32_t db_idx_double_upperbound(uint64_t code, uint64_t scope, uint64_t table, float64_t& secondary,
+                                       uint64_t& primary) override {
+         return -1;
+      }
+
+      int32_t db_idx_double_end(uint64_t code, uint64_t scope, uint64_t table) override {
+         return -1;
+      }
+
+      int32_t db_idx_double_next(int32_t iterator, uint64_t& primary) override {
+         return -1;
+      }
+
+      int32_t db_idx_double_previous(int32_t iterator, uint64_t& primary) override {
+         return -1;
+      }
+
+      /**
+       * interface for long double secondary
+       */
+      int32_t db_idx_long_double_store(uint64_t scope, uint64_t table, account_name payer, uint64_t id,
+                                       const float128_t& secondary) override {
+         return -1;
+      }
+
+      void db_idx_long_double_update(int32_t iterator, account_name payer, const float128_t& secondary) override {
+      }
+
+      void db_idx_long_double_remove(int32_t iterator) override {
+      }
+
+      int32_t db_idx_long_double_find_secondary(uint64_t code, uint64_t scope, uint64_t table,
+                                                const float128_t& secondary, uint64_t& primary) override {
+         return -1;
+      }
+
+      int32_t db_idx_long_double_find_primary(uint64_t code, uint64_t scope, uint64_t table,
+                                              float128_t& secondary, uint64_t primary) override {
+         return -1;
+      }
+
+      int32_t db_idx_long_double_lowerbound(uint64_t code, uint64_t scope, uint64_t table, float128_t& secondary,
+                                            uint64_t& primary) override {
+         return -1;
+      }
+
+      int32_t db_idx_long_double_upperbound(uint64_t code, uint64_t scope, uint64_t table, float128_t& secondary,
+                                            uint64_t& primary) override {
+         return -1;
+      }
+
+      int32_t db_idx_long_double_end(uint64_t code, uint64_t scope, uint64_t table) override {
+         return -1;
+      }
+
+      int32_t db_idx_long_double_next(int32_t iterator, uint64_t& primary) override {
+         return -1;
+      }
+
+      int32_t db_idx_long_double_previous(int32_t iterator, uint64_t& primary) override {
+         return -1;
+      }
+   }; // db_context_rocksdb
+
+}} // namespace eosio::chain

--- a/libraries/chain/db_key_value_format.cpp
+++ b/libraries/chain/db_key_value_format.cpp
@@ -1,0 +1,49 @@
+#include <eosio/chain/db_key_value_format.hpp>
+
+namespace eosio { namespace chain {
+   std::string db_key_value_format::to_string(const key_type& kt) {
+      switch (kt) {
+         case key_type::primary: return "primary key of type uint64_t";
+         case key_type::sec_i64: return "seconday key of type uint64_t";
+         case key_type::sec_i128: return "seconday key of type uint128_t";
+         case key_type::sec_i256: return "seconday key of type key256_t";
+         case key_type::sec_double: return "seconday key of type float64_t";
+         case key_type::sec_long_double: return "seconday key of type float128_t";
+         default:
+            const int kt_as_int = static_cast<char>(kt);
+            return std::string("<invalid key_type: ") + std::to_string(kt_as_int) + ">";
+      }
+   }
+
+   db_key_value_format::key_type db_key_value_format::extract_from_composite_key(bytes::const_iterator& key_loc, bytes::const_iterator key_end, name& scope, name& table) {
+      uint64_t temp_name = 0;
+      EOS_ASSERT(b1::chain_kv::extract_key(key_loc, key_end, temp_name), bad_composite_key_exception,
+                 "DB intrinsic key-value store composite key is malformed, it does not contain a scope");
+      scope = name{temp_name};
+      EOS_ASSERT(b1::chain_kv::extract_key(key_loc, key_end, temp_name), bad_composite_key_exception,
+                 "DB intrinsic key-value store composite key is malformed, it does not contain a table");
+      table = name{temp_name};
+      EOS_ASSERT(key_loc != key_end, bad_composite_key_exception,
+                 "DB intrinsic key-value store composite key is malformed, it does not contain an indication of the "
+                 "type of the db-key (primary uint64_t or secondary uint64_t/uint128_t/etc)");
+      return key_type(*key_loc++);
+   }
+
+   bytes db_key_value_format::create_primary_key(name scope, name table, uint64_t db_key) {
+      bytes composite_key;
+      prepare_composite_key<uint64_t, key_type::primary>(composite_key, scope, table, sizeof(uint64_t));
+      b1::chain_kv::append_key(composite_key, db_key);
+      return composite_key;
+   }
+
+   void db_key_value_format::get_primary_key(const bytes& composite_key, name& scope, name& table, uint64_t& db_key) {
+      bytes::const_iterator composite_loc = composite_key.cbegin();
+      auto kt = extract_from_composite_key(composite_loc, composite_key.cend(), scope, table);
+      EOS_ASSERT(kt == key_type::primary, bad_composite_key_exception,
+                 "DB intrinsic key-value store composite key is malformed, it is supposed to be a primary key, "
+                 "but it is a: " + to_string(kt));
+      EOS_ASSERT(b1::chain_kv::extract_key(composite_loc, composite_key.cend(), db_key), bad_composite_key_exception,
+                 "DB intrinsic key-value store composite key is malformed, it is supposed to have a primary key");
+   }
+
+}} // namespace eosio::chain

--- a/libraries/chain/db_key_value_format.cpp
+++ b/libraries/chain/db_key_value_format.cpp
@@ -4,11 +4,11 @@ namespace eosio { namespace chain {
    std::string db_key_value_format::to_string(const key_type& kt) {
       switch (kt) {
          case key_type::primary: return "primary key of type uint64_t";
-         case key_type::sec_i64: return "seconday key of type uint64_t";
-         case key_type::sec_i128: return "seconday key of type uint128_t";
-         case key_type::sec_i256: return "seconday key of type key256_t";
-         case key_type::sec_double: return "seconday key of type float64_t";
-         case key_type::sec_long_double: return "seconday key of type float128_t";
+         case key_type::sec_i64: return "secondary key of type uint64_t";
+         case key_type::sec_i128: return "secondary key of type uint128_t";
+         case key_type::sec_i256: return "secondary key of type key256_t";
+         case key_type::sec_double: return "secondary key of type float64_t";
+         case key_type::sec_long_double: return "secondary key of type float128_t";
          default:
             const int kt_as_int = static_cast<char>(kt);
             return std::string("<invalid key_type: ") + std::to_string(kt_as_int) + ">";

--- a/libraries/chain/db_key_value_format.cpp
+++ b/libraries/chain/db_key_value_format.cpp
@@ -15,7 +15,7 @@ namespace eosio { namespace chain {
       }
    }
 
-   db_key_value_format::key_type db_key_value_format::extract_from_composite_key(bytes::const_iterator& key_loc, bytes::const_iterator key_end, name& scope, name& table) {
+   db_key_value_format::key_type db_key_value_format::extract_from_composite_key(b1::chain_kv::bytes::const_iterator& key_loc, b1::chain_kv::bytes::const_iterator key_end, name& scope, name& table) {
       uint64_t temp_name = 0;
       EOS_ASSERT(b1::chain_kv::extract_key(key_loc, key_end, temp_name), bad_composite_key_exception,
                  "DB intrinsic key-value store composite key is malformed, it does not contain a scope");
@@ -29,15 +29,15 @@ namespace eosio { namespace chain {
       return key_type(*key_loc++);
    }
 
-   bytes db_key_value_format::create_primary_key(name scope, name table, uint64_t db_key) {
-      bytes composite_key;
+   b1::chain_kv::bytes db_key_value_format::create_primary_key(name scope, name table, uint64_t db_key) {
+      b1::chain_kv::bytes composite_key;
       prepare_composite_key<uint64_t, key_type::primary>(composite_key, scope, table, sizeof(uint64_t));
       b1::chain_kv::append_key(composite_key, db_key);
       return composite_key;
    }
 
-   void db_key_value_format::get_primary_key(const bytes& composite_key, name& scope, name& table, uint64_t& db_key) {
-      bytes::const_iterator composite_loc = composite_key.cbegin();
+   void db_key_value_format::get_primary_key(const b1::chain_kv::bytes& composite_key, name& scope, name& table, uint64_t& db_key) {
+      b1::chain_kv::bytes::const_iterator composite_loc = composite_key.cbegin();
       auto kt = extract_from_composite_key(composite_loc, composite_key.cend(), scope, table);
       EOS_ASSERT(kt == key_type::primary, bad_composite_key_exception,
                  "DB intrinsic key-value store composite key is malformed, it is supposed to be a primary key, "

--- a/libraries/chain/db_key_value_format.cpp
+++ b/libraries/chain/db_key_value_format.cpp
@@ -1,50 +1,52 @@
 #include <eosio/chain/db_key_value_format.hpp>
 
-namespace eosio { namespace chain {
-   std::string db_key_value_format::to_string(const key_type& kt) {
-      switch (kt) {
-         case key_type::primary: return "primary key of type uint64_t";
-         case key_type::sec_i64: return "secondary key of type uint64_t";
-         case key_type::sec_i128: return "secondary key of type uint128_t";
-         case key_type::sec_i256: return "secondary key of type key256_t";
-         case key_type::sec_double: return "secondary key of type float64_t";
-         case key_type::sec_long_double: return "secondary key of type float128_t";
-         default:
-            const int kt_as_int = static_cast<char>(kt);
-            return std::string("<invalid key_type: ") + std::to_string(kt_as_int) + ">";
+namespace eosio { namespace chain { namespace db_key_value_format {
+   namespace detail {
+      std::string to_string(const key_type& kt) {
+         switch (kt) {
+            case key_type::primary: return "primary key of type uint64_t";
+            case key_type::sec_i64: return "secondary key of type uint64_t";
+            case key_type::sec_i128: return "secondary key of type uint128_t";
+            case key_type::sec_i256: return "secondary key of type key256_t";
+            case key_type::sec_double: return "secondary key of type float64_t";
+            case key_type::sec_long_double: return "secondary key of type float128_t";
+            default:
+               const int kt_as_int = static_cast<char>(kt);
+               return std::string("<invalid key_type: ") + std::to_string(kt_as_int) + ">";
+         }
       }
-   }
 
-   db_key_value_format::intermittent_decomposed_values db_key_value_format::extract_from_composite_key(b1::chain_kv::bytes::const_iterator begin, b1::chain_kv::bytes::const_iterator key_end) {
-      auto key_loc = begin;
-      uint64_t scope_name = 0;
-      EOS_ASSERT(b1::chain_kv::extract_key(key_loc, key_end, scope_name), bad_composite_key_exception,
-                 "DB intrinsic key-value store composite key is malformed, it does not contain a scope");
-      uint64_t table_name = 0;
-      EOS_ASSERT(b1::chain_kv::extract_key(key_loc, key_end, table_name), bad_composite_key_exception,
-                 "DB intrinsic key-value store composite key is malformed, it does not contain a table");
-      EOS_ASSERT(key_loc != key_end, bad_composite_key_exception,
-                 "DB intrinsic key-value store composite key is malformed, it does not contain an indication of the "
-                 "type of the db-key (primary uint64_t or secondary uint64_t/uint128_t/etc)");
-      return { name{scope_name}, name{table_name}, key_loc, key_type(*key_loc++) };
-   }
+      intermittent_decomposed_values extract_from_composite_key(b1::chain_kv::bytes::const_iterator begin, b1::chain_kv::bytes::const_iterator key_end) {
+         auto key_loc = begin;
+         uint64_t scope_name = 0;
+         EOS_ASSERT(b1::chain_kv::extract_key(key_loc, key_end, scope_name), bad_composite_key_exception,
+                    "DB intrinsic key-value store composite key is malformed, it does not contain a scope");
+         uint64_t table_name = 0;
+         EOS_ASSERT(b1::chain_kv::extract_key(key_loc, key_end, table_name), bad_composite_key_exception,
+                    "DB intrinsic key-value store composite key is malformed, it does not contain a table");
+         EOS_ASSERT(key_loc != key_end, bad_composite_key_exception,
+                    "DB intrinsic key-value store composite key is malformed, it does not contain an indication of the "
+                    "type of the db-key (primary uint64_t or secondary uint64_t/uint128_t/etc)");
+         return { name{scope_name}, name{table_name}, key_loc, key_type(*key_loc++) };
+      }
+   } // namespace detail
 
-   b1::chain_kv::bytes db_key_value_format::create_primary_key(name scope, name table, uint64_t db_key) {
+   b1::chain_kv::bytes create_primary_key(name scope, name table, uint64_t db_key) {
       b1::chain_kv::bytes composite_key;
-      prepare_composite_key<uint64_t, key_type::primary>(composite_key, scope, table, sizeof(uint64_t));
+      detail::prepare_composite_key<uint64_t, key_type::primary>(composite_key, scope, table, sizeof(uint64_t));
       b1::chain_kv::append_key(composite_key, db_key);
       return composite_key;
    }
 
-   void db_key_value_format::get_primary_key(const b1::chain_kv::bytes& composite_key, name& scope, name& table, uint64_t& db_key) {
+   void get_primary_key(const b1::chain_kv::bytes& composite_key, name& scope, name& table, uint64_t& db_key) {
       b1::chain_kv::bytes::const_iterator composite_loc;
       key_type kt = key_type::sec_i64;
-      std::tie(scope, table, composite_loc, kt) = extract_from_composite_key(composite_key.cbegin(), composite_key.cend());
+      std::tie(scope, table, composite_loc, kt) = detail::extract_from_composite_key(composite_key.cbegin(), composite_key.cend());
       EOS_ASSERT(kt == key_type::primary, bad_composite_key_exception,
                  "DB intrinsic key-value store composite key is malformed, it is supposed to be a primary key, "
-                 "but it is a: " + to_string(kt));
+                 "but it is a: " + detail::to_string(kt));
       EOS_ASSERT(b1::chain_kv::extract_key(composite_loc, composite_key.cend(), db_key), bad_composite_key_exception,
                  "DB intrinsic key-value store composite key is malformed, it is supposed to have a primary key");
    }
 
-}} // namespace eosio::chain
+}}} // namespace eosio::chain::db_key_value_format

--- a/libraries/chain/include/eosio/chain/db_key_value_format.hpp
+++ b/libraries/chain/include/eosio/chain/db_key_value_format.hpp
@@ -74,9 +74,10 @@ namespace eosio { namespace chain {
 
       template<typename Key, key_type kt = determine_sec_type<Key>::kt>
       static void prepare_composite_key(b1::chain_kv::bytes& key_storage, name scope, name table, std::size_t key_size) {
-         const auto scope_size = sizeof(scope);
-         const auto table_size = sizeof(table);
-         const auto type_size = sizeof(key_type);
+         constexpr static auto scope_size = sizeof(scope);
+         constexpr static auto table_size = sizeof(table);
+         constexpr static auto type_size = sizeof(key_type);
+         static_assert( type_size == 1, "" );
          key_storage.reserve(scope_size + table_size + type_size + key_size);
          b1::chain_kv::append_key(key_storage, scope.to_uint64_t());
          b1::chain_kv::append_key(key_storage, table.to_uint64_t());

--- a/libraries/chain/include/eosio/chain/db_key_value_format.hpp
+++ b/libraries/chain/include/eosio/chain/db_key_value_format.hpp
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <eosio/chain/name.hpp>
+#include <chain_kv/chain_kv.hpp>
+#include <eosio/chain/exceptions.hpp>
+#include <memory>
+#include <stdint.h>
+
+namespace eosio { namespace chain {
+   class db_key_value_format {
+   public:
+      static bytes create_primary_key(name scope, name table, uint64_t db_key);
+
+      static void get_primary_key(const bytes& composite_key, name& scope, name& table, uint64_t& db_key);
+
+      template<typename Key>
+      static bytes create_secondary_key(name scope, name table, const Key& db_key) {
+         bytes composite_key;
+         prepare_composite_key<Key>(composite_key, scope, table, sizeof(Key));
+         b1::chain_kv::append_key(composite_key, db_key);
+         return composite_key;
+      }
+
+      template<typename Key>
+      static bool get_secondary_key(const bytes& composite_key, name& scope, name& table, Key& db_key) {
+         bytes::const_iterator composite_loc = composite_key.cbegin();
+         auto kt = extract_from_composite_key(composite_loc, composite_key.cend(), scope, table);
+         const auto expected_kt = determine_sec_type<Key>::kt;
+         if (kt != expected_kt) {
+            return false;
+         }
+         EOS_ASSERT(b1::chain_kv::extract_key(composite_loc, composite_key.cend(), db_key), bad_composite_key_exception,
+                    "DB intrinsic key-value store composite key is malformed, it is supposed to have an underlying: " +
+                    to_string(kt));
+         return true;
+      }
+
+      enum class key_type : char {
+         primary = 0,
+         sec_i64 = 1,
+         sec_i128 = 2,
+         sec_i256 = 3,
+         sec_double = 4,
+         sec_long_double = 5
+      };
+
+   private:
+
+      template<typename Key>
+      struct determine_sec_type {
+      };
+
+      template<>
+      struct determine_sec_type<uint64_t> { static constexpr key_type kt = key_type::sec_i64; };
+
+      template<>
+      struct determine_sec_type<uint128_t> { static constexpr key_type kt = key_type::sec_i128; };
+
+      template<>
+      struct determine_sec_type<key256_t> { static constexpr key_type kt = key_type::sec_i256; };
+
+      template<>
+      struct determine_sec_type<float64_t> {static constexpr key_type kt = key_type::sec_double; };
+
+      template<>
+      struct determine_sec_type<float128_t> { static constexpr key_type kt = key_type::sec_long_double; };
+
+      static std::string to_string(const key_type& kt);
+
+      template<typename Key, key_type kt = determine_sec_type<Key>::kt>
+      static void prepare_composite_key(bytes& key_storage, name scope, name table, std::size_t key_size) {
+         const auto scope_size = sizeof(scope);
+         const auto table_size = sizeof(table);
+         const auto type_size = sizeof(key_type);
+         key_storage.reserve(scope_size + table_size + type_size + key_size);
+         b1::chain_kv::append_key(key_storage, scope.to_uint64_t());
+         b1::chain_kv::append_key(key_storage, table.to_uint64_t());
+         key_storage.push_back(static_cast<char>(kt));
+      }
+
+      static key_type extract_from_composite_key(bytes::const_iterator& key_loc, bytes::const_iterator key_end, name& scope, name& table);
+
+   };
+
+}} // ns eosio::chain

--- a/libraries/chain/include/eosio/chain/db_key_value_format.hpp
+++ b/libraries/chain/include/eosio/chain/db_key_value_format.hpp
@@ -7,49 +7,22 @@
 #include <memory>
 #include <stdint.h>
 
-namespace eosio { namespace chain {
-   class db_key_value_format {
-   public:
-      using key256_t = std::array<uint128_t, 2>;
-      static b1::chain_kv::bytes create_primary_key(name scope, name table, uint64_t db_key);
+namespace eosio { namespace chain { namespace db_key_value_format {
+   using key256_t = std::array<uint128_t, 2>;
+   b1::chain_kv::bytes create_primary_key(name scope, name table, uint64_t db_key);
 
-      static void get_primary_key(const b1::chain_kv::bytes& composite_key, name& scope, name& table, uint64_t& db_key);
+   void get_primary_key(const b1::chain_kv::bytes& composite_key, name& scope, name& table, uint64_t& db_key);
 
-      template<typename Key>
-      static b1::chain_kv::bytes create_secondary_key(name scope, name table, const Key& db_key, uint64_t primary_key) {
-         b1::chain_kv::bytes composite_key;
-         prepare_composite_key<Key>(composite_key, scope, table, sizeof(Key));
-         b1::chain_kv::append_key(composite_key, db_key);
-         b1::chain_kv::append_key(composite_key, primary_key);
-         return composite_key;
-      }
+   enum class key_type : char {
+      primary = 0,
+      sec_i64 = 1,
+      sec_i128 = 2,
+      sec_i256 = 3,
+      sec_double = 4,
+      sec_long_double = 5
+   };
 
-      template<typename Key>
-      static bool get_secondary_key(const b1::chain_kv::bytes& composite_key, name& scope, name& table, Key& db_key, uint64_t& primary_key) {
-         b1::chain_kv::bytes::const_iterator composite_loc;
-         key_type kt = key_type::sec_i64;
-         std::tie(scope, table, composite_loc, kt) = extract_from_composite_key(composite_key.cbegin(), composite_key.cend());
-         constexpr static auto expected_kt = determine_sec_type<Key>::kt;
-         if (kt != expected_kt) {
-            return false;
-         }
-         EOS_ASSERT(b1::chain_kv::extract_key(composite_loc, composite_key.cend(), db_key), bad_composite_key_exception,
-                    "DB intrinsic key-value store composite key is malformed, it is supposed to have an underlying: " +
-                    to_string(kt));
-         EOS_ASSERT(b1::chain_kv::extract_key(composite_loc, composite_key.cend(), primary_key), bad_composite_key_exception,
-                    "DB intrinsic key-value store composite key is malformed, it is supposed to have a trailing primary key");
-         return true;
-      }
-
-      enum class key_type : char {
-         primary = 0,
-         sec_i64 = 1,
-         sec_i128 = 2,
-         sec_i256 = 3,
-         sec_double = 4,
-         sec_long_double = 5
-      };
-   private:
+   namespace detail {
 
       template<typename Key>
       struct determine_sec_type {
@@ -70,10 +43,10 @@ namespace eosio { namespace chain {
       template<>
       struct determine_sec_type<float128_t> { static constexpr key_type kt = key_type::sec_long_double; };
 
-      static std::string to_string(const key_type& kt);
+      std::string to_string(const key_type& kt);
 
       template<typename Key, key_type kt = determine_sec_type<Key>::kt>
-      static void prepare_composite_key(b1::chain_kv::bytes& key_storage, name scope, name table, std::size_t key_size) {
+      void prepare_composite_key(b1::chain_kv::bytes& key_storage, name scope, name table, std::size_t key_size) {
          constexpr static auto scope_size = sizeof(scope);
          constexpr static auto table_size = sizeof(table);
          constexpr static auto type_size = sizeof(key_type);
@@ -86,8 +59,34 @@ namespace eosio { namespace chain {
 
       using intermittent_decomposed_values = std::tuple<name, name, b1::chain_kv::bytes::const_iterator, key_type>;
 
-      static intermittent_decomposed_values extract_from_composite_key(b1::chain_kv::bytes::const_iterator begin, b1::chain_kv::bytes::const_iterator key_end);
+      intermittent_decomposed_values extract_from_composite_key(b1::chain_kv::bytes::const_iterator begin, b1::chain_kv::bytes::const_iterator key_end);
 
-   };
+   }
 
-}} // ns eosio::chain
+   template<typename Key>
+   b1::chain_kv::bytes create_secondary_key(name scope, name table, const Key& db_key, uint64_t primary_key) {
+      b1::chain_kv::bytes composite_key;
+      detail::prepare_composite_key<Key>(composite_key, scope, table, sizeof(Key));
+      b1::chain_kv::append_key(composite_key, db_key);
+      b1::chain_kv::append_key(composite_key, primary_key);
+      return composite_key;
+   }
+
+   template<typename Key>
+   bool get_secondary_key(const b1::chain_kv::bytes& composite_key, name& scope, name& table, Key& db_key, uint64_t& primary_key) {
+      b1::chain_kv::bytes::const_iterator composite_loc;
+      key_type kt = key_type::sec_i64;
+      std::tie(scope, table, composite_loc, kt) = detail::extract_from_composite_key(composite_key.cbegin(), composite_key.cend());
+      constexpr static auto expected_kt = detail::determine_sec_type<Key>::kt;
+      if (kt != expected_kt) {
+         return false;
+      }
+      EOS_ASSERT(b1::chain_kv::extract_key(composite_loc, composite_key.cend(), db_key), bad_composite_key_exception,
+                 "DB intrinsic key-value store composite key is malformed, it is supposed to have an underlying: " +
+                 detail::to_string(kt));
+      EOS_ASSERT(b1::chain_kv::extract_key(composite_loc, composite_key.cend(), primary_key), bad_composite_key_exception,
+                 "DB intrinsic key-value store composite key is malformed, it is supposed to have a trailing primary key");
+      return true;
+   }
+
+}}} // ns eosio::chain::db_key_value_format

--- a/libraries/chain/include/eosio/chain/db_key_value_format.hpp
+++ b/libraries/chain/include/eosio/chain/db_key_value_format.hpp
@@ -3,27 +3,30 @@
 #include <eosio/chain/name.hpp>
 #include <chain_kv/chain_kv.hpp>
 #include <eosio/chain/exceptions.hpp>
+#include <eosio/chain/types.hpp>
 #include <memory>
 #include <stdint.h>
 
 namespace eosio { namespace chain {
    class db_key_value_format {
    public:
-      static bytes create_primary_key(name scope, name table, uint64_t db_key);
+      using key256_t = std::array<uint128_t, 2>;
+      static b1::chain_kv::bytes create_primary_key(name scope, name table, uint64_t db_key);
 
-      static void get_primary_key(const bytes& composite_key, name& scope, name& table, uint64_t& db_key);
+      static void get_primary_key(const b1::chain_kv::bytes& composite_key, name& scope, name& table, uint64_t& db_key);
 
       template<typename Key>
-      static bytes create_secondary_key(name scope, name table, const Key& db_key) {
-         bytes composite_key;
+      static b1::chain_kv::bytes create_secondary_key(name scope, name table, const Key& db_key, uint64_t primary_key) {
+         b1::chain_kv::bytes composite_key;
          prepare_composite_key<Key>(composite_key, scope, table, sizeof(Key));
          b1::chain_kv::append_key(composite_key, db_key);
+         b1::chain_kv::append_key(composite_key, primary_key);
          return composite_key;
       }
 
       template<typename Key>
-      static bool get_secondary_key(const bytes& composite_key, name& scope, name& table, Key& db_key) {
-         bytes::const_iterator composite_loc = composite_key.cbegin();
+      static bool get_secondary_key(const b1::chain_kv::bytes& composite_key, name& scope, name& table, Key& db_key, uint64_t& primary_key) {
+         b1::chain_kv::bytes::const_iterator composite_loc = composite_key.cbegin();
          auto kt = extract_from_composite_key(composite_loc, composite_key.cend(), scope, table);
          const auto expected_kt = determine_sec_type<Key>::kt;
          if (kt != expected_kt) {
@@ -32,6 +35,8 @@ namespace eosio { namespace chain {
          EOS_ASSERT(b1::chain_kv::extract_key(composite_loc, composite_key.cend(), db_key), bad_composite_key_exception,
                     "DB intrinsic key-value store composite key is malformed, it is supposed to have an underlying: " +
                     to_string(kt));
+         EOS_ASSERT(b1::chain_kv::extract_key(composite_loc, composite_key.cend(), primary_key), bad_composite_key_exception,
+                    "DB intrinsic key-value store composite key is malformed, it is supposed to have a trailing primary key");
          return true;
       }
 
@@ -54,7 +59,7 @@ namespace eosio { namespace chain {
       struct determine_sec_type<uint64_t> { static constexpr key_type kt = key_type::sec_i64; };
 
       template<>
-      struct determine_sec_type<uint128_t> { static constexpr key_type kt = key_type::sec_i128; };
+      struct determine_sec_type<eosio::chain::uint128_t> { static constexpr key_type kt = key_type::sec_i128; };
 
       template<>
       struct determine_sec_type<key256_t> { static constexpr key_type kt = key_type::sec_i256; };
@@ -68,7 +73,7 @@ namespace eosio { namespace chain {
       static std::string to_string(const key_type& kt);
 
       template<typename Key, key_type kt = determine_sec_type<Key>::kt>
-      static void prepare_composite_key(bytes& key_storage, name scope, name table, std::size_t key_size) {
+      static void prepare_composite_key(b1::chain_kv::bytes& key_storage, name scope, name table, std::size_t key_size) {
          const auto scope_size = sizeof(scope);
          const auto table_size = sizeof(table);
          const auto type_size = sizeof(key_type);
@@ -78,7 +83,7 @@ namespace eosio { namespace chain {
          key_storage.push_back(static_cast<char>(kt));
       }
 
-      static key_type extract_from_composite_key(bytes::const_iterator& key_loc, bytes::const_iterator key_end, name& scope, name& table);
+      static key_type extract_from_composite_key(b1::chain_kv::bytes::const_iterator& key_loc, b1::chain_kv::bytes::const_iterator key_end, name& scope, name& table);
 
    };
 

--- a/libraries/chain/include/eosio/chain/db_key_value_format.hpp
+++ b/libraries/chain/include/eosio/chain/db_key_value_format.hpp
@@ -26,9 +26,10 @@ namespace eosio { namespace chain {
 
       template<typename Key>
       static bool get_secondary_key(const b1::chain_kv::bytes& composite_key, name& scope, name& table, Key& db_key, uint64_t& primary_key) {
-         b1::chain_kv::bytes::const_iterator composite_loc = composite_key.cbegin();
-         auto kt = extract_from_composite_key(composite_loc, composite_key.cend(), scope, table);
-         const auto expected_kt = determine_sec_type<Key>::kt;
+         b1::chain_kv::bytes::const_iterator composite_loc;
+         key_type kt = key_type::sec_i64;
+         std::tie(scope, table, composite_loc, kt) = extract_from_composite_key(composite_key.cbegin(), composite_key.cend());
+         constexpr static auto expected_kt = determine_sec_type<Key>::kt;
          if (kt != expected_kt) {
             return false;
          }
@@ -48,7 +49,6 @@ namespace eosio { namespace chain {
          sec_double = 4,
          sec_long_double = 5
       };
-
    private:
 
       template<typename Key>
@@ -84,7 +84,9 @@ namespace eosio { namespace chain {
          key_storage.push_back(static_cast<char>(kt));
       }
 
-      static key_type extract_from_composite_key(b1::chain_kv::bytes::const_iterator& key_loc, b1::chain_kv::bytes::const_iterator key_end, name& scope, name& table);
+      using intermittent_decomposed_values = std::tuple<name, name, b1::chain_kv::bytes::const_iterator, key_type>;
+
+      static intermittent_decomposed_values extract_from_composite_key(b1::chain_kv::bytes::const_iterator begin, b1::chain_kv::bytes::const_iterator key_end);
 
    };
 

--- a/libraries/chain/include/eosio/chain/exceptions.hpp
+++ b/libraries/chain/include/eosio/chain/exceptions.hpp
@@ -330,6 +330,8 @@ namespace eosio { namespace chain {
                                     3060006, "Chainbase and chain-kv databases are at different revisions" )
       FC_DECLARE_DERIVED_EXCEPTION( database_move_kv_disk_exception, database_exception,
                                     3060007, "Chainbase already contains eosio.kvdisk entries; use resync, replay, or snapshot to move these to rocksdb" )
+      FC_DECLARE_DERIVED_EXCEPTION( bad_composite_key_exception, database_exception,
+                                    3060008, "Retrieved composite key from key/value store that was formatted incorrectly" )
 
    FC_DECLARE_DERIVED_EXCEPTION( guard_exception, database_exception,
                                  3060100, "Guard Exception" )

--- a/libraries/chain_kv/CMakeLists.txt
+++ b/libraries/chain_kv/CMakeLists.txt
@@ -3,7 +3,7 @@ file(GLOB_RECURSE HEADERS "include/*.hpp")
 add_library( chain_kv INTERFACE )
 
 target_link_libraries( chain_kv 
-                       INTERFACE fc rocksdb
+                       INTERFACE fc rocksdb softfloat
                      )
 
 target_include_directories( chain_kv

--- a/libraries/chain_kv/include/b1/chain_kv/chain_kv.hpp
+++ b/libraries/chain_kv/include/b1/chain_kv/chain_kv.hpp
@@ -112,7 +112,7 @@ inline bytes get_next_prefix(const bytes& prefix) {
 }
 
 namespace detail {
-   typedef __uint128_t uint128_t;
+   using uint128_t = __uint128_t;
 
    template<std::size_t Size, std::size_t N>
    void copy_and_swap_to_buffer(char* to, const char* from) {
@@ -130,20 +130,20 @@ namespace detail {
 
    template<typename T>
    struct value_storage<T*> {
-      char* as_char_ptr(T* value) const { return reinterpret_cast<char*>(value); }
+      constexpr char* as_char_ptr(T* value) const { return reinterpret_cast<char*>(value); }
       constexpr std::size_t size() const { return sizeof(T); }
    };
 
    template<typename T>
    struct value_storage {
-      char* as_char_ptr(T& value) const { return reinterpret_cast<char*>(&value); }
+      constexpr char* as_char_ptr(T& value) const { return reinterpret_cast<char*>(&value); }
       constexpr std::size_t size() const { return sizeof(T); }
    };
 
    template <typename T, std::size_t N>
    auto append_key(bytes& dest, T value) {
-      constexpr auto type_size = value_storage<T>().size();
-      constexpr auto buf_size = type_size * N;
+      constexpr static auto type_size = value_storage<T>().size();
+      constexpr static auto buf_size = type_size * N;
       char buf[buf_size];
       detail::copy_and_swap_to_buffer<type_size, N>(buf, value_storage<T>().as_char_ptr(value));
       std::reverse(std::begin(buf), std::end(buf));
@@ -181,8 +181,8 @@ namespace detail {
    template<typename Key, std::size_t N>
    bool extract_key(bytes::const_iterator& key_loc, bytes::const_iterator key_end, Key& key) {
       const auto distance = std::distance(key_loc, key_end);
-      constexpr auto type_size = value_storage<Key>().size();
-      constexpr auto key_size = type_size * N;
+      constexpr static auto type_size = value_storage<Key>().size();
+      constexpr static auto key_size = type_size * N;
       if (distance < key_size)
          return false;
 

--- a/unittests/db_to_kv_tests.cpp
+++ b/unittests/db_to_kv_tests.cpp
@@ -5,6 +5,7 @@
 #include <cstring>
 
 using key_type = eosio::chain::db_key_value_format::key_type;
+using name = eosio::chain::name;
 
 BOOST_AUTO_TEST_SUITE(db_to_kv_tests)
 
@@ -24,7 +25,7 @@ void verify_secondary_wont_convert(const b1::chain_kv::bytes& composite_key, key
       name scope;
       name table;
       uint64_t key = 0;
-      BOOST_CHECK_THROW(eosio::chain::db_key_value_format::get_primary_key(composite_key, scope, table, key), bad_composite_key_exception);
+      BOOST_CHECK_THROW(eosio::chain::db_key_value_format::get_primary_key(composite_key, scope, table, key), eosio::chain::bad_composite_key_exception);
    }
    if (except != key_type::sec_i64) { verify_secondary_wont_convert<uint64_t>(composite_key); }
    if (except != key_type::sec_i128) { verify_secondary_wont_convert<eosio::chain::uint128_t>(composite_key); }

--- a/unittests/db_to_kv_tests.cpp
+++ b/unittests/db_to_kv_tests.cpp
@@ -9,7 +9,7 @@ using name = eosio::chain::name;
 
 BOOST_AUTO_TEST_SUITE(db_to_kv_tests)
 
-const uint64_t overhead_size = sizeof(name) * 2 + 1; // 8 (scope) + 8 (table) + 1 (key type)
+constexpr uint64_t overhead_size = sizeof(name) * 2 + 1; // 8 (scope) + 8 (table) + 1 (key type)
 
 template<typename Type>
 void verify_secondary_wont_convert(const b1::chain_kv::bytes& composite_key) {
@@ -103,13 +103,13 @@ b1::chain_kv::bytes prim_drop_extra_key(name scope, name table, uint64_t db_key,
 };
 
 template<typename T, typename KeyFunc>
-void check_ordered_keys(const std::vector<T> ordered_keys, KeyFunc key_func, bool skip_trailing_prim_key = false) {
+void check_ordered_keys(const std::vector<T>& ordered_keys, KeyFunc key_func, bool skip_trailing_prim_key = false) {
    verify_scope_table_order(ordered_keys[0], ordered_keys[1], key_func, skip_trailing_prim_key);
    name scope{0};
    name table{0};
    const uint64_t prim_key = 0;
    std::vector<b1::chain_kv::bytes> composite_keys;
-   for (const auto key: ordered_keys) {
+   for (const auto& key: ordered_keys) {
       auto comp_key = key_func(scope, table, key, prim_key);
       composite_keys.push_back(comp_key);
    }
@@ -167,7 +167,7 @@ BOOST_AUTO_TEST_CASE(ui64_keys_conversions_test) {
    check_ordered_keys(keys2, &eosio::chain::db_key_value_format::create_secondary_key<uint64_t>);
 }
 
-eosio::chain::uint128_t create_uint128(uint64_t upper, uint64_t lower) {
+constexpr eosio::chain::uint128_t create_uint128(uint64_t upper, uint64_t lower) {
    return (eosio::chain::uint128_t(upper) << 64) + lower;
 }
 
@@ -206,7 +206,7 @@ BOOST_AUTO_TEST_CASE(ui128_key_conversions_test) {
    check_ordered_keys(keys, &eosio::chain::db_key_value_format::create_secondary_key<eosio::chain::uint128_t>);
 }
 
-eosio::chain::key256_t create_key256(eosio::chain::uint128_t upper, eosio::chain::uint128_t lower) {
+constexpr eosio::chain::key256_t create_key256(eosio::chain::uint128_t upper, eosio::chain::uint128_t lower) {
    return { upper, lower };
 }
 

--- a/unittests/db_to_kv_tests.cpp
+++ b/unittests/db_to_kv_tests.cpp
@@ -1,0 +1,323 @@
+#include <eosio/testing/tester.hpp>
+#include <eosio/chain/db_key_value_format.hpp>
+
+#include <boost/test/unit_test.hpp>
+#include <cstring>
+
+using key_type = eosio::chain::db_key_value_format::key_type;
+
+BOOST_AUTO_TEST_SUITE(db_to_kv_tests)
+
+const uint64_t overhead_size = sizeof(name) * 2 + 1; // 8 (scope) + 8 (table) + 1 (key type)
+
+void print_bytes(const bytes& composite_key) {
+   printf("byte contents: ");
+   uint64_t i = 0;
+   for (; i < overhead_size; ++i) {
+      printf("%02x ", (uint8_t)composite_key[i]);
+   }
+   printf(" -> < ");
+   for (; i < composite_key.size(); ++i) {
+      printf("%02x ", (uint8_t)composite_key[i]);
+   }
+   printf("> \n");
+}
+
+void print_hex(uint8_t* num, uint64_t size) {
+   printf("key ptr: %08lx\n", reinterpret_cast<uint64_t>(num));
+   printf("key: ");
+   for (uint64_t i = 0; i < size; ++i) {
+      printf("%02x ", num[i]);
+   }
+   printf("\n");
+}
+
+template<typename Type>
+void verify_secondary_wont_convert(const bytes& composite_key) {
+   name scope;
+   name table;
+   Type key;
+   BOOST_CHECK(!eosio::chain::db_key_value_format::get_secondary_key(composite_key, scope, table, key));
+}
+
+void verify_secondary_wont_convert(const bytes& composite_key, key_type except) {
+   if (except != key_type::primary) {
+      name scope;
+      name table;
+      uint64_t key = 0;
+      BOOST_CHECK_THROW(eosio::chain::db_key_value_format::get_primary_key(composite_key, scope, table, key), bad_composite_key_exception);
+   }
+   if (except != key_type::sec_i64) { verify_secondary_wont_convert<uint64_t>(composite_key); }
+   if (except != key_type::sec_i128) { verify_secondary_wont_convert<eosio::chain::uint128_t>(composite_key); }
+   if (except != key_type::sec_i256) { verify_secondary_wont_convert<eosio::chain::key256_t>(composite_key); }
+   if (except != key_type::sec_double) { verify_secondary_wont_convert<float64_t>(composite_key); }
+   if (except != key_type::sec_long_double) { verify_secondary_wont_convert<float128_t>(composite_key); }
+}
+
+float128_t to_softfloat128( long double d ) {
+   float128_t x;
+   memcpy(&x, &d, sizeof(d));
+   return x;
+}
+
+void compare_composite_keys(const std::vector<bytes>& keys, uint64_t lhs_index, std::string desc) {
+   const bytes& lhs = keys[lhs_index];
+   const bytes& rhs = keys[lhs_index + 1];
+   bool found_less_than = false;
+   printf("left :");
+   for (unsigned int j = 0; j < lhs.size(); ++j) {
+      const auto cur_char = uint64_t(static_cast<unsigned char>(lhs[j]));
+      printf(" %02lx", cur_char);
+   }
+   printf("\nright:");
+   for (unsigned int j = 0; j < lhs.size(); ++j) {
+      const auto cur_char = uint64_t(static_cast<unsigned char>(rhs[j]));
+      printf(" %02lx", cur_char);
+   }
+   printf("\n");
+   for (unsigned int j = 0; j < lhs.size(); ++j) {
+      const auto left = uint64_t(static_cast<unsigned char>(lhs[j]));
+      const auto right = uint64_t(static_cast<unsigned char>(rhs[j]));
+      const auto op = left < right ? "<" : (right < left ? ">" : "==");
+      ilog("${j}:  ${k} ${l} ${m}", ("j", j)("k", std::to_string(left))("l", op)("m", std::to_string(right)));
+      if (left != right) {
+         BOOST_CHECK_MESSAGE(left < right, "expected " + std::to_string(lhs_index) +
+                             "th composite key to be less than the " + std::to_string(lhs_index + 1) + "th, but the " + std::to_string(j) +
+                             "th character is actually greater on the left than the right (" + std::to_string(left) + " > " +
+                             std::to_string(right) + ").  Called from: " + desc);
+         found_less_than = true;
+         break;
+      }
+   }
+   BOOST_CHECK_MESSAGE(found_less_than, "expected " + std::to_string(lhs_index) +
+                                        "th composite key to be less than the " + std::to_string(lhs_index + 1) +
+                                        "th, but they were identical.  Called from: " + desc);
+}
+
+template<typename T, typename KeyFunc>
+void verify_table_scope_order(T low_key, T high_key, KeyFunc key_func) {
+   std::vector<bytes> comp_keys;
+   comp_keys.push_back(key_func(name{0}, name{0}, low_key));
+   comp_keys.push_back(key_func(name{1}, name{0}, low_key));
+   comp_keys.push_back(key_func(name{1}, name{1}, low_key));
+   comp_keys.push_back(key_func(name{1}, name{1}, high_key));
+   comp_keys.push_back(key_func(name{1}, name{2}, low_key));
+   comp_keys.push_back(key_func(name{1}, name{0xffff'ffff'ffff'ffff}, low_key));
+   comp_keys.push_back(key_func(name{0xffff'ffff'ffff'ffff}, name{0}, low_key));
+   comp_keys.push_back(key_func(name{0xffff'ffff'ffff'ffff}, name{0xffff'ffff'ffff'ffff}, low_key));
+   for (unsigned int i = 0; i < comp_keys.size() - 1; ++i) {
+      compare_composite_keys(comp_keys, i, "verify_table_scope_order");
+   }
+}
+
+template<typename T, typename KeyFunc>
+void check_ordered_keys(const std::vector<T> ordered_keys, KeyFunc key_func) {
+   verify_table_scope_order(ordered_keys[0], ordered_keys[1], key_func);
+   name scope{0};
+   name table{0};
+   std::vector<bytes> composite_keys;
+   for (const auto key: ordered_keys) {
+      auto comp_key = key_func(scope, table, key);
+      comp_key.push_back('\0');
+      composite_keys.push_back(comp_key);
+   }
+   for (unsigned int i = 0; i < composite_keys.size() - 1; ++i) {
+      compare_composite_keys(composite_keys, i, "check_ordered_keys");
+   }
+}
+
+BOOST_AUTO_TEST_CASE(ui64_keys_conversions_test) {
+   const name scope = N(myscope);
+   const name table = N(thisscope);
+   const uint64_t key = 0xdead87654321beef;
+   const auto composite_key = eosio::chain::db_key_value_format::create_primary_key(scope, table, key);
+   BOOST_REQUIRE_EQUAL(overhead_size + sizeof(key), composite_key.size());
+
+   name decomposed_scope;
+   name decomposed_table;
+   uint64_t decomposed_key = 0x0;
+   BOOST_REQUIRE_NO_THROW(eosio::chain::db_key_value_format::get_primary_key(composite_key, decomposed_scope, decomposed_table, decomposed_key));
+   BOOST_CHECK_EQUAL(scope.to_string(), decomposed_scope.to_string());
+   BOOST_CHECK_EQUAL(table.to_string(), decomposed_table.to_string());
+   BOOST_CHECK_EQUAL(key, decomposed_key);
+   verify_secondary_wont_convert(composite_key, key_type::primary);
+
+   std::vector<uint64_t> keys;
+   keys.push_back(0x0);
+   keys.push_back(0x1);
+   keys.push_back(0x7FFF'FFFF'FFFF'FFFF);
+   keys.push_back(0x8000'0000'0000'0000);
+   keys.push_back(0xFFFF'FFFF'FFFF'FFFF);
+   check_ordered_keys(keys, &eosio::chain::db_key_value_format::create_primary_key);
+
+   const name scope2 = N(myscope);
+   const name table2 = N(thisscope);
+   const uint64_t key2 = 0xdead87654321beef;
+   const auto composite_key2 = eosio::chain::db_key_value_format::create_secondary_key(scope2, table2, key2);
+   BOOST_REQUIRE_EQUAL(25, composite_key2.size());
+
+   BOOST_CHECK(eosio::chain::db_key_value_format::get_secondary_key(composite_key2, decomposed_scope, decomposed_table, decomposed_key));
+   BOOST_CHECK_EQUAL(scope2.to_string(), decomposed_scope.to_string());
+   BOOST_CHECK_EQUAL(table2.to_string(), decomposed_table.to_string());
+   BOOST_CHECK_EQUAL(key2, decomposed_key);
+   verify_secondary_wont_convert(composite_key2, key_type::sec_i64);
+
+   std::vector<uint64_t> keys2;
+   keys2.push_back(0x0);
+   keys2.push_back(0x1);
+   keys2.push_back(0x7FFF'FFFF'FFFF'FFFF);
+   keys2.push_back(0x8000'0000'0000'0000);
+   keys2.push_back(0xFFFF'FFFF'FFFF'FFFF);
+   check_ordered_keys(keys2, &eosio::chain::db_key_value_format::create_secondary_key<uint64_t>);
+}
+
+eosio::chain::uint128_t create_uint128(uint64_t upper, uint64_t lower) {
+   return (eosio::chain::uint128_t(upper) << 64) + lower;
+}
+
+BOOST_AUTO_TEST_CASE(ui128_key_conversions_test) {
+   const name scope = N(myscope);
+   const name table = N(thisscope);
+   const eosio::chain::uint128_t key = create_uint128(0xdead12345678beef, 0x0123456789abcdef);
+
+   const auto composite_key = eosio::chain::db_key_value_format::create_secondary_key(scope, table, key);
+   BOOST_REQUIRE_EQUAL(overhead_size + sizeof(key), composite_key.size());
+   ilog("key size= ${ks}",("ks", composite_key.size()));
+
+   name decomposed_scope;
+   name decomposed_table;
+   eosio::chain::uint128_t decomposed_key = 0x0;
+   BOOST_REQUIRE_NO_THROW(eosio::chain::db_key_value_format::get_secondary_key(composite_key, decomposed_scope, decomposed_table, decomposed_key));
+   BOOST_CHECK_EQUAL(scope.to_string(), decomposed_scope.to_string());
+   BOOST_CHECK_EQUAL(table.to_string(), decomposed_table.to_string());
+   BOOST_CHECK(key == decomposed_key);
+
+   verify_secondary_wont_convert(composite_key, key_type::sec_i128);
+
+   std::vector<eosio::chain::uint128_t> keys;
+   keys.push_back(create_uint128(0x0, 0x0));
+   keys.push_back(create_uint128(0x0, 0x1));
+   keys.push_back(create_uint128(0x0, 0x7FFF'FFFF'FFFF'FFFF));
+   keys.push_back(create_uint128(0x0, 0x8000'0000'0000'0000));
+   keys.push_back(create_uint128(0x0, 0xFFFF'FFFF'FFFF'FFFF));
+   keys.push_back(create_uint128(0x1, 0x0));
+   keys.push_back(create_uint128(0x1, 0xFFFF'FFFF'FFFF'FFFF));
+   keys.push_back(create_uint128(0x7FFF'FFFF'FFFF'FFFF, 0xFFFF'FFFF'FFFF'FFFF));
+   keys.push_back(create_uint128(0x8000'0000'0000'0000, 0xFFFF'FFFF'FFFF'FFFF));
+   keys.push_back(create_uint128(0xFFFF'FFFF'FFFF'FFFF, 0xFFFF'FFFF'FFFF'FFFF));
+   check_ordered_keys(keys, &eosio::chain::db_key_value_format::create_secondary_key<eosio::chain::uint128_t>);
+}
+
+eosio::chain::key256_t create_key256(eosio::chain::uint128_t upper, eosio::chain::uint128_t lower) {
+   return { upper, lower };
+}
+
+BOOST_AUTO_TEST_CASE(ui256_key_conversions_test) {
+   const name scope = N(myscope);
+   const name table = N(thisscope);
+   const eosio::chain::key256_t key = create_key256(create_uint128(0xdead12345678beef, 0x0123456789abcdef),
+                                                    create_uint128(0xbadf2468013579ec, 0xf0e1d2c3b4a59687));
+   const auto composite_key = eosio::chain::db_key_value_format::create_secondary_key(scope, table, key);
+   BOOST_REQUIRE_EQUAL(overhead_size + sizeof(key), composite_key.size());
+
+   name decomposed_scope;
+   name decomposed_table;
+   eosio::chain::key256_t decomposed_key = create_key256(create_uint128(0x0, 0x0), create_uint128(0x0, 0x0));
+   BOOST_REQUIRE_NO_THROW(eosio::chain::db_key_value_format::get_secondary_key(composite_key, decomposed_scope, decomposed_table, decomposed_key));
+   BOOST_CHECK_EQUAL(scope.to_string(), decomposed_scope.to_string());
+   BOOST_CHECK_EQUAL(table.to_string(), decomposed_table.to_string());
+
+   BOOST_CHECK(key == decomposed_key);
+
+   verify_secondary_wont_convert(composite_key, key_type::sec_i256);
+
+   std::vector<eosio::chain::key256_t> keys;
+   keys.push_back(create_key256(create_uint128(0x0, 0x0), create_uint128(0x0, 0x0)));
+   keys.push_back(create_key256(create_uint128(0x0, 0x0), create_uint128(0x0, 0x01)));
+   keys.push_back(create_key256(create_uint128(0x0, 0x0), create_uint128(0x0, 0x7FFF'FFFF'FFFF'FFFF)));
+   keys.push_back(create_key256(create_uint128(0x0, 0x0), create_uint128(0x0, 0x8000'0000'0000'0000)));
+   keys.push_back(create_key256(create_uint128(0x0, 0x0), create_uint128(0x0, 0xFFFF'FFFF'FFFF'FFFF)));
+   keys.push_back(create_key256(create_uint128(0x0, 0x0), create_uint128(0x1, 0x0)));
+   keys.push_back(create_key256(create_uint128(0x0, 0x0), create_uint128(0xFFFF'FFFF'FFFF'FFFF, 0x0)));
+   keys.push_back(create_key256(create_uint128(0x0, 0x1), create_uint128(0x0, 0x0)));
+   keys.push_back(create_key256(create_uint128(0x0, 0xFFFF'FFFF'FFFF'FFFF), create_uint128(0x0, 0x0)));
+   keys.push_back(create_key256(create_uint128(0x1, 0x0), create_uint128(0x0, 0x0)));
+   keys.push_back(create_key256(create_uint128(0xFFFF'FFFF'FFFF'FFFF, 0x0), create_uint128(0x0, 0x0)));
+   check_ordered_keys(keys, &eosio::chain::db_key_value_format::create_secondary_key<eosio::chain::key256_t>);
+}
+
+BOOST_AUTO_TEST_CASE(test_test) {
+   const auto key1 = to_softfloat64(0.0);
+   const auto key2 = to_softfloat64(0.1);
+   const auto key3 = to_softfloat64(0.2);
+   const auto composite_key1 = eosio::chain::db_key_value_format::create_secondary_key(name{2}, name{4}, key1);
+   const auto composite_key2 = eosio::chain::db_key_value_format::create_secondary_key(name{2}, name{4}, key2);
+   const auto composite_key3 = eosio::chain::db_key_value_format::create_secondary_key(name{2}, name{4}, key3);
+   print_hex((uint8_t*)composite_key1.data(), composite_key1.size());
+   print_hex((uint8_t*)composite_key2.data(), composite_key2.size());
+   print_hex((uint8_t*)composite_key3.data(), composite_key3.size());
+}
+
+BOOST_AUTO_TEST_CASE(float64_key_conversions_test) {
+   const name scope = N(myscope);
+   const name table = N(thisscope);
+   const float64_t key = to_softfloat64(6.0);
+   const auto composite_key = eosio::chain::db_key_value_format::create_secondary_key(scope, table, key);
+   BOOST_REQUIRE_EQUAL(overhead_size + sizeof(key), composite_key.size());
+
+   name decomposed_scope;
+   name decomposed_table;
+   float64_t decomposed_key = to_softfloat64(0.0);
+   BOOST_REQUIRE_NO_THROW(eosio::chain::db_key_value_format::get_secondary_key(composite_key, decomposed_scope, decomposed_table, decomposed_key));
+   BOOST_CHECK_EQUAL(scope.to_string(), decomposed_scope.to_string());
+   BOOST_CHECK_EQUAL(table.to_string(), decomposed_table.to_string());
+
+   BOOST_CHECK_EQUAL(key, decomposed_key);
+
+   verify_secondary_wont_convert(composite_key, key_type::sec_double);
+
+   std::vector<float64_t> keys;
+   keys.push_back(to_softfloat64(-100000.0));
+   keys.push_back(to_softfloat64(-99999.9));
+   keys.push_back(to_softfloat64(-1.9));
+   keys.push_back(to_softfloat64(0.0));
+   keys.push_back(to_softfloat64(0.1));
+   keys.push_back(to_softfloat64(1.9));
+   keys.push_back(to_softfloat64(99999.9));
+   keys.push_back(to_softfloat64(100000.0));
+   check_ordered_keys(keys, &eosio::chain::db_key_value_format::create_secondary_key<float64_t>);
+}
+
+BOOST_AUTO_TEST_CASE(float128_key_conversions_test) {
+   const name scope = N(myscope);
+   const name table = N(thisscope);
+   const float128_t key = to_softfloat128(99.99);
+   const auto composite_key = eosio::chain::db_key_value_format::create_secondary_key(scope, table, key);
+   BOOST_REQUIRE_EQUAL(overhead_size + sizeof(key), composite_key.size());
+
+   name decomposed_scope;
+   name decomposed_table;
+   float128_t decomposed_key = to_softfloat128(0.0);
+   BOOST_REQUIRE_NO_THROW(eosio::chain::db_key_value_format::get_secondary_key(composite_key, decomposed_scope, decomposed_table, decomposed_key));
+   BOOST_CHECK_EQUAL(scope.to_string(), decomposed_scope.to_string());
+   BOOST_CHECK_EQUAL(table.to_string(), decomposed_table.to_string());
+
+   BOOST_CHECK_EQUAL(key, decomposed_key);
+
+   verify_secondary_wont_convert(composite_key, key_type::sec_long_double);
+
+   std::vector<float128_t> keys;
+   keys.push_back(to_softfloat128(-100000.001));
+   keys.push_back(to_softfloat128(-100000.0));
+   keys.push_back(to_softfloat128(-99999.9));
+   keys.push_back(to_softfloat128(-1.9));
+   keys.push_back(to_softfloat128(0.0));
+   keys.push_back(to_softfloat128(0.1));
+   keys.push_back(to_softfloat128(1.9));
+   keys.push_back(to_softfloat128(99999.9));
+   keys.push_back(to_softfloat128(100000.0));
+   keys.push_back(to_softfloat128(100000.001));
+   check_ordered_keys(keys, &eosio::chain::db_key_value_format::create_secondary_key<float128_t>);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/unittests/resource_limits_test.cpp
+++ b/unittests/resource_limits_test.cpp
@@ -482,7 +482,7 @@ BOOST_AUTO_TEST_SUITE(resource_limits_test)
          trigger_block->transactions.back().net_usage_words.value = 2*((reqauth_net_usage_delta + 7)/8); // double the NET bill
 
          // Re-calculate the transaction merkle
-         deque<digest_type> trx_digests;
+         eosio::chain::deque<digest_type> trx_digests;
          const auto& trxs = trigger_block->transactions;
          for( const auto& a : trxs )
             trx_digests.emplace_back( a.digest() );
@@ -524,7 +524,7 @@ BOOST_AUTO_TEST_SUITE(resource_limits_test)
          trigger_block->transactions.back().net_usage_words.value = ((reqauth_net_usage_delta + 7)/8)/2; // half the original NET bill
 
          // Re-calculate the transaction merkle
-         deque<digest_type> trx_digests;
+         eosio::chain::deque<digest_type> trx_digests;
          const auto& trxs = trigger_block->transactions;
          for( const auto& a : trxs )
             trx_digests.emplace_back( a.digest() );


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->
## Change Description
db intrinsics are "keyed" off of scope, table, and a primary key.  This is how all objects are stored.  It also allows for a secondary key for each type. In chainbase, the secondary keys are ordered by the order of that secondary key, and then by the order of the primary key that is stored with it.
db_key_value_format is a class designed to provide the formatting for creating composite keys to store in RocksDB for primary and secondary keys.
Unit tests verify key construction and deconstruction, ordering and error handling.
Also, threw in an empty place holder for db_context_rocksdb.cpp.


## Change Type
**Select ONE**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [ ] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [ ] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the relase notes. Please include a description of the change for inclusion in the release notes.-->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
