### PR TITLE
Support Running Version Tests on Fresh OS Installs

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -95,8 +95,8 @@ set_property(TEST keosd_auto_launch_test PROPERTY LABELS nonparallelizable_tests
 add_test(NAME db_modes_test COMMAND tests/db_modes_test.sh WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 set_tests_properties(db_modes_test PROPERTIES COST 6000)
 add_test(NAME release-build-test COMMAND tests/release-build.sh WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-add_test(NAME version-label-test COMMAND tests/version-label.sh ${VERSION_FULL} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-add_test(NAME full-version-label-test COMMAND tests/full-version-label.sh ${VERSION_FULL} ${CMAKE_SOURCE_DIR} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+add_test(NAME version-label-test COMMAND tests/version-label.sh "v${VERSION_FULL}" WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+add_test(NAME full-version-label-test COMMAND tests/full-version-label.sh "v${VERSION_FULL}" ${CMAKE_SOURCE_DIR} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 add_test(NAME print-build-info-test COMMAND tests/print-build-info.sh ${CMAKE_SOURCE_DIR} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 
 # Long running tests

--- a/tests/full-version-label.sh
+++ b/tests/full-version-label.sh
@@ -6,13 +6,15 @@ echo '##### Nodeos Full Version Label Test #####'
 [[ -z "$BUILD_ROOT" ]] && export BUILD_ROOT="$(pwd)"
 echo "Using BUILD_ROOT=\"$BUILD_ROOT\"."
 [[ -z "$CMAKE_SOURCE_DIR" ]] && export CMAKE_SOURCE_DIR="$2"
-EXPECTED=$1
+# test expectations
+if [[ -z "$EXPECTED" ]]; then
+    [[ -z "$BUILDKITE_COMMIT" ]] && export BUILDKITE_COMMIT="$(pushd "$CMAKE_SOURCE_DIR" &>/dev/null && git rev-parse HEAD 2>/dev/null ; popd &>/dev/null)"
+    export EXPECTED="v$1-$BUILDKITE_COMMIT"
+fi
 if [[ -z "$EXPECTED" ]]; then
     echo "Missing version input."
     exit 1
 fi
-[[ -z "$BUILDKITE_COMMIT" ]] && export BUILDKITE_COMMIT="$(pushd "$CMAKE_SOURCE_DIR" &>/dev/null && git rev-parse HEAD 2>/dev/null ; popd &>/dev/null)"
-EXPECTED=v$EXPECTED-$BUILDKITE_COMMIT
 echo "Expecting \"$EXPECTED\"..."
 # get nodeos version
 ACTUAL=$($BUILD_ROOT/bin/nodeos --full-version)

--- a/tests/full-version-label.sh
+++ b/tests/full-version-label.sh
@@ -9,7 +9,7 @@ echo "Using BUILD_ROOT=\"$BUILD_ROOT\"."
 # test expectations
 if [[ -z "$EXPECTED" ]]; then
     [[ -z "$BUILDKITE_COMMIT" ]] && export BUILDKITE_COMMIT="$(pushd "$CMAKE_SOURCE_DIR" &>/dev/null && git rev-parse HEAD 2>/dev/null ; popd &>/dev/null)"
-    export EXPECTED="v$1-$BUILDKITE_COMMIT"
+    export EXPECTED="$1-$BUILDKITE_COMMIT"
 fi
 if [[ -z "$EXPECTED" ]]; then
     echo "Missing version input."

--- a/tests/full-version-label.sh
+++ b/tests/full-version-label.sh
@@ -9,7 +9,7 @@ echo "Using BUILD_ROOT=\"$BUILD_ROOT\"."
 # test expectations
 if [[ -z "$EXPECTED" ]]; then
     [[ -z "$BUILDKITE_COMMIT" ]] && export BUILDKITE_COMMIT="$(pushd "$CMAKE_SOURCE_DIR" &>/dev/null && git rev-parse HEAD 2>/dev/null ; popd &>/dev/null)"
-    [[ -z "$BUILDKITE_TAG" ]] export BUILDKITE_TAG="${GIT_TAG:-$1}"
+    [[ -z "$BUILDKITE_TAG" ]] && export BUILDKITE_TAG="${GIT_TAG:-$1}"
     export EXPECTED="$BUILDKITE_TAG-$BUILDKITE_COMMIT"
 fi
 if [[ -z "$EXPECTED" ]]; then

--- a/tests/full-version-label.sh
+++ b/tests/full-version-label.sh
@@ -3,7 +3,7 @@ set -eo pipefail
 # The purpose of this test is to ensure that the output of the "nodeos --full-version" command matches the version string defined by our CMake files
 echo '##### Nodeos Full Version Label Test #####'
 # orient ourselves
-[[ "$BUILD_ROOT" == '' ]] && BUILD_ROOT=$(pwd)
+[[ -z "$BUILD_ROOT" ]] && export BUILD_ROOT="$(pwd)"
 echo "Using BUILD_ROOT=\"$BUILD_ROOT\"."
 [[ -z "$CMAKE_SOURCE_DIR" ]] && export CMAKE_SOURCE_DIR="$2"
 EXPECTED=$1

--- a/tests/full-version-label.sh
+++ b/tests/full-version-label.sh
@@ -5,12 +5,13 @@ echo '##### Nodeos Full Version Label Test #####'
 # orient ourselves
 [[ "$BUILD_ROOT" == '' ]] && BUILD_ROOT=$(pwd)
 echo "Using BUILD_ROOT=\"$BUILD_ROOT\"."
+[[ -z "$CMAKE_SOURCE_DIR" ]] && export CMAKE_SOURCE_DIR="$2"
 EXPECTED=$1
 if [[ -z "$EXPECTED" ]]; then
     echo "Missing version input."
     exit 1
 fi
-VERSION_HASH="$(pushd $2 &>/dev/null && git rev-parse HEAD 2>/dev/null ; popd &>/dev/null)"
+VERSION_HASH="$(pushd "$CMAKE_SOURCE_DIR" &>/dev/null && git rev-parse HEAD 2>/dev/null ; popd &>/dev/null)"
 EXPECTED=v$EXPECTED-$VERSION_HASH
 echo "Expecting \"$EXPECTED\"..."
 # get nodeos version

--- a/tests/full-version-label.sh
+++ b/tests/full-version-label.sh
@@ -11,8 +11,8 @@ if [[ -z "$EXPECTED" ]]; then
     echo "Missing version input."
     exit 1
 fi
-VERSION_HASH="$(pushd "$CMAKE_SOURCE_DIR" &>/dev/null && git rev-parse HEAD 2>/dev/null ; popd &>/dev/null)"
-EXPECTED=v$EXPECTED-$VERSION_HASH
+[[ -z "$BUILDKITE_COMMIT" ]] && export BUILDKITE_COMMIT="$(pushd "$CMAKE_SOURCE_DIR" &>/dev/null && git rev-parse HEAD 2>/dev/null ; popd &>/dev/null)"
+EXPECTED=v$EXPECTED-$BUILDKITE_COMMIT
 echo "Expecting \"$EXPECTED\"..."
 # get nodeos version
 ACTUAL=$($BUILD_ROOT/bin/nodeos --full-version)

--- a/tests/full-version-label.sh
+++ b/tests/full-version-label.sh
@@ -9,7 +9,8 @@ echo "Using BUILD_ROOT=\"$BUILD_ROOT\"."
 # test expectations
 if [[ -z "$EXPECTED" ]]; then
     [[ -z "$BUILDKITE_COMMIT" ]] && export BUILDKITE_COMMIT="$(pushd "$CMAKE_SOURCE_DIR" &>/dev/null && git rev-parse HEAD 2>/dev/null ; popd &>/dev/null)"
-    export EXPECTED="$1-$BUILDKITE_COMMIT"
+    [[ -z "$BUILDKITE_TAG" ]] export BUILDKITE_TAG="${GIT_TAG:-$1}"
+    export EXPECTED="$BUILDKITE_TAG-$BUILDKITE_COMMIT"
 fi
 if [[ -z "$EXPECTED" ]]; then
     echo "Missing version input."

--- a/tests/print-build-info.sh
+++ b/tests/print-build-info.sh
@@ -6,6 +6,7 @@ echo '##### Nodeos Print Build Info Test #####'
 # orient ourselves
 [[ "$BUILD_ROOT" == '' ]] && BUILD_ROOT="$(pwd)"
 echo "Using BUILD_ROOT=\"$BUILD_ROOT\"."
+[[ -z "$CMAKE_SOURCE_DIR" ]] && export CMAKE_SOURCE_DIR="$1"
 
 exec 9>&1 # enable tee to write to STDOUT as a file
 PRINT_BUILD_INFO="$BUILD_ROOT/bin/nodeos --print-build-info 2>&1 | tee >(cat - >&9) || :"
@@ -44,7 +45,7 @@ if [[ "$PLATFORM_TYPE" == "pinned" ]]; then
         echo "Missing IMAGE_TAG variable."
         exit 1
     fi
-    FILE=$(ls $1/.cicd/platforms/pinned/$IMAGE_TAG* | head)
+    FILE=$(ls $CMAKE_SOURCE_DIR/.cicd/platforms/pinned/$IMAGE_TAG* | head)
     BOOST=$(cat $FILE | grep boost | tr -d '\r\n' | sed -E 's/^.+boost_([0-9]+_[0-9]+_[0-9]+).+$/\1/' | head)
     BOOST_MAJOR=$(echo $BOOST | sed -E 's/^([0-9])+_[0-9]+_[0-9]+$/\1/')
     BOOST_MINOR=$(echo $BOOST | sed -E 's/^[0-9]+_([0-9]+)_[0-9]+$/\1/')

--- a/tests/print-build-info.sh
+++ b/tests/print-build-info.sh
@@ -4,7 +4,7 @@ set -eo pipefail
 # This includes verifying valid output in JSON shape and checking parameters (only boost for now).
 echo '##### Nodeos Print Build Info Test #####'
 # orient ourselves
-[[ "$BUILD_ROOT" == '' ]] && BUILD_ROOT="$(pwd)"
+[[ -z "$BUILD_ROOT" ]] && export BUILD_ROOT="$(pwd)"
 echo "Using BUILD_ROOT=\"$BUILD_ROOT\"."
 [[ -z "$CMAKE_SOURCE_DIR" ]] && export CMAKE_SOURCE_DIR="$1"
 

--- a/tests/version-label.sh
+++ b/tests/version-label.sh
@@ -5,7 +5,10 @@ echo '##### Nodeos Version Label Test #####'
 # orient ourselves
 [[ -z "$BUILD_ROOT" ]] && export BUILD_ROOT="$(pwd)"
 echo "Using BUILD_ROOT=\"$BUILD_ROOT\"."
-EXPECTED=v$1
+# test expectations
+if [[ -z "$EXPECTED" ]]; then
+    export EXPECTED="v$1"
+fi
 if [[ -z "$EXPECTED" ]]; then
     echo "Missing version input."
     exit 1

--- a/tests/version-label.sh
+++ b/tests/version-label.sh
@@ -7,7 +7,7 @@ echo '##### Nodeos Version Label Test #####'
 echo "Using BUILD_ROOT=\"$BUILD_ROOT\"."
 # test expectations
 if [[ -z "$EXPECTED" ]]; then
-    export EXPECTED="v$1"
+    export EXPECTED="$1"
 fi
 if [[ -z "$EXPECTED" ]]; then
     echo "Missing version input."

--- a/tests/version-label.sh
+++ b/tests/version-label.sh
@@ -7,7 +7,8 @@ echo '##### Nodeos Version Label Test #####'
 echo "Using BUILD_ROOT=\"$BUILD_ROOT\"."
 # test expectations
 if [[ -z "$EXPECTED" ]]; then
-    export EXPECTED="$1"
+    [[ -z "$BUILDKITE_TAG" ]] export BUILDKITE_TAG="${GIT_TAG:-$1}"
+    export EXPECTED="$BUILDKITE_TAG"
 fi
 if [[ -z "$EXPECTED" ]]; then
     echo "Missing version input."

--- a/tests/version-label.sh
+++ b/tests/version-label.sh
@@ -7,7 +7,7 @@ echo '##### Nodeos Version Label Test #####'
 echo "Using BUILD_ROOT=\"$BUILD_ROOT\"."
 # test expectations
 if [[ -z "$EXPECTED" ]]; then
-    [[ -z "$BUILDKITE_TAG" ]] export BUILDKITE_TAG="${GIT_TAG:-$1}"
+    [[ -z "$BUILDKITE_TAG" ]] && export BUILDKITE_TAG="${GIT_TAG:-$1}"
     export EXPECTED="$BUILDKITE_TAG"
 fi
 if [[ -z "$EXPECTED" ]]; then

--- a/tests/version-label.sh
+++ b/tests/version-label.sh
@@ -3,7 +3,7 @@ set -eo pipefail
 # The purpose of this test is to ensure that the output of the "nodeos --version" command matches the version string defined by our CMake files
 echo '##### Nodeos Version Label Test #####'
 # orient ourselves
-[[ "$BUILD_ROOT" == '' ]] && BUILD_ROOT="$(pwd)"
+[[ -z "$BUILD_ROOT" ]] && export BUILD_ROOT="$(pwd)"
 echo "Using BUILD_ROOT=\"$BUILD_ROOT\"."
 EXPECTED=v$1
 if [[ -z "$EXPECTED" ]]; then


### PR DESCRIPTION
## Change Description
From [AUTO-629](https://blockone.atlassian.net/browse/AUTO-629), I am creating the [eosio-version-check](https://buildkite.com/EOSIO/eosio-version-check) pipeline to validate the correct assets have been attached to an EOSIO release by downloading the release assets from GitHub, installing them on clean operating systems, and running these version label tests. These tests work by comparing the output of the `nodeos` binary to reference values from `git` and our CMake. However, clean Linux docker images straight from the operating system vendor do not include these utilities!

This pull request modifies the version tests to accept expected values from environment variables so they can be run in a sanitary environment without installing any other software besides EOSIO. If these variables are not present, the current mechanism of obtaining expected values from `ctest` and `git` is used.

### See Also
- eos-buildkite-pipelines
  - [Pull Request 129](https://github.com/EOSIO/eos-buildkite-pipelines/pull/129) -- Provision eosio-version-check Pipeline
  - [Pull Request 130](https://github.com/EOSIO/eos-buildkite-pipelines/pull/130) -- Provision Release Practice Pipeline, As Well
  - [Pull Request 131](https://github.com/EOSIO/eos-buildkite-pipelines/pull/131) -- Build Out EOSIO Version Check Pipelines
- auto-events-subscribers
  - [Pull Request 451](https://github.com/EOSIO/auto-events-subscribers/pull/451) -- Create githubReleaseBuildkiteTrigger Lambda
  - [Pull Request 452](https://github.com/EOSIO/auto-events-subscribers/pull/452) -- githubReleaseBuildkiteTrigger Lambda Improvements
- eos
  - [Pull Request 10231](https://github.com/EOSIO/eos/pull/10231) -- `eos:develop`
  - [Pull Request 10232](https://github.com/EOSIO/eos/pull/10232) -- `eos:release/2.1.x`
  - [Pull Request 10233](https://github.com/EOSIO/eos/pull/10233) -- `eos:release/2.0.x`

## Change Type
**Select *ONE*:**
- [ ] Documentation
- [ ] Stability bug fix
- [x] Other
- [ ] Other - special case

## Testing Changes
**Select *ANY* that apply:**
- [ ] New Tests
- [x] Existing Tests
- [ ] Test Framework
- [ ] CI System
- [ ] Other

## Consensus Changes
- [ ] Consensus Changes
None.

## API Changes
- [ ] API Changes
None.

## Documentation Additions
- [ ] Documentation Additions
None.