### PR TITLE
Re-enable test_kv_ram_usage and test_kv_resource_limit

### DIFF
--- a/unittests/kv_tests.cpp
+++ b/unittests/kv_tests.cpp
@@ -734,7 +734,6 @@ BOOST_FIXTURE_TEST_CASE(kv_iterase, kv_tester) try { //
 }
 FC_LOG_AND_RETHROW()
 
-  /*
 BOOST_FIXTURE_TEST_CASE(kv_ram_usage, kv_tester) try { //
    test_kv_ram_usage_common();
 }
@@ -744,7 +743,6 @@ BOOST_FIXTURE_TEST_CASE(kv_resource_limit, kv_tester) try { //
    test_kv_resource_limit_common();
 }
 FC_LOG_AND_RETHROW()
-*/
 
 BOOST_FIXTURE_TEST_CASE(kv_key_value_limit, kv_tester) try { //
    test_kv_key_value_limit_common();
@@ -810,7 +808,6 @@ BOOST_FIXTURE_TEST_CASE(kv_iterase_rocksdb, kv_rocksdb_tester) try { //
 }
 FC_LOG_AND_RETHROW()
 
-  /*
 BOOST_FIXTURE_TEST_CASE(kv_ram_usage_rocksdb, kv_rocksdb_tester) try { //
    test_kv_ram_usage_common();
 }
@@ -820,7 +817,6 @@ BOOST_FIXTURE_TEST_CASE(kv_resource_limit_rocksdb, kv_rocksdb_tester) try { //
    test_kv_resource_limit_common();
 }
 FC_LOG_AND_RETHROW()
-*/
 
 BOOST_FIXTURE_TEST_CASE(kv_key_value_limit_rocksdb, kv_rocksdb_tester) try { //
    test_kv_key_value_limit_common();


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->
## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
test_kv_ram_usage and test_kv_resource_limit were disabled while database id "disk" was being removed.
I have verified that both tests pass now. Re-enable them.

## Change Type
**Select ONE**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [ ] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [X] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the relase notes. Please include a description of the change for inclusion in the release notes.-->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
