### PR TITLE
Beta Test Upgraded Buildfleet

### DIFF
--- a/.cicd/generate-pipeline.sh
+++ b/.cicd/generate-pipeline.sh
@@ -4,8 +4,8 @@ set -eo pipefail
 . ./.cicd/helpers/general.sh
 export PLATFORMS_JSON_ARRAY='[]'
 [[ -z "$ROUNDS" ]] && export ROUNDS='1'
-BUILDKITE_BUILD_AGENT_QUEUE='automation-eks-eos-builder-fleet'
-BUILDKITE_TEST_AGENT_QUEUE='automation-eks-eos-tester-fleet'
+BUILDKITE_BUILD_AGENT_QUEUE='automation-eks-eos-builder-beta-fleet'
+BUILDKITE_TEST_AGENT_QUEUE='automation-eks-eos-tester-beta-fleet'
 # Determine if it's a forked PR and make sure to add git fetch so we don't have to git clone the forked repo's url
 if [[ $BUILDKITE_BRANCH =~ ^pull/[0-9]+/head: ]]; then
     PR_ID=$(echo $BUILDKITE_BRANCH | cut -d/ -f2)


### PR DESCRIPTION
## Change Description
From [AUTO-461](https://blockone.atlassian.net/browse/AUTO-461) and auto-eks-buildfleet [build 993](https://buildkite.com/EOSIO/auto-eks-buildfleet/builds/993), a number of our docker containers are failing to build. Most of them appear to be failing due to `get_pip.py` being deprecated for Python 2 installations of `pip`, but we are finding some other bugs introduced, as well.

This pull request points the CI system at two new beta fleets we created, `automation-eks-eos-builder-beta-fleet` and `automation-eks-eos-tester-beta-fleet`, to test that the CI code still works with the upgrades. **This pull request will _NOT_ be merged.**

### See Also
- auto-eks-buildfleet
  - [Pull Request 177](https://github.com/EOSIO/auto-eks-buildfleet/pull/177) - `buildkite-base`
  - [Pull Request 178](https://github.com/EOSIO/auto-eks-buildfleet/pull/178) - `buildkite-eks-ecr-builder`
  - [Pull Request 180](https://github.com/EOSIO/auto-eks-buildfleet/pull/180) - Fix AWS CLI for pre-command Hook in buildkite-eks-ecr-builder Docker Image
  - [Pull Request 181](https://github.com/EOSIO/auto-eks-buildfleet/pull/181) - Create Python 3 Beta Fleets for the EOSIO Builds and Tests
  - [Pull Request 182](https://github.com/EOSIO/auto-eks-buildfleet/pull/182) - upgrade to python3 and awscli2 for terraform buildfleet
  - [Pull Request 183](https://github.com/EOSIO/auto-eks-buildfleet/pull/183) - Terraform doesn't require awscli.
  - [Pull Request 184](https://github.com/EOSIO/auto-eks-buildfleet/pull/184) - Deploy Buildfleet Upgrades to Production
- eos
  - [Pull Request 10002](https://github.com/EOSIO/eos/pull/10002) - `eos:develop`
  - [Pull Request 10003](https://github.com/EOSIO/eos/pull/10003) - `eos:release/2.1.x`
  - [Pull Request 10004](https://github.com/EOSIO/eos/pull/10004) - `eos:release/2.0.x`
  - [Pull Request 10005](https://github.com/EOSIO/eos/pull/10005) - `eos:release/1.8.x`
- eosio.cdt
  - [Pull Request 1049](https://github.com/EOSIO/eosio.cdt/pull/1049) - `eosio.cdt:develop`
  - [Pull Request 1050](https://github.com/EOSIO/eosio.cdt/pull/1050) - `eosio.cdt:release/1.8.x`
  - [Pull Request 1051](https://github.com/EOSIO/eosio.cdt/pull/1051) - `eosio.cdt:release/1.7.x`
- eosio.contracts
  - [Pull Request 555](https://github.com/EOSIO/eosio.contracts/pull/555) - `eosio.contracts:develop`
  - [Pull Request 556](https://github.com/EOSIO/eosio.contracts/pull/556) - `eosio.contracts:release/1.9.x`
  - [Pull Request 557](https://github.com/EOSIO/eosio.contracts/pull/557) - `eosio.contracts:release/1.8.x`
- eos-vm
  - [Pull Request 200](https://github.com/EOSIO/eos-vm/pull/200) - `eos-vm:develop`
  - [Pull Request 201](https://github.com/EOSIO/eos-vm/pull/201) - `eos-vm:eosio`
  - [Pull Request 202](https://github.com/EOSIO/eos-vm/pull/202) - `eos-vm:eosio-2.0.x`

## Change Type
**Select *ONE*:**
- [ ] Documentation
- [ ] Stability bug fix
- [x] Other
- [ ] Other - special case

## Testing Changes
**Select *ANY* that apply:**
- [ ] New Tests
- [ ] Existing Tests
- [ ] Test Framework
- [x] CI System
- [ ] Other

## Consensus Changes
- [ ] Consensus Changes
None.

## API Changes
- [ ] API Changes
None.

## Documentation Additions
- [ ] Documentation Additions
None.