### PR TITLE
Separate amqp_trx_plugin from amqp_trace_plugin

### DIFF
--- a/libraries/amqp/include/eosio/amqp/amqp_handler.hpp
+++ b/libraries/amqp/include/eosio/amqp/amqp_handler.hpp
@@ -22,7 +22,7 @@ public:
    // delivery_tag type of consume, use for ack/reject
    using delivery_tag_t = uint64_t;
    // called from amqp thread on consume of message
-   using on_consume_t = std::function<void(const AMQP::Message& message, const delivery_tag_t& delivery_tag, bool redelivered)>;
+   using on_consume_t = std::function<void(const AMQP::Message& message, delivery_tag_t delivery_tag, bool redelivered)>;
 
    /// @param address AMQP address
    /// @param name AMQP routing key
@@ -229,9 +229,8 @@ private:
          on_error( message );
          first_connect_.set();
       } );
-      consumer.onReceived( [&](const AMQP::Message& message, const delivery_tag_t& delivery_tag, bool redelivered) {
-         on_consume_( message, delivery_tag, redelivered );
-      } );
+      static_assert( std::is_same_v<on_consume_t, AMQP::MessageCallback>, "AMQP::MessageCallback interface changed" );
+      consumer.onReceived( on_consume_ );
    }
 
    // called from amqp thread

--- a/libraries/amqp/include/eosio/amqp/amqp_handler.hpp
+++ b/libraries/amqp/include/eosio/amqp/amqp_handler.hpp
@@ -22,7 +22,7 @@ public:
    // delivery_tag type of consume, use for ack/reject
    using delivery_tag_t = uint64_t;
    // called from amqp thread on consume of message
-   using on_consume_t = std::function<void(const delivery_tag_t& delivery_tag, const char* buf, size_t s)>;
+   using on_consume_t = std::function<void(const AMQP::Message& message, const delivery_tag_t& delivery_tag, bool redelivered)>;
 
    /// @param address AMQP address
    /// @param name AMQP routing key
@@ -230,7 +230,7 @@ private:
          first_connect_.set();
       } );
       consumer.onReceived( [&](const AMQP::Message& message, const delivery_tag_t& delivery_tag, bool redelivered) {
-         on_consume_( delivery_tag, message.body(), message.bodySize() );
+         on_consume_( message, delivery_tag, redelivered );
       } );
    }
 

--- a/libraries/amqp/include/eosio/amqp/reliable_amqp_publisher.hpp
+++ b/libraries/amqp/include/eosio/amqp/reliable_amqp_publisher.hpp
@@ -47,9 +47,10 @@ class reliable_amqp_publisher {
       /// \param data message to send
       void publish_message_raw(std::vector<char>&& data);
 
+      /// \param routing_key if empty() uses class provided default routing_key
       /// \param correlation_id if not empty() sets as correlation id of the message envelope
       /// \param data message to send
-      void publish_message_raw(const std::string& correlation_id, std::vector<char>&& data);
+      void publish_message_raw(const std::string& routing_key, const std::string& correlation_id, std::vector<char>&& data);
 
       /// Publish messages. May be called from any thread.
       /// \param queue set of messages to send in one transaction <routing_key, message_data>

--- a/libraries/amqp/reliable_amqp_publisher.cpp
+++ b/libraries/amqp/reliable_amqp_publisher.cpp
@@ -29,7 +29,7 @@ struct reliable_amqp_publisher_impl {
    ~reliable_amqp_publisher_impl();
    void pump_queue();
    void publish_message_raw(std::vector<char>&& data);
-   void publish_message_raw(const std::string& correlation_id, std::vector<char>&& data);
+   void publish_message_raw(const std::string& routing_key, const std::string& correlation_id, std::vector<char>&& data);
    void publish_messages_raw(std::deque<std::pair<std::string, std::vector<char>>>&& queue);
    void publish_message_direct(const std::string& routing_key, const std::string& correlation_id,
                                std::vector<char> data, reliable_amqp_publisher::error_callback_t on_error);
@@ -221,17 +221,19 @@ void reliable_amqp_publisher_impl::publish_message_raw(std::vector<char>&& data)
    pump_queue();
 }
 
-void reliable_amqp_publisher_impl::publish_message_raw(const std::string& correlation_id, std::vector<char>&& data) {
+void reliable_amqp_publisher_impl::publish_message_raw(const std::string& routing_key,
+                                                       const std::string& correlation_id,
+                                                       std::vector<char>&& data) {
    if(!ctx.get_executor().running_in_this_thread()) {
-      boost::asio::post(user_submitted_work_strand, [this, d=std::move(data), id=correlation_id]() mutable {
-         publish_message_raw(id, std::move(d));
+      boost::asio::post(user_submitted_work_strand, [this, d=std::move(data), rk=routing_key, id=correlation_id]() mutable {
+         publish_message_raw(rk, id, std::move(d));
       });
       return;
    }
 
    if( !verify_max_queue_size() ) return;
 
-   message_deque.emplace_back(amqp_message{0, "", correlation_id, std::move(data)});
+   message_deque.emplace_back(amqp_message{0, routing_key, correlation_id, std::move(data)});
    pump_queue();
 }
 
@@ -291,8 +293,8 @@ void reliable_amqp_publisher::publish_message_raw(std::vector<char>&& data) {
    my->publish_message_raw( std::move( data ) );
 }
 
-void reliable_amqp_publisher::publish_message_raw(const std::string& correlation_id, std::vector<char>&& data) {
-   my->publish_message_raw( correlation_id, std::move( data ) );
+void reliable_amqp_publisher::publish_message_raw(const std::string& routing_key, const std::string& correlation_id, std::vector<char>&& data) {
+   my->publish_message_raw( routing_key, correlation_id, std::move( data ) );
 }
 
 void reliable_amqp_publisher::publish_messages_raw(std::deque<std::pair<std::string, std::vector<char>>>&& queue) {

--- a/plugins/amqp_trace_plugin/amqp_trace_plugin.cpp
+++ b/plugins/amqp_trace_plugin/amqp_trace_plugin.cpp
@@ -25,7 +25,7 @@ amqp_trace_plugin::amqp_trace_plugin()
 amqp_trace_plugin::~amqp_trace_plugin() {}
 
 void amqp_trace_plugin::publish_error( std::string tid, int64_t error_code, std::string error_message ) {
-   my->publish_error( std::move(tid), error_code, std::move(error_message) );
+   my->publish_error( std::string(), std::move(tid), error_code, std::move(error_message) );
 }
 
 void amqp_trace_plugin::set_program_options(options_description& cli, options_description& cfg) {

--- a/plugins/amqp_trace_plugin/include/eosio/amqp_trace_plugin/amqp_trace_plugin_impl.hpp
+++ b/plugins/amqp_trace_plugin/include/eosio/amqp_trace_plugin/amqp_trace_plugin_impl.hpp
@@ -18,21 +18,19 @@ struct amqp_trace_plugin_impl : std::enable_shared_from_this<amqp_trace_plugin_i
    std::string amqp_trace_address;
    std::string amqp_trace_queue_name;
    std::string amqp_trace_exchange;
-   reliable_mode pub_reliable_mode;
+   reliable_mode pub_reliable_mode = reliable_mode::queue;
    bool started = false;
 
 public:
 
    // called from any thread
-   void publish_error( std::string tid, int64_t error_code, std::string error_message );
+   void publish_error( std::string routing_key, std::string tid, int64_t error_code, std::string error_message );
 
    // called on application thread
    void on_applied_transaction(const chain::transaction_trace_ptr& trace, const chain::packed_transaction_ptr& t);
 
-private:
-
-   // called from application thread
-   void publish_result( const chain::packed_transaction_ptr& trx, const chain::transaction_trace_ptr& trace );
+   // called from any thread
+   void publish_result( std::string routing_key, const chain::packed_transaction_ptr& trx, const chain::transaction_trace_ptr& trace );
 };
 
 std::istream& operator>>(std::istream& in, amqp_trace_plugin_impl::reliable_mode& m);

--- a/plugins/amqp_trace_plugin/include/eosio/amqp_trace_plugin/amqp_trace_plugin_impl.hpp
+++ b/plugins/amqp_trace_plugin/include/eosio/amqp_trace_plugin/amqp_trace_plugin_impl.hpp
@@ -19,7 +19,6 @@ struct amqp_trace_plugin_impl : std::enable_shared_from_this<amqp_trace_plugin_i
    std::string amqp_trace_queue_name;
    std::string amqp_trace_exchange;
    reliable_mode pub_reliable_mode = reliable_mode::queue;
-   bool started = false;
 
 public:
 


### PR DESCRIPTION
## Change Description

- `amqp_trx_plugin` no longer depends on `amqp_trace_plugin` for sending transaction traces to AMQP. `amqp_trace_plugin` still exists and provides ability to send all transaction traces to AMQP. `amqp_trx_plugin` is setup to only send transaction traces for transactions that it processes.
- The AMQP reply-to-queue pattern is now used by `amqp_trx_plugin`. If a `reply-to` is sent with the transaction then the trace will be send to the AMQP default exchange connection with that `routing-key`. The `correlation-id` is set to the transaction id. If a `reply-to` is not specified then no trace is sent to AMQP.

## Change Type
**Select *ONE*:**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [ ] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [x] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the release notes. Please include a description of the change for inclusion in the release notes. -->


## Testing Changes
**Select *ANY* that apply:**
- [ ] New Tests
<!-- checked [x] = new test cases were added; unchecked [ ] = no new test cases -->
- [ ] Existing Tests
<!-- checked [x] = existing test cases were edited; unchecked [ ] = no existing tests were modified -->
- [ ] Test Framework
<!-- checked [x] = this modifies the test framework; unchecked [ ] = no test framework changes -->
- [ ] CI System
<!-- checked [x] = this changes the CI system; unchecked [ ] = no CI changes -->
- [ ] Other
<!-- checked [x] = this integrates an external test system; unchecked [ ] = no miscellaneous test-related changes -->
<!-- Please describe your test changes, or list each new test and its purpose, under each respective checkbox -->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [x] Documentation Additions

```
  --amqp-trx-trace-reliable-mode arg (=queue)
                                        Reliable mode 'exit', exit application
                                        on any AMQP publish error.
                                        Reliable mode 'queue', queue
                                        transaction traces to send to AMQP on
                                        connection establishment.
                                        Reliable mode 'log', log an error and
                                        drop message when unable to directly
                                        publish to AMQP.

```