### PR TITLE
Reliable amqp_trx_plugin & amqp_trace_plugin

### DIFF
--- a/libraries/amqp/include/eosio/amqp/amqp_handler.hpp
+++ b/libraries/amqp/include/eosio/amqp/amqp_handler.hpp
@@ -1,20 +1,21 @@
 #pragma once
 
+#include <eosio/amqp/retrying_amqp_connection.hpp>
 #include <eosio/amqp/util.hpp>
 #include <eosio/chain/thread_utils.hpp>
 #include <fc/log/logger.hpp>
 #include <fc/exception/exception.hpp>
 #include <amqpcpp.h>
-#include <amqpcpp/libboostasio.h>
-#include <amqpcpp/linux_tcp.h>
+#include <condition_variable>
 
 
 namespace eosio {
 
 /// Designed to work with internal io_service running on a dedicated thread.
-/// All publish methods can be called from any thread, but should be sync'ed with stop() & destructor.
+/// Calls on_consume from internal thread.
+/// ack() & reject() & publish methods can be called from any thread, but should be sync'ed with stop() & destructor.
 /// Constructor, stop(), destructor should be called from same thread.
-class amqp {
+class amqp_handler {
 public:
    // called from amqp thread or calling thread, but not concurrently
    using on_error_t = std::function<void(const std::string& err)>;
@@ -28,8 +29,8 @@ public:
    /// @param on_err callback for errors, called from amqp thread or caller thread, can be nullptr
    /// @param on_consume callback for consume on routing key name, called from amqp thread, null if no consume needed.
    ///        user required to ack/reject delivery_tag for each callback.
-   amqp( const std::string& address, std::string name, on_error_t on_err, on_consume_t on_consume = nullptr )
-         : amqp( address, std::move(name), "", "", std::move(on_err), std::move(on_consume))
+   amqp_handler( const std::string& address, std::string name, on_error_t on_err, on_consume_t on_consume = nullptr )
+         : amqp_handler( address, std::move(name), "", "", std::move(on_err), std::move(on_consume))
    {}
 
    /// @param address AMQP address
@@ -38,54 +39,68 @@ public:
    /// @param on_err callback for errors, called from amqp thread or caller thread, can be nullptr
    /// @param on_consume callback for consume on routing key name, called from amqp thread, null if no consume needed.
    ///        user required to ack/reject delivery_tag for each callback.
-   amqp( const std::string& address, std::string exchange_name, std::string exchange_type, on_error_t on_err, on_consume_t on_consume = nullptr )
-         : amqp( address, "", std::move(exchange_name), std::move(exchange_type), std::move(on_err), std::move(on_consume))
+   amqp_handler( const std::string& address, std::string exchange_name, std::string exchange_type, on_error_t on_err, on_consume_t on_consume = nullptr )
+         : amqp_handler( address, "", std::move(exchange_name), std::move(exchange_type), std::move(on_err), std::move(on_consume))
    {}
 
    /// drain queue and stop thread
-   ~amqp() {
+   ~amqp_handler() {
       stop();
    }
 
    /// publish to AMQP address with routing key name
+   //  on_error() called if not connected
    void publish( std::string exchange, std::string correlation_id, std::vector<char> buf ) {
-      boost::asio::post( *handler_->amqp_strand(),
+      boost::asio::post( thread_pool_.get_executor(),
             [my=this, exchange=std::move(exchange), cid=std::move(correlation_id), buf=std::move(buf)]() {
                AMQP::Envelope env( buf.data(), buf.size() );
                env.setCorrelationID( cid );
-               my->channel_->publish( exchange, my->name_, env, 0 );
+               if( my->channel_ )
+                  my->channel_->publish( exchange, my->name_, env, 0 );
+               else
+                  my->on_error( "AMQP Unable to publish: " + cid );
       } );
    }
 
    /// publish to AMQP calling f() -> std::vector<char> on amqp thread
+   //  on_error() called if not connected
    template<typename Func>
    void publish( std::string exchange, std::string correlation_id, Func f ) {
-      boost::asio::post( *handler_->amqp_strand(),
+      boost::asio::post( thread_pool_.get_executor(),
             [my=this, exchange=std::move(exchange), cid=std::move(correlation_id), f=std::move(f)]() {
                std::vector<char> buf = f();
                AMQP::Envelope env( buf.data(), buf.size() );
                env.setCorrelationID( cid );
-               my->channel_->publish( exchange, my->name_, env, 0 );
+               if( my->channel_ )
+                  my->channel_->publish( exchange, my->name_, env, 0 );
+               else
+                  my->on_error( "AMQP Unable to publish: " + cid );
       } );
    }
 
    /// ack consume message
    /// @param multiple true if given delivery_tag and all previous should be ack'ed
    void ack( const delivery_tag_t& delivery_tag, bool multiple = false ) {
-      boost::asio::post( *handler_->amqp_strand(),
+      boost::asio::post( thread_pool_.get_executor(),
             [my = this, delivery_tag, multiple]() {
                try {
-                  my->channel_->ack( delivery_tag, multiple ? AMQP::multiple : 0 );
+                  if( my->channel_ )
+                     my->channel_->ack( delivery_tag, multiple ? AMQP::multiple : 0 );
+                  else
+                     my->on_error( "AMQP Unable to ack: " + std::to_string(delivery_tag) );
                } FC_LOG_AND_DROP()
             } );
    }
 
    // reject consume message
    void reject( const delivery_tag_t& delivery_tag ) {
-      boost::asio::post( *handler_->amqp_strand(),
+      boost::asio::post( thread_pool_.get_executor(),
             [my = this, delivery_tag]() {
                try {
-                  my->channel_->reject( delivery_tag );
+                  if( my->channel_ )
+                     my->channel_->reject( delivery_tag );
+                  else
+                     my->on_error( "AMQP Unable to reject: " + std::to_string(delivery_tag) );
                } FC_LOG_AND_DROP()
             } );
    }
@@ -94,11 +109,11 @@ public:
    /// Not thread safe, call only once from constructor/destructor thread
    /// Do not call from lambda's passed to publish or constructor e.g. on_error
    void stop() {
-      if( handler_ ) {
+      if( first_connect_.un_set() ) {
          // drain amqp queue
          std::promise<void> stop_promise;
          auto future = stop_promise.get_future();
-         boost::asio::post( *handler_->amqp_strand(), [&]() {
+         boost::asio::post( thread_pool_.get_executor(), [&]() {
             if( channel_ && channel_->usable() ) {
                auto& cb = channel_->close();
                cb.onFinalize( [&]() {
@@ -119,15 +134,16 @@ public:
          future.wait();
 
          thread_pool_.stop();
-         handler_.reset();
       }
    }
 
 private:
 
-   amqp(const std::string& address, std::string name, std::string exchange_name, std::string exchange_type, on_error_t on_err, on_consume_t on_consume)
-         : thread_pool_( "ampq", 1 ) // amqp is not thread safe, use only one thread
-         , connected_future_( connected_.get_future() )
+   amqp_handler(const std::string& address, std::string name, std::string exchange_name, std::string exchange_type,
+                on_error_t on_err, on_consume_t on_consume)
+         : first_connect_()
+         , thread_pool_( "ampq", 1 ) // amqp is not thread safe, use only one thread
+         , amqp_connection_(  thread_pool_.get_executor(), address, [this](AMQP::Channel* c){channel_ready(c);}, [this](){channel_failed();} )
          , name_( std::move( name ) )
          , exchange_name_( std::move( exchange_name ) )
          , exchange_type_( std::move( exchange_type ) )
@@ -137,23 +153,39 @@ private:
       AMQP::Address amqp_address( address );
       ilog( "Connecting to AMQP address ${a} - Queue: ${q}...", ("a", amqp_address)("q", name_) );
 
-      handler_ = std::make_unique<amqp_handler>( *this, thread_pool_.get_executor() );
-      boost::asio::post( *handler_->amqp_strand(), [&]() {
-         connection_ = std::make_unique<AMQP::TcpConnection>( handler_.get(), amqp_address );
-      });
       wait();
    }
 
+   // called from non-amqp thread
+   void wait() {
+      if( !first_connect_.wait() ) {
+         boost::asio::post( thread_pool_.get_executor(), [this](){
+            on_error( "AMQP timeout connecting and declaring queue" );
+         } );
+      }
+   }
+
    // called from amqp thread
-   void init( AMQP::TcpConnection* c ) {
-      channel_ = std::make_unique<AMQP::TcpChannel>( c );
+   void channel_ready(AMQP::Channel* c) {
+      channel_ = c;
+      init();
+   }
+
+   // called from amqp thread
+   void channel_failed() {
+      channel_ = nullptr;
+   }
+
+   // called from amqp thread
+   void init() {
+      if(!channel_) return;
       if( !exchange_type_.empty() ) {
          auto type = AMQP::direct;
          if (exchange_type_ == "fanout") {
             type = AMQP::fanout;
          } else if (exchange_type_ != "direct") {
             on_error( "Unsupported exchange type: " + exchange_type_ );
-            connected_.set_value();
+            first_connect_.set();
             return;
          }
 
@@ -164,7 +196,7 @@ private:
          } );
          exchange.onError([this](const char* error_message) {
             on_error( std::string("AMQP Queue error: ") + error_message );
-            connected_.set_value();
+            first_connect_.set();
          });
       } else {
          auto& queue = channel_->declareQueue( name_, AMQP::durable );
@@ -175,7 +207,7 @@ private:
          } );
          queue.onError( [&]( const char* error_message ) {
             on_error( error_message );
-            connected_.set_value();
+            first_connect_.set();
          } );
       }
    }
@@ -183,73 +215,62 @@ private:
    // called from amqp thread
    void init_consume() {
       if( !on_consume_ ) {
-         connected_.set_value();
+         first_connect_.set();
          return;
       }
 
       auto& consumer = channel_->consume( name_ );
       consumer.onSuccess( [&]( const std::string& consumer_tag ) {
          dlog( "consume started: ${tag}", ("tag", consumer_tag) );
-         connected_.set_value();
+         first_connect_.set();
       } );
       consumer.onError( [&]( const char* message ) {
          wlog( "consume failed: ${e}", ("e", message) );
          on_error( message );
-         connected_.set_value();
+         first_connect_.set();
       } );
       consumer.onReceived( [&](const AMQP::Message& message, const delivery_tag_t& delivery_tag, bool redelivered) {
          on_consume_( delivery_tag, message.body(), message.bodySize() );
       } );
    }
 
-   // called from non-amqp thread
-   void wait() {
-      auto r = connected_future_.wait_for( std::chrono::seconds( 10 ) );
-      if( r == std::future_status::timeout ) {
-         on_error( "AMQP timeout declaring queue" );
-      }
-   }
-
+   // called from amqp thread
    void on_error( const std::string& message ) {
-      std::lock_guard<std::mutex> g(mtx_);
       if( on_error_ ) on_error_( message );
    }
 
-   class amqp_handler : public AMQP::LibBoostAsioHandler {
+private:
+   class start_cond {
+   private:
+      std::mutex mtx_;
+      bool started_ = false;
+      std::condition_variable start_cond_;
    public:
-      explicit amqp_handler( amqp& impl, boost::asio::io_service& io_service )
-            : AMQP::LibBoostAsioHandler( io_service )
-            , amqp_(impl)
-      {}
-
-      void onError( AMQP::TcpConnection* connection, const char* message ) override {
-         elog( "amqp connection failed: ${m}", ("m", message) );
-         amqp_.on_error( message );
+      void set() {
+         {
+            auto lock = std::scoped_lock(mtx_);
+            started_ = true;
+         }
+         start_cond_.notify_one();
       }
-
-      uint16_t onNegotiate( AMQP::TcpConnection* connection, uint16_t interval ) override {
-         return 0; // disable heartbeats
+      bool wait() {
+         std::unique_lock<std::mutex> lk(mtx_);
+         return start_cond_.wait_for( lk, std::chrono::seconds( 10 ), [&]{ return started_; } );
       }
-
-      void onReady(AMQP::TcpConnection* c) override {
-         amqp_.init( c );
+      // only unset on shutdown, return prev value
+      bool un_set() {
+         auto lock = std::scoped_lock( mtx_ );
+         bool s = started_;
+         started_ = false;
+         return s;
       }
-
-      strand_shared_ptr& amqp_strand() {
-         return _strand;
-      }
-
-      amqp& amqp_;
    };
 
 private:
-   std::mutex mtx_;
+   start_cond first_connect_;
    eosio::chain::named_thread_pool thread_pool_;
-   std::unique_ptr<amqp_handler> handler_;
-   std::unique_ptr<AMQP::TcpConnection> connection_;
-   std::unique_ptr<AMQP::TcpChannel> channel_;
-   std::promise<void> connected_;
-   std::future<void> connected_future_;
+   single_channel_retrying_amqp_connection amqp_connection_;
+   AMQP::Channel* channel_ = nullptr; // null when not connected
    std::string name_;
    std::string exchange_name_;
    std::string exchange_type_;

--- a/libraries/amqp/include/eosio/amqp/reliable_amqp_publisher.hpp
+++ b/libraries/amqp/include/eosio/amqp/reliable_amqp_publisher.hpp
@@ -48,8 +48,9 @@ class reliable_amqp_publisher {
       /// Publish message directly to AMQP queue
       /// Bypasses all reliable mechanisms and just does a simple AMQP publish. Does not queue or retry.
       /// \param routing_key if empty() uses class provided default routing_key
+      /// \param correlation_id if not empty() sets as correlation id of the message envelope
       /// \param data message to send
-      void publish_message_direct(const std::string& routing_key, std::vector<char> data);
+      void publish_message_direct(const std::string& routing_key, const std::string& correlation_id, std::vector<char> data);
 
       /// reliable_amqp_publisher runs its own thread. In some cases it may be desirable to skip a needless thread jump
       ///  when performing work. This method will allow submission of work to reliable_amqp_publisher's thread.

--- a/libraries/amqp/include/eosio/amqp/reliable_amqp_publisher.hpp
+++ b/libraries/amqp/include/eosio/amqp/reliable_amqp_publisher.hpp
@@ -17,7 +17,7 @@ namespace eosio {
  * reliable_amqp_publisher's queue until the exchange exists because the queue will be unable to make progress.
  *
  * At a large enough unconfirmed queue depth (currently on the order of 1 million entries) reliable_amqp_publisher
- * will call fatal_error() and then start dropping messages after logging an error.
+ * will call on_fatal_error() but continue queuing messages.
  */
 
 class reliable_amqp_publisher {
@@ -30,7 +30,7 @@ class reliable_amqp_publisher {
       /// \param exchange the exchange to publish to
       /// \param routing_key on published messages, used if no routing_key provided for publish_message.. calls
       /// \param unconfirmed_path path to save/load unconfirmed message to be tried again after stop/start
-      /// \param on_fatal_error called from amqp thread when unconfirmed queue depth about to be exceeded.
+      /// \param on_fatal_error called from AMQP thread when unconfirmed queue depth is exceeded.
       /// \param message_id optional message id to send with each message
       reliable_amqp_publisher(const std::string& server_url, const std::string& exchange, const std::string& routing_key,
                               const boost::filesystem::path& unconfirmed_path, error_callback_t on_fatal_error,

--- a/libraries/amqp/include/eosio/amqp/reliable_amqp_publisher.hpp
+++ b/libraries/amqp/include/eosio/amqp/reliable_amqp_publisher.hpp
@@ -16,20 +16,25 @@ namespace eosio {
  * to already exist. Publishing to a non-existing exchange will effectively block
  * reliable_amqp_publisher's queue until the exchange exists because the queue will be unable to make progress.
  *
- * At a large enough uncomfirmed queue depth (currently on the order of 1 million entries) reliable_amqp_publisher
- * will start dropping messages after logging an error.
+ * At a large enough unconfirmed queue depth (currently on the order of 1 million entries) reliable_amqp_publisher
+ * will call fatal_error() and then start dropping messages after logging an error.
  */
 
 class reliable_amqp_publisher {
    public:
+      // Called from amqp thread when unconfirmed queue depth about to be exceeded.
+      using error_callback_t = std::function<void(const std::string& err)>;
+
       /// Create a reliable queue to the given server publishing to the given exchange
       /// \param server_url server url as amqp://...
       /// \param exchange the exchange to publish to
       /// \param routing_key on published messages, used if no routing_key provided for publish_message.. calls
       /// \param unconfirmed_path path to save/load unconfirmed message to be tried again after stop/start
+      /// \param on_fatal_error called from amqp thread when unconfirmed queue depth about to be exceeded.
       /// \param message_id optional message id to send with each message
       reliable_amqp_publisher(const std::string& server_url, const std::string& exchange, const std::string& routing_key,
-                              const boost::filesystem::path& unconfirmed_path, const std::optional<std::string>& message_id = {});
+                              const boost::filesystem::path& unconfirmed_path, error_callback_t on_fatal_error,
+                              const std::optional<std::string>& message_id = {});
 
       /// Publish a message. May be called from any thread.
       /// \param t serializable object

--- a/libraries/amqp/include/eosio/amqp/reliable_amqp_publisher.hpp
+++ b/libraries/amqp/include/eosio/amqp/reliable_amqp_publisher.hpp
@@ -44,7 +44,12 @@ class reliable_amqp_publisher {
          publish_message_raw(std::move(v));
       }
 
+      /// \param data message to send
       void publish_message_raw(std::vector<char>&& data);
+
+      /// \param correlation_id if not empty() sets as correlation id of the message envelope
+      /// \param data message to send
+      void publish_message_raw(const std::string& correlation_id, std::vector<char>&& data);
 
       /// Publish messages. May be called from any thread.
       /// \param queue set of messages to send in one transaction <routing_key, message_data>
@@ -55,7 +60,9 @@ class reliable_amqp_publisher {
       /// \param routing_key if empty() uses class provided default routing_key
       /// \param correlation_id if not empty() sets as correlation id of the message envelope
       /// \param data message to send
-      void publish_message_direct(const std::string& routing_key, const std::string& correlation_id, std::vector<char> data);
+      /// \param on_error() call from AMQP thread if unable to directly publish (e.g. not currently connected)
+      void publish_message_direct(const std::string& routing_key, const std::string& correlation_id,
+                                  std::vector<char> data, error_callback_t on_error);
 
       /// reliable_amqp_publisher runs its own thread. In some cases it may be desirable to skip a needless thread jump
       ///  when performing work. This method will allow submission of work to reliable_amqp_publisher's thread.

--- a/libraries/amqp/reliable_amqp_publisher.cpp
+++ b/libraries/amqp/reliable_amqp_publisher.cpp
@@ -312,4 +312,4 @@ reliable_amqp_publisher::~reliable_amqp_publisher() = default;
 
 }
 
-FC_REFLECT( eosio::reliable_amqp_publisher_impl::amqp_message, (num)(routing_key)(data) )
+FC_REFLECT( eosio::reliable_amqp_publisher_impl::amqp_message, (num)(routing_key)(correlation_id)(data) )

--- a/libraries/amqp/reliable_amqp_publisher.cpp
+++ b/libraries/amqp/reliable_amqp_publisher.cpp
@@ -33,7 +33,7 @@ struct reliable_amqp_publisher_impl {
    void publish_messages_raw(std::deque<std::pair<std::string, std::vector<char>>>&& queue);
    void publish_message_direct(const std::string& routing_key, const std::string& correlation_id,
                                std::vector<char> data, reliable_amqp_publisher::error_callback_t on_error);
-   bool verify_max_queue_size();
+   void verify_max_queue_size();
 
    void channel_ready(AMQP::Channel* channel);
    void channel_failed();
@@ -62,7 +62,6 @@ struct reliable_amqp_publisher_impl {
    const std::string exchange;
    const std::string routing_key;
    const std::optional<std::string> message_id;
-   bool logged_exceeded_max_depth = false;
 
    boost::asio::strand<boost::asio::io_context::executor_type> user_submitted_work_strand = boost::asio::make_strand(ctx);
 };
@@ -177,7 +176,6 @@ void reliable_amqp_publisher_impl::pump_queue() {
 
    channel->commitTransaction().onSuccess([this](){
       message_deque.erase(message_deque.begin(), message_deque.begin()+in_flight);
-      logged_exceeded_max_depth = false;
    })
    .onFinalize([this]() {
       in_flight = 0;
@@ -190,21 +188,15 @@ void reliable_amqp_publisher_impl::pump_queue() {
    });
 }
 
-bool reliable_amqp_publisher_impl::verify_max_queue_size() {
+void reliable_amqp_publisher_impl::verify_max_queue_size() {
    constexpr unsigned max_queued_messages = 1u << 20u;
 
-   if(message_deque.size() > max_queued_messages - 1000) {
+   if(message_deque.size() > max_queued_messages) {
+      elog("AMQP connection ${a} publishing to \"${e}\" has reached ${max} unconfirmed messages",
+           ("a", retrying_connection.address())("e", exchange)("max", max_queued_messages));
       std::string err = "AMQP publishing to " + exchange + " has reached " + std::to_string(message_deque.size()) + " unconfirmed messages";
       on_fatal_error(err);
    }
-   if(message_deque.size() > max_queued_messages) {
-      if(logged_exceeded_max_depth == false)
-         elog("AMQP connection ${a} publishing to \"${e}\" has reached ${max} unconfirmed messages; dropping messages",
-              ("a", retrying_connection.address())("e", exchange)("max", max_queued_messages));
-      logged_exceeded_max_depth = true;
-      return false;
-   }
-   return true;
 }
 
 void reliable_amqp_publisher_impl::publish_message_raw(std::vector<char>&& data) {
@@ -215,7 +207,7 @@ void reliable_amqp_publisher_impl::publish_message_raw(std::vector<char>&& data)
       return;
    }
 
-   if( !verify_max_queue_size() ) return;
+   verify_max_queue_size();
 
    message_deque.emplace_back(amqp_message{0, "", "", std::move(data)});
    pump_queue();
@@ -229,7 +221,7 @@ void reliable_amqp_publisher_impl::publish_message_raw(const std::string& correl
       return;
    }
 
-   if( !verify_max_queue_size() ) return;
+   verify_max_queue_size();
 
    message_deque.emplace_back(amqp_message{0, "", correlation_id, std::move(data)});
    pump_queue();
@@ -243,7 +235,7 @@ void reliable_amqp_publisher_impl::publish_messages_raw(std::deque<std::pair<std
       return;
    }
 
-   if( !verify_max_queue_size() ) return;
+   verify_max_queue_size();
 
    ++batch_num.value;
    if( batch_num == 0u ) ++batch_num.value;

--- a/libraries/amqp/reliable_amqp_publisher.cpp
+++ b/libraries/amqp/reliable_amqp_publisher.cpp
@@ -195,7 +195,7 @@ void reliable_amqp_publisher_impl::verify_max_queue_size() {
       elog("AMQP connection ${a} publishing to \"${e}\" has reached ${max} unconfirmed messages",
            ("a", retrying_connection.address())("e", exchange)("max", max_queued_messages));
       std::string err = "AMQP publishing to " + exchange + " has reached " + std::to_string(message_deque.size()) + " unconfirmed messages";
-      on_fatal_error(err);
+      if( on_fatal_error) on_fatal_error(err);
    }
 }
 

--- a/plugins/amqp_compressed_proof_plugin/amqp_compressed_proof_plugin.cpp
+++ b/plugins/amqp_compressed_proof_plugin/amqp_compressed_proof_plugin.cpp
@@ -253,7 +253,12 @@ void amqp_compressed_proof_plugin::plugin_initialize(const variables_map& option
             EOS_ASSERT(filtered_receivers.size(), chain::plugin_config_exception, "Cannot have empty filter list for compressed-proof");
 
             const boost::filesystem::path amqp_unconfimed_file   = dir / (file_prefix + "-unconfirmed-"s + name + ".bin"s);
-            reliable_amqp_publisher& publisher = my->publishers.emplace_back(tokens[2], tokens[3], "", amqp_unconfimed_file, "eosio.node.compressed_proof_v0");
+            reliable_amqp_publisher& publisher = my->publishers.emplace_back(tokens[2], tokens[3], "", amqp_unconfimed_file,
+                                                                             [](const std::string& err){
+                                                                                elog("AMQP fatal error: ${e}", ("e", err));
+                                                                                appbase::app().quit();
+                                                                             },
+                                                                             "eosio.node.compressed_proof_v0");
 
             //the presence of an empty set means any action on that receiver
             std::map<chain::name, std::set<chain::name>> filter_on_names_and_actions;

--- a/plugins/amqp_trace_plugin/amqp_trace_plugin.cpp
+++ b/plugins/amqp_trace_plugin/amqp_trace_plugin.cpp
@@ -57,7 +57,11 @@ void amqp_trace_plugin::plugin_startup() {
 
          const boost::filesystem::path trace_data_file_path = appbase::app().data_dir() / "amqp_trace_plugin" / "trace.bin";
 
-         my->amqp_trace.emplace( my->amqp_trace_address, my->amqp_trace_exchange, my->amqp_trace_queue_name, trace_data_file_path );
+         my->amqp_trace.emplace( my->amqp_trace_address, my->amqp_trace_exchange, my->amqp_trace_queue_name, trace_data_file_path,
+                                 []( const std::string& err ) {
+                                    elog( "AMQP fatal error: ${e}", ("e", err) );
+                                    appbase::app().quit();
+                                 } );
 
          auto chain_plug = app().find_plugin<chain_plugin>();
          EOS_ASSERT( chain_plug, chain::missing_chain_plugin_exception, "chain_plugin required" );

--- a/plugins/amqp_trace_plugin/amqp_trace_plugin_impl.cpp
+++ b/plugins/amqp_trace_plugin/amqp_trace_plugin_impl.cpp
@@ -33,7 +33,7 @@ std::ostream& operator<<(std::ostream& osm, amqp_trace_plugin_impl::reliable_mod
    return osm;
 }
 
-// called from any thread
+// Can be called from any thread except reliable_amqp_publisher thread
 void amqp_trace_plugin_impl::publish_error( std::string tid, int64_t error_code, std::string error_message ) {
    try {
       // reliable_amqp_publisher ensures that any post_on_io_context() is called before its dtor returns

--- a/plugins/amqp_trace_plugin/amqp_trace_plugin_impl.cpp
+++ b/plugins/amqp_trace_plugin/amqp_trace_plugin_impl.cpp
@@ -3,21 +3,56 @@
 #include <eosio/state_history/type_convert.hpp>
 #include <eosio/for_each_field.hpp>
 #include <eosio/to_bin.hpp>
-
 #include <eosio/chain/exceptions.hpp>
 #include <eosio/chain/transaction.hpp>
+#include <appbase/application.hpp>
 
 namespace eosio {
+
+std::istream& operator>>(std::istream& in, amqp_trace_plugin_impl::reliable_mode& m) {
+   std::string s;
+   in >> s;
+   if( s == "exit" )
+      m = amqp_trace_plugin_impl::reliable_mode::exit;
+   else if( s == "log" )
+      m = amqp_trace_plugin_impl::reliable_mode::log;
+   else if( s == "queue" )
+      m = amqp_trace_plugin_impl::reliable_mode::queue;
+   else
+      in.setstate( std::ios_base::failbit );
+   return in;
+}
+
+std::ostream& operator<<(std::ostream& osm, amqp_trace_plugin_impl::reliable_mode m) {
+   if( m == amqp_trace_plugin_impl::reliable_mode::exit )
+      osm << "exit";
+   else if( m == amqp_trace_plugin_impl::reliable_mode::log )
+      osm << "log";
+   else if( m == amqp_trace_plugin_impl::reliable_mode::queue )
+      osm << "queue";
+   return osm;
+}
 
 // called from any thread
 void amqp_trace_plugin_impl::publish_error( std::string tid, int64_t error_code, std::string error_message ) {
    try {
       // reliable_amqp_publisher ensures that any post_on_io_context() is called before its dtor returns
-      amqp_trace->post_on_io_context([&amqp_trace = *amqp_trace, tid{std::move(tid)}, error_code, em{std::move(error_message)}]() mutable {
+      amqp_trace->post_on_io_context(
+            [&amqp_trace = *amqp_trace, mode=pub_reliable_mode,
+             tid{std::move(tid)}, error_code, em{std::move(error_message)}]() mutable {
          transaction_trace_msg msg{transaction_trace_exception{error_code}};
          std::get<transaction_trace_exception>( msg ).error_message = std::move( em );
          std::vector<char> buf = convert_to_bin( msg );
-         amqp_trace.publish_message_direct(std::string(), tid, std::move(buf));
+         if( mode == reliable_mode::queue) {
+            amqp_trace.publish_message_raw( tid, std::move( buf ) );
+         } else {
+            amqp_trace.publish_message_direct( std::string(), tid, std::move( buf ),
+                                               [mode]( const std::string& err ) {
+                                                  elog( "AMQP direct message error: ${e}", ("e", err) );
+                                                  if( mode == reliable_mode::exit )
+                                                     appbase::app().quit();
+                                               } );
+         }
       });
    }
    FC_LOG_AND_DROP()
@@ -37,7 +72,8 @@ void amqp_trace_plugin_impl::publish_result( const chain::packed_transaction_ptr
                                              const chain::transaction_trace_ptr& trace ) {
    try {
       // reliable_amqp_publisher ensures that any post_on_io_context() is called before its dtor returns
-      amqp_trace->post_on_io_context([&amqp_trace = *amqp_trace, trx, trace]() {
+      amqp_trace->post_on_io_context(
+            [&amqp_trace = *amqp_trace, trx, trace, mode=pub_reliable_mode]() {
          if( !trace->except ) {
             dlog( "chain accepted transaction, bcast ${id}", ("id", trace->id) );
          } else {
@@ -45,7 +81,16 @@ void amqp_trace_plugin_impl::publish_result( const chain::packed_transaction_ptr
          }
          transaction_trace_msg msg{ eosio::state_history::convert( *trace ) };
          std::vector<char> buf = convert_to_bin( msg );
-         amqp_trace.publish_message_direct(std::string(), trx->id(), std::move(buf));
+         if( mode == reliable_mode::queue) {
+            amqp_trace.publish_message_raw( trx->id(), std::move( buf ) );
+         } else {
+            amqp_trace.publish_message_direct( std::string(), trx->id(), std::move( buf ),
+                                               [mode]( const std::string& err ) {
+                                                  elog( "AMQP direct message error: ${e}", ("e", err) );
+                                                  if( mode == reliable_mode::exit )
+                                                     appbase::app().quit();
+                                               } );
+         }
       });
    }
    FC_LOG_AND_DROP()

--- a/plugins/amqp_trace_plugin/amqp_trace_plugin_impl.cpp
+++ b/plugins/amqp_trace_plugin/amqp_trace_plugin_impl.cpp
@@ -12,10 +12,13 @@ namespace eosio {
 // called from any thread
 void amqp_trace_plugin_impl::publish_error( std::string tid, int64_t error_code, std::string error_message ) {
    try {
-      transaction_trace_msg msg{transaction_trace_exception{error_code}};
-      std::get<transaction_trace_exception>( msg ).error_message = std::move( error_message );
-      auto buf = convert_to_bin( msg );
-      amqp_trace->publish( amqp_trace_exchange, tid, std::move( buf ) );
+      // reliable_amqp_publisher ensures that any post_on_io_context() is called before its dtor returns
+      amqp_trace->post_on_io_context([&amqp_trace = *amqp_trace, tid{std::move(tid)}, error_code, em{std::move(error_message)}]() mutable {
+         transaction_trace_msg msg{transaction_trace_exception{error_code}};
+         std::get<transaction_trace_exception>( msg ).error_message = std::move( em );
+         std::vector<char> buf = convert_to_bin( msg );
+         amqp_trace.publish_message_direct(std::string(), tid, std::move(buf));
+      });
    }
    FC_LOG_AND_DROP()
 }
@@ -33,15 +36,17 @@ void amqp_trace_plugin_impl::on_applied_transaction( const chain::transaction_tr
 void amqp_trace_plugin_impl::publish_result( const chain::packed_transaction_ptr& trx,
                                              const chain::transaction_trace_ptr& trace ) {
    try {
-      if( !trace->except ) {
-         dlog( "chain accepted transaction, bcast ${id}", ("id", trace->id) );
-      } else {
-         dlog( "trace except : ${m}", ("m", trace->except->to_string()) );
-      }
-      amqp_trace->publish( amqp_trace_exchange, trx->id(), [trace]() {
+      // reliable_amqp_publisher ensures that any post_on_io_context() is called before its dtor returns
+      amqp_trace->post_on_io_context([&amqp_trace = *amqp_trace, trx, trace]() {
+         if( !trace->except ) {
+            dlog( "chain accepted transaction, bcast ${id}", ("id", trace->id) );
+         } else {
+            dlog( "trace except : ${m}", ("m", trace->except->to_string()) );
+         }
          transaction_trace_msg msg{ eosio::state_history::convert( *trace ) };
-         return convert_to_bin( msg );
-      } );
+         std::vector<char> buf = convert_to_bin( msg );
+         amqp_trace.publish_message_direct(std::string(), trx->id(), std::move(buf));
+      });
    }
    FC_LOG_AND_DROP()
 }

--- a/plugins/amqp_trace_plugin/include/eosio/amqp_trace_plugin/amqp_trace_plugin_impl.hpp
+++ b/plugins/amqp_trace_plugin/include/eosio/amqp_trace_plugin/amqp_trace_plugin_impl.hpp
@@ -10,6 +10,7 @@ struct amqp_trace_plugin_impl : std::enable_shared_from_this<amqp_trace_plugin_i
    std::optional<reliable_amqp_publisher> amqp_trace;
 
    std::string amqp_trace_address;
+   std::string amqp_trace_queue_name;
    std::string amqp_trace_exchange;
    bool started = false;
 

--- a/plugins/amqp_trace_plugin/include/eosio/amqp_trace_plugin/amqp_trace_plugin_impl.hpp
+++ b/plugins/amqp_trace_plugin/include/eosio/amqp_trace_plugin/amqp_trace_plugin_impl.hpp
@@ -7,11 +7,18 @@ namespace eosio {
 
 struct amqp_trace_plugin_impl : std::enable_shared_from_this<amqp_trace_plugin_impl> {
 
+   enum class reliable_mode {
+      exit,
+      log,
+      queue
+   };
+
    std::optional<reliable_amqp_publisher> amqp_trace;
 
    std::string amqp_trace_address;
    std::string amqp_trace_queue_name;
    std::string amqp_trace_exchange;
+   reliable_mode pub_reliable_mode;
    bool started = false;
 
 public:
@@ -27,5 +34,8 @@ private:
    // called from application thread
    void publish_result( const chain::packed_transaction_ptr& trx, const chain::transaction_trace_ptr& trace );
 };
+
+std::istream& operator>>(std::istream& in, amqp_trace_plugin_impl::reliable_mode& m);
+std::ostream& operator<<(std::ostream& osm, amqp_trace_plugin_impl::reliable_mode m);
 
 } // namespace eosio

--- a/plugins/amqp_trace_plugin/include/eosio/amqp_trace_plugin/amqp_trace_plugin_impl.hpp
+++ b/plugins/amqp_trace_plugin/include/eosio/amqp_trace_plugin/amqp_trace_plugin_impl.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <eosio/amqp/amqp_handler.hpp>
+#include <eosio/amqp/reliable_amqp_publisher.hpp>
 #include <eosio/chain/trace.hpp>
 #include <eosio/chain/transaction.hpp>
 
@@ -7,7 +7,7 @@ namespace eosio {
 
 struct amqp_trace_plugin_impl : std::enable_shared_from_this<amqp_trace_plugin_impl> {
 
-   std::optional<amqp> amqp_trace;
+   std::optional<reliable_amqp_publisher> amqp_trace;
 
    std::string amqp_trace_address;
    std::string amqp_trace_exchange;

--- a/plugins/amqp_trx_plugin/amqp_trx_plugin.cpp
+++ b/plugins/amqp_trx_plugin/amqp_trx_plugin.cpp
@@ -59,6 +59,7 @@ struct amqp_trx_plugin_impl : std::enable_shared_from_this<amqp_trx_plugin_impl>
    std::optional<amqp_handler> amqp_trx;
 
    std::string amqp_trx_address;
+   std::string amqp_trx_queue;
    ack_mode acked = ack_mode::executed;
    std::map<uint32_t, eosio::amqp_handler::delivery_tag_t> tracked_delivery_tags; // block, highest delivery_tag for block
    uint32_t trx_processing_queue_size = 1000;
@@ -176,7 +177,9 @@ void amqp_trx_plugin::set_program_options(options_description& cli, options_desc
    auto op = cfg.add_options();
    op("amqp-trx-address", bpo::value<std::string>(),
       "AMQP address: Format: amqp://USER:PASSWORD@ADDRESS:PORT\n"
-      "Will consume from 'trx' queue.");
+      "Will consume from amqp-trx-queue-name ('trx') queue.");
+   op("amqp-trx-queue-name", bpo::value<std::string>()->default_value("trx"),
+      "AMQP queue to consume transactions from.");
    op("amqp-trx-queue-size", bpo::value<uint32_t>()->default_value(my->trx_processing_queue_size),
       "The maximum number of transactions to pull from the AMQP queue at any given time.");
    op("amqp-trx-speculative-execution", bpo::bool_switch()->default_value(false),
@@ -195,6 +198,9 @@ void amqp_trx_plugin::plugin_initialize(const variables_map& options) {
 
       EOS_ASSERT( options.count("amqp-trx-address"), chain::plugin_config_exception, "amqp-trx-address required" );
       my->amqp_trx_address = options.at("amqp-trx-address").as<std::string>();
+
+      my->amqp_trx_queue = options.at("amqp-trx-queue-name").as<std::string>();
+      EOS_ASSERT( !my->amqp_trx_queue.empty(), chain::plugin_config_exception, "amqp-trx-queue-name required" );
 
       my->acked = options.at("amqp-trx-ack-mode").as<ack_mode>();
 
@@ -245,7 +251,7 @@ void amqp_trx_plugin::plugin_startup() {
 
       my->trx_queue_ptr->run();
 
-      my->amqp_trx.emplace( my->amqp_trx_address, "trx",
+      my->amqp_trx.emplace( my->amqp_trx_address, my->amqp_trx_queue,
             [](const std::string& err) {
                elog( "amqp error: ${e}", ("e", err) );
                app().quit();

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -442,7 +442,7 @@ fc::variant push_transaction( signed_transaction& trx, const std::vector<public_
             auto buf = fc::raw::pack( msg );
             const auto& tid = std::get<packed_transaction>(msg).id();
             string id = tid.str();
-            eosio::amqp qp_trx( amqp_address, "trx", []( const std::string& err ) {
+            eosio::amqp_handler qp_trx( amqp_address, "trx", []( const std::string& err ) {
                std::cerr << "AMQP trx error: " << err << std::endl;
                exit( 1 );
             } );

--- a/programs/rodeos/streams/rabbitmq.hpp
+++ b/programs/rodeos/streams/rabbitmq.hpp
@@ -41,7 +41,11 @@ class rabbitmq : public stream_handler {
          error = true;
       } );
       if( error ) return;
-      amqp_publisher_ = std::make_shared<eosio::reliable_amqp_publisher>(address_, "", "", unconfirmed_path_);
+      amqp_publisher_ = std::make_shared<eosio::reliable_amqp_publisher>(address_, "", "", unconfirmed_path_,
+                                                                         [](const std::string& err) {
+                                                                            elog("AMQP fatal error: ${e}", ("e", err));
+                                                                            appbase::app().quit();
+                                                                         });
    }
 
    rabbitmq(std::vector<eosio::name> routes, const AMQP::Address& address, bool publish_immediately,
@@ -60,7 +64,11 @@ class rabbitmq : public stream_handler {
          error = true;
       } );
       if( error ) return;
-      amqp_publisher_ = std::make_shared<eosio::reliable_amqp_publisher>( address_, exchange_name_, "", unconfirmed_path_ );
+      amqp_publisher_ = std::make_shared<eosio::reliable_amqp_publisher>(address_, exchange_name_, "", unconfirmed_path_,
+                                                                         [](const std::string& err){
+                                                                            elog("AMQP fatal error: ${e}", ("e", err));
+                                                                            appbase::app().quit();
+                                                                         });
    }
 
    const std::vector<eosio::name>& get_routes() const override { return routes_; }

--- a/programs/rodeos/streams/rabbitmq.hpp
+++ b/programs/rodeos/streams/rabbitmq.hpp
@@ -35,7 +35,7 @@ class rabbitmq : public stream_handler {
    {
       ilog("Connecting to RabbitMQ address ${a} - Queue: ${q}...", ("a", address)( "q", queue_name_));
       bool error = false;
-      eosio::amqp declare_queue( address_, queue_name_, [&error](const std::string& err){
+      eosio::amqp_handler declare_queue( address_, queue_name_, [&error](const std::string& err){
          elog("AMQP Queue error: ${e}", ("e", err));
          appbase::app().quit();
          error = true;
@@ -54,7 +54,7 @@ class rabbitmq : public stream_handler {
    {
       ilog("Connecting to RabbitMQ address ${a} - Exchange: ${e}...", ("a", address)( "e", exchange_name_));
       bool error = false;
-      eosio::amqp declare_exchange( address_, exchange_name_, exchange_type, [&error](const std::string& err){
+      eosio::amqp_handler declare_exchange( address_, exchange_name_, exchange_type, [&error](const std::string& err){
          elog("AMQP Exchange error: ${e}", ("e", err));
          appbase::app().quit();
          error = true;

--- a/programs/rodeos/streams/rabbitmq.hpp
+++ b/programs/rodeos/streams/rabbitmq.hpp
@@ -87,13 +87,19 @@ class rabbitmq : public stream_handler {
    void publish(const std::vector<char>& data, const eosio::name& routing_key) override {
       if (exchange_name_.empty()) {
          if( publish_immediately_ ) {
-            amqp_publisher_->publish_message_direct( queue_name_, std::string(), data );
+            amqp_publisher_->publish_message_direct( queue_name_, std::string(), data,
+                                                     []( const std::string& err ) {
+                                                        elog( "AMQP direct message error: ${e}", ("e", err) );
+                                                     } );
          } else {
             queue_.emplace_back( std::make_pair( queue_name_, data ) );
          }
       } else {
          if( publish_immediately_ ) {
-            amqp_publisher_->publish_message_direct( routing_key.to_string(), std::string(), data );
+            amqp_publisher_->publish_message_direct( routing_key.to_string(), std::string(), data,
+                                                     []( const std::string& err ) {
+                                                        elog( "AMQP direct message error: ${e}", ("e", err) );
+                                                     } );
          } else {
             queue_.emplace_back( std::make_pair( routing_key.to_string(), data ) );
          }

--- a/programs/rodeos/streams/rabbitmq.hpp
+++ b/programs/rodeos/streams/rabbitmq.hpp
@@ -79,13 +79,13 @@ class rabbitmq : public stream_handler {
    void publish(const std::vector<char>& data, const eosio::name& routing_key) override {
       if (exchange_name_.empty()) {
          if( publish_immediately_ ) {
-            amqp_publisher_->publish_message_direct( queue_name_, data );
+            amqp_publisher_->publish_message_direct( queue_name_, std::string(), data );
          } else {
             queue_.emplace_back( std::make_pair( queue_name_, data ) );
          }
       } else {
          if( publish_immediately_ ) {
-            amqp_publisher_->publish_message_direct( routing_key.to_string(), data );
+            amqp_publisher_->publish_message_direct( routing_key.to_string(), std::string(), data );
          } else {
             queue_.emplace_back( std::make_pair( routing_key.to_string(), data ) );
          }


### PR DESCRIPTION
## Change Description

Add reliability options to `amqp_trx_plugin` & `amqp_trace_plugin`

- `amqp_trace_plugin` now has configurable reliability via  `amqp-trace-reliable-mode`
  - Reliable mode 'exit', exit application on any AMQP publish error.
  - Reliable mode 'queue', queue transaction traces to send to AMQP on connection establishment.
  - Reliable mode 'log', log an error and drop message when unable to directly publish to AMQP.
- `amqp_trace_plugin` now has configurable queue via `amqp-trace-queue-name` option.
- `amqp_trx_plugin` now has configurable queue via `amqp-trx-queue-name` option.
- Added correlation_id and error callback support to `reliable_amqp_publisher`.
- `reliable_amqp_publisher` now calls `on_fatal_error` callback instead of dropping messages which in all cases calls `app().quit()` now.
- Modified `amqp_handler` to use `single_channel_retrying_amqp_connection` to provide reliability and to move away from unsupported `AMQP::LibBoostAsioHandler`.

Note: A follow-on PR is planned that will separate `amqp_trace_plugin` from `amqp_trx_plugin`.

## Change Type
**Select *ONE*:**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [ ] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [x] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the release notes. Please include a description of the change for inclusion in the release notes. -->


## Testing Changes
**Select *ANY* that apply:**
- [ ] New Tests
<!-- checked [x] = new test cases were added; unchecked [ ] = no new test cases -->
- [ ] Existing Tests
<!-- checked [x] = existing test cases were edited; unchecked [ ] = no existing tests were modified -->
- [ ] Test Framework
<!-- checked [x] = this modifies the test framework; unchecked [ ] = no test framework changes -->
- [ ] CI System
<!-- checked [x] = this changes the CI system; unchecked [ ] = no CI changes -->
- [ ] Other
<!-- checked [x] = this integrates an external test system; unchecked [ ] = no miscellaneous test-related changes -->
<!-- Please describe your test changes, or list each new test and its purpose, under each respective checkbox -->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [x] Documentation Additions

  --amqp-trace-queue-name arg (=trace)  AMQP queue to publish transaction
                                        traces.
  --amqp-trace-reliable-mode arg (=queue)
                                        Reliable mode 'exit', exit application
                                        on any AMQP publish error.
                                        Reliable mode 'queue', queue
                                        transaction traces to send to AMQP on
                                        connection establishment.
                                        Reliable mode 'log', log an error and
                                        drop message when unable to directly
                                        publish to AMQP.

  --amqp-trx-queue-name arg (=trx)      AMQP queue to consume transactions
                                        from.