### PR TITLE
Track and use return_failure_trace in unapplied transaction queue.

### DIFF
--- a/unittests/unapplied_transaction_queue_tests.cpp
+++ b/unittests/unapplied_transaction_queue_tests.cpp
@@ -338,12 +338,12 @@ BOOST_AUTO_TEST_CASE( unapplied_transaction_queue_erase_add ) try {
    auto trx8 = unique_trx_meta_data();
    auto trx9 = unique_trx_meta_data();
 
-   q.add_incoming( trx1, false, [](auto){} );
-   q.add_incoming( trx2, false, [](auto){} );
-   q.add_incoming( trx3, false, [](auto){} );
-   q.add_incoming( trx4, false, [](auto){} );
-   q.add_incoming( trx5, false, [](auto){} );
-   q.add_incoming( trx6, false, [](auto){} );
+   q.add_incoming( trx1, false, false, [](auto){} );
+   q.add_incoming( trx2, false, false, [](auto){} );
+   q.add_incoming( trx3, false, false, [](auto){} );
+   q.add_incoming( trx4, false, false, [](auto){} );
+   q.add_incoming( trx5, false, false, [](auto){} );
+   q.add_incoming( trx6, false, false, [](auto){} );
 
    auto itr = q.incoming_begin();
    auto end = q.incoming_end();
@@ -360,7 +360,7 @@ BOOST_AUTO_TEST_CASE( unapplied_transaction_queue_erase_add ) try {
       if( count == 2 ) BOOST_CHECK( trx_meta == trx5 );
       if( count == 1 ) BOOST_CHECK( trx_meta == trx6 );
       itr = q.erase( itr );
-      q.add_incoming( trx_meta, false, [](auto){} );
+      q.add_incoming( trx_meta, false, false, [](auto){} );
       --count;
    }
 
@@ -374,12 +374,12 @@ BOOST_AUTO_TEST_CASE( unapplied_transaction_queue_erase_add ) try {
    BOOST_CHECK( q.empty() );
 
    // incoming ++itr w/ erase
-   q.add_incoming( trx1, false, [](auto){} );
-   q.add_incoming( trx2, false, [](auto){} );
-   q.add_incoming( trx3, false, [](auto){} );
-   q.add_incoming( trx4, false, [](auto){} );
-   q.add_incoming( trx5, false, [](auto){} );
-   q.add_incoming( trx6, false, [](auto){} );
+   q.add_incoming( trx1, false, false, [](auto){} );
+   q.add_incoming( trx2, false, false, [](auto){} );
+   q.add_incoming( trx3, false, false, [](auto){} );
+   q.add_incoming( trx4, false, false, [](auto){} );
+   q.add_incoming( trx5, false, false, [](auto){} );
+   q.add_incoming( trx6, false, false, [](auto){} );
 
    itr = q.incoming_begin();
    end = q.incoming_end();
@@ -403,7 +403,7 @@ BOOST_AUTO_TEST_CASE( unapplied_transaction_queue_erase_add ) try {
    q.add_persisted( trx4 );
    q.add_persisted( trx5 );
    q.add_persisted( trx6 );
-   q.add_incoming( trx7, false, [](auto){} );
+   q.add_incoming( trx7, false, false, [](auto){} );
 
    itr = q.persisted_begin();
    end = q.persisted_end();
@@ -429,7 +429,7 @@ BOOST_AUTO_TEST_CASE( unapplied_transaction_queue_erase_add ) try {
    q.add_persisted( trx4 );
    q.add_persisted( trx5 );
    q.add_persisted( trx6 );
-   q.add_incoming( trx7, false, [](auto){} );
+   q.add_incoming( trx7, false, false, [](auto){} );
 
    itr = q.unapplied_begin();
    end = q.unapplied_end();
@@ -461,12 +461,12 @@ BOOST_AUTO_TEST_CASE( unapplied_transaction_queue_incoming_count ) try {
    auto trx5 = unique_trx_meta_data();
    auto trx6 = unique_trx_meta_data();
 
-   q.add_incoming( trx1, false, [](auto){} );
-   q.add_incoming( trx2, false, [](auto){} );
-   q.add_incoming( trx3, false, [](auto){} );
-   q.add_incoming( trx4, false, [](auto){} );
-   q.add_incoming( trx5, false, [](auto){} );
-   q.add_incoming( trx6, false, [](auto){} );
+   q.add_incoming( trx1, false, false, [](auto){} );
+   q.add_incoming( trx2, false, false, [](auto){} );
+   q.add_incoming( trx3, false, false, [](auto){} );
+   q.add_incoming( trx4, false, false, [](auto){} );
+   q.add_incoming( trx5, false, false, [](auto){} );
+   q.add_incoming( trx6, false, false, [](auto){} );
 
    auto expected = q.size();
 
@@ -488,7 +488,7 @@ BOOST_AUTO_TEST_CASE( unapplied_transaction_queue_incoming_count ) try {
    end = q.end();
 
    while( itr != end ) {
-      q.add_incoming( itr->trx_meta, false, [](auto){} );
+      q.add_incoming( itr->trx_meta, false, false, [](auto){} );
       ++expected;
       BOOST_CHECK( q.incoming_size() == expected );
       ++itr;


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->
## Change Description
When support for returning failure traces was introduced, it was only added to the immediate transaction processing path, resulting in unexpected failure to honor the flag when nodeos silently queued a transaction.  The unapplied transaction queue will now track the flag so producer_plugin can apply it appropriately.  Resolves EPE-1130.

## Change Type
**Select *ONE*:**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [x] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [ ] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the release notes. Please include a description of the change for inclusion in the release notes. -->


## Testing Changes
**Select *ANY* that apply:**
- [ ] New Tests
<!-- checked [x] = new test cases were added; unchecked [ ] = no new test cases -->
- [ ] Existing Tests
<!-- checked [x] = existing test cases were edited; unchecked [ ] = no existing tests were modified -->
- [ ] Test Framework
<!-- checked [x] = this modifies the test framework; unchecked [ ] = no test framework changes -->
- [ ] CI System
<!-- checked [x] = this changes the CI system; unchecked [ ] = no CI changes -->
- [ ] Other
<!-- checked [x] = this integrates an external test system; unchecked [ ] = no miscellaneous test-related changes -->
<!-- Please describe your test changes, or list each new test and its purpose, under each respective checkbox -->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
