### PR TITLE
Fix client sending most recent block id to sync

### DIFF
--- a/plugins/blockvault_client_plugin/tests/postgres_backend_tests.cpp
+++ b/plugins/blockvault_client_plugin/tests/postgres_backend_tests.cpp
@@ -246,4 +246,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_sync, T, test_types) {
       // sync from existant block id
       BOOST_REQUIRE_NO_THROW(fixture.sync(mock_block_id{12, 'c'}, callback));
    }
+
+   {
+      mock_sync_callback callback;
+      // sync from the most recent block id
+      BOOST_REQUIRE_NO_THROW(fixture.sync(mock_block_id{14, 'g'}, callback));
+   }
 }


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->
## Change Description

This PR fix the problem when the client send the most recent block id for sync if would return snapshot and all blocks instead of just returning nothing. 

## Change Type
**Select ONE**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [ ] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [x] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the relase notes. Please include a description of the change for inclusion in the release notes.-->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
