### PR TITLE
Fix memory leak (24GB per second) when rodeos starts with --filter-wa…

### DIFF
--- a/libraries/rodeos/include/b1/rodeos/filter.hpp
+++ b/libraries/rodeos/include/b1/rodeos/filter.hpp
@@ -50,6 +50,8 @@ struct filter_state : b1::rodeos::data_state<backend_t>, b1::rodeos::console_sta
 #ifdef EOSIO_EOS_VM_OC_RUNTIME_ENABLED
    std::optional<eosvmoc_tier> eosvmoc_tierup;
 #endif
+
+   ~filter_state();
 };
 
 struct callbacks : b1::rodeos::chaindb_callbacks<callbacks>,

--- a/libraries/rodeos/include/b1/rodeos/wasm_ql.hpp
+++ b/libraries/rodeos/include/b1/rodeos/wasm_ql.hpp
@@ -30,6 +30,8 @@ struct shared_state {
 struct thread_state : action_state, console_state, query_state {
    std::shared_ptr<const shared_state> shared = {};
    eosio::vm::wasm_allocator           wa     = {};
+
+   ~thread_state();
 };
 
 class thread_state_cache : public std::enable_shared_from_this<thread_state_cache> {

--- a/libraries/rodeos/rodeos.cpp
+++ b/libraries/rodeos/rodeos.cpp
@@ -273,6 +273,11 @@ void rodeos_db_snapshot::write_deltas(const ship_protocol::get_blocks_result_v2&
    write_deltas(block_num, result.deltas, shutdown);
 }
 
+filter::filter_state::~filter_state() {
+   // wasm allocator must be explicitly freed
+   wa.free();
+}
+
 std::once_flag registered_filter_callbacks;
 
 rodeos_filter::rodeos_filter(eosio::name name, const std::string& wasm_filename, bool profile

--- a/libraries/rodeos/wasm_ql.cpp
+++ b/libraries/rodeos/wasm_ql.cpp
@@ -163,6 +163,11 @@ shared_state::shared_state(std::shared_ptr<chain_kv::database> db)
 
 shared_state::~shared_state() {}
 
+thread_state::~thread_state() {
+   // wasm allocator must be explicitly freed
+   wa.free();
+}
+
 std::optional<std::vector<uint8_t>> read_code(wasm_ql::thread_state& thread_state, eosio::name account) {
    std::optional<std::vector<uint8_t>> code;
    if (!thread_state.shared->contract_dir.empty()) {


### PR DESCRIPTION
…sm and is not connected to nodeos

<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->
## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
When `rodeos`'  `ship_client` fails to connect to `nodeos` (like when `nodeos` is not running),. `ship_client` calls `cloner_session`'s `close`() with `retry` set to `true`. This triggers `cloner_plugin` to recreate `cloner_session` every second until a connection is established. `cloner_session` creates `rodeos_filter` object if `rodeos` starts with `--filter-wasm` option. Although  destructor of `rodeos_filter` is called before recreation, its memory is not completely freed. The root cause is the `filter_state` in `rodeos_filter` has a member `eosio::vm::wasm_allocator  wa`. `wa` allocates VM memory when initiated. This memory must be released by explicit `free()`.

The same problem in `thread_state` is fixed by this PR as well.


## Change Type
**Select *ONE*:**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [x] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [ ] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the release notes. Please include a description of the change for inclusion in the release notes. -->


## Testing Changes
**Select *ANY* that apply:**
- [ ] New Tests
<!-- checked [x] = new test cases were added; unchecked [ ] = no new test cases -->
- [ ] Existing Tests
<!-- checked [x] = existing test cases were edited; unchecked [ ] = no existing tests were modified -->
- [ ] Test Framework
<!-- checked [x] = this modifies the test framework; unchecked [ ] = no test framework changes -->
- [ ] CI System
<!-- checked [x] = this changes the CI system; unchecked [ ] = no CI changes -->
- [ ] Other
<!-- checked [x] = this integrates an external test system; unchecked [ ] = no miscellaneous test-related changes -->
<!-- Please describe your test changes, or list each new test and its purpose, under each respective checkbox -->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
