### PR TITLE
Fix app() shutdown - develop

### DIFF
--- a/libraries/appbase/application.cpp
+++ b/libraries/appbase/application.cpp
@@ -413,16 +413,18 @@ void application::set_thread_priority_max() {
 }
 
 void application::exec() {
-   boost::asio::io_service::work work(*io_serv);
-   (void)work;
-   bool more = true;
-   while( more || io_serv->run_one() ) {
-      while( io_serv->poll_one() ) {}
-      // execute the highest priority item
-      more = pri_queue.execute_highest();
-   }
+   {
+      boost::asio::io_service::work work( *io_serv );
+      (void) work;
+      bool more = true;
+      while( more || io_serv->run_one() ) {
+         while( io_serv->poll_one() ) {}
+         // execute the highest priority item
+         more = pri_queue.execute_highest();
+      }
 
-   shutdown(); /// perform synchronous shutdown
+      shutdown(); /// perform synchronous shutdown
+   }
    io_serv.reset();
 }
 


### PR DESCRIPTION
## Change Description

- `boost::asio::io_service::work`  "Destructor notifies the io_context that the work is complete."
  - Do not destroy the `io_service` before `~work()`

## Change Type
**Select ONE**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [x] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [ ] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the relase notes. Please include a description of the change for inclusion in the release notes.-->


## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
