### PR TITLE
Rodeos timeout fix

### DIFF
--- a/programs/rodeos/wasm_ql_http.cpp
+++ b/programs/rodeos/wasm_ql_http.cpp
@@ -405,6 +405,10 @@ class http_session {
                 : self(self), msg(std::move(msg)) {}
 
             void operator()() {
+               // expires_after controls two timers (read & write) which are only reset if there are no pending calls
+               // set expires_after here before write and also below before read to make sure both timers are reset
+               self.derived_session().stream.expires_after(std::chrono::milliseconds(self.http_config->idle_timeout_ms));
+
                http::async_write(
                      self.derived_session().stream, msg,
                      beast::bind_front_handler(&http_session::on_write, self.derived_session().shared_from_this(), msg.need_eof()));
@@ -469,8 +473,10 @@ class http_session {
       if (ec == http::error::end_of_stream)
          return do_close();
 
-      if (ec)
-         return fail(ec, "read");
+      if (ec) {
+         fail( ec, "read" );
+         return do_close();
+      }
 
       // Send the response
       handle_request(*http_config, *shared_state, *state_cache, parser->release(), queue_);
@@ -483,8 +489,10 @@ class http_session {
    void on_write(bool close, beast::error_code ec, std::size_t bytes_transferred) {
       boost::ignore_unused(bytes_transferred);
 
-      if (ec)
-         return fail(ec, "write");
+      if (ec) {
+         fail( ec, "write" );
+         do_close();
+      }
 
       if (close) {
          // This means we should close the connection, usually because
@@ -630,10 +638,18 @@ class listener : public std::enable_shared_from_this<listener> {
             fail(ec, "accept");
          } else {
             // Create the http session and run it
-            if constexpr (std::is_same_v<Acceptor, tcp::acceptor>)
-               std::make_shared<tcp_http_session>(http_config, shared_state, state_cache, std::move(socket))->run();
-            else if constexpr (std::is_same_v<Acceptor, unixs::acceptor>)
-               std::make_shared<unix_http_session>(http_config, shared_state, state_cache, std::move(socket))->run();
+            if constexpr (std::is_same_v<Acceptor, tcp::acceptor>) {
+               boost::system::error_code ec;
+               dlog( "Accepting connection from ${ra}:${rp} to ${la}:${lp}",
+                     ("ra", socket.remote_endpoint(ec).address().to_string())("rp", socket.remote_endpoint(ec).port())
+                     ("la", socket.local_endpoint(ec).address().to_string())("lp", socket.local_endpoint(ec).port()) );
+               std::make_shared<tcp_http_session>( http_config, shared_state, state_cache, std::move( socket ) )->run();
+            } else if constexpr (std::is_same_v<Acceptor, unixs::acceptor>) {
+               boost::system::error_code ec;
+               auto rep = socket.remote_endpoint(ec);
+               dlog( "Accepting connection from ${r}", ("r", rep.path()) );
+               std::make_shared<unix_http_session>( http_config, shared_state, state_cache, std::move( socket ) )->run();
+            }
          }
 
          // Accept another connection

--- a/programs/rodeos/wasm_ql_http.cpp
+++ b/programs/rodeos/wasm_ql_http.cpp
@@ -405,10 +405,6 @@ class http_session {
                 : self(self), msg(std::move(msg)) {}
 
             void operator()() {
-               // expires_after controls two timers (read & write) which are only reset if there are no pending calls
-               // set expires_after here before write and also below before read to make sure both timers are reset
-               self.derived_session().stream.expires_after(std::chrono::milliseconds(self.http_config->idle_timeout_ms));
-
                http::async_write(
                      self.derived_session().stream, msg,
                      beast::bind_front_handler(&http_session::on_write, self.derived_session().shared_from_this(), msg.need_eof()));
@@ -458,9 +454,6 @@ class http_session {
       // of the body in bytes to prevent abuse.
       // todo: make configurable
       parser->body_limit(http_config->max_request_size);
-
-      // Set the timeout.
-      derived_session().stream.expires_after(std::chrono::milliseconds(http_config->idle_timeout_ms));
 
       // Read a request using the parser-oriented interface
       http::async_read(derived_session().stream, buffer, *parser, beast::bind_front_handler(&http_session::on_read, derived_session().shared_from_this()));

--- a/programs/rodeos/wasm_ql_http.hpp
+++ b/programs/rodeos/wasm_ql_http.hpp
@@ -7,7 +7,6 @@ namespace b1::rodeos::wasm_ql {
 struct http_config {
    uint32_t                               num_threads      = {};
    uint32_t                               max_request_size = {};
-   uint64_t                               idle_timeout_ms  = {};
    std::string                            allow_origin     = {};
    std::string                            static_dir       = {};
    std::string                            address          = {};

--- a/programs/rodeos/wasm_ql_plugin.cpp
+++ b/programs/rodeos/wasm_ql_plugin.cpp
@@ -86,7 +86,7 @@ void wasm_ql_plugin::set_program_options(options_description& cli, options_descr
    op("wql-console-size", bpo::value<uint32_t>()->default_value(0), "Maximum size of console data");
    op("wql-wasm-cache-size", bpo::value<uint32_t>()->default_value(100), "Maximum number of compiled wasms to cache");
    op("wql-max-request-size", bpo::value<uint32_t>()->default_value(10000), "HTTP maximum request body size (bytes)");
-   op("wql-idle-timeout", bpo::value<uint64_t>()->default_value(30000), "HTTP idle connection timeout (ms)");
+   op("wql-idle-timeout", bpo::value<uint64_t>()->default_value(std::numeric_limits<uint32_t>::max()), "HTTP idle connection timeout (ms)");
    op("wql-exec-time", bpo::value<uint64_t>()->default_value(200), "Max query execution time (ms)");
    op("wql-checkpoint-dir", bpo::value<boost::filesystem::path>(),
       "Directory to place checkpoints. Caution: this allows anyone to create a checkpoint using RPC (default: "

--- a/programs/rodeos/wasm_ql_plugin.cpp
+++ b/programs/rodeos/wasm_ql_plugin.cpp
@@ -86,7 +86,8 @@ void wasm_ql_plugin::set_program_options(options_description& cli, options_descr
    op("wql-console-size", bpo::value<uint32_t>()->default_value(0), "Maximum size of console data");
    op("wql-wasm-cache-size", bpo::value<uint32_t>()->default_value(100), "Maximum number of compiled wasms to cache");
    op("wql-max-request-size", bpo::value<uint32_t>()->default_value(10000), "HTTP maximum request body size (bytes)");
-   op("wql-idle-timeout", bpo::value<uint64_t>()->default_value(std::numeric_limits<uint32_t>::max()), "HTTP idle connection timeout (ms)");
+   op("wql-idle-timeout", bpo::value<uint64_t>()->default_value(std::numeric_limits<uint32_t>::max()),
+      "HTTP idle connection timeout (currently no timeout supported, this option is ignored)");
    op("wql-exec-time", bpo::value<uint64_t>()->default_value(200), "Max query execution time (ms)");
    op("wql-checkpoint-dir", bpo::value<boost::filesystem::path>(),
       "Directory to place checkpoints. Caution: this allows anyone to create a checkpoint using RPC (default: "
@@ -118,7 +119,6 @@ void wasm_ql_plugin::plugin_initialize(const variables_map& options) {
       shared_state->max_console_size = options.at("wql-console-size").as<uint32_t>();
       shared_state->wasm_cache_size  = options.at("wql-wasm-cache-size").as<uint32_t>();
       http_config->max_request_size  = options.at("wql-max-request-size").as<uint32_t>();
-      http_config->idle_timeout_ms   = options.at("wql-idle-timeout").as<uint64_t>();
       shared_state->max_exec_time_ms = options.at("wql-exec-time").as<uint64_t>();
       shared_state->max_action_return_value_size = options.at("wql-max-action-return-value").as<uint32_t>();
       if (options.count("wql-contract-dir"))


### PR DESCRIPTION
## Change Description

- Remove expires_after calls on connections.
- Explicitly close connection on read/write error including timeout.
- Ignore existing `wql-idle-timeout` option as it does not work as intended (see below)

boost’s new `expire_after` timer(s) is a terrible interface if you ask me. rodeos was killing an active connection after the default 30 second timer because the reset of the timer was only reseting one of the internal timers.

Here is the code for boost `expires_after`

```
if(! impl_->read.pending)
    BOOST_VERIFY(
        impl_->read.timer.expires_after(
            expiry_time) == 0);
if(! impl_->write.pending)
    BOOST_VERIFY(
        impl_->write.timer.expires_after(
            expiry_time) == 0);
```
and the comment from the code

```
/** Set the timeout for the next logical operation.    
    This sets either the read timer, the write timer, or
    both timers to expire after the specified amount of time
    has elapsed. If a timer expires when the corresponding
    asynchronous operation is outstanding, the stream will be
    closed and any outstanding operations will complete with the
    error @ref beast::error::timeout. Otherwise, if the timer
    expires while no operations are outstanding, and the expiraton
    is not set again, the next operation will time out immediately.    
    The timer applies collectively to any asynchronous reads
    or writes initiated after the expiration is set, until the
    expiration is set again. A call to @ref async_connect
    counts as both a read and a write.    
    @param expiry_time The amount of time after which a logical
    operation should be considered timed out.
*/
```
So there are TWO timers and if you are not VERY careful it will only set ONE of them.

In our test case, only one was reset. The other timer would fire and kill the connection.
Unless I’m missing something, the boost example code also has the same issue.
 https://www.boost.org/doc/libs/1_75_0/libs/beast/example/http/server/async/http_server_async.cpp

If there is an outstanding (pending) read or write then the associated timer is not touched.
I think the way forward here is to implement our own timers for idle timeout and read/write operations. This will be worked under a different PR.

## Change Type
**Select *ONE*:**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [x] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [ ] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the release notes. Please include a description of the change for inclusion in the release notes. -->


## Testing Changes
**Select *ANY* that apply:**
- [ ] New Tests
<!-- checked [x] = new test cases were added; unchecked [ ] = no new test cases -->
- [ ] Existing Tests
<!-- checked [x] = existing test cases were edited; unchecked [ ] = no existing tests were modified -->
- [ ] Test Framework
<!-- checked [x] = this modifies the test framework; unchecked [ ] = no test framework changes -->
- [ ] CI System
<!-- checked [x] = this changes the CI system; unchecked [ ] = no CI changes -->
- [ ] Other
<!-- checked [x] = this integrates an external test system; unchecked [ ] = no miscellaneous test-related changes -->
<!-- Please describe your test changes, or list each new test and its purpose, under each respective checkbox -->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [x] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->

`wql-idle-timeout` option is now ignored.
