### PR TITLE
Allow HTTP-RPC with empty response

### DIFF
--- a/plugins/http_plugin/http_plugin.cpp
+++ b/plugins/http_plugin/http_plugin.cpp
@@ -498,7 +498,7 @@ class http_plugin_impl : public std::enable_shared_from_this<http_plugin_impl> {
              * const accessor
              * @return const reference to the contained object
              */
-            const T& get() const {
+            const T& obj() const {
                return _object;
             }
 
@@ -506,7 +506,7 @@ class http_plugin_impl : public std::enable_shared_from_this<http_plugin_impl> {
              * mutable accessor (can be moved from)
              * @return mutable reference to the contained object
              */
-            T& get() {
+            T& obj() {
                return _object;
             }
 
@@ -551,7 +551,7 @@ class http_plugin_impl : public std::enable_shared_from_this<http_plugin_impl> {
                app().post( priority, [next_ptr, conn=std::move(conn), r=std::move(r), tracked_b, wrapped_then=std::move(wrapped_then)]() mutable {
                   try {
                      // call the `next` url_handler and wrap the response handler
-                     (*next_ptr)( std::move( r ), std::move(*(*tracked_b)), std::move(wrapped_then)) ;
+                     (*next_ptr)( std::move( r ), std::move(tracked_b->obj()), std::move(wrapped_then)) ;
                   } catch( ... ) {
                      conn->handle_exception();
                   }
@@ -595,10 +595,10 @@ class http_plugin_impl : public std::enable_shared_from_this<http_plugin_impl> {
                boost::asio::post( my->thread_pool->get_executor(),
                                   [my, abstract_conn_ptr, code, tracked_response=std::move(tracked_response)]() {
                   try {
-                     if( tracked_response->get().has_value() ) {
-                        std::string json = fc::json::to_string( *tracked_response->get(), fc::time_point::now() + my->max_response_time );
+                     if( tracked_response->obj().has_value() ) {
+                        std::string json = fc::json::to_string( *tracked_response->obj(), fc::time_point::now() + my->max_response_time );
                         auto tracked_json = make_in_flight( std::move( json ), my );
-                        abstract_conn_ptr->send_response( std::move( tracked_json->get() ), code );
+                        abstract_conn_ptr->send_response( std::move( tracked_json->obj() ), code );
                      } else {
                         abstract_conn_ptr->send_response( {}, code );
                      }

--- a/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
@@ -65,13 +65,13 @@ namespace eosio {
    {
       public:
         http_plugin();
-        virtual ~http_plugin();
+        ~http_plugin() override;
 
         //must be called before initialize
-        static void set_defaults(const http_plugin_defaults config);
+        static void set_defaults(const http_plugin_defaults& config);
 
         APPBASE_PLUGIN_REQUIRES()
-        virtual void set_program_options(options_description&, options_description& cfg) override;
+        void set_program_options(options_description&, options_description& cfg) override;
 
         void plugin_initialize(const variables_map& options);
         void plugin_startup();
@@ -134,7 +134,7 @@ namespace eosio {
 
          static const uint8_t details_limit = 10;
 
-         error_info() {};
+         error_info() = default;
 
          error_info(const fc::exception& exc, bool include_full_log) {
             code = exc.code();


### PR DESCRIPTION
## Change Description

Current http request handlers always return the json string converted from fc::variant, it is not allowed to make HTTP-RPC with empty response. (At least, it will have "null" in the case of `fc::variant()`)

I am writing jsonrpc_plugin working upon http_plugin, and when request is given without "id" (it's called notification), JSONRPC server must not reply to it. This patch makes it possible to create API with empty response.

This PR created to fix merge conflicts of original PR: https://github.com/EOSIO/eos/pull/9341

Thanks @conr2d 
Co-Authored-By: conr2d@gmail.com

## Change Type
**Select ONE**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [ ] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [x] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the relase notes. Please include a description of the change for inclusion in the release notes.-->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
