### PR TITLE
plugin_http_api_test - fix timing issue

### DIFF
--- a/tests/Node.py
+++ b/tests/Node.py
@@ -1410,10 +1410,12 @@ class Node(object):
                     break
         return protocolFeatureDigestDict
 
-    def waitForHeadToAdvance(self, timeout=6):
+    def waitForHeadToAdvance(self, blocksToAdvance=1, timeout=None):
         currentHead = self.getHeadBlockNum()
+        if timeout is None:
+            timeout = 6 + blocksToAdvance / 2
         def isHeadAdvancing():
-            return self.getHeadBlockNum() > currentHead
+            return self.getHeadBlockNum() >= currentHead + blocksToAdvance
         return Utils.waitForTruth(isHeadAdvancing, timeout)
 
     def waitForLibToAdvance(self, timeout=30):
@@ -1431,7 +1433,7 @@ class Node(object):
         self.scheduleProtocolFeatureActivations([preactivateFeatureDigest])
 
         # Wait for the next block to be produced so the scheduled protocol feature is activated
-        assert self.waitForHeadToAdvance(), print("ERROR: TIMEOUT WAITING FOR PREACTIVATE")
+        assert self.waitForHeadToAdvance(blocksToAdvance=2), print("ERROR: TIMEOUT WAITING FOR PREACTIVATE")
 
     # Return an array of feature digests to be preactivated in a correct order respecting dependencies
     # Require producer_api_plugin
@@ -1458,7 +1460,7 @@ class Node(object):
             if trans is None or not trans[0]:
                 Utils.Print("ERROR: Failed to preactive digest {}".format(digest))
                 return None
-        self.waitForHeadToAdvance()
+        self.waitForHeadToAdvance(blocksToAdvance=2)
 
     # Require PREACTIVATE_FEATURE to be activated and require eosio.bios with preactivate_feature
     def preactivateAllBuiltinProtocolFeature(self):


### PR DESCRIPTION
Consider the following scenario:

The overall plan is to activate a total of 17 protocol features.

- The first 5 protocol features are activated and added to some block (let's say block 18).
- While still on block 18, the remaining 12 protocol features transactions are executed (and they will be added to block 19, and the features will be active on block 20), and the check for waitForHeadToAdvance also gets executed while we are still on this block 18.
- When the chain advances to block 19, the waitForHeadToAdvance method returns, but only 5 protocol features are really activated, leading to a state on the chain where we return from this method, but the protocol features are in realityy still not activated, leading to some failure on some further asserts that assume that this is the case after we return from preactivateAllBuiltinProtocolFeature.

Solution:

To handle this edge case, we wait 2 blocks, instead of 1, to make sure that all the transactions for protocol feature activations are executed and activated, also modify the timeout of the check for head advance to be proportional to the number of blocks we want to wait to advance.

<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->
## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->


## Change Type
**Select *ONE*:**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [ ] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [ ] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the release notes. Please include a description of the change for inclusion in the release notes. -->


## Testing Changes
**Select *ANY* that apply:**
- [ ] New Tests
<!-- checked [x] = new test cases were added; unchecked [ ] = no new test cases -->
- [ ] Existing Tests
<!-- checked [x] = existing test cases were edited; unchecked [ ] = no existing tests were modified -->
- [ ] Test Framework
<!-- checked [x] = this modifies the test framework; unchecked [ ] = no test framework changes -->
- [ ] CI System
<!-- checked [x] = this changes the CI system; unchecked [ ] = no CI changes -->
- [ ] Other
<!-- checked [x] = this integrates an external test system; unchecked [ ] = no miscellaneous test-related changes -->
<!-- Please describe your test changes, or list each new test and its purpose, under each respective checkbox -->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
