### PR TITLE
Fix build script problem with older version of cmake

### DIFF
--- a/plugins/blockvault_client_plugin/CMakeLists.txt
+++ b/plugins/blockvault_client_plugin/CMakeLists.txt
@@ -21,7 +21,7 @@ pkg_check_modules(pqxx IMPORTED_TARGET libpqxx>=6.0)
 if (pqxx_FOUND)
 
    add_library(pqxx STATIC IMPORTED)
-   set_property(TARGET pqxx PROPERTY IMPORTED_LOCATION ${pqxx_STATIC_LIBRARY_DIRS}/libpqxx.a)
+   set_property(TARGET pqxx PROPERTY IMPORTED_LOCATION ${pqxx_LIBDIR}/libpqxx.a)
    target_include_directories(pqxx INTERFACE ${pqxx_STATIC_INCLUDE_DIRS})
    target_link_libraries(pqxx INTERFACE PkgConfig::pq)
 

--- a/scripts/helpers/eosio.sh
+++ b/scripts/helpers/eosio.sh
@@ -346,10 +346,10 @@ function ensure-libpq-and-libpqxx() {
         if [ ! -d ${OPT_DIR}/pqxx ]; then
             execute bash -c "cd $SRC_DIR && \
                 curl -L https://github.com/jtv/libpqxx/archive/7.2.1.tar.gz | tar zxvf - && \
-                cd  libpqxx-7.2.1  && \
-                ${CMAKE} $CXX_SPEC $EXTRA_CMAKE_FLAGS -DCMAKE_INSTALL_PREFIX=${OPT_DIR}/pqxx -DSKIP_BUILD_TEST=ON -DCMAKE_BUILD_TYPE=Release -S . -B build && \
-                ${CMAKE} --build build && ${CMAKE} --install build && \
-                cd .. && rm -rf libpqxx-7.2.1"
+                cd libpqxx-7.2.1 && mkdir build && cd build && \
+                ${CMAKE} $CXX_SPEC $EXTRA_CMAKE_FLAGS -DCMAKE_INSTALL_PREFIX=${OPT_DIR}/pqxx -DSKIP_BUILD_TEST=ON -DCMAKE_BUILD_TYPE=Release .. && \
+                make -j${JOBS} && make install && \
+                cd ../.. && rm -rf libpqxx-7.2.1"
         fi
 
         if [ -z "$PKG_CONFIG_PATH" ]; then


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->
## Change Description

This PR fixes issue #9784 where the eosio-build.sh script failed to build libpqxx when using an older version of cmake.


## Change Type
**Select *ONE*:**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [ ] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [x] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the release notes. Please include a description of the change for inclusion in the release notes. -->


## Testing Changes
**Select *ANY* that apply:**
- [ ] New Tests
<!-- checked [x] = new test cases were added; unchecked [ ] = no new test cases -->
- [ ] Existing Tests
<!-- checked [x] = existing test cases were edited; unchecked [ ] = no existing tests were modified -->
- [ ] Test Framework
<!-- checked [x] = this modifies the test framework; unchecked [ ] = no test framework changes -->
- [ ] CI System
<!-- checked [x] = this changes the CI system; unchecked [ ] = no CI changes -->
- [ ] Other
<!-- checked [x] = this integrates an external test system; unchecked [ ] = no miscellaneous test-related changes -->
<!-- Please describe your test changes, or list each new test and its purpose, under each respective checkbox -->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
