### PR TITLE
Always resync after receiving block less than LIB.

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2681,15 +2681,12 @@ namespace eosio {
             std::unique_lock<std::mutex> g( conn_mtx );
             const auto last_sent_lib = last_handshake_sent.last_irreversible_block_num;
             g.unlock();
-            if( blk_num < last_sent_lib ) {
-               fc_ilog( logger, "received block ${n} less than sent lib ${lib}", ("n", blk_num)("lib", last_sent_lib) );
-               close();
-            } else {
-               fc_ilog( logger, "received block ${n} less than lib ${lib}", ("n", blk_num)("lib", lib) );
-               enqueue( (sync_request_message) {0, 0} );
-               send_handshake();
-               cancel_wait();
-            }
+            fc_ilog( logger, "received block ${n} less than ${which}lib ${lib}",
+                     ("n", blk_num)("which", blk_num < last_sent_lib ? "sent " : "")
+                     ("lib", blk_num < last_sent_lib ? last_sent_lib : lib) );
+            enqueue( (sync_request_message) {0, 0} );
+            send_handshake();
+            cancel_wait();
 
             pending_message_buffer.advance_read_ptr( message_length );
             return true;


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->
## Change Description
Previous behavior was to close connection if a block was received from a peer with a block number lower than our last requested LIB, but in high latency situations this can happen.  Closing the connection in that situation results in unnecessary and ultimately harmful attempts to drop and recreate a connection while already suffering latency problems.  Instead, send a new sync request.

## Change Type
**Select *ONE*:**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [x] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [ ] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the release notes. Please include a description of the change for inclusion in the release notes. -->


## Testing Changes
**Select *ANY* that apply:**
- [ ] New Tests
<!-- checked [x] = new test cases were added; unchecked [ ] = no new test cases -->
- [ ] Existing Tests
<!-- checked [x] = existing test cases were edited; unchecked [ ] = no existing tests were modified -->
- [ ] Test Framework
<!-- checked [x] = this modifies the test framework; unchecked [ ] = no test framework changes -->
- [ ] CI System
<!-- checked [x] = this changes the CI system; unchecked [ ] = no CI changes -->
- [ ] Other
<!-- checked [x] = this integrates an external test system; unchecked [ ] = no miscellaneous test-related changes -->
<!-- Please describe your test changes, or list each new test and its purpose, under each respective checkbox -->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
