### PR TITLE
Invalidate iterators on session.

### DIFF
--- a/libraries/chain_kv/include/b1/session/rocks_session.hpp
+++ b/libraries/chain_kv/include/b1/session/rocks_session.hpp
@@ -27,6 +27,8 @@ class session<rocksdb_t> {
    template <typename Iterator_traits>
    class rocks_iterator {
     public:
+      friend session<rocksdb_t>;
+
       using difference_type   = typename Iterator_traits::difference_type;
       using value_type        = typename Iterator_traits::value_type;
       using pointer           = typename Iterator_traits::pointer;
@@ -119,6 +121,9 @@ class session<rocksdb_t> {
    const_iterator lower_bound(const shared_bytes& key) const;
    iterator       upper_bound(const shared_bytes& key);
    const_iterator upper_bound(const shared_bytes& key) const;
+
+   iterator& begin(iterator& it) const;
+   iterator& end(iterator& it) const;
 
    void undo();
    void commit();
@@ -347,6 +352,29 @@ inline typename session<rocksdb_t>::const_iterator session<rocksdb_t>::find(cons
       }
    };
    return make_iterator_(predicate);
+}
+
+inline typename session<rocksdb_t>::iterator& session<rocksdb_t>::begin(iterator& it) const {
+   if (!it.m_iterator) {
+      return it;
+   }
+
+   it.m_iterator->Refresh();
+   it.m_iterator->SeekToFirst();
+   return it;
+}
+
+inline typename session<rocksdb_t>::iterator& session<rocksdb_t>::end(iterator& it) const {
+   if (!it.m_iterator) {
+      return it;
+   }
+
+   it.m_iterator->Refresh();
+   it.m_iterator->SeekToLast();
+   if (it.m_iterator->Valid()) {
+      it.m_iterator->Next();
+   }
+   return it;
 }
 
 inline typename session<rocksdb_t>::iterator session<rocksdb_t>::begin() {

--- a/libraries/chain_kv/include/b1/session/session.hpp
+++ b/libraries/chain_kv/include/b1/session/session.hpp
@@ -309,10 +309,9 @@ void session<Parent>::undo() {
 
 template <typename Parent>
 typename session<Parent>::iterator& session<Parent>::begin_(session<Parent>& s, typename session<Parent>::iterator& it) const {
-   auto it_cache = std::begin(s.m_iterator_cache);
    it = session<Parent>::iterator{};
    it.m_iterator_version = it_cache->second.version;
-   it.m_active_iterator = it_cache;
+   it.m_active_iterator = std::begin(s.m_iterator_cache);
    it.m_active_session = &s;
    return it;
 }
@@ -330,10 +329,9 @@ typename Parent::iterator& session<Parent>::begin_(Parent& p, typename Parent::i
 
 template <typename Parent>
 typename session<Parent>::iterator& session<Parent>::end_(session<Parent>& s, typename session<Parent>::iterator& it) const {
-   auto it_cache = std::end(s.m_iterator_cache);
    it = session<Parent>::iterator{};
    it.m_iterator_version = it_cache->second.version;
-   it.m_active_iterator = it_cache;
+   it.m_active_iterator = std::end(s.m_iterator_cache);
    it.m_active_session = &s;
    return it;
 }

--- a/libraries/chain_kv/include/b1/session/session.hpp
+++ b/libraries/chain_kv/include/b1/session/session.hpp
@@ -309,9 +309,10 @@ void session<Parent>::undo() {
 
 template <typename Parent>
 typename session<Parent>::iterator& session<Parent>::begin_(session<Parent>& s, typename session<Parent>::iterator& it) const {
+   auto it_cache = std::begin(s.m_iterator_cache);
    it = session<Parent>::iterator{};
    it.m_iterator_version = it_cache->second.version;
-   it.m_active_iterator = std::begin(s.m_iterator_cache);
+   it.m_active_iterator = std::move(it_cache);
    it.m_active_session = &s;
    return it;
 }
@@ -329,9 +330,10 @@ typename Parent::iterator& session<Parent>::begin_(Parent& p, typename Parent::i
 
 template <typename Parent>
 typename session<Parent>::iterator& session<Parent>::end_(session<Parent>& s, typename session<Parent>::iterator& it) const {
+   auto it_cache = std::end(s.m_iterator_cache);
    it = session<Parent>::iterator{};
    it.m_iterator_version = it_cache->second.version;
-   it.m_active_iterator = std::end(s.m_iterator_cache);
+   it.m_active_iterator = std::move(it_cache);
    it.m_active_session = &s;
    return it;
 }

--- a/libraries/chain_kv/include/b1/session/session.hpp
+++ b/libraries/chain_kv/include/b1/session/session.hpp
@@ -332,7 +332,6 @@ template <typename Parent>
 typename session<Parent>::iterator& session<Parent>::end_(session<Parent>& s, typename session<Parent>::iterator& it) const {
    auto it_cache = std::end(s.m_iterator_cache);
    it = session<Parent>::iterator{};
-   it.m_iterator_version = it_cache->second.version;
    it.m_active_iterator = std::move(it_cache);
    it.m_active_session = &s;
    return it;

--- a/libraries/chain_kv/include/b1/session/shared_bytes.hpp
+++ b/libraries/chain_kv/include/b1/session/shared_bytes.hpp
@@ -175,8 +175,8 @@ inline shared_bytes::iterator shared_bytes::begin() const { return m_data.get();
 inline shared_bytes::iterator shared_bytes::end() const { return m_data.get() + size(); }
 
 inline std::ostream& operator<<(std::ostream& os, const shared_bytes& bytes) {
-    std::cout << fc::base64_encode({bytes.data(), bytes.size()});
-    return os;
+   std::cout << fc::base64_encode({ bytes.data(), bytes.size() });
+   return os;
 }
 
 } // namespace eosio::session

--- a/libraries/chain_kv/include/b1/session/undo_stack.hpp
+++ b/libraries/chain_kv/include/b1/session/undo_stack.hpp
@@ -97,15 +97,9 @@ void undo_stack<Session>::commit(int64_t revision) {
       return;
    }
 
-   auto  start_index       = revision - initial_revision;
-   auto& session_to_commit = m_sessions[start_index++];
+   auto  start_index = revision - initial_revision + 1;
 
-   session_to_commit.detach();
-   session_to_commit.attach(*m_head);
-   session_to_commit.commit();
-   session_to_commit.detach();
-
-   for (int64_t i = 0; i < start_index; ++i) { m_sessions[i].detach(); }
+   for (int64_t i = start_index; i >= 0; --i) { m_sessions[i].commit(); }
    m_sessions.erase(std::begin(m_sessions), std::begin(m_sessions) + start_index);
    if (!m_sessions.empty()) {
       m_sessions.front().attach(*m_head);

--- a/libraries/chain_kv/include/b1/session/undo_stack.hpp
+++ b/libraries/chain_kv/include/b1/session/undo_stack.hpp
@@ -49,9 +49,7 @@ undo_stack<Session>::undo_stack(Session& head) : m_head{ &head } {}
 
 template <typename Session>
 undo_stack<Session>::~undo_stack() {
-  for (auto& session : m_sessions) {
-    session.undo();
-  }
+   for (auto& session : m_sessions) { session.undo(); }
 }
 
 template <typename Session>
@@ -97,7 +95,7 @@ void undo_stack<Session>::commit(int64_t revision) {
       return;
    }
 
-   auto  start_index = revision - initial_revision + 1;
+   auto start_index = revision - initial_revision + 1;
 
    for (int64_t i = start_index; i >= 0; --i) { m_sessions[i].commit(); }
    m_sessions.erase(std::begin(m_sessions), std::begin(m_sessions) + start_index);

--- a/libraries/chain_kv/unit_tests/session_undo_stack_tests.cpp
+++ b/libraries/chain_kv/unit_tests/session_undo_stack_tests.cpp
@@ -82,10 +82,10 @@ BOOST_AUTO_TEST_CASE(undo_stack_test) {
                 collapse({ session_kvs_1, session_kvs_2, session_kvs_3, session_kvs_4, session_kvs_5, session_kvs_6 }),
                 int_t{});
 
-   // Commit revision 13 and verify that the top session has the correct key values.
+   // Commit revision 3 and verify that the top session has the correct key values.
    undo.commit(3);
    BOOST_REQUIRE(undo.revision() == 4);
-   verify_equal(undo.top(), collapse({ session_kvs_1, session_kvs_5, session_kvs_6 }), int_t{});
+   verify_equal(undo.top(), collapse({ session_kvs_1, session_kvs_2, session_kvs_3, session_kvs_4, session_kvs_5, session_kvs_6 }), int_t{});
 }
 
 BOOST_AUTO_TEST_SUITE_END();

--- a/unittests/kv_tests.cpp
+++ b/unittests/kv_tests.cpp
@@ -415,12 +415,6 @@ class kv_tester : public tester {
 
    void test_iterase() {
       for(bool reinsert : {false, true}) {
-         if (reinsert && get_config().backing_store == eosio::chain::backing_store_type::ROCKSDB) {
-           // With the session api, erasing a key doesn't invalidate the iterator
-           // AND reinserting that key after erasing it, also doesn't invalidate the iterator.
-           // The Session iterator will still be pointing to the correct thing.
-           continue;
-         }
          // pre-inserted
          for(bool insert : {false, true}) {
             for(int i = 0; i < 8; ++i) {


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->
## Change Description
This includes a few fixes:
1.  After requesting an iterator from the Session type and the key that the iterator refers to is deleted and then written to the Session again during the scope of the iterator, that iterator should be invalidated.
2.  There was a bug in priming the iterator cache, in that we only need to ask the parent for its bounds and go no further up the hierarchy.
3.  When committing a revision through the undo_stack type, all revisions prior to that revision should be committed as well.
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->


## Change Type
**Select ONE**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [x] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [ ] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the relase notes. Please include a description of the change for inclusion in the release notes.-->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
