### PR TITLE
Log store implementation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -28,3 +28,6 @@
 [submodule "libraries/appbase"]
 	path = libraries/appbase
 	url = https://github.com/eosio/appbase
+[submodule "libraries/nuraft"]
+	path = libraries/nuraft
+	url = https://github.com/eBay/NuRaft

--- a/libraries/CMakeLists.txt
+++ b/libraries/CMakeLists.txt
@@ -53,3 +53,35 @@ find_package(OpenSSL REQUIRED)
 option(AMQP-CPP_LINUX_TCP CACHE ON)
 add_subdirectory( amqp-cpp EXCLUDE_FROM_ALL )
 target_include_directories(amqpcpp PRIVATE "${OPENSSL_INCLUDE_DIR}")
+
+
+find_package(Boost 1.70 REQUIRED COMPONENTS system)
+
+add_library(nuraft STATIC 
+    nuraft/src/asio_service.cxx
+    nuraft/src/buffer.cxx
+    nuraft/src/buffer_serializer.cxx
+    nuraft/src/cluster_config.cxx
+    nuraft/src/crc32.cxx
+    nuraft/src/error_code.cxx
+    nuraft/src/handle_append_entries.cxx
+    nuraft/src/handle_client_request.cxx
+    nuraft/src/handle_custom_notification.cxx
+    nuraft/src/handle_commit.cxx
+    nuraft/src/handle_join_leave.cxx
+    nuraft/src/handle_priority.cxx
+    nuraft/src/handle_snapshot_sync.cxx
+    nuraft/src/handle_timeout.cxx
+    nuraft/src/handle_user_cmd.cxx
+    nuraft/src/handle_vote.cxx
+    nuraft/src/launcher.cxx
+    nuraft/src/peer.cxx
+    nuraft/src/raft_server.cxx
+    nuraft/src/snapshot.cxx
+    nuraft/src/snapshot_sync_req.cxx
+    nuraft/src/srv_config.cxx
+    nuraft/src/stat_mgr.cxx)
+
+target_include_directories(nuraft PRIVATE ${Boost_INCLUDE_DIR}/boost nuraft/include/libnuraft PUBLIC nuraft/include)
+target_compile_definitions(nuraft PRIVATE USE_BOOST_ASIO)
+target_link_libraries(nuraft Boost::system OpenSSL::SSL)

--- a/programs/blockvaultd/CMakeLists.txt
+++ b/programs/blockvaultd/CMakeLists.txt
@@ -26,9 +26,11 @@ configure_file(config.hpp.in config.hpp ESCAPE_QUOTES)
 target_include_directories(${BLOCKVAULTD_EXECUTABLE_NAME} PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
 
 target_link_libraries( ${BLOCKVAULTD_EXECUTABLE_NAME}
-        PRIVATE appbase version fc ${CMAKE_DL_LIBS} ${PLATFORM_SPECIFIC_LIBS})
+        PRIVATE appbase version fc nuraft ${CMAKE_DL_LIBS} ${PLATFORM_SPECIFIC_LIBS})
 
 copy_bin( ${BLOCKVAULTD_EXECUTABLE_NAME} )
 install( TARGETS
    ${BLOCKVAULTD_EXECUTABLE_NAME} RUNTIME DESTINATION ${CMAKE_INSTALL_FULL_BINDIR} COMPONENT base
 )
+
+add_subdirectory(unittests)

--- a/programs/blockvaultd/log_store.cpp
+++ b/programs/blockvaultd/log_store.cpp
@@ -1,0 +1,279 @@
+#include "log_store.hpp"
+#include <cassert>
+#include <iostream>
+
+namespace blockvault {
+
+using namespace nuraft;
+namespace fs = std::filesystem;
+
+ptr<log_entry> empty_log_entry() {
+   static ptr<buffer>    buf = buffer::alloc(sz_ulong);
+   static ptr<log_entry> r   = cs_new<log_entry>(0, buf);
+   return r;
+}
+
+fs::path path_for_index(const fs::path& log_dir, ulong index) {
+   // the log is stored in log_dir/<log_index>.log
+   return (log_dir / std::to_string(index)).concat(".log");
+}
+
+fs::path store_log(const fs::path& log_dir, const unsigned char* data, int sz) {
+   namespace fs = std::filesystem;
+
+   auto file = log_dir / std::tmpnam(nullptr);
+   auto fp   = std::unique_ptr<FILE, decltype(&fclose)>{fopen(file.c_str(), "w"), &fclose};
+   if (!fp)
+      throw fs::filesystem_error("file open error", file, std::make_error_code(static_cast<std::errc>(errno)));
+   fwrite(data, 1, sz, fp.get());
+   return file;
+}
+
+struct log_entry_meta {
+   ulong term;
+   byte  type;
+
+   log_entry_meta(ulong tm = 0, log_val_type tp = log_val_type::app_log)
+       : term(tm)
+       , type(static_cast<byte>(tp)) {}
+};
+
+constexpr int log_entry_meta_size = sizeof(ulong) + sizeof(byte);
+
+fs::path store_log(const fs::path& log_dir, nuraft::ptr<nuraft::log_entry>& entry) {
+   namespace fs = std::filesystem;
+
+   auto file = log_dir / std::tmpnam(nullptr);
+   auto fp   = std::unique_ptr<FILE, decltype(&fclose)>{fopen(file.c_str(), "w"), &fclose};
+   if (!fp)
+      throw fs::filesystem_error("file open error", file, std::make_error_code(static_cast<std::errc>(errno)));
+
+   log_entry_meta meta{entry->get_term(), entry->get_val_type()};
+
+   fwrite(&meta, log_entry_meta_size, 1, fp.get());
+   auto& buf = entry->get_buf();
+   buf.pos(0); // reset the position
+   fwrite(buf.data(), 1, buf.size(), fp.get());
+   return file;
+}
+
+class log_entry_reader {
+ public:
+   log_entry_reader() = default;
+   log_entry_reader(fs::path log_dir, ulong index) { set(log_dir, index); }
+   ~log_entry_reader() {
+      if (!fname.empty()) {
+         std::error_code ec;
+         fs::remove(fname, ec);
+      }
+   }
+
+   log_entry_reader(const log_entry_reader&) = delete;
+   log_entry_reader& operator=(const log_entry_reader&) = delete;
+   log_entry_reader(log_entry_reader&& other) { fname.swap(other.fname); }
+
+   void set(fs::path log_dir, ulong index) {
+      auto original = path_for_index(log_dir, index);
+      if (fs::exists(original)) {
+         fname = log_dir / std::tmpnam(nullptr);
+         fs::create_hard_link(path_for_index(log_dir, index), fname);
+      }
+   }
+
+   ptr<log_entry> get() {
+      auto fp = std::unique_ptr<FILE, decltype(&fclose)>(fopen(fname.c_str(), "r"), &fclose);
+      if (fp) {
+         int            sz  = std::filesystem::file_size(fname) - log_entry_meta_size;
+         ptr<buffer>    buf = buffer::alloc(sz);
+         log_entry_meta meta;
+         fread(&meta, log_entry_meta_size, 1, fp.get());
+         fread(buf->get_raw(sz), sz, 1, fp.get());
+         buf->pos(0); // reset the position
+         return cs_new<log_entry>(meta.term, buf, static_cast<log_val_type>(meta.type));
+      }
+
+      return empty_log_entry();
+   }
+
+   size_t size() const {
+      std::error_code ec;
+      size_t          sz = fs::file_size(fname, ec);
+      return ec ? 0 : sz - log_entry_meta_size;
+   }
+
+ private:
+   fs::path fname;
+};
+
+log_store::log_store(std::filesystem::path p)
+    : log_dir_(p)
+    , start_idx_(1)
+    , next_slot_(1) {}
+
+ulong log_store::next_slot() const { return next_slot_; }
+
+ulong log_store::start_index() const { return start_idx_; }
+
+ptr<log_entry> log_store::last_entry() const {
+   log_entry_reader reader;
+   {
+      std::lock_guard<std::mutex> l(logs_lock_);
+      reader.set(log_dir_, next_slot_ - 1);
+   }
+   return reader.get();
+}
+
+ulong log_store::append(ptr<log_entry>& entry) {
+
+   auto                        tmp_path = store_log(log_dir_, entry);
+   std::lock_guard<std::mutex> l(logs_lock_);
+   fs::rename(tmp_path, path_for_index(log_dir_, next_slot_));
+   return next_slot_++;
+}
+
+void log_store::write_at(ulong index, ptr<log_entry>& entry) {
+
+   auto tmp_path = store_log(log_dir_, entry);
+   // Discard all logs equal to or greater than `index.
+   std::lock_guard<std::mutex> l(logs_lock_);
+
+   for (ulong i = index; i < next_slot_; ++i) {
+      auto            p = (log_dir_ / std::to_string(i)).concat(".log");
+      std::error_code ec;
+      fs::remove(p, ec);
+   }
+   fs::rename(tmp_path, path_for_index(log_dir_, index));
+
+   next_slot_ = index + 1;
+}
+
+ptr<std::vector<ptr<log_entry>>> log_store::log_entries(ulong start, ulong end) {
+
+   std::vector<log_entry_reader> readers;
+   readers.reserve(end - start);
+   {
+      std::lock_guard<std::mutex> l(logs_lock_);
+      for (ulong ii = start; ii < end; ++ii) {
+         readers.emplace_back(log_dir_, ii);
+      }
+   }
+
+   ptr<std::vector<ptr<log_entry>>> ret = cs_new<std::vector<ptr<log_entry>>>();
+   ret->reserve(readers.size());
+   for (auto& r : readers) {
+      ret->emplace_back(r.get());
+   }
+   return ret;
+}
+
+ptr<std::vector<ptr<log_entry>>> log_store::log_entries_ext(ulong start, ulong end, int64 batch_size_hint_in_bytes) {
+   ptr<std::vector<ptr<log_entry>>> ret = cs_new<std::vector<ptr<log_entry>>>();
+   if (batch_size_hint_in_bytes < 0) {
+      return ret;
+   }
+   std::vector<log_entry_reader> readers;
+   readers.reserve(end - start);
+
+   {
+      size_t accum_size = 0;
+
+      std::lock_guard<std::mutex> l(logs_lock_);
+      for (ulong ii = start; ii < end; ++ii) {
+         readers.emplace_back(log_dir_, ii);
+         accum_size += readers.back().size();
+         if (batch_size_hint_in_bytes && accum_size >= (ulong)batch_size_hint_in_bytes)
+            break;
+      }
+   }
+   ret->reserve(readers.size());
+   for (auto& r : readers) {
+      ret->emplace_back(r.get());
+   }
+   return ret;
+}
+
+ptr<log_entry> log_store::entry_at(ulong index) {
+   log_entry_reader reader;
+   {
+      std::lock_guard<std::mutex> l(logs_lock_);
+      reader.set(log_dir_, index);
+   }
+   return reader.get();
+}
+
+ulong log_store::term_at(ulong index) {
+   ulong                       term = 0;
+   std::lock_guard<std::mutex> l(logs_lock_);
+   auto                        p = path_for_index(log_dir_, index);
+   if (fs::exists(p)) {
+      auto fp = std::unique_ptr<FILE, decltype(&fclose)>{fopen(p.c_str(), "r"), &fclose};
+      fread(&term, sizeof(term), 1, fp.get());
+   }
+
+   return term;
+}
+
+ptr<buffer> log_store::pack(ulong index, int32 cnt) {
+   std::vector<ptr<buffer>> logs;
+
+   size_t                      size_total = 0;
+   std::lock_guard<std::mutex> l(logs_lock_);
+   ulong                       last = std::min(index + cnt, next_slot_);
+   for (ulong ii = index; ii < last; ++ii) {
+      auto p = (log_dir_ / std::to_string(ii)).concat(".log");
+      size_total += std::filesystem::file_size(p);
+   }
+
+   ptr<buffer> buf_out = buffer::alloc(sizeof(int32) + cnt * sizeof(int32) + size_total);
+   buf_out->pos(0);
+   buf_out->put((int32)cnt);
+
+   for (ulong ii = index; ii < last; ++ii) {
+      auto  p  = (log_dir_ / std::to_string(ii)).concat(".log");
+      int32 sz = std::filesystem::file_size(p);
+      buf_out->put(sz);
+      auto fp = std::unique_ptr<FILE, decltype(&fclose)>{fopen(p.c_str(), "r"), &fclose};
+      fread(buf_out->get_raw(sz), 1, sz, fp.get());
+   }
+   return buf_out;
+}
+
+void log_store::apply_pack(ulong index, buffer& pack) {
+   pack.pos(0);
+   int32                 num_logs = pack.get_int();
+   std::vector<fs::path> tmp_paths;
+   for (int32 ii = 0; ii < num_logs; ++ii) {
+      size_t buf_size;
+      auto   data = pack.get_bytes(buf_size);
+      tmp_paths.push_back(store_log(log_dir_, data, buf_size));
+   }
+
+   std::lock_guard<std::mutex> l(logs_lock_);
+   for (int32 ii = 0; ii < num_logs; ++ii) {
+      fs::rename(tmp_paths[ii], path_for_index(log_dir_, index + ii));
+   }
+   if (index >= next_slot_) {
+      // TODO: remove all pre-existing logs
+      start_idx_ = index;
+   } else
+      start_idx_ = std::min(start_idx_, index);
+
+   next_slot_ = index + num_logs;
+}
+
+bool log_store::compact(ulong last_log_index) {
+   std::lock_guard<std::mutex> l(logs_lock_);
+   for (ulong ii = start_idx_; ii <= last_log_index; ++ii) {
+      auto            p = (log_dir_ / std::to_string(ii)).concat(".log");
+      std::error_code ec;
+      std::filesystem::remove(p, ec);
+   }
+
+   // WARNING:
+   //   Even though nothing has been erased,
+   //   we should set `start_idx_` to new index.
+   start_idx_ = last_log_index + 1;
+   return true;
+}
+
+} // namespace blockvault

--- a/programs/blockvaultd/log_store.cpp
+++ b/programs/blockvaultd/log_store.cpp
@@ -1,11 +1,63 @@
 #include "log_store.hpp"
+#include "utils.hpp"
+#include <algorithm>
+#include <boost/container/flat_map.hpp>
+#include <boost/iostreams/device/mapped_file.hpp>
 #include <cassert>
 #include <iostream>
-
+#include <libnuraft/logger.hxx>
+#include <regex>
+#include <unistd.h>
 namespace blockvault {
+
+/*
+ * The log store is partitioned into segments. Each segments has a fix number of entries (defined by log_stride). Each
+ * segments is further stored with 2 files: data file and index file. For example, given the log_stride 1000, the log
+ * entries 0 to 999 would be stored in `log-entry-0.data' with index file `log-entry-0.index`, and the entries 1000 to
+ * 1999 would be stored in `log-entry-1000.data' with index file `log-entry-1000.index`. The data file is a file to
+ * store log entries payload and their correspoding header. Entries should only be appended to the data file. The index
+ * file stores each entry positions in the data file that enables O(1) random access lookup by entry index number.
+ *
+ *                                                Data file format
+ * +--------------------+
+ * | Data file Preamble |
+ * +----------------+-----------------+----------------+-----------------+-----+-------------------+--------------------+
+ * | Entry 1 header | Entry 1 payload | Entry 2 header | Entry 2 payload | ... | Last entry header | Last entry payload
+ * |
+ * +----------------+-----------------+----------------+-----------------+-----+-------------------+--------------------+
+ *
+ * +--------------------------------+------------------------------+---------+--------------------------+
+ * |      Entry 1 end position      |      Entry 2 end position    | ....... | Last entry  end position |
+ * +--------------------------------+------------------------------+---------+--------------------------+
+ *                                                Index file format
+ */
 
 using namespace nuraft;
 namespace fs = std::filesystem;
+
+const uint32_t log_store_version = 0;
+
+struct data_file_preamble {
+   uint64_t start_index = 0;
+   uint32_t version     = log_store_version;
+   data_file_preamble() = default;
+   data_file_preamble(uint64_t idx)
+       : start_index(idx) {}
+};
+
+struct __attribute__((__packed__)) log_entry_header {
+   uint32_t length; // this should the sum of sizeof(term), sizeof(type) and payload size
+   ulong    term;
+   byte     type;
+
+   log_entry_header() = default;
+   log_entry_header(ulong log_entry_term, nuraft::log_val_type log_entry_type, uint32_t payload_size)
+       : length(payload_size + sizeof(term) + sizeof(type))
+       , term(log_entry_term)
+       , type(static_cast<byte>(log_entry_type)) {}
+
+   uint32_t get_payload_size() const { return length - sizeof(term) - sizeof(type); }
+};
 
 ptr<log_entry> empty_log_entry() {
    static ptr<buffer>    buf = buffer::alloc(sz_ulong);
@@ -13,267 +65,563 @@ ptr<log_entry> empty_log_entry() {
    return r;
 }
 
-fs::path path_for_index(const fs::path& log_dir, ulong index) {
-   // the log is stored in log_dir/<log_index>.log
-   return (log_dir / std::to_string(index)).concat(".log");
-}
+using data_collection_t = boost::container::flat_map<ulong, fs::path>;
 
-fs::path store_log(const fs::path& log_dir, const unsigned char* data, int sz) {
-   namespace fs = std::filesystem;
+class tmp_data_collection_t {
+   data_collection_t impl_;
 
-   auto file = log_dir / std::tmpnam(nullptr);
-   auto fp   = std::unique_ptr<FILE, decltype(&fclose)>{fopen(file.c_str(), "w"), &fclose};
-   if (!fp)
-      throw fs::filesystem_error("file open error", file, std::make_error_code(static_cast<std::errc>(errno)));
-   fwrite(data, 1, sz, fp.get());
-   return file;
-}
+ public:
+   tmp_data_collection_t()                             = default;
+   tmp_data_collection_t(const tmp_data_collection_t&) = delete;
+   tmp_data_collection_t& operator=(const tmp_data_collection_t&) = delete;
 
-struct log_entry_meta {
-   ulong term;
-   byte  type;
+   ~tmp_data_collection_t() {
+      for (auto& v : impl_) {
+         fs::remove(v.second);
+      }
+   }
 
-   log_entry_meta(ulong tm = 0, log_val_type tp = log_val_type::app_log)
-       : term(tm)
-       , type(static_cast<byte>(tp)) {}
+   void assign(data_collection_t::const_iterator first, data_collection_t::const_iterator last) {
+      std::for_each(first, last, [this](const auto& v) {
+         fs::path orig_path = v.second;
+         char     hard_linked_name[PATH_MAX];
+         snprintf(hard_linked_name, PATH_MAX, "%s-XXXXXX", orig_path.c_str());
+         mktemp(hard_linked_name);
+         fs::path new_path = hard_linked_name;
+         impl_.emplace(v.first, new_path);
+         fs::create_hard_link(orig_path.replace_extension("data"), new_path.replace_extension("data"));
+      });
+   }
+
+   data_collection_t::const_iterator cbegin() const { return impl_.cbegin(); }
+   data_collection_t::const_iterator cend() const { return impl_.cend(); }
 };
 
-constexpr int log_entry_meta_size = sizeof(ulong) + sizeof(byte);
+struct log_catalog {
+   using size_type                 = typename data_collection_t::size_type;
+   static constexpr size_type npos = std::numeric_limits<size_type>::max();
 
-fs::path store_log(const fs::path& log_dir, nuraft::ptr<nuraft::log_entry>& entry) {
-   namespace fs = std::filesystem;
+   data_collection_t collection_;
+   size_type         active_index_ = npos;
+   file_reader       log_data_;
+   file_reader       log_index_;
 
-   auto file = log_dir / std::tmpnam(nullptr);
-   auto fp   = std::unique_ptr<FILE, decltype(&fclose)>{fopen(file.c_str(), "w"), &fclose};
-   if (!fp)
-      throw fs::filesystem_error("file open error", file, std::make_error_code(static_cast<std::errc>(errno)));
+   bool empty() const { return collection_.empty(); }
 
-   log_entry_meta meta{entry->get_term(), entry->get_val_type()};
+   void clear() {
+      for (const auto& e : collection_) {
+         auto prefix = e.second;
+         fs::remove(prefix.replace_extension("index"));
+         fs::remove(prefix.replace_extension("data"));
+      }
 
-   fwrite(&meta, log_entry_meta_size, 1, fp.get());
-   auto& buf = entry->get_buf();
-   buf.pos(0); // reset the position
-   fwrite(buf.data(), 1, buf.size(), fp.get());
-   return file;
-}
+      collection_.clear();
+      active_index_ = npos;
+   }
 
-class log_entry_reader {
- public:
-   log_entry_reader() = default;
-   log_entry_reader(fs::path log_dir, ulong index) { set(log_dir, index); }
-   ~log_entry_reader() {
-      if (!fname.empty()) {
-         std::error_code ec;
-         fs::remove(fname, ec);
+   uint32_t start_index() const {
+      if (empty())
+         return 0;
+      return collection_.begin()->first;
+   }
+
+   fs::path current_log_prefix() { return collection_.rbegin()->second; }
+
+   int open(const fs::path& log_dir) {
+
+      const char*                               pattern = "log-entry-\\d+\\.index";
+      boost::container::flat_map<ulong, size_t> num_entries;
+
+      for_each_file_in_dir_matches(log_dir, pattern, [this, &num_entries](const fs::path& index_path) {
+         auto index_file_size = fs::file_size(index_path);
+         if (index_file_size % sizeof(uint64_t) != 0)
+            throw std::runtime_error(std::string("log_store: invalid index file ") + index_path.string());
+
+         auto path_without_extension = fs::path(index_path).replace_extension();
+         auto data_path              = fs::path(index_path).replace_extension("data");
+
+         file_reader        log(data_path);
+         data_file_preamble preamble;
+         log.read(preamble);
+
+         num_entries[preamble.start_index] = index_file_size / sizeof(uint64_t);
+         collection_[preamble.start_index] = path_without_extension;
+      });
+
+      ulong next_start_index = 0;
+      // make sure there's no missing entries in between log entries files.
+      auto i = collection_.cbegin();
+      auto j = num_entries.cbegin();
+      for (; i < collection_.cend(); ++i, ++j) {
+         if (next_start_index != 0 && next_start_index != i->first) {
+            throw std::runtime_error("log_store: the persistent log store has missing entries");
+         }
+         next_start_index = i->first + j->second;
+      }
+
+      if (next_start_index > 0) {
+         // when the index and data file does not match, we trust index instead of the data file,
+         // because it's earier to make writing to the index file transactional.
+         auto last_log_index               = next_start_index - 1;
+         auto [last_seg_index, seg_prefix] = *collection_.rbegin();
+         auto     expect_data_file_size    = end_of_entry_position(collection_.end() - 1, last_log_index);
+         fs::path last_seg_data_file       = fs::path(seg_prefix).replace_extension("data");
+         auto     actual_data_file_size    = fs::file_size(last_seg_data_file);
+         if (actual_data_file_size < expect_data_file_size) {
+            // this shouldn't happen unless someone manually messes with index or data files.
+            throw std::runtime_error(
+                "log_store: the persisted log store is not in a consistent state which can be recovered from");
+         } else if (actual_data_file_size > expect_data_file_size) {
+            // this could happen when the system crashes while writing the log data
+            fs::resize_file(last_seg_data_file, expect_data_file_size);
+         }
+      }
+      return next_start_index;
+   }
+
+   uint64_t set_entry_position_by_index_offset(ulong index_offset) {
+      uint64_t data_offset;
+      if (index_offset == 0)
+         data_offset = sizeof(data_file_preamble);
+      else {
+         log_index_.seek((index_offset - 1) * sizeof(uint64_t));
+         log_index_.read(data_offset);
+      }
+      log_data_.seek(data_offset);
+      return data_offset;
+   }
+
+   uint64_t set_entry_position(ulong entry_index) {
+      if (active_index_ != npos) {
+         auto active_item = collection_.nth(active_index_);
+         auto next_item   = active_item + 1;
+         if (active_item->first <= entry_index && (next_item == collection_.end() || entry_index < next_item->first)) {
+            return set_entry_position_by_index_offset(entry_index - active_item->first);
+         }
+      }
+      if (collection_.empty() || entry_index < collection_.begin()->first)
+         throw std::runtime_error("log_store: invalid log entry index");
+
+      auto it             = --collection_.upper_bound(entry_index);
+      auto name           = it->second;
+      log_data_           = file_reader(name.replace_extension("data"));
+      log_index_          = file_reader(name.replace_extension("index"));
+      this->active_index_ = collection_.index_of(it);
+      return set_entry_position_by_index_offset(entry_index - it->first);
+   }
+
+   ptr<log_entry> get_entry(ulong entry_index) {
+      set_entry_position(entry_index);
+      log_entry_header header;
+      log_data_.read(header);
+      auto        payload_size = header.get_payload_size();
+      ptr<buffer> buf          = buffer::alloc(payload_size);
+      log_data_.read(buf->get_raw(payload_size), payload_size);
+      buf->pos(0);
+      return cs_new<log_entry>(header.term, buf, static_cast<log_val_type>(header.type));
+   }
+
+   ulong term_at(ulong entry_index) {
+      set_entry_position(entry_index);
+
+      log_entry_header header;
+      log_data_.read(header);
+      return header.term;
+   }
+
+   void add(ulong start_entry_index, const fs::path& new_path) {
+      this->collection_.emplace(start_entry_index, new_path);
+   }
+
+   void compact_back(ulong last_log_index) {
+      auto itr = collection_.lower_bound(last_log_index);
+      if (itr == collection_.end()) {
+         return;
+      }
+
+      std::for_each(collection_.rbegin(), data_collection_t::reverse_iterator(itr), [](const auto& entry) {
+         auto filebase = entry.second;
+         fs::remove(filebase.replace_extension("index"));
+         fs::remove(filebase.replace_extension("data"));
+      });
+
+      auto [seg_index, prefix] = *collection_.rbegin();
+      collection_.erase(itr, collection_.end());
+
+      if (!collection_.empty()) {
+         auto [seg_index, prefix] = *collection_.rbegin();
+         ulong num_entry_to_keep  = last_log_index - seg_index + 1;
+         auto  data_file_size     = end_of_entry_position(collection_.end() - 1, last_log_index);
+         fs::resize_file(fs::path(prefix).replace_extension("index"), num_entry_to_keep * sizeof(uint64_t));
+         fs::resize_file(fs::path(prefix).replace_extension("data"), data_file_size);
+      }
+      active_index_ = npos;
+   }
+
+   void compact_front(ulong last_log_index) {
+      data_collection_t::const_iterator itr = collection_.upper_bound(last_log_index);
+      if (itr == collection_.cbegin()) {
+         return;
+      }
+
+      if (itr->first != last_log_index + 1)
+         --itr;
+      std::for_each(collection_.cbegin(), itr, [](const auto& entry) {
+         auto filebase = entry.second;
+         fs::remove(filebase.replace_extension("index"));
+         fs::remove(filebase.replace_extension("data"));
+      });
+
+      collection_.erase(collection_.begin(), itr);
+      active_index_ = npos;
+   }
+
+   struct pack_read_segment {
+      fs::path path;
+      uint64_t start, end;
+   };
+
+   uint64_t start_of_entry_position(data_collection_t::const_iterator it, ulong entry_index) {
+      if (it->first == entry_index) {
+         return sizeof(data_file_preamble);
+      }
+      return end_of_entry_position(it, entry_index - 1);
+   }
+
+   uint64_t end_of_entry_position(data_collection_t::const_iterator it, ulong idx) {
+      file_reader index_reader(fs::path(it->second).replace_extension("index"));
+      uint64_t    position;
+      int         offset = (idx - it->first) * sizeof(uint64_t);
+      index_reader.seek(offset);
+      index_reader.read(position);
+      return position;
+   }
+
+   ptr<buffer> pack(ulong index, int32 cnt) {
+      if (cnt == 0)
+         return ptr<buffer>{};
+      data_collection_t::const_iterator start_pack_itr = collection_.upper_bound(index);
+      if (start_pack_itr == collection_.cbegin()) {
+         return ptr<buffer>{};
+      }
+      --start_pack_itr;
+
+      data_collection_t::const_iterator end_pack_itr   = collection_.upper_bound(index + cnt);
+      ulong                             end_pack_index = index + cnt;
+
+      std::vector<pack_read_segment> segments;
+      segments.reserve(end_pack_itr - start_pack_itr);
+      for (auto i = start_pack_itr; i < end_pack_itr && i->first != end_pack_index; ++i) {
+         auto path             = fs::path(i->second).replace_extension("data");
+         auto last_entry_index = end_pack_index;
+         if (i + 1 < end_pack_itr) {
+            last_entry_index = (i + 1)->first;
+         }
+         segments.push_back(
+             pack_read_segment{path, sizeof(data_file_preamble), end_of_entry_position(i, last_entry_index - 1)});
+      }
+
+      segments.front().start = start_of_entry_position(start_pack_itr, index);
+
+      // calculate the needed buffer size
+      uint64_t buf_size = 0;
+      for (const auto& seg : segments) {
+         buf_size += (seg.end - seg.start);
+      }
+
+      ptr<buffer> buf_out = buffer::alloc(sizeof(int32) + buf_size);
+      buf_out->pos(0);
+      buf_out->put((int32)cnt);
+
+      for (const auto& seg : segments) {
+         file_reader reader(seg.path);
+         reader.seek(seg.start);
+         std::size_t sz = seg.end - seg.start;
+         reader.read(buf_out->get_raw(sz), sz);
+      }
+      buf_out->pos(0);
+      return buf_out;
+   }
+
+   static void for_each_app_entry(ulong start_index, ulong end_index, uint64_t start_position,
+                                  data_collection_t::const_iterator                   start_itr,
+                                  data_collection_t::const_iterator                   end_itr,
+                                  const std::function<void(ulong, std::string_view)>& callback) {
+
+      ulong cur_idx = start_index;
+
+      for (auto it = start_itr; it != end_itr; ++it) {
+         auto                                 data_file_path = fs::path(it->second).replace_extension("data");
+         boost::iostreams::mapped_file_source src(data_file_path.generic_string());
+         auto                                 data = src.data() + start_position;
+         while (data < src.data() + src.size() && cur_idx < end_index) {
+            log_entry_header header;
+            memcpy(&header, data, sizeof(header));
+            if (header.type == log_val_type::app_log) {
+               callback(cur_idx, std::string_view(data + sizeof(header), header.get_payload_size()));
+            }
+            cur_idx++;
+            data += sizeof(uint32_t) + header.length;
+         }
+         start_position = sizeof(data_file_preamble);
       }
    }
 
-   log_entry_reader(const log_entry_reader&) = delete;
-   log_entry_reader& operator=(const log_entry_reader&) = delete;
-   log_entry_reader(log_entry_reader&& other) { fname.swap(other.fname); }
+   void thr_safe_for_each_app_entry(std::mutex& lock, ulong start_index, ulong end_index,
+                                    const std::function<void(ulong, std::string_view)>& callback) {
+      uint64_t              start_position;
+      tmp_data_collection_t new_collection;
+      {
+         std::lock_guard<std::mutex> guard(lock);
+         auto                        start_itr = collection_.upper_bound(start_index);
+         if (start_itr != collection_.cbegin())
+            --start_itr;
+         else // start_index is smaller than smallest index of kept log entries, adjust it.
+            start_index = start_itr->first;
 
-   void set(fs::path log_dir, ulong index) {
-      auto original = path_for_index(log_dir, index);
-      if (fs::exists(original)) {
-         fname = log_dir / std::tmpnam(nullptr);
-         fs::create_hard_link(path_for_index(log_dir, index), fname);
+         auto end_itr   = collection_.lower_bound(end_index);
+         start_position = start_of_entry_position(start_itr, start_index);
+         new_collection.assign(start_itr, end_itr);
+      }
+      for_each_app_entry(start_index, end_index, start_position, new_collection.cbegin(), new_collection.cend(),
+                         callback);
+   }
+};
+
+struct log_store_impl {
+   std::filesystem::path log_dir_;
+   log_catalog           catalog_;
+   ulong                 next_slot_ = 1;
+   file_writer           data_out_;
+   file_writer           index_out_;
+   uint32_t              log_stride_;
+   std::mutex            logs_lock_;
+
+   log_store_impl(std::filesystem::path log_dir, uint32_t log_stride)
+       : log_dir_(log_dir)
+       , log_stride_(log_stride) {
+
+      // find existing index/data files
+
+      next_slot_ = catalog_.open(log_dir);
+      if (next_slot_ == 0) {
+         this->append(0, log_val_type::app_log, nullptr, 0);
       }
    }
 
-   ptr<log_entry> get() {
-      auto fp = std::unique_ptr<FILE, decltype(&fclose)>(fopen(fname.c_str(), "r"), &fclose);
-      if (fp) {
-         int            sz  = std::filesystem::file_size(fname) - log_entry_meta_size;
-         ptr<buffer>    buf = buffer::alloc(sz);
-         log_entry_meta meta;
-         fread(&meta, log_entry_meta_size, 1, fp.get());
-         fread(buf->get_raw(sz), sz, 1, fp.get());
-         buf->pos(0); // reset the position
-         return cs_new<log_entry>(meta.term, buf, static_cast<log_val_type>(meta.type));
+   void write_data_file_preamble(ulong start_index) {
+      char buf[128];
+      snprintf(buf, 128, "log-entry-%llu", start_index);
+
+      fs::path active_prefix = log_dir_ / buf;
+      catalog_.add(start_index, active_prefix);
+      data_out_  = file_writer(active_prefix.replace_extension("data"), "wb");
+      index_out_ = file_writer(active_prefix.replace_extension("index"), "wb");
+
+      data_out_.write(data_file_preamble{start_index});
+   }
+
+   void prepare_out_files_for_append() {
+      fs::path active_prefix = catalog_.current_log_prefix();
+      data_out_              = file_writer(active_prefix.replace_extension("data"), "ab");
+      index_out_             = file_writer(active_prefix.replace_extension("index"), "ab");
+   }
+
+   void append(ulong term, log_val_type type, const byte* payload, size_t payload_size) {
+      if (next_slot_ % log_stride_ == 0) {
+         write_data_file_preamble(next_slot_);
+      } else if (!data_out_.is_open() || !index_out_.is_open()) {
+         prepare_out_files_for_append();
       }
 
+      data_out_.write(log_entry_header{term, type, static_cast<uint32_t>(payload_size)});
+      data_out_.sync_write(payload, payload_size);
+      uint64_t position = data_out_.cur_position();
+      index_out_.sync_write(position);
+      next_slot_++;
+   }
+
+   ulong append_entry(ptr<log_entry>& entry) {
+      auto&                       buf = entry->get_buf();
+      std::lock_guard<std::mutex> l(logs_lock_);
+      append(entry->get_term(), entry->get_val_type(), buf.data_begin(), buf.size());
+      return next_slot_;
+   }
+
+   ptr<log_entry> last_entry() {
+      std::lock_guard<std::mutex> l(logs_lock_);
+      return catalog_.get_entry(next_slot_ - 1);
+   }
+
+   void write_at(ulong idx, ptr<log_entry>& entry) {
+      auto&                       buf = entry->get_buf();
+      std::lock_guard<std::mutex> l(logs_lock_);
+      if (idx < next_slot_) {
+         catalog_.compact_back(idx - 1);
+         next_slot_ = idx;
+         data_out_.close();
+         append(entry->get_term(), entry->get_val_type(), buf.data_begin(), buf.size());
+      }
+   }
+
+   ptr<std::vector<ptr<log_entry>>> log_entries(ulong start, ulong end) {
+
+      ptr<std::vector<ptr<log_entry>>> ret = cs_new<std::vector<ptr<log_entry>>>();
+      ret->reserve(end - start);
+      std::lock_guard<std::mutex> l(logs_lock_);
+      if (start < start_index() || end > this->next_slot_)
+         throw std::runtime_error("log_store: log_entries() requests nonexistent entry");
+      for (ulong i = start; i < end; ++i) {
+         ret->emplace_back(catalog_.get_entry(i));
+      }
+      return ret;
+   }
+
+   ptr<std::vector<ptr<log_entry>>> log_entries_ext(ulong start, ulong end, int64 batch_size_hint_in_bytes) {
+      ptr<std::vector<ptr<log_entry>>> ret = cs_new<std::vector<ptr<log_entry>>>();
+      ret->reserve(end - start);
+      int64_t                     total_size = 0;
+      std::lock_guard<std::mutex> l(logs_lock_);
+      if (start < start_index() || end > this->next_slot_)
+         throw std::runtime_error("log_store: log_entries_ext() requests nonexistent entry");
+
+      for (ulong i = start; i < end && total_size < batch_size_hint_in_bytes; ++i) {
+         ret->emplace_back(catalog_.get_entry(i));
+         total_size += ret->back()->get_buf().size();
+      }
+      return ret;
+   }
+
+   ulong start_index() const { return catalog_.start_index(); }
+
+   ptr<log_entry> entry_at(ulong index) {
+      std::lock_guard<std::mutex> l(logs_lock_);
+      if (index >= start_index() && index < next_slot_)
+         return catalog_.get_entry(index);
       return empty_log_entry();
    }
 
-   size_t size() const {
-      std::error_code ec;
-      size_t          sz = fs::file_size(fname, ec);
-      return ec ? 0 : sz - log_entry_meta_size;
+   ulong term_at(ulong index) {
+      std::lock_guard<std::mutex> l(logs_lock_);
+      if (index >= start_index() && index < next_slot_)
+         return catalog_.term_at(index);
+      return 0;
    }
 
- private:
-   fs::path fname;
+   ptr<buffer> pack(ulong index, int32 cnt) {
+      std::lock_guard<std::mutex> l(logs_lock_);
+      return catalog_.pack(index, cnt);
+   }
+
+   void apply_pack_segment(ulong seg_index, std::vector<uint64_t>& segment_positions, const byte* seg_begin,
+                           const byte* seg_end) {
+
+      if (catalog_.empty() || seg_index % log_stride_ == 0)
+         write_data_file_preamble(seg_index);
+      else
+         prepare_out_files_for_append();
+
+      auto offset = data_out_.cur_position();
+
+      std::for_each(segment_positions.begin(), segment_positions.end(), [offset](auto& pos) { pos += offset; });
+      // write data
+      data_out_.sync_write(seg_begin, seg_end - seg_begin);
+      // write index
+      index_out_.sync_write(&segment_positions.front(), segment_positions.size() * sizeof(uint64_t));
+   }
+
+   void apply_pack(ulong index, buffer& pack) {
+      pack.pos(0);
+      int32                       num_entries = pack.get_int();
+      std::lock_guard<std::mutex> l(logs_lock_);
+      if (next_slot_ > index)
+         catalog_.compact_back(index - 1);
+      else {
+         data_out_.close();
+         index_out_.close();
+         catalog_.clear();
+      }
+
+      next_slot_ = index;
+
+      std::vector<uint64_t> segment_positions;
+      segment_positions.reserve(this->log_stride_);
+
+      const byte* it                = pack.data();
+      const byte* end               = pack.data_begin() + pack.size();
+      const byte* cur_segment_begin = it;
+      ulong       next_index        = index;
+
+      while (it < end) {
+         uint32_t size;
+         memcpy(&size, it, sizeof(size));
+         it += sizeof(uint32_t) + size;
+         segment_positions.push_back(it - cur_segment_begin);
+         ++next_index;
+         if (next_index % this->log_stride_ == 0) {
+            apply_pack_segment(next_index - segment_positions.size(), segment_positions, cur_segment_begin, it);
+            segment_positions.resize(0);
+            cur_segment_begin = it;
+            next_slot_        = next_index;
+         }
+      }
+
+      if (cur_segment_begin != end) {
+         apply_pack_segment(next_slot_, segment_positions, cur_segment_begin, it);
+         next_slot_ = next_index;
+      }
+
+      if (next_slot_ != index + num_entries)
+         throw std::runtime_error(
+             "log_store: log store received pack whose declared size does not match what it actually contains");
+   }
+
+   bool compact(ulong last_log_index) {
+      if (last_log_index < start_index())
+         return false;
+      std::lock_guard<std::mutex> l(logs_lock_);
+      catalog_.compact_front(last_log_index);
+      data_out_.close();
+      return true;
+   }
 };
 
-log_store::log_store(std::filesystem::path p)
-    : log_dir_(p)
-    , start_idx_(1)
-    , next_slot_(1) {}
+log_store::log_store(std::filesystem::path log_dir, uint32_t stride)
+    : impl_(new log_store_impl(log_dir, stride)) {}
 
-ulong log_store::next_slot() const { return next_slot_; }
+log_store::~log_store() { delete impl_; }
 
-ulong log_store::start_index() const { return start_idx_; }
+ulong log_store::next_slot() const { return impl_->next_slot_; }
 
-ptr<log_entry> log_store::last_entry() const {
-   log_entry_reader reader;
-   {
-      std::lock_guard<std::mutex> l(logs_lock_);
-      reader.set(log_dir_, next_slot_ - 1);
-   }
-   return reader.get();
-}
+ulong log_store::start_index() const { return impl_->start_index(); }
 
-ulong log_store::append(ptr<log_entry>& entry) {
+ptr<log_entry> log_store::last_entry() const { return impl_->last_entry(); }
 
-   auto                        tmp_path = store_log(log_dir_, entry);
-   std::lock_guard<std::mutex> l(logs_lock_);
-   fs::rename(tmp_path, path_for_index(log_dir_, next_slot_));
-   return next_slot_++;
-}
+ulong log_store::append(ptr<log_entry>& entry) { return impl_->append_entry(entry); }
 
-void log_store::write_at(ulong index, ptr<log_entry>& entry) {
-
-   auto tmp_path = store_log(log_dir_, entry);
-   // Discard all logs equal to or greater than `index.
-   std::lock_guard<std::mutex> l(logs_lock_);
-
-   for (ulong i = index; i < next_slot_; ++i) {
-      auto            p = (log_dir_ / std::to_string(i)).concat(".log");
-      std::error_code ec;
-      fs::remove(p, ec);
-   }
-   fs::rename(tmp_path, path_for_index(log_dir_, index));
-
-   next_slot_ = index + 1;
-}
+void log_store::write_at(ulong index, ptr<log_entry>& entry) { impl_->write_at(index, entry); }
 
 ptr<std::vector<ptr<log_entry>>> log_store::log_entries(ulong start, ulong end) {
-
-   std::vector<log_entry_reader> readers;
-   readers.reserve(end - start);
-   {
-      std::lock_guard<std::mutex> l(logs_lock_);
-      for (ulong ii = start; ii < end; ++ii) {
-         readers.emplace_back(log_dir_, ii);
-      }
-   }
-
-   ptr<std::vector<ptr<log_entry>>> ret = cs_new<std::vector<ptr<log_entry>>>();
-   ret->reserve(readers.size());
-   for (auto& r : readers) {
-      ret->emplace_back(r.get());
-   }
-   return ret;
+   return impl_->log_entries(start, end);
 }
 
 ptr<std::vector<ptr<log_entry>>> log_store::log_entries_ext(ulong start, ulong end, int64 batch_size_hint_in_bytes) {
-   ptr<std::vector<ptr<log_entry>>> ret = cs_new<std::vector<ptr<log_entry>>>();
-   if (batch_size_hint_in_bytes < 0) {
-      return ret;
-   }
-   std::vector<log_entry_reader> readers;
-   readers.reserve(end - start);
-
-   {
-      size_t accum_size = 0;
-
-      std::lock_guard<std::mutex> l(logs_lock_);
-      for (ulong ii = start; ii < end; ++ii) {
-         readers.emplace_back(log_dir_, ii);
-         accum_size += readers.back().size();
-         if (batch_size_hint_in_bytes && accum_size >= (ulong)batch_size_hint_in_bytes)
-            break;
-      }
-   }
-   ret->reserve(readers.size());
-   for (auto& r : readers) {
-      ret->emplace_back(r.get());
-   }
-   return ret;
+   return impl_->log_entries_ext(start, end, batch_size_hint_in_bytes);
 }
 
-ptr<log_entry> log_store::entry_at(ulong index) {
-   log_entry_reader reader;
-   {
-      std::lock_guard<std::mutex> l(logs_lock_);
-      reader.set(log_dir_, index);
-   }
-   return reader.get();
-}
+ptr<log_entry> log_store::entry_at(ulong index) { return impl_->entry_at(index); }
 
-ulong log_store::term_at(ulong index) {
-   ulong                       term = 0;
-   std::lock_guard<std::mutex> l(logs_lock_);
-   auto                        p = path_for_index(log_dir_, index);
-   if (fs::exists(p)) {
-      auto fp = std::unique_ptr<FILE, decltype(&fclose)>{fopen(p.c_str(), "r"), &fclose};
-      fread(&term, sizeof(term), 1, fp.get());
-   }
+ulong log_store::term_at(ulong index) { return impl_->term_at(index); }
 
-   return term;
-}
+ptr<buffer> log_store::pack(ulong index, int32 cnt) { return impl_->pack(index, cnt); }
 
-ptr<buffer> log_store::pack(ulong index, int32 cnt) {
-   std::vector<ptr<buffer>> logs;
+void log_store::apply_pack(ulong index, buffer& pack) { impl_->apply_pack(index, pack); }
 
-   size_t                      size_total = 0;
-   std::lock_guard<std::mutex> l(logs_lock_);
-   ulong                       last = std::min(index + cnt, next_slot_);
-   for (ulong ii = index; ii < last; ++ii) {
-      auto p = (log_dir_ / std::to_string(ii)).concat(".log");
-      size_total += std::filesystem::file_size(p);
-   }
+bool log_store::compact(ulong last_log_index) { return impl_->compact(last_log_index); }
 
-   ptr<buffer> buf_out = buffer::alloc(sizeof(int32) + cnt * sizeof(int32) + size_total);
-   buf_out->pos(0);
-   buf_out->put((int32)cnt);
-
-   for (ulong ii = index; ii < last; ++ii) {
-      auto  p  = (log_dir_ / std::to_string(ii)).concat(".log");
-      int32 sz = std::filesystem::file_size(p);
-      buf_out->put(sz);
-      auto fp = std::unique_ptr<FILE, decltype(&fclose)>{fopen(p.c_str(), "r"), &fclose};
-      fread(buf_out->get_raw(sz), 1, sz, fp.get());
-   }
-   return buf_out;
-}
-
-void log_store::apply_pack(ulong index, buffer& pack) {
-   pack.pos(0);
-   int32                 num_logs = pack.get_int();
-   std::vector<fs::path> tmp_paths;
-   for (int32 ii = 0; ii < num_logs; ++ii) {
-      size_t buf_size;
-      auto   data = pack.get_bytes(buf_size);
-      tmp_paths.push_back(store_log(log_dir_, data, buf_size));
-   }
-
-   std::lock_guard<std::mutex> l(logs_lock_);
-   for (int32 ii = 0; ii < num_logs; ++ii) {
-      fs::rename(tmp_paths[ii], path_for_index(log_dir_, index + ii));
-   }
-   if (index >= next_slot_) {
-      // TODO: remove all pre-existing logs
-      start_idx_ = index;
-   } else
-      start_idx_ = std::min(start_idx_, index);
-
-   next_slot_ = index + num_logs;
-}
-
-bool log_store::compact(ulong last_log_index) {
-   std::lock_guard<std::mutex> l(logs_lock_);
-   for (ulong ii = start_idx_; ii <= last_log_index; ++ii) {
-      auto            p = (log_dir_ / std::to_string(ii)).concat(".log");
-      std::error_code ec;
-      std::filesystem::remove(p, ec);
-   }
-
-   // WARNING:
-   //   Even though nothing has been erased,
-   //   we should set `start_idx_` to new index.
-   start_idx_ = last_log_index + 1;
-   return true;
+void log_store::for_each_app_entry(ulong start_index, ulong end_index,
+                                   const std::function<void(ulong, std::string_view)>& callback) {
+   impl_->catalog_.thr_safe_for_each_app_entry(impl_->logs_lock_, start_index, end_index, callback);
 }
 
 } // namespace blockvault

--- a/programs/blockvaultd/log_store.hpp
+++ b/programs/blockvaultd/log_store.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <libnuraft/log_store.hxx>
+#include <filesystem>
+#include <map>
+#include <mutex>
+
+namespace blockvault {
+
+class log_store : public nuraft::log_store {
+public:
+    log_store(std::filesystem::path dir);
+
+    ulong next_slot() const override;
+
+    ulong start_index() const override;
+
+    nuraft::ptr<nuraft::log_entry> last_entry() const override;
+
+    ulong append(nuraft::ptr<nuraft::log_entry>& entry) override;
+
+    void write_at(ulong index, nuraft::ptr<nuraft::log_entry>& entry) override;
+
+    nuraft::ptr<std::vector<nuraft::ptr<nuraft::log_entry>>> log_entries(ulong start, ulong end) override;
+
+    nuraft::ptr<std::vector<nuraft::ptr<nuraft::log_entry>>> log_entries_ext(
+            ulong start, ulong end, int64 batch_size_hint_in_bytes = 0) override;
+
+    nuraft::ptr<nuraft::log_entry> entry_at(ulong index) override;
+
+    ulong term_at(ulong index) override;
+
+    nuraft::ptr<nuraft::buffer> pack(ulong index, int32 cnt) override;
+
+    void apply_pack(ulong index, nuraft::buffer& pack) override;
+
+    bool compact(ulong last_log_index) override;
+
+    bool flush() override { return true; }
+
+private:
+
+    std::filesystem::path log_dir_;
+    ulong                 start_idx_, next_slot_;
+
+    mutable std::mutex logs_lock_;
+    
+};
+
+}

--- a/programs/blockvaultd/log_store.hpp
+++ b/programs/blockvaultd/log_store.hpp
@@ -5,11 +5,19 @@
 #include <map>
 #include <mutex>
 
+namespace nuraft {
+class logger;
+}
+
 namespace blockvault {
+struct log_store_impl;
 
 class log_store : public nuraft::log_store {
 public:
-    log_store(std::filesystem::path dir);
+    log_store(std::filesystem::path log_dir, uint32_t log_stride);
+    ~log_store();
+    log_store(const log_store&) = delete;
+    const log_store& operator=(const log_store&) = delete;
 
     ulong next_slot() const override;
 
@@ -38,13 +46,10 @@ public:
 
     bool flush() override { return true; }
 
-private:
+    void for_each_app_entry(ulong start_index, ulong end_index, const std::function <void(ulong, std::string_view)>&);
 
-    std::filesystem::path log_dir_;
-    ulong                 start_idx_, next_slot_;
-
-    mutable std::mutex logs_lock_;
-    
+  private:
+    log_store_impl* impl_;  
 };
 
 }

--- a/programs/blockvaultd/unittests/CMakeLists.txt
+++ b/programs/blockvaultd/unittests/CMakeLists.txt
@@ -2,4 +2,4 @@
 add_executable(blockvault_unittests main.cpp log_store_tests.cpp ../log_store.cpp)
 target_link_libraries(blockvault_unittests nuraft fc Boost::unit_test_framework)
 
-add_test(NAME blockvault_tests COMMAND blockvault_unittests)
+add_test(NAME blockvault_unittests COMMAND blockvault_unittests)

--- a/programs/blockvaultd/unittests/CMakeLists.txt
+++ b/programs/blockvaultd/unittests/CMakeLists.txt
@@ -1,0 +1,5 @@
+
+add_executable(blockvault_unittests main.cpp log_store_tests.cpp ../log_store.cpp)
+target_link_libraries(blockvault_unittests nuraft fc Boost::unit_test_framework)
+
+add_test(NAME blockvault_tests COMMAND blockvault_unittests)

--- a/programs/blockvaultd/unittests/log_store_tests.cpp
+++ b/programs/blockvaultd/unittests/log_store_tests.cpp
@@ -1,8 +1,8 @@
 #include "../log_store.hpp"
+#include <boost/iterator/transform_iterator.hpp>
 #include <boost/test/unit_test.hpp>
 #include <cstdlib>
 #include <numeric>
-#include <boost/iterator/transform_iterator.hpp>
 
 namespace fs = std::filesystem;
 
@@ -20,7 +20,7 @@ class new_temp_directory_path : public fs::path {
 
 nuraft::ptr<nuraft::log_entry> make_log_entry(ulong term, nuraft::log_val_type type) {
    auto buf = nuraft::buffer::alloc(sizeof(int32_t) + std::rand() % 32);
-   auto r = nuraft::cs_new<nuraft::log_entry>(term, buf, type);
+   auto r   = nuraft::cs_new<nuraft::log_entry>(term, buf, type);
    buf->put(std::rand());
    return r;
 }
@@ -29,125 +29,196 @@ namespace nuraft {
 
 std::ostream& operator<<(std::ostream& os, const log_entry& lhs) {
    os << "{ term: " << lhs.get_term() << ", type: " << lhs.get_val_type() << ", buf: ";
-   std::ios_base::fmtflags f( os.flags() );
+   std::ios_base::fmtflags f(os.flags());
    os << std::hex << std::setfill('0') << std::setw(2);
    const auto& buf = lhs.get_buf();
    std::copy(buf.data_begin(), buf.data_begin() + buf.size(), std::ostream_iterator<int>(os));
-   os.flags( f );
+   os.flags(f);
    os << " }";
    return os;
 }
 
-bool operator == (const log_entry& lhs, const log_entry& rhs) {
+bool operator==(const log_entry& lhs, const log_entry& rhs) {
    return lhs.get_term() == rhs.get_term() && lhs.get_val_type() == rhs.get_val_type() &&
-          lhs.get_buf().size() == rhs.get_buf().size() && memcmp(lhs.get_buf().data_begin(), rhs.get_buf().data_begin(), lhs.get_buf().size()) == 0;   
+          lhs.get_buf().size() == rhs.get_buf().size() &&
+          memcmp(lhs.get_buf().data_begin(), rhs.get_buf().data_begin(), lhs.get_buf().size()) == 0;
 }
 
-}
+} // namespace nuraft
 
 BOOST_AUTO_TEST_CASE(test_log_store) {
    new_temp_directory_path tmp_dir;
-   blockvault::log_store   test_store(tmp_dir);
+   blockvault::log_store   test_store(tmp_dir, 20);
 
-   BOOST_CHECK_EQUAL(test_store.start_index(), 1);
+   BOOST_CHECK_EQUAL(test_store.start_index(), 0);
    BOOST_CHECK_EQUAL(test_store.next_slot(), 1);
    BOOST_CHECK_EQUAL(test_store.last_entry()->get_term(), 0);
 
-
    // test append()
-   ulong term = 0;
-   int type = 0;
+   ulong                                       term = 0;
+   int                                         type = 0;
    std::vector<nuraft::ptr<nuraft::log_entry>> entries;
    entries.emplace_back();
-   for (int i = 0; i < 10; ++i) {
+   for (int i = 1; i < 150; ++i) {
       // change term and type so that they won't always be the same
-      if (i % 2) 
+      if (i % 2)
          ++term;
       else {
          type = (++type) % 6;
       }
 
       auto entry = make_log_entry(term, static_cast<nuraft::log_val_type>(type));
+
       entries.push_back(entry);
       test_store.append(entry);
 
-      BOOST_CHECK_EQUAL(test_store.start_index(), 1);
-      BOOST_CHECK_EQUAL(test_store.next_slot(), i + 2);
+      BOOST_CHECK_EQUAL(test_store.start_index(), 0);
+      BOOST_CHECK_EQUAL(test_store.next_slot(), i + 1);
 
       auto ret_entry = test_store.last_entry();
-      BOOST_CHECK_EQUAL(*entry, *ret_entry);
+
+      BOOST_REQUIRE_EQUAL(*entry, *ret_entry);
    }
 
    // test entry_at()
-   for (int i = 1; i <= 10; ++i) {
+   for (int i = 1; i < 150; ++i) {
       BOOST_CHECK_EQUAL(*entries[i], *test_store.entry_at(i));
    }
 
    // test term_at
-   for (int i = 1; i <= 10; ++i) {
+   for (int i = 1; i < 150; ++i) {
       BOOST_CHECK_EQUAL(entries[i]->get_term(), test_store.term_at(i));
    }
 
-   // test log_entries()
-   auto r0 = test_store.log_entries(3, 8);
-   for (int idx = 3; idx < 8; ++idx) {
-      BOOST_CHECK_EQUAL(*entries[idx], *(r0->at(idx-3)));
+   // test log_entries() in the same segment
+   auto r0 = test_store.log_entries(60, 70);
+   BOOST_CHECK_EQUAL(70 - 60, r0->size());
+   for (int idx = 60; idx < 70; ++idx) {
+      BOOST_CHECK_EQUAL(*entries[idx], *(r0->at(idx - 60)));
+   }
+
+   // test log_entries() across segments
+   auto r00 = test_store.log_entries(90, 110);
+   BOOST_CHECK_EQUAL(110 - 90, r00->size());
+   for (int idx = 90; idx < 110; ++idx) {
+      BOOST_CHECK_EQUAL(*entries[idx], *(r00->at(idx - 90)));
    }
 
    // test log_entries_ext()
    std::vector<uint64_t> total_sizes;
-   total_sizes.resize(10);
+   total_sizes.resize(150 + 1);
    auto entry_buf_size = [](const nuraft::ptr<nuraft::log_entry>& e) { return e->get_buf().size(); };
-   std::partial_sum(boost::make_transform_iterator(entries.begin()+1, entry_buf_size),
-                    boost::make_transform_iterator(entries.end(), entry_buf_size), total_sizes.begin());
+   std::partial_sum(boost::make_transform_iterator(entries.begin() + 1, entry_buf_size),
+                    boost::make_transform_iterator(entries.end(), entry_buf_size), total_sizes.begin() + 2);
 
-   auto r1 = test_store.log_entries_ext(2, 10, total_sizes[5]-total_sizes[0]);
+   auto r1 = test_store.log_entries_ext(90, 110, total_sizes[95] - total_sizes[90]);
    BOOST_CHECK_EQUAL(r1->size(), 5);
 
-   auto r2 = test_store.log_entries_ext(2, 10, -1);
+   auto r11 = test_store.log_entries_ext(90, 110, total_sizes[105] - total_sizes[90]);
+   BOOST_CHECK_EQUAL(r11->size(), 15);
+
+   auto r2 = test_store.log_entries_ext(90, 110, -1);
    BOOST_CHECK_EQUAL(r2->size(), 0);
 
-   auto r3 = test_store.log_entries_ext(2, 10, total_sizes[9]-total_sizes[0]+100);
-   BOOST_CHECK_EQUAL(r3->size(), 8);
+   auto r3 = test_store.log_entries_ext(90, 110, total_sizes[98] - total_sizes[90] + 1);
+   BOOST_CHECK_EQUAL(r3->size(), 9);
 
    // test pack() and apply_pack()
 
-   auto pack = test_store.pack(5, 5);
+   auto pack = test_store.pack(110, 40);
 
    new_temp_directory_path tmp_dir2;
-   blockvault::log_store   test_store2(tmp_dir2);
+   {
+      blockvault::log_store test_store2(tmp_dir2, 10);
 
-   test_store2.apply_pack(5, *pack);
-   BOOST_CHECK_EQUAL(test_store2.start_index(), 5);
-   BOOST_CHECK_EQUAL(test_store2.next_slot(), 10);
+      test_store2.apply_pack(110, *pack);
+      BOOST_CHECK_EQUAL(test_store2.start_index(), 110);
+      BOOST_CHECK_EQUAL(test_store2.next_slot(), 150);
 
-   for (int i = 5; i < 10; ++i) {
-      BOOST_CHECK_EQUAL(*entries[i], *test_store2.entry_at(i));
+      for (int i = 110; i < 150; ++i) {
+         BOOST_CHECK_EQUAL(*entries[i], *test_store2.entry_at(i));
+      }
+
+      pack = test_store.pack(130, 10);
+      test_store2.apply_pack(130, *pack);
+
+      BOOST_CHECK_EQUAL(test_store2.start_index(), 110);
+      BOOST_CHECK_EQUAL(test_store2.next_slot(), 140);
+
+      for (int i = 110; i < 140; ++i) {
+         BOOST_CHECK_EQUAL(*entries[i], *test_store2.entry_at(i));
+      }
    }
 
-
-   pack = test_store.pack(8, 3);
-   test_store2.apply_pack(8, *pack);
-   BOOST_CHECK_EQUAL(test_store2.start_index(), 5);
-   BOOST_CHECK_EQUAL(test_store2.next_slot(), 11);
-
-   for (int i = 8; i < 11; ++i) {
-      BOOST_CHECK_EQUAL(*entries[i], *test_store2.entry_at(i));
+   // test restart
+   {
+      blockvault::log_store test_store2(tmp_dir2, 10);
+      BOOST_CHECK_EQUAL(test_store2.start_index(), 110);
+      BOOST_CHECK_EQUAL(test_store2.next_slot(), 140);
    }
 
    // test write_at()
    auto entry = make_log_entry(term, static_cast<nuraft::log_val_type>(type));
-   test_store.write_at(5, entry);
-   BOOST_CHECK_EQUAL(test_store.next_slot(), 6);
-   for (int i = 1; i <= 4; ++i) {
+   test_store.write_at(135, entry);
+   BOOST_CHECK_EQUAL(test_store.next_slot(), 136);
+   for (int i = 130; i <= 134; ++i) {
       BOOST_CHECK_EQUAL(*entries[i], *test_store.entry_at(i));
    }
-   BOOST_CHECK_EQUAL(*entry, *test_store.entry_at(5));
+   BOOST_CHECK_EQUAL(*entry, *test_store.entry_at(135));
 
-   // test compact()
+   // test for_each_app_entry
 
-   test_store.compact(3);
-   BOOST_CHECK_EQUAL(test_store.start_index(), 4);
-   BOOST_CHECK_EQUAL(test_store.next_slot(), 6);
+   std::set<ulong> app_entry_indices;
+
+   test_store.for_each_app_entry(90, 120, [&entries, &app_entry_indices](ulong index, std::string_view payload) {
+      const auto& entry = entries[index];
+      BOOST_CHECK_EQUAL(entry->get_val_type(), nuraft::app_log);
+      BOOST_CHECK_EQUAL(entry->get_buf().size(), payload.size());
+      BOOST_CHECK_EQUAL(memcmp(entry->get_buf().data_begin(), payload.data(), payload.size()), 0);
+      app_entry_indices.emplace(index);
+   });
+
+   for (int i = 90; i < 120; ++i) {
+      // make sure all app_log entries are received from for_each_app_entry
+      const auto& entry = entries[i];
+      if (entry->get_val_type() == nuraft::app_log) {
+         BOOST_CHECK_EQUAL(app_entry_indices.count(i), 1);
+      }
+   }
+
+   // test compact() with index not in the segment boundary
+
+   test_store.compact(90);
+   BOOST_CHECK_EQUAL(test_store.start_index(), 80);
+   BOOST_CHECK_EQUAL(test_store.next_slot(), 136);
+
+   test_store.compact(99);
+   BOOST_CHECK_EQUAL(test_store.start_index(), 100);
+   BOOST_CHECK_EQUAL(test_store.next_slot(), 136);
+
+   // test for_each_app_entry when the start_index is out of range
+   app_entry_indices.clear();
+
+   test_store.for_each_app_entry(90, 120, [&entries, &app_entry_indices](ulong index, std::string_view payload) {
+      const auto& entry = entries[index];
+      BOOST_CHECK_EQUAL(entry->get_val_type(), nuraft::app_log);
+      BOOST_CHECK_EQUAL(entry->get_buf().size(), payload.size());
+      BOOST_CHECK_EQUAL(memcmp(entry->get_buf().data_begin(), payload.data(), payload.size()), 0);
+      app_entry_indices.emplace(index);
+   });
+
+   for (int i = 100; i < 120; ++i) {
+      // make sure all app_log entries are received from for_each_app_entry
+      const auto& entry = entries[i];
+      if (entry->get_val_type() == nuraft::app_log) {
+         BOOST_CHECK_EQUAL(app_entry_indices.count(i), 1);
+      }
+   }
+
+   // test compact() with index in the segment boundary
+
+   test_store.compact(120);
+   BOOST_CHECK_EQUAL(test_store.start_index(), 120);
+   BOOST_CHECK_EQUAL(test_store.next_slot(), 136);
 
 }

--- a/programs/blockvaultd/unittests/log_store_tests.cpp
+++ b/programs/blockvaultd/unittests/log_store_tests.cpp
@@ -1,0 +1,153 @@
+#include "../log_store.hpp"
+#include <boost/test/unit_test.hpp>
+#include <cstdlib>
+#include <numeric>
+#include <boost/iterator/transform_iterator.hpp>
+
+namespace fs = std::filesystem;
+
+class new_temp_directory_path : public fs::path {
+ public:
+   new_temp_directory_path()
+       : std::filesystem::path(std::tmpnam(nullptr)) {
+      fs::create_directory(*this);
+   }
+   ~new_temp_directory_path() { fs::remove_all(*this); }
+
+   new_temp_directory_path(const new_temp_directory_path&) = delete;
+   new_temp_directory_path& operator=(const new_temp_directory_path&) = delete;
+};
+
+nuraft::ptr<nuraft::log_entry> make_log_entry(ulong term, nuraft::log_val_type type) {
+   auto buf = nuraft::buffer::alloc(sizeof(int32_t) + std::rand() % 32);
+   auto r = nuraft::cs_new<nuraft::log_entry>(term, buf, type);
+   buf->put(std::rand());
+   return r;
+}
+
+namespace nuraft {
+
+std::ostream& operator<<(std::ostream& os, const log_entry& lhs) {
+   os << "{ term: " << lhs.get_term() << ", type: " << lhs.get_val_type() << ", buf: ";
+   std::ios_base::fmtflags f( os.flags() );
+   os << std::hex << std::setfill('0') << std::setw(2);
+   const auto& buf = lhs.get_buf();
+   std::copy(buf.data_begin(), buf.data_begin() + buf.size(), std::ostream_iterator<int>(os));
+   os.flags( f );
+   os << " }";
+   return os;
+}
+
+bool operator == (const log_entry& lhs, const log_entry& rhs) {
+   return lhs.get_term() == rhs.get_term() && lhs.get_val_type() == rhs.get_val_type() &&
+          lhs.get_buf().size() == rhs.get_buf().size() && memcmp(lhs.get_buf().data_begin(), rhs.get_buf().data_begin(), lhs.get_buf().size()) == 0;   
+}
+
+}
+
+BOOST_AUTO_TEST_CASE(test_log_store) {
+   new_temp_directory_path tmp_dir;
+   blockvault::log_store   test_store(tmp_dir);
+
+   BOOST_CHECK_EQUAL(test_store.start_index(), 1);
+   BOOST_CHECK_EQUAL(test_store.next_slot(), 1);
+   BOOST_CHECK_EQUAL(test_store.last_entry()->get_term(), 0);
+
+
+   // test append()
+   ulong term = 0;
+   int type = 0;
+   std::vector<nuraft::ptr<nuraft::log_entry>> entries;
+   entries.emplace_back();
+   for (int i = 0; i < 10; ++i) {
+      // change term and type so that they won't always be the same
+      if (i % 2) 
+         ++term;
+      else {
+         type = (++type) % 6;
+      }
+
+      auto entry = make_log_entry(term, static_cast<nuraft::log_val_type>(type));
+      entries.push_back(entry);
+      test_store.append(entry);
+
+      BOOST_CHECK_EQUAL(test_store.start_index(), 1);
+      BOOST_CHECK_EQUAL(test_store.next_slot(), i + 2);
+
+      auto ret_entry = test_store.last_entry();
+      BOOST_CHECK_EQUAL(*entry, *ret_entry);
+   }
+
+   // test entry_at()
+   for (int i = 1; i <= 10; ++i) {
+      BOOST_CHECK_EQUAL(*entries[i], *test_store.entry_at(i));
+   }
+
+   // test term_at
+   for (int i = 1; i <= 10; ++i) {
+      BOOST_CHECK_EQUAL(entries[i]->get_term(), test_store.term_at(i));
+   }
+
+   // test log_entries()
+   auto r0 = test_store.log_entries(3, 8);
+   for (int idx = 3; idx < 8; ++idx) {
+      BOOST_CHECK_EQUAL(*entries[idx], *(r0->at(idx-3)));
+   }
+
+   // test log_entries_ext()
+   std::vector<uint64_t> total_sizes;
+   total_sizes.resize(10);
+   auto entry_buf_size = [](const nuraft::ptr<nuraft::log_entry>& e) { return e->get_buf().size(); };
+   std::partial_sum(boost::make_transform_iterator(entries.begin()+1, entry_buf_size),
+                    boost::make_transform_iterator(entries.end(), entry_buf_size), total_sizes.begin());
+
+   auto r1 = test_store.log_entries_ext(2, 10, total_sizes[5]-total_sizes[0]);
+   BOOST_CHECK_EQUAL(r1->size(), 5);
+
+   auto r2 = test_store.log_entries_ext(2, 10, -1);
+   BOOST_CHECK_EQUAL(r2->size(), 0);
+
+   auto r3 = test_store.log_entries_ext(2, 10, total_sizes[9]-total_sizes[0]+100);
+   BOOST_CHECK_EQUAL(r3->size(), 8);
+
+   // test pack() and apply_pack()
+
+   auto pack = test_store.pack(5, 5);
+
+   new_temp_directory_path tmp_dir2;
+   blockvault::log_store   test_store2(tmp_dir2);
+
+   test_store2.apply_pack(5, *pack);
+   BOOST_CHECK_EQUAL(test_store2.start_index(), 5);
+   BOOST_CHECK_EQUAL(test_store2.next_slot(), 10);
+
+   for (int i = 5; i < 10; ++i) {
+      BOOST_CHECK_EQUAL(*entries[i], *test_store2.entry_at(i));
+   }
+
+
+   pack = test_store.pack(8, 3);
+   test_store2.apply_pack(8, *pack);
+   BOOST_CHECK_EQUAL(test_store2.start_index(), 5);
+   BOOST_CHECK_EQUAL(test_store2.next_slot(), 11);
+
+   for (int i = 8; i < 11; ++i) {
+      BOOST_CHECK_EQUAL(*entries[i], *test_store2.entry_at(i));
+   }
+
+   // test write_at()
+   auto entry = make_log_entry(term, static_cast<nuraft::log_val_type>(type));
+   test_store.write_at(5, entry);
+   BOOST_CHECK_EQUAL(test_store.next_slot(), 6);
+   for (int i = 1; i <= 4; ++i) {
+      BOOST_CHECK_EQUAL(*entries[i], *test_store.entry_at(i));
+   }
+   BOOST_CHECK_EQUAL(*entry, *test_store.entry_at(5));
+
+   // test compact()
+
+   test_store.compact(3);
+   BOOST_CHECK_EQUAL(test_store.start_index(), 4);
+   BOOST_CHECK_EQUAL(test_store.next_slot(), 6);
+
+}

--- a/programs/blockvaultd/unittests/main.cpp
+++ b/programs/blockvaultd/unittests/main.cpp
@@ -1,0 +1,2 @@
+#define BOOST_TEST_MODULE BlockVault
+#include <boost/test/unit_test.hpp>

--- a/programs/blockvaultd/utils.hpp
+++ b/programs/blockvaultd/utils.hpp
@@ -1,0 +1,120 @@
+#include <filesystem>
+#include <regex>
+#include <unistd.h>
+
+namespace blockvault {
+
+namespace fs = std::filesystem;
+
+template <typename Lambda>
+void for_each_file_in_dir_matches(const fs::path& dir, std::string pattern, Lambda&& lambda) {
+   const std::regex       base_regex(pattern);
+   std::smatch            base_match;
+   fs::directory_iterator end_itr; // Default ctor yields past-the-end
+   for (fs::directory_iterator p(dir); p != end_itr; ++p) {
+      // Skip if not a file
+      if (!fs::is_regular_file(p->status()))
+         continue;
+      // skip if it does not match the pattern
+      std::string fname(p->path().filename().c_str());
+      if (!std::regex_match(fname, base_match, base_regex))
+         continue;
+      lambda(p->path());
+   }
+}
+
+class file_ptr : public std::unique_ptr<FILE, decltype(&fclose)> {
+ public:
+   file_ptr(FILE* f = nullptr)
+       : std::unique_ptr<FILE, decltype(&fclose)>(f, &fclose) {}
+
+   file_ptr(fs::path fname, const char* mode)
+       : file_ptr(fopen(fname.c_str(), mode)) {
+      if (this->get() == nullptr)
+         throw fs::filesystem_error("file open error", fname, std::make_error_code(static_cast<std::errc>(errno)));
+   }
+};
+
+class file_writer {
+   file_ptr fp_;
+   fs::path fname_;
+
+ public:
+   file_writer() = default;
+   file_writer(fs::path path, const char* mode)
+       : fp_(path, mode)
+       , fname_(path) {}
+   file_writer(file_writer&&) = default;
+   file_writer& operator=(file_writer&&) = default;
+
+   void sync() {
+      fflush(fp_.get());
+      fsync(fileno(fp_.get()));
+   }
+
+   int write(const void* data, int num_bytes) { return fwrite(data, 1, num_bytes, fp_.get()); }
+
+   template <typename T>
+   int write(const T& data) {
+      return write(&data, sizeof(data));
+   }
+
+   void sync_write(const void* data, int num_bytes) {
+      int r = fwrite(data, 1, num_bytes, fp_.get());
+      if (r != num_bytes)
+         throw fs::filesystem_error("file write error", fname_, std::make_error_code(static_cast<std::errc>(errno)));
+      sync();
+   }
+
+   template <typename T>
+   void sync_write(const T& data) {
+      sync_write(&data, sizeof(data));
+   }
+
+   uint64_t cur_position() const { return ftell(fp_.get()); }
+
+   bool is_open() const { return fp_.get(); }
+
+   void seek(long int offset, int origin = SEEK_SET) {
+      if (fseek(fp_.get(), offset, origin) != 0)
+         throw fs::filesystem_error("file seek error", fname_, std::make_error_code(static_cast<std::errc>(errno)));
+   }
+
+   void close() { fp_.reset(); }
+};
+
+class file_reader {
+   file_ptr fp_;
+   fs::path fname_;
+
+ public:
+   file_reader() = default;
+   file_reader(fs::path path)
+       : fp_(path, "r")
+       , fname_(path) {}
+   file_reader(file_reader&&) = default;
+
+   file_reader& operator=(file_reader&&) = default;
+
+   void seek(long int offset, int origin = SEEK_SET) {
+      if (fseek(fp_.get(), offset, origin) != 0)
+         throw fs::filesystem_error("file seek error", fname_, std::make_error_code(static_cast<std::errc>(errno)));
+   }
+
+   void read(void* buf, std::size_t size) {
+      if (fread(buf, 1, size, fp_.get()) != size)
+         throw fs::filesystem_error("file read error", fname_, std::make_error_code(static_cast<std::errc>(errno)));
+   }
+
+   template <typename T>
+   void read(T& obj) {
+      if (fread(&obj, 1, sizeof(T), fp_.get()) != sizeof(T))
+         throw fs::filesystem_error("file read error", fname_, std::make_error_code(static_cast<std::errc>(errno)));
+   }
+
+   std::size_t size() const { return fs::file_size(fname_); }
+
+   fs::path path() const { return fname_; }
+};
+
+}


### PR DESCRIPTION
## Change Description
This PR implements the nuraft log_store interface to persist log entries which allows the state to be recovered from restart.

## Change Type
**Select ONE**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [ ] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [x] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the release notes. Please include a description of the change for inclusion in the release notes.-->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->