### PR TITLE
fix centOS 8 test failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,10 +2,11 @@
   "name": "eosio",
   "version": "1.0.0",
   "dependencies": {
-    "eosjs": "20.0.0",
+    "eosjs": "^20.0.0",
     "ws": "7.2.0",
     "commander": "4.0.1",
     "zlib": "1.0.5",
-    "node-fetch": "2.6.0"
+    "node-fetch": "2.6.0",
+    "util": "^0.12.3"
   }
 }

--- a/scripts/eosio_build_centos.sh
+++ b/scripts/eosio_build_centos.sh
@@ -38,6 +38,7 @@ if [[ "$(echo ${VERSION} | sed 's/ .*//g')" == 8 ]]; then
         install-package https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
         group-install-package 'Development Tools'
         install-package openssl-devel
+        install-package which
 	install-package git 
 	install-package autoconf
 	install-package automake
@@ -52,6 +53,8 @@ if [[ "$(echo ${VERSION} | sed 's/ .*//g')" == 8 ]]; then
 	install-package libusbx-devel
     	install-package libcurl-devel
 	install-package patch
+        install-package vim-common
+        install-package jq
     	install-package python3
 	install-package python3-devel
 	install-package clang
@@ -59,9 +62,27 @@ if [[ "$(echo ${VERSION} | sed 's/ .*//g')" == 8 ]]; then
 	install-package llvm-static
 	install-package procps-ng
 	install-package util-linux
+        install-package sudo
 	install-package libstdc++
+        install-package dnf-plugins-core
+        sudo dnf config-manager --set-enabled PowerTools
+        install-package doxygen
+        install-package ocaml
 	install-package ncurses-compat-libs
-	ln -s /usr/lib64/libtinfo.so.6 /usr/local/lib/libtinfo.so
+        install-package nodejs
+        install-package epel-release
+
+        curl --silent --location https://dl.yarnpkg.com/rpm/yarn.repo | sudo tee /etc/yum.repos.d/yarn.repo
+        sudo rpm --import https://dl.yarnpkg.com/rpm/pubkey.gpg
+        install-package yarn
+
+        pushd ${REPO_ROOT}
+        yarn install
+        popd
+
+        if [ ! -L "/usr/local/lib/libtinfo.so" ] ; then
+	    ln -s /usr/lib64/libtinfo.so.6 /usr/local/lib/libtinfo.so
+        fi
 fi
 
 # Handle clang/compiler


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->
## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
When building with scripts/eosio_build.sh in centos 8, a few test failed since some packages were missing. This change adds the dependencies. Now all tests pass in centos 8.

## Change Type
**Select ONE**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [ ] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [ ] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [x] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the relase notes. Please include a description of the change for inclusion in the release notes.-->



## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
