### PR TITLE
Fix Tester linkage

### DIFF
--- a/CMakeModules/EosioTester.cmake.in
+++ b/CMakeModules/EosioTester.cmake.in
@@ -110,6 +110,7 @@ macro(add_eosio_test_executable test_name)
        ${Boost_IOSTREAMS_LIBRARY}
        "-lz" # Needed by Boost iostreams
        ${Boost_DATE_TIME_LIBRARY}
+       ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY}
 
        ${LLVM_LIBS}
 

--- a/CMakeModules/EosioTesterBuild.cmake.in
+++ b/CMakeModules/EosioTesterBuild.cmake.in
@@ -109,6 +109,7 @@ macro(add_eosio_test_executable test_name)
        ${Boost_IOSTREAMS_LIBRARY}
        "-lz" # Needed by Boost iostreams
        ${Boost_DATE_TIME_LIBRARY}
+       ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY}
 
        ${LLVM_LIBS}
 


### PR DESCRIPTION
Signed-off-by: Anthony Fieroni <bvbfan@abv.bg>

When you use `add_eosio_test` as well as `add_eosio_test_executable` your executable will fail to link since boost unit_test_framework library is missing. In addition it's needed `target_link_libraries( <TARGET> ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} )` to have correct output. The patch aims to fix this issue.