### PR TITLE
[blockvault] Fix CICD Test Failure

### DIFF
--- a/.cicd/platforms/unpinned/macos-10.15-unpinned.sh
+++ b/.cicd/platforms/unpinned/macos-10.15-unpinned.sh
@@ -3,6 +3,6 @@ set -eo pipefail
 VERSION=1
 export SDKROOT="$(xcrun --sdk macosx --show-sdk-path)"
 brew update
-brew install git cmake python libtool libusb graphviz automake wget gmp pkgconfig doxygen openssl jq boost libpq libpqxx || :
+brew install git cmake python libtool libusb graphviz automake wget gmp pkgconfig doxygen openssl jq boost || :
 # install nvm for ship_test
 cd ~ && brew install nvm && mkdir -p ~/.nvm && echo "export NVM_DIR=$HOME/.nvm" >> ~/.bash_profile && echo 'source $(brew --prefix nvm)/nvm.sh' >> ~/.bash_profile && cat ~/.bash_profile && source ~/.bash_profile && echo $NVM_DIR && nvm install --lts=dubnium


### PR DESCRIPTION
~~Installing the dependencies in `libpq` and `libpqxx` in the `.cicd/platforms/unpinned/macos-10.15-unpinned.sh` script is causing the test `snapshot_unit_test_eos-vm`. This change addresses that issue.~~
![image](https://user-images.githubusercontent.com/35586806/99719886-e87fd300-2a7a-11eb-9d6f-942d575ef6f5.png)
