### PR TITLE
net_plugin bugfix for privacy test corner case

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -3417,7 +3417,15 @@ namespace eosio {
          peer_requested.reset();
          flush_queues();
       } else {
-         peer_requested = peer_sync_state( msg.start_block, msg.end_block, msg.start_block-1);
+         if (peer_requested) {
+            // This happens when peer already requested some range and sync is still in progress
+            // It could be higher in case of peer requested head catchup and current request is lib catchup
+            // So to make sure peer will receive all requested blocks we assign end_block to highest value
+            peer_requested->end_block = std::max(msg.end_block, peer_requested->end_block);
+         }
+         else {
+            peer_requested = peer_sync_state( msg.start_block, msg.end_block, msg.start_block-1);
+         }
          enqueue_sync_block();
       }
    }

--- a/tests/privacy_scenario_3_test.py
+++ b/tests/privacy_scenario_3_test.py
@@ -244,13 +244,7 @@ try:
     # node1 and node2 start to receive blocks
     assert apiNode1.waitForLibToAdvance()
     Print("After {} became LIB API Node1 head = {} API Node2 head = {}".format(trans_block_num, apiNode1.getHeadBlockNum(), apiNode2.getHeadBlockNum()))
-    #######################################################################
-    # Workaround.
-    # Restart shouldn't be needed here but due to bug in net_plugin we have to.
-    # this supposed to be fixed in nodeos and removed
-    apiNode2.kill(signal.SIGTERM)
-    apiNode2.relaunch(cachePopen=True)
-    #######################################################################
+    
     apiNode2.waitForBlock(trans_block_num, timeout=240, blockType=BlockType.lib, reportInterval=1, errorContext="API Node2 didn't sync after restart")
     Print("API Node2 LIB block is now {}".format(trans_block_num))
     assert apiNode2.waitForHeadToAdvance()


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->
## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
There is a flaky bug (appears in at least 30-50% of runs) in net_plugin that reproduces in my newly added test for feature privacy. For now I have workaround node restart to avoid it.
What happens?
topology: `[Prod1, Prod2]` -> `Node1` -> `Node2`
on some point via security group removal we cause `Node1` (and hence `Node2`) to stop receive any blocks. After a while we are adding node1 back and it starts to receive blocks again.
it getting new blocks and sends those to `Node2`.
Shortly it gets unlink-able block exception because of gap, sends handshake, gets notice and enters lib catchup state [sync 1 (head < lib received)].
Once in sync it sends handshake to everyone including `Node2`
`Node2` enters head catchup state [sync 3 (head < head received)] as head/lib sent by node1 was smaller than those sent by prod1/prod2
Then it receives one of most recent blocks (probably queued earlier), gets unlinkable exception, sends handshake and after back and forth notice exchange receives lib notice. it responses with `sync_request_message` to it without breaking current head catchup. Issue happening here because of it is doing this while still in head catchup state.
why?
`Node1` getting `sync_request_message` and overwrites `peer_requested` structure that contains range of blocks to be send. `Node2` saved in its state that it wants HEAD and once it will get it it will send handshake.
However because of this interrupted LIB catchup `Node1` now thinks that `Node2` requires different range and since LIB < HEAD, it doesn’t send requested HEAD block.
So `Node2` is waiting for few more blocks to send handshake
Node1 thinks it sent everything and waits for handshake before moving `Node2` back to in sync to continue to send fresh blocks.

FIX:
Do not overwrite peer_requested structure if it contains valid range, instead extend it to have maximum end_block (either existing or newly requested). This looks easiest fix not to change protocol. Discussed with @brianjohnson5972 and @heifner 

## Change Type
**Select *ONE*:**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [x] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [ ] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the release notes. Please include a description of the change for inclusion in the release notes. -->


## Testing Changes
**Select *ANY* that apply:**
- [ ] New Tests
<!-- checked [x] = new test cases were added; unchecked [ ] = no new test cases -->
- [x] Existing Tests
<!-- checked [x] = existing test cases were edited; unchecked [ ] = no existing tests were modified -->
- [ ] Test Framework
<!-- checked [x] = this modifies the test framework; unchecked [ ] = no test framework changes -->
- [ ] CI System
<!-- checked [x] = this changes the CI system; unchecked [ ] = no CI changes -->
- [ ] Other
<!-- checked [x] = this integrates an external test system; unchecked [ ] = no miscellaneous test-related changes -->
<!-- Please describe your test changes, or list each new test and its purpose, under each respective checkbox -->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
