### PR TITLE
Switch default backing_store from RocksDB to chainbase

### DIFF
--- a/libraries/chain/combined_database.cpp
+++ b/libraries/chain/combined_database.cpp
@@ -88,15 +88,17 @@ namespace eosio { namespace chain {
    static const std::vector<char> rocksdb_contract_kv_prefix{ 0x11 }; // for KV API
    static const std::vector<char> rocksdb_contract_db_prefix{ 0x12 }; // for DB API
 
-   combined_database::combined_database(backing_store_type backing_store_,
-                                        chainbase::database& chain_db,
+   combined_database::combined_database(chainbase::database& chain_db)
+       : backing_store(backing_store_type::CHAINBASE), db(chain_db) {}
+
+   combined_database::combined_database(chainbase::database& chain_db,
                                         const std::string& rocksdb_path,
                                         bool rocksdb_create_if_missing,
                                         uint32_t rocksdb_threads,
                                         int rocksdb_max_open_files)
-       : backing_store(backing_store_), db(chain_db),
-         kv_database(rocksdb_path.c_str(), rocksdb_create_if_missing, rocksdb_threads, rocksdb_max_open_files),
-         kv_undo_stack(kv_database, rocksdb_undo_prefix) {}
+       : backing_store(backing_store_type::ROCKSDB), db(chain_db),
+         kv_database(std::make_unique<b1::chain_kv::database>(rocksdb_path.c_str(), rocksdb_create_if_missing, rocksdb_threads, rocksdb_max_open_files)),
+         kv_undo_stack(std::make_unique<b1::chain_kv::undo_stack>(*kv_database, rocksdb_undo_prefix)) {}
 
    void combined_database::set_backing_store(backing_store_type backing_store) {
       if (backing_store == backing_store_type::ROCKSDB) {
@@ -116,48 +118,71 @@ namespace eosio { namespace chain {
    }
 
    void combined_database::set_revision(uint64_t revision) {
-      try {
+      switch (backing_store) {
+      case backing_store_type::CHAINBASE:
+         db.set_revision(revision);
+         break;
+      case backing_store_type::ROCKSDB:
          try {
-            db.set_revision(revision);
+            try {
+               db.set_revision(revision);
 #warning TODO: Chain_kv needs to fix kv_undo_stack's revision after restart
-            // kv_undo_stack.set_revision(revision, false);
+               // kv_undo_stack->set_revision(revision, false);
+            }
+            FC_LOG_AND_RETHROW()
          }
-         FC_LOG_AND_RETHROW()
+         CATCH_AND_EXIT_DB_FAILURE()
       }
-      CATCH_AND_EXIT_DB_FAILURE()
    }
 
    void combined_database::undo() {
-      try {
+      switch (backing_store) {
+      case backing_store_type::CHAINBASE:
+         db.undo();
+         break;
+      case backing_store_type::ROCKSDB:
          try {
-            db.undo();
-            kv_undo_stack.undo(false);
+            try {
+               db.undo();
+               kv_undo_stack->undo(false);
+            }
+            FC_LOG_AND_RETHROW()
          }
-         FC_LOG_AND_RETHROW()
+         CATCH_AND_EXIT_DB_FAILURE()
       }
-      CATCH_AND_EXIT_DB_FAILURE()
    }
 
    void combined_database::commit(int64_t revision) {
-      try {
+      switch (backing_store) {
+      case backing_store_type::CHAINBASE:
+         db.commit(revision);
+         break;
+      case backing_store_type::ROCKSDB:
          try {
-            db.commit(revision);
-            kv_undo_stack.commit(revision);
+            try {
+               db.commit(revision);
+               kv_undo_stack->commit(revision);
+            }
+            FC_LOG_AND_RETHROW()
          }
-         FC_LOG_AND_RETHROW()
+         CATCH_AND_EXIT_DB_FAILURE()
       }
-      CATCH_AND_EXIT_DB_FAILURE()
    }
 
    void combined_database::flush() {
-      try {
+      switch (backing_store) {
+      case backing_store_type::CHAINBASE:
+         break;
+      case backing_store_type::ROCKSDB:
          try {
-            kv_undo_stack.write_state();
-            kv_database.flush(true, true);
+            try {
+               kv_undo_stack->write_state();
+               kv_database->flush(true, true);
+            }
+            FC_LOG_AND_RETHROW()
          }
-         FC_LOG_AND_RETHROW()
+         CATCH_AND_EXIT_DB_FAILURE()
       }
-      CATCH_AND_EXIT_DB_FAILURE()
    }
 
    std::unique_ptr<kv_context> combined_database::create_kv_context(name receiver,
@@ -166,12 +191,11 @@ namespace eosio { namespace chain {
       switch (backing_store) {
          case backing_store_type::ROCKSDB:
             return create_kv_rocksdb_context<b1::chain_kv::view, b1::chain_kv::write_session, kv_resource_manager>(
-                  kv_database, kv_undo_stack, receiver, resource_manager, limits);
+                  *kv_database, *kv_undo_stack, receiver, resource_manager, limits);
          case backing_store_type::CHAINBASE:
             return create_kv_chainbase_context(db, receiver, resource_manager, limits);
-         default:
-            EOS_ASSERT(false, action_validate_exception, "Unknown backing store.");
       }
+      EOS_ASSERT(false, action_validate_exception, "Unknown backing store.");
    }
 
    void combined_database::add_to_snapshot(
@@ -210,7 +234,7 @@ namespace eosio { namespace chain {
                // This ordering depends on the fact the eosio.kvdisk is before eosio.kvram and only eosio.kvdisk can be
                // stored in rocksdb.
                if (db.get<kv_db_config_object>().backing_store == backing_store_type::ROCKSDB) {
-                  std::unique_ptr<rocksdb::Iterator> it{ kv_database.rdb->NewIterator(rocksdb::ReadOptions()) };
+                  std::unique_ptr<rocksdb::Iterator> it{ kv_database->rdb->NewIterator(rocksdb::ReadOptions()) };
                   std::vector<char>                  prefix = rocksdb_contract_kv_prefix;
                   it->Seek(b1::chain_kv::to_slice(rocksdb_contract_kv_prefix));
                   while (it->Valid()) {
@@ -375,7 +399,7 @@ namespace eosio { namespace chain {
                   }
                });
 #warning TODO: Split the batch to avoid storing it all in memory at once.
-               kv_database.write(batch);
+               kv_database->write(batch);
                return;
             }
          }

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -228,8 +228,10 @@ struct controller_impl {
     reversible_blocks( cfg.blog.log_dir/config::reversible_blocks_dir_name,
         cfg.read_only ? database::read_only : database::read_write,
         cfg.reversible_cache_size, false, cfg.db_map_mode, cfg.db_hugepage_paths ),
-    kv_db(cfg.backing_store, db, (cfg.state_dir / "chain-kv").string(), !cfg.read_only,
-          cfg.rocksdb_threads, cfg.rocksdb_max_open_files),
+    kv_db(cfg.backing_store == backing_store_type::CHAINBASE
+          ? combined_database(db)
+          : combined_database(db, (cfg.state_dir / "chain-kv").string(), !cfg.read_only,
+                              cfg.rocksdb_threads, cfg.rocksdb_max_open_files)),
     blog( cfg.blog ),
     fork_db( cfg.state_dir ),
     wasmif( cfg.wasm_runtime, cfg.eosvmoc_tierup, db, cfg.state_dir, cfg.eosvmoc_config ),
@@ -260,7 +262,6 @@ struct controller_impl {
       self.irreversible_block.connect([this](const block_state_ptr& bsp) {
          wasmif.current_lib(bsp->block_num);
       });
-
 
 #define SET_APP_HANDLER( receiver, contract, action) \
    set_apply_handler( account_name(#receiver), account_name(#contract), action_name(#action), \

--- a/libraries/chain/include/eosio/chain/combined_database.hpp
+++ b/libraries/chain/include/eosio/chain/combined_database.hpp
@@ -48,9 +48,7 @@ namespace eosio { namespace chain {
     public:
       combined_session() = default;
 
-      combined_session(chainbase::database& cb_database);
-
-      combined_session(chainbase::database& cb_database, b1::chain_kv::undo_stack& kv_undo_stack);
+      combined_session(chainbase::database& cb_database, b1::chain_kv::undo_stack* kv_undo_stack);
 
       combined_session(combined_session&& src) noexcept;
 
@@ -87,8 +85,7 @@ namespace eosio { namespace chain {
       static combined_session make_no_op_session() { return combined_session(); }
 
       combined_session make_session() {
-         return backing_store == backing_store_type::ROCKSDB ? combined_session(db, *kv_undo_stack)
-                                                             : combined_session(db);
+         return combined_session(db, kv_undo_stack.get());
       }
 
       void set_revision(uint64_t revision);

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -82,7 +82,7 @@ namespace eosio { namespace chain {
             uint16_t                 thread_pool_size           = chain::config::default_controller_thread_pool_size;
             uint16_t                 max_retained_block_files   = chain::config::default_max_retained_block_files;
             uint64_t                 blocks_log_stride          = chain::config::default_blocks_log_stride;
-            backing_store_type       backing_store              = backing_store_type::ROCKSDB;
+            backing_store_type       backing_store              = backing_store_type::CHAINBASE;
             uint16_t                 rocksdb_threads        =  chain::config::default_rocksdb_threads;
             int                      rocksdb_max_open_files =  chain::config::default_rocksdb_max_open_files;
             fc::microseconds         abi_serializer_max_time_us = fc::microseconds(chain::config::default_abi_serializer_max_time_us);

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -297,7 +297,7 @@ void chain_plugin::set_program_options(options_description& cli, options_descrip
           "Override default maximum ABI serialization time allowed in ms")
          ("chain-state-db-size-mb", bpo::value<uint64_t>()->default_value(config::default_state_size / (1024  * 1024)), "Maximum size (in MiB) of the chain state database")
          ("chain-state-db-guard-size-mb", bpo::value<uint64_t>()->default_value(config::default_state_guard_size / (1024  * 1024)), "Safely shut down node when free space remaining in the chain state database drops below this size (in MiB).")
-         ("backing-store", boost::program_options::value<eosio::chain::backing_store_type>()->default_value(eosio::chain::backing_store_type::ROCKSDB),
+         ("backing-store", boost::program_options::value<eosio::chain::backing_store_type>()->default_value(eosio::chain::backing_store_type::CHAINBASE),
           "The storage for state, CHAINBASE or ROCKSDB")
          ("rocksdb-threads", bpo::value<uint16_t>()->default_value(config::default_rocksdb_threads),
           "Number of rocksdb threads for flush and compaction")


### PR DESCRIPTION
## Change Description

Previously, the default backing store was set to ROCKSDB, which was a mistake. This PR switches the default backing store to CHAINBASE and fixes the fallout of this change.

## Change Type

- [ ] Documentation
- [x] Stability bug fix
- [ ] Other
- [ ] Other - special case

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
