### PR TITLE
Update Zipkin connection retry - 2.1.x

### DIFF
--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -342,6 +342,8 @@ void chain_plugin::set_program_options(options_description& cli, options_descrip
           "Zipkin localEndpoint.serviceName sent with each span" )
          ("telemetry-timeout-us", bpo::value<uint32_t>()->default_value(200000),
           "Timeout for sending Zipkin span." )
+         ("telemetry-retry-interval-us", bpo::value<uint32_t>()->default_value(30000000),
+          "Retry interval for connecting to Zipkin." )
          ("actor-whitelist", boost::program_options::value<vector<string>>()->composing()->multitoken(),
           "Account added to actor whitelist (may specify multiple times)")
          ("actor-blacklist", boost::program_options::value<vector<string>>()->composing()->multitoken(),
@@ -1230,7 +1232,8 @@ void chain_plugin::plugin_initialize(const variables_map& options) {
       if (options.count("telemetry-url")) {
          fc::zipkin_config::init( options["telemetry-url"].as<std::string>(),
                                   options["telemetry-service-name"].as<std::string>(),
-                                  options["telemetry-timeout-us"].as<uint32_t>() );
+                                  options["telemetry-timeout-us"].as<uint32_t>(),
+                                  options["telemetry-retry-interval-us"].as<uint32_t>() );
       }
 
 

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -3872,6 +3872,7 @@ namespace eosio {
 
    void net_plugin::handle_sighup() {
       fc::logger::update( logger_name, logger );
+      fc::zipkin_config::handle_sighup();
    }
 
    void net_plugin::plugin_shutdown() {

--- a/programs/rodeos/cloner_plugin.cpp
+++ b/programs/rodeos/cloner_plugin.cpp
@@ -231,6 +231,8 @@ void cloner_plugin::set_program_options(options_description& cli, options_descri
       "Zipkin localEndpoint.serviceName sent with each span" );
    op("telemetry-timeout-us", bpo::value<uint32_t>()->default_value(200000),
       "Timeout for sending Zipkin span." );
+   op("telemetry-retry-interval-us", bpo::value<uint32_t>()->default_value(30000000),
+      "Retry interval for connecting to Zipkin." );
    // todo: remove
    op("filter-name", bpo::value<std::string>(), "Filter name");
    op("filter-wasm", bpo::value<std::string>(), "Filter wasm");
@@ -258,7 +260,8 @@ void cloner_plugin::plugin_initialize(const variables_map& options) {
       if (options.count("telemetry-url")) {
          fc::zipkin_config::init( options["telemetry-url"].as<std::string>(),
                                   options["telemetry-service-name"].as<std::string>(),
-                                  options["telemetry-timeout-us"].as<uint32_t>() );
+                                  options["telemetry-timeout-us"].as<uint32_t>(),
+                                  options["telemetry-retry-interval-us"].as<uint32_t>() );
       }
    }
    FC_LOG_AND_RETHROW()
@@ -282,6 +285,7 @@ void cloner_plugin::set_streamer(std::function<void(const char* data, uint64_t d
 }
 
 void cloner_plugin::handle_sighup() {
+   fc::zipkin_config::handle_sighup();
 }
 
 } // namespace b1


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->
## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
[EPE-933](https://blockone.atlassian.net/browse/EPE-933) [GitHub:issue:[10255](https://github.com/EOSIO/eos/issues/10255)]:

on networks like EOS Mainnet, 9 attempts is very small and useless for intermittent failures like running a zipkin upgrade. For production use, need to work more like:

1. retry every 30 seconds
2. have health reporting as to if connected or not
3. process SIGHUP or similar to force re-connect
4. Further if `telemetry-url` is a DNS name that points to multiple A or AAAA records, nodeos should try all the addreses returned before giving up. 


Notes:
- Existing code supports item 4 above. 
- Changes made in` fc submodule` https://github.com/EOSIO/fc/pull/201 

## Change Type
**Select *ONE*:**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [ ] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [x] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the release notes. Please include a description of the change for inclusion in the release notes. -->


## Testing Changes
**Select *ANY* that apply:**
- [ ] New Tests
<!-- checked [x] = new test cases were added; unchecked [ ] = no new test cases -->
- [ ] Existing Tests
<!-- checked [x] = existing test cases were edited; unchecked [ ] = no existing tests were modified -->
- [ ] Test Framework
<!-- checked [x] = this modifies the test framework; unchecked [ ] = no test framework changes -->
- [ ] CI System
<!-- checked [x] = this changes the CI system; unchecked [ ] = no CI changes -->
- [ ] Other
<!-- checked [x] = this integrates an external test system; unchecked [ ] = no miscellaneous test-related changes -->
<!-- Please describe your test changes, or list each new test and its purpose, under each respective checkbox -->


## Documentation Additions
- [x] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
Method handle_sighup() defined in zipkin is to handle signal SIGHUP, and this method is not called directly from the original SIGHUP signal handler but from other handlers, e.g., handle_sighup() of net_plugin, one of the mandatory plugins, can be used to forward signal SIGHUP by calling zipkin's handle_sighup().

Add a new option:
`telemetry-retry-interval-us`, optional parameter, specifies the retry interval for connecting to zipkin with default value set to 30000000