### PR TITLE
Event id minor issue

### DIFF
--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -737,7 +737,7 @@ const table_id_object& apply_context::find_or_create_table( name code, name scop
       event_id = db_context::table_event(code, scope, table);
    }
 
-   update_db_usage(payer, config::billable_size_v<table_id_object>, db_context::add_table_trace(get_action_id(), event_id.c_str()));
+   update_db_usage(payer, config::billable_size_v<table_id_object>, db_context::add_table_trace(get_action_id(), event_id));
 
    return db.create<table_id_object>([&](table_id_object &t_id){
       t_id.code = code;
@@ -757,7 +757,7 @@ void apply_context::remove_table( const table_id_object& tid ) {
       event_id = db_context::table_event(tid.code, tid.scope, tid.table);
    }
 
-   update_db_usage(tid.payer, - config::billable_size_v<table_id_object>, db_context::rem_table_trace(get_action_id(), event_id.c_str()) );
+   update_db_usage(tid.payer, - config::billable_size_v<table_id_object>, db_context::rem_table_trace(get_action_id(), event_id) );
 
    if (auto dm_logger = control.get_deep_mind_logger()) {
       db_context::write_remove_table(*dm_logger, get_action_id(), tid.code, tid.scope, tid.table, tid.payer);
@@ -877,7 +877,7 @@ int apply_context::db_store_i64_chainbase( name scope, name table, const account
       event_id = db_context::table_event(tab.code, tab.scope, tab.table, name(obj.primary_key));
    }
 
-   update_db_usage( payer, billable_size, db_context::row_add_trace(get_action_id(), event_id.c_str()) );
+   update_db_usage( payer, billable_size, db_context::row_add_trace(get_action_id(), event_id) );
 
    if (auto dm_logger = control.get_deep_mind_logger()) {
       db_context::write_row_insert(*dm_logger, get_action_id(), tab.code, tab.scope, tab.table, payer, name(obj.primary_key), buffer, buffer_size);
@@ -908,12 +908,12 @@ void apply_context::db_update_i64_chainbase( int iterator, account_name payer, c
 
    if( account_name(obj.payer) != payer ) {
       // refund the existing payer
-      update_db_usage( obj.payer, -(old_size), db_context::row_update_rem_trace(get_action_id(), event_id.c_str()) );
+      update_db_usage( obj.payer, -(old_size), db_context::row_update_rem_trace(get_action_id(), event_id) );
       // charge the new payer
-      update_db_usage( payer,  (new_size), db_context::row_update_add_trace(get_action_id(), event_id.c_str()) );
+      update_db_usage( payer,  (new_size), db_context::row_update_add_trace(get_action_id(), event_id) );
    } else if(old_size != new_size) {
       // charge/refund the existing payer the difference
-      update_db_usage( obj.payer, new_size - old_size, db_context::row_update_trace(get_action_id(), event_id.c_str()) );
+      update_db_usage( obj.payer, new_size - old_size, db_context::row_update_trace(get_action_id(), event_id) );
    }
 
    if (auto dm_logger = control.get_deep_mind_logger()) {
@@ -941,7 +941,7 @@ void apply_context::db_remove_i64_chainbase( int iterator ) {
       event_id = db_context::table_event(table_obj.code, table_obj.scope, table_obj.table, name(obj.primary_key));
    }
 
-   update_db_usage( obj.payer,  -(obj.value.size() + config::billable_size_v<key_value_object>), db_context::row_rem_trace(get_action_id(), event_id.c_str()) );
+   update_db_usage( obj.payer,  -(obj.value.size() + config::billable_size_v<key_value_object>), db_context::row_rem_trace(get_action_id(), event_id) );
 
    if (auto dm_logger = control.get_deep_mind_logger()) {
       db_context::write_row_remove(*dm_logger, get_action_id(), table_obj.code, table_obj.scope, table_obj.table, obj.payer, name(obj.primary_key), obj.value.data(), obj.value.size());

--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -551,7 +551,7 @@ void apply_context::schedule_deferred_transaction( const uint128_t& sender_id, a
 
    uint32_t trx_size = 0;
    std::string event_id;
-   std::string operation;
+   const char* operation = "";
    if ( auto ptr = db.find<generated_transaction_object,by_sender_id>(boost::make_tuple(receiver, sender_id)) ) {
       EOS_ASSERT( replace_existing, deferred_tx_duplicate, "deferred transaction with the same sender_id and payer already exists" );
 
@@ -666,7 +666,7 @@ void apply_context::schedule_deferred_transaction( const uint128_t& sender_id, a
                subjective_block_production_exception,
                "Cannot charge RAM to other accounts during notify."
    );
-   add_ram_usage( payer, (config::billable_size_v<generated_transaction_object> + trx_size), storage_usage_trace(get_action_id(), event_id.c_str(), "deferred_trx", operation.c_str(), "deferred_trx_add") );
+   add_ram_usage( payer, (config::billable_size_v<generated_transaction_object> + trx_size), storage_usage_trace(get_action_id(), event_id.c_str(), "deferred_trx", operation, "deferred_trx_add") );
 }
 
 bool apply_context::cancel_deferred_transaction( const uint128_t& sender_id, account_name sender ) {

--- a/libraries/chain/backing_store/db_context_rocksdb.cpp
+++ b/libraries/chain/backing_store/db_context_rocksdb.cpp
@@ -192,7 +192,7 @@ namespace eosio { namespace chain { namespace backing_store {
          event_id = db_context::table_event(receiver, scope_name, table_name, name(id));
       }
 
-      update_db_usage( payer, billable_size, db_context::row_add_trace(context.get_action_id(), event_id.c_str()) );
+      update_db_usage( payer, billable_size, db_context::row_add_trace(context.get_action_id(), event_id) );
 
       if (dm_logger != nullptr) {
          db_context::write_row_insert(*dm_logger, context.get_action_id(), receiver, scope_name, table_name, payer,
@@ -234,15 +234,15 @@ namespace eosio { namespace chain { namespace backing_store {
       const int64_t new_size = static_cast<int64_t>(value_size + db_key_value_any_lookup::overhead);
       if( old_payer != payer ) {
          // refund the existing payer
-         update_db_usage( old_payer, -(old_size), db_context::row_update_rem_trace(context.get_action_id(), event_id.c_str()) );
+         update_db_usage( old_payer, -(old_size), db_context::row_update_rem_trace(context.get_action_id(), event_id) );
          // charge the new payer
-         update_db_usage( payer,  (new_size), db_context::row_update_add_trace(context.get_action_id(), event_id.c_str()) );
+         update_db_usage( payer,  (new_size), db_context::row_update_add_trace(context.get_action_id(), event_id) );
 
          // swap the payer in the iterator store
          swap(itr, payer);
       } else if(old_size != new_size) {
          // charge/refund the existing payer the difference
-         update_db_usage( old_payer, new_size - old_size, db_context::row_update_trace(context.get_action_id(), event_id.c_str()) );
+         update_db_usage( old_payer, new_size - old_size, db_context::row_update_trace(context.get_action_id(), event_id) );
       }
 
       if (dm_logger != nullptr) {
@@ -270,7 +270,7 @@ namespace eosio { namespace chain { namespace backing_store {
       }
 
       payer_payload pp(*old_key_value.value);
-      update_db_usage( old_payer,  -((int64_t)pp.value_size + db_key_value_any_lookup::overhead), db_context::row_rem_trace(context.get_action_id(), event_id.c_str()) );
+      update_db_usage( old_payer,  -((int64_t)pp.value_size + db_key_value_any_lookup::overhead), db_context::row_rem_trace(context.get_action_id(), event_id) );
 
       if (dm_logger != nullptr) {
          db_context::write_row_remove(*dm_logger, context.get_action_id(), table_store.contract, table_store.scope,

--- a/libraries/chain/backing_store/db_key_value_any_lookup.cpp
+++ b/libraries/chain/backing_store/db_key_value_any_lookup.cpp
@@ -32,7 +32,7 @@ namespace eosio { namespace chain { namespace backing_store {
             event_id = db_context::table_event(parent.receiver, scope, table);
          }
 
-         context.update_db_usage(payer, table_overhead, db_context::add_table_trace(context.get_action_id(), event_id.c_str()));
+         context.update_db_usage(payer, table_overhead, db_context::add_table_trace(context.get_action_id(), event_id));
 
          payer_payload pp(payer, nullptr, 0);
          current_session.write(table_key, pp.as_payload());
@@ -71,7 +71,7 @@ namespace eosio { namespace chain { namespace backing_store {
          event_id = db_context::table_event(parent.receiver, scope, table);
       }
 
-      context.update_db_usage(payer, - table_overhead, db_context::rem_table_trace(context.get_action_id(), event_id.c_str()) );
+      context.update_db_usage(payer, - table_overhead, db_context::rem_table_trace(context.get_action_id(), event_id) );
 
       if (dm_logger != nullptr) {
          db_context::write_remove_table(*dm_logger, context.get_action_id(), parent.receiver, scope, table, payer);

--- a/libraries/chain/include/eosio/chain/apply_context.hpp
+++ b/libraries/chain/include/eosio/chain/apply_context.hpp
@@ -60,7 +60,7 @@ class apply_context {
                   }
                });
 
-               context.update_db_usage( payer, config::billable_size_v<ObjectType>, backing_store::db_context::secondary_add_trace(context.get_action_id(), event_id.c_str()) );
+               context.update_db_usage( payer, config::billable_size_v<ObjectType>, backing_store::db_context::secondary_add_trace(context.get_action_id(), event_id) );
 
                itr_cache.cache_table( tab );
                return itr_cache.add( obj );
@@ -77,7 +77,7 @@ class apply_context {
                   event_id = backing_store::db_context::table_event(table_obj.code, table_obj.scope, table_obj.table, name(obj.primary_key));
                }
 
-               context.update_db_usage( obj.payer, -( config::billable_size_v<ObjectType> ), backing_store::db_context::secondary_rem_trace(context.get_action_id(), event_id.c_str()) );
+               context.update_db_usage( obj.payer, -( config::billable_size_v<ObjectType> ), backing_store::db_context::secondary_rem_trace(context.get_action_id(), event_id) );
 
 //               context.require_write_lock( table_obj.scope );
 
@@ -111,8 +111,8 @@ class apply_context {
                }
 
                if( obj.payer != payer ) {
-                  context.update_db_usage( obj.payer, -(billing_size), backing_store::db_context::secondary_update_rem_trace(context.get_action_id(), event_id.c_str()) );
-                  context.update_db_usage( payer, +(billing_size), backing_store::db_context::secondary_update_add_trace(context.get_action_id(), event_id.c_str()) );
+                  context.update_db_usage( obj.payer, -(billing_size), backing_store::db_context::secondary_update_rem_trace(context.get_action_id(), event_id) );
+                  context.update_db_usage( payer, +(billing_size), backing_store::db_context::secondary_update_add_trace(context.get_action_id(), event_id) );
                }
 
                context.db.modify( obj, [&]( auto& o ) {

--- a/libraries/chain/include/eosio/chain/backing_store/db_key_value_sec_lookup.hpp
+++ b/libraries/chain/include/eosio/chain/backing_store/db_key_value_sec_lookup.hpp
@@ -130,7 +130,7 @@ namespace eosio { namespace chain { namespace backing_store {
             event_id = db_context::table_event(parent.receiver, scope, table, name(id));
          }
 
-         parent.context.update_db_usage( payer, helper.overhead(), backing_store::db_context::secondary_add_trace(parent.context.get_action_id(), event_id.c_str()) );
+         parent.context.update_db_usage( payer, helper.overhead(), backing_store::db_context::secondary_add_trace(parent.context.get_action_id(), event_id) );
 
          const unique_table t { parent.receiver, scope, table };
          const auto table_ei = iter_store.cache_table(t);
@@ -158,7 +158,7 @@ namespace eosio { namespace chain { namespace backing_store {
             event_id = db_context::table_event(table.contract, table.scope, table.table, name(key_store.primary));
          }
 
-         parent.context.update_db_usage( key_store.payer, -( helper.overhead() ), db_context::secondary_rem_trace(parent.context.get_action_id(), event_id.c_str()) );
+         parent.context.update_db_usage( key_store.payer, -( helper.overhead() ), db_context::secondary_rem_trace(parent.context.get_action_id(), event_id) );
 
          current_session.erase(secondary_key.full_secondary_key);
          current_session.erase(secondary_key.full_primary_to_sec_key);
@@ -193,8 +193,8 @@ namespace eosio { namespace chain { namespace backing_store {
          }
 
          if( key_store.payer != payer ) {
-            context.update_db_usage( key_store.payer, -(helper.overhead()), backing_store::db_context::secondary_update_rem_trace(context.get_action_id(), event_id.c_str()) );
-            context.update_db_usage( payer, +(helper.overhead()), backing_store::db_context::secondary_update_add_trace(context.get_action_id(), event_id.c_str()) );
+            context.update_db_usage( key_store.payer, -(helper.overhead()), backing_store::db_context::secondary_update_rem_trace(context.get_action_id(), event_id) );
+            context.update_db_usage( payer, +(helper.overhead()), backing_store::db_context::secondary_update_add_trace(context.get_action_id(), event_id) );
          }
 
          // if the secondary value is different, remove the old key and add the new key


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->
## Change Description
Some methods that were refactored into db_context to wrap calls to storage_usage_trace had been continued to be called passing in event_id.c_str(), instead of passing in event_id.  Also cleaned up a call to storage_usage_trace that stored literal strings in a std::string and converted to c_str.


## Change Type
**Select ONE**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [ ] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [x] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the relase notes. Please include a description of the change for inclusion in the release notes.-->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
