### PR TITLE
huangminghuang/ship-max-retained-files-2.1.x

### DIFF
--- a/plugins/state_history_plugin/state_history_plugin.cpp
+++ b/plugins/state_history_plugin/state_history_plugin.cpp
@@ -414,7 +414,7 @@ void state_history_plugin::set_program_options(options_description& cli, options
          "When the stride is reached, the current history log and index will be renamed '*-history-<start num>-<end num>.log/index'\n"
          "and a new current history log and index will be created with the most recent blocks. All files following\n"
          "this format will be used to construct an extended history log.");
-   options("max-retained-history-files", bpo::value<uint32_t>()->default_value(10),
+   options("max-retained-history-files", bpo::value<uint32_t>()->default_value(UINT32_MAX),
           "the maximum number of history file groups to retain so that the blocks in those files can be queried.\n" 
           "When the number is reached, the oldest history file would be moved to archive dir or deleted if the archive dir is empty.\n"
           "The retained history log files should not be manipulated by users." );

--- a/unittests/state_history_tests.cpp
+++ b/unittests/state_history_tests.cpp
@@ -335,6 +335,8 @@ BOOST_AUTO_TEST_CASE(test_splitted_log) {
    BOOST_CHECK(bfs::exists( retained_dir / "trace_history-121-140.log" ));
    BOOST_CHECK(bfs::exists( retained_dir / "trace_history-121-140.index" ));
 
+   BOOST_CHECK_EQUAL(chain.traces_log.begin_block(), 41);
+
    BOOST_CHECK(bfs::exists( retained_dir / "chain_state_history-41-60.log" ));
    BOOST_CHECK(bfs::exists( retained_dir / "chain_state_history-41-60.index" ));
    BOOST_CHECK(bfs::exists( retained_dir / "chain_state_history-61-80.log" ));
@@ -345,6 +347,8 @@ BOOST_AUTO_TEST_CASE(test_splitted_log) {
    BOOST_CHECK(bfs::exists( retained_dir / "chain_state_history-101-120.index" ));
    BOOST_CHECK(bfs::exists( retained_dir / "chain_state_history-121-140.log" ));
    BOOST_CHECK(bfs::exists( retained_dir / "chain_state_history-121-140.index" ));
+
+   BOOST_CHECK_EQUAL(chain.chain_state_log.begin_block(), 41);
 
    BOOST_CHECK(get_traces(chain.traces_log, 10).empty());
    BOOST_CHECK(get_traces(chain.traces_log, 100).size());


### PR DESCRIPTION
## Change Description
This PR changes the default value of max-retained-history-files option in state history plugin.

## Change Type
**Select *ONE*:**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [ ] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [ ] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the release notes. Please include a description of the change for inclusion in the release notes. -->


## Testing Changes
**Select *ANY* that apply:**
- [ ] New Tests
<!-- checked [x] = new test cases were added; unchecked [ ] = no new test cases -->
- [ ] Existing Tests
<!-- checked [x] = existing test cases were edited; unchecked [ ] = no existing tests were modified -->
- [ ] Test Framework
<!-- checked [x] = this modifies the test framework; unchecked [ ] = no test framework changes -->
- [ ] CI System
<!-- checked [x] = this changes the CI system; unchecked [ ] = no CI changes -->
- [ ] Other
<!-- checked [x] = this integrates an external test system; unchecked [ ] = no miscellaneous test-related changes -->
<!-- Please describe your test changes, or list each new test and its purpose, under each respective checkbox -->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [x] Documentation Additions
The documentation should add cautionary statement how the --max-retained-history-files can affect the data availiability from SHiP. `--max-retained-history-files` would cause the trace/state history to become unavailable when the threshold is met; therefore, a client should connect to nodeos before it happens.