### PR TITLE
Fix stdout console logging: Merge back #9582 to 2.0.x

### DIFF
--- a/programs/nodeos/logging.json
+++ b/programs/nodeos/logging.json
@@ -15,7 +15,8 @@
             "level": "error",
             "color": "red"
           }
-        ]
+        ],
+        "flush": true
       },
       "enabled": true
     },{
@@ -33,7 +34,8 @@
             "level": "error",
             "color": "red"
           }
-        ]
+        ],
+        "flush": true
       },
       "enabled": true
     },{


### PR DESCRIPTION
## Change Description

Merge back pull https://github.com/EOSIO/eos/pull/9582 to 2.0.x. 

- `std_out` option for console logging has never worked.
- Fix support of `std_out` `stream` option for logging.
- Add `flush` option to example `logging.json` since someone might want to set it to false for stdout logging.

## Change Type
**Select ONE**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [x] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [ ] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the relase notes. Please include a description of the change for inclusion in the release notes.-->


## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions

- The `flush` option is not documented and should be added to the nodeos logging section.
https://developers.eos.io/manuals/eos/latest/nodeos/logging/index
