### PR TITLE
net_plugin monitor heartbeat of peers

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -3576,7 +3576,7 @@ namespace eosio {
            "   _port  \tremote port number of peer\n\n"
            "   _lip   \tlocal IP address connected to peer\n\n"
            "   _lport \tlocal port number connected to peer\n\n")
-         ( "p2p-keepalive-interval", bpo::value<int>()->default_value(def_keepalive_interval), "peer heartbeat keepalive message interval in miliseconds")
+         ( "p2p-keepalive-interval-ms", bpo::value<int>()->default_value(def_keepalive_interval), "peer heartbeat keepalive message interval in milliseconds")
 
         ;
    }
@@ -3602,12 +3602,12 @@ namespace eosio {
          my->p2p_accept_transactions = options.at( "p2p-accept-transactions" ).as<bool>();
 
          my->use_socket_read_watermark = options.at( "use-socket-read-watermark" ).as<bool>();
-         my->keepalive_interval = std::chrono::milliseconds( options.at( "p2p-keepalive-interval" ).as<int>() );
+         my->keepalive_interval = std::chrono::milliseconds( options.at( "p2p-keepalive-interval-ms" ).as<int>() );
          EOS_ASSERT( my->keepalive_interval.count() > 0, chain::plugin_config_exception,
-                     "p2p-keepalive_interval must be greater than 0" );
+                     "p2p-keepalive_interval-ms must be greater than 0" );
 
-         if( options.count( "p2p-keepalive-interval" )) {
-            my->heartbeat_timeout = std::chrono::milliseconds( options.at( "p2p-keepalive-interval" ).as<int>() * 2 );
+         if( options.count( "p2p-keepalive-interval-ms" )) {
+            my->heartbeat_timeout = std::chrono::milliseconds( options.at( "p2p-keepalive-interval-ms" ).as<int>() * 2 );
          }
 
          if( options.count( "p2p-listen-endpoint" ) && options.at("p2p-listen-endpoint").as<string>().length()) {

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -3576,7 +3576,7 @@ namespace eosio {
            "   _port  \tremote port number of peer\n\n"
            "   _lip   \tlocal IP address connected to peer\n\n"
            "   _lport \tlocal port number connected to peer\n\n")
-         ( "keepalive-interval", bpo::value<int>()->default_value(def_keepalive_interval), "heartbeat keepalive message interval in miliseconds")
+         ( "p2p-keepalive-interval", bpo::value<int>()->default_value(def_keepalive_interval), "peer heartbeat keepalive message interval in miliseconds")
 
         ;
    }
@@ -3602,10 +3602,12 @@ namespace eosio {
          my->p2p_accept_transactions = options.at( "p2p-accept-transactions" ).as<bool>();
 
          my->use_socket_read_watermark = options.at( "use-socket-read-watermark" ).as<bool>();
-         my->keepalive_interval = std::chrono::milliseconds( options.at( "keepalive-interval" ).as<int>() );
+         my->keepalive_interval = std::chrono::milliseconds( options.at( "p2p-keepalive-interval" ).as<int>() );
+         EOS_ASSERT( my->keepalive_interval.count() > 0, chain::plugin_config_exception,
+                     "p2p-keepalive_interval must be greater than 0" );
 
-         if( options.count( "keepalive-interval" )) {
-            my->heartbeat_timeout = std::chrono::milliseconds( options.at( "keepalive-interval" ).as<int>() * 2 );
+         if( options.count( "p2p-keepalive-interval" )) {
+            my->heartbeat_timeout = std::chrono::milliseconds( options.at( "p2p-keepalive-interval" ).as<int>() * 2 );
          }
 
          if( options.count( "p2p-listen-endpoint" ) && options.at("p2p-listen-endpoint").as<string>().length()) {

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -1100,16 +1100,15 @@ namespace eosio {
    {
       if( protocol_version >= heartbeat_interval ) {
          if( latest_msg_time > 0 &&  current_time > latest_msg_time + hb_timeout ) {
+            no_retry = benign_other;
             if( !peer_address().empty() ) {
                fc_wlog(logger, "heartbeat timed out for peer address ${adr}", ("adr", peer_address()));
-               no_retry = benign_other;
                close(true);  // reconnect
             } else {
                {
                   std::lock_guard<std::mutex> g_conn( conn_mtx );
                   fc_wlog(logger, "heartbeat timed out from ${p} ${ag}", ("p", last_handshake_recv.p2p_address)("ag", last_handshake_recv.agent));
                }
-               no_retry = fatal_other;
                close(false); // don't reconnect
             }
             return;


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->
## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
Implemented heartbeat monitoring of connections.
- Added config option --p2p-keepalive-interval-ms N  
- Updated time stamp of received messages
- ticker timer function checks each connections latest time stamp and current time stamp. 
As ticker() is executed on keepalive interval, heartbeat time out may not be the exact 2 * p2p-keepalive-interval-ms.
- For connection to peer-address, it will try to reconnect.  For accepted connection,  the connection is disconnected and destroyed.
- For connections from old network_version, the heartbeat timeout will not be enabled.



## Change Type
**Select ONE**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [ ] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [x] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the relase notes. Please include a description of the change for inclusion in the release notes.-->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [x] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->

>nodeos --help 
  ...                                     
                                        
  --p2p-keepalive-interval-ms arg (=32000)     heartbeat keepalive message interval in
                                        miliseconds
...


1. Every p2p-keepalive-interval-ms milliseconds a time_message is published to all the connections. 
2. If any messages not received over 2 * p2p-keepalive-interval-ms milliseoncds, a heartbeat timeout occurs and the  connection is closed.   If the connection is to peer, it will be reconnected when the peer restarts.  If it is an accepted connection, it will not be reconnected and the connection is closed and removed. 
3. Heartbeat timeout is disabled on connection from older version.    

