### PR TITLE
[blockvault] Fix accessing an empty watermark

### DIFF
--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -2073,6 +2073,7 @@ void producer_plugin_impl::produce_block() {
    if ( blockvault_plug->get() != nullptr ) {
       std::promise<bool> p;
       std::future<bool> f = p.get_future();
+      consider_new_watermark( pending_blk_state->header.producer, pending_blk_state->block_num, pending_blk_state->block->timestamp );
       std::optional<producer_watermark> watermark{get_watermark(pending_blk_state->header.producer)};
       EOS_ASSERT(watermark.has_value(), empty_watermark, "Attempting to use a watermark that does not exist");
       blockvault_plug->get()->async_propose_constructed_block(watermark.value(), pending_blk_state->dpos_irreversible_blocknum, pending_blk_state->block, [&p](bool b) {

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -2073,10 +2073,9 @@ void producer_plugin_impl::produce_block() {
    if ( blockvault_plug->get() != nullptr ) {
       std::promise<bool> p;
       std::future<bool> f = p.get_future();
-      consider_new_watermark( pending_blk_state->header.producer, pending_blk_state->block_num, pending_blk_state->block->timestamp );
-      std::optional<producer_watermark> watermark{get_watermark(pending_blk_state->header.producer)};
-      EOS_ASSERT(watermark.has_value(), empty_watermark, "Attempting to use a watermark that does not exist");
-      blockvault_plug->get()->async_propose_constructed_block(watermark.value(), pending_blk_state->dpos_irreversible_blocknum, pending_blk_state->block, [&p](bool b) {
+      blockvault_plug->get()->async_propose_constructed_block({pending_blk_state->block->block_num(), pending_blk_state->block->timestamp},
+                                                               pending_blk_state->dpos_irreversible_blocknum,
+                                                               pending_blk_state->block, [&p](bool b) {
          p.set_value( b );
       });
       EOS_ASSERT( f.get(), blockvault_failure, "Blockvault failure" );


### PR DESCRIPTION
The producer watermark is now constructed within the function call to `async_propose_constructed_block`, as opposed to calling `get_watermark`.

<hr>

**Pattern used in `on_block_header` to generate producer watermarks (for posterity):**
```c++
void on_block_header( const block_state_ptr& bsp ) {
   consider_new_watermark( bsp->header.producer, bsp->block_num, bsp->block->timestamp );
}
```
```c++
my->_accepted_block_header_connection.emplace(chain.accepted_block_header.connect( [this]( const auto& bsp ){ my->on_block_header( bsp ); } ));
```
```c++
void commit_block( bool add_to_fork_db ) {
   auto reset_pending_on_exit = fc::make_scoped_exit([this]{
      pending.reset();
   });

   try {
      // ...

      emit( self.accepted_block, bsp );

      // ...
   }

   // push the state for pending.
   pending->push();
}
```

<hr>

So `nodeos_run_test.py` currently has this output:
```bash
...
debug 2020-11-17T08:26:10.000 thread-0  producer_plugin.cpp:1472      start_block          ] Starting block #30 at 2020-11-17T08:26:10.000 producer defproducerb
debug 2020-11-17T08:26:10.001 thread-0  producer_plugin.cpp:1640      remove_expired_trxs  ] Processed 0 expired transactions of the 0 transactions in the unapplied queue, Persistent expired 0, Other expired 0
debug 2020-11-17T08:26:10.001 thread-0  producer_plugin.cpp:1943      schedule_maybe_produ ] Scheduling Block Production on Normal Block #30 for 2020-11-17T08:26:10.400
debug 2020-11-17T08:26:10.401 thread-0  producer_plugin.cpp:1957      operator()           ] Produce block timer for 30 running at 2020-11-17T08:26:10.401
debug 2020-11-17T08:26:10.401 thread-0  producer_plugin.cpp:2023      operator()           ] Signing took 165us
info  2020-11-17T08:26:10.412 thread-1  block_vault_impl.hpp:71       operator()           ] propose_constructed_block({30, 1317833541}, 28) returns false
warn  2020-11-17T08:26:10.412 thread-0  producer_plugin.cpp:2012      maybe_produce_block  ] 3170014 blockvault_failure: Blockvault server-side failure
Blockvault failure
    {}
    thread-0  producer_plugin.cpp:2082 produce_block

debug 2020-11-17T08:26:10.412 thread-0  producer_plugin.cpp:2014      maybe_produce_block  ] Aborting block due to produce_block error
error 2020-11-17T08:26:10.412 thread-0  producer_plugin.cpp:1437      start_block          ] Not producing block because "defproducerb" signed a block at a higher block number (30) than the current fork's head (29)
debug 2020-11-17T08:26:10.412 thread-0  producer_plugin.cpp:1466      start_block          ] Not starting speculative block until 2020-11-17T08:26:10.000
debug 2020-11-17T08:26:10.412 thread-0  producer_plugin.cpp:1990      schedule_delayed_pro ] Scheduling Speculative/Production Change at 2020-11-17T08:26:10.000
debug 2020-11-17T08:26:10.412 thread-0  producer_plugin.cpp:1959      operator()           ] Producing Block #30 returned: false
error 2020-11-17T08:26:10.413 thread-0  producer_plugin.cpp:1437      start_block          ] Not producing block because "defproducerb" signed a block at a higher block number (30) than the current fork's head (29)
debug 2020-11-17T08:26:10.413 thread-0  producer_plugin.cpp:1472      start_block          ] Starting block #30 at 2020-11-17T08:26:10.413 producer defproducerb
debug 2020-11-17T08:26:10.413 thread-0  producer_plugin.cpp:1640      remove_expired_trxs  ] Processed 0 expired transactions of the 0 transactions in the unapplied queue, Persistent expired 0, Other expired 0
debug 2020-11-17T08:26:10.413 thread-0  producer_plugin.cpp:1922      schedule_production_ ] Speculative Block Created; Scheduling Speculative/Production Change
debug 2020-11-17T08:26:10.413 thread-0  producer_plugin.cpp:1990      schedule_delayed_pro ] Scheduling Speculative/Production Change at 2020-11-17T08:26:10.500
error 2020-11-17T08:26:10.500 thread-0  producer_plugin.cpp:1437      start_block          ] Not producing block because "defproducerb" signed a block at a higher block number (30) than the current fork's head (29)
debug 2020-11-17T08:26:10.500 thread-0  producer_plugin.cpp:1472      start_block          ] Starting block #30 at 2020-11-17T08:26:10.500 producer defproducerb
debug 2020-11-17T08:26:10.501 thread-0  producer_plugin.cpp:1640      remove_expired_trxs  ] Processed 0 expired transactions of the 0 transactions in the unapplied queue, Persistent expired 0, Other expired 0
debug 2020-11-17T08:26:10.501 thread-0  producer_plugin.cpp:1922      schedule_production_ ] Speculative Block Created; Scheduling Speculative/Production Change
debug 2020-11-17T08:26:10.501 thread-0  producer_plugin.cpp:1990      schedule_delayed_pro ] Scheduling Speculative/Production Change at 2020-11-17T08:26:11.000
error 2020-11-17T08:26:11.000 thread-0  producer_plugin.cpp:1437      start_block          ] Not producing block because "defproducerb" signed a block at a higher block number (30) than the current fork's head (29)
debug 2020-11-17T08:26:11.000 thread-0  producer_plugin.cpp:1472      start_block          ] Starting block #30 at 2020-11-17T08:26:11.000 producer defproducerb
debug 2020-11-17T08:26:11.000 thread-0  producer_plugin.cpp:1640      remove_expired_trxs  ] Processed 0 expired transactions of the 0 transactions in the unapplied queue, Persistent expired 0, Other expired 0
debug 2020-11-17T08:26:11.000 thread-0  producer_plugin.cpp:1922      schedule_production_ ] Speculative Block Created; Scheduling Speculative/Production Change
debug 2020-11-17T08:26:11.000 thread-0  producer_plugin.cpp:1990      schedule_delayed_pro ] Scheduling Speculative/Production Change at 2020-11-17T08:26:11.500
debug 2020-11-17T08:26:11.348 thread-2  net_plugin.cpp:2063           expire_txns          ] expire_local_txns size 55 removed 48
debug 2020-11-17T08:26:11.348 thread-2  net_plugin.cpp:3260           expire               ] expire_txns 233us
...
```