### PR TITLE
Investigate Buildfleet Artifact Download Timeouts

### DIFF
--- a/.cicd/generate-pipeline.sh
+++ b/.cicd/generate-pipeline.sh
@@ -6,7 +6,7 @@ export PLATFORMS_JSON_ARRAY='[]'
 [[ -z "$ROUNDS" ]] && export ROUNDS='1'
 [[ -z "$ROUND_SIZE" ]] && export ROUND_SIZE='1'
 BUILDKITE_BUILD_AGENT_QUEUE='automation-eks-eos-builder-fleet'
-BUILDKITE_TEST_AGENT_QUEUE='automation-eks-eos-tester-fleet'
+[[ "$DEBUG" != 'true' ]] && BUILDKITE_TEST_AGENT_QUEUE='automation-eks-eos-tester-fleet' || BUILDKITE_TEST_AGENT_QUEUE='automation-eks-eos-tester-debug-fleet'
 # attach pipeline documentation
 export DOCS_URL="https://github.com/EOSIO/eos/blob/$(git rev-parse HEAD)/.cicd"
 export RETRY="$([[ "$BUILDKITE" == 'true' ]] && buildkite-agent meta-data get pipeline-upload-retries --default '0' || echo "${RETRY:-0}")"

--- a/.cicd/test.sh
+++ b/.cicd/test.sh
@@ -2,6 +2,12 @@
 set -eo pipefail
 # variables
 . ./.cicd/helpers/general.sh
+if [[ "$DEBUG" == 'true' ]]; then
+    echo '+++ :ladybug: DEBUG MODE'
+    echo 'The artifact download completed successfully, so this Buildkite job step cannot be used for debugging the issue.'
+    echo "To run a normal build, do not set DEBUG='true' in the build environment."
+    echo 'Exiting without running tests.'
+fi
 # tests
 if [[ $(uname) == 'Darwin' ]]; then # macOS
     set +e # defer error handling to end

--- a/.cicd/test.sh
+++ b/.cicd/test.sh
@@ -7,6 +7,7 @@ if [[ "$DEBUG" == 'true' ]]; then
     echo 'The artifact download completed successfully, so this Buildkite job step cannot be used for debugging the issue.'
     echo "To run a normal build, do not set DEBUG='true' in the build environment."
     echo 'Exiting without running tests.'
+    exit 0
 fi
 # tests
 if [[ $(uname) == 'Darwin' ]]; then # macOS


### PR DESCRIPTION
## Change Description
From [#help-automation](https://blockone.slack.com/archives/CMTAZ9L4D/p1629147945026200?thread_ts=1629147942.026100&cid=CMTAZ9L4D) and service item [AUTO-1280](https://blockone.atlassian.net/browse/AUTO-1280), Blockchain is experiencing a high incidence of job step timeouts where Buildkite is hanging while attempting to download artifacts. Senior Blockchain engineers are reporting this is happening essentially every build, and these false pull request checks impede their work. The Buildkite job steps usually succeed on a retry. We have yet to observe any reports from macOS instances.

This pull request introduces debugging code which _should **not** be merged_. This code causes test steps which have passed the artifact download to immediately exit when `DEBUG` is set to `true` in the build environment. This will allow me to kick off a build with a very large number of test steps without wasting Linux agents. Hopefully, some steps encounter the bug and hang themselves. A very large Buildkite step timeout will allow me to shell onto them in the Kubernetes cluster and investigate further.

First attempt, eosio-test-stability [build 122](https://buildkite.com/EOSIO/eosio-test-stability/builds/122):
```bash
DEBUG='true'
PINNED='true'
ROUNDS='1'
ROUND_SIZE='1'
RUN_ALL_TESTS='true'
SKIP_DOCKER='true'
SKIP_MAC='true'
SKIP_MULTIVERSION_TEST='true'
TIMEOUT='480'
```
Through coincidence or bad luck, that did not encounter the bug so I increased `ROUNDS` in [build 129](https://buildkite.com/EOSIO/eosio-test-stability/builds/129):
```bash
DEBUG='true'
PINNED='true'
ROUNDS='23'
ROUND_SIZE='1'
RUN_ALL_TESTS='true'
SKIP_DOCKER='true'
SKIP_MAC='true'
SKIP_MULTIVERSION_TEST='true'
TIMEOUT='600'
```
While waiting on that build, I created the `automation-eks-eos-tester-debug-fleet` in auto-eks-buildfleet [pull request 241](https://github.com/EOSIO/auto-eks-buildfleet/pull/241) which has additional debugging flags set for `buildkite-agent`, then pointed this branch at that. Unfortunately, the previous two builds _still_ did not encounter the error! I am beginning to believe this was an intermittent networking issue that went unreported by either [Buildkite](https://www.buildkitestatus.com) or [AWS](https://status.aws.amazon.com). I am giving this one more try using the debug fleet in [build 140](https://buildkite.com/EOSIO/eosio-test-stability/builds/140) with the variables above...

### See Also
- eos
  - [Pull Request 10626](https://github.com/EOSIO/eos/pull/10626) -- Investigate Buildfleet Artifact Download Timeouts
- auto-eks-buildfleet
  - [Pull Request 241](https://github.com/EOSIO/auto-eks-buildfleet/pull/241) -- Create EOSIO Tester Debug Fleet

## Change Type
**Select *ONE*:**
- [ ] Documentation
- [ ] Stability bug fix
- [x] Other
- [ ] Other - special case


## Testing Changes
**Select *ANY* that apply:**
- [ ] New Tests
- [ ] Existing Tests
- [ ] Test Framework
- [x] CI System
- [ ] Other

Buildfleet debugging code.

## Consensus Changes
- [ ] Consensus Changes

None.

## API Changes
- [ ] API Changes

None.

## Documentation Additions
- [ ] Documentation Additions

None.