### PR TITLE
Add "Ubuntu 20.04 Package Builder" step to pipeline.yml

### DIFF
--- a/.cicd/generate-pipeline.sh
+++ b/.cicd/generate-pipeline.sh
@@ -554,6 +554,20 @@ cat <<EOF
     timeout: ${TIMEOUT:-10}
     skip: ${SKIP_UBUNTU_18_04}${SKIP_PACKAGE_BUILDER}${SKIP_LINUX}
 
+  - label: ":ubuntu: Ubuntu 20.04 - Package Builder"
+    command:
+      - "buildkite-agent artifact download build.tar.gz . --step ':ubuntu: Ubuntu 20.04 - Build' && tar -xzf build.tar.gz"
+      - "./.cicd/package.sh"
+    env:
+      IMAGE_TAG: "ubuntu-20.04-$PLATFORM_TYPE"
+      PLATFORM_TYPE: $PLATFORM_TYPE
+      OS: "ubuntu-20.04" # OS and PKGTYPE required for lambdas
+      PKGTYPE: "deb"
+    agents:
+      queue: "$BUILDKITE_TEST_AGENT_QUEUE"
+    timeout: ${TIMEOUT:-10}
+    skip: ${SKIP_UBUNTU_20_04}${SKIP_PACKAGE_BUILDER}${SKIP_LINUX}
+
   - label: ":darwin: macOS 10.14 - Package Builder"
     command:
       - "git clone \$BUILDKITE_REPO eos && cd eos && $GIT_FETCH git checkout -f \$BUILDKITE_COMMIT"

--- a/scripts/generate_deb.sh
+++ b/scripts/generate_deb.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 set -eo pipefail
 
 PREFIX="usr"

--- a/scripts/generate_deb.sh
+++ b/scripts/generate_deb.sh
@@ -19,7 +19,7 @@ if [[ -f '/etc/upstream-release/lsb-release' ]]; then
 elif [[ -f '/etc/lsb-release' ]]; then
     source '/etc/lsb-release'
 else
-    echo 'Unrecognized Debian derivative. Not generating .deb file.'
+    echo 'Operating system not recognized, exiting...'
     exit 1
 fi
 

--- a/scripts/generate_deb.sh
+++ b/scripts/generate_deb.sh
@@ -33,8 +33,10 @@ else
     exit 2
 fi
 
+echo "Creating './${PROJECT}/DEBIAN/'."
 mkdir -p "${PROJECT}/DEBIAN"
 chmod 0755 "${PROJECT}/DEBIAN"
+echo "Writing control file to '${PROJECT}/DEBIAN/control'."
 echo "Package: ${PROJECT}
 Version: ${VERSION_NO_SUFFIX}-${RELEASE}
 Section: devel
@@ -43,12 +45,17 @@ Depends: libc6, libgcc1, ${RELEASE_SPECIFIC_DEPS}, libstdc++6, libtinfo5, zlib1g
 Architecture: amd64
 Homepage: ${URL}
 Maintainer: ${EMAIL}
-Description: ${DESC}" &> "${PROJECT}/DEBIAN/control"
-cat "${PROJECT}/DEBIAN/control"
+Description: ${DESC}" | tee &> "${PROJECT}/DEBIAN/control"
 
-. ./generate_tarball.sh "${NAME}"
-echo "Unpacking tarball: ${NAME}.tar.gz..."
+GENERATE_TARBALL=". ./generate_tarball.sh '${NAME}'"
+echo "$ $GENERATE_TARBALL"
+eval $GENERATE_TARBALL
+echo "Unpacking '${NAME}.tar.gz'..."
 tar -xzvf "${NAME}.tar.gz" -C "${PROJECT}"
-$(type -P fakeroot) dpkg-deb --build "${PROJECT}"
+DPKG_BUILD="\$(type -P fakeroot) dpkg-deb --build '${PROJECT}'"
+echo "$ $DPKG_BUILD"
+eval $DPKG_BUILD
+echo "Deleting './${PROJECT}/DEBIAN/'."
 mv "${PROJECT}.deb" "${NAME}.deb"
 rm -r "${PROJECT}"
+echo "Done, package is '${NAME}.deb'."

--- a/scripts/generate_deb.sh
+++ b/scripts/generate_deb.sh
@@ -23,12 +23,13 @@ else
     exit 1
 fi
 
-if [[ "${DISTRIB_RELEASE}" == '16.04' ]]; then
-    RELEASE_SPECIFIC_DEPS='libssl1.0.0'
-elif [[ "${DISTRIB_RELEASE}" == '18.04' ]]; then
+DISTRIB_MAJOR_VERSION="$(echo "$DISTRIB_RELEASE" | cut -d '.' -f '1')"
+if (( "$DISTRIB_MAJOR_VERSION" >= 18 )); then
     RELEASE_SPECIFIC_DEPS='libssl1.1'
+elif (( "$DISTRIB_MAJOR_VERSION" >= 16 )); then
+    RELEASE_SPECIFIC_DEPS='libssl1.0.0'
 else
-    echo 'Unrecognized Ubuntu version. Update generate_deb.sh. Not generating .deb file.'
+    echo "Found Ubuntu $DISTRIB_MAJOR_VERSION, but not sure which version of libssl to use. Exiting..."
     exit 2
 fi
 

--- a/scripts/generate_deb.sh
+++ b/scripts/generate_deb.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 set -eo pipefail
 
-PREFIX='usr'
-SPREFIX="${PREFIX}"
-SUBPREFIX="opt/${PROJECT}/${VERSION}"
-SSUBPREFIX="opt\/${PROJECT}\/${VERSION}"
+export PREFIX='usr'
+export SPREFIX="${PREFIX}"
+export SUBPREFIX="opt/${PROJECT}/${VERSION}"
+export SSUBPREFIX="opt\/${PROJECT}\/${VERSION}"
 RELEASE="${VERSION_SUFFIX}"
 
 # default release to "1" if there is no suffix
@@ -44,11 +44,6 @@ Homepage: ${URL}
 Maintainer: ${EMAIL}
 Description: ${DESC}" &> "${PROJECT}/DEBIAN/control"
 cat "${PROJECT}/DEBIAN/control"
-
-export PREFIX
-export SUBPREFIX
-export SPREFIX
-export SSUBPREFIX
 
 . ./generate_tarball.sh "${NAME}"
 echo "Unpacking tarball: ${NAME}.tar.gz..."

--- a/scripts/generate_deb.sh
+++ b/scripts/generate_deb.sh
@@ -29,7 +29,7 @@ elif [ ${DISTRIB_RELEASE} = "18.04" ]; then
     RELEASE_SPECIFIC_DEPS="libssl1.1"
 else
     echo "Unrecognized Ubuntu version.  Update generate_deb.sh.  Not generating .deb file."
-    exit 1
+    exit 2
 fi
 
 mkdir -p ${PROJECT}/DEBIAN

--- a/scripts/generate_deb.sh
+++ b/scripts/generate_deb.sh
@@ -1,39 +1,39 @@
 #!/bin/bash
 set -eo pipefail
 
-PREFIX="usr"
-SPREFIX=${PREFIX}
+PREFIX='usr'
+SPREFIX="${PREFIX}"
 SUBPREFIX="opt/${PROJECT}/${VERSION}"
 SSUBPREFIX="opt\/${PROJECT}\/${VERSION}"
 RELEASE="${VERSION_SUFFIX}"
 
 # default release to "1" if there is no suffix
-if [[ -z $RELEASE ]]; then
-    RELEASE="1"
+if [[ -z "$RELEASE" ]]; then
+    RELEASE='1'
 fi
 
 NAME="${PROJECT}_${VERSION_NO_SUFFIX}-${RELEASE}_amd64"
 
-if [[ -f /etc/upstream-release/lsb-release ]]; then
-    source /etc/upstream-release/lsb-release
-elif [[ -f /etc/lsb-release ]]; then
-    source /etc/lsb-release
+if [[ -f '/etc/upstream-release/lsb-release' ]]; then
+    source '/etc/upstream-release/lsb-release'
+elif [[ -f '/etc/lsb-release' ]]; then
+    source '/etc/lsb-release'
 else
-    echo "Unrecognized Debian derivative.  Not generating .deb file."
+    echo 'Unrecognized Debian derivative. Not generating .deb file.'
     exit 1
 fi
 
-if [ ${DISTRIB_RELEASE} = "16.04" ]; then
-    RELEASE_SPECIFIC_DEPS="libssl1.0.0"
-elif [ ${DISTRIB_RELEASE} = "18.04" ]; then
-    RELEASE_SPECIFIC_DEPS="libssl1.1"
+if [[ "${DISTRIB_RELEASE}" == '16.04' ]]; then
+    RELEASE_SPECIFIC_DEPS='libssl1.0.0'
+elif [[ "${DISTRIB_RELEASE}" == '18.04' ]]; then
+    RELEASE_SPECIFIC_DEPS='libssl1.1'
 else
-    echo "Unrecognized Ubuntu version.  Update generate_deb.sh.  Not generating .deb file."
+    echo 'Unrecognized Ubuntu version. Update generate_deb.sh. Not generating .deb file.'
     exit 2
 fi
 
-mkdir -p ${PROJECT}/DEBIAN
-chmod 0755 ${PROJECT}/DEBIAN
+mkdir -p "${PROJECT}/DEBIAN"
+chmod 0755 "${PROJECT}/DEBIAN"
 echo "Package: ${PROJECT}
 Version: ${VERSION_NO_SUFFIX}-${RELEASE}
 Section: devel
@@ -42,17 +42,17 @@ Depends: libc6, libgcc1, ${RELEASE_SPECIFIC_DEPS}, libstdc++6, libtinfo5, zlib1g
 Architecture: amd64
 Homepage: ${URL}
 Maintainer: ${EMAIL}
-Description: ${DESC}" &> ${PROJECT}/DEBIAN/control
-cat ${PROJECT}/DEBIAN/control
+Description: ${DESC}" &> "${PROJECT}/DEBIAN/control"
+cat "${PROJECT}/DEBIAN/control"
 
 export PREFIX
 export SUBPREFIX
 export SPREFIX
 export SSUBPREFIX
 
-. ./generate_tarball.sh ${NAME}
+. ./generate_tarball.sh "${NAME}"
 echo "Unpacking tarball: ${NAME}.tar.gz..."
-tar -xzvf ${NAME}.tar.gz -C ${PROJECT}
-$(type -P fakeroot) dpkg-deb --build ${PROJECT}
-mv ${PROJECT}.deb ${NAME}.deb
-rm -r ${PROJECT}
+tar -xzvf "${NAME}.tar.gz" -C "${PROJECT}"
+$(type -P fakeroot) dpkg-deb --build "${PROJECT}"
+mv "${PROJECT}.deb" "${NAME}.deb"
+rm -r "${PROJECT}"

--- a/scripts/generate_deb.sh
+++ b/scripts/generate_deb.sh
@@ -9,27 +9,27 @@ RELEASE="${VERSION_SUFFIX}"
 
 # default release to "1" if there is no suffix
 if [[ -z $RELEASE ]]; then
-  RELEASE="1"
+    RELEASE="1"
 fi
 
 NAME="${PROJECT}_${VERSION_NO_SUFFIX}-${RELEASE}_amd64"
 
 if [[ -f /etc/upstream-release/lsb-release ]]; then
-  source /etc/upstream-release/lsb-release
+    source /etc/upstream-release/lsb-release
 elif [[ -f /etc/lsb-release ]]; then
-  source /etc/lsb-release
+    source /etc/lsb-release
 else
-  echo "Unrecognized Debian derivative.  Not generating .deb file."
-  exit 1
+    echo "Unrecognized Debian derivative.  Not generating .deb file."
+    exit 1
 fi
 
 if [ ${DISTRIB_RELEASE} = "16.04" ]; then
-  RELEASE_SPECIFIC_DEPS="libssl1.0.0"
+    RELEASE_SPECIFIC_DEPS="libssl1.0.0"
 elif [ ${DISTRIB_RELEASE} = "18.04" ]; then
-  RELEASE_SPECIFIC_DEPS="libssl1.1"
+    RELEASE_SPECIFIC_DEPS="libssl1.1"
 else
-  echo "Unrecognized Ubuntu version.  Update generate_deb.sh.  Not generating .deb file."
-  exit 1
+    echo "Unrecognized Ubuntu version.  Update generate_deb.sh.  Not generating .deb file."
+    exit 1
 fi
 
 mkdir -p ${PROJECT}/DEBIAN

--- a/scripts/generate_deb.sh
+++ b/scripts/generate_deb.sh
@@ -33,7 +33,7 @@ else
 fi
 
 mkdir -p ${PROJECT}/DEBIAN
-chmod 0755 ${PROJECT}/DEBIAN || exit 1
+chmod 0755 ${PROJECT}/DEBIAN
 echo "Package: ${PROJECT}
 Version: ${VERSION_NO_SUFFIX}-${RELEASE}
 Section: devel
@@ -52,7 +52,7 @@ export SSUBPREFIX
 
 . ./generate_tarball.sh ${NAME}
 echo "Unpacking tarball: ${NAME}.tar.gz..."
-tar -xzvf ${NAME}.tar.gz -C ${PROJECT} || exit 1
-$(type -P fakeroot) dpkg-deb --build ${PROJECT} || exit 1
-mv ${PROJECT}.deb ${NAME}.deb || exit 1
-rm -r ${PROJECT} || exit 1
+tar -xzvf ${NAME}.tar.gz -C ${PROJECT}
+$(type -P fakeroot) dpkg-deb --build ${PROJECT}
+mv ${PROJECT}.deb ${NAME}.deb
+rm -r ${PROJECT}

--- a/scripts/generate_tarball.sh
+++ b/scripts/generate_tarball.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 set -eo pipefail
 
 NAME=$1

--- a/scripts/generate_tarball.sh
+++ b/scripts/generate_tarball.sh
@@ -35,8 +35,8 @@ cp -R ${BUILD_DIR}/licenses/eosio/* ${EOS_PREFIX}/licenses || exit 1
 #popd &> /dev/null
 
 for f in $(ls "${BUILD_DIR}/bin/"); do
-   bn=$(basename $f)
-   ln -sf ../${SUBPREFIX}/bin/$bn ${PREFIX}/bin/$bn || exit 1
+    bn=$(basename $f)
+    ln -sf ../${SUBPREFIX}/bin/$bn ${PREFIX}/bin/$bn || exit 1
 done
 echo "Generating Tarball $NAME.tar.gz..."
 tar -cvzf $NAME.tar.gz ./${PREFIX}/* || exit 1

--- a/scripts/generate_tarball.sh
+++ b/scripts/generate_tarball.sh
@@ -4,35 +4,14 @@ set -eo pipefail
 NAME=$1
 EOS_PREFIX=${PREFIX}/${SUBPREFIX}
 mkdir -p ${PREFIX}/bin/
-#mkdir -p ${PREFIX}/lib/cmake/${PROJECT}
 mkdir -p ${EOS_PREFIX}/bin
 mkdir -p ${EOS_PREFIX}/licenses/eosio
-#mkdir -p ${EOS_PREFIX}/include
-#mkdir -p ${EOS_PREFIX}/lib/cmake/${PROJECT}
-#mkdir -p ${EOS_PREFIX}/cmake
-#mkdir -p ${EOS_PREFIX}/scripts
 
 # install binaries 
 cp -R ${BUILD_DIR}/bin/* ${EOS_PREFIX}/bin
 
 # install licenses
 cp -R ${BUILD_DIR}/licenses/eosio/* ${EOS_PREFIX}/licenses
-
-# install libraries
-#cp -R ${BUILD_DIR}/lib/* ${EOS_PREFIX}/lib
-
-# install cmake modules
-#sed "s/_PREFIX_/\/${SPREFIX}/g" ${BUILD_DIR}/modules/EosioTesterPackage.cmake &> ${EOS_PREFIX}/lib/cmake/${PROJECT}/EosioTester.cmake
-#sed "s/_PREFIX_/\/${SPREFIX}\/${SSUBPREFIX}/g" ${BUILD_DIR}/modules/${PROJECT}-config.cmake.package &> ${EOS_PREFIX}/lib/cmake/${PROJECT}/${PROJECT}-config.cmake
-
-# install includes
-#cp -R ${BUILD_DIR}/include/* ${EOS_PREFIX}/include
-
-# make symlinks
-#pushd ${PREFIX}/lib/cmake/${PROJECT} &> /dev/null
-#ln -sf ../../../${SUBPREFIX}/lib/cmake/${PROJECT}/${PROJECT}-config.cmake ${PROJECT}-config.cmake
-#ln -sf ../../../${SUBPREFIX}/lib/cmake/${PROJECT}/EosioTester.cmake EosioTester.cmake
-#popd &> /dev/null
 
 for f in $(ls "${BUILD_DIR}/bin/"); do
     bn=$(basename $f)

--- a/scripts/generate_tarball.sh
+++ b/scripts/generate_tarball.sh
@@ -1,22 +1,22 @@
 #!/bin/bash
 set -eo pipefail
 
-NAME=$1
-EOS_PREFIX=${PREFIX}/${SUBPREFIX}
-mkdir -p ${PREFIX}/bin/
-mkdir -p ${EOS_PREFIX}/bin
-mkdir -p ${EOS_PREFIX}/licenses/eosio
+NAME="$1"
+EOS_PREFIX="${PREFIX}/${SUBPREFIX}"
+mkdir -p "${PREFIX}/bin/"
+mkdir -p "${EOS_PREFIX}/bin"
+mkdir -p "${EOS_PREFIX}/licenses/eosio"
 
 # install binaries 
-cp -R ${BUILD_DIR}/bin/* ${EOS_PREFIX}/bin
+cp -R "${BUILD_DIR}"/bin/* ${EOS_PREFIX}/bin
 
 # install licenses
-cp -R ${BUILD_DIR}/licenses/eosio/* ${EOS_PREFIX}/licenses
+cp -R "${BUILD_DIR}"/licenses/eosio/* ${EOS_PREFIX}/licenses
 
 for f in $(ls "${BUILD_DIR}/bin/"); do
-    bn=$(basename $f)
-    ln -sf ../${SUBPREFIX}/bin/$bn ${PREFIX}/bin/$bn
+    bn=$(basename "$f")
+    ln -sf ../"${SUBPREFIX}/bin/$bn" "${PREFIX}/bin/$bn"
 done
 echo "Generating Tarball $NAME.tar.gz..."
-tar -cvzf $NAME.tar.gz ./${PREFIX}/*
-rm -r ${PREFIX}
+tar -cvzf "$NAME.tar.gz" ./"${PREFIX}"/*
+rm -r "${PREFIX}"

--- a/scripts/generate_tarball.sh
+++ b/scripts/generate_tarball.sh
@@ -17,6 +17,6 @@ for f in $(ls "${BUILD_DIR}/bin/"); do
     bn=$(basename "$f")
     ln -sf ../"${SUBPREFIX}/bin/$bn" "${PREFIX}/bin/$bn"
 done
-echo "Generating Tarball $NAME.tar.gz..."
+echo "Compressing '$NAME.tar.gz'..."
 tar -cvzf "$NAME.tar.gz" ./"${PREFIX}"/*
 rm -r "${PREFIX}"

--- a/scripts/generate_tarball.sh
+++ b/scripts/generate_tarball.sh
@@ -13,10 +13,10 @@ mkdir -p ${EOS_PREFIX}/licenses/eosio
 #mkdir -p ${EOS_PREFIX}/scripts
 
 # install binaries 
-cp -R ${BUILD_DIR}/bin/* ${EOS_PREFIX}/bin  || exit 1
+cp -R ${BUILD_DIR}/bin/* ${EOS_PREFIX}/bin
 
 # install licenses
-cp -R ${BUILD_DIR}/licenses/eosio/* ${EOS_PREFIX}/licenses || exit 1
+cp -R ${BUILD_DIR}/licenses/eosio/* ${EOS_PREFIX}/licenses
 
 # install libraries
 #cp -R ${BUILD_DIR}/lib/* ${EOS_PREFIX}/lib
@@ -36,8 +36,8 @@ cp -R ${BUILD_DIR}/licenses/eosio/* ${EOS_PREFIX}/licenses || exit 1
 
 for f in $(ls "${BUILD_DIR}/bin/"); do
     bn=$(basename $f)
-    ln -sf ../${SUBPREFIX}/bin/$bn ${PREFIX}/bin/$bn || exit 1
+    ln -sf ../${SUBPREFIX}/bin/$bn ${PREFIX}/bin/$bn
 done
 echo "Generating Tarball $NAME.tar.gz..."
-tar -cvzf $NAME.tar.gz ./${PREFIX}/* || exit 1
-rm -r ${PREFIX} || exit 1
+tar -cvzf $NAME.tar.gz ./${PREFIX}/*
+rm -r ${PREFIX}


### PR DESCRIPTION
## Change Description
From [AUTO-278](https://blockone.atlassian.net/browse/AUTO-278), I was asked to add an Ubuntu 20.04 Package Builder step to the [`eosio`](https://buildkite.com/EOSIO/eosio) CI pipeline. You can see it running [here](https://buildkite.com/EOSIO/eosio/builds/25335#cd8b64e9-e053-403a-b892-fdbe60e52111). The new package was tested with the following commands, after manually downloading the package from Buildkite:
```bash
docker run -v "$(pwd):/eos" -w /eos -it ubuntu:20.04 /bin/bash
```
Then, inside the container:
```bash
apt-get update
apt install -y /eos/eosio_2.1.0-alpha2_amd64.deb
```
The binary runs:
```bash
$ nodeos --full-version
v2.1.0-alpha2-792f8935c0911c897306b6a44d7e44721fed0329
```

## Change Type
**Select *ONE*:**
- [ ] Documentation
- [ ] Stability bug fix
- [ ] Other
- [ ] Other - special case

## Testing Changes
**Select *ANY* that apply:**
- [ ] New Tests
- [ ] Existing Tests
- [ ] Test Framework
- [x] CI System
- [ ] Other

## Consensus Changes
- [ ] Consensus Changes
None.

## API Changes
- [ ] API Changes
None.

## Documentation Additions
- [ ] Documentation Additions
None.