### PR TITLE
Reduce Docker Hub Manifest Queries

### DIFF
--- a/.cicd/docker-tag.sh
+++ b/.cicd/docker-tag.sh
@@ -50,15 +50,15 @@ echo '--- :put_litter_in_its_place: Cleaning Up'
 for REGISTRY in ${CONTRACT_REGISTRIES[*]}; do
     if [[ ! -z "$REGISTRY" ]]; then
         echo "Cleaning up from $REGISTRY."
-        DOCKER_RMI_COMMAND="docker rmi '$REGISTRY:$PREFIX-$SANITIZED_BRANCH'"
+        DOCKER_RMI_COMMAND="docker rmi '$REGISTRY:$PREFIX-$SANITIZED_BRANCH' || :"
         echo "$ $DOCKER_RMI_COMMAND"
         eval $DOCKER_RMI_COMMAND
         if [[ ! -z "$BUILDKITE_TAG" && "$SANITIZED_BRANCH" != "$SANITIZED_TAG" ]]; then
-            DOCKER_RMI_COMMAND="docker rmi '$REGISTRY:$PREFIX-$SANITIZED_TAG'"
+            DOCKER_RMI_COMMAND="docker rmi '$REGISTRY:$PREFIX-$SANITIZED_TAG' || :"
             echo "$ $DOCKER_RMI_COMMAND"
             eval $DOCKER_RMI_COMMAND
         fi
-        DOCKER_RMI_COMMAND="docker rmi '$REGISTRY:$PREFIX-$BUILDKITE_COMMIT-$PLATFORM_TYPE'"
+        DOCKER_RMI_COMMAND="docker rmi '$REGISTRY:$PREFIX-$BUILDKITE_COMMIT-$PLATFORM_TYPE' || :"
         echo "$ $DOCKER_RMI_COMMAND"
         eval $DOCKER_RMI_COMMAND
     fi

--- a/.cicd/docker-tag.sh
+++ b/.cicd/docker-tag.sh
@@ -53,6 +53,9 @@ for REGISTRY in ${CONTRACT_REGISTRIES[*]}; do
         DOCKER_RMI_COMMAND="docker rmi '$REGISTRY:$PREFIX-$SANITIZED_BRANCH' || :"
         echo "$ $DOCKER_RMI_COMMAND"
         eval $DOCKER_RMI_COMMAND
+        DOCKER_RMI_COMMAND="docker rmi '$REGISTRY:$PREFIX-$BUILDKITE_COMMIT' || :"
+        echo "$ $DOCKER_RMI_COMMAND"
+        eval $DOCKER_RMI_COMMAND
         if [[ ! -z "$BUILDKITE_TAG" && "$SANITIZED_BRANCH" != "$SANITIZED_TAG" ]]; then
             DOCKER_RMI_COMMAND="docker rmi '$REGISTRY:$PREFIX-$SANITIZED_TAG' || :"
             echo "$ $DOCKER_RMI_COMMAND"

--- a/.cicd/docker-tag.sh
+++ b/.cicd/docker-tag.sh
@@ -9,23 +9,17 @@ echo '$ echo ${#CONTRACT_REGISTRIES[*]} # array length'
 echo ${#CONTRACT_REGISTRIES[*]}
 echo '$ echo ${CONTRACT_REGISTRIES[*]} # array'
 echo ${CONTRACT_REGISTRIES[*]}
+export IMAGE="${MIRROR_REGISTRY:-$DOCKERHUB_CI_REGISTRY}:$PREFIX-$BUILDKITE_COMMIT-$PLATFORM_TYPE"
 # pull
 echo '+++ :arrow_down: Pulling Container(s)'
-for REGISTRY in ${CONTRACT_REGISTRIES[*]}; do
-    if [[ ! -z "$REGISTRY" ]]; then
-        echo "Pulling from '$REGISTRY'."
-        IMAGE="$REGISTRY:$PREFIX-$BUILDKITE_COMMIT-$PLATFORM_TYPE"
-        DOCKER_PULL_COMMAND="docker pull '$IMAGE'"
-        echo "$ $DOCKER_PULL_COMMAND"
-        eval $DOCKER_PULL_COMMAND
-    fi
-done
+DOCKER_PULL_COMMAND="docker pull '$IMAGE'"
+echo "$ $DOCKER_PULL_COMMAND"
+eval $DOCKER_PULL_COMMAND
 # tag
 echo '+++ :label: Tagging Container(s)'
 for REGISTRY in ${CONTRACT_REGISTRIES[*]}; do
     if [[ ! -z "$REGISTRY" ]]; then
         echo "Tagging for registry $REGISTRY."
-        IMAGE="$REGISTRY:$PREFIX-$BUILDKITE_COMMIT-$PLATFORM_TYPE"
         DOCKER_TAG_COMMAND="docker tag '$IMAGE' '$REGISTRY:$PREFIX-$SANITIZED_BRANCH'"
         echo "$ $DOCKER_TAG_COMMAND"
         eval $DOCKER_TAG_COMMAND

--- a/.cicd/generate-base-images.sh
+++ b/.cicd/generate-base-images.sh
@@ -7,8 +7,7 @@ echo '--- :docker: Build or Pull Base Image :minidisc:'
 echo "Looking for '$HASHED_IMAGE_TAG' container in our registries."
 export EXISTS_DOCKER_HUB='false'
 export EXISTS_ECR='false'
-MANIFEST_QUERY_REGISTRY="${MIRROR_REGISTRY:-$DOCKERHUB_CI_REGISTRY}"
-MANIFEST_COMMAND="docker manifest inspect '$MANIFEST_QUERY_REGISTRY:$HASHED_IMAGE_TAG'"
+MANIFEST_COMMAND="docker manifest inspect '${MIRROR_REGISTRY:-$DOCKERHUB_CI_REGISTRY}:$HASHED_IMAGE_TAG'"
 echo "$ $MANIFEST_COMMAND"
 set +e
 eval $MANIFEST_COMMAND
@@ -23,13 +22,13 @@ if [[ "$MANIFEST_INSPECT_EXIT_STATUS" == '0' ]]; then
 fi
 # pull and copy as-necessary
 if [[ "$EXISTS_ECR" == 'true' ]]; then
-    DOCKER_PULL_COMMAND="docker pull '$MANIFEST_QUERY_REGISTRY:$HASHED_IMAGE_TAG'"
+    DOCKER_PULL_COMMAND="docker pull '$MIRROR_REGISTRY:$HASHED_IMAGE_TAG'"
     echo "$ $DOCKER_PULL_COMMAND"
     eval $DOCKER_PULL_COMMAND
     # copy, if necessary
     if [[ "$EXISTS_DOCKER_HUB" == 'false' ]]; then
         # tag
-        DOCKER_TAG_COMMAND="docker tag '$MANIFEST_QUERY_REGISTRY:$HASHED_IMAGE_TAG' '$DOCKERHUB_CI_REGISTRY:$HASHED_IMAGE_TAG'"
+        DOCKER_TAG_COMMAND="docker tag '$MIRROR_REGISTRY:$HASHED_IMAGE_TAG' '$DOCKERHUB_CI_REGISTRY:$HASHED_IMAGE_TAG'"
         echo "$ $DOCKER_TAG_COMMAND"
         eval $DOCKER_TAG_COMMAND
         # push
@@ -45,7 +44,7 @@ elif [[ "$EXISTS_DOCKER_HUB" == 'true' && ! -z "$MIRROR_REGISTRY" ]]; then
     # copy, if necessary
     if [[ "$EXISTS_DOCKER_HUB" == 'false' ]]; then
         # tag
-        DOCKER_TAG_COMMAND="docker tag '$DOCKERHUB_CI_REGISTRY:$HASHED_IMAGE_TAG' '$MANIFEST_QUERY_REGISTRY:$HASHED_IMAGE_TAG'"
+        DOCKER_TAG_COMMAND="docker tag '$DOCKERHUB_CI_REGISTRY:$HASHED_IMAGE_TAG' '$MIRROR_REGISTRY:$HASHED_IMAGE_TAG'"
         echo "$ $DOCKER_TAG_COMMAND"
         eval $DOCKER_TAG_COMMAND
         # push

--- a/.cicd/generate-base-images.sh
+++ b/.cicd/generate-base-images.sh
@@ -21,7 +21,7 @@ if [[ "$MANIFEST_INSPECT_EXIT_STATUS" == '0' ]]; then
     fi
 fi
 # pull and copy as-necessary
-if [[ "$EXISTS_ECR" == 'true' ]]; then
+if [[ "$EXISTS_ECR" == 'true' && ! -z "$MIRROR_REGISTRY" ]]; then
     DOCKER_PULL_COMMAND="docker pull '$MIRROR_REGISTRY:$HASHED_IMAGE_TAG'"
     echo "$ $DOCKER_PULL_COMMAND"
     eval $DOCKER_PULL_COMMAND
@@ -37,12 +37,12 @@ if [[ "$EXISTS_ECR" == 'true' ]]; then
         eval $DOCKER_PUSH_COMMAND
         export EXISTS_DOCKER_HUB='true'
     fi
-elif [[ "$EXISTS_DOCKER_HUB" == 'true' && ! -z "$MIRROR_REGISTRY" ]]; then
+elif [[ "$EXISTS_DOCKER_HUB" == 'true' ]]; then
     DOCKER_PULL_COMMAND="docker pull '$DOCKERHUB_CI_REGISTRY:$HASHED_IMAGE_TAG'"
     echo "$ $DOCKER_PULL_COMMAND"
     eval $DOCKER_PULL_COMMAND
     # copy, if necessary
-    if [[ "$EXISTS_DOCKER_HUB" == 'false' ]]; then
+    if [[ "$EXISTS_ECR" == 'false' && ! -z "$MIRROR_REGISTRY" ]]; then
         # tag
         DOCKER_TAG_COMMAND="docker tag '$DOCKERHUB_CI_REGISTRY:$HASHED_IMAGE_TAG' '$MIRROR_REGISTRY:$HASHED_IMAGE_TAG'"
         echo "$ $DOCKER_TAG_COMMAND"

--- a/.cicd/generate-base-images.sh
+++ b/.cicd/generate-base-images.sh
@@ -5,55 +5,58 @@ set -eo pipefail
 # search for base image in docker registries
 echo '--- :docker: Build or Pull Base Image :minidisc:'
 echo "Looking for '$HASHED_IMAGE_TAG' container in our registries."
-EXISTS_ALL='true'
-EXISTS_DOCKER_HUB='false'
-EXISTS_ECR='false'
-for REGISTRY in ${CI_REGISTRIES[*]}; do
-    if [[ ! -z "$REGISTRY" ]]; then
-        MANIFEST_COMMAND="docker manifest inspect '$REGISTRY:$HASHED_IMAGE_TAG'"
-        echo "$ $MANIFEST_COMMAND"
-        set +e
-        eval $MANIFEST_COMMAND
-        MANIFEST_INSPECT_EXIT_STATUS="$?"
-        set -eo pipefail
-        if [[ "$MANIFEST_INSPECT_EXIT_STATUS" == '0' ]]; then
-            if [[ "$(echo "$REGISTRY" | grep -icP '[.]amazonaws[.]com/')" != '0' ]]; then
-                EXISTS_ECR='true'
-            elif [[ "$(echo "$REGISTRY" | grep -icP 'docker[.]io/')" != '0' ]]; then
-                EXISTS_DOCKER_HUB='true'
-            fi
-        else
-            EXISTS_ALL='false'
-        fi
+export EXISTS_DOCKER_HUB='false'
+export EXISTS_ECR='false'
+MANIFEST_QUERY_REGISTRY="${MIRROR_REGISTRY:-$DOCKERHUB_CI_REGISTRY}"
+MANIFEST_COMMAND="docker manifest inspect '$MANIFEST_QUERY_REGISTRY:$HASHED_IMAGE_TAG'"
+echo "$ $MANIFEST_COMMAND"
+set +e
+eval $MANIFEST_COMMAND
+MANIFEST_INSPECT_EXIT_STATUS="$?"
+set -eo pipefail
+if [[ "$MANIFEST_INSPECT_EXIT_STATUS" == '0' ]]; then
+    if [[ "$(echo "$REGISTRY" | grep -icP 'docker[.]io/')" != '0' ]]; then
+        export EXISTS_DOCKER_HUB='true'
+    else
+        export EXISTS_ECR='true'
     fi
-done
-# copy, if possible, since it is so much faster
-if [[ "$EXISTS_ECR" == 'false' && "$EXISTS_DOCKER_HUB" == 'true' && "$OVERWRITE_BASE_IMAGE" != 'true' && ! -z "$MIRROR_REGISTRY" ]]; then
-    echo 'Attempting copy from Docker Hub to the mirror instead of a new base image build.'
+fi
+# pull and copy as-necessary
+if [[ "$EXISTS_ECR" == 'true' ]]; then
+    DOCKER_PULL_COMMAND="docker pull '$MANIFEST_QUERY_REGISTRY:$HASHED_IMAGE_TAG'"
+    echo "$ $DOCKER_PULL_COMMAND"
+    eval $DOCKER_PULL_COMMAND
+    # copy, if necessary
+    if [[ "$EXISTS_DOCKER_HUB" == 'false' ]]; then
+        # tag
+        DOCKER_TAG_COMMAND="docker tag '$MANIFEST_QUERY_REGISTRY:$HASHED_IMAGE_TAG' '$DOCKERHUB_CI_REGISTRY:$HASHED_IMAGE_TAG'"
+        echo "$ $DOCKER_TAG_COMMAND"
+        eval $DOCKER_TAG_COMMAND
+        # push
+        DOCKER_PUSH_COMMAND="docker push '$DOCKERHUB_CI_REGISTRY:$HASHED_IMAGE_TAG'"
+        echo "$ $DOCKER_PUSH_COMMAND"
+        eval $DOCKER_PUSH_COMMAND
+        export EXISTS_DOCKER_HUB='true'
+    fi
+elif [[ "$EXISTS_DOCKER_HUB" == 'true' && ! -z "$MIRROR_REGISTRY" ]]; then
     DOCKER_PULL_COMMAND="docker pull '$DOCKERHUB_CI_REGISTRY:$HASHED_IMAGE_TAG'"
     echo "$ $DOCKER_PULL_COMMAND"
-    set +e
     eval $DOCKER_PULL_COMMAND
-    DOCKER_PULL_EXIT_STATUS="$?"
-    set -eo pipefail
-    if [[ "$DOCKER_PULL_EXIT_STATUS" == '0' ]]; then
-        echo 'Pull from Docker Hub worked! Pushing to mirror.'
+    # copy, if necessary
+    if [[ "$EXISTS_DOCKER_HUB" == 'false' ]]; then
         # tag
-        DOCKER_TAG_COMMAND="docker tag '$DOCKERHUB_CI_REGISTRY:$HASHED_IMAGE_TAG' '$MIRROR_REGISTRY:$HASHED_IMAGE_TAG'"
+        DOCKER_TAG_COMMAND="docker tag '$DOCKERHUB_CI_REGISTRY:$HASHED_IMAGE_TAG' '$MANIFEST_QUERY_REGISTRY:$HASHED_IMAGE_TAG'"
         echo "$ $DOCKER_TAG_COMMAND"
         eval $DOCKER_TAG_COMMAND
         # push
         DOCKER_PUSH_COMMAND="docker push '$MIRROR_REGISTRY:$HASHED_IMAGE_TAG'"
         echo "$ $DOCKER_PUSH_COMMAND"
         eval $DOCKER_PUSH_COMMAND
-        EXISTS_ALL='true'
-        EXISTS_ECR='true'
-    else
-        echo 'Pull from Docker Hub failed, rebuilding base image from scratch.'
+        export EXISTS_ECR='true'
     fi
 fi
 # esplain yerself
-if [[ "$EXISTS_ALL" == 'false' ]]; then
+if [[ "$EXISTS_DOCKER_HUB" == 'false' && "$EXISTS_ECR" == 'false' ]]; then
     echo 'Building base image from scratch.'
 elif [[ "$OVERWRITE_BASE_IMAGE" == 'true' ]]; then
     echo "OVERWRITE_BASE_IMAGE is set to 'true', building from scratch and pushing to docker registries."
@@ -61,7 +64,7 @@ elif [[ "$FORCE_BASE_IMAGE" == 'true' ]]; then
     echo "FORCE_BASE_IMAGE is set to 'true', building from scratch and NOT pushing to docker registries."
 fi
 # build, if neccessary
-if [[ "$EXISTS_ALL" == 'false' || "$FORCE_BASE_IMAGE" == 'true' || "$OVERWRITE_BASE_IMAGE" == 'true' ]]; then # if we cannot pull the image, we build and push it first
+if [[ ("$EXISTS_DOCKER_HUB" == 'false' && "$EXISTS_ECR" == 'false') || "$FORCE_BASE_IMAGE" == 'true' || "$OVERWRITE_BASE_IMAGE" == 'true' ]]; then # if we cannot pull the image, we build and push it first
     export DOCKER_BUILD_COMMAND="docker build --no-cache -t 'ci:$HASHED_IMAGE_TAG' -f '$CICD_DIR/platforms/$PLATFORM_TYPE/$IMAGE_TAG.dockerfile' ."
     echo "$ $DOCKER_BUILD_COMMAND"
     eval $DOCKER_BUILD_COMMAND

--- a/.cicd/generate-pipeline.sh
+++ b/.cicd/generate-pipeline.sh
@@ -678,7 +678,7 @@ cat <<EOF
     command:  "./.cicd/create-docker-from-binary.sh"
     agents:
       queue: "$BUILDKITE_BUILD_AGENT_QUEUE"
-    skip: ${SKIP_INSTALL}${SKIP_LINUX}${SKIP_DOCKER}${SKIP_PACKAGE_BUILDER}
+    skip: ${SKIP_INSTALL}${SKIP_LINUX}${SKIP_DOCKER}${SKIP_PACKAGE_BUILDER}${SKIP_PUBLIC_DOCKER}
     timeout: ${TIMEOUT:-10}
 EOF
 IFS=$oIFS


### PR DESCRIPTION
## Change Description
From [AUTO-562](https://blockone.atlassian.net/browse/AUTO-562) and IM, another business unit decided to use our service account for Docker Hub, and they blew through our rate limits. EOSIO builds are now stuck anywhere that we are hitting Docker Hub for manifest queries or pulls.

This pull request edits the pipeline code to only query our mirror, except in cases where no mirror is specified or where the image does not exist. This should unblock nearly all builds.

### See Also
- [Pull Request 10044](https://github.com/EOSIO/eos/pull/10044) -- `eos:develop`
- [Pull Request 10046](https://github.com/EOSIO/eos/pull/10046) -- `eos:release/2.1.x`
- [Pull Request 10047](https://github.com/EOSIO/eos/pull/10047) -- `eos:release/2.0.x`
- [Pull Request 10048](https://github.com/EOSIO/eos/pull/10048) -- `eos:release/1.8.x`

## Change Type
**Select *ONE*:**
- [ ] Documentation
- [ ] Stability bug fix
- [x] Other
- [ ] Other - special case
CI.

## Testing Changes
**Select *ANY* that apply:**
- [ ] New Tests
- [ ] Existing Tests
- [ ] Test Framework
- [x] CI System
- [ ] Other

## Consensus Changes
- [ ] Consensus Changes
None.

## API Changes
- [ ] API Changes
None.

## Documentation Additions
- [ ] Documentation Additions
None.