### PR TITLE
state-history-exit-on-write-failure-2.0.x

### DIFF
--- a/libraries/chain/include/eosio/chain/exceptions.hpp
+++ b/libraries/chain/include/eosio/chain/exceptions.hpp
@@ -480,6 +480,8 @@ namespace eosio { namespace chain {
                                  3140000, "Exceptions that are allowed to bubble out of emit calls in controller" )
       FC_DECLARE_DERIVED_EXCEPTION( checkpoint_exception,          controller_emit_signal_exception,
                                    3140001, "Block does not match checkpoint" )
+      FC_DECLARE_DERIVED_EXCEPTION( state_history_write_exception, controller_emit_signal_exception,
+                                   3140002, "State history write error" )
 
 
    FC_DECLARE_DERIVED_EXCEPTION( abi_exception,                           chain_exception,

--- a/plugins/state_history_plugin/include/eosio/state_history_plugin/state_history_log.hpp
+++ b/plugins/state_history_plugin/include/eosio/state_history_plugin/state_history_log.hpp
@@ -124,9 +124,14 @@ class state_history_log {
       }
       catch(const chain::plugin_exception& e) {
          elog( "chain::plugin_exception: ${details}", ("details", e.to_detail_string()) );
-         elog("State history encountered an Error which it cannot recover from.  Please resolve the error and relaunch "
-              "the process");
+         // Both app().quit() and exception throwing are required. Without app().quit(),
+         // the exception would be caught and drop before reaching main(). The exception is
+         // to ensure the block won't be commited. 
          appbase::app().quit();
+         EOS_THROW(
+             chain::state_history_write_exception,
+             "State history encountered an Error which it cannot recover from.  Please resolve the error and relaunch "
+             "the process");
       }
    }
 

--- a/plugins/state_history_plugin/include/eosio/state_history_plugin/state_history_log.hpp
+++ b/plugins/state_history_plugin/include/eosio/state_history_plugin/state_history_log.hpp
@@ -9,7 +9,7 @@
 #include <eosio/chain/types.hpp>
 #include <fc/log/logger.hpp>
 #include <fc/io/cfile.hpp>
-
+#include <appbase/application.hpp>
 namespace eosio {
 
 /*
@@ -123,8 +123,10 @@ class state_history_log {
          last_block_id = header.block_id;
       }
       catch(const chain::plugin_exception& e) {
-         wlog( "chain::plugin_exception: ${details}", ("details", e.to_detail_string()) );
-         EOS_THROW(chain::controller_emit_signal_exception, "State history encountered an Error which it cannot recover from.  Please resolve the error and relaunch the process")
+         elog( "chain::plugin_exception: ${details}", ("details", e.to_detail_string()) );
+         elog("State history encountered an Error which it cannot recover from.  Please resolve the error and relaunch "
+              "the process");
+         appbase::app().quit();
       }
    }
 

--- a/plugins/state_history_plugin/include/eosio/state_history_plugin/state_history_log.hpp
+++ b/plugins/state_history_plugin/include/eosio/state_history_plugin/state_history_log.hpp
@@ -87,39 +87,45 @@ class state_history_log {
 
    template <typename F>
    void write_entry(const state_history_log_header& header, const chain::block_id_type& prev_id, F write_payload) {
-      auto block_num = chain::block_header::num_from_id(header.block_id);
-      EOS_ASSERT(_begin_block == _end_block || block_num <= _end_block, chain::plugin_exception,
-                 "missed a block in ${name}.log", ("name", name));
+      try {
+         auto block_num = chain::block_header::num_from_id(header.block_id);
+         EOS_ASSERT(_begin_block == _end_block || block_num <= _end_block, chain::plugin_exception,
+                  "missed a block in ${name}.log", ("name", name));
 
-      if (_begin_block != _end_block && block_num > _begin_block) {
-         if (block_num == _end_block) {
-            EOS_ASSERT(prev_id == last_block_id, chain::plugin_exception, "missed a fork change in ${name}.log",
-                       ("name", name));
-         } else {
-            state_history_log_header prev;
-            get_entry(block_num - 1, prev);
-            EOS_ASSERT(prev_id == prev.block_id, chain::plugin_exception, "missed a fork change in ${name}.log",
-                       ("name", name));
+         if (_begin_block != _end_block && block_num > _begin_block) {
+            if (block_num == _end_block) {
+               EOS_ASSERT(prev_id == last_block_id, chain::plugin_exception, "missed a fork change in ${name}.log",
+                        ("name", name));
+            } else {
+               state_history_log_header prev;
+               get_entry(block_num - 1, prev);
+               EOS_ASSERT(prev_id == prev.block_id, chain::plugin_exception, "missed a fork change in ${name}.log",
+                        ("name", name));
+            }
          }
+
+         if (block_num < _end_block)
+            truncate(block_num);
+         log.seek_end(0);
+         uint64_t pos = log.tellp();
+         write_header(header);
+         write_payload(log);
+         uint64_t end = log.tellp();
+         EOS_ASSERT(end == pos + state_history_log_header_serial_size + header.payload_size, chain::plugin_exception,
+                  "wrote payload with incorrect size to ${name}.log", ("name", name));
+         log.write((char*)&pos, sizeof(pos));
+
+         index.seek_end(0);
+         index.write((char*)&pos, sizeof(pos));
+         if (_begin_block == _end_block)
+            _begin_block = block_num;
+         _end_block    = block_num + 1;
+         last_block_id = header.block_id;
       }
-
-      if (block_num < _end_block)
-         truncate(block_num);
-      log.seek_end(0);
-      uint64_t pos = log.tellp();
-      write_header(header);
-      write_payload(log);
-      uint64_t end = log.tellp();
-      EOS_ASSERT(end == pos + state_history_log_header_serial_size + header.payload_size, chain::plugin_exception,
-                 "wrote payload with incorrect size to ${name}.log", ("name", name));
-      log.write((char*)&pos, sizeof(pos));
-
-      index.seek_end(0);
-      index.write((char*)&pos, sizeof(pos));
-      if (_begin_block == _end_block)
-         _begin_block = block_num;
-      _end_block    = block_num + 1;
-      last_block_id = header.block_id;
+      catch(const chain::plugin_exception& e) {
+         wlog( "chain::plugin_exception: ${details}", ("details", e.to_detail_string()) );
+         EOS_THROW(chain::controller_emit_signal_exception, "State history encountered an Error which it cannot recover from.  Please resolve the error and relaunch the process")
+      }
    }
 
    // returns cfile positioned at payload


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->
## Change Description

This PR address IS #9483  and IS #10113 so that the nodeos would exit when the state history plugin is unable to write trace/delta because of some invariant violations. 

## Change Type
**Select *ONE*:**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [ ] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [x] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the release notes. Please include a description of the change for inclusion in the release notes. -->


## Testing Changes
**Select *ANY* that apply:**
- [ ] New Tests
<!-- checked [x] = new test cases were added; unchecked [ ] = no new test cases -->
- [ ] Existing Tests
<!-- checked [x] = existing test cases were edited; unchecked [ ] = no existing tests were modified -->
- [ ] Test Framework
<!-- checked [x] = this modifies the test framework; unchecked [ ] = no test framework changes -->
- [ ] CI System
<!-- checked [x] = this changes the CI system; unchecked [ ] = no CI changes -->
- [ ] Other
<!-- checked [x] = this integrates an external test system; unchecked [ ] = no miscellaneous test-related changes -->
<!-- Please describe your test changes, or list each new test and its purpose, under each respective checkbox -->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [x] Documentation Additions

Add language to warn user that a nodoes node with state history plugin should not be configured as producer node because it may leave the fork db in an inconsistent state when it is unable to write traces/deltas to disk.  
