### PR TITLE
Handle payer for KV API on RocksDB

### DIFF
--- a/libraries/chain/include/eosio/chain/exceptions.hpp
+++ b/libraries/chain/include/eosio/chain/exceptions.hpp
@@ -330,6 +330,8 @@ namespace eosio { namespace chain {
                                     3060006, "Chainbase and chain-kv databases are at different revisions" )
       FC_DECLARE_DERIVED_EXCEPTION( database_move_kv_disk_exception, database_exception,
                                     3060007, "Chainbase already contains eosio.kvdisk entries; use resync, replay, or snapshot to move these to rocksdb" )
+      FC_DECLARE_DERIVED_EXCEPTION( kv_rocksdb_bad_value_size_exception, database_exception,
+                                    3060008, "The size of value returned from RocksDB is less than payer's size" )
 
    FC_DECLARE_DERIVED_EXCEPTION( guard_exception, database_exception,
                                  3060100, "Guard Exception" )

--- a/libraries/chain/include/eosio/chain/kv_context.hpp
+++ b/libraries/chain/include/eosio/chain/kv_context.hpp
@@ -88,9 +88,9 @@ namespace eosio { namespace chain {
 
      protected:
       // Updates resource usage for payer and returns resource delta
-      int64_t create_table_usage(kv_resource_manager& resource_manager, const account_name& payer, const char* key, uint32_t key_size, uint32_t value_size);
-      int64_t erase_table_usage(kv_resource_manager& resource_manager, const account_name& payer, const char* key, uint32_t key_size, uint32_t value_size);
-      int64_t update_table_usage(kv_resource_manager&  resource_manager, const account_name& old_payer, const account_name& new_payer, const char* key, uint32_t key_size, uint32_t old_value_size, uint32_t new_value_size);
+      int64_t create_table_usage(kv_resource_manager& resource_manager, const account_name& payer, const char* key, const uint32_t key_size, const uint32_t value_size);
+      int64_t erase_table_usage(kv_resource_manager& resource_manager, const account_name& payer, const char* key, const uint32_t key_size, const uint32_t value_size);
+      int64_t update_table_usage(kv_resource_manager&  resource_manager, const account_name& old_payer, const account_name& new_payer, const char* key, const uint32_t key_size, const uint32_t old_value_size, const uint32_t new_value_size);
    };
 
    std::unique_ptr<kv_context> create_kv_chainbase_context(chainbase::database& db, name receiver,

--- a/libraries/chain/include/eosio/chain/kv_context.hpp
+++ b/libraries/chain/include/eosio/chain/kv_context.hpp
@@ -85,6 +85,12 @@ namespace eosio { namespace chain {
       virtual uint32_t kv_get_data(uint32_t offset, char* data, uint32_t data_size)                        = 0;
 
       virtual std::unique_ptr<kv_iterator> kv_it_create(uint64_t contract, const char* prefix, uint32_t size) = 0;
+
+     protected:
+      // Updates resource usage for payer and returns resource delta
+      int64_t create_table_usage(kv_resource_manager& resource_manager, const account_name& payer, const char* key, uint32_t key_size, uint32_t value_size);
+      int64_t erase_table_usage(kv_resource_manager& resource_manager, const account_name& payer, const char* key, uint32_t key_size, uint32_t value_size);
+      int64_t update_table_usage(kv_resource_manager&  resource_manager, const account_name& old_payer, const account_name& new_payer, const char* key, uint32_t key_size, uint32_t old_value_size, uint32_t new_value_size);
    };
 
    std::unique_ptr<kv_context> create_kv_chainbase_context(chainbase::database& db, name receiver,

--- a/libraries/chain/kv_context.cpp
+++ b/libraries/chain/kv_context.cpp
@@ -19,19 +19,19 @@ namespace eosio { namespace chain {
       return {&context, config::billable_size_v<kv_object>, &kv_resource_manager_update_ram};
    }
 
-   int64_t kv_context::create_table_usage(kv_resource_manager& resource_manager, const account_name& payer, const char* key, uint32_t key_size, uint32_t value_size) {
+   int64_t kv_context::create_table_usage(kv_resource_manager& resource_manager, const account_name& payer, const char* key, const uint32_t key_size, const uint32_t value_size) {
       int64_t resource_delta = (static_cast<int64_t>(resource_manager.billable_size) + key_size + value_size);
       resource_manager.update_table_usage(payer, resource_delta, kv_resource_trace(key, key_size, kv_resource_trace::operation::create));
       return resource_delta;
    }
 
-   int64_t kv_context::erase_table_usage(kv_resource_manager& resource_manager, const account_name& payer, const char* key, uint32_t key_size, uint32_t value_size) {
+   int64_t kv_context::erase_table_usage(kv_resource_manager& resource_manager, const account_name& payer, const char* key, uint32_t const key_size, const uint32_t value_size) {
       int64_t resource_delta = -(static_cast<int64_t>(resource_manager.billable_size) + key_size + value_size);
       resource_manager.update_table_usage(payer, resource_delta, kv_resource_trace(key, key_size, kv_resource_trace::operation::erase));
       return resource_delta;
    }
 
-   int64_t kv_context::update_table_usage(kv_resource_manager& resource_manager, const account_name& old_payer, const account_name& new_payer, const char* key, uint32_t key_size, uint32_t old_value_size, uint32_t new_value_size) {
+   int64_t kv_context::update_table_usage(kv_resource_manager& resource_manager, const account_name& old_payer, const account_name& new_payer, const char* key, const uint32_t key_size, const uint32_t old_value_size, const uint32_t new_value_size) {
       // 64-bit arithmetic cannot overflow, because both the key and value are limited to 32-bits
       int64_t old_size = key_size + old_value_size;
       int64_t new_size = key_size + new_value_size;

--- a/libraries/chain/kv_context.cpp
+++ b/libraries/chain/kv_context.cpp
@@ -18,4 +18,35 @@ namespace eosio { namespace chain {
    kv_resource_manager create_kv_resource_manager(apply_context& context) {
       return {&context, config::billable_size_v<kv_object>, &kv_resource_manager_update_ram};
    }
+
+   int64_t kv_context::create_table_usage(kv_resource_manager& resource_manager, const account_name& payer, const char* key, uint32_t key_size, uint32_t value_size) {
+      int64_t resource_delta = (static_cast<int64_t>(resource_manager.billable_size) + key_size + value_size);
+      resource_manager.update_table_usage(payer, resource_delta, kv_resource_trace(key, key_size, kv_resource_trace::operation::create));
+      return resource_delta;
+   }
+
+   int64_t kv_context::erase_table_usage(kv_resource_manager& resource_manager, const account_name& payer, const char* key, uint32_t key_size, uint32_t value_size) {
+      int64_t resource_delta = -(static_cast<int64_t>(resource_manager.billable_size) + key_size + value_size);
+      resource_manager.update_table_usage(payer, resource_delta, kv_resource_trace(key, key_size, kv_resource_trace::operation::erase));
+      return resource_delta;
+   }
+
+   int64_t kv_context::update_table_usage(kv_resource_manager& resource_manager, const account_name& old_payer, const account_name& new_payer, const char* key, uint32_t key_size, uint32_t old_value_size, uint32_t new_value_size) {
+      // 64-bit arithmetic cannot overflow, because both the key and value are limited to 32-bits
+      int64_t old_size = key_size + old_value_size;
+      int64_t new_size = key_size + new_value_size;
+      int64_t resource_delta = new_size - old_size;
+
+      if (old_payer != new_payer) {
+         // refund the existing payer
+         resource_manager.update_table_usage(old_payer, -(old_size + resource_manager.billable_size), kv_resource_trace(key, key_size, kv_resource_trace::operation::update));
+         // charge the new payer for full amount
+         resource_manager.update_table_usage(new_payer, new_size + resource_manager.billable_size, kv_resource_trace(key, key_size, kv_resource_trace::operation::update));
+      } else if (old_size != new_size) {
+         // adjust delta for the existing payer
+         resource_manager.update_table_usage(new_payer, resource_delta, kv_resource_trace(key, key_size, kv_resource_trace::operation::update));
+      } // No need for a final "else" as usage does not change
+
+      return resource_delta;
+   }
 }}

--- a/libraries/chain/kv_context.cpp
+++ b/libraries/chain/kv_context.cpp
@@ -25,7 +25,7 @@ namespace eosio { namespace chain {
       return resource_delta;
    }
 
-   int64_t kv_context::erase_table_usage(kv_resource_manager& resource_manager, const account_name& payer, const char* key, uint32_t const key_size, const uint32_t value_size) {
+   int64_t kv_context::erase_table_usage(kv_resource_manager& resource_manager, const account_name& payer, const char* key, const uint32_t key_size, const uint32_t value_size) {
       int64_t resource_delta = -(static_cast<int64_t>(resource_manager.billable_size) + key_size + value_size);
       resource_manager.update_table_usage(payer, resource_delta, kv_resource_trace(key, key_size, kv_resource_trace::operation::erase));
       return resource_delta;

--- a/libraries/chain/kv_context.cpp
+++ b/libraries/chain/kv_context.cpp
@@ -20,22 +20,22 @@ namespace eosio { namespace chain {
    }
 
    int64_t kv_context::create_table_usage(kv_resource_manager& resource_manager, const account_name& payer, const char* key, const uint32_t key_size, const uint32_t value_size) {
-      int64_t resource_delta = (static_cast<int64_t>(resource_manager.billable_size) + key_size + value_size);
+      const int64_t resource_delta = (static_cast<int64_t>(resource_manager.billable_size) + key_size + value_size);
       resource_manager.update_table_usage(payer, resource_delta, kv_resource_trace(key, key_size, kv_resource_trace::operation::create));
       return resource_delta;
    }
 
    int64_t kv_context::erase_table_usage(kv_resource_manager& resource_manager, const account_name& payer, const char* key, const uint32_t key_size, const uint32_t value_size) {
-      int64_t resource_delta = -(static_cast<int64_t>(resource_manager.billable_size) + key_size + value_size);
+      const int64_t resource_delta = -(static_cast<int64_t>(resource_manager.billable_size) + key_size + value_size);
       resource_manager.update_table_usage(payer, resource_delta, kv_resource_trace(key, key_size, kv_resource_trace::operation::erase));
       return resource_delta;
    }
 
    int64_t kv_context::update_table_usage(kv_resource_manager& resource_manager, const account_name& old_payer, const account_name& new_payer, const char* key, const uint32_t key_size, const uint32_t old_value_size, const uint32_t new_value_size) {
       // 64-bit arithmetic cannot overflow, because both the key and value are limited to 32-bits
-      int64_t old_size = key_size + old_value_size;
-      int64_t new_size = key_size + new_value_size;
-      int64_t resource_delta = new_size - old_size;
+      const int64_t old_size = key_size + old_value_size;
+      const int64_t new_size = key_size + new_value_size;
+      const int64_t resource_delta = new_size - old_size;
 
       if (old_payer != new_payer) {
          // refund the existing payer

--- a/libraries/chain/kv_context_chainbase.cpp
+++ b/libraries/chain/kv_context_chainbase.cpp
@@ -163,8 +163,7 @@ namespace eosio { namespace chain {
                boost::make_tuple(database_id, name{ contract }, std::string_view{ key, key_size }));
          if (!kv)
             return 0;
-         int64_t resource_delta = -(static_cast<int64_t>(resource_manager.billable_size) + kv->kv_key.size() + kv->kv_value.size());
-         resource_manager.update_table_usage(kv->payer, resource_delta, kv_resource_trace(key, key_size, kv_resource_trace::operation::erase));
+         int64_t resource_delta = erase_table_usage(resource_manager, kv->payer, key, kv->kv_key.size(), kv->kv_value.size());
 
          if (auto dm_logger = resource_manager._context->control.get_deep_mind_logger()) {
             fc_dlog(*dm_logger, "KV_OP REM ${action_id} ${db} ${payer} ${key} ${odata}",
@@ -191,19 +190,7 @@ namespace eosio { namespace chain {
          auto* kv = db.find<kv_object, by_kv_key>(
                boost::make_tuple(database_id, name{ contract }, std::string_view{ key, key_size }));
          if (kv) {
-            // 64-bit arithmetic cannot overflow, because both the key and value are limited to 32-bits
-            int64_t old_size = static_cast<int64_t>(kv->kv_key.size()) + kv->kv_value.size();
-            int64_t new_size = static_cast<int64_t>(value_size) + key_size;
-            int64_t resource_delta = new_size - old_size;
-
-            if (kv->payer != payer) {
-               // refund the existing payer
-               resource_manager.update_table_usage(kv->payer, -(old_size + resource_manager.billable_size), kv_resource_trace(key, key_size, kv_resource_trace::operation::update));
-               // charge the new payer
-               resource_manager.update_table_usage(payer, new_size + resource_manager.billable_size, kv_resource_trace(key, key_size, kv_resource_trace::operation::update));
-            } else if (old_size != new_size) {
-               resource_manager.update_table_usage(payer, resource_delta, kv_resource_trace(key, key_size, kv_resource_trace::operation::update));
-            }
+            auto resource_delta = update_table_usage(resource_manager, kv->payer, payer, key, key_size, kv->kv_value.size(), value_size);
 
             if (auto dm_logger = resource_manager._context->control.get_deep_mind_logger()) {
                fc_dlog(*dm_logger, "KV_OP UPD ${action_id} ${db} ${payer} ${key} ${odata}:${ndata}",
@@ -223,9 +210,7 @@ namespace eosio { namespace chain {
             });
             return resource_delta;
          } else {
-            int64_t new_size = static_cast<int64_t>(value_size) + key_size;
-            int64_t resource_delta = new_size + resource_manager.billable_size;
-            resource_manager.update_table_usage(payer, resource_delta, kv_resource_trace(key, key_size, kv_resource_trace::operation::create));
+            int64_t resource_delta = create_table_usage(resource_manager, payer, key, key_size, value_size);
             db.create<kv_object>([&](auto& obj) {
                obj.database_id = database_id;
                obj.contract    = name{ contract };

--- a/libraries/chain/kv_context_chainbase.cpp
+++ b/libraries/chain/kv_context_chainbase.cpp
@@ -163,7 +163,7 @@ namespace eosio { namespace chain {
                boost::make_tuple(database_id, name{ contract }, std::string_view{ key, key_size }));
          if (!kv)
             return 0;
-         int64_t resource_delta = erase_table_usage(resource_manager, kv->payer, key, kv->kv_key.size(), kv->kv_value.size());
+         const int64_t resource_delta = erase_table_usage(resource_manager, kv->payer, key, kv->kv_key.size(), kv->kv_value.size());
 
          if (auto dm_logger = resource_manager._context->control.get_deep_mind_logger()) {
             fc_dlog(*dm_logger, "KV_OP REM ${action_id} ${db} ${payer} ${key} ${odata}",
@@ -190,7 +190,7 @@ namespace eosio { namespace chain {
          auto* kv = db.find<kv_object, by_kv_key>(
                boost::make_tuple(database_id, name{ contract }, std::string_view{ key, key_size }));
          if (kv) {
-            auto resource_delta = update_table_usage(resource_manager, kv->payer, payer, key, key_size, kv->kv_value.size(), value_size);
+            const auto resource_delta = update_table_usage(resource_manager, kv->payer, payer, key, key_size, kv->kv_value.size(), value_size);
 
             if (auto dm_logger = resource_manager._context->control.get_deep_mind_logger()) {
                fc_dlog(*dm_logger, "KV_OP UPD ${action_id} ${db} ${payer} ${key} ${odata}:${ndata}",
@@ -210,7 +210,7 @@ namespace eosio { namespace chain {
             });
             return resource_delta;
          } else {
-            int64_t resource_delta = create_table_usage(resource_manager, payer, key, key_size, value_size);
+            const int64_t resource_delta = create_table_usage(resource_manager, payer, key, key_size, value_size);
             db.create<kv_object>([&](auto& obj) {
                obj.database_id = database_id;
                obj.contract    = name{ contract };

--- a/libraries/chain/kv_context_rocksdb.cpp
+++ b/libraries/chain/kv_context_rocksdb.cpp
@@ -12,8 +12,10 @@ namespace eosio { namespace chain {
       return (raw_value_size - kv_payer_size);
    }
 
-   static void get_payer(const char* data, account_name& payer) {
+   static account_name get_payer(const char* data) {
+      account_name payer;
       memcpy(&payer, data, kv_payer_size);
+      return payer;
    }
 
    static const char* actual_value_start(const char* data) {
@@ -236,8 +238,7 @@ namespace eosio { namespace chain {
          }
          CATCH_AND_EXIT_DB_FAILURE()
 
-         account_name payer;
-         get_payer(old_value->data(), payer);
+         account_name payer = get_payer(old_value->data());
 
          return erase_table_usage(resource_manager, payer, key, key_size, actual_old_value_size);
       }
@@ -278,8 +279,7 @@ namespace eosio { namespace chain {
 
          int64_t resource_delta;
          if (old_value) {
-            account_name old_payer;
-            get_payer(old_value->data(), old_payer);
+            account_name old_payer = get_payer(old_value->data());
 
             resource_delta = update_table_usage(resource_manager, old_payer, payer, key, key_size, old_value_size, value_size);
          } else {


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->
## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
This PR adds logic to handle payer for KV API on RocksDb. For security reasons, the payer name is stored internally
when kv_set is called. At kv_set, the payer is charged; if existing payer different from new payer, the existing payer's account
is updated accordingly. At kv_erase, the payer's account is updated too. 


## Change Type
**Select ONE**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [ ] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [X] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the relase notes. Please include a description of the change for inclusion in the release notes.-->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
