### PR TITLE
Allow amqp_trx_plugin without chain_api_plugin

### DIFF
--- a/plugins/amqp_trx_plugin/amqp_trx_plugin.cpp
+++ b/plugins/amqp_trx_plugin/amqp_trx_plugin.cpp
@@ -204,6 +204,8 @@ void amqp_trx_plugin::plugin_initialize(const variables_map& options) {
 
       EOS_ASSERT( my->acked != ack_mode::in_block || !my->allow_speculative_execution, chain::plugin_config_exception,
                   "amqp-trx-ack-mode = in_block not supported with amqp-trx-speculative-execution" );
+
+      my->chain_plug->enable_accept_transactions();
    }
    FC_LOG_AND_RETHROW()
 }


### PR DESCRIPTION
## Change Description

- Enable accepting transactions on `chain_plugin`  so that `amqp_trx_plugi`n can be run without `chain_api_plugin` and without `net_plugin` accepting transactions.

## Change Type
**Select ONE**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [x] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [ ] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the relase notes. Please include a description of the change for inclusion in the release notes.-->


## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
