### PR TITLE
Improve RockDB performance option configuration

### DIFF
--- a/libraries/chain/combined_database.cpp
+++ b/libraries/chain/combined_database.cpp
@@ -126,16 +126,13 @@ namespace eosio { namespace chain {
             options.level0_file_num_compaction_trigger = 2;
 
             // Size of L0 = write_buffer_size * min_write_buffer_number_to_merge * level0_file_num_compaction_trigger
-            // therefore: L0 in stable state = 128MB * 2 * 2 = 512MB
-            // max_bytes_for_level_basei is total size of level 1.
-            // For optimal performance make this equal to L0 hence 512MB
-            options.max_bytes_for_level_base = cfg.rocksdb_max_bytes_for_level_base; 
+            // For optimal performance make this equal to L0
+            options.max_bytes_for_level_base = cfg.rocksdb_write_buffer_size * options.min_write_buffer_number_to_merge * options.level0_file_num_compaction_trigger; 
 
             // Files in level 1 will have target_file_size_base
             // bytes. It’s recommended setting target_file_size_base
-            // to be max_bytes_for_level_base / 10,
-            // so that there are 10 files in level 1.i.e. 512MB/10
-            options.target_file_size_base = cfg.rocksdb_target_file_size_base;
+            // to be max_bytes_for_level_base / 10.
+            options.target_file_size_base = options.max_bytes_for_level_base / 10;
 
             // This value represents the maximum number of threads
             // that will concurrently perform a compaction job by

--- a/libraries/chain/include/eosio/chain/config.hpp
+++ b/libraries/chain/include/eosio/chain/config.hpp
@@ -86,11 +86,8 @@ const static uint32_t   default_block_cpu_effort_pct                 = 80 * perc
 const static uint16_t   default_controller_thread_pool_size          = 2;
 const static uint32_t   default_max_variable_signature_length        = 16384u;
 const static uint32_t   default_max_nonprivileged_inline_action_size = 4 * 1024; // 4 KB
-const static uint16_t   default_rocksdb_threads                = 1;
 const static int        default_rocksdb_max_open_files         = -1;
 const static uint64_t   default_rocksdb_write_buffer_size      = 128 * 1024 * 1024;
-const static uint64_t   default_rocksdb_target_file_size_base  = 50 * 1024 * 1024;
-const static uint64_t   default_rocksdb_max_bytes_for_level_base = 512 * 1024 * 1024;
 
 const static uint32_t   default_max_kv_key_size                = 1024;
 const static uint32_t   default_max_kv_value_size              = 1024*1024; // Large enough to hold most contracts

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -83,11 +83,9 @@ namespace eosio { namespace chain {
             uint16_t                 max_retained_block_files   = chain::config::default_max_retained_block_files;
             uint64_t                 blocks_log_stride          = chain::config::default_blocks_log_stride;
             backing_store_type       backing_store              = backing_store_type::CHAINBASE;
-            uint16_t                 rocksdb_threads        =  chain::config::default_rocksdb_threads;
+            uint16_t                 rocksdb_threads        =  0; // Will be set to number of cores dynamically or by user configuration;
             int                      rocksdb_max_open_files =  chain::config::default_rocksdb_max_open_files;
             uint64_t                 rocksdb_write_buffer_size =  chain::config::default_rocksdb_write_buffer_size;
-            uint64_t                 rocksdb_target_file_size_base = chain::config::default_rocksdb_target_file_size_base;
-            uint64_t                 rocksdb_max_bytes_for_level_base =  chain::config::default_rocksdb_max_bytes_for_level_base;
             fc::microseconds         abi_serializer_max_time_us = fc::microseconds(chain::config::default_abi_serializer_max_time_us);
             uint32_t   max_nonprivileged_inline_action_size =  chain::config::default_max_nonprivileged_inline_action_size;
             bool                     read_only                  = false;


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->
## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
This PR improves RocksDB performance option configuration in several ways:
1. For `rocksdb_threads`, if user does not configure it, use the number of CPU cores dynamically found from the system.
2. `target-file-size-base` and `max-bytes-for-level-base` rely on `write-buffer-size` only. Remove them from options to prevent possible errors from the user. Nodeos now calculates them automatically.
3. Change `rocksdb-write-buffer-size` to `rocksdb-write-buffer-size-mb` for simpler and consistent configuration.
## Change Type
**Select ONE**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [ ] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [ ] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the relase notes. Please include a description of the change for inclusion in the release notes.-->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
