### PR TITLE
Add log path for unsupported log version exception

### DIFF
--- a/libraries/chain/block_log.cpp
+++ b/libraries/chain/block_log.cpp
@@ -37,8 +37,6 @@ namespace eosio { namespace chain {
       uint32_t version         = 0;
       uint32_t first_block_num = 0;
       std::variant<genesis_state, chain_id_type> chain_context;
-      fc::path log_path; 
-      
 
       chain_id_type chain_id() const {
          return std::visit(overloaded{[](const chain_id_type& id) { return id; },
@@ -49,14 +47,14 @@ namespace eosio { namespace chain {
       constexpr static int nbytes_with_chain_id = // the bytes count when the preamble contains chain_id
           sizeof(version) + sizeof(first_block_num) + sizeof(chain_id_type) + sizeof(block_log::npos);
 
-      void read_from(fc::datastream<const char*>& ds) {
+      void read_from(fc::datastream<const char*>& ds, const fc::path& log_path) {
         ds.read((char*)&version, sizeof(version));
          EOS_ASSERT(version > 0, block_log_exception, "Block log was not setup properly");
          EOS_ASSERT(
              block_log::is_supported_version(version), block_log_unsupported_version,
              "Unsupported version of block log. Block log version is ${version} while code supports version(s) "
              "[${min},${max}], log file: ${log}",
-             ("version", version)("min", block_log::min_supported_version)("max", block_log::max_supported_version)("log", log_path));
+             ("version", version)("min", block_log::min_supported_version)("max", block_log::max_supported_version)("log", log_path.generic_string()));
 
          first_block_num = 1;
          if (version != initial_version) {
@@ -281,10 +279,7 @@ namespace eosio { namespace chain {
    public:
 
      block_log_data() = default;
-     block_log_data(const fc::path& path, mapmode mode = mapmode::readonly) { 
-        preamble.log_path = path;
-        open(path, mode); 
-     }
+     block_log_data(const fc::path& path, mapmode mode = mapmode::readonly) { open(path, mode); }
 
      const block_log_preamble& get_preamble() const { return preamble; }
 
@@ -293,7 +288,7 @@ namespace eosio { namespace chain {
            file.close();
         file.open(path.string(), mode);
         fc::datastream<const char*> ds(this->data(), this->size());
-        preamble.read_from(ds);
+        preamble.read_from(ds, path);
         first_block_pos = ds.tellp();
         return ds;
       }
@@ -302,7 +297,6 @@ namespace eosio { namespace chain {
       uint32_t      first_block_num() const { return preamble.first_block_num; }
       uint64_t      first_block_position() const { return first_block_pos; }
       chain_id_type chain_id() const { return preamble.chain_id(); }
-      fc::path      log_path() const { return preamble.log_path; }
 
       std::optional<genesis_state> get_genesis_state() const {
          return std::visit(overloaded{[](const chain_id_type&) { return std::optional<genesis_state>{}; },
@@ -404,11 +398,11 @@ namespace eosio { namespace chain {
       block_log_data  log_data;
       block_log_index log_index;
 
-      block_log_bundle(fc::path block_dir) 
-      : block_file_name (block_dir / "blocks.log")
-      , log_data(block_file_name)
-      {
+      block_log_bundle(fc::path block_dir) {
+         block_file_name = block_dir / "blocks.log";
          index_file_name = block_dir / "blocks.index";
+
+         log_data.open(block_file_name);
          log_index.open(index_file_name);
 
          uint32_t log_num_blocks   = log_data.num_blocks();


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->
## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

For issue: https://github.com/EOSIO/eos/issues/9871

## Change Type
**Select *ONE*:**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [ ] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [ ] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [x] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the release notes. Please include a description of the change for inclusion in the release notes. -->

warn  2021-01-19T17:55:50.003 thread-0  chain_plugin.cpp:1321         plugin_initialize    ] 3190001 block_log_unsupported_version: unsupported version of block log
Unsupported version of block log. Block log version is 808464432 while code supports version(s) [1,4], log file: /Users/yue.han/workspace/eosio/develop/bin/dogfooding/data/blocks/blocks.log
    {"version":808464432,"min":1,"max":4,"log":"/Users/yue.han/workspace/eosio/develop/bin/dogfooding/data/blocks/blocks.log"}
    thread-0  block_log.cpp:57 read_from

error 2021-01-19T17:55:50.003 thread-0  main.cpp:163                  main                 ] 3190001 block_log_unsupported_version: unsupported version of block log
Unsupported version of block log. Block log version is 808464432 while code supports version(s) [1,4], log file: /Users/yue.han/workspace/eosio/develop/bin/dogfooding/data/blocks/blocks.log
    {"version":808464432,"min":1,"max":4,"log":"/Users/yue.han/workspace/eosio/develop/bin/dogfooding/data/blocks/blocks.log"}
    thread-0  block_log.cpp:57 read_from
rethrow
    {}
    thread-0  chain_plugin.cpp:1321 plugin_initialize


## Testing Changes
**Select *ANY* that apply:**
- [ ] New Tests
<!-- checked [x] = new test cases were added; unchecked [ ] = no new test cases -->
- [ ] Existing Tests
<!-- checked [x] = existing test cases were edited; unchecked [ ] = no existing tests were modified -->
- [ ] Test Framework
<!-- checked [x] = this modifies the test framework; unchecked [ ] = no test framework changes -->
- [ ] CI System
<!-- checked [x] = this changes the CI system; unchecked [ ] = no CI changes -->
- [x] Other
<!-- checked [x] = this integrates an external test system; unchecked [ ] = no miscellaneous test-related changes -->
<!-- Please describe your test changes, or list each new test and its purpose, under each respective checkbox -->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
