### PR TITLE
add block_state_ptr to compressed proof callback 📦

### DIFF
--- a/plugins/amqp_compressed_proof_plugin/amqp_compressed_proof_plugin.cpp
+++ b/plugins/amqp_compressed_proof_plugin/amqp_compressed_proof_plugin.cpp
@@ -3,18 +3,11 @@
 #include <eosio/chain/protocol_feature_manager.hpp>
 #include <eosio/chain/exceptions.hpp>
 
-#include <eosio/amqp/reliable_amqp_publisher.hpp>
-
-#include <boost/multi_index_container.hpp>
-#include <boost/multi_index/key.hpp>
-#include <boost/multi_index/ordered_index.hpp>
-#include <boost/multi_index/hashed_index.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string.hpp>
 
-#include <fc/io/cfile.hpp>
+#include <eosio/amqp/reliable_amqp_publisher.hpp>
 
-using namespace boost::multi_index;
 using namespace std::string_literals;
 
 namespace eosio {
@@ -169,7 +162,7 @@ struct compressed_proof_generator_impl {
          }
 
          if(any_interested)
-            cb.second(cc.generate_serialized_proof(action_return_value_active_this_block));
+            cb.second(bsp, cc.generate_serialized_proof(action_return_value_active_this_block));
       }
    }
 
@@ -290,7 +283,7 @@ void amqp_compressed_proof_plugin::plugin_initialize(const variables_map& option
                   }
                   return false;
                },
-               [&publisher](std::vector<char>&& serialized_proof) {
+               [&publisher](const chain::block_state_ptr& bsp, std::vector<char>&& serialized_proof) {
                   publisher.publish_message_raw(std::move(serialized_proof));
                }
             ));

--- a/plugins/amqp_compressed_proof_plugin/include/eosio/amqp_compressed_proof_plugin/amqp_compressed_proof_plugin.hpp
+++ b/plugins/amqp_compressed_proof_plugin/include/eosio/amqp_compressed_proof_plugin/amqp_compressed_proof_plugin.hpp
@@ -10,7 +10,7 @@ using namespace appbase;
 class compressed_proof_generator {
 public:
    using action_filter_func = std::function<bool(const chain::action& a)>;
-   using merkle_proof_result_func = std::function<void(std::vector<char>&&)>;
+   using merkle_proof_result_func = std::function<void(const chain::block_state_ptr&, std::vector<char>&&)>;
    using result_callback_funcs = std::pair<action_filter_func, merkle_proof_result_func>;
 
    compressed_proof_generator(chain::controller& controller, std::vector<result_callback_funcs>&& callbacks);

--- a/unittests/compressed_merkle_tests.cpp
+++ b/unittests/compressed_merkle_tests.cpp
@@ -121,7 +121,7 @@ BOOST_AUTO_TEST_CASE(test_proof_no_actions) try {
 
    compressed_proof_generator proof_generator(*chain.control, {std::make_pair(
       [&](const auto&){return true;},  //include all actions in proof
-      [&](auto&& x) {
+      [&](auto bsp, auto&& x) {
          //but no actions in block means no callback should ever be fired
          BOOST_FAIL("Callback should not be called");
       }
@@ -151,7 +151,7 @@ BOOST_DATA_TEST_CASE(test_proof_actions, boost::unit_test::data::xrange(1u, 10u)
       [&](const chain::action& act){
          return act.account == N(interested);
       },
-      [&](std::vector<char>&& serialized_compressed_proof) {
+      [&](auto bsp, std::vector<char>&& serialized_compressed_proof) {
          BOOST_CHECK(expecting_callback);
          computed_action_mroot = validate_compressed_merkle_proof(serialized_compressed_proof, [](uint64_t receiver, uint64_t action) {
             BOOST_CHECK(name(receiver) == N(interested));
@@ -187,7 +187,7 @@ BOOST_AUTO_TEST_CASE(test_proof_arv_activation) try {
       [&](const chain::action& act){
          return true;
       },
-      [&](std::vector<char>&& serialized_compressed_proof) {
+      [&](auto bsp, std::vector<char>&& serialized_compressed_proof) {
          computed_action_mroot = validate_compressed_merkle_proof(serialized_compressed_proof, [](uint64_t receiver, uint64_t action) {});
       }
    )});
@@ -242,7 +242,7 @@ BOOST_AUTO_TEST_CASE(test_proof_presist_reversible) try {
          [&](const chain::action& act){
             return true;
          },
-         [&](std::vector<char>&& serialized_compressed_proof) {
+         [&](auto bsp, std::vector<char>&& serialized_compressed_proof) {
             blocks_seen++;
          }
       )});
@@ -255,7 +255,7 @@ BOOST_AUTO_TEST_CASE(test_proof_presist_reversible) try {
          [&](const chain::action& act){
             return true;
          },
-         [&](std::vector<char>&& serialized_compressed_proof) {
+         [&](auto bsp, std::vector<char>&& serialized_compressed_proof) {
             blocks_seen++;
          }
       )});
@@ -277,7 +277,7 @@ BOOST_AUTO_TEST_CASE(test_proof_ooo_sequence) try {
       [&](const chain::action& act) {
          return act.account == N(interested);
       },
-      [&](std::vector<char>&& serialized_compressed_proof) {
+      [&](auto bsp, std::vector<char>&& serialized_compressed_proof) {
          computed_action_mroot = validate_compressed_merkle_proof(serialized_compressed_proof, [&](uint64_t receiver, uint64_t action) {
             BOOST_CHECK(name(receiver) == N(interested));
             num_actions++;
@@ -310,7 +310,7 @@ BOOST_AUTO_TEST_CASE(test_proof_delayed) try {
       [&](const chain::action& act) {
          return true;
       },
-      [&](std::vector<char>&& serialized_compressed_proof) {
+      [&](auto bsp, std::vector<char>&& serialized_compressed_proof) {
          computed_action_mroot = validate_compressed_merkle_proof(serialized_compressed_proof, [&](uint64_t receiver, uint64_t action) {
             seen_interested |= name(receiver) == N(interested);
          });
@@ -350,7 +350,7 @@ BOOST_AUTO_TEST_CASE(test_proof_deferred_soft_fail) try {
       [&](const chain::action& act) {
          return true;
       },
-      [&](std::vector<char>&& serialized_compressed_proof) {
+      [&](auto bsp, std::vector<char>&& serialized_compressed_proof) {
          computed_action_mroot = validate_compressed_merkle_proof(serialized_compressed_proof, [&](uint64_t receiver, uint64_t action) {
             seen_interested |= name(receiver) == N(interested) && action_name(action) == N(onerror);
          });
@@ -393,7 +393,7 @@ BOOST_AUTO_TEST_CASE(test_proof_multiple) try {
       [&](const chain::action& act){
          return act.account == N(spoon);
       },
-      [&](std::vector<char>&& serialized_compressed_proof) {
+      [&](auto bsp, std::vector<char>&& serialized_compressed_proof) {
          BOOST_CHECK(expect_spoon);
          computed_action_mroot1 = validate_compressed_merkle_proof(serialized_compressed_proof, [](uint64_t receiver, uint64_t action) {
             BOOST_CHECK(name(receiver) == N(spoon));
@@ -405,7 +405,7 @@ BOOST_AUTO_TEST_CASE(test_proof_multiple) try {
       [&](const chain::action& act){
          return act.account == N(spoon) && act.name == N(banana);
       },
-      [&](std::vector<char>&& serialized_compressed_proof) {
+      [&](auto bsp, std::vector<char>&& serialized_compressed_proof) {
          BOOST_CHECK(expect_banana);
          computed_action_mroot2 = validate_compressed_merkle_proof(serialized_compressed_proof, [](uint64_t receiver, uint64_t action) {
             BOOST_CHECK(name(receiver) == N(spoon));


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->
## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
Useful for an out-of-tree plugin to get extra information upon delivery of a compressed proof. There is probably an argument to be made to lift the compressed proof code out in to libraries/ instead of leaving it in the plugin, but this change just aims to stay small for now.

Branched from tpm_sig_provider for the time being because said plugin requires both these changes.

## Change Type
**Select ONE**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [ ] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [X] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the relase notes. Please include a description of the change for inclusion in the release notes.-->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
