### PR TITLE
added next_key_bytes

### DIFF
--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -2395,9 +2395,9 @@ read_only::get_table_rows_result read_only::get_kv_table_rows_context( const rea
             row_key.resize(key_size);
             auto status = itr->kv_it_key(0, row_key.data(), key_size, value_size);
             EOS_ASSERT(status != chain::kv_it_stat::iterator_erased && value_size >= prefix_size(), chain::contract_table_query_exception,  "Invalid lower bound iterator in ${t} ${i}", ("t", p.table)("i", p.index_name));
-            auto next_key = string(&row_key.data()[prefix_size()], row_key.size() - prefix_size());
+            auto next_key_bytes = string(&row_key.data()[prefix_size()], row_key.size() - prefix_size());
 
-            boost::algorithm::hex(next_key.begin(), next_key.end(), std::back_inserter(result.next_key));
+            boost::algorithm::hex(next_key_bytes.begin(), next_key_bytes.end(), std::back_inserter(result.next_key_bytes));
        }
       } // end of for
    };

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -365,6 +365,7 @@ public:
       vector<fc::variant> rows; ///< one row per item, either encoded as hex String or JSON object
       bool                more = false; ///< true if last element in data is not the end and sizeof data() < limit
       string              next_key; ///< fill lower_bound with this value to fetch more rows
+      string              next_key_bytes; ///< fill lower_bound with this value to fetch more rows with encode-type of "bytes"
    };
 
    get_table_rows_result get_table_rows( const get_table_rows_params& params )const;
@@ -1098,7 +1099,7 @@ FC_REFLECT( eosio::chain_apis::read_write::push_transaction_results, (transactio
 
 FC_REFLECT( eosio::chain_apis::read_only::get_table_rows_params, (json)(code)(scope)(table)(table_key)(lower_bound)(upper_bound)(limit)(key_type)(index_position)(encode_type)(reverse)(show_payer) )
 FC_REFLECT( eosio::chain_apis::read_only::get_kv_table_rows_params, (json)(code)(table)(index_name)(encode_type)(index_value)(lower_bound)(upper_bound)(limit)(reverse)(show_payer) )
-FC_REFLECT( eosio::chain_apis::read_only::get_table_rows_result, (rows)(more)(next_key) );
+FC_REFLECT( eosio::chain_apis::read_only::get_table_rows_result, (rows)(more)(next_key)(next_key_bytes) );
 
 FC_REFLECT( eosio::chain_apis::read_only::get_table_by_scope_params, (code)(table)(lower_bound)(upper_bound)(limit)(reverse) )
 FC_REFLECT( eosio::chain_apis::read_only::get_table_by_scope_result_row, (code)(scope)(table)(payer)(count));

--- a/tests/get_kv_table_nodeos_tests.cpp
+++ b/tests/get_kv_table_nodeos_tests.cpp
@@ -199,18 +199,18 @@ BOOST_FIXTURE_TEST_CASE( get_kv_table_nodeos_test, TESTER ) try {
    result = plugin.read_only::get_kv_table_rows(p);
    BOOST_REQUIRE_EQUAL(2u, result.rows.size());
    BOOST_REQUIRE_EQUAL(result.more, true);
-   BOOST_REQUIRE_EQUAL(result.next_key != "", true);
+   BOOST_REQUIRE_EQUAL(result.next_key_bytes != "", true);
    chk_result(0, 1);
    chk_result(1, 2);
 
-   p.lower_bound = result.next_key;
+   p.lower_bound = result.next_key_bytes;
    p.encode_type = "bytes";
    result = plugin.read_only::get_kv_table_rows(p);
    BOOST_REQUIRE_EQUAL(2u, result.rows.size());
    chk_result(0, 3);
    chk_result(1, 4);
 
-   p.lower_bound = result.next_key;
+   p.lower_bound = result.next_key_bytes;
    p.encode_type = "bytes";
    p.limit = 1;
    result = plugin.read_only::get_kv_table_rows(p);
@@ -218,7 +218,7 @@ BOOST_FIXTURE_TEST_CASE( get_kv_table_nodeos_test, TESTER ) try {
    BOOST_REQUIRE_EQUAL(result.more, true);
    chk_result(0, 5);
 
-   p.lower_bound = result.next_key;
+   p.lower_bound = result.next_key_bytes;
    p.encode_type = "bytes";
    p.limit = 20;
    result = plugin.read_only::get_kv_table_rows(p);
@@ -335,7 +335,7 @@ BOOST_FIXTURE_TEST_CASE( get_kv_table_nodeos_test, TESTER ) try {
    chk_result(0, 1);
    chk_result(1, 2);
 
-   p.lower_bound = result.next_key;
+   p.lower_bound = result.next_key_bytes;
    p.encode_type = "bytes";
    p.limit = 3;
    result = plugin.read_only::get_kv_table_rows(p);
@@ -345,7 +345,7 @@ BOOST_FIXTURE_TEST_CASE( get_kv_table_nodeos_test, TESTER ) try {
    chk_result(1, 4);
    chk_result(2, 5);
 
-   p.lower_bound = result.next_key;
+   p.lower_bound = result.next_key_bytes;
    p.encode_type = "bytes";
    p.limit = 20;
    result = plugin.read_only::get_kv_table_rows(p);
@@ -493,7 +493,7 @@ BOOST_FIXTURE_TEST_CASE( get_kv_table_nodeos_test, TESTER ) try {
    chk_result(0, 1);
    chk_result(1, 2);
 
-   p.lower_bound = result.next_key;
+   p.lower_bound = result.next_key_bytes;
    p.encode_type = "bytes";
    p.limit = 3;
    result = plugin.read_only::get_kv_table_rows(p);
@@ -503,7 +503,7 @@ BOOST_FIXTURE_TEST_CASE( get_kv_table_nodeos_test, TESTER ) try {
    chk_result(1, 4);
    chk_result(2, 5);
 
-   p.lower_bound = result.next_key;
+   p.lower_bound = result.next_key_bytes;
    p.limit = 20;
    result = plugin.read_only::get_kv_table_rows(p);
    BOOST_REQUIRE_EQUAL(5u, result.rows.size());
@@ -594,18 +594,18 @@ BOOST_FIXTURE_TEST_CASE( get_kv_table_nodeos_test, TESTER ) try {
    result = plugin.read_only::get_kv_table_rows(p);
    BOOST_REQUIRE_EQUAL(2u, result.rows.size());
    BOOST_REQUIRE_EQUAL(result.more, true);
-   BOOST_REQUIRE_EQUAL(result.next_key != "", true);
+   BOOST_REQUIRE_EQUAL(result.next_key_bytes != "", true);
    chk_result(0, 1);
    chk_result(1, 2);
 
-   p.lower_bound = result.next_key;
+   p.lower_bound = result.next_key_bytes;
    p.upper_bound = "";
    p.encode_type = "bytes";
    p.limit = 2;
    result = plugin.read_only::get_kv_table_rows(p);
    BOOST_REQUIRE_EQUAL(2u, result.rows.size());
    BOOST_REQUIRE_EQUAL(result.more, true);
-   BOOST_REQUIRE_EQUAL(result.next_key != "", true);
+   BOOST_REQUIRE_EQUAL(result.next_key_bytes != "", true);
    chk_result(0, 3);
    chk_result(1, 4);
 
@@ -654,18 +654,18 @@ BOOST_FIXTURE_TEST_CASE( get_kv_table_nodeos_test, TESTER ) try {
    result = plugin.read_only::get_kv_table_rows(p);
    BOOST_REQUIRE_EQUAL(2u, result.rows.size());
    BOOST_REQUIRE_EQUAL(result.more, true);
-   BOOST_REQUIRE_EQUAL(result.next_key != "", true);
+   BOOST_REQUIRE_EQUAL(result.next_key_bytes != "", true);
    chk_result(0, 1);
    chk_result(1, 2);
 
    p.encode_type = "bytes";
-   p.lower_bound = result.next_key;
+   p.lower_bound = result.next_key_bytes;
    p.upper_bound = "";
    p.limit = 2;
    result = plugin.read_only::get_kv_table_rows(p);
    BOOST_REQUIRE_EQUAL(2u, result.rows.size());
    BOOST_REQUIRE_EQUAL(result.more, true);
-   BOOST_REQUIRE_EQUAL(result.next_key != "", true);
+   BOOST_REQUIRE_EQUAL(result.next_key_bytes != "", true);
    chk_result(0, 3);
    chk_result(1, 4);
 
@@ -781,18 +781,18 @@ BOOST_FIXTURE_TEST_CASE( get_kv_table_nodeos_test, TESTER ) try {
    result = plugin.read_only::get_kv_table_rows(p);
    BOOST_REQUIRE_EQUAL(2u, result.rows.size());
    BOOST_REQUIRE_EQUAL(result.more, true);
-   BOOST_REQUIRE_EQUAL(result.next_key != "", true);
+   BOOST_REQUIRE_EQUAL(result.next_key_bytes != "", true);
    chk_result(0, 2);
    chk_result(1, 3);
 
    p.encode_type = "bytes";
-   p.lower_bound = result.next_key;
+   p.lower_bound = result.next_key_bytes;
    p.upper_bound = "";
    p.limit = 2;
    result = plugin.read_only::get_kv_table_rows(p);
    BOOST_REQUIRE_EQUAL(2u, result.rows.size());
    BOOST_REQUIRE_EQUAL(result.more, true);
-   BOOST_REQUIRE_EQUAL(result.next_key != "", true);
+   BOOST_REQUIRE_EQUAL(result.next_key_bytes != "", true);
    chk_result(0, 4);
    chk_result(1, 5);
 


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->
## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

Added next_key_bytes field to get_table_rows_result structure to indicate there are more rows. 
As the value is encoded as "bytes", the subsequent query must use --encode-type "bytes" to use it.

## Change Type
**Select *ONE*:**
- [x] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [ ] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [ ] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the release notes. Please include a description of the change for inclusion in the release notes. -->


## Testing Changes
**Select *ANY* that apply:**
- [ ] New Tests
<!-- checked [x] = new test cases were added; unchecked [ ] = no new test cases -->
- [ ] Existing Tests
<!-- checked [x] = existing test cases were edited; unchecked [ ] = no existing tests were modified -->
- [ ] Test Framework
<!-- checked [x] = this modifies the test framework; unchecked [ ] = no test framework changes -->
- [ ] CI System
<!-- checked [x] = this changes the CI system; unchecked [ ] = no CI changes -->
- [ ] Other
<!-- checked [x] = this integrates an external test system; unchecked [ ] = no miscellaneous test-related changes -->
<!-- Please describe your test changes, or list each new test and its purpose, under each respective checkbox -->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->

## Documentation Additions
- [x] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->

When the “more” field is set to true, the “next_key” field will be set to a value that can be provided with --lower (or --upper if --reverse is also being used) using the same --encode-type that was provided with the original request (NOTE: This feature is not yet implemented). Also the “next_key_bytes” field will be set to a value that can be provided with --lower (or --upper if --reverse is also being used) but “ --encode-type  bytes” must be used.
