### PR TITLE
remove unity build

### DIFF
--- a/.cicd/build.sh
+++ b/.cicd/build.sh
@@ -2,7 +2,7 @@
 set -eo pipefail
 . ./.cicd/helpers/general.sh
 mkdir -p $BUILD_DIR
-CMAKE_EXTRAS="$CMAKE_EXTRAS -DCMAKE_BUILD_TYPE='Release' -DENABLE_MULTIVERSION_PROTOCOL_TEST=true -DENABLE_UNITY_BUILD=ON -DAMQP_CONN_STR='amqp://guest:guest@localhost:5672'"
+CMAKE_EXTRAS="$CMAKE_EXTRAS -DCMAKE_BUILD_TYPE='Release' -DENABLE_MULTIVERSION_PROTOCOL_TEST=true -DAMQP_CONN_STR='amqp://guest:guest@localhost:5672'"
 if [[ "$(uname)" == 'Darwin' && $FORCE_LINUX != true ]]; then
     # You can't use chained commands in execute
     if [[ "$GITHUB_ACTIONS" == 'true' ]]; then

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,14 +186,7 @@ if (NOT DISABLE_WASM_SPEC_TESTS)
 add_subdirectory( eosio-wasm-spec-tests/generated-tests )
 endif()
 
-
-if (ENABLE_UNITY_BUILD)
-  set(CMAKE_EXPORT_COMPILE_COMMANDS "OFF")
-  set_target_properties(eosio_chain chainbase fc rodeos_lib state_history unit_test wasm_spec_test trace_api_plugin
-                        PROPERTIES UNITY_BUILD TRUE)
-else()
-  set(CMAKE_EXPORT_COMPILE_COMMANDS "ON")
-endif()
+set(CMAKE_EXPORT_COMPILE_COMMANDS "ON")
 
 install_directory_permissions(DIRECTORY ${CMAKE_INSTALL_FULL_SYSCONFDIR}/eosio)
 

--- a/libraries/fc/CMakeLists.txt
+++ b/libraries/fc/CMakeLists.txt
@@ -123,12 +123,6 @@ list(APPEND sources ${fc_headers})
 
 setup_library( fc SOURCES ${sources} LIBRARY_TYPE STATIC DONT_INSTALL_LIBRARY )
 
-if(ENABLE_UNITY_BUILD)
-   set_source_files_properties(src/io/json.cpp 
-                               PROPERTIES SKIP_UNITY_BUILD_INCLUSION TRUE)
-endif() 
-
-
 function(detect_thread_name)
   include(CheckSymbolExists)
   list(APPEND CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -44,11 +44,6 @@ add_executable( unit_test ${UNIT_TESTS} protocol_feature_digest_tests.cpp) # bui
 
 target_link_libraries( unit_test eosio_chain_wrap chainbase eosio_testing fc appbase state_history abieos amqp_compressed_proof_plugin ${PLATFORM_SPECIFIC_LIBS} )
 
-if(ENABLE_UNITY_BUILD)
-   set_source_files_properties(state_history_tests.cpp compressed_proof_validator.cpp
-                               PROPERTIES SKIP_UNITY_BUILD_INCLUSION TRUE)
-endif() 
-
 target_compile_options(unit_test PUBLIC -DDISABLE_EOSLIB_SERIALIZE)
 target_include_directories( unit_test PUBLIC
                             ${CMAKE_SOURCE_DIR}/libraries/testing/include


### PR DESCRIPTION
## Change Description

- Remove UNITY build. cherry-picked from https://github.com/EOSIO/eos/pull/9444

## Change Type
**Select ONE**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [ ] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [x] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the relase notes. Please include a description of the change for inclusion in the release notes.-->


## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
