### PR TITLE
Speculative validation optimizations

### DIFF
--- a/libraries/chain/include/eosio/chain/unapplied_transaction_queue.hpp
+++ b/libraries/chain/include/eosio/chain/unapplied_transaction_queue.hpp
@@ -162,7 +162,6 @@ public:
    }
 
    void add_forked( const branch_type& forked_branch ) {
-      if( mode == process_mode::non_speculative || mode == process_mode::speculative_non_producer ) return;
       // forked_branch is in reverse order
       for( auto ritr = forked_branch.rbegin(), rend = forked_branch.rend(); ritr != rend; ++ritr ) {
          const block_state_ptr& bsptr = *ritr;
@@ -176,7 +175,6 @@ public:
    }
 
    void add_aborted( deque<transaction_metadata_ptr> aborted_trxs ) {
-      if( mode == process_mode::non_speculative || mode == process_mode::speculative_non_producer ) return;
       for( auto& trx : aborted_trxs ) {
          fc::time_point expiry = trx->packed_trx()->expiration();
          auto insert_itr = queue.insert( { std::move( trx ), expiry, trx_enum_type::aborted } );

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1356,8 +1356,12 @@ fc::time_point producer_plugin_impl::calculate_pending_block_time() const {
 }
 
 fc::time_point producer_plugin_impl::calculate_block_deadline( const fc::time_point& block_time ) const {
-   bool last_block = ((block_timestamp_type(block_time).slot % config::producer_repetitions) == config::producer_repetitions - 1);
-   return block_time + fc::microseconds(last_block ? _last_block_time_offset_us : _produce_time_offset_us);
+   if( _pending_block_mode == pending_block_mode::producing ) {
+      bool last_block = ((block_timestamp_type( block_time ).slot % config::producer_repetitions) == config::producer_repetitions - 1);
+      return block_time + fc::microseconds(last_block ? _last_block_time_offset_us : _produce_time_offset_us);
+   } else {
+      return block_time + fc::microseconds(_produce_time_offset_us);
+   }
 }
 
 producer_plugin_impl::start_block_result producer_plugin_impl::start_block() {

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -733,11 +733,6 @@ void producer_plugin::plugin_initialize(const boost::program_options::variables_
    LOAD_VALUE_SET(options, "producer-name", my->_producers)
 
    chain::controller& chain = my->chain_plug->chain();
-   unapplied_transaction_queue::process_mode unapplied_mode =
-      (chain.get_read_mode() != chain::db_read_mode::SPECULATIVE) ? unapplied_transaction_queue::process_mode::non_speculative :
-         my->_producers.empty() ? unapplied_transaction_queue::process_mode::speculative_non_producer :
-            unapplied_transaction_queue::process_mode::speculative_producer;
-   my->_unapplied_transactions.set_mode( unapplied_mode );
 
    if( options.count("private-key") )
    {


### PR DESCRIPTION
## Change Description

- `unapplied_transaction_queue`  used to have a `process_mode` where it would not store aborted or forked-out transactions when in knew that the node would never produce a block. This was an optimization because there seemed to be no reason to cache aborted or forked-out transactions. Since the trx has been validated locally and will not be validated again, why keep it around? If you are producing you need to keep it so on a fork-switch the trxs are not lost. But there seemed to be no reason to keep them for speculative mode. However, the `unapplied_transaction_queue` is also used when validating a block to look up already validated and constructed `transaction_metadata`. Keeping the already validated trxs in the queue allows for faster validation of received blocks for all the transactions already received by the node.
- Before this change, when a speculative node's speculative block ran out of cpu or net, it would stop validating transactions until it received a block -- which would cause it to start a new speculative block after processing the received block. With this PR, a new speculative block is created anytime a block is exhausted during speculative transaction processing.
- Before this change speculative 12th blocks would use the `last-block-time-offset-us` which doesn't really make any sense since the block is only speculative and will not be broadcast on the network. With this PR, all speculative blocks use the `produce-time-offset-us` including the 12th block.

## Change Type
**Select ONE**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [ ] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [x] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the relase notes. Please include a description of the change for inclusion in the release notes.-->


## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
