### PR TITLE
Snapshot memory exhaustion

### DIFF
--- a/libraries/chain/combined_database.cpp
+++ b/libraries/chain/combined_database.cpp
@@ -562,15 +562,28 @@ namespace eosio { namespace chain {
       std::vector<std::pair<eosio::session::shared_bytes, eosio::session::shared_bytes>> batch;
       bool                more     = !section.empty();
       auto                read_row = [&section, &more, &db](auto& row) { more = section.read_row(row, db); };
+      uint64_t            batch_mem_size = 0;
 
       while (more) {
          // read the row for the table
          backing_store::table_id_object_view table_obj;
          read_row(table_obj);
-         auto put = [&batch, &table_obj](auto&& value, auto create_fun, auto&&... args) {
+         auto put = [&batch, &table_obj, &batch_mem_size, &kv_database, snapshot_batch_threashold]
+               (auto&& value, auto create_fun, auto&&... args) {
             auto composite_key = create_fun(table_obj.scope, table_obj.table, std::forward<decltype(args)>(args)...);
             batch.emplace_back(backing_store::db_key_value_format::create_full_key(composite_key, table_obj.code),
                                std::forward<decltype(value)>(value));
+
+            const auto& back = batch.back();
+            const auto size = back.first.size() + back.second.size();
+            if (size >= snapshot_batch_threashold || snapshot_batch_threashold - size < batch_mem_size) {
+               kv_database.write(batch);
+               batch_mem_size = 0;
+               batch.clear();
+            }
+            else {
+               batch_mem_size += size;
+            }
          };
 
          // handle the primary key index
@@ -607,6 +620,7 @@ namespace eosio { namespace chain {
          backing_store::payer_payload pp{table_obj.payer, nullptr, 0};
          b1::chain_kv::bytes (*create_table_key)(name scope, name table) = backing_store::db_key_value_format::create_table_key;
          put(pp.as_payload(), create_table_key);
+
       }
       kv_database.write(batch);
    }
@@ -614,7 +628,7 @@ namespace eosio { namespace chain {
    void combined_database::read_contract_tables_from_snapshot(const snapshot_reader_ptr& snapshot) {
       snapshot->read_section("contract_tables", [this](auto& section) {
          if (kv_undo_stack && db.get<kv_db_config_object>().backing_store == backing_store_type::ROCKSDB)
-            rocksdb_read_contract_tables_from_snapshot(*kv_database, db, section);
+            rocksdb_read_contract_tables_from_snapshot(*kv_database, db, section, kv_snapshot_batch_threashold);
          else
             chainbase_read_contract_tables_from_snapshot(db, section);
       });

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -233,7 +233,7 @@ struct controller_impl {
         cfg.read_only ? database::read_only : database::read_write,
         cfg.reversible_cache_size, false, cfg.db_map_mode ),
     kv_db(cfg.backing_store == backing_store_type::CHAINBASE
-          ? combined_database(db)
+          ? combined_database(db, cfg.persistent_storage_mbytes_batch)
           : combined_database(db, cfg)), 
     blog( cfg.blog ),
     fork_db( cfg.state_dir ),

--- a/libraries/chain/include/eosio/chain/combined_database.hpp
+++ b/libraries/chain/include/eosio/chain/combined_database.hpp
@@ -84,7 +84,8 @@ namespace eosio { namespace chain {
 
    class combined_database {
     public:
-      explicit combined_database(chainbase::database& chain_db);
+      explicit combined_database(chainbase::database& chain_db,
+                                 uint32_t snapshot_batch_threashold);
 
       combined_database(chainbase::database& chain_db,
                         const controller::config& cfg);
@@ -138,6 +139,7 @@ namespace eosio { namespace chain {
       chainbase::database&                                       db;
       std::unique_ptr<rocks_db_type>                             kv_database;
       kv_undo_stack_ptr                                          kv_undo_stack;
+      const uint64_t                                             kv_snapshot_batch_threashold;
    };
 
    std::optional<eosio::chain::genesis_state> extract_legacy_genesis_state(snapshot_reader& snapshot, uint32_t version);

--- a/libraries/chain/include/eosio/chain/config.hpp
+++ b/libraries/chain/include/eosio/chain/config.hpp
@@ -92,6 +92,7 @@ const static uint16_t   default_persistent_storage_num_threads       = 1;
 const static int        default_persistent_storage_max_num_files     = -1;
 const static uint64_t   default_persistent_storage_write_buffer_size = 128 * 1024 * 1024;
 const static uint64_t   default_persistent_storage_bytes_per_sync    = 1 * 1024 * 1024;
+const static uint32_t   default_persistent_storage_mbytes_batch      = 50;
 
 static_assert(MAX_SIZE_OF_BYTE_ARRAYS == 20*1024*1024, "Changing MAX_SIZE_OF_BYTE_ARRAYS breaks consensus. Make sure this is expected");
 

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -89,6 +89,7 @@ namespace eosio { namespace chain {
             int                      persistent_storage_max_num_files = chain::config::default_persistent_storage_max_num_files;
             uint64_t                 persistent_storage_write_buffer_size = chain::config::default_persistent_storage_write_buffer_size;
             uint64_t                 persistent_storage_bytes_per_sync = chain::config::default_persistent_storage_bytes_per_sync;
+            uint32_t                 persistent_storage_mbytes_batch = chain::config::default_persistent_storage_mbytes_batch;
             fc::microseconds         abi_serializer_max_time_us = fc::microseconds(chain::config::default_abi_serializer_max_time_us);
             uint32_t   max_nonprivileged_inline_action_size =  chain::config::default_max_nonprivileged_inline_action_size;
             bool                     read_only                  = false;

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -312,6 +312,8 @@ void chain_plugin::set_program_options(options_description& cli, options_descrip
           "Size of a single rocksdb memtable (in MiB)")
          ("persistent-storage-bytes-per-sync", bpo::value<uint64_t>()->default_value(config::default_persistent_storage_bytes_per_sync),
           "Rocksdb write rate of flushes and compactions.")
+         ("persistent-storage-mbytes-snapshot-batch", bpo::value<uint32_t>()->default_value(config::default_persistent_storage_mbytes_batch),
+          "Rocksdb batch size threshold before writing read in snapshot data to database.")
 
          ("reversible-blocks-db-size-mb", bpo::value<uint64_t>()->default_value(config::default_reversible_cache_size / (1024  * 1024)), "Maximum size (in MiB) of the reversible blocks database")
          ("reversible-blocks-db-guard-size-mb", bpo::value<uint64_t>()->default_value(config::default_reversible_guard_size / (1024  * 1024)), "Safely shut down node when free space remaining in the reverseible blocks database drops below this size (in MiB).")
@@ -855,6 +857,10 @@ void chain_plugin::plugin_initialize(const variables_map& options) {
          EOS_ASSERT( my->chain_config->persistent_storage_bytes_per_sync > 0, plugin_config_exception,
                      "persistent-storage-bytes-per-sync ${num} must be greater than 0", ("num", my->chain_config->persistent_storage_bytes_per_sync) );
       }
+
+      my->chain_config->persistent_storage_mbytes_batch = options.at( "persistent-storage-mbytes-snapshot-batch" ).as<uint32_t>();
+      EOS_ASSERT( my->chain_config->persistent_storage_mbytes_batch > 0, plugin_config_exception,
+                  "persistent-storage-mbytes-snapshot-batch ${num} must be greater than 0", ("num", my->chain_config->persistent_storage_mbytes_batch) );
 
       if( options.count( "reversible-blocks-db-size-mb" ))
          my->chain_config->reversible_cache_size =


### PR DESCRIPTION
# Change Description
Code previously was batching up all key-value pairs from db intrinsic tables during initialization from a snapshot. Changed to track how much memory was being stored and writing out the batch when it passes a newly added configuration threshold.

## Change Type
**Select ONE**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [x] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [ ] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the relase notes. Please include a description of the change for inclusion in the release notes.-->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [x] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
New configuration parameter:
"persistent-storage-mbytes-snapshot-batch"
          Rocksdb threshold, in MB, to determine how  much memory in Key-Value pairs to batch before writing data read from a snapshot. Depending on the resources available on your machine, increasing this number may result in faster loading of a snapshot.

## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
