### PR TITLE
Restrict the maximum number of open HTTP RPC requests

### DIFF
--- a/plugins/http_plugin/http_plugin.cpp
+++ b/plugins/http_plugin/http_plugin.cpp
@@ -405,7 +405,7 @@ namespace eosio {
             }
 
             void update_connection(const std::string & body, int code) override {
-               _conn->set_body(std::move(body));
+               _conn->set_body(body);
                _conn->set_status( websocketpp::http::status_code::value( code ) );
                _conn->send_http_response();
             }
@@ -568,7 +568,7 @@ namespace eosio {
                   try {
                      std::string json = fc::json::to_string( *(*tracked_response), fc::time_point::now() + max_response_time );
                      auto tracked_json = make_in_flight(std::move(json), *this);
-                     abstract_conn_ptr->update_connection(*(*tracked_json) , code);
+                     abstract_conn_ptr->update_connection(std::move(*(*tracked_json)), code);
                   } catch( ... ) {
                      abstract_conn_ptr->handle_exception();
                   }

--- a/plugins/http_plugin/http_plugin.cpp
+++ b/plugins/http_plugin/http_plugin.cpp
@@ -731,9 +731,9 @@ namespace eosio {
             ("max-body-size", bpo::value<uint32_t>()->default_value(1024*1024),
              "The maximum body size in bytes allowed for incoming RPC requests")
             ("http-max-bytes-in-flight-mb", bpo::value<uint32_t>()->default_value(500),
-             "Maximum size in megabytes http_plugin should use for processing http requests. 503 error response when exceeded." )
+             "Maximum size in megabytes http_plugin should use for processing http requests. 429 error response when exceeded." )
             ("http-max-in-flight-requests", bpo::value<int32_t>()->default_value(-1),
-             "Maximum number of requests http_plugin should use for processing http requests. 503 error response when exceeded." )
+             "Maximum number of requests http_plugin should use for processing http requests. 429 error response when exceeded." )
             ("http-max-response-time-ms", bpo::value<uint32_t>()->default_value(30),
              "Maximum time for processing a request.")
             ("verbose-http-errors", bpo::bool_switch()->default_value(false),

--- a/plugins/http_plugin/http_plugin.cpp
+++ b/plugins/http_plugin/http_plugin.cpp
@@ -136,7 +136,7 @@ namespace eosio {
          virtual bool verify_max_requests_in_flight() = 0;
          virtual void handle_exception() = 0;
 
-         virtual void update_connection(const std::string & body, int code) = 0;
+         virtual void send_response(std::string body, int code) = 0;
       };
 
       using abstract_conn_ptr = std::shared_ptr<abstract_conn>;
@@ -404,8 +404,8 @@ namespace eosio {
                http_plugin_impl::handle_exception<T>(_conn);
             }
 
-            void update_connection(const std::string & body, int code) override {
-               _conn->set_body(body);
+            void send_response(std::string body, int code) override {
+               _conn->set_body(std::move(body));
                _conn->set_status( websocketpp::http::status_code::value( code ) );
                _conn->send_http_response();
             }
@@ -568,7 +568,7 @@ namespace eosio {
                   try {
                      std::string json = fc::json::to_string( *(*tracked_response), fc::time_point::now() + max_response_time );
                      auto tracked_json = make_in_flight(std::move(json), *this);
-                     abstract_conn_ptr->update_connection(std::move(*(*tracked_json)), code);
+                     abstract_conn_ptr->send_response(std::move(*(*tracked_json)), code);
                   } catch( ... ) {
                      abstract_conn_ptr->handle_exception();
                   }


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->
## Change Description
Added a new option for `http-plugin` : `http-max-in-flight-requests`. It restricts the maximum requests the flight can hold if --http-max-in-flight-requests = positive number. If the limit exceeds, it sends a 429 error to the client. if --http-max-in-flight-requests = -1, there is no limit so the feature is turned off. It protects non-producing nodeos against the flood of requests when it cannot get new blocks.

## Change Type
**Select ONE**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [ ] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [x] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the relase notes. Please include a description of the change for inclusion in the release notes.-->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [x] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
Added a new http_plugin option --http-max-in-flight-requests. "--http-max-in-flight-requests = positive number" sets the limit of requests that the flight can hold. If the limit is exceeded, a 429 error is sent to the client. if --http-max-in-flight-requests = -1, the feature is turned off. The feature is turned off in default. The doc is: "Maximum number of requests http_plugin should use for processing http requests. 429 error response when exceeded."

A change is made for the http_plugin option http-max-bytes-in-flight-mb. When the limit is exceeded, the error coode is 429, instead of 503. The new doc is: "Maximum size in megabytes http_plugin should use for processing http requests. 429 error response when exceeded."