### PR TITLE
Saving and restoring undo stack at shutdown and startup

### DIFF
--- a/libraries/chain/combined_database.cpp
+++ b/libraries/chain/combined_database.cpp
@@ -272,6 +272,20 @@ namespace eosio { namespace chain {
       }
    }
 
+   int64_t combined_database::revision() {
+      if (backing_store == backing_store_type::ROCKSDB) {
+         try {
+            try {
+                return kv_undo_stack->revision();
+            }
+            FC_LOG_AND_RETHROW()
+         }
+         CATCH_AND_EXIT_DB_FAILURE()
+      } else {
+        return db.revision();
+      }
+   }
+
    void combined_database::undo() {
       db.undo();
 

--- a/libraries/chain/combined_database.cpp
+++ b/libraries/chain/combined_database.cpp
@@ -73,6 +73,12 @@ namespace eosio { namespace chain {
       }
    }
 
+   void combined_session::set_datadir(const fc::path& datadir) {
+       if ( kv_undo_stack ) {
+          kv_undo_stack->set_datadir( datadir );
+       }
+   }
+
    template <typename Util, typename F>
    void walk_index(const Util& utils, const chainbase::database& db, F&& function) {
       utils.walk(db, std::forward<F>(function));
@@ -309,6 +315,12 @@ namespace eosio { namespace chain {
             FC_LOG_AND_RETHROW()
          }
          CATCH_AND_EXIT_DB_FAILURE()
+      }
+   }
+
+   void combined_database::set_datadir(const fc::path& datadir) {
+      if (backing_store == backing_store_type::ROCKSDB) {
+         kv_undo_stack->set_datadir(datadir);
       }
    }
 

--- a/libraries/chain/combined_database.cpp
+++ b/libraries/chain/combined_database.cpp
@@ -73,12 +73,6 @@ namespace eosio { namespace chain {
       }
    }
 
-   void combined_session::set_datadir(const fc::path& datadir) {
-       if ( kv_undo_stack ) {
-          kv_undo_stack->set_datadir( datadir );
-       }
-   }
-
    template <typename Util, typename F>
    void walk_index(const Util& utils, const chainbase::database& db, F&& function) {
       utils.walk(db, std::forward<F>(function));
@@ -238,7 +232,7 @@ namespace eosio { namespace chain {
             auto rdb        = std::shared_ptr<rocksdb::DB>{ p };
             return std::make_unique<rocks_db_type>(eosio::session::make_session(std::move(rdb), 1024));
          }() },
-         kv_undo_stack(std::make_unique<eosio::session::undo_stack<rocks_db_type>>(*kv_database)),
+         kv_undo_stack(std::make_unique<eosio::session::undo_stack<rocks_db_type>>(*kv_database, cfg.state_dir)),
          kv_snapshot_batch_threashold(cfg.persistent_storage_mbytes_batch * 1024 * 1024)  {}
 
    void combined_database::check_backing_store_setting(bool clean_startup) {
@@ -315,12 +309,6 @@ namespace eosio { namespace chain {
             FC_LOG_AND_RETHROW()
          }
          CATCH_AND_EXIT_DB_FAILURE()
-      }
-   }
-
-   void combined_database::set_datadir(const fc::path& datadir) {
-      if (backing_store == backing_store_type::ROCKSDB) {
-         kv_undo_stack->set_datadir(datadir);
       }
    }
 

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -487,13 +487,8 @@ struct controller_impl {
 
    void startup(std::function<void()> shutdown, std::function<bool()> check_shutdown, const snapshot_reader_ptr& snapshot) {
       EOS_ASSERT( snapshot, snapshot_exception, "No snapshot reader provided" );
-# warning TODO: Chain_kv needs to fix kv_undo_stack's revision after restar
-      // Currently kv_undo_stack returns a wrong revision after restart,
-      // failing tests/terminate-scenarios-test.py.
-      // As chain_kv is being rewritten, comment out this check for now
-      // and retest after chain_kv rewriting is finished.
-      //EOS_ASSERT( db.revision() == kv_undo_stack.revision(), database_revision_mismatch_exception,
-      //            "chainbase is at revision ${a}, but chain-kv is at revision ${b}", ("a", db.revision())("b", kv_undo_stack.revision()) );
+      EOS_ASSERT( db.revision() == kv_db.revision(), database_revision_mismatch_exception,
+                  "chainbase is at revision ${a}, but chain-kv is at revision ${b}", ("a", db.revision())("b", kv_db.revision()) );
       this->shutdown = shutdown;
       ilog( "Starting initialization from snapshot, this may take a significant amount of time" );
       try {
@@ -526,13 +521,8 @@ struct controller_impl {
 
    void startup(std::function<void()> shutdown, std::function<bool()> check_shutdown, const genesis_state& genesis) {
       EOS_ASSERT( db.revision() < 1, database_exception, "This version of controller::startup only works with a fresh state database." );
-# warning TODO: Chain_kv needs to fix kv_undo_stack's revision
-      // Currently kv_undo_stack returns a wrong revision after restart,
-      // failing tests/terminate-scenarios-test.py.
-      // As chain_kv is being rewritten, comment out this check for now
-      // and retest after chain_kv rewriting is finished.
-      //EOS_ASSERT( db.revision() == kv_undo_stack.revision(), database_revision_mismatch_exception,
-      //            "chainbase is at revision ${a}, but chain-kv is at revision ${b}", ("a", db.revision())("b", kv_undo_stack.revision()) );
+      EOS_ASSERT( db.revision() == kv_db.revision(), database_revision_mismatch_exception,
+                  "chainbase is at revision ${a}, but chain-kv is at revision ${b}", ("a", db.revision())("b", kv_db.revision()) );
       const auto& genesis_chain_id = genesis.compute_chain_id();
       EOS_ASSERT( genesis_chain_id == chain_id, chain_id_type_exception,
                   "genesis state provided to startup corresponds to a chain ID (${genesis_chain_id}) that does not match the chain ID that controller was constructed with (${controller_chain_id})",
@@ -566,9 +556,8 @@ struct controller_impl {
 
    void startup(std::function<void()> shutdown, std::function<bool()> check_shutdown) {
       EOS_ASSERT( db.revision() >= 1, database_exception, "This version of controller::startup does not work with a fresh state database." );
-# warning TODO: Chain_kv needs to fix kv_undo_stack's revision
-      //EOS_ASSERT( db.revision() == kv_undo_stack.revision(), database_revision_mismatch_exception,
-      //            "chainbase is at revision ${a}, but chain-kv is at revision ${b}", ("a", db.revision())("b", kv_undo_stack.revision()) );
+      EOS_ASSERT( db.revision() == kv_db.revision(), database_revision_mismatch_exception,
+                  "chainbase is at revision ${a}, but chain-kv is at revision ${b}", ("a", db.revision())("b", kv_db.revision()) );
       EOS_ASSERT( fork_db.head(), fork_database_exception, "No existing fork database despite existing chain state. Replay required." );
 
       this->shutdown = shutdown;

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -252,6 +252,11 @@ struct controller_impl {
                            { check_protocol_features( timestamp, cur_features, new_features ); }
       );
 
+      // Might be too late?
+      if ( cfg.backing_store == backing_store_type::ROCKSDB ) {
+         kv_db.set_datadir( cfg.state_dir );
+      }
+
       set_activation_handler<builtin_protocol_feature_t::preactivate_feature>();
       set_activation_handler<builtin_protocol_feature_t::replace_deferred>();
       set_activation_handler<builtin_protocol_feature_t::get_sender>();

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -252,11 +252,6 @@ struct controller_impl {
                            { check_protocol_features( timestamp, cur_features, new_features ); }
       );
 
-      // Might be too late?
-      if ( cfg.backing_store == backing_store_type::ROCKSDB ) {
-         kv_db.set_datadir( cfg.state_dir );
-      }
-
       set_activation_handler<builtin_protocol_feature_t::preactivate_feature>();
       set_activation_handler<builtin_protocol_feature_t::replace_deferred>();
       set_activation_handler<builtin_protocol_feature_t::get_sender>();

--- a/libraries/chain/include/eosio/chain/combined_database.hpp
+++ b/libraries/chain/include/eosio/chain/combined_database.hpp
@@ -76,6 +76,8 @@ namespace eosio { namespace chain {
 
       void undo();
 
+      void set_datadir(const fc::path& datadir);
+
     private:
       std::unique_ptr<chainbase::database::session> cb_session    = {};
       eosio::session::undo_stack<rocks_db_type>*     kv_undo_stack = nullptr;
@@ -110,6 +112,8 @@ namespace eosio { namespace chain {
       void commit(int64_t revision);
 
       void flush();
+
+      void set_datadir(const fc::path& datadir);
 
       static void destroy(const fc::path& p);
 

--- a/libraries/chain/include/eosio/chain/combined_database.hpp
+++ b/libraries/chain/include/eosio/chain/combined_database.hpp
@@ -105,6 +105,8 @@ namespace eosio { namespace chain {
 
       void set_revision(uint64_t revision);
 
+      int64_t revision();
+
       void undo();
 
       void commit(int64_t revision);

--- a/libraries/chain/include/eosio/chain/combined_database.hpp
+++ b/libraries/chain/include/eosio/chain/combined_database.hpp
@@ -76,8 +76,6 @@ namespace eosio { namespace chain {
 
       void undo();
 
-      void set_datadir(const fc::path& datadir);
-
     private:
       std::unique_ptr<chainbase::database::session> cb_session    = {};
       eosio::session::undo_stack<rocks_db_type>*     kv_undo_stack = nullptr;
@@ -112,8 +110,6 @@ namespace eosio { namespace chain {
       void commit(int64_t revision);
 
       void flush();
-
-      void set_datadir(const fc::path& datadir);
 
       static void destroy(const fc::path& p);
 

--- a/libraries/chain_kv/include/b1/session/session.hpp
+++ b/libraries/chain_kv/include/b1/session/session.hpp
@@ -139,7 +139,7 @@ class session {
 
    /// \brief Constructs a child session from another instance of the same session type.
    explicit session(session& parent, std::nullptr_t);
-   //session(const session&) = delete;
+   session(const session&) = delete;
    session(session&& other);
    ~session();
 

--- a/libraries/chain_kv/include/b1/session/session.hpp
+++ b/libraries/chain_kv/include/b1/session/session.hpp
@@ -139,7 +139,7 @@ class session {
 
    /// \brief Constructs a child session from another instance of the same session type.
    explicit session(session& parent, std::nullptr_t);
-   session(const session&) = delete;
+   //session(const session&) = delete;
    session(session&& other);
    ~session();
 
@@ -259,7 +259,8 @@ class session {
    It& first_not_deleted_in_iterator_cache_(It& it, const It& end) const;
 
  private:
-   parent_variant_type m_parent{ nullptr };
+   //parent_variant_type m_parent{ nullptr };
+   parent_variant_type m_parent{ static_cast<Parent*>(nullptr) };
    cache_type          m_cache;
 };
 

--- a/libraries/chain_kv/include/b1/session/session.hpp
+++ b/libraries/chain_kv/include/b1/session/session.hpp
@@ -259,7 +259,6 @@ class session {
    It& first_not_deleted_in_iterator_cache_(It& it, const It& end) const;
 
  private:
-   //parent_variant_type m_parent{ nullptr };
    parent_variant_type m_parent{ static_cast<Parent*>(nullptr) };
    cache_type          m_cache;
 };

--- a/libraries/chain_kv/include/b1/session/shared_bytes.hpp
+++ b/libraries/chain_kv/include/b1/session/shared_bytes.hpp
@@ -508,7 +508,13 @@ shared_bytes::shared_bytes_iterator<Iterator_traits>::operator[](size_t index) c
    return m_buffer[index];
 }
 
+struct shared_bytes_reflect{
+   std::vector<char> data;
+};
+
 } // namespace eosio::session
+
+FC_REFLECT(eosio::session::shared_bytes_reflect, (data))
 
 namespace std {
 

--- a/libraries/chain_kv/include/b1/session/shared_bytes.hpp
+++ b/libraries/chain_kv/include/b1/session/shared_bytes.hpp
@@ -11,6 +11,8 @@
 #include <boost/endian/detail/intrinsic.hpp>
 
 #include <fc/crypto/base64.hpp>
+#include <fc/io/datastream.hpp>
+#include <fc/io/raw.hpp>
 
 #include <eosio/chain/exceptions.hpp>
 
@@ -365,6 +367,23 @@ inline std::ostream& operator<<(std::ostream& os, const shared_bytes& bytes) {
    return os;
 }
 
+template <typename Stream>
+inline Stream& operator<<(Stream& ds, const shared_bytes& b) {
+   fc::raw::pack( ds, b.size() );
+   ds.write(b.data(), b.size());
+   return ds;
+}
+
+template <typename Stream>
+inline Stream& operator>>(Stream& ds, shared_bytes& b) {
+   std::size_t sz;
+   fc::raw::unpack( ds, sz );
+   shared_bytes tmp = {sz};
+   ds.read(tmp.data(), tmp.size());
+   b = tmp;
+   return ds;
+}
+
 inline shared_bytes shared_bytes::from_hex_string(const std::string& str) {
    if (str.empty()) {
       return shared_bytes{};
@@ -508,13 +527,7 @@ shared_bytes::shared_bytes_iterator<Iterator_traits>::operator[](size_t index) c
    return m_buffer[index];
 }
 
-struct shared_bytes_reflect{
-   std::vector<char> data;
-};
-
 } // namespace eosio::session
-
-FC_REFLECT(eosio::session::shared_bytes_reflect, (data))
 
 namespace std {
 

--- a/libraries/chain_kv/include/b1/session/undo_stack.hpp
+++ b/libraries/chain_kv/include/b1/session/undo_stack.hpp
@@ -270,9 +270,8 @@ void undo_stack<Session>::open() {
                shared_bytes key; ds >> key;
                session.erase(key);
             }
-
-            m_revision = rev; // restore head revision
          }
+         m_revision = rev; // restore head revision
       } FC_CAPTURE_AND_RETHROW( (undo_stack_dat) )
 
       fc::remove( undo_stack_dat );

--- a/libraries/chain_kv/include/b1/session/undo_stack.hpp
+++ b/libraries/chain_kv/include/b1/session/undo_stack.hpp
@@ -298,12 +298,16 @@ void undo_stack<Session>::close() {
       fc::raw::pack( out, updated_keys.size() ); // number of updated keys
 
       for (const auto& key: updated_keys) {
-        auto value = session.read(key);
+         auto value = session.read(key);
 
-        if ( value ) {
-           out << key;
-           out << *value;
-        }
+         if ( value ) {
+            out << key;
+            out << *value;
+         } else {
+            fc::remove( undo_stack_dat ); // May not be used by next startup
+            elog( "Did not find value for ${k}", ("k", key.data() ) );
+            return; // Do not assert as we are during shutdown
+         }
       }
 
       auto deleted_keys = session.deleted_keys();

--- a/libraries/chain_kv/include/b1/session/undo_stack.hpp
+++ b/libraries/chain_kv/include/b1/session/undo_stack.hpp
@@ -318,6 +318,7 @@ void undo_stack<Session>::close() {
          fc::raw::pack( out, key );
       }
 
+      session.detach();
       m_sessions.pop_front();
    }
 }

--- a/libraries/chain_kv/include/b1/session/undo_stack.hpp
+++ b/libraries/chain_kv/include/b1/session/undo_stack.hpp
@@ -2,11 +2,21 @@
 
 #include <queue>
 
+#include <fc/filesystem.hpp>
+#include <fc/io/fstream.hpp>
+#include <fc/io/datastream.hpp>
+#include <fc/io/raw.hpp>
+#include <fc/reflect/typename.hpp>
+#include <fstream>
 #include <b1/session/session.hpp>
 #include <b1/session/session_variant.hpp>
 #include <eosio/chain/exceptions.hpp>
 
 namespace eosio::session {
+   const uint32_t undo_stack_magic_number = 0x30510ABC;
+   const uint32_t undo_stack_min_supported_version = 1;
+   const uint32_t undo_stack_max_supported_version = 1;
+   constexpr auto undo_stack_filename = "undo_stack.dat";
 
 /// \brief Represents a container of pending sessions to be committed.
 template <typename Session>
@@ -66,18 +76,27 @@ class undo_stack {
    /// \remarks This is the next session to be committed.
    const_variant_type bottom() const;
 
+   void set_datadir(const fc::path& datadir);
+   void open();
+   void close();
+
  private:
    int64_t                  m_revision{ 0 };
    Session*                 m_head;
    std::deque<session_type> m_sessions; // Need a deque so pointers don't become invalidated.  The session holds a
                                         // pointer to the parent internally.
+   fc::path                 m_datadir;
 };
 
 template <typename Session>
-undo_stack<Session>::undo_stack(Session& head) : m_head{ &head } {}
+undo_stack<Session>::undo_stack(Session& head) : m_head{ &head } {
+   open();
+}
 
 template <typename Session>
 undo_stack<Session>::~undo_stack() {
+   close();
+
    for (auto& session : m_sessions) { session.undo(); }
 }
 
@@ -197,4 +216,109 @@ typename undo_stack<Session>::const_variant_type undo_stack<Session>::bottom() c
    return { *m_head, nullptr };
 }
 
+template <typename Session>
+void undo_stack<Session>::set_datadir(const fc::path& datadir) {
+   m_datadir = datadir;
+}
+
+template <typename Session>
+void undo_stack<Session>::open() {
+   if (!fc::is_directory(m_datadir))
+      fc::create_directories(m_datadir);
+
+   auto undo_stack_dat = m_datadir / undo_stack_filename;
+   if( fc::exists( undo_stack_dat ) ) {
+      try {
+         std::string content;
+         fc::read_file_contents( undo_stack_dat, content );
+
+         fc::datastream<const char*> ds( content.data(), content.size() );
+
+         // validate totem
+         uint32_t totem = 0;
+         fc::raw::unpack( ds, totem );
+         EOS_ASSERT( totem == undo_stack_magic_number, eosio::chain::chain_exception,
+                     "Undo stack data file '${filename}' has unexpected magic number: ${actual_totem}. Expected ${expected_totem}",
+                     ("filename", undo_stack_dat.generic_string())
+                     ("actual_totem", totem)
+                     ("expected_totem", undo_stack_magic_number)
+         );
+
+         // validate version
+         uint32_t version = 0;
+         fc::raw::unpack( ds, version );
+         EOS_ASSERT( version >= undo_stack_min_supported_version && version <= undo_stack_max_supported_version,
+                    eosio::chain::chain_exception,
+                    "Unsupported version of Undo stack data file '${filename}'. "
+                    "Undo stack data version is ${version} while code supports version(s) [${min},${max}]",
+                    ("filename", undo_stack_dat.generic_string())
+                    ("version", version)
+                    ("min", undo_stack_min_supported_version)
+                    ("max", undo_stack_max_supported_version)
+         );
+
+         int64_t rev; fc::raw::unpack( ds, rev );
+         revision(rev);
+
+         size_t num_sessions; fc::raw::unpack( ds, num_sessions );
+         for( size_t i = 0; i < num_sessions; ++i ) {
+            session_type session;
+            if (m_sessions.empty())
+               session.attach(*m_head);
+            else
+               session.attach(m_sessions.back());
+
+            size_t num_updated_keys; fc::raw::unpack( ds, num_updated_keys );
+            for( size_t j = 0; j < num_updated_keys; ++j ) {
+               shared_bytes_reflect raw_key; fc::raw::unpack( ds, raw_key );
+               shared_bytes_reflect raw_value; fc::raw::unpack( ds, raw_value );
+
+               shared_bytes key(raw_key.data.data(), raw_key.data.size());
+               shared_bytes value(raw_value.data.data(), raw_value.data.size());
+               session.write(key, value);
+            }
+
+            m_sessions.emplace_back(std::move(session));
+         }
+      } FC_CAPTURE_AND_RETHROW( (undo_stack_dat) )
+
+      fc::remove( undo_stack_dat );
+   }
+}
+
+template <typename Session>
+void undo_stack<Session>::close() {
+   auto undo_stack_dat = m_datadir / undo_stack_filename;
+
+   std::ofstream out( undo_stack_dat.generic_string().c_str(), std::ios::out | std::ios::binary | std::ofstream::trunc );
+   fc::raw::pack( out, undo_stack_magic_number );
+   fc::raw::pack( out, undo_stack_max_supported_version );
+
+   fc::raw::pack( out, revision() );
+   fc::raw::pack( out, size() ); // number of sessions
+
+   while ( !m_sessions.empty() ) {
+      auto& session = m_sessions.front();
+      auto updated_keys = session.updated_keys();
+      fc::raw::pack( out, updated_keys.size() ); // number of updated keys
+
+      for (const auto& key: updated_keys) {
+        auto value = session.read(key);
+
+        if ( value ) {
+           fc::raw::pack( out, key );
+           fc::raw::pack( out, value );
+        }
+      }
+
+      auto deleted_keys = session.deleted_keys();
+      fc::raw::pack( out, deleted_keys.size() ); // number of deleted keys
+
+      for (const auto& key: deleted_keys) {
+         fc::raw::pack( out, key );
+      }
+
+      m_sessions.pop_front();
+   }
+}
 } // namespace eosio::session


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->
## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
This PR saves RocksDB backing store undo stack when shutdown and restores undo stack upon startup.

This is a draft PR calling for review and quick turn around of resolving any design/coding issues.

## Change Type
**Select *ONE*:**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [ ] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [x] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the release notes. Please include a description of the change for inclusion in the release notes. -->


## Testing Changes
**Select *ANY* that apply:**
- [ ] New Tests
<!-- checked [x] = new test cases were added; unchecked [ ] = no new test cases -->
- [ ] Existing Tests
<!-- checked [x] = existing test cases were edited; unchecked [ ] = no existing tests were modified -->
- [ ] Test Framework
<!-- checked [x] = this modifies the test framework; unchecked [ ] = no test framework changes -->
- [ ] CI System
<!-- checked [x] = this changes the CI system; unchecked [ ] = no CI changes -->
- [ ] Other
<!-- checked [x] = this integrates an external test system; unchecked [ ] = no miscellaneous test-related changes -->
<!-- Please describe your test changes, or list each new test and its purpose, under each respective checkbox -->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [x] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
In \<the configured data-dir\>/state directory, a new file **undo_stack.dat** is introduced if ` --backing-store rocksdb` is used . It saves RocksDB undo stack's state before node shutdown and is used to restore __nodeos__'s undo stack at startup.