### PR TITLE
add linked actions to the RPC output for get_account

### DIFF
--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -3,6 +3,7 @@
 #include <eosio/chain/block_log.hpp>
 #include <eosio/chain/exceptions.hpp>
 #include <eosio/chain/authorization_manager.hpp>
+#include <eosio/chain/permission_link_object.hpp>
 #include <eosio/chain/code_object.hpp>
 #include <eosio/chain/config.hpp>
 #include <eosio/chain/wasm_interface.hpp>
@@ -3036,6 +3037,19 @@ read_only::get_account_results read_only::get_account( const get_account_params&
    }
    result.ram_usage = rm.get_account_ram_usage( result.account_name );
 
+   const auto linked_action_map = ([&](){
+      const auto& links = d.get_index<permission_link_index,by_permission_name>();
+      auto iter = links.lower_bound( boost::make_tuple( params.account_name ) );
+
+      std::multimap<name, linked_action> result;
+      while (iter != links.end() && iter->account == params.account_name ) {
+         result.emplace(std::make_pair(iter->required_permission, linked_action{iter->code, iter->message_type}));
+         ++iter;
+      }
+
+      return result;
+   })();
+
    const auto& permissions = d.get_index<permission_index,by_owner>();
    auto perm = permissions.lower_bound( boost::make_tuple( params.account_name ) );
    while( perm != permissions.end() && perm->owner == params.account_name ) {
@@ -3051,7 +3065,14 @@ read_only::get_account_results read_only::get_account( const get_account_params&
          }
       }
 
-      result.permissions.push_back( permission{ perm->name, parent, perm->auth.to_authority() } );
+      auto link_bounds = linked_action_map.equal_range(perm->name);
+      auto linked_actions = std::vector<linked_action>();
+      linked_actions.reserve(linked_action_map.count(perm->name));
+      for (auto link = link_bounds.first; link != link_bounds.second; ++link) {
+         linked_actions.push_back(link->second);
+      }
+
+      result.permissions.push_back( permission{ perm->name, parent, perm->auth.to_authority(), std::move(linked_actions)} );
       ++perm;
    }
 

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -3043,7 +3043,8 @@ read_only::get_account_results read_only::get_account( const get_account_params&
 
       std::multimap<name, linked_action> result;
       while (iter != links.end() && iter->account == params.account_name ) {
-         result.emplace(std::make_pair(iter->required_permission, linked_action{iter->code, iter->message_type}));
+         auto action = iter->message_type.empty() ? std::optional<name>() : std::optional<name>(iter->message_type);
+         result.emplace(std::make_pair(iter->required_permission, linked_action{iter->code, std::move(action)}));
          ++iter;
       }
 

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -46,10 +46,16 @@ namespace eosio {
 namespace chain_apis {
 struct empty{};
 
+struct linked_action {
+   name              account;
+   name              action;
+};
+
 struct permission {
-   name              perm_name;
-   name              parent;
-   authority         required_auth;
+   name                       perm_name;
+   name                       parent;
+   authority                  required_auth;
+   std::vector<linked_action> linked_actions;
 };
 
 template<typename>
@@ -802,7 +808,8 @@ private:
 
 }
 
-FC_REFLECT( eosio::chain_apis::permission, (perm_name)(parent)(required_auth) )
+FC_REFLECT( eosio::chain_apis::linked_action, (account)(action) )
+FC_REFLECT( eosio::chain_apis::permission, (perm_name)(parent)(required_auth)(linked_actions) )
 FC_REFLECT(eosio::chain_apis::empty, )
 FC_REFLECT(eosio::chain_apis::read_only::get_info_results,
            (server_version)(chain_id)(head_block_num)(last_irreversible_block_num)(last_irreversible_block_id)

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -52,10 +52,10 @@ struct linked_action {
 };
 
 struct permission {
-   name                       perm_name;
-   name                       parent;
-   authority                  required_auth;
-   std::vector<linked_action> linked_actions;
+   name                                       perm_name;
+   name                                       parent;
+   authority                                  required_auth;
+   std::optional<std::vector<linked_action>>  linked_actions;
 };
 
 template<typename>

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -47,8 +47,8 @@ namespace chain_apis {
 struct empty{};
 
 struct linked_action {
-   name              account;
-   name              action;
+   name                account;
+   std::optional<name> action;
 };
 
 struct permission {

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -2287,9 +2287,11 @@ void get_account( const string& accountName, const string& coresym, bool json_fo
                header_printed = true;
             }
 
-            std::cout << indent << p.perm_name.to_string() + ":" << std::endl;
-            for ( auto it = p.linked_actions->begin(); it != p.linked_actions->end(); ++it ) {
-               std::cout << indent << indent << it->account << "::" << it->action << std::endl;
+            if (!p.linked_actions->empty()) {
+               std::cout << indent << p.perm_name.to_string() + ":" << std::endl;
+               for ( auto it = p.linked_actions->begin(); it != p.linked_actions->end(); ++it ) {
+                  std::cout << indent << indent << it->account << "::" << it->action << std::endl;
+               }
             }
          }
       };

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -2239,9 +2239,26 @@ void get_account( const string& accountName, const string& coresym, bool json_fo
          // looks a little crazy, but should be efficient
          cache.insert( std::make_pair(name, std::move(perm)) );
       }
-      std::function<void (account_name, int)> dfs_print = [&]( account_name name, int depth ) -> void {
+
+      using dfs_fn_t = std::function<void (const eosio::chain_apis::permission&, int)>;
+      std::function<void (account_name, int, dfs_fn_t&)> dfs_exec = [&]( account_name name, int depth, dfs_fn_t& f ) -> void {
          auto& p = cache.at(name);
-         std::cout << indent << std::string(depth*3, ' ') << name << ' ' << std::setw(5) << p.required_auth.threshold << ":    ";
+
+         f(p, depth);
+
+         auto it = tree.find( name );
+         if (it != tree.end()) {
+            auto& children = it->second;
+            sort( children.begin(), children.end() );
+            for ( auto& n : children ) {
+               // we have a tree, not a graph, so no need to check for already visited nodes
+               dfs_exec( n, depth+1, f );
+            }
+         } // else it's a leaf node
+      };
+
+      dfs_fn_t print_auth = [&]( const eosio::chain_apis::permission& p, int depth ) -> void {
+         std::cout << indent << std::string(depth*3, ' ') << p.perm_name << ' ' << std::setw(5) << p.required_auth.threshold << ":    ";
          const char *sep = "";
          for ( auto it = p.required_auth.keys.begin(); it != p.required_auth.keys.end(); ++it ) {
             std::cout << sep << it->weight << ' ' << it->key.to_string();
@@ -2252,19 +2269,37 @@ void get_account( const string& accountName, const string& coresym, bool json_fo
             sep = ", ";
          }
          std::cout << std::endl;
-         auto it = tree.find( name );
-         if (it != tree.end()) {
-            auto& children = it->second;
-            sort( children.begin(), children.end() );
-            for ( auto& n : children ) {
-               // we have a tree, not a graph, so no need to check for already visited nodes
-               dfs_print( n, depth+1 );
-            }
-         } // else it's a leaf node
       };
+
       std::sort(roots.begin(), roots.end());
       for ( auto r : roots ) {
-         dfs_print( r, 0 );
+         dfs_exec( r, 0, print_auth );
+      }
+
+      std::cout << std::endl;
+
+      bool header_printed = false;
+      dfs_fn_t print_links = [&](const eosio::chain_apis::permission& p, int) -> void {
+         if (!p.linked_actions.empty()) {
+
+            if (!header_printed) {
+               std::cout << "permission links: " << std::endl;
+               header_printed = true;
+            }
+
+            std::cout << indent << p.perm_name.to_string() + ":" << std::endl;
+            for ( auto it = p.linked_actions.begin(); it != p.linked_actions.end(); ++it ) {
+               std::cout << indent << indent << it->account << "::" << it->action << std::endl;
+            }
+         }
+      };
+
+      for ( auto r : roots ) {
+         dfs_exec( r, 0, print_links);
+      }
+
+      if (header_printed) {
+         std::cout << std::endl;
       }
 
       auto to_pretty_net = []( int64_t nbytes, uint8_t width_for_units = 5 ) {

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -2280,7 +2280,7 @@ void get_account( const string& accountName, const string& coresym, bool json_fo
 
       bool header_printed = false;
       dfs_fn_t print_links = [&](const eosio::chain_apis::permission& p, int) -> void {
-         if (!p.linked_actions.empty()) {
+         if (p.linked_actions) {
 
             if (!header_printed) {
                std::cout << "permission links: " << std::endl;
@@ -2288,7 +2288,7 @@ void get_account( const string& accountName, const string& coresym, bool json_fo
             }
 
             std::cout << indent << p.perm_name.to_string() + ":" << std::endl;
-            for ( auto it = p.linked_actions.begin(); it != p.linked_actions.end(); ++it ) {
+            for ( auto it = p.linked_actions->begin(); it != p.linked_actions->end(); ++it ) {
                std::cout << indent << indent << it->account << "::" << it->action << std::endl;
             }
          }

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -2290,7 +2290,8 @@ void get_account( const string& accountName, const string& coresym, bool json_fo
             if (!p.linked_actions->empty()) {
                std::cout << indent << p.perm_name.to_string() + ":" << std::endl;
                for ( auto it = p.linked_actions->begin(); it != p.linked_actions->end(); ++it ) {
-                  std::cout << indent << indent << it->account << "::" << it->action << std::endl;
+                  auto action_value = it->action ? it->action->to_string() : std::string("*");
+                  std::cout << indent << indent << it->account << "::" << action_value << std::endl;
                }
             }
          }


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->
## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

This PR adds linked actions to the RPC output for get_account (eg):

```
$ curl http://127.0.0.1:8888/v1/chain/get_account -d '{"account_name":"alice"}' 2>/dev/null | jq
{
  "account_name": "alice",
  ...
  "permissions": [
    {
      "perm_name": "active",
      "parent": "owner",
      "required_auth": {...},
      "linked_actions": [
        {
          "account": "eosio.token",
          "action": "create"
        },
        {
          "account": "eosio.token",
          "action": "issue"
        },
        {
          "account": "eosio.token",
          "action": "burn"
        }
      ]
    },
    {
      "perm_name": "owner",
      "parent": "",
      "required_auth": {...},
      "linked_actions": [
        {
          "account": "eosio.token",
          "action": "transfer"
        },
        {
          "account": "eosio.token",
          "action": "open"
        },
        {
          "account": "eosio.token",
          "action": "close"
        },
        {
          "account": "eosio.token"
        }
      ]
    }
  ]
}
```

In addition it enables `cleos` to pretty-print these linked actions when they are available (eg):

```
$ cleos get account alice
created: 2020-10-28T17:13:49.000
permissions: 
     owner     1:    1 EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV
        active     1:    1 EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV

permission links: 
     owner:
          eosio.token::transfer
          eosio.token::open
          eosio.token::close
          eosio.token::*
     active:
          eosio.token::create
          eosio.token::issue
          eosio.token::burn

memory: 
     quota:       unlimited  used:     3.504 KiB  

net bandwidth: 
     used:               unlimited
     available:          unlimited
     limit:              unlimited

cpu bandwidth:
     used:               unlimited
     available:          unlimited
     limit:              unlimited
```

When an account has no explicit links AND the RPC server is new enough to provide this information, the `permission links` section header is printed and will be empty.  

If instead the RPC server is not new enough to provide this data, the `permission links` section header is printed and will be omitted.  This is to prevent misinterpretation by the user who may think that an empty section means "all actions are defaulted" erroneously if the RPC server does not provide the data.

resolves #5255

## Change Type
**Select ONE**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [ ] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [ ] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the relase notes. Please include a description of the change for inclusion in the release notes.-->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [x] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->

If merged, the OpenAPI files will need to be adjusted for the Permission data type. 
