### PR TITLE
Make get_kv_table_rows work without --lower and --upper and --index

### DIFF
--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -2297,10 +2297,7 @@ read_only::get_table_rows_result read_only::get_kv_table_rows_context( const rea
       ub_key.resize(ub_key_size);
       status_ub = ub_itr->kv_it_key(0, ub_key.data(), ub_key_size, ub_key_actual_size);
       EOS_ASSERT(ub_key_size == ub_key_actual_size, chain::contract_table_query_exception, "Invalid upper bound iterator in ${t} ${i}", ("t", p.table)("i", p.index_name));
-   }
-
-   // Set upper bound iterator
-   if (has_no_bound) {
+   }else if(has_no_bound) {
        //Set the last item as the upper bound
        ub_itr = kv_context.kv_it_create(p.code.to_uint64_t(), prefix.data(), prefix.size());
        auto status_nb = ub_itr->kv_it_move_to_end();

--- a/tests/get_kv_table_nodeos_tests.cpp
+++ b/tests/get_kv_table_nodeos_tests.cpp
@@ -338,8 +338,6 @@ BOOST_FIXTURE_TEST_CASE( get_kv_table_nodeos_test, TESTER ) try {
    result = plugin.read_only::get_kv_table_rows(p);
    BOOST_REQUIRE_EQUAL(10u, result.rows.size());
 
-
-
    p.index_value = "";
    p.encode_type = "dec";
    p.lower_bound = "0";
@@ -1118,6 +1116,47 @@ BOOST_FIXTURE_TEST_CASE( get_kv_table_nodeos_test, TESTER ) try {
    BOOST_REQUIRE_EQUAL(result.next_key_bytes, "C014333333333333");
    chk_result(0, 4);
    chk_result(1, 5);
+
+   // test no --lower, --upper, and --index
+    p.reverse = false;
+    p.index_name = "foo"_n;
+    p.encode_type = "dec";
+    p.limit = 20;
+    p.index_value = "";
+    p.lower_bound = "";
+    p.upper_bound = "";
+    result = plugin.read_only::get_kv_table_rows(p);
+    BOOST_REQUIRE_EQUAL(10u, result.rows.size());
+    BOOST_REQUIRE_EQUAL(result.more, false);
+    BOOST_REQUIRE_EQUAL(result.next_key, "");
+    BOOST_REQUIRE_EQUAL(result.next_key_bytes, "");
+    chk_result(0, 1);
+    chk_result(1, 2);
+    chk_result(2, 3);
+    chk_result(3, 4);
+    chk_result(4, 5);
+    chk_result(5, 6);
+    chk_result(6, 7);
+    chk_result(7, 8);
+    chk_result(8, 9);
+    chk_result(9, 10);
+
+    p.reverse = true;
+    result = plugin.read_only::get_kv_table_rows(p);
+    BOOST_REQUIRE_EQUAL(10u, result.rows.size());
+    BOOST_REQUIRE_EQUAL(result.more, false);
+    BOOST_REQUIRE_EQUAL(result.next_key, "");
+    BOOST_REQUIRE_EQUAL(result.next_key_bytes, "");
+    chk_result(0, 10);
+    chk_result(1, 9);
+    chk_result(2, 8);
+    chk_result(3, 7);
+    chk_result(4, 6);
+    chk_result(5, 5);
+    chk_result(6, 4);
+    chk_result(7, 3);
+    chk_result(8, 2);
+    chk_result(9, 1);
 
 }
 FC_LOG_AND_RETHROW()

--- a/tests/get_kv_table_nodeos_tests.cpp
+++ b/tests/get_kv_table_nodeos_tests.cpp
@@ -158,15 +158,6 @@ BOOST_FIXTURE_TEST_CASE( get_kv_table_nodeos_test, TESTER ) try {
    chk_result(8, 2);
    chk_result(9, 1);
 
-   p.lower_bound = "bobc";
-   p.upper_bound = "";
-   BOOST_CHECK_THROW(plugin.read_only::get_kv_table_rows(p), chain::contract_table_query_exception);
-
-   p.reverse = false;
-   p.lower_bound = "";
-   p.upper_bound = "bobz";
-   BOOST_CHECK_THROW(plugin.read_only::get_kv_table_rows(p), chain::contract_table_query_exception);
-
    p.reverse = true;
    p.lower_bound = "bobj";
    p.upper_bound = "bobz";
@@ -1117,14 +1108,30 @@ BOOST_FIXTURE_TEST_CASE( get_kv_table_nodeos_test, TESTER ) try {
    chk_result(0, 4);
    chk_result(1, 5);
 
-   // test no --lower, --upper, and --index
+   // test no --lower, --upper, and --index with different --limit
     p.reverse = false;
     p.index_name = "foo"_n;
     p.encode_type = "dec";
-    p.limit = 20;
     p.index_value = "";
     p.lower_bound = "";
     p.upper_bound = "";
+    p.limit = 9;
+    result = plugin.read_only::get_kv_table_rows(p);
+    BOOST_REQUIRE_EQUAL(9u, result.rows.size());
+    BOOST_REQUIRE_EQUAL(result.more, true);
+    BOOST_REQUIRE_EQUAL(result.next_key, std::to_string(10));
+    BOOST_REQUIRE_EQUAL(result.next_key_bytes, "000000000000000A");
+    chk_result(0, 1);
+    chk_result(1, 2);
+    chk_result(2, 3);
+    chk_result(3, 4);
+    chk_result(4, 5);
+    chk_result(5, 6);
+    chk_result(6, 7);
+    chk_result(7, 8);
+    chk_result(8, 9);
+
+    p.limit = 20;
     result = plugin.read_only::get_kv_table_rows(p);
     BOOST_REQUIRE_EQUAL(10u, result.rows.size());
     BOOST_REQUIRE_EQUAL(result.more, false);
@@ -1142,6 +1149,23 @@ BOOST_FIXTURE_TEST_CASE( get_kv_table_nodeos_test, TESTER ) try {
     chk_result(9, 10);
 
     p.reverse = true;
+    p.limit = 9;
+    result = plugin.read_only::get_kv_table_rows(p);
+    BOOST_REQUIRE_EQUAL(9u, result.rows.size());
+    BOOST_REQUIRE_EQUAL(result.more, true);
+    BOOST_REQUIRE_EQUAL(result.next_key, std::to_string(1));
+    BOOST_REQUIRE_EQUAL(result.next_key_bytes, "0000000000000001");
+    chk_result(0, 10);
+    chk_result(1, 9);
+    chk_result(2, 8);
+    chk_result(3, 7);
+    chk_result(4, 6);
+    chk_result(5, 5);
+    chk_result(6, 4);
+    chk_result(7, 3);
+    chk_result(8, 2);
+
+    p.limit = 20;
     result = plugin.read_only::get_kv_table_rows(p);
     BOOST_REQUIRE_EQUAL(10u, result.rows.size());
     BOOST_REQUIRE_EQUAL(result.more, false);
@@ -1157,6 +1181,45 @@ BOOST_FIXTURE_TEST_CASE( get_kv_table_nodeos_test, TESTER ) try {
     chk_result(7, 3);
     chk_result(8, 2);
     chk_result(9, 1);
+
+    // test default lower bound
+    p.reverse = false;
+    p.lower_bound = "";
+    p.upper_bound = "9";
+    result = plugin.read_only::get_kv_table_rows(p);
+    BOOST_REQUIRE_EQUAL(9u, result.rows.size());
+    BOOST_REQUIRE_EQUAL(result.more, false);
+    BOOST_REQUIRE_EQUAL(result.next_key, "");
+    BOOST_REQUIRE_EQUAL(result.next_key_bytes, "");
+    chk_result(0, 1);
+    chk_result(1, 2);
+    chk_result(2, 3);
+    chk_result(3, 4);
+    chk_result(4, 5);
+    chk_result(5, 6);
+    chk_result(6, 7);
+    chk_result(7, 8);
+    chk_result(8, 9);
+
+    // test default upper bound
+    p.reverse = true;
+    p.lower_bound = "2";
+    p.upper_bound = "";
+    result = plugin.read_only::get_kv_table_rows(p);
+    BOOST_REQUIRE_EQUAL(9u, result.rows.size());
+    BOOST_REQUIRE_EQUAL(result.more, false);
+    BOOST_REQUIRE_EQUAL(result.next_key, "");
+    BOOST_REQUIRE_EQUAL(result.next_key_bytes, "");
+    chk_result(0, 10);
+    chk_result(1, 9);
+    chk_result(2, 8);
+    chk_result(3, 7);
+    chk_result(4, 6);
+    chk_result(5, 5);
+    chk_result(6, 4);
+    chk_result(7, 3);
+    chk_result(8, 2);
+
 
 }
 FC_LOG_AND_RETHROW()


### PR DESCRIPTION
## Change Description
https://blockone.atlassian.net/browse/EPE-554
The fix in this PR is to make sure that chain_plugin `get_kv_table_rows` is capable of retrieving entries without specifying --lower, --upper and --index.


## Change Type
**Select *ONE*:**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [x] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [ ] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the release notes. Please include a description of the change for inclusion in the release notes. -->


## Testing Changes
**Select *ANY* that apply:**
- [ ] New Tests
<!-- checked [x] = new test cases were added; unchecked [ ] = no new test cases -->
- [x] Existing Tests
<!-- checked [x] = existing test cases were edited; unchecked [ ] = no existing tests were modified -->
- [ ] Test Framework
<!-- checked [x] = this modifies the test framework; unchecked [ ] = no test framework changes -->
- [ ] CI System
<!-- checked [x] = this changes the CI system; unchecked [ ] = no CI changes -->
- [ ] Other
<!-- checked [x] = this integrates an external test system; unchecked [ ] = no miscellaneous test-related changes -->
<!-- Please describe your test changes, or list each new test and its purpose, under each respective checkbox -->








