### PR TITLE
[docs] 2.1.x - improve annotation for db_update_i64

### DIFF
--- a/libraries/chain/include/eosio/chain/webassembly/interface.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/interface.hpp
@@ -792,7 +792,13 @@ namespace webassembly {
           * @param itr - iterator to the table row containing the record to update.
           * @param payer -  the account that pays for the storage costs.
           * @param buffer - new updated record.
-          *
+          * 
+          * @details This function does not allow changing the primary key of a 
+          * table row. The serialized data that is stored in the table row of a 
+          * primary table may include a primary key and that primary key value 
+          * could be changed by the contract calling the db_update_i64 intrinsic; 
+          * but that does not change the actual primary key of the table row.
+          * 
           * @pre `itr` points to an existing table row in the table.
           * @post the record contained in the table row pointed to by `itr` is replaced with the new updated record.
           */

--- a/libraries/chain/include/eosio/chain/webassembly/interface.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/interface.hpp
@@ -793,7 +793,7 @@ namespace webassembly {
           * @param payer -  the account that pays for the storage costs.
           * @param buffer - new updated record.
           * 
-          * @details This function does not allow changing the primary key of a 
+          * @remark This function does not allow changing the primary key of a 
           * table row. The serialized data that is stored in the table row of a 
           * primary table may include a primary key and that primary key value 
           * could be changed by the contract calling the db_update_i64 intrinsic; 


### PR DESCRIPTION
improve annotation for db_update_i64
based on this issue EOSIO/eosio.cdt#819

sister PR for: https://github.com/EOSIO/eos/pull/9951

the same improvement will be done in the cdt repo for db_update_i64