### PR TITLE
flakiness fix for eosio_blocklog_prune_test

### DIFF
--- a/tests/eosio_blocklog_prune_test.py
+++ b/tests/eosio_blocklog_prune_test.py
@@ -175,8 +175,10 @@ try:
 
     assert headAdvanced or lvnPostInfo["head_block_num"] >= cfTrxBlockNum, "the light validation node stops syncing"
 
-    #lib will be cfTrxBlockNum-2 and head cfTrxBlockNum-1 because of when we will receive incomplete block we won't advance lib
-    fullValidationNode.waitForBlock(cfTrxBlockNum-2, blockType=BlockType.lib, timeout=WaitSpec.calculate(leeway=timeForNodesToWorkOutReconnect), errorContext="fullValidationNode LIB did not advance")
+    # Maximum lib will be cfTrxBlockNum-2 and head cfTrxBlockNum-1 because of when we will receive incomplete block we won't advance lib
+    # However lib & head could be less in case net plugin receives unlinkable block before it processed previous blocks
+    # This check ensures LIB doesn't go beyond cfTrxBlockNum-1
+    assert False == fullValidationNode.waitForBlock(cfTrxBlockNum-1, blockType=BlockType.lib, timeout=WaitSpec.calculate(leeway=timeForNodesToWorkOutReconnect))
     Utils.Print("Ensure full validation node stops syncing")
     headAdvanced = fullValidationNode.waitForHeadToAdvance()
     if headAdvanced:


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->
## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
This is fix to flakiness of `eosio_blocklog_prune_test`.
Test could fail if following occurs:
full validation node receives few blocks including unlinkable block.
`connection::handle_message( const block_id_type& id, signed_block_ptr ptr )` first checks if it is complete block and then posts block processing to application thread.
Sometimes messages queued faster than they are processed and once we get unlinkable block we close entire connection. After doing this `connection::process_signed_block` drops processing entire queue even if those are valid blocks.
Fix:
Do not restrict test to check full validation node to have exactly unlinkable-1 block number. It can be earlier block.

## Change Type
**Select *ONE*:**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [x] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [ ] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the release notes. Please include a description of the change for inclusion in the release notes. -->


## Testing Changes
**Select *ANY* that apply:**
- [ ] New Tests
<!-- checked [x] = new test cases were added; unchecked [ ] = no new test cases -->
- [ ] Existing Tests
<!-- checked [x] = existing test cases were edited; unchecked [ ] = no existing tests were modified -->
- [ ] Test Framework
<!-- checked [x] = this modifies the test framework; unchecked [ ] = no test framework changes -->
- [ ] CI System
<!-- checked [x] = this changes the CI system; unchecked [ ] = no CI changes -->
- [ ] Other
<!-- checked [x] = this integrates an external test system; unchecked [ ] = no miscellaneous test-related changes -->
<!-- Please describe your test changes, or list each new test and its purpose, under each respective checkbox -->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
