### PR TITLE
Fixed shell expansion of chmod command within .cicd/packages.sh script

### DIFF
--- a/.cicd/package.sh
+++ b/.cicd/package.sh
@@ -13,7 +13,7 @@ else # Linux
     echo '--- :docker: Selecting Container'
     ARGS="${ARGS:-"--rm --init -v \"\$(pwd):$MOUNTED_DIR\""}"
     . "$HELPERS_DIR/file-hash.sh" "$CICD_DIR/platforms/$PLATFORM_TYPE/$IMAGE_TAG.dockerfile"
-    PRE_COMMANDS="cd \"$MOUNTED_DIR/build/packages\" && chmod 755 ./*.sh"
+    PRE_COMMANDS="cd \"$MOUNTED_DIR/build/packages\" && chmod 755 './*.sh'" # the single quotes around `chmod` parameter are required so shell expansion is performed within the Docker container
     if [[ "$IMAGE_TAG" =~ "ubuntu" ]]; then
         ARTIFACT='*.deb'
         PACKAGE_TYPE='deb'


### PR DESCRIPTION
## Change Description
In the past, I had submitted some fixes to `.cicd` pipeline so it was usable in different environment (see #8972).

Some recent change (https://github.com/EOSIO/eos/commit/9986ee747281171d8745e045f4038dd2cd3a1c32) remove that. Here is a new fix that works with the new changes that have been made to the `.cicd` pipeline.

Tested this change locally on my workstation (Mac OS X) as well as in our CI system (CloudBuild so Linux host), both worked appropriately performing the shell expansion inside the Docker container and not in the host.

Ping @kj4ezj since you are the one who did the commit so just want to be sure it's all right.

I have a similar patch for `master`, just waiting for an heads-up to open a PR on `master` branch. 

## Change Type
- [ ] Documentation
- [ ] Stability bug fix
- [X] Other

## Testing Changes
- [ ] New Tests
- [ ] Existing Tests
- [ ] Test Framework
- [X] CI System
- [ ] Other

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
