### PR TITLE
Stop scanning a trace index log when a target block is found - develop

### DIFF
--- a/plugins/trace_api_plugin/store_provider.cpp
+++ b/plugins/trace_api_plugin/store_provider.cpp
@@ -67,6 +67,7 @@ namespace eosio::trace_api {
             const auto& block = std::get<block_entry_v0>(e);
             if (block.number == block_height) {
                trace_offset = block.offset;
+               return false; // stop scanning
             }
          } else if (std::holds_alternative<lib_entry_v0>(e)) {
             auto lib = std::get<lib_entry_v0>(e).lib;


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->
## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

Regarding RPC API `/trace_api/get_block`, since block numbers are unique in trace index logs, it doesn't look like necessary to keep scanning an index log when a target block is found in the log. 



## Change Type
**Select *ONE*:**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [ ] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [x] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the release notes. Please include a description of the change for inclusion in the release notes. -->


## Testing Changes
**Select *ANY* that apply:**
- [ ] New Tests
<!-- checked [x] = new test cases were added; unchecked [ ] = no new test cases -->
- [ ] Existing Tests
<!-- checked [x] = existing test cases were edited; unchecked [ ] = no existing tests were modified -->
- [ ] Test Framework
<!-- checked [x] = this modifies the test framework; unchecked [ ] = no test framework changes -->
- [ ] CI System
<!-- checked [x] = this changes the CI system; unchecked [ ] = no CI changes -->
- [ ] Other
<!-- checked [x] = this integrates an external test system; unchecked [ ] = no miscellaneous test-related changes -->
<!-- Please describe your test changes, or list each new test and its purpose, under each respective checkbox -->

