### PR TITLE
Add CentOS 8 Package Builder Step

### DIFF
--- a/.cicd/generate-pipeline.sh
+++ b/.cicd/generate-pipeline.sh
@@ -526,6 +526,20 @@ cat <<EOF
     timeout: ${TIMEOUT:-10}
     skip: ${SKIP_CENTOS_7_7}${SKIP_PACKAGE_BUILDER}${SKIP_LINUX}
 
+  - label: ":centos: CentOS 8 - Package Builder"
+    command:
+      - "buildkite-agent artifact download build.tar.gz . --step ':centos: CentOS 8 - Build' && tar -xzf build.tar.gz"
+      - "./.cicd/package.sh"
+    env:
+      IMAGE_TAG: "centos-8-$PLATFORM_TYPE"
+      PLATFORM_TYPE: $PLATFORM_TYPE
+      OS: "el8" # OS and PKGTYPE required for lambdas
+      PKGTYPE: "rpm"
+    agents:
+      queue: "$BUILDKITE_TEST_AGENT_QUEUE"
+    timeout: ${TIMEOUT:-10}
+    skip: ${SKIP_CENTOS_8}${SKIP_PACKAGE_BUILDER}${SKIP_LINUX}
+
   - label: ":ubuntu: Ubuntu 16.04 - Package Builder"
     command:
       - "buildkite-agent artifact download build.tar.gz . --step ':ubuntu: Ubuntu 16.04 - Build' && tar -xzf build.tar.gz"


### PR DESCRIPTION
## Change Description
From [AUTO-279](https://blockone.atlassian.net/browse/AUTO-279), the CI system and build scripts have been updated to support CentOS 8. However, where most of the steps in the CI system are auto-generated based on what platforms are defined in the `.cicd/platforms` folder, the package builder steps must be added to the CI system by hand because every operating system is like a snowflake...lol.

### Tested Working
To verify the new binary works, I downloaded `eosio-2.1.0-alpha2.x86_64.rpm` from the [CentOS 8 Package Builder]() step in eosio [build 25943](). Then, in the folder with that artifact:
```bash
docker pull centos:8
docker run -v "$(pwd):/eos" -w /eos -it centos:8 /bin/bash
```
Finally, inside the container:
```bash
yum update
yum install -y /eos/eosio-2.1.0-alpha2.x86_64.rpm
nodeos --version
nodeos --help
```
The output is omitted here for brevity, but it worked as expected.

### See Also
- [Pull Request 9776](https://github.com/EOSIO/eos/pull/9776) -- `eos:develop`
- [Pull Request 9802](https://github.com/EOSIO/eos/pull/9802) -- `eos:release/2.1.x`

## Change Type
**Select *ONE*:**
- [ ] Documentation
- [ ] Stability bug fix
- [x] Other
- [ ] Other - special case

## Testing Changes
**Select *ANY* that apply:**
- [ ] New Tests
- [ ] Existing Tests
- [ ] Test Framework
- [x] CI System
- [ ] Other

## Consensus Changes
- [ ] Consensus Changes
None.

## API Changes
- [ ] API Changes
None.

## Documentation Additions
- [ ] Documentation Additions
None.