### PR TITLE
Merge security fix PR#364 into release/2.1.x

### DIFF
--- a/plugins/chain_plugin/test/test_account_query_db.cpp
+++ b/plugins/chain_plugin/test/test_account_query_db.cpp
@@ -115,22 +115,22 @@ BOOST_AUTO_TEST_CASE(fork_test) { try {
       }
 
       // produce a block on node A with a new account and permission
-      const auto& tester_account = N(tester);
-      const auto& tester_account2 = N(tester2);
+      const auto& tester_account = "tester"_n;
+      const auto& tester_account2 = "tester2"_n;
       const string role = "first";
       node_a.create_account(tester_account);
       node_a.create_account(tester_account2);
 
       const auto trace_ptr = node_a.push_action(config::system_account_name, updateauth::get_name(), tester_account, fc::mutable_variant_object()
             ("account", tester_account)
-            ("permission", N(role))
+            ("permission", "role"_n)
             ("parent", "active")
             ("auth",  authority(node_a.get_public_key(tester_account, role), 5)), 1
       );
       aq_db.cache_transaction_trace(trace_ptr);
       const auto trace_ptr2 = node_a.push_action(config::system_account_name, updateauth::get_name(), tester_account2, fc::mutable_variant_object()
             ("account", tester_account2)
-            ("permission", N(role))
+            ("permission", "role"_n)
             ("parent", "active")
             ("auth",  authority(node_a.get_public_key(tester_account2, role), 5)), 2
       );
@@ -141,7 +141,7 @@ BOOST_AUTO_TEST_CASE(fork_test) { try {
       pars.keys.emplace_back(node_a.get_public_key(tester_account, role));
 
       const auto pre_results = aq_db.get_accounts_by_authorizers(pars);
-      BOOST_TEST_REQUIRE(find_account_auth(pre_results, tester_account, N(role)) == true);
+      BOOST_TEST_REQUIRE(find_account_auth(pre_results, tester_account, "role"_n) == true);
 
       // have node B take over from head-1 and also update permissions
       node_b.create_account(tester_account);
@@ -149,14 +149,14 @@ BOOST_AUTO_TEST_CASE(fork_test) { try {
 
       const auto trace_ptr3 = node_b.push_action(config::system_account_name, updateauth::get_name(), tester_account, fc::mutable_variant_object()
             ("account", tester_account)
-            ("permission", N(role))
+            ("permission", "role"_n)
             ("parent", "active")
             ("auth",  authority(node_b.get_public_key(tester_account, role), 6)), 1
       );
       aq_db.cache_transaction_trace(trace_ptr3);
       const auto trace_ptr4 = node_b.push_action(config::system_account_name, updateauth::get_name(), tester_account2, fc::mutable_variant_object()
             ("account", tester_account2)
-            ("permission", N(role))
+            ("permission", "role"_n)
             ("parent", "active")
             ("auth",  authority(node_b.get_public_key(tester_account2, role), 6)), 2
       );
@@ -167,14 +167,14 @@ BOOST_AUTO_TEST_CASE(fork_test) { try {
 
       const auto trace_ptr5 = node_b.push_action(config::system_account_name, updateauth::get_name(), tester_account, fc::mutable_variant_object()
             ("account", tester_account)
-            ("permission", N(role))
+            ("permission", "role"_n)
             ("parent", "active")
             ("auth",  authority(node_b.get_public_key(tester_account, role), 5)), 3
       );
       aq_db.cache_transaction_trace(trace_ptr5);
       const auto trace_ptr6 = node_b.push_action(config::system_account_name, updateauth::get_name(), tester_account2, fc::mutable_variant_object()
             ("account", tester_account2)
-            ("permission", N(role))
+            ("permission", "role"_n)
             ("parent", "active")
             ("auth",  authority(node_b.get_public_key(tester_account2, role), 5)), 4
       );

--- a/plugins/chain_plugin/test/test_account_query_db.cpp
+++ b/plugins/chain_plugin/test/test_account_query_db.cpp
@@ -97,5 +97,99 @@ BOOST_FIXTURE_TEST_CASE(updateauth_test, TESTER) { try {
 
 } FC_LOG_AND_RETHROW() }
 
+BOOST_AUTO_TEST_CASE(fork_test) { try {
+      tester node_a(setup_policy::none);
+      tester node_b(setup_policy::none);
+
+      // instantiate an account_query_db
+      auto aq_db = account_query_db(*node_a.control);
+
+      //link aq_db to the `accepted_block` signal on the controller
+      auto c = node_a.control->accepted_block.connect([&](const block_state_ptr& blk) {
+         aq_db.commit_block( blk);
+      });
+
+      // create 10 blocks synced
+      for (int i = 0; i < 10; i++) {
+         node_b.push_block(node_a.produce_block());
+      }
+
+      // produce a block on node A with a new account and permission
+      const auto& tester_account = N(tester);
+      const auto& tester_account2 = N(tester2);
+      const string role = "first";
+      node_a.create_account(tester_account);
+      node_a.create_account(tester_account2);
+
+      const auto trace_ptr = node_a.push_action(config::system_account_name, updateauth::get_name(), tester_account, fc::mutable_variant_object()
+            ("account", tester_account)
+            ("permission", N(role))
+            ("parent", "active")
+            ("auth",  authority(node_a.get_public_key(tester_account, role), 5)), 1
+      );
+      aq_db.cache_transaction_trace(trace_ptr);
+      const auto trace_ptr2 = node_a.push_action(config::system_account_name, updateauth::get_name(), tester_account2, fc::mutable_variant_object()
+            ("account", tester_account2)
+            ("permission", N(role))
+            ("parent", "active")
+            ("auth",  authority(node_a.get_public_key(tester_account2, role), 5)), 2
+      );
+      aq_db.cache_transaction_trace(trace_ptr2);
+      node_a.produce_block();
+
+      params pars;
+      pars.keys.emplace_back(node_a.get_public_key(tester_account, role));
+
+      const auto pre_results = aq_db.get_accounts_by_authorizers(pars);
+      BOOST_TEST_REQUIRE(find_account_auth(pre_results, tester_account, N(role)) == true);
+
+      // have node B take over from head-1 and also update permissions
+      node_b.create_account(tester_account);
+      node_b.create_account(tester_account2);
+
+      const auto trace_ptr3 = node_b.push_action(config::system_account_name, updateauth::get_name(), tester_account, fc::mutable_variant_object()
+            ("account", tester_account)
+            ("permission", N(role))
+            ("parent", "active")
+            ("auth",  authority(node_b.get_public_key(tester_account, role), 6)), 1
+      );
+      aq_db.cache_transaction_trace(trace_ptr3);
+      const auto trace_ptr4 = node_b.push_action(config::system_account_name, updateauth::get_name(), tester_account2, fc::mutable_variant_object()
+            ("account", tester_account2)
+            ("permission", N(role))
+            ("parent", "active")
+            ("auth",  authority(node_b.get_public_key(tester_account2, role), 6)), 2
+      );
+      aq_db.cache_transaction_trace(trace_ptr4);
+
+      // push b's onto a
+      node_a.push_block(node_b.produce_block());
+
+      const auto trace_ptr5 = node_b.push_action(config::system_account_name, updateauth::get_name(), tester_account, fc::mutable_variant_object()
+            ("account", tester_account)
+            ("permission", N(role))
+            ("parent", "active")
+            ("auth",  authority(node_b.get_public_key(tester_account, role), 5)), 3
+      );
+      aq_db.cache_transaction_trace(trace_ptr5);
+      const auto trace_ptr6 = node_b.push_action(config::system_account_name, updateauth::get_name(), tester_account2, fc::mutable_variant_object()
+            ("account", tester_account2)
+            ("permission", N(role))
+            ("parent", "active")
+            ("auth",  authority(node_b.get_public_key(tester_account2, role), 5)), 4
+      );
+      aq_db.cache_transaction_trace(trace_ptr6);
+
+      node_a.push_block(node_b.produce_block());
+
+      // ensure the account was forked away
+      const auto post_results = aq_db.get_accounts_by_authorizers(pars);
+
+      // verify correct account is in results
+      BOOST_TEST_REQUIRE(post_results.accounts.size() == 1);
+
+   } FC_LOG_AND_RETHROW() }
+
+
 BOOST_AUTO_TEST_SUITE_END()
 


### PR DESCRIPTION
- Fix issue with account query db that could result in incorrect data or hung processes
- change N(tester) to "tester"_n and N(role) to "role"_n

Co-Authored-By: Bart Wyatt bart.wyatt@block.one
Co-Authored-By: Kevin Heifner heifnerk@objectcomputing.com
Co-Authored-By: Lin Huang lin.huang@block.one

## Change Type
**Select *ONE*:**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [x] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [ ] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the release notes. Please include a description of the change for inclusion in the release notes. -->

## Testing Changes
**Select *ANY* that apply:**
- [x] New Tests
<!-- checked [x] = new test cases were added; unchecked [ ] = no new test cases -->
- [ ] Existing Tests
<!-- checked [x] = existing test cases were edited; unchecked [ ] = no existing tests were modified -->
- [ ] Test Framework
<!-- checked [x] = this modifies the test framework; unchecked [ ] = no test framework changes -->
- [ ] CI System
<!-- checked [x] = this changes the CI system; unchecked [ ] = no CI changes -- >