### PR TITLE
implement splitting/extracting block log for eosio_blocklog

### DIFF
--- a/libraries/chain/block_log.cpp
+++ b/libraries/chain/block_log.cpp
@@ -1086,8 +1086,8 @@ namespace eosio { namespace chain {
       return std::clamp(version, min_supported_version, max_supported_version) == version;
    }
 
-   void extract_blocklog_i(block_log_bundle& log_bundle, fc::path new_block_filename, fc::path new_index_filename, uint32_t first_block_num,
-                           uint32_t num_blocks) {
+   void extract_blocklog_i(block_log_bundle& log_bundle, fc::path new_block_filename, fc::path new_index_filename,
+                           uint32_t first_block_num, uint32_t num_blocks) {
 
       auto position_for_block = [&log_bundle](uint64_t block_num) {
          uint64_t block_order = block_num - log_bundle.log_data.first_block_num();
@@ -1118,13 +1118,13 @@ namespace eosio { namespace chain {
       }
 
       fc::datastream<char*> ds(new_block_file.data(), new_block_file.size());
-      block_log_preamble preamble;
+      block_log_preamble    preamble;
       // version 4 or above have different log entry format; therefore version 1 to 3 can only be upgrade up to version
       // 3 format.
       preamble.version = log_bundle.log_data.version() < pruned_transaction_version ? genesis_state_or_chain_id_version
                                                                                     : block_log::max_supported_version;
       preamble.first_block_num = first_block_num;
-      preamble.chain_context = log_bundle.log_data.chain_id();
+      preamble.chain_context   = log_bundle.log_data.chain_id();
       preamble.write_to(ds);
       ds.write(log_bundle.log_data.data() + first_kept_block_pos, last_block_pos - first_kept_block_pos);
 
@@ -1234,16 +1234,18 @@ namespace eosio { namespace chain {
       return std::make_pair(new_block_filename, new_index_filename);
    }
 
-   void block_log::extract_blocklog(const fc::path& log_filename, const fc::path& index_filename, const fc::path& dest_dir, uint32_t start_block_num,
-                                    uint32_t num_blocks) {
+   void block_log::extract_blocklog(const fc::path& log_filename, const fc::path& index_filename,
+                                    const fc::path& dest_dir, uint32_t start_block_num, uint32_t num_blocks) {
 
       block_log_bundle log_bundle(log_filename, index_filename);
 
       EOS_ASSERT(start_block_num >= log_bundle.log_data.first_block_num(), block_log_exception,
-         "The first available block is block ${first_block}.", ("first_block", log_bundle.log_data.first_block_num()));
-         
-      EOS_ASSERT(start_block_num + num_blocks -1 <= log_bundle.log_data.last_block_num(), block_log_exception,
-         "The last available block is block ${last_block}.", ("last_block", log_bundle.log_data.last_block_num()));
+                 "The first available block is block ${first_block}.",
+                 ("first_block", log_bundle.log_data.first_block_num()));
+
+      EOS_ASSERT(start_block_num + num_blocks - 1 <= log_bundle.log_data.last_block_num(), block_log_exception,
+                 "The last available block is block ${last_block}.",
+                 ("last_block", log_bundle.log_data.last_block_num()));
 
       if (!fc::exists(dest_dir))
          fc::create_directories(dest_dir);
@@ -1262,14 +1264,14 @@ namespace eosio { namespace chain {
       if (!fc::exists(dest_dir))
          fc::create_directories(dest_dir);
 
-      for (uint32_t i = (first_block_num - 1) / stride;
-           i < (last_block_num + stride - 1)/stride; ++i) {
+      for (uint32_t i = (first_block_num - 1) / stride; i < (last_block_num + stride - 1) / stride; ++i) {
          uint32_t start_block_num = std::max(i * stride + 1, first_block_num);
-         uint32_t num_blocks = std::min( (i+1)*stride, last_block_num) - start_block_num + 1;
+         uint32_t num_blocks      = std::min((i + 1) * stride, last_block_num) - start_block_num + 1;
 
          auto [new_block_filename, new_index_filename] = blocklog_files(dest_dir, start_block_num, num_blocks);
 
          extract_blocklog_i(log_bundle, new_block_filename, new_index_filename, start_block_num, num_blocks);
       }
    }
-}} /// eosio::chain
+   } // namespace chain
+   } // namespace eosio

--- a/libraries/chain/block_log.cpp
+++ b/libraries/chain/block_log.cpp
@@ -398,7 +398,9 @@ namespace eosio { namespace chain {
       block_log_data  log_data;
       block_log_index log_index;
 
-      block_log_bundle(fc::path block_file_name, fc::path index_file_name) {
+      block_log_bundle(fc::path block_file, fc::path index_file)
+          : block_file_name(block_file)
+          , index_file_name(index_file) {
 
          log_data.open(block_file_name);
          log_index.open(index_file_name);
@@ -406,10 +408,11 @@ namespace eosio { namespace chain {
          uint32_t log_num_blocks   = log_data.num_blocks();
          uint32_t index_num_blocks = log_index.num_blocks();
 
-         EOS_ASSERT(
-             log_num_blocks == index_num_blocks, block_log_exception,
-             "${block_file_name} says it has ${log_num_blocks} blocks which disagrees with ${index_num_blocks} indicated by ${index_file_name}",
-             ("block_file_name", block_file_name)("log_num_blocks", log_num_blocks)("index_num_blocks", index_num_blocks)("index_file_name", index_file_name));
+         EOS_ASSERT(log_num_blocks == index_num_blocks, block_log_exception,
+                    "${block_file_name} says it has ${log_num_blocks} blocks which disagrees with ${index_num_blocks} "
+                    "indicated by ${index_file_name}",
+                    ("block_file_name", block_file_name)("log_num_blocks", log_num_blocks)(
+                        "index_num_blocks", index_num_blocks)("index_file_name", index_file_name));
       }
 
       block_log_bundle(fc::path block_dir) : block_log_bundle(block_dir / "blocks.log", block_dir / "blocks.index") {

--- a/libraries/chain/include/eosio/chain/block_log.hpp
+++ b/libraries/chain/include/eosio/chain/block_log.hpp
@@ -103,8 +103,8 @@ namespace eosio { namespace chain {
           */
          static void smoke_test(fc::path block_dir, uint32_t n);
 
-         static void extract_blocklog(const fc::path& block_dir, const fc::path& dest_dir, uint32_t start_block,
-                                      uint32_t num_blocks);
+         static void extract_blocklog(const fc::path& log_filename, const fc::path& index_filename,
+                                      const fc::path& dest_dir, uint32_t start_block, uint32_t num_blocks);
          static void split_blocklog(const fc::path& block_dir, const fc::path& dest_dir, uint32_t stride);
 
        private:

--- a/libraries/chain/include/eosio/chain/block_log.hpp
+++ b/libraries/chain/include/eosio/chain/block_log.hpp
@@ -103,7 +103,11 @@ namespace eosio { namespace chain {
           */
          static void smoke_test(fc::path block_dir, uint32_t n);
 
-   private:
+         static void extract_blocklog(const fc::path& block_dir, const fc::path& dest_dir, uint32_t start_block,
+                                      uint32_t num_blocks);
+         static void split_blocklog(const fc::path& block_dir, const fc::path& dest_dir, uint32_t stride);
+
+       private:
          std::unique_ptr<detail::block_log_impl> my;
    };
 } }

--- a/libraries/chain/include/eosio/chain/log_index.hpp
+++ b/libraries/chain/include/eosio/chain/log_index.hpp
@@ -32,6 +32,8 @@ class log_index {
    uint64_t back() const { return *(this->end() - 1); }
    int      num_blocks() const { return file.size() / sizeof(uint64_t); }
    uint64_t nth_block_position(uint32_t n) const { return *(begin() + n); }
+
+   const char* data() const { return file.data(); }
 };
 
 } // namespace chain

--- a/programs/eosio-blocklog/main.cpp
+++ b/programs/eosio-blocklog/main.cpp
@@ -178,6 +178,9 @@ void blocklog::set_program_options(options_description& cli)
    cli.add_options()
          ("blocks-dir", bpo::value<bfs::path>()->default_value("blocks"),
           "the location of the blocks directory (absolute path or relative to the current directory)")
+          ("blocks-filebase", bpo::value<bfs::path>()->default_value("blocks"),
+          "the name of the blocks log/index files without file extension (absolute path or relative to the current directory)."
+          " This can only used for extract-blocklog.")
          ("state-history-dir", bpo::value<bfs::path>()->default_value("state-history"),
            "the location of the state-history directory (absolute path or relative to the current dir)")
          ("output-file,o", bpo::value<bfs::path>(),
@@ -209,7 +212,7 @@ void blocklog::set_program_options(options_description& cli)
           "split the block log file based on the stride and store the result in the specified 'output-dir'.")
          ("extract-blocklog", bpo::bool_switch(&extract_blocklog)->default_value(false),
           "Extract blocks from blocks.log and blocks.index and keep the original." 
-          " Must give 'blocks-dir','output-dir', 'first and 'last'.")
+          " Must give 'blocks-dir' or 'blocks-filebase','output-dir', 'first' and 'last'.")
          ("help,h", bpo::bool_switch(&help)->default_value(false), "Print this help message and exit.")
          ;
 }
@@ -296,6 +299,9 @@ int prune_transactions(bfs::path block_dir, bfs::path state_history_dir, uint32_
           prune_transactions<state_history_traces_log>("state history traces log", state_history_dir, block_num, ids);
 }
 
+inline bfs::path operator+(bfs::path left, bfs::path right){return bfs::path(left)+=right;}
+
+
 int main(int argc, char** argv) {
    std::ios::sync_with_stdio(false); // for potential performance boost for large block log files
    options_description cli ("eosio-blocklog command line options");
@@ -311,8 +317,9 @@ int main(int argc, char** argv) {
          return 0;
       }
 
-      const auto  blocks_dir = vmap["blocks-dir"].as<bfs::path>();
-      if (!block_log::exists(blocks_dir)) {
+      const auto blocks_dir = vmap["blocks-dir"].as<bfs::path>();
+
+      if (!blog.extract_blocklog && !block_log::exists(blocks_dir)) {
          std::cerr << "The specified blocks-dir must contain blocks.log and blocks.index files";
          return -1;
       }
@@ -377,11 +384,26 @@ int main(int argc, char** argv) {
       }
 
       if (blog.extract_blocklog) {
+
          if (blog.first_block == 0 && blog.last_block == std::numeric_limits<uint32_t>::max()) {
             std::cerr << "extract_blocklog does nothing unless specify first and/or last block.";
+         }
+         
+         bfs::path blocks_filebase = vmap["blocks-filebase"].as<bfs::path>();
+         if (blocks_filebase.empty() && !blocks_dir.empty()) {
+            blocks_filebase = blocks_dir / "blocks";
+         }
+
+         bfs::path log_filename = blocks_filebase + ".log";
+         bfs::path index_filename = blocks_filebase + ".index";
+
+         if (!bfs::exists(log_filename) || !bfs::exists(index_filename)){
+            std::cerr << "Both "<< log_filename << " and " << index_filename << " must exist";
             return -1;
          }
-         block_log::extract_blocklog(blocks_dir, output_dir, blog.first_block, blog.last_block-blog.first_block+1);
+
+         block_log::extract_blocklog(log_filename, index_filename, output_dir, blog.first_block,
+                                       blog.last_block - blog.first_block + 1);
          return 0;
       } 
 

--- a/unittests/restart_chain_tests.cpp
+++ b/unittests/restart_chain_tests.cpp
@@ -312,6 +312,57 @@ BOOST_AUTO_TEST_CASE(test_split_log) {
    BOOST_CHECK( ! chain.control->fetch_block_by_number(160));
 }
 
+BOOST_AUTO_TEST_CASE(test_split_log_util) {
+   namespace bfs = boost::filesystem;
+   fc::temp_directory temp_dir;
+
+   tester chain;
+   chain.produce_blocks(160);
+
+   uint32_t head_block_num = chain.control->head_block_num();
+
+   controller::config copied_config = chain.get_config();
+   auto               genesis       = chain::block_log::extract_genesis_state(chain.get_config().blog.log_dir);
+   BOOST_REQUIRE(genesis);
+
+   chain.close();
+
+   auto blocks_dir = chain.get_config().blog.log_dir;
+   auto retained_dir = blocks_dir / "retained";
+   block_log::split_blocklog(blocks_dir, retained_dir, 50);
+
+   BOOST_CHECK(bfs::exists( retained_dir / "blocks-1-50.log" ));
+   BOOST_CHECK(bfs::exists( retained_dir / "blocks-1-50.index" ));
+   BOOST_CHECK(bfs::exists( retained_dir / "blocks-51-100.log" ));
+   BOOST_CHECK(bfs::exists( retained_dir / "blocks-51-100.index" ));
+   BOOST_CHECK(bfs::exists( retained_dir / "blocks-101-150.log" ));
+   BOOST_CHECK(bfs::exists( retained_dir / "blocks-101-150.index" ));
+   char buf[64];
+   snprintf(buf, 64, "blocks-151-%u.log", head_block_num-1);
+   bfs::path last_block_file = retained_dir / buf;
+   snprintf(buf, 64, "blocks-151-%u.index", head_block_num-1);
+   bfs::path last_index_file = retained_dir / buf;
+   BOOST_CHECK(bfs::exists(last_block_file));
+   BOOST_CHECK(bfs::exists( last_index_file ));
+
+   bfs::rename(last_block_file, blocks_dir / "blocks.log");
+   bfs::rename(last_index_file, blocks_dir / "blocks.index");
+
+
+   // remove the state files to make sure we are starting from block log
+   remove_existing_states(copied_config);
+   // we need to remove the reversible blocks so that new blocks can be produced from the new chain
+   bfs::remove_all(copied_config.blog.log_dir/"reversible");
+   copied_config.blog.retained_dir       = retained_dir;
+   copied_config.blog.stride             = 50;
+   copied_config.blog.max_retained_files = 5;
+   tester from_block_log_chain(copied_config, *genesis);
+   BOOST_CHECK( from_block_log_chain.control->fetch_block_by_number(1)->block_num() == 1);
+   BOOST_CHECK( from_block_log_chain.control->fetch_block_by_number(75)->block_num() == 75);
+   BOOST_CHECK( from_block_log_chain.control->fetch_block_by_number(100)->block_num() == 100);
+   BOOST_CHECK( from_block_log_chain.control->fetch_block_by_number(150)->block_num() == 150);
+}
+
 BOOST_AUTO_TEST_CASE(test_split_log_no_archive) {
 
    namespace bfs = boost::filesystem;

--- a/unittests/restart_chain_tests.cpp
+++ b/unittests/restart_chain_tests.cpp
@@ -312,7 +312,7 @@ BOOST_AUTO_TEST_CASE(test_split_log) {
    BOOST_CHECK( ! chain.control->fetch_block_by_number(160));
 }
 
-BOOST_AUTO_TEST_CASE(test_split_log_util) {
+BOOST_AUTO_TEST_CASE(test_split_log_util1) {
    namespace bfs = boost::filesystem;
    fc::temp_directory temp_dir;
 
@@ -619,6 +619,31 @@ BOOST_AUTO_TEST_CASE(test_trim_blocklog_front_v2) {
 
 BOOST_AUTO_TEST_CASE(test_trim_blocklog_front_v3) {
    trim_blocklog_front(3);
+}
+
+BOOST_AUTO_TEST_CASE(test_split_log_util2) {
+   namespace bfs = boost::filesystem;
+   
+
+   tester chain;
+   chain.produce_blocks(160);
+   chain.close();
+
+   auto blocks_dir = chain.get_config().blog.log_dir;
+   auto retained_dir = blocks_dir / "retained";
+   fc::temp_directory temp_dir;
+
+   BOOST_REQUIRE_NO_THROW(block_log::trim_blocklog_front(blocks_dir, temp_dir.path(), 50));
+   BOOST_REQUIRE_NO_THROW(block_log::trim_blocklog_end(blocks_dir, 150));
+
+   BOOST_CHECK_NO_THROW(block_log::split_blocklog(blocks_dir, retained_dir, 50));
+
+   BOOST_CHECK(bfs::exists( retained_dir / "blocks-50-50.log" ));
+   BOOST_CHECK(bfs::exists( retained_dir / "blocks-50-50.index" ));
+   BOOST_CHECK(bfs::exists( retained_dir / "blocks-51-100.log" ));
+   BOOST_CHECK(bfs::exists( retained_dir / "blocks-51-100.index" ));
+   BOOST_CHECK(bfs::exists( retained_dir / "blocks-101-150.log" ));
+   BOOST_CHECK(bfs::exists( retained_dir / "blocks-101-150.index" ));
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Change Description

implement splitting/extracting block log for eosio_blocklog

## Change Type
**Select *ONE*:**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [ ] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [x] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the release notes. Please include a description of the change for inclusion in the release notes. -->


## Testing Changes
**Select *ANY* that apply:**
- [ ] New Tests
<!-- checked [x] = new test cases were added; unchecked [ ] = no new test cases -->
- [ ] Existing Tests
<!-- checked [x] = existing test cases were edited; unchecked [ ] = no existing tests were modified -->
- [ ] Test Framework
<!-- checked [x] = this modifies the test framework; unchecked [ ] = no test framework changes -->
- [ ] CI System
<!-- checked [x] = this changes the CI system; unchecked [ ] = no CI changes -->
- [ ] Other
<!-- checked [x] = this integrates an external test system; unchecked [ ] = no miscellaneous test-related changes -->
<!-- Please describe your test changes, or list each new test and its purpose, under each respective checkbox -->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [x ] Documentation Additions
`eosio_blocklog` added two new options
   - split-blocklog: split the block log file based on the stride and store the result in the specified 'output-dir'
   - extract-blocklog: extract blocks from blocks.log and blocks.index and keep the original .