### PR TITLE
Wlb/adding nodeos param tests 2.0.x

### DIFF
--- a/.cicd/generate-pipeline.sh
+++ b/.cicd/generate-pipeline.sh
@@ -223,6 +223,9 @@ EOF
             - 'registry_2'
       - EOSIO/skip-checkout#v0.1.1:
           cd: ~
+    env:
+      IMAGE_TAG: $(echo "$PLATFORM_JSON" | jq -r .FILE_NAME)
+      PLATFORM_TYPE: $PLATFORM_TYPE
     agents: "queue=mac-anka-node-fleet"
     retry:
       manual:

--- a/pipeline.jsonc
+++ b/pipeline.jsonc
@@ -35,6 +35,7 @@
             "170=v1.7.0"
         ]
     },
+    // eosio-resume-from-state documentation: https://github.com/EOSIO/auto-eks-sync-nodes/blob/master/pipelines/eosio-resume-from-state/README.md
     "eosio-resume-from-state":
     {
         "test":

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -50,6 +50,8 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/db_modes_test.sh ${CMAKE_CURRENT_BINA
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/prod_preactivation_test.py ${CMAKE_CURRENT_BINARY_DIR}/prod_preactivation_test.py COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/release-build.sh ${CMAKE_CURRENT_BINARY_DIR}/release-build.sh COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/version-label.sh ${CMAKE_CURRENT_BINARY_DIR}/version-label.sh COPYONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/full-version-label.sh ${CMAKE_CURRENT_BINARY_DIR}/full-version-label.sh COPYONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/print-build-info.sh ${CMAKE_CURRENT_BINARY_DIR}/print-build-info.sh COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/nodeos_producer_watermark_test.py ${CMAKE_CURRENT_BINARY_DIR}/nodeos_producer_watermark_test.py COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cli_test.py ${CMAKE_CURRENT_BINARY_DIR}/cli_test.py COPYONLY)
 
@@ -94,6 +96,8 @@ add_test(NAME db_modes_test COMMAND tests/db_modes_test.sh WORKING_DIRECTORY ${C
 set_tests_properties(db_modes_test PROPERTIES COST 6000)
 add_test(NAME release-build-test COMMAND tests/release-build.sh WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 add_test(NAME version-label-test COMMAND tests/version-label.sh WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+add_test(NAME full-version-label-test COMMAND tests/full-version-label.sh WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+add_test(NAME print-build-info-test COMMAND tests/print-build-info.sh WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 
 # Long running tests
 add_test(NAME nodeos_sanity_lr_test COMMAND tests/nodeos_run_test.py -v --sanity-test --clean-run --dump-error-detail WORKING_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/tests/full-version-label.sh
+++ b/tests/full-version-label.sh
@@ -60,7 +60,13 @@ EXPECTED=$EXPECTED-$VERSION_HASH
 echo "Expecting \"$EXPECTED\"..."
 # get nodeos version
 ACTUAL=$($EOSIO_ROOT/build/bin/nodeos --full-version)
-# test
+EXIT_CODE=$?
+# verify 0 exit code explicitly
+if [[ $EXIT_CODE -ne 0 ]]; then
+    echo "Nodeos produced non-zero exit code \"$EXIT_CODE\"."
+    exit $EXIT_CODE
+fi
+# test version
 if [[ "$EXPECTED" == "$ACTUAL" ]]; then
     echo "Passed with \"$ACTUAL\"."
     exit 0

--- a/tests/full-version-label.sh
+++ b/tests/full-version-label.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# The purpose of this test is to ensure that the output of the "nodeos --version" command matches the version string defined by our CMake files
-echo '##### Nodeos Version Label Test #####'
+# The purpose of this test is to ensure that the output of the "nodeos --full-version" command matches the version string defined by our CMake files
+echo '##### Nodeos Full Version Label Test #####'
 # orient ourselves
 [[ "$EOSIO_ROOT" == '' ]] && EOSIO_ROOT=$(echo $(pwd)/ | grep -ioe '.*/eos/')
 [[ "$EOSIO_ROOT" == '' ]] && EOSIO_ROOT=$(echo $(pwd)/ | grep -ioe '.*/EOSIO/eosio/')
@@ -28,7 +28,7 @@ elif [[ -f "$CMAKE_LISTS" ]]; then
     EXPECTED="v$VERSION_FULL"
 fi
 # fail if no expected value was found
-if [[ "$EXPECTED" == '' ]]; then
+if [[ -z "$EXPECTED" ]]; then
     echo 'ERROR: Could not determine expected value for version label!'
     set +e
     echo "EOSIO_ROOT=\"$EOSIO_ROOT\""
@@ -51,12 +51,18 @@ if [[ "$EXPECTED" == '' ]]; then
     ls -la "$EOSIO_ROOT/build"
     exit 1
 fi
+VERSION_HASH=$(grep -Irn version_hash $EOSIO_ROOT/build/libraries/version | grep std::string | sed 's/^.\+"\([a-f0-9]\+\)".\+$/\1/')
+if [[ -z "$VERSION_HASH" ]]; then
+    echo 'No version hash found.'
+    exit 1
+fi
+EXPECTED=$EXPECTED-$VERSION_HASH
 echo "Expecting \"$EXPECTED\"..."
 # get nodeos version
-ACTUAL=$($EOSIO_ROOT/build/bin/nodeos --version) || : # nodeos currently returns -1 for --version
+ACTUAL=$($EOSIO_ROOT/build/bin/nodeos --full-version)
 # test
 if [[ "$EXPECTED" == "$ACTUAL" ]]; then
-    echo 'Passed with \"$ACTUAL\".'
+    echo "Passed with \"$ACTUAL\"."
     exit 0
 fi
 echo 'Failed!'

--- a/tests/full-version-label.sh
+++ b/tests/full-version-label.sh
@@ -51,11 +51,7 @@ if [[ -z "$EXPECTED" ]]; then
     ls -la "$EOSIO_ROOT/build"
     exit 1
 fi
-VERSION_HASH=$BUILDKITE_COMMIT
-if [[ -z "$VERSION_HASH" ]]; then
-    echo 'No version hash found.'
-    exit 1
-fi
+[[ -z "$BUILDKITE_COMMIT" ]] && VERSION_HASH="$(git rev-parse HEAD 2>/dev/null || :)" || VERSION_HASH=$BUILDKITE_COMMIT
 EXPECTED=$EXPECTED-$VERSION_HASH
 echo "Expecting \"$EXPECTED\"..."
 # get nodeos version

--- a/tests/full-version-label.sh
+++ b/tests/full-version-label.sh
@@ -51,7 +51,7 @@ if [[ -z "$EXPECTED" ]]; then
     ls -la "$EOSIO_ROOT/build"
     exit 1
 fi
-VERSION_HASH=$(grep -Irn version_hash $EOSIO_ROOT/build/libraries/version | grep std::string | sed 's/^.\+"\([a-f0-9]\+\)".\+$/\1/')
+VERSION_HASH=$BUILDKITE_COMMIT
 if [[ -z "$VERSION_HASH" ]]; then
     echo 'No version hash found.'
     exit 1

--- a/tests/full-version-label.sh
+++ b/tests/full-version-label.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -eo pipefail
 # The purpose of this test is to ensure that the output of the "nodeos --full-version" command matches the version string defined by our CMake files
 echo '##### Nodeos Full Version Label Test #####'
 # orient ourselves

--- a/tests/print-build-info.sh
+++ b/tests/print-build-info.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # The purpose of this test is to ensure that the output of the "nodeos --print-build-info" command.
+# This includes verifying valid output in JSON shape and checking parameters (only boost for now).
 echo '##### Nodeos Print Build Info Test #####'
 # orient ourselves
 [[ "$EOSIO_ROOT" == '' ]] && EOSIO_ROOT=$(echo $(pwd)/ | grep -ioe '.*/eos/')

--- a/tests/print-build-info.sh
+++ b/tests/print-build-info.sh
@@ -16,8 +16,8 @@ if [[ $EXIT_CODE -eq 0 ]]; then
 fi
 
 OUTPUT=$(echo "$OUTPUT" | tr -d '\r\n')
-OUTPUT=$(echo "$OUTPUT" | sed 's/^.\+JSON://')
-OUTPUT=$(echo "$OUTPUT" | sed 's/}.\+$/}/')
+OUTPUT=$(echo "$OUTPUT" | sed -E 's/^.+JSON://')
+OUTPUT=$(echo "$OUTPUT" | sed -E 's/}.+$/}/')
 
 JQ_OUTPUT=$(echo "$OUTPUT" | jq type)
 EXIT_CODE=$?
@@ -48,10 +48,10 @@ if [[ "$PLATFORM_TYPE" == "pinned" ]]; then
         exit 1
     fi
     FILE=$(ls $EOSIO_ROOT/.cicd/platforms/pinned/$IMAGE_TAG* | head)
-    BOOST=$(cat $FILE | grep boost | tr -d '\r\n' | sed 's/^.\+boost_\([0-9_]\+\) .\+$/\1/' | head)
-    BOOST_MAJOR=$(echo $BOOST | sed 's/^\([0-9]\)\+_[0-9]\+_[0-9]\+$/\1/')
-    BOOST_MINOR=$(echo $BOOST | sed 's/^[0-9]\+_\([0-9]\+\)_[0-9]\+$/\1/')
-    BOOST_PATCH=$(echo $BOOST | sed 's/^[0-9]\+_[0-9]\+_\([0-9]\)\+$/\1/')
+    BOOST=$(cat $FILE | grep boost | tr -d '\r\n' | sed -E 's/^.+boost_([0-9]+_[0-9]+_[0-9]+).+$/\1/' | head)
+    BOOST_MAJOR=$(echo $BOOST | sed -E 's/^([0-9])+_[0-9]+_[0-9]+$/\1/')
+    BOOST_MINOR=$(echo $BOOST | sed -E 's/^[0-9]+_([0-9]+)_[0-9]+$/\1/')
+    BOOST_PATCH=$(echo $BOOST | sed -E 's/^[0-9]+_[0-9]+_([0-9])+$/\1/')
     E_BOOST=$(printf "%d%03d%02d" $BOOST_MAJOR $BOOST_MINOR $BOOST_PATCH)
 
     echo "Verifying boost version: \"$E_BOOST\" == \"$V_BOOST\"."

--- a/tests/print-build-info.sh
+++ b/tests/print-build-info.sh
@@ -1,59 +1,65 @@
 #!/bin/bash
-# The purpose of this test is to ensure that the output of the "nodeos --print-build-info" command matches the version string defined by our CMake files
-echo '##### Nodeos Version Label Test #####'
+# The purpose of this test is to ensure that the output of the "nodeos --print-build-info" command.
+echo '##### Nodeos Print Build Info Test #####'
 # orient ourselves
 [[ "$EOSIO_ROOT" == '' ]] && EOSIO_ROOT=$(echo $(pwd)/ | grep -ioe '.*/eos/')
 [[ "$EOSIO_ROOT" == '' ]] && EOSIO_ROOT=$(echo $(pwd)/ | grep -ioe '.*/EOSIO/eosio/')
 [[ "$EOSIO_ROOT" == '' ]] && EOSIO_ROOT=$(echo $(pwd)/ | grep -ioe '.*/build/' | sed 's,/build/,,')
 echo "Using EOSIO_ROOT=\"$EOSIO_ROOT\"."
-# determine expected value
-BUILD_VARS="$EOSIO_ROOT/scripts/.build_vars"
-if [[ -f "$BUILD_VARS" ]]; then
-    echo "Parsing \"$BUILD_VARS\"..."
-    $(cat $BUILD_VARS | grep -ie 'export BOOST_VERSION_MAJOR' | cut -d '(' -f 2 | cut -d ')' -f 1 | awk '{print $1" "$2}')
-    $(cat $BUILD_VARS | grep -ie 'export BOOST_VERSION_MINOR' | cut -d '(' -f 2 | cut -d ')' -f 1 | awk '{print $1" "$2}')
-    $(cat $BUILD_VARS | grep -ie 'export BOOST_VERSION_PATCH' | cut -d '(' -f 2 | cut -d ')' -f 1 | awk '{print $1" "$2}')
-    EXPECTED_BOOST_VERSION=$(printf "%d%03d%02d" $BOOST_VERSION_MAJOR $BOOST_VERSION_MINOR $BOOST_VERSION_PATCH)
-else
-    echo 'No build vars available.'
-    exit 1
-fi
-# fail if no expected value was found
-if [[ -z "$BOOST_VERSION_MAJOR" || -z "$BOOST_VERSION_MINOR" || -z "$BOOST_VERSION_PATCH" ]]; then
-    echo 'ERROR: Could not determine expected value for version label!'
-    set +e
-    echo "EOSIO_ROOT=\"$EOSIO_ROOT\""
-    echo "BUILD_VARS=\"$BUILD_VARS\""
-    echo ''
-    echo "BOOST_VERSION_MAJOR=\"$BOOST_VERSION_MAJOR\""
-    echo "BOOST_VERSION_MINOR=\"$BOOST_VERSION_MINOR\""
-    echo "BOOST_VERSION_PATCH=\"$BOOST_VERSION_PATCH\""
-    echo "EXPECTED_BOOST_VERSION=\"$EXPECTED_BOOST_VERSION\""
-    echo ''
-    echo '$ pwd'
-    pwd
-    echo '$ ls -la "$EOSIO_ROOT"'
-    ls -la "$EOSIO_ROOT"
-    echo '$ ls -la "$EOSIO_ROOT/build"'
-    ls -la "$EOSIO_ROOT/build"
-    exit 1
-fi
 
 OUTPUT=$($EOSIO_ROOT/build/bin/nodeos --print-build-info 2>&1)
-if [[ $? -eq 0 ]]; then
+EXIT_CODE=$?
+echo "$OUTPUT"
+if [[ $EXIT_CODE -eq 0 ]]; then
     echo 'Expected non-zero nodeos exit code.'
     exit 1
 fi
 
-JSON=$(echo $OUTPUT | tr -d '\r\n' | sed 's/^.\+ JSON: \({ .\+ }\).\+$/\1/')
-ACTUAL_BOOST_VERSION=$(echo $JSON | sed 's/^.\+"boost_version": \([0-9]\+\).\+$/\1/')
+OUTPUT=$(echo "$OUTPUT" | tr -d '\r\n')
+OUTPUT=$(echo "$OUTPUT" | sed 's/^.\+JSON://')
+OUTPUT=$(echo "$OUTPUT" | sed 's/}.\+$/}/')
 
-echo "Expecting boost version \"$EXPECTED_BOOST_VERSION\"..."
-if [[ "$EXPECTED_BOOST_VERSION" == "$ACTUAL_BOOST_VERSION" ]]; then
-    echo "Passed with \"$ACTUAL_BOOST_VERSION\"."
-    exit 0;
+JQ_OUTPUT=$(echo "$OUTPUT" | jq type)
+EXIT_CODE=$?
+if [[ "$EXIT_CODE" -ne 0 ]]; then
+    echo "Not valid JSON type."
+    exit $EXIT_CODE
 fi
 
-echo 'Failed!'
-echo "\"$EXPECTED_BOOST_VERSION\" != \"$ACTUAL_BOOST_VERSION\""
-exit 1
+V_ARCH=$(echo "$OUTPUT" | jq '.arch')
+echo "ARCH: $V_ARCH"
+V_BOOST=$(echo "$OUTPUT" | jq '.boost_version')
+echo "BOOST_VERSION: $V_BOOST"
+V_COMPILER=$(echo "$OUTPUT" | jq '.compiler')
+echo "COMPILER: $V_COMPILER"
+V_DEBUG=$(echo "$OUTPUT" | jq '.debug')
+echo "DEBUG: $V_DEBUG"
+V_OS=$(echo "$OUTPUT" | jq '.os')
+echo "OS: $V_OS"
+
+if [[ -z "$V_ARCH" || -z "$V_BOOST" || -z "$V_COMPILER" || -z "$V_DEBUG" || -z "$V_OS" ]]; then
+    echo "Missing expected build info key(s)."
+    exit 1
+fi
+
+if [[ "$PLATFORM_TYPE" == "pinned" ]]; then
+    if [[ -z "$IMAGE_TAG" ]]; then
+        echo "Missing IMAGE_TAG variable."
+        exit 1
+    fi
+    FILE=$(ls $EOSIO_ROOT/.cicd/platforms/pinned/$IMAGE_TAG* | head)
+    BOOST=$(cat $FILE | grep boost | tr -d '\r\n' | sed 's/^.\+boost_\([0-9_]\+\) .\+$/\1/' | head)
+    BOOST_MAJOR=$(echo $BOOST | sed 's/^\([0-9]\)\+_[0-9]\+_[0-9]\+$/\1/')
+    BOOST_MINOR=$(echo $BOOST | sed 's/^[0-9]\+_\([0-9]\+\)_[0-9]\+$/\1/')
+    BOOST_PATCH=$(echo $BOOST | sed 's/^[0-9]\+_[0-9]\+_\([0-9]\)\+$/\1/')
+    E_BOOST=$(printf "%d%03d%02d" $BOOST_MAJOR $BOOST_MINOR $BOOST_PATCH)
+
+    echo "Verifying boost version: \"$E_BOOST\" == \"$V_BOOST\"."
+    if [[ "$E_BOOST" != "$V_BOOST" ]]; then
+        echo "Expected boost version \"$E_BOOST\" does not match actual \"$V_BOOST\"."
+        exit 1
+    fi
+fi
+
+echo "Validation of build info complete."
+exit 0

--- a/tests/print-build-info.sh
+++ b/tests/print-build-info.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# The purpose of this test is to ensure that the output of the "nodeos --print-build-info" command matches the version string defined by our CMake files
+# If the environment variable BUILDKITE_TAG is empty or unset, this test will echo success
+echo '##### Nodeos Version Label Test #####'
+if [[ "$BUILDKITE_TAG" == '' || "$BUILDKITE" != 'true' ]]; then
+    echo 'This test is only run in Buildkite against tagged builds.'
+    [[ "$BUILDKITE" != 'true' ]] && echo 'This is not Buildkite.'
+    [[ "$BUILDKITE_TAG" == '' ]] && echo 'This is not a tagged build.'
+    echo 'Exiting...'
+    exit 0
+fi
+echo 'Tagged build detected, running test.'
+# orient ourselves
+[[ "$EOSIO_ROOT" == '' ]] && EOSIO_ROOT=$(echo $(pwd)/ | grep -ioe '.*/eos/')
+[[ "$EOSIO_ROOT" == '' ]] && EOSIO_ROOT=$(echo $(pwd)/ | grep -ioe '.*/EOSIO/eosio/')
+[[ "$EOSIO_ROOT" == '' ]] && EOSIO_ROOT=$(echo $(pwd)/ | grep -ioe '.*/build/' | sed 's,/build/,,')
+echo "Using EOSIO_ROOT=\"$EOSIO_ROOT\"."
+# determine expected value
+BUILD_VARS="$EOSIO_ROOT/scripts/.build_vars"
+if [[ -f "$BUILD_VARS" ]]; then
+    echo "Parsing \"$BUILD_VARS\"..."
+    $(cat $BUILD_VARS | grep -ie 'export BOOST_VERSION_MAJOR' | cut -d '(' -f 2 | cut -d ')' -f 1 | awk '{print $1" "$2}')
+    $(cat $BUILD_VARS | grep -ie 'export BOOST_VERSION_MINOR' | cut -d '(' -f 2 | cut -d ')' -f 1 | awk '{print $1" "$2}')
+    $(cat $BUILD_VARS | grep -ie 'export BOOST_VERSION_PATCH' | cut -d '(' -f 2 | cut -d ')' -f 1 | awk '{print $1" "$2}')
+    EXPECTED_BOOST_VERSION=$(printf "%d%03d%02d" $BOOST_VERSION_MAJOR $BOOST_VERSION_MINOR $BOOST_VERSION_PATCH)
+else
+    echo 'No build vars available.'
+    exit 1
+fi
+# fail if no expected value was found
+if [[ -z "$BOOST_VERSION_MAJOR" || -z "$BOOST_VERSION_MINOR" || -z "$BOOST_VERSION_PATCH" ]]; then
+    echo 'ERROR: Could not determine expected value for version label!'
+    set +e
+    echo "EOSIO_ROOT=\"$EOSIO_ROOT\""
+    echo "BUILD_VARS=\"$BUILD_VARS\""
+    echo ''
+    echo "BOOST_VERSION_MAJOR=\"$BOOST_VERSION_MAJOR\""
+    echo "BOOST_VERSION_MINOR=\"$BOOST_VERSION_MINOR\""
+    echo "BOOST_VERSION_PATCH=\"$BOOST_VERSION_PATCH\""
+    echo "EXPECTED_BOOST_VERSION=\"$EXPECTED_BOOST_VERSION\""
+    echo ''
+    echo '$ pwd'
+    pwd
+    echo '$ ls -la "$EOSIO_ROOT"'
+    ls -la "$EOSIO_ROOT"
+    echo '$ ls -la "$EOSIO_ROOT/build"'
+    ls -la "$EOSIO_ROOT/build"
+    exit 1
+fi
+
+OUTPUT=$($EOSIO_ROOT/build/bin/nodeos --print-build-info 2>&1)
+if [[ $? -eq 0 ]]; then
+    echo 'Expected non-zero nodeos exit code.'
+    exit 1
+fi
+
+JSON=$(echo $OUTPUT | tr -d '\r\n' | sed 's/^.\+ JSON: \({ .\+ }\).\+$/\1/')
+ACTUAL_BOOST_VERSION=$(echo $JSON | sed 's/^.\+"boost_version": \([0-9]\+\).\+$/\1/')
+
+echo "Expecting boost version \"$EXPECTED_BOOST_VERSION\"..."
+if [[ "$EXPECTED_BOOST_VERSION" == "$ACTUAL_BOOST_VERSION" ]]; then
+    echo "Passed with \"$ACTUAL_BOOST_VERSION\"."
+    exit 0;
+fi
+
+echo 'Failed!'
+echo "\"$EXPECTED_BOOST_VERSION\" != \"$ACTUAL_BOOST_VERSION\""
+exit 1

--- a/tests/print-build-info.sh
+++ b/tests/print-build-info.sh
@@ -1,15 +1,6 @@
 #!/bin/bash
 # The purpose of this test is to ensure that the output of the "nodeos --print-build-info" command matches the version string defined by our CMake files
-# If the environment variable BUILDKITE_TAG is empty or unset, this test will echo success
 echo '##### Nodeos Version Label Test #####'
-if [[ "$BUILDKITE_TAG" == '' || "$BUILDKITE" != 'true' ]]; then
-    echo 'This test is only run in Buildkite against tagged builds.'
-    [[ "$BUILDKITE" != 'true' ]] && echo 'This is not Buildkite.'
-    [[ "$BUILDKITE_TAG" == '' ]] && echo 'This is not a tagged build.'
-    echo 'Exiting...'
-    exit 0
-fi
-echo 'Tagged build detected, running test.'
 # orient ourselves
 [[ "$EOSIO_ROOT" == '' ]] && EOSIO_ROOT=$(echo $(pwd)/ | grep -ioe '.*/eos/')
 [[ "$EOSIO_ROOT" == '' ]] && EOSIO_ROOT=$(echo $(pwd)/ | grep -ioe '.*/EOSIO/eosio/')

--- a/tests/version-label.sh
+++ b/tests/version-label.sh
@@ -53,8 +53,14 @@ if [[ "$EXPECTED" == '' ]]; then
 fi
 echo "Expecting \"$EXPECTED\"..."
 # get nodeos version
-ACTUAL=$($EOSIO_ROOT/build/bin/nodeos --version) || : # nodeos currently returns -1 for --version
-# test
+ACTUAL=$($EOSIO_ROOT/build/bin/nodeos --version)
+EXIT_CODE=$?
+# verify 0 exit code explicitly
+if [[ $EXIT_CODE -ne 0 ]]; then
+    echo "Nodeos produced non-zero exit code \"$EXIT_CODE\"."
+    exit $EXIT_CODE
+fi
+# test version
 if [[ "$EXPECTED" == "$ACTUAL" ]]; then
     echo "Passed with \"$ACTUAL\"."
     exit 0

--- a/tests/version-label.sh
+++ b/tests/version-label.sh
@@ -56,7 +56,7 @@ echo "Expecting \"$EXPECTED\"..."
 ACTUAL=$($EOSIO_ROOT/build/bin/nodeos --version) || : # nodeos currently returns -1 for --version
 # test
 if [[ "$EXPECTED" == "$ACTUAL" ]]; then
-    echo 'Passed with \"$ACTUAL\".'
+    echo "Passed with \"$ACTUAL\"."
     exit 0
 fi
 echo 'Failed!'

--- a/tests/version-label.sh
+++ b/tests/version-label.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -eo pipefail
 # The purpose of this test is to ensure that the output of the "nodeos --version" command matches the version string defined by our CMake files
 echo '##### Nodeos Version Label Test #####'
 # orient ourselves


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->
## Change Description

Adding tests for `nodeos` parameters `--full-version` and `--print-build-info`.

Test for `--print-build-info` checks `boost_version`. I had originally planned to check the `compiler` output also, but it was a little less intuitive.

Output from the unit tests taken from Mac 10.14 https://buildkite.com/EOSIO/eosio/builds/27460#94aa4efc-0891-4ba4-95e5-1fa62e276da5 which I checked specifically because of needing to and the env parameters.

```
test 103
--
  | Start 103: version-label-test
  |  
  | 103: Test command: /Users/anka/eos/build/tests/version-label.sh
  | 103: Test timeout computed to be: 1500
  | 103: ##### Nodeos Version Label Test #####
  | 103: Using EOSIO_ROOT="/Users/anka/eos/".
  | 103: Parsing "/Users/anka/eos//build/CMakeCache.txt"...
  | 103: Expecting "v2.0.10"...
  | 103: Passed with "v2.0.10".
  | 89/92 Test #103: version-label-test .................................   Passed    0.03 sec
  | test 104
  | Start 104: full-version-label-test
  |  
  | 104: Test command: /Users/anka/eos/build/tests/full-version-label.sh
  | 104: Test timeout computed to be: 1500
  | 104: ##### Nodeos Full Version Label Test #####
  | 104: Using EOSIO_ROOT="/Users/anka/eos/".
  | 104: Parsing "/Users/anka/eos//build/CMakeCache.txt"...
  | 104: Expecting "v2.0.10-8a46d87e01d28b365f78e8ab00f48ee0d21a5927"...
  | 104: Passed with "v2.0.10-8a46d87e01d28b365f78e8ab00f48ee0d21a5927".
  | 90/92 Test #104: full-version-label-test ............................   Passed    0.03 sec
  | test 105
  | Start 105: print-build-info-test
  |  
  | 105: Test command: /Users/anka/eos/build/tests/print-build-info.sh
  | 105: Test timeout computed to be: 1500
  | 105: ##### Nodeos Print Build Info Test #####
  | 105: Using EOSIO_ROOT="/Users/anka/eos/".
  | 105: $ /Users/anka/eos//build/bin/nodeos --print-build-info 2>&1 \| tee >(cat - >&9) \|\| :
  | 105: info  2021-03-15T22:04:17.056 thread-0  chain_plugin.cpp:628          plugin_initialize    ] initializing chain plugin
  | 105: info  2021-03-15T22:04:17.056 thread-0  chain_plugin.cpp:643          plugin_initialize    ] Build environment JSON:
  | 105: {
  | 105:   "debug": false,
  | 105:   "os": "OS_MACOS",
  | 105:   "arch": "ARCH_X86_64",
  | 105:   "boost_version": 107100,
  | 105:   "compiler": "4.2.1 Compatible Clang 8.0.1 (https://git.llvm.org/git/clang.git a03da8be08a208122e292016cb6cea1f30229677) (https://git.llvm.org/git/llvm.git 18e41dc964f916504ec90dba523826ac74d235c4)"
  | 105: }
  | 105: warn  2021-03-15T22:04:17.057 thread-0  chain_plugin.cpp:1138         plugin_initialize    ] 3100009 node_management_success: Node management operation successfully executed
  | 105: reported build environment information
  | 105:     {}
  | 105:     thread-0  chain_plugin.cpp:660 plugin_initialize
  | 105:
  | 105: Failed to initialize
  | 105: ARCH: "ARCH_X86_64"
  | 105: BOOST_VERSION: 107100
  | 105: COMPILER: "4.2.1 Compatible Clang 8.0.1 (https://git.llvm.org/git/clang.git a03da8be08a208122e292016cb6cea1f30229677) (https://git.llvm.org/git/llvm.git 18e41dc964f916504ec90dba523826ac74d235c4)"
  | 105: DEBUG: false
  | 105: OS: "OS_MACOS"
  | 105: Verifying boost version: "107100" == "107100".
  | 105: Validation of build info complete.
  | 91/92 Test #105: print-build-info-test ..............................   Passed    0.20 sec
```


## Change Type
**Select *ONE*:**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [ ] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [x] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the release notes. Please include a description of the change for inclusion in the release notes. -->


## Testing Changes
**Select *ANY* that apply:**
- [x] New Tests
<!-- checked [x] = new test cases were added; unchecked [ ] = no new test cases -->
- [x] Existing Tests
<!-- checked [x] = existing test cases were edited; unchecked [ ] = no existing tests were modified -->
- [ ] Test Framework
<!-- checked [x] = this modifies the test framework; unchecked [ ] = no test framework changes -->
- [ ] CI System
<!-- checked [x] = this changes the CI system; unchecked [ ] = no CI changes -->
- [ ] Other
<!-- checked [x] = this integrates an external test system; unchecked [ ] = no miscellaneous test-related changes -->
<!-- Please describe your test changes, or list each new test and its purpose, under each respective checkbox -->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
