### PR TITLE
Fixes for DB intrinsic replay logic

### DIFF
--- a/libraries/chain/backing_store/db_context_rocksdb.cpp
+++ b/libraries/chain/backing_store/db_context_rocksdb.cpp
@@ -338,7 +338,7 @@ namespace eosio { namespace chain { namespace backing_store {
          if (past_end(session_iter)) {
             --session_iter;
             // either way, the iterator after our known table should have a primary key in this table as the previous iterator
-            if (!past_end(session_iter) || session_iter == current_session.begin()) {
+            if (past_end(session_iter)) {
                // NOTE: matching chainbase functionality, if iterator store found, but no key in db for table
                return primary_iter_store.invalid_iterator();
             }

--- a/libraries/chain/backing_store/db_key_value_any_lookup.cpp
+++ b/libraries/chain/backing_store/db_key_value_any_lookup.cpp
@@ -45,7 +45,7 @@ namespace eosio { namespace chain { namespace backing_store {
 
    void db_key_value_any_lookup::remove_table_if_empty(const shared_bytes& key) {
       // look for any other entries in the table
-      auto entire_table_prefix_key = db_key_value_format::create_full_key_prefix(key, end_of_prefix::at_type);
+      auto entire_table_prefix_key = db_key_value_format::create_full_key_prefix(key, end_of_prefix::pre_type);
       // since this prefix key is just scope and table, it will include all primary, secondary, and table keys
       auto session_itr = current_session.lower_bound(entire_table_prefix_key);
       EOS_ASSERT( session_itr != current_session.end(), db_rocksdb_invalid_operation_exception,


### PR DESCRIPTION
## Change Description
Fixed issue with finding a rocksdb key in a table to identify if the table needs to be removed.  Also fixed issue with identifying the last key entry in a table using the table end iterator.

## Change Type
**Select ONE**
- [] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [x] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [ ] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the relase notes. Please include a description of the change for inclusion in the release notes.-->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
