### PR TITLE
Pop back a delta with empty rows #9386

### DIFF
--- a/libraries/state_history/create_deltas.cpp
+++ b/libraries/state_history/create_deltas.cpp
@@ -104,6 +104,10 @@ std::vector<table_delta> create_deltas(const chainbase::database& db, bool full_
          for (auto& row : undo.new_values) {
             delta.rows.obj.emplace_back(true, pack_row(row));
          }
+
+         if(delta.rows.obj.empty()) {
+            deltas.pop_back();
+         }
       }
    };
 

--- a/unittests/state_history_tests.cpp
+++ b/unittests/state_history_tests.cpp
@@ -494,6 +494,19 @@ private:
    deltas_vector v;
 };
 
+BOOST_AUTO_TEST_CASE(test_deltas_not_empty) {
+   for (backing_store_type backing_store : { backing_store_type::CHAINBASE/* TODO: uncomment this , backing_store_type::ROCKSDB*/ } ) {
+      table_deltas_tester chain;
+      chain.set_backing_store(backing_store);
+
+      auto deltas = eosio::state_history::create_deltas(chain.control->kv_db(), false);
+
+      for(const auto &delta: deltas) {
+         BOOST_REQUIRE(!delta.rows.obj.empty());
+      }
+   }
+}
+
 BOOST_AUTO_TEST_CASE(test_deltas_account_creation) {
    for (backing_store_type backing_store : { backing_store_type::CHAINBASE, backing_store_type::ROCKSDB }) {
       table_deltas_tester chain;


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->
## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
In the SHiP delta creation, it may happen that when undo.new_values and undo.removed_values are empty, but undo.old_values is not empty, but the include_delta comparison evaluates to false for these objects and none of them are included on the delta's rows, creating a delta with empty rows. Detect this case and pop back the created table_delta object for this case.

This address issue https://github.com/EOSIO/eos/issues/9386

## Change Type
**Select ONE**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [x] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [ ] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the relase notes. Please include a description of the change for inclusion in the release notes.-->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
