### PR TITLE
Create eosio-debug-build Pipeline

### DIFF
--- a/.cicd/build.sh
+++ b/.cicd/build.sh
@@ -3,8 +3,8 @@ set -eo pipefail
 [[ "$ENABLE_INSTALL" == 'true' ]] || echo '--- :evergreen_tree: Configuring Environment'
 . ./.cicd/helpers/general.sh
 mkdir -p "$BUILD_DIR"
-[[ -z "$CMAKE_BUILD_TYPE" ]] && export CMAKE_BUILD_TYPE='Release'
-CMAKE_EXTRAS="-DCMAKE_BUILD_TYPE=\"$CMAKE_BUILD_TYPE\" -DENABLE_MULTIVERSION_PROTOCOL_TEST=\"true\""
+[[ -z "$DCMAKE_BUILD_TYPE" ]] && export DCMAKE_BUILD_TYPE='Release'
+CMAKE_EXTRAS="-DCMAKE_BUILD_TYPE=\"$DCMAKE_BUILD_TYPE\" -DENABLE_MULTIVERSION_PROTOCOL_TEST=\"true\""
 if [[ "$(uname)" == 'Darwin' && "$FORCE_LINUX" != 'true' ]]; then
     # You can't use chained commands in execute
     if [[ "$GITHUB_ACTIONS" == 'true' ]]; then

--- a/.cicd/build.sh
+++ b/.cicd/build.sh
@@ -3,7 +3,8 @@ set -eo pipefail
 [[ "$ENABLE_INSTALL" == 'true' ]] || echo '--- :evergreen_tree: Configuring Environment'
 . ./.cicd/helpers/general.sh
 mkdir -p "$BUILD_DIR"
-CMAKE_EXTRAS="-DCMAKE_BUILD_TYPE=\"Release\" -DENABLE_MULTIVERSION_PROTOCOL_TEST=\"true\""
+[[ -z "$CMAKE_BUILD_TYPE" ]] && export CMAKE_BUILD_TYPE='Release'
+CMAKE_EXTRAS="-DCMAKE_BUILD_TYPE=\"$CMAKE_BUILD_TYPE\" -DENABLE_MULTIVERSION_PROTOCOL_TEST=\"true\""
 if [[ "$(uname)" == 'Darwin' && "$FORCE_LINUX" != 'true' ]]; then
     # You can't use chained commands in execute
     if [[ "$GITHUB_ACTIONS" == 'true' ]]; then

--- a/.cicd/generate-pipeline.sh
+++ b/.cicd/generate-pipeline.sh
@@ -189,14 +189,15 @@ cat <<EOF
 EOF
 # tests
 IFS=$oIFS
-for ROUND in $(seq 1 $ROUNDS); do
-    IFS=$''
-    echo "    # round $ROUND of $ROUNDS"
-    # parallel tests
-    echo '    # parallel tests'
-    echo $PLATFORMS_JSON_ARRAY | jq -cr '.[]' | while read -r PLATFORM_JSON; do
-        if [[ ! "$(echo "$PLATFORM_JSON" | jq -r .FILE_NAME)" =~ 'macos' ]]; then
-            cat <<EOF
+if [[ "$CMAKE_BUILD_TYPE" != 'Debug' ]]; then
+  for ROUND in $(seq 1 $ROUNDS); do
+      IFS=$''
+      echo "    # round $ROUND of $ROUNDS"
+      # parallel tests
+      echo '    # parallel tests'
+      echo $PLATFORMS_JSON_ARRAY | jq -cr '.[]' | while read -r PLATFORM_JSON; do
+          if [[ ! "$(echo "$PLATFORM_JSON" | jq -r .FILE_NAME)" =~ 'macos' ]]; then
+              cat <<EOF
   - label: "$(echo "$PLATFORM_JSON" | jq -r .ICON) $(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_FULL) - Unit Tests"
     command:
       - "buildkite-agent artifact download build.tar.gz . --step '$(echo "$PLATFORM_JSON" | jq -r .ICON) $(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_FULL) - Build' && tar -xzf build.tar.gz"
@@ -213,8 +214,8 @@ for ROUND in $(seq 1 $ROUNDS); do
     skip: \${SKIP_$(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_UPCASE)_$(echo "$PLATFORM_JSON" | jq -r .VERSION_MAJOR)$(echo "$PLATFORM_JSON" | jq -r .VERSION_MINOR)}${SKIP_UNIT_TESTS}
 
 EOF
-        else
-            cat <<EOF
+          else
+              cat <<EOF
   - label: "$(echo "$PLATFORM_JSON" | jq -r .ICON) $(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_FULL) - Unit Tests"
     command:
       - "git clone \$BUILDKITE_REPO eos && cd eos && $GIT_FETCH git checkout -f \$BUILDKITE_COMMIT && git submodule update --init --recursive"
@@ -242,14 +243,14 @@ EOF
     skip: \${SKIP_$(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_UPCASE)_$(echo "$PLATFORM_JSON" | jq -r .VERSION_MAJOR)$(echo "$PLATFORM_JSON" | jq -r .VERSION_MINOR)}${SKIP_UNIT_TESTS}
 
 EOF
-        fi
-    echo
-    done
-    # wasm spec tests
-    echo '    # wasm spec tests'
-    echo $PLATFORMS_JSON_ARRAY | jq -cr '.[]' | while read -r PLATFORM_JSON; do
-        if [[ ! "$(echo "$PLATFORM_JSON" | jq -r .FILE_NAME)" =~ 'macos' ]]; then
-            cat <<EOF
+          fi
+      echo
+      done
+      # wasm spec tests
+      echo '    # wasm spec tests'
+      echo $PLATFORMS_JSON_ARRAY | jq -cr '.[]' | while read -r PLATFORM_JSON; do
+          if [[ ! "$(echo "$PLATFORM_JSON" | jq -r .FILE_NAME)" =~ 'macos' ]]; then
+              cat <<EOF
   - label: "$(echo "$PLATFORM_JSON" | jq -r .ICON) $(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_FULL) - WASM Spec Tests"
     command:
       - "buildkite-agent artifact download build.tar.gz . --step '$(echo "$PLATFORM_JSON" | jq -r .ICON) $(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_FULL) - Build' && tar -xzf build.tar.gz"
@@ -266,8 +267,8 @@ EOF
     skip: \${SKIP_$(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_UPCASE)_$(echo "$PLATFORM_JSON" | jq -r .VERSION_MAJOR)$(echo "$PLATFORM_JSON" | jq -r .VERSION_MINOR)}${SKIP_WASM_SPEC_TESTS}
 
 EOF
-        else
-            cat <<EOF
+          else
+              cat <<EOF
   - label: "$(echo "$PLATFORM_JSON" | jq -r .ICON) $(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_FULL) - WASM Spec Tests"
     command:
       - "git clone \$BUILDKITE_REPO eos && cd eos && $GIT_FETCH git checkout -f \$BUILDKITE_COMMIT && git submodule update --init --recursive"
@@ -295,17 +296,17 @@ EOF
     skip: \${SKIP_$(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_UPCASE)_$(echo "$PLATFORM_JSON" | jq -r .VERSION_MAJOR)$(echo "$PLATFORM_JSON" | jq -r .VERSION_MINOR)}${SKIP_WASM_SPEC_TESTS}
 
 EOF
-        fi
-    echo
-    done
-    # serial tests
-    echo '    # serial tests'
-    echo $PLATFORMS_JSON_ARRAY | jq -cr '.[]' | while read -r PLATFORM_JSON; do
-        IFS=$oIFS
-        SERIAL_TESTS="$(cat tests/CMakeLists.txt | grep nonparallelizable_tests | grep -v "^#" | awk -F" " '{ print $2 }')"
-        for TEST_NAME in $SERIAL_TESTS; do
-            if [[ ! "$(echo "$PLATFORM_JSON" | jq -r .FILE_NAME)" =~ 'macos' ]]; then
-                cat <<EOF
+          fi
+      echo
+      done
+      # serial tests
+      echo '    # serial tests'
+      echo $PLATFORMS_JSON_ARRAY | jq -cr '.[]' | while read -r PLATFORM_JSON; do
+          IFS=$oIFS
+          SERIAL_TESTS="$(cat tests/CMakeLists.txt | grep nonparallelizable_tests | grep -v "^#" | awk -F" " '{ print $2 }')"
+          for TEST_NAME in $SERIAL_TESTS; do
+              if [[ ! "$(echo "$PLATFORM_JSON" | jq -r .FILE_NAME)" =~ 'macos' ]]; then
+                  cat <<EOF
   - label: "$(echo "$PLATFORM_JSON" | jq -r .ICON) $(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_FULL) - $TEST_NAME"
     command:
       - "buildkite-agent artifact download build.tar.gz . --step '$(echo "$PLATFORM_JSON" | jq -r .ICON) $(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_FULL) - Build' && tar -xzf build.tar.gz"
@@ -322,8 +323,8 @@ EOF
     skip: \${SKIP_$(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_UPCASE)_$(echo "$PLATFORM_JSON" | jq -r .VERSION_MAJOR)$(echo "$PLATFORM_JSON" | jq -r .VERSION_MINOR)}${SKIP_SERIAL_TESTS}
 
 EOF
-            else
-                cat <<EOF
+              else
+                  cat <<EOF
   - label: "$(echo "$PLATFORM_JSON" | jq -r .ICON) $(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_FULL) - $TEST_NAME"
     command:
       - "git clone \$BUILDKITE_REPO eos && cd eos && $GIT_FETCH git checkout -f \$BUILDKITE_COMMIT && git submodule update --init --recursive"
@@ -350,19 +351,19 @@ EOF
     timeout: ${TIMEOUT:-60}
     skip: \${SKIP_$(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_UPCASE)_$(echo "$PLATFORM_JSON" | jq -r .VERSION_MAJOR)$(echo "$PLATFORM_JSON" | jq -r .VERSION_MINOR)}${SKIP_SERIAL_TESTS}
 EOF
-            fi
-            echo
-        done
-        IFS=$nIFS
-    done
-    # long-running tests
-    echo '    # long-running tests'
-    echo $PLATFORMS_JSON_ARRAY | jq -cr '.[]' | while read -r PLATFORM_JSON; do
-        IFS=$oIFS
-        LR_TESTS="$(cat tests/CMakeLists.txt | grep long_running_tests | grep -v "^#" | awk -F" " '{ print $2 }')"
-        for TEST_NAME in $LR_TESTS; do
-            if [[ ! "$(echo "$PLATFORM_JSON" | jq -r .FILE_NAME)" =~ 'macos' ]]; then
-                cat <<EOF
+              fi
+              echo
+          done
+          IFS=$nIFS
+      done
+      # long-running tests
+      echo '    # long-running tests'
+      echo $PLATFORMS_JSON_ARRAY | jq -cr '.[]' | while read -r PLATFORM_JSON; do
+          IFS=$oIFS
+          LR_TESTS="$(cat tests/CMakeLists.txt | grep long_running_tests | grep -v "^#" | awk -F" " '{ print $2 }')"
+          for TEST_NAME in $LR_TESTS; do
+              if [[ ! "$(echo "$PLATFORM_JSON" | jq -r .FILE_NAME)" =~ 'macos' ]]; then
+                  cat <<EOF
   - label: "$(echo "$PLATFORM_JSON" | jq -r .ICON) $(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_FULL) - $TEST_NAME"
     command:
       - "buildkite-agent artifact download build.tar.gz . --step '$(echo "$PLATFORM_JSON" | jq -r .ICON) $(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_FULL) - Build' ${BUILD_SOURCE} && tar -xzf build.tar.gz"
@@ -379,8 +380,8 @@ EOF
     skip: \${SKIP_$(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_UPCASE)_$(echo "$PLATFORM_JSON" | jq -r .VERSION_MAJOR)$(echo "$PLATFORM_JSON" | jq -r .VERSION_MINOR)}${SKIP_LONG_RUNNING_TESTS:-true}
 
 EOF
-            else
-                cat <<EOF
+              else
+                  cat <<EOF
   - label: "$(echo "$PLATFORM_JSON" | jq -r .ICON) $(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_FULL) - $TEST_NAME"
     command:
       - "git clone \$BUILDKITE_REPO eos && cd eos && $GIT_FETCH git checkout -f \$BUILDKITE_COMMIT && git submodule update --init --recursive"
@@ -407,20 +408,20 @@ EOF
     timeout: ${TIMEOUT:-180}
     skip: \${SKIP_$(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_UPCASE)_$(echo "$PLATFORM_JSON" | jq -r .VERSION_MAJOR)$(echo "$PLATFORM_JSON" | jq -r .VERSION_MINOR)}${SKIP_LONG_RUNNING_TESTS:-true}
 EOF
-            fi
-            echo
-        done
-        IFS=$nIFS
-    done
-    IFS=$oIFS
-    if [[ "$ROUND" != "$ROUNDS" ]]; then
-        echo '  - wait'
-        echo ''
-    fi
-done
-# Execute multiversion test
-if [[ ! "$PINNED" == 'false' || "$SKIP_MULTIVERSION_TEST" == 'false' ]]; then
-        cat <<EOF
+              fi
+              echo
+          done
+          IFS=$nIFS
+      done
+      IFS=$oIFS
+      if [[ "$ROUND" != "$ROUNDS" ]]; then
+          echo '  - wait'
+          echo ''
+      fi
+  done
+  # Execute multiversion test
+  if [[ ! "$PINNED" == 'false' || "$SKIP_MULTIVERSION_TEST" == 'false' ]]; then
+          cat <<EOF
   - label: ":pipeline: Multiversion Test"
     command: 
       - "buildkite-agent artifact download build.tar.gz . --step ':ubuntu: Ubuntu 18.04 - Build' && tar -xzf build.tar.gz"
@@ -434,11 +435,11 @@ if [[ ! "$PINNED" == 'false' || "$SKIP_MULTIVERSION_TEST" == 'false' ]]; then
     skip: ${SKIP_LINUX}${SKIP_UBUNTU_18_04}${SKIP_MULTIVERSION_TEST}
 
 EOF
-fi
-# trigger eosio-lrt post pr
-if [[ -z $BUILDKITE_TRIGGERED_FROM_BUILD_ID && $TRIGGER_JOB == "true" ]]; then
-    if ( [[ ! $PINNED == false ]] ); then
-        cat <<EOF
+  fi
+  # trigger eosio-lrt post pr
+  if [[ -z $BUILDKITE_TRIGGERED_FROM_BUILD_ID && $TRIGGER_JOB == "true" ]]; then
+      if ( [[ ! $PINNED == false ]] ); then
+          cat <<EOF
   - label: ":pipeline: Trigger Long Running Tests"
     trigger: "eosio-lrt"
     async: true
@@ -456,11 +457,11 @@ if [[ -z $BUILDKITE_TRIGGERED_FROM_BUILD_ID && $TRIGGER_JOB == "true" ]]; then
         PINNED: "${PINNED}"
 
 EOF
-    fi
-fi
-# trigger eosio-sync-from-genesis for every build
-if [[ "$BUILDKITE_PIPELINE_SLUG" == 'eosio' && -z "${SKIP_INSTALL}${SKIP_LINUX}${SKIP_DOCKER}${SKIP_SYNC_TESTS}" ]]; then
-    cat <<EOF
+      fi
+  fi
+  # trigger eosio-sync-from-genesis for every build
+  if [[ "$BUILDKITE_PIPELINE_SLUG" == 'eosio' && -z "${SKIP_INSTALL}${SKIP_LINUX}${SKIP_DOCKER}${SKIP_SYNC_TESTS}" ]]; then
+      cat <<EOF
   - label: ":chains: Sync from Genesis Test"
     trigger: "eosio-sync-from-genesis"
     async: false
@@ -477,10 +478,10 @@ if [[ "$BUILDKITE_PIPELINE_SLUG" == 'eosio' && -z "${SKIP_INSTALL}${SKIP_LINUX}$
         TIMEOUT: "${TIMEOUT}"
 
 EOF
-fi
-# trigger eosio-resume-from-state for every build
-if [[ "$BUILDKITE_PIPELINE_SLUG" == 'eosio' && -z "${SKIP_INSTALL}${SKIP_LINUX}${SKIP_DOCKER}${SKIP_SYNC_TESTS}" ]]; then
-    cat <<EOF
+  fi
+  # trigger eosio-resume-from-state for every build
+  if [[ "$BUILDKITE_PIPELINE_SLUG" == 'eosio' && -z "${SKIP_INSTALL}${SKIP_LINUX}${SKIP_DOCKER}${SKIP_SYNC_TESTS}" ]]; then
+      cat <<EOF
   - label: ":outbox_tray: Resume from State Test"
     trigger: "eosio-resume-from-state"
     async: false
@@ -497,6 +498,7 @@ if [[ "$BUILDKITE_PIPELINE_SLUG" == 'eosio' && -z "${SKIP_INSTALL}${SKIP_LINUX}$
         TIMEOUT: "${TIMEOUT}"
 
 EOF
+  fi
 fi
 # pipeline tail
 cat <<EOF

--- a/.cicd/generate-pipeline.sh
+++ b/.cicd/generate-pipeline.sh
@@ -425,7 +425,7 @@ EOF
     done
     # Execute multiversion test
     if [[ ! "$PINNED" == 'false' || "$SKIP_MULTIVERSION_TEST" == 'false' ]]; then
-            cat <<EOF
+        cat <<EOF
   - label: ":pipeline: Multiversion Test"
     command: 
       - "buildkite-agent artifact download build.tar.gz . --step ':ubuntu: Ubuntu 18.04 - Build' && tar -xzf build.tar.gz"

--- a/.cicd/generate-pipeline.sh
+++ b/.cicd/generate-pipeline.sh
@@ -59,7 +59,7 @@ for FILE in $(ls "$CICD_DIR/platforms/$PLATFORM_TYPE"); do
     [[ $FILE_NAME =~ 'centos' ]] && export ICON=':centos:'
     [[ $FILE_NAME =~ 'macos' ]] && export ICON=':darwin:'
     . "$HELPERS_DIR/file-hash.sh" "$CICD_DIR/platforms/$PLATFORM_TYPE/$FILE" # returns HASHED_IMAGE_TAG, etc
-    export PLATFORM_NAME_SKIP_SUFFIX="${PLATFORM_NAME_UPCASE}_${VERSION_MAJOR}${VERSION_MINOR}"
+    export PLATFORM_SKIP_VAR="SKIP_${PLATFORM_NAME_UPCASE}_${VERSION_MAJOR}${VERSION_MINOR}"
     # Anka Template and Tags
     export ANKA_TAG_BASE='clean::cicd::git-ssh::nas::brew::buildkite-agent'
     if [[ $FILE_NAME =~ 'macos-10.14' ]]; then
@@ -73,7 +73,7 @@ for FILE in $(ls "$CICD_DIR/platforms/$PLATFORM_TYPE"); do
     export PLATFORMS_JSON_ARRAY=$(echo $PLATFORMS_JSON_ARRAY | jq -c '. += [{ 
         "FILE_NAME": env.FILE_NAME, 
         "PLATFORM_NAME": env.PLATFORM_NAME,
-        "PLATFORM_NAME_SKIP_SUFFIX": env.PLATFORM_NAME_SKIP_SUFFIX,
+        "PLATFORM_SKIP_VAR": env.PLATFORM_SKIP_VAR,
         "PLATFORM_NAME_UPCASE": env.PLATFORM_NAME_UPCASE,
         "VERSION_MAJOR": env.VERSION_MAJOR,
         "VERSION_MINOR": env.VERSION_MINOR,
@@ -130,7 +130,7 @@ echo $PLATFORMS_JSON_ARRAY | jq -cr '.[]' | while read -r PLATFORM_JSON; do
     agents:
       queue: "$BUILDKITE_BUILD_AGENT_QUEUE"
     timeout: ${TIMEOUT:-180}
-    skip: $(echo "$SKIP_$(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_SKIP_SUFFIX)")${SKIP_BUILD}
+    skip: $(echo "$PLATFORM_JSON" | jq -r '.PLATFORM_SKIP_VAR | env[.]')${SKIP_BUILD}
 
 EOF
     else
@@ -169,7 +169,7 @@ EOF
       PROJECT_TAG: $(echo "$PLATFORM_JSON" | jq -r .HASHED_IMAGE_TAG)
     timeout: ${TIMEOUT:-180}
     agents: "queue=mac-anka-large-node-fleet"
-    skip: $(echo "$SKIP_$(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_SKIP_SUFFIX)")${SKIP_BUILD}
+    skip: $(echo "$PLATFORM_JSON" | jq -r '.PLATFORM_SKIP_VAR | env[.]')${SKIP_BUILD}
 EOF
     fi
 done
@@ -212,7 +212,7 @@ if [[ "$DCMAKE_BUILD_TYPE" != 'Debug' ]]; then
       manual:
         permit_on_passed: true
     timeout: ${TIMEOUT:-30}
-    skip: $(echo "$SKIP_$(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_SKIP_SUFFIX)")${SKIP_UNIT_TESTS}
+    skip: $(echo "$PLATFORM_JSON" | jq -r '.PLATFORM_SKIP_VAR | env[.]')${SKIP_UNIT_TESTS}
 
 EOF
             else
@@ -241,7 +241,7 @@ EOF
       manual:
         permit_on_passed: true
     timeout: ${TIMEOUT:-60}
-    skip: $(echo "$SKIP_$(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_SKIP_SUFFIX)")${SKIP_UNIT_TESTS}
+    skip: $(echo "$PLATFORM_JSON" | jq -r '.PLATFORM_SKIP_VAR | env[.]')${SKIP_UNIT_TESTS}
 
 EOF
             fi
@@ -265,7 +265,7 @@ EOF
       manual:
         permit_on_passed: true
     timeout: ${TIMEOUT:-30}
-    skip: $(echo "$SKIP_$(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_SKIP_SUFFIX)")${SKIP_WASM_SPEC_TESTS}
+    skip: $(echo "$PLATFORM_JSON" | jq -r '.PLATFORM_SKIP_VAR | env[.]')${SKIP_WASM_SPEC_TESTS}
 
 EOF
             else
@@ -294,7 +294,7 @@ EOF
       manual:
         permit_on_passed: true
     timeout: ${TIMEOUT:-60}
-    skip: $(echo "$SKIP_$(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_SKIP_SUFFIX)")${SKIP_WASM_SPEC_TESTS}
+    skip: $(echo "$PLATFORM_JSON" | jq -r '.PLATFORM_SKIP_VAR | env[.]')${SKIP_WASM_SPEC_TESTS}
 
 EOF
             fi
@@ -321,7 +321,7 @@ EOF
       manual:
         permit_on_passed: true
     timeout: ${TIMEOUT:-20}
-    skip: $(echo "$SKIP_$(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_SKIP_SUFFIX)")${SKIP_SERIAL_TESTS}
+    skip: $(echo "$PLATFORM_JSON" | jq -r '.PLATFORM_SKIP_VAR | env[.]')${SKIP_SERIAL_TESTS}
 
 EOF
                 else
@@ -350,7 +350,7 @@ EOF
       manual:
         permit_on_passed: true
     timeout: ${TIMEOUT:-60}
-    skip: $(echo "$SKIP_$(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_SKIP_SUFFIX)")${SKIP_SERIAL_TESTS}
+    skip: $(echo "$PLATFORM_JSON" | jq -r '.PLATFORM_SKIP_VAR | env[.]')${SKIP_SERIAL_TESTS}
 EOF
                 fi
                 echo
@@ -378,7 +378,7 @@ EOF
       manual:
         permit_on_passed: true
     timeout: ${TIMEOUT:-180}
-    skip: $(echo "$SKIP_$(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_SKIP_SUFFIX)")${SKIP_LONG_RUNNING_TESTS:-true}
+    skip: $(echo "$PLATFORM_JSON" | jq -r '.PLATFORM_SKIP_VAR | env[.]')${SKIP_LONG_RUNNING_TESTS:-true}
 
 EOF
                 else
@@ -407,7 +407,7 @@ EOF
       manual:
         permit_on_passed: true
     timeout: ${TIMEOUT:-180}
-    skip: $(echo "$SKIP_$(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_SKIP_SUFFIX)")${SKIP_LONG_RUNNING_TESTS:-true}
+    skip: $(echo "$PLATFORM_JSON" | jq -r '.PLATFORM_SKIP_VAR | env[.]')${SKIP_LONG_RUNNING_TESTS:-true}
 EOF
                 fi
                 echo

--- a/.cicd/generate-pipeline.sh
+++ b/.cicd/generate-pipeline.sh
@@ -117,7 +117,6 @@ if [[ "$DEBUG" == 'true' ]]; then
 fi
 echo '    # builds'
 echo $PLATFORMS_JSON_ARRAY | jq -cr '.[]' | while read -r PLATFORM_JSON; do
-    # release build
     if [[ ! "$(echo "$PLATFORM_JSON" | jq -r .FILE_NAME)" =~ 'macos' ]]; then
         cat <<EOF
   - label: "$(echo "$PLATFORM_JSON" | jq -r .ICON) $(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_FULL) - Build"
@@ -167,33 +166,6 @@ EOF
     timeout: ${TIMEOUT:-180}
     agents: "queue=mac-anka-large-node-fleet"
     skip: \${SKIP_$(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_UPCASE)_$(echo "$PLATFORM_JSON" | jq -r .VERSION_MAJOR)$(echo "$PLATFORM_JSON" | jq -r .VERSION_MINOR)}${SKIP_BUILD}
-EOF
-    fi
-    # debug build
-    if [[ "$PLATFORM_TYPE" == 'pinned' && "$(echo "$PLATFORM_JSON" | jq -r .FILE_NAME)" == "$(echo "$LATEST_UBUNTU" | jq -r '.FILE_NAME')" ]]; then
-        cat <<EOF
-  - label: "$(echo "$PLATFORM_JSON" | jq -r .ICON) $(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_FULL) - RelWithDebInfo Build"
-    command: "./.cicd/build.sh"
-    env:
-      CMAKE_BUILD_TYPE: "RelWithDebInfo"
-      IMAGE_TAG: $(echo "$PLATFORM_JSON" | jq -r .FILE_NAME)
-      PLATFORM_TYPE: $PLATFORM_TYPE
-    agents:
-      queue: "$BUILDKITE_BUILD_AGENT_QUEUE"
-    timeout: ${TIMEOUT:-180}
-    skip: \${SKIP_$(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_UPCASE)_$(echo "$PLATFORM_JSON" | jq -r .VERSION_MAJOR)$(echo "$PLATFORM_JSON" | jq -r .VERSION_MINOR)}${SKIP_BUILD}${SKIP_DEBUG_BUILD}
-
-  - label: "$(echo "$PLATFORM_JSON" | jq -r .ICON) $(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_FULL) - Debug Build"
-    command: "./.cicd/build.sh"
-    env:
-      CMAKE_BUILD_TYPE: "Debug"
-      IMAGE_TAG: $(echo "$PLATFORM_JSON" | jq -r .FILE_NAME)
-      PLATFORM_TYPE: $PLATFORM_TYPE
-    agents:
-      queue: "$BUILDKITE_BUILD_AGENT_QUEUE"
-    timeout: ${TIMEOUT:-180}
-    skip: \${SKIP_$(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_UPCASE)_$(echo "$PLATFORM_JSON" | jq -r .VERSION_MAJOR)$(echo "$PLATFORM_JSON" | jq -r .VERSION_MINOR)}${SKIP_BUILD}${SKIP_DEBUG_BUILD}
-
 EOF
     fi
 done

--- a/.cicd/generate-pipeline.sh
+++ b/.cicd/generate-pipeline.sh
@@ -170,6 +170,7 @@ EOF
     timeout: ${TIMEOUT:-180}
     agents: "queue=mac-anka-large-node-fleet"
     skip: $(echo "$PLATFORM_JSON" | jq -r '.PLATFORM_SKIP_VAR | env[.]')${SKIP_BUILD}
+
 EOF
     fi
 done
@@ -351,6 +352,7 @@ EOF
         permit_on_passed: true
     timeout: ${TIMEOUT:-60}
     skip: $(echo "$PLATFORM_JSON" | jq -r '.PLATFORM_SKIP_VAR | env[.]')${SKIP_SERIAL_TESTS}
+
 EOF
                 fi
                 echo
@@ -408,6 +410,7 @@ EOF
         permit_on_passed: true
     timeout: ${TIMEOUT:-180}
     skip: $(echo "$PLATFORM_JSON" | jq -r '.PLATFORM_SKIP_VAR | env[.]')${SKIP_LONG_RUNNING_TESTS:-true}
+
 EOF
                 fi
                 echo
@@ -677,6 +680,5 @@ cat <<EOF
       queue: "$BUILDKITE_BUILD_AGENT_QUEUE"
     skip: ${SKIP_INSTALL}${SKIP_LINUX}${SKIP_DOCKER}${SKIP_PACKAGE_BUILDER}
     timeout: ${TIMEOUT:-10}
-
 EOF
 IFS=$oIFS

--- a/.cicd/generate-pipeline.sh
+++ b/.cicd/generate-pipeline.sh
@@ -107,7 +107,7 @@ nIFS=$IFS # fix array splitting (\n won't work)
 echo '  - wait'
 echo ''
 # build steps
-[[ -z "$CMAKE_BUILD_TYPE" ]] && export CMAKE_BUILD_TYPE='Release'
+[[ -z "$DCMAKE_BUILD_TYPE" ]] && export DCMAKE_BUILD_TYPE='Release'
 export LATEST_UBUNTU="$(echo "$PLATFORMS_JSON_ARRAY" | jq -c 'map(select(.PLATFORM_NAME == "ubuntu")) | sort_by(.VERSION_MAJOR) | .[-1]')" # isolate latest ubuntu from array
 if [[ "$DEBUG" == 'true' ]]; then
     echo '# PLATFORMS_JSON_ARRAY'
@@ -123,7 +123,7 @@ echo $PLATFORMS_JSON_ARRAY | jq -cr '.[]' | while read -r PLATFORM_JSON; do
   - label: "$(echo "$PLATFORM_JSON" | jq -r .ICON) $(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_FULL) - Build"
     command: "./.cicd/build.sh"
     env:
-      CMAKE_BUILD_TYPE: $CMAKE_BUILD_TYPE
+      DCMAKE_BUILD_TYPE: $DCMAKE_BUILD_TYPE
       IMAGE_TAG: $(echo "$PLATFORM_JSON" | jq -r .FILE_NAME)
       PLATFORM_TYPE: $PLATFORM_TYPE
     agents:
@@ -157,7 +157,7 @@ EOF
       - EOSIO/skip-checkout#v0.1.1:
           cd: ~
     env:
-      CMAKE_BUILD_TYPE: $CMAKE_BUILD_TYPE
+      DCMAKE_BUILD_TYPE: $DCMAKE_BUILD_TYPE
       REPO: ${BUILDKITE_PULL_REQUEST_REPO:-$BUILDKITE_REPO}
       REPO_COMMIT: $BUILDKITE_COMMIT
       TEMPLATE: $(echo "$PLATFORM_JSON" | jq -r .ANKA_TEMPLATE_NAME)
@@ -189,7 +189,7 @@ cat <<EOF
 EOF
 # tests
 IFS=$oIFS
-if [[ "$CMAKE_BUILD_TYPE" != 'Debug' ]]; then
+if [[ "$DCMAKE_BUILD_TYPE" != 'Debug' ]]; then
   for ROUND in $(seq 1 $ROUNDS); do
       IFS=$''
       echo "    # round $ROUND of $ROUNDS"

--- a/.cicd/generate-pipeline.sh
+++ b/.cicd/generate-pipeline.sh
@@ -6,11 +6,10 @@ export PLATFORMS_JSON_ARRAY='[]'
 [[ -z "$ROUNDS" ]] && export ROUNDS='1'
 BUILDKITE_BUILD_AGENT_QUEUE='automation-eks-eos-builder-fleet'
 BUILDKITE_TEST_AGENT_QUEUE='automation-eks-eos-tester-fleet'
-
 # Determine if it's a forked PR and make sure to add git fetch so we don't have to git clone the forked repo's url
 if [[ $BUILDKITE_BRANCH =~ ^pull/[0-9]+/head: ]]; then
-  PR_ID=$(echo $BUILDKITE_BRANCH | cut -d/ -f2)
-  export GIT_FETCH="git fetch -v --prune origin refs/pull/$PR_ID/head &&"
+    PR_ID=$(echo $BUILDKITE_BRANCH | cut -d/ -f2)
+    export GIT_FETCH="git fetch -v --prune origin refs/pull/$PR_ID/head &&"
 fi
 # Determine which dockerfiles/scripts to use for the pipeline.
 if [[ $PINNED == false ]]; then
@@ -64,12 +63,12 @@ for FILE in $(ls "$CICD_DIR/platforms/$PLATFORM_TYPE"); do
     # Anka Template and Tags
     export ANKA_TAG_BASE='clean::cicd::git-ssh::nas::brew::buildkite-agent'
     if [[ $FILE_NAME =~ 'macos-10.14' ]]; then
-      export ANKA_TEMPLATE_NAME='10.14.6_6C_14G_80G'
+        export ANKA_TEMPLATE_NAME='10.14.6_6C_14G_80G'
     elif [[ $FILE_NAME =~ 'macos-10.15' ]]; then
-      export ANKA_TEMPLATE_NAME='10.15.5_6C_14G_80G'
+        export ANKA_TEMPLATE_NAME='10.15.5_6C_14G_80G'
     else # Linux
-      export ANKA_TAG_BASE=''
-      export ANKA_TEMPLATE_NAME=''
+        export ANKA_TAG_BASE=''
+        export ANKA_TEMPLATE_NAME=''
     fi
     export PLATFORMS_JSON_ARRAY=$(echo $PLATFORMS_JSON_ARRAY | jq -c '. += [{ 
         "FILE_NAME": env.FILE_NAME, 
@@ -192,14 +191,14 @@ EOF
 # tests
 IFS=$oIFS
 if [[ "$DCMAKE_BUILD_TYPE" != 'Debug' ]]; then
-  for ROUND in $(seq 1 $ROUNDS); do
-      IFS=$''
-      echo "    # round $ROUND of $ROUNDS"
-      # parallel tests
-      echo '    # parallel tests'
-      echo $PLATFORMS_JSON_ARRAY | jq -cr '.[]' | while read -r PLATFORM_JSON; do
-          if [[ ! "$(echo "$PLATFORM_JSON" | jq -r .FILE_NAME)" =~ 'macos' ]]; then
-              cat <<EOF
+    for ROUND in $(seq 1 $ROUNDS); do
+        IFS=$''
+        echo "    # round $ROUND of $ROUNDS"
+        # parallel tests
+        echo '    # parallel tests'
+        echo $PLATFORMS_JSON_ARRAY | jq -cr '.[]' | while read -r PLATFORM_JSON; do
+            if [[ ! "$(echo "$PLATFORM_JSON" | jq -r .FILE_NAME)" =~ 'macos' ]]; then
+                cat <<EOF
   - label: "$(echo "$PLATFORM_JSON" | jq -r .ICON) $(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_FULL) - Unit Tests"
     command:
       - "buildkite-agent artifact download build.tar.gz . --step '$(echo "$PLATFORM_JSON" | jq -r .ICON) $(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_FULL) - Build' && tar -xzf build.tar.gz"
@@ -216,8 +215,8 @@ if [[ "$DCMAKE_BUILD_TYPE" != 'Debug' ]]; then
     skip: $(echo "$SKIP_$(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_SKIP_SUFFIX)")${SKIP_UNIT_TESTS}
 
 EOF
-          else
-              cat <<EOF
+            else
+                cat <<EOF
   - label: "$(echo "$PLATFORM_JSON" | jq -r .ICON) $(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_FULL) - Unit Tests"
     command:
       - "git clone \$BUILDKITE_REPO eos && cd eos && $GIT_FETCH git checkout -f \$BUILDKITE_COMMIT && git submodule update --init --recursive"
@@ -245,14 +244,14 @@ EOF
     skip: $(echo "$SKIP_$(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_SKIP_SUFFIX)")${SKIP_UNIT_TESTS}
 
 EOF
-          fi
-      echo
-      done
-      # wasm spec tests
-      echo '    # wasm spec tests'
-      echo $PLATFORMS_JSON_ARRAY | jq -cr '.[]' | while read -r PLATFORM_JSON; do
-          if [[ ! "$(echo "$PLATFORM_JSON" | jq -r .FILE_NAME)" =~ 'macos' ]]; then
-              cat <<EOF
+            fi
+        echo
+        done
+        # wasm spec tests
+        echo '    # wasm spec tests'
+        echo $PLATFORMS_JSON_ARRAY | jq -cr '.[]' | while read -r PLATFORM_JSON; do
+            if [[ ! "$(echo "$PLATFORM_JSON" | jq -r .FILE_NAME)" =~ 'macos' ]]; then
+                cat <<EOF
   - label: "$(echo "$PLATFORM_JSON" | jq -r .ICON) $(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_FULL) - WASM Spec Tests"
     command:
       - "buildkite-agent artifact download build.tar.gz . --step '$(echo "$PLATFORM_JSON" | jq -r .ICON) $(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_FULL) - Build' && tar -xzf build.tar.gz"
@@ -269,8 +268,8 @@ EOF
     skip: $(echo "$SKIP_$(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_SKIP_SUFFIX)")${SKIP_WASM_SPEC_TESTS}
 
 EOF
-          else
-              cat <<EOF
+            else
+                cat <<EOF
   - label: "$(echo "$PLATFORM_JSON" | jq -r .ICON) $(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_FULL) - WASM Spec Tests"
     command:
       - "git clone \$BUILDKITE_REPO eos && cd eos && $GIT_FETCH git checkout -f \$BUILDKITE_COMMIT && git submodule update --init --recursive"
@@ -298,17 +297,17 @@ EOF
     skip: $(echo "$SKIP_$(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_SKIP_SUFFIX)")${SKIP_WASM_SPEC_TESTS}
 
 EOF
-          fi
-      echo
-      done
-      # serial tests
-      echo '    # serial tests'
-      echo $PLATFORMS_JSON_ARRAY | jq -cr '.[]' | while read -r PLATFORM_JSON; do
-          IFS=$oIFS
-          SERIAL_TESTS="$(cat tests/CMakeLists.txt | grep nonparallelizable_tests | grep -v "^#" | awk -F" " '{ print $2 }')"
-          for TEST_NAME in $SERIAL_TESTS; do
-              if [[ ! "$(echo "$PLATFORM_JSON" | jq -r .FILE_NAME)" =~ 'macos' ]]; then
-                  cat <<EOF
+            fi
+        echo
+        done
+        # serial tests
+        echo '    # serial tests'
+        echo $PLATFORMS_JSON_ARRAY | jq -cr '.[]' | while read -r PLATFORM_JSON; do
+            IFS=$oIFS
+            SERIAL_TESTS="$(cat tests/CMakeLists.txt | grep nonparallelizable_tests | grep -v "^#" | awk -F" " '{ print $2 }')"
+            for TEST_NAME in $SERIAL_TESTS; do
+                if [[ ! "$(echo "$PLATFORM_JSON" | jq -r .FILE_NAME)" =~ 'macos' ]]; then
+                    cat <<EOF
   - label: "$(echo "$PLATFORM_JSON" | jq -r .ICON) $(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_FULL) - $TEST_NAME"
     command:
       - "buildkite-agent artifact download build.tar.gz . --step '$(echo "$PLATFORM_JSON" | jq -r .ICON) $(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_FULL) - Build' && tar -xzf build.tar.gz"
@@ -325,8 +324,8 @@ EOF
     skip: $(echo "$SKIP_$(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_SKIP_SUFFIX)")${SKIP_SERIAL_TESTS}
 
 EOF
-              else
-                  cat <<EOF
+                else
+                    cat <<EOF
   - label: "$(echo "$PLATFORM_JSON" | jq -r .ICON) $(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_FULL) - $TEST_NAME"
     command:
       - "git clone \$BUILDKITE_REPO eos && cd eos && $GIT_FETCH git checkout -f \$BUILDKITE_COMMIT && git submodule update --init --recursive"
@@ -353,19 +352,19 @@ EOF
     timeout: ${TIMEOUT:-60}
     skip: $(echo "$SKIP_$(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_SKIP_SUFFIX)")${SKIP_SERIAL_TESTS}
 EOF
-              fi
-              echo
-          done
-          IFS=$nIFS
-      done
-      # long-running tests
-      echo '    # long-running tests'
-      echo $PLATFORMS_JSON_ARRAY | jq -cr '.[]' | while read -r PLATFORM_JSON; do
-          IFS=$oIFS
-          LR_TESTS="$(cat tests/CMakeLists.txt | grep long_running_tests | grep -v "^#" | awk -F" " '{ print $2 }')"
-          for TEST_NAME in $LR_TESTS; do
-              if [[ ! "$(echo "$PLATFORM_JSON" | jq -r .FILE_NAME)" =~ 'macos' ]]; then
-                  cat <<EOF
+                fi
+                echo
+            done
+            IFS=$nIFS
+        done
+        # long-running tests
+        echo '    # long-running tests'
+        echo $PLATFORMS_JSON_ARRAY | jq -cr '.[]' | while read -r PLATFORM_JSON; do
+            IFS=$oIFS
+            LR_TESTS="$(cat tests/CMakeLists.txt | grep long_running_tests | grep -v "^#" | awk -F" " '{ print $2 }')"
+            for TEST_NAME in $LR_TESTS; do
+                if [[ ! "$(echo "$PLATFORM_JSON" | jq -r .FILE_NAME)" =~ 'macos' ]]; then
+                    cat <<EOF
   - label: "$(echo "$PLATFORM_JSON" | jq -r .ICON) $(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_FULL) - $TEST_NAME"
     command:
       - "buildkite-agent artifact download build.tar.gz . --step '$(echo "$PLATFORM_JSON" | jq -r .ICON) $(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_FULL) - Build' ${BUILD_SOURCE} && tar -xzf build.tar.gz"
@@ -382,8 +381,8 @@ EOF
     skip: $(echo "$SKIP_$(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_SKIP_SUFFIX)")${SKIP_LONG_RUNNING_TESTS:-true}
 
 EOF
-              else
-                  cat <<EOF
+                else
+                    cat <<EOF
   - label: "$(echo "$PLATFORM_JSON" | jq -r .ICON) $(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_FULL) - $TEST_NAME"
     command:
       - "git clone \$BUILDKITE_REPO eos && cd eos && $GIT_FETCH git checkout -f \$BUILDKITE_COMMIT && git submodule update --init --recursive"
@@ -410,20 +409,20 @@ EOF
     timeout: ${TIMEOUT:-180}
     skip: $(echo "$SKIP_$(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_SKIP_SUFFIX)")${SKIP_LONG_RUNNING_TESTS:-true}
 EOF
-              fi
-              echo
-          done
-          IFS=$nIFS
-      done
-      IFS=$oIFS
-      if [[ "$ROUND" != "$ROUNDS" ]]; then
-          echo '  - wait'
-          echo ''
-      fi
-  done
-  # Execute multiversion test
-  if [[ ! "$PINNED" == 'false' || "$SKIP_MULTIVERSION_TEST" == 'false' ]]; then
-          cat <<EOF
+                fi
+                echo
+            done
+            IFS=$nIFS
+        done
+        IFS=$oIFS
+        if [[ "$ROUND" != "$ROUNDS" ]]; then
+            echo '  - wait'
+            echo ''
+        fi
+    done
+    # Execute multiversion test
+    if [[ ! "$PINNED" == 'false' || "$SKIP_MULTIVERSION_TEST" == 'false' ]]; then
+            cat <<EOF
   - label: ":pipeline: Multiversion Test"
     command: 
       - "buildkite-agent artifact download build.tar.gz . --step ':ubuntu: Ubuntu 18.04 - Build' && tar -xzf build.tar.gz"
@@ -437,11 +436,11 @@ EOF
     skip: ${SKIP_LINUX}${SKIP_UBUNTU_18_04}${SKIP_MULTIVERSION_TEST}
 
 EOF
-  fi
-  # trigger eosio-lrt post pr
-  if [[ -z $BUILDKITE_TRIGGERED_FROM_BUILD_ID && $TRIGGER_JOB == "true" ]]; then
-      if ( [[ ! $PINNED == false ]] ); then
-          cat <<EOF
+    fi
+    # trigger eosio-lrt post pr
+    if [[ -z $BUILDKITE_TRIGGERED_FROM_BUILD_ID && $TRIGGER_JOB == "true" ]]; then
+        if ( [[ ! $PINNED == false ]] ); then
+            cat <<EOF
   - label: ":pipeline: Trigger Long Running Tests"
     trigger: "eosio-lrt"
     async: true
@@ -459,11 +458,11 @@ EOF
         PINNED: "${PINNED}"
 
 EOF
-      fi
-  fi
-  # trigger eosio-sync-from-genesis for every build
-  if [[ "$BUILDKITE_PIPELINE_SLUG" == 'eosio' && -z "${SKIP_INSTALL}${SKIP_LINUX}${SKIP_DOCKER}${SKIP_SYNC_TESTS}" ]]; then
-      cat <<EOF
+        fi
+    fi
+    # trigger eosio-sync-from-genesis for every build
+    if [[ "$BUILDKITE_PIPELINE_SLUG" == 'eosio' && -z "${SKIP_INSTALL}${SKIP_LINUX}${SKIP_DOCKER}${SKIP_SYNC_TESTS}" ]]; then
+        cat <<EOF
   - label: ":chains: Sync from Genesis Test"
     trigger: "eosio-sync-from-genesis"
     async: false
@@ -480,10 +479,10 @@ EOF
         TIMEOUT: "${TIMEOUT}"
 
 EOF
-  fi
-  # trigger eosio-resume-from-state for every build
-  if [[ "$BUILDKITE_PIPELINE_SLUG" == 'eosio' && -z "${SKIP_INSTALL}${SKIP_LINUX}${SKIP_DOCKER}${SKIP_SYNC_TESTS}" ]]; then
-      cat <<EOF
+    fi
+    # trigger eosio-resume-from-state for every build
+    if [[ "$BUILDKITE_PIPELINE_SLUG" == 'eosio' && -z "${SKIP_INSTALL}${SKIP_LINUX}${SKIP_DOCKER}${SKIP_SYNC_TESTS}" ]]; then
+        cat <<EOF
   - label: ":outbox_tray: Resume from State Test"
     trigger: "eosio-resume-from-state"
     async: false
@@ -500,7 +499,7 @@ EOF
         TIMEOUT: "${TIMEOUT}"
 
 EOF
-  fi
+    fi
 fi
 # pipeline tail
 cat <<EOF

--- a/.cicd/generate-pipeline.sh
+++ b/.cicd/generate-pipeline.sh
@@ -60,6 +60,7 @@ for FILE in $(ls "$CICD_DIR/platforms/$PLATFORM_TYPE"); do
     [[ $FILE_NAME =~ 'centos' ]] && export ICON=':centos:'
     [[ $FILE_NAME =~ 'macos' ]] && export ICON=':darwin:'
     . "$HELPERS_DIR/file-hash.sh" "$CICD_DIR/platforms/$PLATFORM_TYPE/$FILE" # returns HASHED_IMAGE_TAG, etc
+    export PLATFORM_NAME_SKIP_SUFFIX="${PLATFORM_NAME_UPCASE}_${VERSION_MAJOR}${VERSION_MINOR}"
     # Anka Template and Tags
     export ANKA_TAG_BASE='clean::cicd::git-ssh::nas::brew::buildkite-agent'
     if [[ $FILE_NAME =~ 'macos-10.14' ]]; then
@@ -73,6 +74,7 @@ for FILE in $(ls "$CICD_DIR/platforms/$PLATFORM_TYPE"); do
     export PLATFORMS_JSON_ARRAY=$(echo $PLATFORMS_JSON_ARRAY | jq -c '. += [{ 
         "FILE_NAME": env.FILE_NAME, 
         "PLATFORM_NAME": env.PLATFORM_NAME,
+        "PLATFORM_NAME_SKIP_SUFFIX": env.PLATFORM_NAME_SKIP_SUFFIX,
         "PLATFORM_NAME_UPCASE": env.PLATFORM_NAME_UPCASE,
         "VERSION_MAJOR": env.VERSION_MAJOR,
         "VERSION_MINOR": env.VERSION_MINOR,
@@ -129,7 +131,7 @@ echo $PLATFORMS_JSON_ARRAY | jq -cr '.[]' | while read -r PLATFORM_JSON; do
     agents:
       queue: "$BUILDKITE_BUILD_AGENT_QUEUE"
     timeout: ${TIMEOUT:-180}
-    skip: \${SKIP_$(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_UPCASE)_$(echo "$PLATFORM_JSON" | jq -r .VERSION_MAJOR)$(echo "$PLATFORM_JSON" | jq -r .VERSION_MINOR)}${SKIP_BUILD}
+    skip: $(echo "$SKIP_$(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_SKIP_SUFFIX)")${SKIP_BUILD}
 
 EOF
     else
@@ -168,7 +170,7 @@ EOF
       PROJECT_TAG: $(echo "$PLATFORM_JSON" | jq -r .HASHED_IMAGE_TAG)
     timeout: ${TIMEOUT:-180}
     agents: "queue=mac-anka-large-node-fleet"
-    skip: \${SKIP_$(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_UPCASE)_$(echo "$PLATFORM_JSON" | jq -r .VERSION_MAJOR)$(echo "$PLATFORM_JSON" | jq -r .VERSION_MINOR)}${SKIP_BUILD}
+    skip: $(echo "$SKIP_$(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_SKIP_SUFFIX)")${SKIP_BUILD}
 EOF
     fi
 done
@@ -211,7 +213,7 @@ if [[ "$DCMAKE_BUILD_TYPE" != 'Debug' ]]; then
       manual:
         permit_on_passed: true
     timeout: ${TIMEOUT:-30}
-    skip: \${SKIP_$(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_UPCASE)_$(echo "$PLATFORM_JSON" | jq -r .VERSION_MAJOR)$(echo "$PLATFORM_JSON" | jq -r .VERSION_MINOR)}${SKIP_UNIT_TESTS}
+    skip: $(echo "$SKIP_$(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_SKIP_SUFFIX)")${SKIP_UNIT_TESTS}
 
 EOF
           else
@@ -240,7 +242,7 @@ EOF
       manual:
         permit_on_passed: true
     timeout: ${TIMEOUT:-60}
-    skip: \${SKIP_$(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_UPCASE)_$(echo "$PLATFORM_JSON" | jq -r .VERSION_MAJOR)$(echo "$PLATFORM_JSON" | jq -r .VERSION_MINOR)}${SKIP_UNIT_TESTS}
+    skip: $(echo "$SKIP_$(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_SKIP_SUFFIX)")${SKIP_UNIT_TESTS}
 
 EOF
           fi
@@ -264,7 +266,7 @@ EOF
       manual:
         permit_on_passed: true
     timeout: ${TIMEOUT:-30}
-    skip: \${SKIP_$(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_UPCASE)_$(echo "$PLATFORM_JSON" | jq -r .VERSION_MAJOR)$(echo "$PLATFORM_JSON" | jq -r .VERSION_MINOR)}${SKIP_WASM_SPEC_TESTS}
+    skip: $(echo "$SKIP_$(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_SKIP_SUFFIX)")${SKIP_WASM_SPEC_TESTS}
 
 EOF
           else
@@ -293,7 +295,7 @@ EOF
       manual:
         permit_on_passed: true
     timeout: ${TIMEOUT:-60}
-    skip: \${SKIP_$(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_UPCASE)_$(echo "$PLATFORM_JSON" | jq -r .VERSION_MAJOR)$(echo "$PLATFORM_JSON" | jq -r .VERSION_MINOR)}${SKIP_WASM_SPEC_TESTS}
+    skip: $(echo "$SKIP_$(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_SKIP_SUFFIX)")${SKIP_WASM_SPEC_TESTS}
 
 EOF
           fi
@@ -320,7 +322,7 @@ EOF
       manual:
         permit_on_passed: true
     timeout: ${TIMEOUT:-20}
-    skip: \${SKIP_$(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_UPCASE)_$(echo "$PLATFORM_JSON" | jq -r .VERSION_MAJOR)$(echo "$PLATFORM_JSON" | jq -r .VERSION_MINOR)}${SKIP_SERIAL_TESTS}
+    skip: $(echo "$SKIP_$(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_SKIP_SUFFIX)")${SKIP_SERIAL_TESTS}
 
 EOF
               else
@@ -349,7 +351,7 @@ EOF
       manual:
         permit_on_passed: true
     timeout: ${TIMEOUT:-60}
-    skip: \${SKIP_$(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_UPCASE)_$(echo "$PLATFORM_JSON" | jq -r .VERSION_MAJOR)$(echo "$PLATFORM_JSON" | jq -r .VERSION_MINOR)}${SKIP_SERIAL_TESTS}
+    skip: $(echo "$SKIP_$(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_SKIP_SUFFIX)")${SKIP_SERIAL_TESTS}
 EOF
               fi
               echo
@@ -377,7 +379,7 @@ EOF
       manual:
         permit_on_passed: true
     timeout: ${TIMEOUT:-180}
-    skip: \${SKIP_$(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_UPCASE)_$(echo "$PLATFORM_JSON" | jq -r .VERSION_MAJOR)$(echo "$PLATFORM_JSON" | jq -r .VERSION_MINOR)}${SKIP_LONG_RUNNING_TESTS:-true}
+    skip: $(echo "$SKIP_$(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_SKIP_SUFFIX)")${SKIP_LONG_RUNNING_TESTS:-true}
 
 EOF
               else
@@ -406,7 +408,7 @@ EOF
       manual:
         permit_on_passed: true
     timeout: ${TIMEOUT:-180}
-    skip: \${SKIP_$(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_UPCASE)_$(echo "$PLATFORM_JSON" | jq -r .VERSION_MAJOR)$(echo "$PLATFORM_JSON" | jq -r .VERSION_MINOR)}${SKIP_LONG_RUNNING_TESTS:-true}
+    skip: $(echo "$SKIP_$(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_SKIP_SUFFIX)")${SKIP_LONG_RUNNING_TESTS:-true}
 EOF
               fi
               echo

--- a/.cicd/generate-pipeline.sh
+++ b/.cicd/generate-pipeline.sh
@@ -107,6 +107,7 @@ nIFS=$IFS # fix array splitting (\n won't work)
 echo '  - wait'
 echo ''
 # build steps
+[[ -z "$CMAKE_BUILD_TYPE" ]] && export CMAKE_BUILD_TYPE='Release'
 export LATEST_UBUNTU="$(echo "$PLATFORMS_JSON_ARRAY" | jq -c 'map(select(.PLATFORM_NAME == "ubuntu")) | sort_by(.VERSION_MAJOR) | .[-1]')" # isolate latest ubuntu from array
 if [[ "$DEBUG" == 'true' ]]; then
     echo '# PLATFORMS_JSON_ARRAY'
@@ -122,6 +123,7 @@ echo $PLATFORMS_JSON_ARRAY | jq -cr '.[]' | while read -r PLATFORM_JSON; do
   - label: "$(echo "$PLATFORM_JSON" | jq -r .ICON) $(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_FULL) - Build"
     command: "./.cicd/build.sh"
     env:
+      CMAKE_BUILD_TYPE: $CMAKE_BUILD_TYPE
       IMAGE_TAG: $(echo "$PLATFORM_JSON" | jq -r .FILE_NAME)
       PLATFORM_TYPE: $PLATFORM_TYPE
     agents:
@@ -155,6 +157,7 @@ EOF
       - EOSIO/skip-checkout#v0.1.1:
           cd: ~
     env:
+      CMAKE_BUILD_TYPE: $CMAKE_BUILD_TYPE
       REPO: ${BUILDKITE_PULL_REQUEST_REPO:-$BUILDKITE_REPO}
       REPO_COMMIT: $BUILDKITE_COMMIT
       TEMPLATE: $(echo "$PLATFORM_JSON" | jq -r .ANKA_TEMPLATE_NAME)

--- a/.cicd/generate-pipeline.sh
+++ b/.cicd/generate-pipeline.sh
@@ -643,34 +643,6 @@ cat <<EOF
     timeout: ${TIMEOUT:-30}
     skip: ${SKIP_MACOS_10_15}${SKIP_PACKAGE_BUILDER}${SKIP_MAC}
 
-  - label: ":ubuntu: Ubuntu 20.04 - RelWithDebInfo Package Builder"
-    command:
-      - "buildkite-agent artifact download build.tar.gz . --step ':ubuntu: Ubuntu 20.04 - RelWithDebInfo Build' && tar -xzf build.tar.gz"
-      - "./.cicd/package.sh"
-    env:
-      IMAGE_TAG: "ubuntu-20.04-$PLATFORM_TYPE"
-      PLATFORM_TYPE: $PLATFORM_TYPE
-      OS: "ubuntu-20.04" # OS and PKGTYPE required for lambdas
-      PKGTYPE: "deb"
-    agents:
-      queue: "$BUILDKITE_TEST_AGENT_QUEUE"
-    timeout: ${TIMEOUT:-10}
-    skip: ${SKIP_UBUNTU_20_04}${SKIP_PACKAGE_BUILDER}${SKIP_LINUX}${SKIP_DEBUG_BUILD}
-
-  - label: ":ubuntu: Ubuntu 20.04 - Debug Package Builder"
-    command:
-      - "buildkite-agent artifact download build.tar.gz . --step ':ubuntu: Ubuntu 20.04 - Debug Build' && tar -xzf build.tar.gz"
-      - "./.cicd/package.sh"
-    env:
-      IMAGE_TAG: "ubuntu-20.04-$PLATFORM_TYPE"
-      PLATFORM_TYPE: $PLATFORM_TYPE
-      OS: "ubuntu-20.04" # OS and PKGTYPE required for lambdas
-      PKGTYPE: "deb"
-    agents:
-      queue: "$BUILDKITE_TEST_AGENT_QUEUE"
-    timeout: ${TIMEOUT:-10}
-    skip: ${SKIP_UBUNTU_20_04}${SKIP_PACKAGE_BUILDER}${SKIP_LINUX}${SKIP_DEBUG_BUILD}
-
   - label: ":docker: Docker - Label Container with Git Branch and Git Tag"
     command: .cicd/docker-tag.sh
     env:

--- a/.cicd/generate-pipeline.sh
+++ b/.cicd/generate-pipeline.sh
@@ -107,6 +107,11 @@ nIFS=$IFS # fix array splitting (\n won't work)
 echo '  - wait'
 echo ''
 # build steps
+if [[ "$DEBUG" == 'true' ]];
+    echo '# PLATFORMS_JSON_ARRAY'
+    echo "# $(echo "$PLATFORMS_JSON_ARRAY" | jq -c '.')"
+    echo ''
+fi
 echo '    # builds'
 echo $PLATFORMS_JSON_ARRAY | jq -cr '.[]' | while read -r PLATFORM_JSON; do
     if [[ ! "$(echo "$PLATFORM_JSON" | jq -r .FILE_NAME)" =~ 'macos' ]]; then

--- a/.cicd/generate-pipeline.sh
+++ b/.cicd/generate-pipeline.sh
@@ -181,7 +181,7 @@ EOF
     agents:
       queue: "$BUILDKITE_BUILD_AGENT_QUEUE"
     timeout: ${TIMEOUT:-180}
-    skip: \${SKIP_$(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_UPCASE)_$(echo "$PLATFORM_JSON" | jq -r .VERSION_MAJOR)$(echo "$PLATFORM_JSON" | jq -r .VERSION_MINOR)}${SKIP_BUILD}
+    skip: \${SKIP_$(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_UPCASE)_$(echo "$PLATFORM_JSON" | jq -r .VERSION_MAJOR)$(echo "$PLATFORM_JSON" | jq -r .VERSION_MINOR)}${SKIP_BUILD}${SKIP_DEBUG_BUILD}
 
 EOF
     fi
@@ -667,7 +667,7 @@ cat <<EOF
     agents:
       queue: "$BUILDKITE_TEST_AGENT_QUEUE"
     timeout: ${TIMEOUT:-10}
-    skip: ${SKIP_UBUNTU_20_04}${SKIP_PACKAGE_BUILDER}${SKIP_LINUX}
+    skip: ${SKIP_UBUNTU_20_04}${SKIP_PACKAGE_BUILDER}${SKIP_LINUX}${SKIP_DEBUG_BUILD}
 
   - label: ":docker: Docker - Label Container with Git Branch and Git Tag"
     command: .cicd/docker-tag.sh

--- a/.cicd/generate-pipeline.sh
+++ b/.cicd/generate-pipeline.sh
@@ -117,6 +117,7 @@ if [[ "$DEBUG" == 'true' ]]; then
 fi
 echo '    # builds'
 echo $PLATFORMS_JSON_ARRAY | jq -cr '.[]' | while read -r PLATFORM_JSON; do
+    # release build
     if [[ ! "$(echo "$PLATFORM_JSON" | jq -r .FILE_NAME)" =~ 'macos' ]]; then
         cat <<EOF
   - label: "$(echo "$PLATFORM_JSON" | jq -r .ICON) $(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_FULL) - Build"
@@ -166,6 +167,22 @@ EOF
     timeout: ${TIMEOUT:-180}
     agents: "queue=mac-anka-large-node-fleet"
     skip: \${SKIP_$(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_UPCASE)_$(echo "$PLATFORM_JSON" | jq -r .VERSION_MAJOR)$(echo "$PLATFORM_JSON" | jq -r .VERSION_MINOR)}${SKIP_BUILD}
+EOF
+    fi
+    # debug build
+    if [[ "$(echo "$PLATFORM_JSON" | jq -r .FILE_NAME)" == "$(echo "$LATEST_UBUNTU" | jq -r '.FILE_NAME')" ]]; then
+        cat <<EOF
+  - label: "$(echo "$PLATFORM_JSON" | jq -r .ICON) $(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_FULL) - Debug Build"
+    command: "./.cicd/build.sh"
+    env:
+      CMAKE_BUILD_TYPE: "Debug"
+      IMAGE_TAG: $(echo "$PLATFORM_JSON" | jq -r .FILE_NAME)
+      PLATFORM_TYPE: $PLATFORM_TYPE
+    agents:
+      queue: "$BUILDKITE_BUILD_AGENT_QUEUE"
+    timeout: ${TIMEOUT:-180}
+    skip: \${SKIP_$(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_UPCASE)_$(echo "$PLATFORM_JSON" | jq -r .VERSION_MAJOR)$(echo "$PLATFORM_JSON" | jq -r .VERSION_MINOR)}${SKIP_BUILD}
+
 EOF
     fi
 done

--- a/.cicd/generate-pipeline.sh
+++ b/.cicd/generate-pipeline.sh
@@ -107,7 +107,7 @@ nIFS=$IFS # fix array splitting (\n won't work)
 echo '  - wait'
 echo ''
 # build steps
-if [[ "$DEBUG" == 'true' ]];
+if [[ "$DEBUG" == 'true' ]]; then
     echo '# PLATFORMS_JSON_ARRAY'
     echo "# $(echo "$PLATFORMS_JSON_ARRAY" | jq -c '.')"
     echo ''

--- a/.cicd/generate-pipeline.sh
+++ b/.cicd/generate-pipeline.sh
@@ -107,9 +107,12 @@ nIFS=$IFS # fix array splitting (\n won't work)
 echo '  - wait'
 echo ''
 # build steps
+export LATEST_UBUNTU="$(echo "$PLATFORMS_JSON_ARRAY" | jq -c 'map(select(.PLATFORM_NAME == "ubuntu")) | sort_by(.VERSION_MAJOR) | .[-1]')" # isolate latest ubuntu from array
 if [[ "$DEBUG" == 'true' ]]; then
     echo '# PLATFORMS_JSON_ARRAY'
     echo "# $(echo "$PLATFORMS_JSON_ARRAY" | jq -c '.')"
+    echo '# LATEST_UBUNTU'
+    echo "# $(echo "$LATEST_UBUNTU" | jq -c '.')"
     echo ''
 fi
 echo '    # builds'

--- a/.cicd/generate-pipeline.sh
+++ b/.cicd/generate-pipeline.sh
@@ -170,7 +170,7 @@ EOF
 EOF
     fi
     # debug build
-    if [[ "$(echo "$PLATFORM_JSON" | jq -r .FILE_NAME)" == "$(echo "$LATEST_UBUNTU" | jq -r '.FILE_NAME')" ]]; then
+    if [[ "$PLATFORM_TYPE" == 'pinned' && "$(echo "$PLATFORM_JSON" | jq -r .FILE_NAME)" == "$(echo "$LATEST_UBUNTU" | jq -r '.FILE_NAME')" ]]; then
         cat <<EOF
   - label: "$(echo "$PLATFORM_JSON" | jq -r .ICON) $(echo "$PLATFORM_JSON" | jq -r .PLATFORM_NAME_FULL) - RelWithDebInfo Build"
     command: "./.cicd/build.sh"

--- a/.cicd/generate-pipeline.sh
+++ b/.cicd/generate-pipeline.sh
@@ -655,6 +655,20 @@ cat <<EOF
     timeout: ${TIMEOUT:-30}
     skip: ${SKIP_MACOS_10_15}${SKIP_PACKAGE_BUILDER}${SKIP_MAC}
 
+  - label: ":ubuntu: Ubuntu 20.04 - Debug Package Builder"
+    command:
+      - "buildkite-agent artifact download build.tar.gz . --step ':ubuntu: Ubuntu 20.04 - Debug Build' && tar -xzf build.tar.gz"
+      - "./.cicd/package.sh"
+    env:
+      IMAGE_TAG: "ubuntu-20.04-$PLATFORM_TYPE"
+      PLATFORM_TYPE: $PLATFORM_TYPE
+      OS: "ubuntu-20.04" # OS and PKGTYPE required for lambdas
+      PKGTYPE: "deb"
+    agents:
+      queue: "$BUILDKITE_TEST_AGENT_QUEUE"
+    timeout: ${TIMEOUT:-10}
+    skip: ${SKIP_UBUNTU_20_04}${SKIP_PACKAGE_BUILDER}${SKIP_LINUX}
+
   - label: ":docker: Docker - Label Container with Git Branch and Git Tag"
     command: .cicd/docker-tag.sh
     env:


### PR DESCRIPTION
## Change Description
From [AUTO-363](https://blockone.atlassian.net/browse/AUTO-363), Blockchain asked that we publish an Ubuntu package produced by a debug build ~~in the [eosio](https://buildkite.com/EOSIO/eosio) pipeline~~.

This pull request modifies the CI code to support the [eosio-debug-build](https://buildkite.com/EOSIO/eosio-debug-build) pipeline, which builds debug builds for each commit. For example:
- [Build 12](https://buildkite.com/EOSIO/eosio-debug-build/builds/12) -- `eos:develop`
- [Build 13](https://buildkite.com/EOSIO/eosio-debug-build/builds/13) -- `eos:release/2.1.x`
- [Build 14](https://buildkite.com/EOSIO/eosio-debug-build/builds/14) -- `eos:release/2.0.x`
- [Build 15](https://buildkite.com/EOSIO/eosio-debug-build/builds/15) -- `eos:release/1.8.x`

The [eosio-debug-build](https://buildkite.com/EOSIO/eosio-debug-build) pipeline also allows engineers to define a build type by declaring `DCMAKE_BUILD_TYPE` in the environment. For example, I performed a `RelWithDebInfo` build in [build 16](https://buildkite.com/EOSIO/eosio-debug-build/builds/16):
```bash
DCMAKE_BUILD_TYPE='RelWithDebInfo'
```
This variable can also be declared in the [eosio](https://buildkite.com/EOSIO/eosio), [eosio-build-unpinned](https://buildkite.com/EOSIO/eosio-build-unpinned), or [eosio-lrt](https://buildkite.com/EOSIO/eosio-lrt) pipelines. However, we do not recommend running tests against non-optimized (debug) builds.

### Background
During startup, `nodeos` performs a number of checks to protect itself from accidentally corrupting the state files, such as verifying the state files were not created with a newer version of `nodeos`, checking the `genesis.json` or `snapshot.bin` chain ID, and comparing the library versions leveraged to write the state files to those in the running copy of `nodeos`. That last check can make it time consuming for Blockchain to debug when replaying real chains.

For example, during an intense late-night debugging video call, we had stood up a cloud instance, loaded hundreds of gigabytes of chain data onto the cloud instance, then ran a release build of `nodeos` obtained from CI. We stopped it at a particular block just before our bug and wanted to step through with a debugger. Unfortunately, these state files are unlikely to be accepted by a debugging build of `nodeos` built on the cloud instance or our local machine, because the build environment and thus libraries are different. So we had to rebuild `nodeos` twice on the same machine, once for a release build and once for a debug build, in order to switch back and forth between a release (optimized) and debug (non-optimized) build of `nodeos` while replaying this problematic chain segment.

~~To prevent this from being an issue in the future, this pull request introduces `Debug` and `RelWithDebInfo` build and packaging steps for the latest supported Ubuntu operating system. Since the CI system uses a deterministic build environment with consistent library versions, this will allow Blockchain engineers to pull packages with the level of debug tooling and optimization necessary for their work, and to switch between them at-will without risk of corrupting their state files or failing the startup checks.~~

### See Also
- [Pull Request 9940](https://github.com/EOSIO/eos/pull/9940) -- `eos:develop`
- [Pull Request 9943](https://github.com/EOSIO/eos/pull/9943) -- `eos:release/2.1.x`
- [Pull Request 9944](https://github.com/EOSIO/eos/pull/9944) -- `eos:release/2.0.x`
- [Pull Request 9945](https://github.com/EOSIO/eos/pull/9945) -- `eos:release/1.8.x`

## Change Type
**Select *ONE*:**
- [ ] Documentation
- [ ] Stability bug fix
- [x] Other
- [ ] Other - special case

## Testing Changes
**Select *ANY* that apply:**
- [ ] New Tests
- [ ] Existing Tests
- [ ] Test Framework
- [x] CI System
- [ ] Other

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions