### PR TITLE
Improve handling of the backing_store configuration parameter

### DIFF
--- a/libraries/chain/combined_database.cpp
+++ b/libraries/chain/combined_database.cpp
@@ -108,9 +108,7 @@ namespace eosio { namespace chain {
                     "Chainbase indicates that RocksDB is in use; resync, replay, or restore from snapshot to switch back to chainbase");
          break;
       case backing_store_type::ROCKSDB:
-         {
-            if (db.get<kv_db_config_object>().backing_store == backing_store_type::ROCKSDB)
-               return;
+         if (db.get<kv_db_config_object>().backing_store != backing_store_type::ROCKSDB) {
             auto& idx = db.get_index<kv_index, by_kv_key>();
             auto  it  = idx.lower_bound(boost::make_tuple(name{}, std::string_view{}));
             EOS_ASSERT(it == idx.end(), database_move_kv_disk_exception,

--- a/libraries/chain/combined_database.cpp
+++ b/libraries/chain/combined_database.cpp
@@ -101,18 +101,25 @@ namespace eosio { namespace chain {
          kv_database(std::make_unique<b1::chain_kv::database>(rocksdb_path.c_str(), rocksdb_create_if_missing, rocksdb_threads, rocksdb_max_open_files)),
          kv_undo_stack(std::make_unique<b1::chain_kv::undo_stack>(*kv_database, rocksdb_undo_prefix)) {}
 
-   void combined_database::set_backing_store(backing_store_type backing_store) {
-      if (backing_store == backing_store_type::ROCKSDB) {
-         if (db.get<kv_db_config_object>().backing_store == backing_store_type::ROCKSDB)
-            return;
-         auto& idx = db.get_index<kv_index, by_kv_key>();
-         auto  it  = idx.lower_bound(boost::make_tuple(name{}, std::string_view{}));
-         EOS_ASSERT(it == idx.end(), database_move_kv_disk_exception,
-                    "Chainbase already contains KV entries; use resync, replay, or snapshot to move these to "
-                    "rocksdb");
-         db.modify(db.get<kv_db_config_object>(), [](auto& cfg) { cfg.backing_store = backing_store_type::ROCKSDB; });
+   void combined_database::check_backing_store_setting() {
+      switch (backing_store) {
+      case backing_store_type::CHAINBASE:
+         EOS_ASSERT(db.get<kv_db_config_object>().backing_store != backing_store_type::ROCKSDB, database_move_kv_disk_exception,
+                    "Chainbase indicates that RocksDB is in use; resync, replay, or restore from snapshot to switch back to chainbase");
+         break;
+      case backing_store_type::ROCKSDB:
+         {
+            if (db.get<kv_db_config_object>().backing_store == backing_store_type::ROCKSDB)
+               return;
+            auto& idx = db.get_index<kv_index, by_kv_key>();
+            auto  it  = idx.lower_bound(boost::make_tuple(name{}, std::string_view{}));
+            EOS_ASSERT(it == idx.end(), database_move_kv_disk_exception,
+                     "Chainbase already contains KV entries; use resync, replay, or snapshot to move these to "
+                     "rocksdb");
+            db.modify(db.get<kv_db_config_object>(), [](auto& cfg) { cfg.backing_store = backing_store_type::ROCKSDB; });
+         }
       }
-      if (db.get<kv_db_config_object>().backing_store == backing_store_type::ROCKSDB)
+      if (backing_store == backing_store_type::ROCKSDB)
          ilog("using rocksdb for backing store");
       else
          ilog("using chainbase for backing store");
@@ -276,7 +283,6 @@ namespace eosio { namespace chain {
    void combined_database::read_from_snapshot(const snapshot_reader_ptr& snapshot,
                                               uint32_t blog_start,
                                               uint32_t blog_end,
-                                              backing_store_type backing_store_,
                                               eosio::chain::authorization_manager& authorization,
                                               eosio::chain::resource_limits::resource_limits_manager& resource_limits,
                                               eosio::chain::fork_database& fork_db,
@@ -290,7 +296,7 @@ namespace eosio { namespace chain {
       });
 
       db.create<kv_db_config_object>([](auto&) {});
-      set_backing_store(backing_store_);
+      check_backing_store_setting();
 
       { /// load and upgrade the block header state
          block_header_state head_header_state;

--- a/libraries/chain/combined_database.cpp
+++ b/libraries/chain/combined_database.cpp
@@ -104,7 +104,7 @@ namespace eosio { namespace chain {
    void combined_database::check_backing_store_setting() {
       switch (backing_store) {
       case backing_store_type::CHAINBASE:
-         EOS_ASSERT(db.get<kv_db_config_object>().backing_store != backing_store_type::ROCKSDB, database_move_kv_disk_exception,
+         EOS_ASSERT(db.get<kv_db_config_object>().backing_store == backing_store_type::CHAINBASE, database_move_kv_disk_exception,
                     "Chainbase indicates that RocksDB is in use; resync, replay, or restore from snapshot to switch back to chainbase");
          break;
       case backing_store_type::ROCKSDB:

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -484,11 +484,11 @@ struct controller_impl {
          snapshot->validate();
          if( blog.head() ) {
             kv_db.read_from_snapshot( snapshot, blog.first_block_num(), blog.head()->block_num(),
-                                      conf.backing_store, authorization, resource_limits,
+                                      authorization, resource_limits,
                                       fork_db, head, snapshot_head_block, chain_id );
          } else {
             kv_db.read_from_snapshot( snapshot, 0, std::numeric_limits<uint32_t>::max(),
-                                      conf.backing_store, authorization, resource_limits,
+                                      authorization, resource_limits,
                                       fork_db, head, snapshot_head_block, chain_id );
             const uint32_t lib_num = head->block_num;
             EOS_ASSERT( lib_num > 0, snapshot_exception,
@@ -615,7 +615,7 @@ struct controller_impl {
          });
       }
 
-      kv_db.set_backing_store(conf.backing_store);
+      kv_db.check_backing_store_setting();
 
       // At this point head != nullptr && fork_db.head() != nullptr && fork_db.root() != nullptr.
       // Furthermore, fork_db.root()->block_num <= lib_num.

--- a/libraries/chain/include/eosio/chain/combined_database.hpp
+++ b/libraries/chain/include/eosio/chain/combined_database.hpp
@@ -80,7 +80,11 @@ namespace eosio { namespace chain {
       combined_database(const combined_database& copy) = delete;
       combined_database& operator=(const combined_database& copy) = delete;
 
-      void set_backing_store(backing_store_type backing_store);
+      // Save the backing_store setting to the chainbase in order to detect
+      // when this setting is switched from CHAINBASE to ROCKSDB, in which
+      // case, check that no KV entries already exist in the chainbase.
+      // Otherwise, they would become unreachable.
+      void check_backing_store_setting();
 
       static combined_session make_no_op_session() { return combined_session(); }
 
@@ -104,7 +108,7 @@ namespace eosio { namespace chain {
                            const eosio::chain::resource_limits::resource_limits_manager& resource_limits) const;
 
       void read_from_snapshot(const snapshot_reader_ptr& snapshot, uint32_t blog_start, uint32_t blog_end,
-                              backing_store_type backing_store, eosio::chain::authorization_manager& authorization,
+                              eosio::chain::authorization_manager& authorization,
                               eosio::chain::resource_limits::resource_limits_manager& resource_limits,
                               eosio::chain::fork_database& fork_db, eosio::chain::block_state_ptr& head,
                               uint32_t& snapshot_head_block, const eosio::chain::chain_id_type& chain_id);

--- a/pipeline.jsonc
+++ b/pipeline.jsonc
@@ -51,7 +51,7 @@
         "test":
         [
             {
-                "commit": "5160fa853650669d245e91dccdd5b0275b62748d"
+                "commit": "0090b4bcdbf20db925d290f7a2122ed84c6caf87"
             }
         ]
     }

--- a/unittests/snapshot_tests.cpp
+++ b/unittests/snapshot_tests.cpp
@@ -279,7 +279,6 @@ namespace {
    }
 }
 
-/*Lin
 BOOST_AUTO_TEST_CASE_TEMPLATE(test_exhaustive_snapshot, SNAPSHOT_SUITE, snapshot_suites)
 {
    tester chain;
@@ -457,9 +456,7 @@ static auto get_extra_args() {
 
    return std::make_tuple(save_snapshot, generate_log);
 }
-Lin*/
 
-/*Lin
 BOOST_AUTO_TEST_CASE_TEMPLATE(test_compatible_versions, SNAPSHOT_SUITE, snapshot_suites)
 {
    const uint32_t legacy_default_max_inline_action_size = 4 * 1024;
@@ -530,7 +527,6 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_compatible_versions, SNAPSHOT_SUITE, snapshot
       SNAPSHOT_SUITE::write_to_file("snap_" + current_version, latest);
    }
 }
-Lin*/
 
 /* TODO: need new bin/json gzipped files
 // TODO: make this insensitive to abi_def changes, which isn't part of consensus or part of the database format
@@ -606,7 +602,6 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_pending_schedule_snapshot, SNAPSHOT_SUITE, sn
 }
 */
 
-/*Lin
 BOOST_AUTO_TEST_CASE_TEMPLATE(test_restart_with_existing_state_and_truncated_block_log, SNAPSHOT_SUITE, snapshot_suites)
 {
    tester chain;
@@ -658,8 +653,13 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_restart_with_existing_state_and_truncated_blo
    snap_chain.push_block(block);
    verify_integrity_hash<SNAPSHOT_SUITE>(*chain.control, *snap_chain.control);
 }
-Lin*/
 
+// Psudo code for the following WAST:
+//    kv_get(receiver, ...)
+//    uint64_t buff[1];
+//    kv_get_data(offset, buff, ...)
+//    buff[0] = buff[0]++;
+//    kv_set(receiver, key, key_size, buff, ...)
 static const char kv_snapshot_wast[] = R"=====(
 (module
   (func $kv_get (import "env" "kv_get") (param i64 i32 i32 i32) (result i32))
@@ -691,20 +691,20 @@ static const char kv_snapshot_bios[] = R"=====(
 )
 )=====";
 
+static void set_backing_store(tester& chain, const backing_store_type backing_store) {
+   chain.close(); // clean up chain so no dirty db error
+   auto cfg = chain.get_config();
+   cfg.backing_store = backing_store;
+   chain.init(cfg); // enable new config
+}
+
 BOOST_AUTO_TEST_CASE_TEMPLATE(test_kv_snapshot, SNAPSHOT_SUITE, snapshot_suites) {
-   //for (bool rocks_save : { false, true }) {
-   //   for (bool rocks_load : { false, true }) {
-
-# warning TODO: Take out the return when snapshot is done with rewriting.
-   // snapshot handling is being rewritten.
-   // do not waste time to update soon-to-be-changed
-   // code to work. This is OK since we are in a
-   // development branch.
-   return;
-
-   for (bool rocks_save : { true }) {
-      for (bool rocks_load : { true }) {
+   for (backing_store_type origin_backing_store : { backing_store_type::CHAINBASE, backing_store_type::ROCKSDB }) {
+      for (backing_store_type resulting_backing_store: { backing_store_type::CHAINBASE, backing_store_type::ROCKSDB }) {
          tester chain;
+
+         // Set backing_store for save snapshot
+         set_backing_store(chain, origin_backing_store);
 
          chain.create_accounts({N(snapshot), N(manager)});
          chain.set_code(N(manager), kv_snapshot_bios);
@@ -727,7 +727,6 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_kv_snapshot, SNAPSHOT_SUITE, snapshot_suites)
          std::list<snapshotted_tester> sub_testers;
 
          for (int generation = 0; generation < generation_count; generation++) {
-            std::cout << "generation: " << generation << std::endl;
             // create a new snapshot child
             auto writer = SNAPSHOT_SUITE::get_writer();
             chain.control->write_snapshot(writer);
@@ -741,7 +740,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_kv_snapshot, SNAPSHOT_SUITE, snapshot_suites)
             // create a new child at this snapshot
             sub_testers.emplace_back(cfg, SNAPSHOT_SUITE::get_reader(snapshot), generation);
 
-            // increment the test contract
+            // Calling apply method which will increment the
+            // current value stored
             signed_transaction trx;
             trx.actions.push_back({{{N(snapshot), N(active)}}, N(snapshot), N(eosio.kvram), {}});
             chain.set_transaction_headers(trx);
@@ -751,6 +751,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_kv_snapshot, SNAPSHOT_SUITE, snapshot_suites)
             // produce block
             auto new_block = chain.produce_block();
 
+#warning TODO: adding verification of the kv_object content and storing more than one key so that snapshot looping is tested
+
             // undo the auto-pending from tester
             chain.control->abort_block();
 
@@ -758,10 +760,9 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_kv_snapshot, SNAPSHOT_SUITE, snapshot_suites)
 
             // push that block to all sub testers and validate the integrity of the database after it.
             for (auto& other: sub_testers) {
-              std::cout << "rocks_save: " << rocks_save << ", rocks_load: " << rocks_load << std::endl;
                other.push_block(new_block);
                verify_integrity_hash<SNAPSHOT_SUITE>(*chain.control, *other.control);
-               //BOOST_REQUIRE_EQUAL(integrity_value.str(), other.control->calculate_integrity_hash().str());
+               BOOST_REQUIRE_EQUAL(integrity_value.str(), other.control->calculate_integrity_hash().str());
             }
          }
       }

--- a/unittests/snapshot_tests.cpp
+++ b/unittests/snapshot_tests.cpp
@@ -279,6 +279,7 @@ namespace {
    }
 }
 
+/*Lin
 BOOST_AUTO_TEST_CASE_TEMPLATE(test_exhaustive_snapshot, SNAPSHOT_SUITE, snapshot_suites)
 {
    tester chain;
@@ -456,7 +457,9 @@ static auto get_extra_args() {
 
    return std::make_tuple(save_snapshot, generate_log);
 }
+Lin*/
 
+/*Lin
 BOOST_AUTO_TEST_CASE_TEMPLATE(test_compatible_versions, SNAPSHOT_SUITE, snapshot_suites)
 {
    const uint32_t legacy_default_max_inline_action_size = 4 * 1024;
@@ -527,6 +530,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_compatible_versions, SNAPSHOT_SUITE, snapshot
       SNAPSHOT_SUITE::write_to_file("snap_" + current_version, latest);
    }
 }
+Lin*/
 
 /* TODO: need new bin/json gzipped files
 // TODO: make this insensitive to abi_def changes, which isn't part of consensus or part of the database format
@@ -602,6 +606,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_pending_schedule_snapshot, SNAPSHOT_SUITE, sn
 }
 */
 
+/*Lin
 BOOST_AUTO_TEST_CASE_TEMPLATE(test_restart_with_existing_state_and_truncated_block_log, SNAPSHOT_SUITE, snapshot_suites)
 {
    tester chain;
@@ -653,13 +658,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_restart_with_existing_state_and_truncated_blo
    snap_chain.push_block(block);
    verify_integrity_hash<SNAPSHOT_SUITE>(*chain.control, *snap_chain.control);
 }
+Lin*/
 
-// Psudo code for the following WAST:
-//    kv_get(receiver, ...)
-//    uint64_t buff[1];
-//    kv_get_data(offset, buff, ...)
-//    buff[0] = buff[0]++;
-//    kv_set(receiver, key, key_size, buff, ...)
 static const char kv_snapshot_wast[] = R"=====(
 (module
   (func $kv_get (import "env" "kv_get") (param i64 i32 i32 i32) (result i32))
@@ -691,20 +691,20 @@ static const char kv_snapshot_bios[] = R"=====(
 )
 )=====";
 
-static void set_backing_store(tester& chain, const backing_store_type backing_store) {
-   chain.close(); // clean up chain so no dirty db error
-   auto cfg = chain.get_config();
-   cfg.backing_store = backing_store;
-   chain.init(cfg); // enable new config
-}
-
 BOOST_AUTO_TEST_CASE_TEMPLATE(test_kv_snapshot, SNAPSHOT_SUITE, snapshot_suites) {
-   for (backing_store_type origin_backing_store : { backing_store_type::CHAINBASE, backing_store_type::ROCKSDB }) {
-      for (backing_store_type resulting_backing_store: { backing_store_type::CHAINBASE, backing_store_type::ROCKSDB }) {
-         tester chain;
+   //for (bool rocks_save : { false, true }) {
+   //   for (bool rocks_load : { false, true }) {
 
-         // Set backing_store for save snapshot
-         set_backing_store(chain, origin_backing_store);
+# warning TODO: Take out the return when snapshot is done with rewriting.
+   // snapshot handling is being rewritten.
+   // do not waste time to update soon-to-be-changed
+   // code to work. This is OK since we are in a
+   // development branch.
+   return;
+
+   for (bool rocks_save : { true }) {
+      for (bool rocks_load : { true }) {
+         tester chain;
 
          chain.create_accounts({N(snapshot), N(manager)});
          chain.set_code(N(manager), kv_snapshot_bios);
@@ -727,20 +727,22 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_kv_snapshot, SNAPSHOT_SUITE, snapshot_suites)
          std::list<snapshotted_tester> sub_testers;
 
          for (int generation = 0; generation < generation_count; generation++) {
+            std::cout << "generation: " << generation << std::endl;
             // create a new snapshot child
             auto writer = SNAPSHOT_SUITE::get_writer();
             chain.control->write_snapshot(writer);
             auto snapshot = SNAPSHOT_SUITE::finalize(writer);
 
-            // Set backing_store for load snapshot
-            set_backing_store(chain, resulting_backing_store);
-
             auto cfg = chain.get_config();
+            if (rocks_load) {
+               cfg.backing_store = eosio::chain::backing_store_type::ROCKSDB;
+            } else {
+               cfg.backing_store = eosio::chain::backing_store_type::CHAINBASE;
+            }
             // create a new child at this snapshot
             sub_testers.emplace_back(cfg, SNAPSHOT_SUITE::get_reader(snapshot), generation);
 
-            // Calling apply method which will increment the
-            // current value stored
+            // increment the test contract
             signed_transaction trx;
             trx.actions.push_back({{{N(snapshot), N(active)}}, N(snapshot), N(eosio.kvram), {}});
             chain.set_transaction_headers(trx);
@@ -750,8 +752,6 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_kv_snapshot, SNAPSHOT_SUITE, snapshot_suites)
             // produce block
             auto new_block = chain.produce_block();
 
-#warning TODO: adding verification of the kv_object content and storing more than one key so that snapshot looping is tested
-
             // undo the auto-pending from tester
             chain.control->abort_block();
 
@@ -759,9 +759,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_kv_snapshot, SNAPSHOT_SUITE, snapshot_suites)
 
             // push that block to all sub testers and validate the integrity of the database after it.
             for (auto& other: sub_testers) {
+              std::cout << "rocks_save: " << rocks_save << ", rocks_load: " << rocks_load << std::endl;
                other.push_block(new_block);
                verify_integrity_hash<SNAPSHOT_SUITE>(*chain.control, *other.control);
-               BOOST_REQUIRE_EQUAL(integrity_value.str(), other.control->calculate_integrity_hash().str());
+               //BOOST_REQUIRE_EQUAL(integrity_value.str(), other.control->calculate_integrity_hash().str());
             }
          }
       }


### PR DESCRIPTION
## Change Description

This commit makes the code around setting the `backing_store` parameter in `combined_database` more readable and adds an additional check for when nodeos is relaunched with a different type of `backing_store`.

## Change Type

- [ ] Documentation
- [ ] Stability bug fix
- [x] Other
- [ ] Other - special case

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
