### PR TITLE
revert changes to empty string as present for lower_bound, upper_bound, or index_value

### DIFF
--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -352,7 +352,7 @@ public:
         name                   code;                  // name of contract
         name                   table;                 // name of kv table,
         name                   index_name;            // name of index index
-        string                 encode_type = "bytes"; // "bytes" : binary values in index_value/lower_bound/upper_bound
+        string                 encode_type;           // encoded type for values in index_value/lower_bound/upper_bound
         string                 index_value;           // index value for point query.  If this is set, it is processed as a point query
         string                 lower_bound;           // lower bound value of index of index_name. If index_value is not set and lower_bound is not set, return from the beginning of range in the prefix
         string                 upper_bound;           // upper bound value of index of index_name, If index_value is not set and upper_bound is not set, It is set to the beginning of the next prefix range.

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -353,9 +353,9 @@ public:
         name                   table;                 // name of kv table,
         name                   index_name;            // name of index index
         string                 encode_type = "bytes"; // "bytes" : binary values in index_value/lower_bound/upper_bound
-        std::optional<string>  index_value;           // index value for point query.  If this is set, it is processed as a point query
-        std::optional<string>  lower_bound;           // lower bound value of index of index_name. If index_value is not set and lower_bound is not set, return from the beginning of range in the prefix
-        std::optional<string>  upper_bound;           // upper bound value of index of index_name, If index_value is not set and upper_bound is not set, It is set to the beginning of the next prefix range.
+        string                 index_value;           // index value for point query.  If this is set, it is processed as a point query
+        string                 lower_bound;           // lower bound value of index of index_name. If index_value is not set and lower_bound is not set, return from the beginning of range in the prefix
+        string                 upper_bound;           // upper bound value of index of index_name, If index_value is not set and upper_bound is not set, It is set to the beginning of the next prefix range.
         uint32_t               limit = 10;            // max number of rows
         bool                   reverse = false;       // if true output rows in reverse order
         bool                   show_payer = false;

--- a/tests/get_kv_table_addr_tests.cpp
+++ b/tests/get_kv_table_addr_tests.cpp
@@ -109,8 +109,8 @@ BOOST_FIXTURE_TEST_CASE( get_kv_table_addr_test, TESTER ) try {
    p.index_name = "accname"_n;
    p.index_value = "john";
    p.encode_type = "name";
-   p.lower_bound = {};
-   p.upper_bound = {};
+   p.lower_bound = "";
+   p.upper_bound = "";
    p.json = true;
    p.reverse = false;
    result = plugin.read_only::get_kv_table_rows(p);
@@ -118,10 +118,10 @@ BOOST_FIXTURE_TEST_CASE( get_kv_table_addr_test, TESTER ) try {
    chk_result(0, 2);
 
    p.index_name = "accname"_n;
-   p.index_value = {};
+   p.index_value = "";
    p.encode_type = "name";
    p.lower_bound = "aaa";
-   p.upper_bound = {};
+   p.upper_bound = "";
    p.reverse = false;
    result = plugin.read_only::get_kv_table_rows(p);
    BOOST_REQUIRE_EQUAL(4u, result.rows.size());
@@ -131,10 +131,10 @@ BOOST_FIXTURE_TEST_CASE( get_kv_table_addr_test, TESTER ) try {
    chk_result(3, 4);
 
    p.index_name = "accname"_n;
-   p.index_value = {};
+   p.index_value = "";
    p.encode_type = "name";
    p.lower_bound = "john";
-   p.upper_bound = {};
+   p.upper_bound = "";
    p.reverse = false;
    result = plugin.read_only::get_kv_table_rows(p);
    BOOST_REQUIRE_EQUAL(3u, result.rows.size());
@@ -143,7 +143,7 @@ BOOST_FIXTURE_TEST_CASE( get_kv_table_addr_test, TESTER ) try {
    chk_result(2, 4);
 
    p.index_name = "accname"_n;
-   p.index_value = {};
+   p.index_value = "";
    p.encode_type = "name";
    p.lower_bound = "john";
    p.upper_bound = "lois";
@@ -153,9 +153,9 @@ BOOST_FIXTURE_TEST_CASE( get_kv_table_addr_test, TESTER ) try {
    chk_result(0, 2);
 
    p.index_name = "accname"_n;
-   p.index_value = {};
+   p.index_value = "";
    p.encode_type = "name";
-   p.lower_bound = {};
+   p.lower_bound = "";
    p.upper_bound = "steve";
    p.reverse = true;
    result = plugin.read_only::get_kv_table_rows(p);
@@ -166,7 +166,7 @@ BOOST_FIXTURE_TEST_CASE( get_kv_table_addr_test, TESTER ) try {
    chk_result(3, 1);
 
    p.index_name = "accname"_n;
-   p.index_value = {};
+   p.index_value = "";
    p.encode_type = "name";
    p.lower_bound = "john";
    p.upper_bound = "steve";
@@ -177,16 +177,16 @@ BOOST_FIXTURE_TEST_CASE( get_kv_table_addr_test, TESTER ) try {
    chk_result(1, 3);
 
    p.index_name = "accname"_n;
-   p.index_value = {};
+   p.index_value = "";
    p.encode_type = "name";
-   p.lower_bound = {};
+   p.lower_bound = "";
    p.upper_bound = "aaaa";
    p.reverse = true;
    result = plugin.read_only::get_kv_table_rows(p);
    BOOST_REQUIRE_EQUAL(0u, result.rows.size());
 
    p.index_name = "accname"_n;
-   p.index_value = {};
+   p.index_value = "";
    p.encode_type = "name";
    p.lower_bound = "steve";
    p.upper_bound = "john";
@@ -195,9 +195,9 @@ BOOST_FIXTURE_TEST_CASE( get_kv_table_addr_test, TESTER ) try {
    BOOST_REQUIRE_EQUAL(0u, result.rows.size());
 
    p.index_name = "accname"_n;
-   p.index_value = {};
+   p.index_value = "";
    p.encode_type = "name";
-   p.lower_bound = {};
+   p.lower_bound = "";
    p.upper_bound = "john";
    p.reverse = true;
    result = plugin.read_only::get_kv_table_rows(p);

--- a/tests/get_kv_table_nodeos_tests.cpp
+++ b/tests/get_kv_table_nodeos_tests.cpp
@@ -142,11 +142,6 @@ BOOST_FIXTURE_TEST_CASE( get_kv_table_nodeos_test, TESTER ) try {
    p.upper_bound = "bobe";
    BOOST_CHECK_THROW(plugin.read_only::get_kv_table_rows(p), contract_table_query_exception);
 
-   p.index_value = "";
-   p.lower_bound = "bobb";
-   p.upper_bound = "bobe";
-   BOOST_CHECK_THROW(plugin.read_only::get_kv_table_rows(p), contract_table_query_exception);
-
    p.index_value = {};
    p.lower_bound = "bobe";
    p.upper_bound = "bobb";
@@ -168,12 +163,6 @@ BOOST_FIXTURE_TEST_CASE( get_kv_table_nodeos_test, TESTER ) try {
    chk_result(7, 8);
    chk_result(8, 9);
    chk_result(9, 10);
-
-   p.show_payer = false;
-   p.lower_bound = "aaaa";
-   p.upper_bound = "";
-   result = plugin.read_only::get_kv_table_rows(p);
-   BOOST_REQUIRE_EQUAL(0u, result.rows.size());
 
    p.lower_bound = "boba";
    p.upper_bound = {};


### PR DESCRIPTION
## Change Description

The PR 
  - reverts the change in PR 9964 which treat empty string as present for lower_bound, upper_bound and index_value  in kv table query
  - removes the bytes default for get_kv_table_rows_params.encode_type

## Change Type
**Select *ONE*:**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [x] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [ ] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the release notes. Please include a description of the change for inclusion in the release notes. -->


## Testing Changes
**Select *ANY* that apply:**
- [ ] New Tests
<!-- checked [x] = new test cases were added; unchecked [ ] = no new test cases -->
- [ ] Existing Tests
<!-- checked [x] = existing test cases were edited; unchecked [ ] = no existing tests were modified -->
- [ ] Test Framework
<!-- checked [x] = this modifies the test framework; unchecked [ ] = no test framework changes -->
- [ ] CI System
<!-- checked [x] = this changes the CI system; unchecked [ ] = no CI changes -->
- [ ] Other
<!-- checked [x] = this integrates an external test system; unchecked [ ] = no miscellaneous test-related changes -->
<!-- Please describe your test changes, or list each new test and its purpose, under each respective checkbox -->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [x] API Changes

The `encode_type` field of `get_kv_table_rows` is not defaulted to "bytes" any longer and is defaulted based off of the abi type for the "index_param". It is defaulted to "name" for a name type, "string" for string type, and "dec" for integer types.

## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
