### PR TITLE
Configurable ack-mode for amqp_trx_plugin

### DIFF
--- a/libraries/amqp/include/eosio/amqp/amqp_handler.hpp
+++ b/libraries/amqp/include/eosio/amqp/amqp_handler.hpp
@@ -70,11 +70,12 @@ public:
    }
 
    /// ack consume message
-   void ack( const delivery_tag_t& delivery_tag ) {
+   /// @param multiple true if given delivery_tag and all previous should be ack'ed
+   void ack( const delivery_tag_t& delivery_tag, bool multiple = false ) {
       boost::asio::post( *handler_->amqp_strand(),
-            [my = this, delivery_tag]() {
+            [my = this, delivery_tag, multiple]() {
                try {
-                  my->channel_->ack( delivery_tag );
+                  my->channel_->ack( delivery_tag, multiple ? AMQP::multiple : 0 );
                } FC_LOG_AND_DROP()
             } );
    }

--- a/plugins/amqp_trx_plugin/amqp_trx_plugin.cpp
+++ b/plugins/amqp_trx_plugin/amqp_trx_plugin.cpp
@@ -109,7 +109,7 @@ struct amqp_trx_plugin_impl : std::enable_shared_from_this<amqp_trx_plugin_impl>
       if( acked == ack_mode::in_block ) {
          const auto& entry = tracked_delivery_tags.find( bsp->block_num );
          if( entry != tracked_delivery_tags.end() ) {
-            amqp_trx->ack( entry->second );
+            amqp_trx->ack( entry->second, true );
             tracked_delivery_tags.erase( entry );
          }
       }

--- a/plugins/amqp_trx_plugin/amqp_trx_plugin.cpp
+++ b/plugins/amqp_trx_plugin/amqp_trx_plugin.cpp
@@ -171,7 +171,9 @@ private:
 };
 
 amqp_trx_plugin::amqp_trx_plugin()
-: my(std::make_shared<amqp_trx_plugin_impl>()) {}
+: my(std::make_shared<amqp_trx_plugin_impl>()) {
+   app().register_config_type<ack_mode>();
+}
 
 amqp_trx_plugin::~amqp_trx_plugin() {}
 

--- a/plugins/amqp_trx_plugin/amqp_trx_plugin.cpp
+++ b/plugins/amqp_trx_plugin/amqp_trx_plugin.cpp
@@ -184,8 +184,9 @@ void amqp_trx_plugin::set_program_options(options_description& cli, options_desc
       "The maximum number of transactions to pull from the AMQP queue at any given time.");
    op("amqp-trx-speculative-execution", bpo::bool_switch()->default_value(false),
       "Allow non-ordered speculative execution of transactions");
-   op("amqp-trx-ack-mode", bpo::value<ack_mode>()->default_value(ack_mode::executed),
-      "When AMQP is ack. When received from AMQP, when executed, or when block is produced that contains trx.");
+   op("amqp-trx-ack-mode", bpo::value<ack_mode>()->default_value(ack_mode::in_block),
+      "AMQP ack when 'received' from AMQP, when 'executed', or when 'in_block' is produced that contains trx.\n"
+      "Options: received, executed, in_block");
 }
 
 void amqp_trx_plugin::plugin_initialize(const variables_map& options) {


### PR DESCRIPTION
## Change Description

- Add new option to `amqp_trx_plugin` that controls when AMQP is ack'ed.
```
     --amqp-trx-ack-mode arg (=in_block)   AMQP ack when 'received' from AMQP,
                                        when 'executed', or when 'in_block' is
                                        produced that contains trx.
                                        Options: received, executed, in_block
```


## Change Type
**Select ONE**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [ ] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [x] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the relase notes. Please include a description of the change for inclusion in the release notes.-->


## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [x] Documentation Additions

See above.
