### PR TITLE
Add cleos system activate subcommand (to activate system feature like kv_database)

### DIFF
--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -2241,11 +2241,10 @@ struct activate_subcommand {
             data =  "[\"" + feature_digest + "\"]";
          } else {
             std::cout << "Can't find system feature : " << feature_name_str << std::endl;
+            return;
          }
          fc::variant action_args_var;
-         if( !data.empty() ) {
-            action_args_var = json_from_file_or_string(data, fc::json::parse_type::relaxed_parser);
-         }
+         action_args_var = json_from_file_or_string(data, fc::json::parse_type::relaxed_parser);
          auto accountPermissions = get_account_permissions(permissions);
          send_actions({chain::action{accountPermissions, name(contract_account), name(action),
                                      variant_to_bin( name(contract_account), name(action), action_args_var ) }}, signing_keys_opt.get_keys());

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -69,6 +69,8 @@ Options:
 #include <vector>
 #include <regex>
 #include <iostream>
+#include <locale>
+#include <unordered_map>
 #include <fc/crypto/hex.hpp>
 #include <fc/variant.hpp>
 #include <fc/io/datastream.hpp>
@@ -2199,6 +2201,58 @@ struct closerex_subcommand {
    }
 };
 
+struct activate_subcommand {
+   string feature_name_str;
+
+   activate_subcommand(CLI::App* actionRoot) {
+      auto activate = actionRoot->add_subcommand("activate", localized("Activate system feature by feature name eg: KV_DATABASE"));
+      activate->add_option("feature",  feature_name_str,  localized("The system feature name to be activated, must be one of below(lowercase also works):\nPREACTIVATE_FEATURE\nONLY_LINK_TO_EXISTING_PERMISSION\nFORWARD_SETCODE\nKV_DATABASE\nWTMSIG_BLOCK_SIGNATURES\nREPLACE_DEFERRED\nNO_DUPLICATE_DEFERRED_ID\nRAM_RESTRICTIONS\nWEBAUTHN_KEY\nBLOCKCHAIN_PARAMETERS\nDISALLOW_EMPTY_PRODUCER_SCHEDULE\nONLY_BILL_FIRST_AUTHORIZER\nRESTRICT_ACTION_TO_SELF\nCONFIGURABLE_WASM_LIMITS\nACTION_RETURN_VALUE\nFIX_LINKAUTH_RESTRICTION\nGET_SENDER"))->required();
+      activate->fallthrough(false);
+      activate->callback([this] {
+         /// map feature name to feature digest
+         std::unordered_map<std::string, std::string> map_name_digest{
+            {"PREACTIVATE_FEATURE",              "0ec7e080177b2c02b278d5088611686b49d739925a92d9bfcacd7fc6b74053bd"},
+            {"ONLY_LINK_TO_EXISTING_PERMISSION", "1a99a59d87e06e09ec5b028a9cbb7749b4a5ad8819004365d02dc4379a8b7241"},
+            {"FORWARD_SETCODE",                  "2652f5f96006294109b3dd0bbde63693f55324af452b799ee137a81a905eed25"},
+            {"KV_DATABASE",                      "825ee6288fb1373eab1b5187ec2f04f6eacb39cb3a97f356a07c91622dd61d16"},
+            {"WTMSIG_BLOCK_SIGNATURES",          "299dcb6af692324b899b39f16d5a530a33062804e41f09dc97e9f156b4476707"},
+            {"REPLACE_DEFERRED",                 "ef43112c6543b88db2283a2e077278c315ae2c84719a8b25f25cc88565fbea99"},
+            {"NO_DUPLICATE_DEFERRED_ID",         "4a90c00d55454dc5b059055ca213579c6ea856967712a56017487886a4d4cc0f"},
+            {"RAM_RESTRICTIONS",                 "4e7bf348da00a945489b2a681749eb56f5de00b900014e137ddae39f48f69d67"},
+            {"WEBAUTHN_KEY",                     "4fca8bd82bbd181e714e283f83e1b45d95ca5af40fb89ad3977b653c448f78c2"},
+            {"BLOCKCHAIN_PARAMETERS",            "5443fcf88330c586bc0e5f3dee10e7f63c76c00249c87fe4fbf7f38c082006b4"},
+            {"DISALLOW_EMPTY_PRODUCER_SCHEDULE", "68dcaa34c0517d19666e6b33add67351d8c5f69e999ca1e37931bc410a297428"},
+            {"ONLY_BILL_FIRST_AUTHORIZER",       "8ba52fe7a3956c5cd3a656a3174b931d3bb2abb45578befc59f283ecd816a405"},
+            {"RESTRICT_ACTION_TO_SELF",          "ad9e3d8f650687709fd68f4b90b41f7d825a365b02c23a636cef88ac2ac00c43"},
+            {"CONFIGURABLE_WASM_LIMITS",         "bf61537fd21c61a60e542a5d66c3f6a78da0589336868307f94a82bccea84e88"},
+            {"ACTION_RETURN_VALUE",              "c3a6138c5061cf291310887c0b5c71fcaffeab90d5deb50d3b9e687cead45071"},
+            {"FIX_LINKAUTH_RESTRICTION",         "e0fb64b1085cc5538970158d05a009c24e276fb94e1a0bf6a528b48fbc4ff526"},
+            {"GET_SENDER",                       "f0af56d2c5a48d60a4a5b5c903edfb7db3a736a94ed589d0b797df33ff9d3e1d"}
+         };
+         // push system feature
+         string contract_account = "eosio";
+         string action="activate";
+         string data;
+         std::locale loc;
+         vector<std::string> permissions = {"eosio"};
+         for(auto & c : feature_name_str) c = std::toupper(c, loc);
+         if(map_name_digest.find(feature_name_str) != map_name_digest.end()){
+            std::string feature_digest = map_name_digest[feature_name_str];
+            data =  "[\"" + feature_digest + "\"]";
+         } else {
+            std::cout << "Can't find system feature : " << feature_name_str << std::endl;
+         }
+         fc::variant action_args_var;
+         if( !data.empty() ) {
+            action_args_var = json_from_file_or_string(data, fc::json::parse_type::relaxed_parser);
+         }
+         auto accountPermissions = get_account_permissions(permissions);
+         send_actions({chain::action{accountPermissions, name(contract_account), name(action),
+                                     variant_to_bin( name(contract_account), name(action), action_args_var ) }}, signing_keys_opt.get_keys());
+      });
+   }
+};
+
 void get_account( const string& accountName, const string& coresym, bool json_format ) {
    fc::variant json;
    if (coresym.empty()) {
@@ -4318,6 +4372,7 @@ int main( int argc, char** argv ) {
    auto unregProxy = unregproxy_subcommand(system);
 
    auto cancelDelay = canceldelay_subcommand(system);
+   auto activate = activate_subcommand(system);
 
    auto rex = system->add_subcommand("rex", localized("Actions related to REX (the resource exchange)"));
    rex->require_subcommand();


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->
## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

Start 10036 description ......

EPE 453
Add cleos system activate subcommand (to activate system feature like kv_database)
you can find usage by:   cleos system activate -h

support all system features.  support uppercase and lowercase   kv_database or KV_DATABASE or KV_database

                              PREACTIVATE_FEATURE
                              ONLY_LINK_TO_EXISTING_PERMISSION
                              FORWARD_SETCODE
                              KV_DATABASE
                              WTMSIG_BLOCK_SIGNATURES
                              REPLACE_DEFERRED
                              NO_DUPLICATE_DEFERRED_ID
                              RAM_RESTRICTIONS
                              WEBAUTHN_KEY
                              BLOCKCHAIN_PARAMETERS
                              DISALLOW_EMPTY_PRODUCER_SCHEDULE
                              ONLY_BILL_FIRST_AUTHORIZER
                              RESTRICT_ACTION_TO_SELF
                              CONFIGURABLE_WASM_LIMITS
                              ACTION_RETURN_VALUE
                              FIX_LINKAUTH_RESTRICTION
                              GET_SENDER

  using :  cleos system activate kv_database
  instead of  using  cleos push action eosio activate '["825ee6288fb1373eab1b5187ec2f04f6eacb39cb3a97f356a07c91622dd61d16"]' -p eosio

End 10036 description ......
## Change Type
**Select ONE**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [ ] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [x] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the relase notes. Please include a description of the change for inclusion in the release notes.-->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [x] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
new subcommand cleos system activate 
see usage by: cleos system activate -h
example:     cleos system activate kv_database
                   cleos system activate KV_DATABASE
                   cleos system activate KV_database
note :   feature name argument is not sensitive to uppercase or lowercase