### PR TITLE
Huangminghuang/postgres backend fix

### DIFF
--- a/plugins/blockvault_client_plugin/postgres_backend.cpp
+++ b/plugins/blockvault_client_plugin/postgres_backend.cpp
@@ -66,6 +66,7 @@ bool postgres_backend::propose_constructed_block(std::pair<uint32_t, uint32_t> w
       pqxx::work w(conn);
 
       pqxx::largeobjectaccess obj(w);
+      obj.write(nullptr, 0);
       pqxx::binarystring      block_id_blob(block_id.data(), block_id.size());
       pqxx::binarystring      previous_block_id_blob(previous_block_id.data(), previous_block_id.size());
       w.exec_prepared0("insert_constructed_block", watermark.first, watermark.second, lib, block_id_blob,
@@ -85,6 +86,7 @@ bool postgres_backend::append_external_block(uint32_t block_num, uint32_t lib, c
       pqxx::work w(conn);
 
       pqxx::largeobjectaccess obj(w);
+      obj.write(nullptr, 0);
       pqxx::binarystring      block_id_blob(block_id.data(), block_id.size());
       pqxx::binarystring      previous_block_id_blob(previous_block_id.data(), previous_block_id.size());
       w.exec_prepared0("insert_external_block", block_num, lib, block_id_blob, previous_block_id_blob, obj.id(),
@@ -108,6 +110,7 @@ bool postgres_backend::propose_snapshot(std::pair<uint32_t, uint32_t> watermark,
 
       pqxx::work              w(conn);
       pqxx::largeobjectaccess obj(w);
+      obj.write(nullptr, 0);
 
       w.exec_prepared0("insert_snapshot", watermark.first, watermark.second, obj.id());
       auto r = w.exec_prepared("get_snapshot_insertion_result", obj.id());

--- a/plugins/blockvault_client_plugin/postgres_backend.cpp
+++ b/plugins/blockvault_client_plugin/postgres_backend.cpp
@@ -20,7 +20,7 @@ postgres_backend::postgres_backend(const std::string& options)
        "insert_constructed_block",
        "INSERT INTO BlockData (watermark_bn, watermark_ts, lib, block_id, previous_block_id, block, block_size) "
        "SELECT $1, $2, $3, $4, $5, $6, $7  WHERE NOT "
-       "EXISTS (SELECT * FROM BlockData WHERE (watermark_bn >= $1) OR (watermark_ts > $2) OR (lib >= $3) OR (block_id "
+       "EXISTS (SELECT * FROM BlockData WHERE (watermark_bn >= $1) OR (watermark_ts > $2) OR (lib > $3) OR (block_id "
        "= $4))");
 
    conn.prepare(

--- a/plugins/blockvault_client_plugin/tests/postgres_backend_tests.cpp
+++ b/plugins/blockvault_client_plugin/tests/postgres_backend_tests.cpp
@@ -82,8 +82,8 @@ typedef boost::mpl::list<eosio::blockvault::postgres_backend> test_types;
 BOOST_AUTO_TEST_CASE_TEMPLATE(test_propose_constructed_block, T, test_types) {
    backend_test_fixture<T> fixture;
 
-   // watermark_bn and lib should be monotonically increasing,
-   // watermark_ts should be non-decreasing
+   // watermark_bn should be increasing,
+   // watermark_ts and lib should be non-decreasing
 
    BOOST_REQUIRE(fixture.propose_constructed_block(10, 1, 1, 'a'));
    BOOST_REQUIRE(fixture.propose_constructed_block(11, 1, 2, 'b'));
@@ -96,7 +96,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_propose_constructed_block, T, test_types) {
    BOOST_REQUIRE(!fixture.propose_constructed_block(12, 1, 4, 'd'));
 
    // lib is not increasing
-   BOOST_REQUIRE(!fixture.propose_constructed_block(13, 1, 3, 'd'));
+   BOOST_REQUIRE(fixture.propose_constructed_block(13, 1, 3, 'd'));
 
    // watermark_bn, watermark_ts and lib are all increasing
    BOOST_REQUIRE(fixture.propose_constructed_block(14, 2, 4, 'e'));
@@ -130,11 +130,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_append_external_block, T, test_types) {
    // block.block_num < max_lib
    BOOST_REQUIRE(!fixture.append_external_block(2, 4));
 
-   // block lib > max_lib (should the max_lib = std::max(lib, max_lib)? )
+   // block lib > max_lib
    BOOST_REQUIRE(fixture.append_external_block(6, 5));
 
-   // ???
-   BOOST_REQUIRE(!fixture.propose_constructed_block(13, 2, 5));
+   BOOST_REQUIRE(fixture.propose_constructed_block(13, 2, 5));
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(test_propose_snapshot, T, test_types) {


### PR DESCRIPTION
## Change Description
1. Fix large object upload problem. We need to write 0 byte so that the oid can be created and insert into the table.
2. Fix propose_constructed_block lib comparison logic. 


## Change Type
**Select ONE**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [ ] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [x] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the relase notes. Please include a description of the change for inclusion in the release notes.-->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
