### PR TITLE
Rel-2.1.x: make cleos unpack a packed transaction before signing and …

### DIFF
--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -80,7 +80,7 @@ def cleos_sign_test():
             '"permission": "active"'
         '}'
         '],'
-        '"data":' "000000000000a6690000000000ea305501000000000000000453595300000000016d"
+        '"data": "000000000000a6690000000000ea305501000000000000000453595300000000016d"'
        '}'
        '],'
         '"transaction_extensions": [],'
@@ -92,7 +92,14 @@ def cleos_sign_test():
     # make sure it is signed
     assert(b'signatures' in output)
     # make sure fields are kept
+    assert(b'"expiration": "2019-08-01T07:15:49"' in output)
     assert(b'"ref_block_num": 34881' in output)
+    assert(b'"ref_block_prefix": 2972818865' in output)
+    assert(b'"account": "eosio.token"' in output)
+    assert(b'"name": "transfer"' in output)
+    assert(b'"actor": "eosio"' in output)
+    assert(b'"permission": "active"' in output)
+    assert(b'"data": "000000000000a6690000000000ea305501000000000000000453595300000000016d"' in output)
 
     packed_trx = ' { "signatures": [], "compression": "none", "packed_context_free_data": "", "packed_trx": "a591425d4188b19d31b1000000000100a6823403ea3055000000572d3ccdcd010000000000ea305500000000a8ed323222000000000000a6690000000000ea305501000000000000000453595300000000016d00" } '
 
@@ -108,7 +115,14 @@ def cleos_sign_test():
     except subprocess.CalledProcessError as ex:
         print(ex.output)
     # make sure fields are unpacked
+    assert(b'"expiration": "2019-08-01T07:15:49"' in errs)
     assert(b'"ref_block_num": 34881' in errs)
+    assert(b'"ref_block_prefix": 2972818865' in errs)
+    assert(b'"account": "eosio.token"' in errs)
+    assert(b'"name": "transfer"' in errs)
+    assert(b'"actor": "eosio"' in errs)
+    assert(b'"permission": "active"' in errs)
+    assert(b'"data": "000000000000a6690000000000ea305501000000000000000453595300000000016d"' in errs)
 
     # Test packed transaction is signed.
     output = subprocess.check_output(['./programs/cleos/cleos', 'sign',

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -57,6 +57,66 @@ def cli11_optional_option_arg_test():
     assert(b'signatures' in output)
 
 
+def cleos_sign_test():
+    """Test that sign can on both regular and packed transactions"""
+    chain = 'cf057bbfb72640471fd910bcb67639c22df9f92470936cddc1ade0e2f2e7dc4f'
+    key = '5Jgfqh3svgBZvCAQkcnUX8sKmVUkaUekYDGqFakm52Ttkc5MBA4'
+
+    # regular trasaction
+    trx = (
+        '{'
+        '"expiration": "2019-08-01T07:15:49",'
+        '"ref_block_num": 34881,'
+        '"ref_block_prefix": 2972818865,'
+        '"max_net_usage_words": 0,'
+        '"max_cpu_usage_ms": 0,'
+        '"delay_sec": 0,'
+        '"context_free_actions": [],'
+        '"actions": [{'
+            '"account": "eosio.token",'
+            '"name": "transfer",'
+            '"authorization": [{'
+            '"actor": "eosio",'
+            '"permission": "active"'
+        '}'
+        '],'
+        '"data":' "000000000000a6690000000000ea305501000000000000000453595300000000016d"
+       '}'
+       '],'
+        '"transaction_extensions": [],'
+        '"context_free_data": []'
+    '}')
+
+    output = subprocess.check_output(['./programs/cleos/cleos', 'sign',
+                                      '-c', chain, '-k', key, trx])
+    # make sure it is signed
+    assert(b'signatures' in output)
+    # make sure fields are kept
+    assert(b'"ref_block_num": 34881' in output)
+
+    packed_trx = ' { "signatures": [], "compression": "none", "packed_context_free_data": "", "packed_trx": "a591425d4188b19d31b1000000000100a6823403ea3055000000572d3ccdcd010000000000ea305500000000a8ed323222000000000000a6690000000000ea305501000000000000000453595300000000016d00" } '
+
+    # Test packed transaction is unpacked. Only with options --print-request and --public-key
+    # the sign request is dumped to stderr.
+    cmd = ['./programs/cleos/cleos', '--print-request', 'sign', '-c', chain, '--public-key', 'EOS8Dq1KosJ9PMn1vKQK3TbiihgfUiDBUsz471xaCE6eYUssPB1KY', packed_trx]
+    outs=None
+    errs=None
+    try:
+        popen=subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        outs,errs=popen.communicate()
+        popen.wait()
+    except subprocess.CalledProcessError as ex:
+        print(ex.output)
+    # make sure fields are unpacked
+    assert(b'"ref_block_num": 34881' in errs)
+
+    # Test packed transaction is signed.
+    output = subprocess.check_output(['./programs/cleos/cleos', 'sign',
+                                      '-c', chain, '-k', key, packed_trx])
+    # Make sure signatures not empty
+    assert(b'signatures' in output)
+    assert(b'"signatures": []' not in output)
+
 nodeos_help_test()
 
 cleos_help_test(['--help'])
@@ -67,3 +127,4 @@ cleos_help_test(['wallet', '--help'])
 cli11_bugfix_test()
 
 cli11_optional_option_arg_test()
+cleos_sign_test()


### PR DESCRIPTION
…add test cases to cleos sign command

<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->
## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
https://blockone.atlassian.net/browse/EPE-806

Currently when signing a packed transaction, `cleos` does not unpack the transaction before signing. A sign request for a packed transaction looks like
```
REQUEST:
---------------------
POST /v1/wallet/sign_transaction HTTP/1.1
Host: /home/ubuntu/eosio-wallet/keosd.sock:
content-length: 563
Accept: /
Connection: close

[{
*"expiration": "1970-01-01T00:00:00",*
"ref_block_num": 0,
"ref_block_prefix": 0,
"max_net_usage_words": 0,
"max_cpu_usage_ms": 0,

```

After this PR, for a packed transaction like
```
{
  "signatures": [],
  "compression": "none",
  "packed_context_free_data": "",
  "packed_trx": "a591425d4188b19d31b1000000000100a6823403ea3055000000572d3ccdcd010000000000ea305500000000a8ed323222000000000000a6690000000000ea305501000000000000000453595300000000016d00"
}
```
`cleos --print-request --print-response sign --public-key EOS8Dq1KosJ9PMn1vKQK3TbiihgfUiDBUsz471xaCE6eYUssPB1KY packed_trx.json` will generate

```
info  2021-03-29T20:32:54.017 thread-0  main.cpp:3757                 operator()           ] grabbing chain_id from nodeos
REQUEST:
---------------------
POST /v1/chain/get_info HTTP/1.1
Host: 127.0.0.1:8888
content-length: 0
Accept: */*
Connection: close
---------------------
RESPONSE:
---------------------
{
  "server_version": "ff2cfa7a",
  "chain_id": "8a34ec7df1b8cd06ff4a8abbaa7cc50300823350cadc59ab296cb00d104d2b8f",
  "head_block_num": 102,
  "last_irreversible_block_num": 101,
  "last_irreversible_block_id": "0000006527042cd9aa0854751a8ecf0fadcb68c5f6324767c7c2a0e148fba529",
  "head_block_id": "00000066cca62dd687f5f70ed2729a80e9b936f85910a32cc439633807828636",
  "head_block_time": "2021-03-29T20:32:54.000",
  "head_block_producer": "eosio",
  "virtual_block_cpu_limit": 221215,
  "virtual_block_net_limit": 1160019,
  "block_cpu_limit": 199900,
  "block_net_limit": 1048576,
  "server_version_string": "v2.1.0-rc3",
  "fork_db_head_block_num": 102,
  "fork_db_head_block_id": "00000066cca62dd687f5f70ed2729a80e9b936f85910a32cc439633807828636",
  "server_full_version_string": "v2.1.0-rc3-ff2cfa7aeac6ac7d8a83a4a38296de7b74908402-dirty",
  "last_irreversible_block_time": "2021-03-29T20:32:53.500"
}
---------------------
REQUEST:
---------------------
POST /v1/wallet/sign_transaction HTTP/1.1
Host: /Users/lin.huang/eosio-wallet/keosd.sock:
content-length: 740
Accept: */*
Connection: close
[{
    "expiration": "2019-08-01T07:15:49",
    "ref_block_num": 34881,
    "ref_block_prefix": 2972818865,
    "max_net_usage_words": 0,
    "max_cpu_usage_ms": 0,
    "delay_sec": 0,
    "context_free_actions": [],
    "actions": [{
        "account": "eosio.token",
        "name": "transfer",
        "authorization": [{
            "actor": "eosio",
            "permission": "active"
          }
        ],
        "data": "000000000000a6690000000000ea305501000000000000000453595300000000016d"
      }
    ],
    "transaction_extensions": [],
    "signatures": [],
    "context_free_data": []
  },[
    "EOS8Dq1KosJ9PMn1vKQK3TbiihgfUiDBUsz471xaCE6eYUssPB1KY"
  ],
  "8a34ec7df1b8cd06ff4a8abbaa7cc50300823350cadc59ab296cb00d104d2b8f"
]
---------------------
RESPONSE:
---------------------
{
  "expiration": "2019-08-01T07:15:49",
  "ref_block_num": 34881,
  "ref_block_prefix": 2972818865,
  "max_net_usage_words": 0,
  "max_cpu_usage_ms": 0,
  "delay_sec": 0,
  "context_free_actions": [],
  "actions": [{
      "account": "eosio.token",
      "name": "transfer",
      "authorization": [{
          "actor": "eosio",
          "permission": "active"
        }
      ],
      "data": "000000000000a6690000000000ea305501000000000000000453595300000000016d"
    }
  ],
  "transaction_extensions": [],
  "signatures": [
    "SIG_K1_KicUhKP4bdYydf8eHY6nLpZvvRiEuF1gQk5cS92McWnHnZKyaunr4356TC8z6BoqU8EK1oShYT2m8gQqsfxUsZNhpDroLi"
  ],
  "context_free_data": []
}
---------------------
{
  "signatures": [
    "SIG_K1_KicUhKP4bdYydf8eHY6nLpZvvRiEuF1gQk5cS92McWnHnZKyaunr4356TC8z6BoqU8EK1oShYT2m8gQqsfxUsZNhpDroLi"
  ],
  "compression": "none",
  "packed_context_free_data": "",
  "packed_trx": "a591425d4188b19d31b1000000000100a6823403ea3055000000572d3ccdcd010000000000ea305500000000a8ed323222000000000000a6690000000000ea305501000000000000000453595300000000016d00"
}
```



## Change Type
**Select *ONE*:**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [x] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [ ] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the release notes. Please include a description of the change for inclusion in the release notes. -->


## Testing Changes
**Select *ANY* that apply:**
- [x] New Tests
<!-- checked [x] = new test cases were added; unchecked [ ] = no new test cases -->
- [ ] Existing Tests
<!-- checked [x] = existing test cases were edited; unchecked [ ] = no existing tests were modified -->
- [ ] Test Framework
<!-- checked [x] = this modifies the test framework; unchecked [ ] = no test framework changes -->
- [ ] CI System
<!-- checked [x] = this changes the CI system; unchecked [ ] = no CI changes -->
- [ ] Other
<!-- checked [x] = this integrates an external test system; unchecked [ ] = no miscellaneous test-related changes -->
<!-- Please describe your test changes, or list each new test and its purpose, under each respective checkbox -->
Tests were added for `cleos` sign command to cover sign unpacked and packed transactions.

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
