### PR TITLE
Add map mode options for EOS VM OC code cache - 2.2

### DIFF
--- a/libraries/chain/include/eosio/chain/webassembly/eos-vm-oc/code_cache.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/eos-vm-oc/code_cache.hpp
@@ -42,7 +42,14 @@ class code_cache_base {
       code_cache_base(const bfs::path data_dir, const eosvmoc::config& eosvmoc_config, code_finder db);
       ~code_cache_base();
 
-      const int& fd() const { return _cache_fd; }
+      //fd of code cache suitable for sending to out of process code manager
+      const int& cache_fd() const { return _cache_fd; }
+      //return a mmap()ing of the code cache (and the mapping size) suitable for execution
+      void cache_mapping_for_execution(const int prot_flags, uint8_t*& addr, size_t& map_size) const;
+
+      size_t number_entries() const {return _cache_index.size();}
+      //only known after completion of a compile
+      std::optional<size_t> free_bytes() const {return _last_known_free_bytes;}
 
       void free_code(const digest_type& code_id, const uint8_t& vm_version);
 
@@ -65,8 +72,16 @@ class code_cache_base {
 
       code_finder _db;
 
-      bfs::path _cache_file_path;
-      int _cache_fd;
+      //handle to the on-disk file
+      int _cache_file_fd;
+
+      //the file to map in, and properties of that mapping
+      int _cache_fd = -1;
+      size_t _mapped_size = 0;
+      bool _populate_on_map = false;
+      bool _mlock_map = false;
+
+      int _extra_mmap_flags = 0;
 
       io_context _ctx;
       local::datagram_protocol::socket _compile_monitor_write_socket{_ctx};
@@ -80,8 +95,11 @@ class code_cache_base {
       size_t _free_bytes_eviction_threshold;
       void check_eviction_threshold(size_t free_bytes);
       void run_eviction_round();
+      std::optional<size_t> _last_known_free_bytes;
 
       void set_on_disk_region_dirty(bool);
+
+      int get_huge_memfd(size_t map_size, int memfd_flags) const;
 
       template <typename T>
       void serialize_cache_index(fc::datastream<T>& ds);

--- a/libraries/chain/include/eosio/chain/webassembly/eos-vm-oc/config.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/eos-vm-oc/config.hpp
@@ -7,12 +7,14 @@
 
 #include <boost/filesystem/path.hpp>
 #include <fc/reflect/reflect.hpp>
+#include <chainbase/pinnable_mapped_file.hpp>
 
 namespace eosio { namespace chain { namespace eosvmoc {
 
 struct config {
    uint64_t cache_size = 1024u*1024u*1024u;
    uint64_t threads    = 1u;
+   chainbase::pinnable_mapped_file::map_mode map_mode = chainbase::pinnable_mapped_file::map_mode::mapped;
 };
 
 }}}

--- a/libraries/chain/webassembly/runtimes/eos-vm-oc/code_cache.cpp
+++ b/libraries/chain/webassembly/runtimes/eos-vm-oc/code_cache.cpp
@@ -1,13 +1,15 @@
 #include <fc/log/logger_config.hpp> //set_thread_name
+#include <fc/scoped_exit.hpp>
 
 #include <eosio/chain/webassembly/eos-vm-oc/code_cache.hpp>
 #include <eosio/chain/webassembly/eos-vm-oc/config.hpp>
-#include <eosio/chain/webassembly/common.hpp>
-#include <eosio/chain/webassembly/eos-vm-oc/memory.hpp>
 #include <eosio/chain/webassembly/eos-vm-oc/eos-vm-oc.hpp>
-#include <eosio/chain/webassembly/eos-vm-oc/intrinsic.hpp>
 #include <eosio/chain/webassembly/eos-vm-oc/compile_monitor.hpp>
 #include <eosio/chain/exceptions.hpp>
+
+#include <boost/iostreams/copy.hpp>
+#include <boost/iostreams/device/file_descriptor.hpp>
+#include <boost/iostreams/device/array.hpp>
 
 #include <unistd.h>
 #include <sys/syscall.h>
@@ -17,10 +19,12 @@
 #include "IR/Module.h"
 #include "IR/Validate.h"
 #include "WASM/WASM.h"
-#include "LLVMJIT.h"
+
+#ifndef _POSIX_SYNCHRONIZED_IO
+#error _POSIX_SYNCHRONIZED_IO not defined for this platform
+#endif
 
 using namespace IR;
-using namespace Runtime;
 
 namespace eosio { namespace chain { namespace eosvmoc {
 
@@ -38,6 +42,19 @@ static constexpr size_t header_dirty_bit_offset_from_file_start = header_offset 
 static constexpr size_t descriptor_ptr_from_file_start = header_offset + offsetof(code_cache_header, serialized_descriptor_index);
 
 static_assert(sizeof(code_cache_header) <= header_size, "code_cache_header too big");
+
+namespace impl {
+   //allows handing off a naked file descriptor to boost::interprocess::mapped_region; normally one would use a bip::file_mapping
+   // but it's not possible to construct a file_mapping with an existing file descriptor. It may be interesting to extend the existing
+   // eosvmoc::wrapped_fd to provide get_mapping_handle(), and remove the naked file descriptors from code_cache.
+   struct bip_wrapped_handle {
+      bip_wrapped_handle(int fd) : fd(fd) {}
+      bip_wrapped_handle(const bip_wrapped_handle&) = delete;
+      bip_wrapped_handle& operator=(const bip_wrapped_handle&) = delete;
+      bip::mapping_handle_t get_mapping_handle() const {return bip::mapping_handle_t{fd, false};}
+      int fd;
+   };
+}
 
 code_cache_async::code_cache_async(const bfs::path data_dir, const eosvmoc::config& eosvmoc_config, code_finder db) :
    code_cache_base(data_dir, eosvmoc_config, std::move(db)),
@@ -202,97 +219,185 @@ const code_descriptor* const code_cache_sync::get_descriptor_for_code_sync(const
    return &*_cache_index.push_front(std::move(std::get<code_descriptor>(result.result))).first;
 }
 
+int code_cache_base::get_huge_memfd(size_t map_size, int memfd_flags) const {
+   int ret;
+
+   ret = syscall(SYS_memfd_create, "eosvmoc_cc", MFD_CLOEXEC | memfd_flags);
+   if(ret < 0)
+      return -1;
+
+   auto close_failed_creation = fc::make_scoped_exit([&](){close(ret);});
+
+   if(ftruncate(ret, map_size) == -1)
+      return -1;
+
+   //Empirically on 5.13.9 there is no need to pass MAP_HUGETLB to have the mapping actually use hugepages.
+   //That makes sense due to the underlying implementation of memfd, but the docs seem ambiguous on expected behavior.
+
+   //The man page states w.r.t. MAP_POPULATE:
+   //     The mmap() call doesn't fail if the mapping cannot be populated (for example,
+   //     due to limitations on the number of mapped huge pages when using MAP_HUGETLB).
+   //Well, empirically on 5.13.9 MAP_POPULATE does cause a failure if there aren't actually enough hugepages available
+   // at the given size. It's not clear how to (easily) more robustly handle what the documentation suggests: where the MAP_POPULATE
+   // passively ignores that we're overcommitted. We could attempt to force the pages to be allocated in a loop after the mmap(),
+   // but we'd just be SIGBUSed if pages aren't available. Handling SIGBUS would fully resolve this I suppose, but that's more
+   // complication than I'd like.
+   //Thus there seems to be a risk according to the documentation that there may be a nasty situation where the platform indicates
+   // 1GB pages are available, MAP_POPULATE passively succeeds, so we then plan to use 1GB pages, but then the later iostreams::copy()
+   // fails via a SIGBUS because the hugepages were overcommitted and not enough are actually available. In such a situation a user
+   // would be stuck and unable to use heap/locked mode; worse, the SIGBUS may leave the main chainbase database dirty.
+   void* mapped = mmap(NULL, map_size, PROT_READ|PROT_WRITE, MAP_SHARED|MAP_POPULATE, ret, 0);
+   if(mapped == MAP_FAILED)
+      return -1;
+
+   if(munmap(mapped, map_size))
+      return -1;
+
+   close_failed_creation.cancel();
+   return ret;
+}
+
 code_cache_base::code_cache_base(const boost::filesystem::path data_dir, const eosvmoc::config& eosvmoc_config, code_finder db) :
-   _db(std::move(db)),
-   _cache_file_path(data_dir/"code_cache.bin")
+   _db(std::move(db))
 {
    static_assert(sizeof(allocator_t) <= header_offset, "header offset intersects with allocator");
 
    bfs::create_directories(data_dir);
+   boost::filesystem::path cache_file_path = data_dir/"code_cache.bin";
 
-   if(!bfs::exists(_cache_file_path)) {
+   if(!bfs::exists(cache_file_path)) {
       EOS_ASSERT(eosvmoc_config.cache_size >= allocator_t::get_min_size(total_header_size), database_exception, "configured code cache size is too small");
-      std::ofstream ofs(_cache_file_path.generic_string(), std::ofstream::trunc);
+      std::ofstream ofs(cache_file_path.generic_string(), std::ofstream::trunc);
       EOS_ASSERT(ofs.good(), database_exception, "unable to create EOS VM Optimized Compiler code cache");
-      bfs::resize_file(_cache_file_path, eosvmoc_config.cache_size);
-      bip::file_mapping creation_mapping(_cache_file_path.generic_string().c_str(), bip::read_write);
+      bfs::resize_file(cache_file_path, eosvmoc_config.cache_size);
+      bip::file_mapping creation_mapping(cache_file_path.generic_string().c_str(), bip::read_write);
       bip::mapped_region creation_region(creation_mapping, bip::read_write);
       new (creation_region.get_address()) allocator_t(eosvmoc_config.cache_size, total_header_size);
       new ((char*)creation_region.get_address() + header_offset) code_cache_header;
    }
 
+   _cache_file_fd = open(cache_file_path.c_str(), O_RDWR);
+   EOS_ASSERT(_cache_file_fd >= 0, database_exception, "failure to open code cache file");
+   auto cleanup_cache_file_fd_on_ctor_exception = fc::make_scoped_exit([&](){close(_cache_file_fd);});
+
    code_cache_header cache_header;
-   {
-      char header_buff[total_header_size];
-      std::ifstream hs(_cache_file_path.generic_string(), std::ifstream::binary);
-      hs.read(header_buff, sizeof(header_buff));
-      EOS_ASSERT(!hs.fail(), bad_database_version_exception, "failed to read code cache header");
-      memcpy((char*)&cache_header, header_buff + header_offset, sizeof(cache_header));
-   }
+   char header_buff[total_header_size];
+   EOS_ASSERT(read(_cache_file_fd, header_buff, sizeof(header_buff)) == sizeof(header_buff), bad_database_version_exception, "failed to read code cache header");
+   memcpy((char*)&cache_header, header_buff + header_offset, sizeof(cache_header));
 
    EOS_ASSERT(cache_header.id == header_id, bad_database_version_exception, "existing EOS VM OC code cache not compatible with this version");
    EOS_ASSERT(!cache_header.dirty, database_exception, "code cache is dirty");
 
    set_on_disk_region_dirty(true);
 
-   auto existing_file_size = bfs::file_size(_cache_file_path);
+   auto existing_file_size = bfs::file_size(cache_file_path);
+   size_t on_disk_size = existing_file_size;
    if(eosvmoc_config.cache_size > existing_file_size) {
-      bfs::resize_file(_cache_file_path, eosvmoc_config.cache_size);
+      EOS_ASSERT(!ftruncate(_cache_file_fd, eosvmoc_config.cache_size), database_exception, "Failed to grow code cache file: ${e}", ("e", strerror(errno)));
 
-      bip::file_mapping resize_mapping(_cache_file_path.generic_string().c_str(), bip::read_write);
-      bip::mapped_region resize_region(resize_mapping, bip::read_write);
+      impl::bip_wrapped_handle wh(_cache_file_fd);
 
+      bip::mapped_region resize_region(wh, bip::read_write);
       allocator_t* resize_allocator = reinterpret_cast<allocator_t*>(resize_region.get_address());
       resize_allocator->grow(eosvmoc_config.cache_size - existing_file_size);
+      on_disk_size = eosvmoc_config.cache_size;
    }
 
-   _cache_fd = ::open(_cache_file_path.generic_string().c_str(), O_RDWR | O_CLOEXEC);
-   EOS_ASSERT(_cache_fd >= 0, database_exception, "failure to open code cache");
+   auto cleanup_cache_handle_fd_on_ctor_exception = fc::make_scoped_exit([&]() {if(_cache_fd >= 0) close(_cache_fd);});
+
+   if(eosvmoc_config.map_mode == chainbase::pinnable_mapped_file::map_mode::mapped) {
+      _cache_fd = dup(_cache_file_fd);
+      EOS_ASSERT(_cache_fd >= 0, database_exception, "failure to open code cache");
+      _mapped_size = on_disk_size;
+   }
+   else {
+      const unsigned _1gb = 1u<<30u;
+      const unsigned _2mb = 1u<<21u;
+
+      _populate_on_map = true;
+      _mlock_map = (eosvmoc_config.map_mode == chainbase::pinnable_mapped_file::map_mode::locked);
+
+      auto round_up_file_size_to = [&](size_t r) {
+         return (on_disk_size + (r-1u))/r*r;
+      };
+
+#if defined(MFD_HUGETLB) && defined(MFD_HUGE_1GB)
+      if((_cache_fd = get_huge_memfd(_mapped_size = round_up_file_size_to(_1gb), MFD_HUGETLB|MFD_HUGE_1GB)) >= 0) {
+         ilog("EOS VM OC code cache using 1GB pages");
+      } else
+#endif
+#if defined(MFD_HUGETLB) && defined(MFD_HUGE_2MB)
+      if((_cache_fd = get_huge_memfd(_mapped_size = round_up_file_size_to(_2mb), MFD_HUGETLB|MFD_HUGE_2MB)) >= 0) {
+         ilog("EOS VM OC code cache using 2MB pages");
+      } else
+#endif
+      {
+         _cache_fd = get_huge_memfd(_mapped_size = round_up_file_size_to(getpagesize()), 0);
+         EOS_ASSERT(_cache_fd >= 0, database_exception, "Failed to allocate code cache memory");
+      }
+
+      ilog("Preloading EOS VM OC code cache. This may take a moment...");
+
+      EOS_ASSERT(lseek(_cache_file_fd, 0, SEEK_SET) == 0, database_exception, "Failed to seek in code cache file");
+      impl::bip_wrapped_handle wh(_cache_fd);
+      bip::mapped_region load_region(wh, bip::read_write);
+
+      boost::iostreams::file_descriptor_source source(_cache_file_fd, boost::iostreams::never_close_handle);
+      boost::iostreams::array_sink sink((char*)load_region.get_address(), load_region.get_size());
+      std::streamsize copied = boost::iostreams::copy(source, sink, 1024*1024);
+      EOS_ASSERT(copied >= on_disk_size, database_exception, "Failed to preload code cache memory");
+   }
 
    //load up the previous cache index
-   char* code_mapping = (char*)mmap(nullptr, eosvmoc_config.cache_size, PROT_READ|PROT_WRITE, MAP_SHARED, _cache_fd, 0);
-   EOS_ASSERT(code_mapping != MAP_FAILED, database_exception, "failure to mmap code cache");
+   impl::bip_wrapped_handle wh(_cache_fd);
 
-   allocator_t* allocator = reinterpret_cast<allocator_t*>(code_mapping);
+   bip::mapped_region load_region(wh, bip::read_write);
+   allocator_t* allocator = reinterpret_cast<allocator_t*>(load_region.get_address());
 
    if(cache_header.serialized_descriptor_index) {
-      fc::datastream<const char*> ds(code_mapping + cache_header.serialized_descriptor_index, eosvmoc_config.cache_size - cache_header.serialized_descriptor_index);
+      fc::datastream<const char*> ds((char*)load_region.get_address() + cache_header.serialized_descriptor_index, eosvmoc_config.cache_size - cache_header.serialized_descriptor_index);
       unsigned number_entries;
       fc::raw::unpack(ds, number_entries);
       for(unsigned i = 0; i < number_entries; ++i) {
          code_descriptor cd;
          fc::raw::unpack(ds, cd);
          if(cd.codegen_version != 0) {
-            allocator->deallocate(code_mapping + cd.code_begin);
-            allocator->deallocate(code_mapping + cd.initdata_begin);
+            allocator->deallocate((char*)load_region.get_address() + cd.code_begin);
+            allocator->deallocate((char*)load_region.get_address() + cd.initdata_begin);
             continue;
          }
          _cache_index.push_back(std::move(cd));
       }
-      allocator->deallocate(code_mapping + cache_header.serialized_descriptor_index);
+      allocator->deallocate((char*)load_region.get_address() + cache_header.serialized_descriptor_index);
 
       ilog("EOS VM Optimized Compiler code cache loaded with ${c} entries; ${f} of ${t} bytes free", ("c", number_entries)("f", allocator->get_free_memory())("t", allocator->get_size()));
    }
-   munmap(code_mapping, eosvmoc_config.cache_size);
 
-   _free_bytes_eviction_threshold = eosvmoc_config.cache_size * .1;
+   _free_bytes_eviction_threshold = on_disk_size * .1;
 
    wrapped_fd compile_monitor_conn = get_connection_to_compile_monitor(_cache_fd);
 
    //okay, let's do this by the book: we're not allowed to write & read on different threads to the same asio socket. So create two fds
    //representing the same unix socket. we'll read on one and write on the other
    int duped = dup(compile_monitor_conn);
+   EOS_ASSERT(duped >= 0, database_exception, "failure to dup compile monitor socket");
    _compile_monitor_write_socket.assign(local::datagram_protocol(), duped);
    _compile_monitor_read_socket.assign(local::datagram_protocol(), compile_monitor_conn.release());
+
+   cleanup_cache_file_fd_on_ctor_exception.cancel();
+   cleanup_cache_handle_fd_on_ctor_exception.cancel();
 }
 
 void code_cache_base::set_on_disk_region_dirty(bool dirty) {
-   bip::file_mapping dirty_mapping(_cache_file_path.generic_string().c_str(), bip::read_write);
-   bip::mapped_region dirty_region(dirty_mapping, bip::read_write);
-
-   *((char*)dirty_region.get_address()+header_dirty_bit_offset_from_file_start) = dirty;
-   if(dirty_region.flush(0, 0, false) == false)
-      elog("Syncing code cache failed");
+   if(lseek(_cache_file_fd, header_dirty_bit_offset_from_file_start, SEEK_SET) == -1) {
+      elog("Seeking to code cache dirty bit failed");
+      return;
+   }
+   char write_me = dirty;
+   if(::write(_cache_file_fd, &write_me, 1) != 1)
+      elog("Writing dirty bit in code cache failed");
+   if(fsync(_cache_file_fd))
+      elog("Syncing code cache dirtyness failed");
 }
 
 template <typename T>
@@ -303,21 +408,35 @@ void code_cache_base::serialize_cache_index(fc::datastream<T>& ds) {
       fc::raw::pack(ds, cd);
 }
 
+void code_cache_base::cache_mapping_for_execution(const int prot_flags, uint8_t*& addr, size_t& map_size) const {
+   int map_flags = MAP_SHARED;
+   if(_populate_on_map)
+      map_flags |= MAP_POPULATE; //see comments in get_huge_memfd(). This is intended solely to populate page table for existing allocated pages
+
+   addr = (uint8_t*)mmap(nullptr, _mapped_size, prot_flags, map_flags, _cache_fd, 0);
+   FC_ASSERT(addr != MAP_FAILED, "failed to map code cache (${e})", ("e", strerror(errno)));
+
+   if(_mlock_map && mlock(addr, _mapped_size)) {
+      int lockerr = errno;
+      munmap(addr, _mapped_size);
+      FC_ASSERT(false, "failed to lock code cache (${e})", ("e", strerror(lockerr)));
+   }
+
+   map_size = _mapped_size;
+}
+
 code_cache_base::~code_cache_base() {
    //reopen the code cache in our process
-   struct stat st;
-   if(fstat(_cache_fd, &st))
-      return;
-   char* code_mapping = (char*)mmap(nullptr, st.st_size, PROT_READ|PROT_WRITE, MAP_SHARED, _cache_fd, 0);
-   if(code_mapping == MAP_FAILED)
-      return;
-
-   allocator_t* allocator = reinterpret_cast<allocator_t*>(code_mapping);
+   impl::bip_wrapped_handle wh(_cache_fd);
+   bip::mapped_region load_region(wh, bip::read_write);
+   allocator_t* allocator = reinterpret_cast<allocator_t*>(load_region.get_address());
 
    //serialize out the cache index
    fc::datastream<size_t> dssz;
    serialize_cache_index(dssz);
    size_t sz = dssz.tellp();
+
+   char* code_mapping = (char*)load_region.get_address();
 
    char* p = nullptr;
    while(_cache_index.size()) {
@@ -343,11 +462,31 @@ code_cache_base::~code_cache_base() {
    else
       *((uintptr_t*)(code_mapping+descriptor_ptr_from_file_start)) = 0;
 
-   msync(code_mapping, allocator->get_size(), MS_SYNC);
-   munmap(code_mapping, allocator->get_size());
+   if(!_populate_on_map) {
+      msync(code_mapping, _mapped_size, MS_SYNC);
+      munmap(code_mapping, _mapped_size);
+   }
+   else {
+      ilog("Writing EOS VM OC code cache to disk. This may take a moment...");
+      struct stat st;
+      if(lseek(_cache_file_fd, 0, SEEK_SET) == 0 && fstat(_cache_file_fd, &st) == 0) {
+         //don't use the mmaped size for source since it has been rounded up from the file size, use file size
+         boost::iostreams::array_source source(code_mapping, st.st_size);
+         boost::iostreams::file_descriptor_sink sink(_cache_file_fd, boost::iostreams::never_close_handle);
+
+         if(boost::iostreams::copy(source, sink, 1024*1024) != st.st_size)
+            elog("Failed to write out EOS VM OC code cache");
+         if(fsync(_cache_file_fd))
+            elog("Syncing code cache data failed");
+      }
+      else {
+         elog("Failed to write out EOS VM OC code cache");
+      }
+   }
+
    close(_cache_fd);
    set_on_disk_region_dirty(false);
-
+   close(_cache_file_fd);
 }
 
 void code_cache_base::free_code(const digest_type& code_id, const uint8_t& vm_version) {
@@ -378,6 +517,7 @@ void code_cache_base::run_eviction_round() {
 }
 
 void code_cache_base::check_eviction_threshold(size_t free_bytes) {
+   _last_known_free_bytes = free_bytes;
    if(free_bytes < _free_bytes_eviction_threshold)
       run_eviction_round();
 }

--- a/libraries/chain/webassembly/runtimes/eos-vm-oc/executor.cpp
+++ b/libraries/chain/webassembly/runtimes/eos-vm-oc/executor.cpp
@@ -144,11 +144,7 @@ executor::executor(const code_cache_base& cc) {
    if(arch_prctl(ARCH_GET_GS, &current_gs) || current_gs)
       wlog("x86_64 GS register is not set as expected. EOS VM OC may not run correctly on this platform");
 
-   struct stat s;
-   FC_ASSERT(fstat(cc.fd(), &s) == 0, "executor failed to get code cache size");
-   code_mapping = (uint8_t*)mmap(nullptr, s.st_size, PROT_EXEC|PROT_READ, MAP_SHARED, cc.fd(), 0);
-   FC_ASSERT(code_mapping != MAP_FAILED, "failed to map code cache in to executor");
-   code_mapping_size = s.st_size;
+   cc.cache_mapping_for_execution(PROT_EXEC|PROT_READ, code_mapping, code_mapping_size);
    mapping_is_executable = true;
 }
 

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -401,6 +401,12 @@ void chain_plugin::set_program_options(options_description& cli, options_descrip
                   EOS_ASSERT(false, plugin_exception, "");
                }
          }), "Number of threads to use for EOS VM OC tier-up")
+         ("eos-vm-oc-code-cache-map-mode", bpo::value<chainbase::pinnable_mapped_file::map_mode>()->default_value(chain::eosvmoc::config().map_mode),
+          "Map mode for EOS VM OC code cache (\"mapped\", \"heap\", or \"locked\").\n"
+          "In \"mapped\" mode code cache is memory mapped as a file.\n"
+          "In \"heap\" mode code cache is preloaded in to swappable memory and will use huge pages if available.\n"
+          "In \"locked\" mode code cache is preloaded, locked in to memory, and will use huge pages if available.\n"
+         )
          ("eos-vm-oc-enable", bpo::bool_switch(), "Enable EOS VM OC tier-up runtime")
 #endif
          ("enable-account-queries", bpo::value<bool>()->default_value(false), "enable queries to find accounts by various metadata.")
@@ -1170,6 +1176,8 @@ void chain_plugin::plugin_initialize(const variables_map& options) {
          my->chain_config->eosvmoc_config.cache_size = options.at( "eos-vm-oc-cache-size-mb" ).as<uint64_t>() * 1024u * 1024u;
       if( options.count("eos-vm-oc-compile-threads") )
          my->chain_config->eosvmoc_config.threads = options.at("eos-vm-oc-compile-threads").as<uint64_t>();
+      if( options.count("eos-vm-oc-code-cache-map-mode") )
+         my->chain_config->eosvmoc_config.map_mode = options.at("eos-vm-oc-code-cache-map-mode").as<chainbase::pinnable_mapped_file::map_mode>();
       if( options["eos-vm-oc-enable"].as<bool>() )
          my->chain_config->eosvmoc_tierup = true;
 #endif

--- a/programs/rodeos/cloner_plugin.cpp
+++ b/programs/rodeos/cloner_plugin.cpp
@@ -320,8 +320,13 @@ void cloner_plugin::set_program_options(options_description& cli, options_descri
          elog("eos-vm-oc-compile-threads must be set to a non-zero value");
          EOS_ASSERT(false, eosio::chain::plugin_exception, "");
       }
-   }),
-      "Number of threads to use for EOS VM OC tier-up");
+   }), "Number of threads to use for EOS VM OC tier-up");
+   op("eos-vm-oc-code-cache-map-mode", bpo::value<chainbase::pinnable_mapped_file::map_mode>()->default_value(eosio::chain::eosvmoc::config().map_mode),
+    "Map mode for EOS VM OC code cache (\"mapped\", \"heap\", or \"locked\").\n"
+    "In \"mapped\" mode code cache is memory mapped as a file.\n"
+    "In \"heap\" mode code cache is preloaded in to swappable memory and will use huge pages if available.\n"
+    "In \"locked\" mode code cache is preloaded, locked in to memory, and will use huge pages if available.\n"
+   );
    op("eos-vm-oc-enable", bpo::bool_switch(), "Enable EOS VM OC tier-up runtime");
 #endif
 }

--- a/programs/rodeos/streamer_plugin.cpp
+++ b/programs/rodeos/streamer_plugin.cpp
@@ -7,6 +7,7 @@
 #include <abieos.hpp>
 #include <eosio/abi.hpp>
 #include <eosio/chain/exceptions.hpp>
+#include <chainbase/pinnable_mapped_file.hpp>
 #include <fc/exception/exception.hpp>
 #include <fc/log/trace.hpp>
 #include <boost/filesystem/operations.hpp>
@@ -62,7 +63,9 @@ struct streamer_plugin_impl : public streamer_t {
 
 static abstract_plugin& _streamer_plugin = app().register_plugin<streamer_plugin>();
 
-streamer_plugin::streamer_plugin() : my(std::make_shared<streamer_plugin_impl>()) {}
+streamer_plugin::streamer_plugin() : my(std::make_shared<streamer_plugin_impl>()) {
+   app().register_config_type<chainbase::pinnable_mapped_file::map_mode>();
+}
 
 streamer_plugin::~streamer_plugin() {}
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -263,6 +263,7 @@ add_test(NAME trace_plugin_test COMMAND tests/trace_plugin_test.py WORKING_DIREC
 set_tests_properties(trace_plugin_test PROPERTIES TIMEOUT 150)
 set_property(TEST trace_plugin_test PROPERTY LABELS nonparallelizable_tests)
 
+add_subdirectory(eosvmoc_tests)
 add_subdirectory(se_tests)
 
 add_test(NAME resource_monitor_plugin_test COMMAND tests/resource_monitor_plugin_test.py WORKING_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/tests/eosvmoc_tests/CMakeLists.txt
+++ b/tests/eosvmoc_tests/CMakeLists.txt
@@ -1,0 +1,9 @@
+if(NOT "eos-vm-oc" IN_LIST EOSIO_WASM_RUNTIMES)
+    return()
+endif()
+
+add_executable(eosvmoc_test main.cpp codecache_tests.cpp)
+
+target_link_libraries(eosvmoc_test PRIVATE eosio_chain_wrap eosio_testing eosio_chain)
+
+add_test(NAME eosvmoc_test COMMAND tests/eosvmoc_tests/eosvmoc_test WORKING_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/tests/eosvmoc_tests/codecache_tests.cpp
+++ b/tests/eosvmoc_tests/codecache_tests.cpp
@@ -1,0 +1,123 @@
+#include <eosio/chain/webassembly/eos-vm-oc/code_cache.hpp>
+#include <eosio/testing/tester.hpp>
+#include <contracts.hpp>
+
+#include <boost/test/unit_test.hpp>
+#include <boost/test/data/test_case.hpp>
+#include <boost/test/data/monomorphic.hpp>
+
+using namespace eosio::chain;
+namespace data = boost::unit_test::data;
+
+//always return same fixed wasm to populate code cache. simple and works for this testing purpose
+static std::string_view get_some_wasm(const digest_type&, uint8_t) {
+   static auto noop_vector = eosio::testing::contracts::noop_wasm();
+   return std::string_view((const char*)noop_vector.data(), noop_vector.size());
+}
+
+static chainbase::pinnable_mapped_file::map_mode mapped_and_heap[] = {chainbase::pinnable_mapped_file::map_mode::mapped,
+                                                                      chainbase::pinnable_mapped_file::map_mode::heap};
+
+BOOST_AUTO_TEST_SUITE(eosvmoc_cc_tests)
+
+//create a code cache in one mode, close it and open it in a second mode ensuring the populated data from the first
+// go around is the same, then close it and open it yet again in the orginal mode
+BOOST_DATA_TEST_CASE(there_and_back_again, data::make(mapped_and_heap) * data::make(mapped_and_heap), first, second) { try {
+   fc::temp_directory tmp_code_cache;
+
+   const eosvmoc::code_descriptor* first_desc = nullptr;
+
+   eosvmoc::config first_eosvmoc_config = {32u*1024u*1024u, 1u, first};
+   eosvmoc::config second_eosvmoc_config = {32u*1024u*1024u, 1u, second};
+
+   {
+      eosvmoc::code_cache_sync cc(tmp_code_cache.path(), first_eosvmoc_config, get_some_wasm);
+      first_desc = cc.get_descriptor_for_code_sync(digest_type(), UINT8_C(0));
+      BOOST_REQUIRE(first_desc);
+   }
+
+   {
+      eosvmoc::code_cache_sync cc(tmp_code_cache.path(), second_eosvmoc_config, get_some_wasm);
+      const eosvmoc::code_descriptor* const second_desc = cc.get_descriptor_for_code_sync(digest_type(), UINT8_C(0));
+      BOOST_REQUIRE(second_desc);
+      BOOST_REQUIRE_EQUAL(first_desc->code_begin, second_desc->code_begin);
+   }
+
+   {
+      eosvmoc::code_cache_sync cc(tmp_code_cache.path(), first_eosvmoc_config, get_some_wasm);
+      const eosvmoc::code_descriptor* const desc = cc.get_descriptor_for_code_sync(digest_type(), UINT8_C(0));
+      BOOST_REQUIRE(desc);
+      BOOST_REQUIRE_EQUAL(first_desc->code_begin, desc->code_begin);
+   }
+} FC_LOG_AND_RETHROW() }
+
+//try to open the code cache while a first instance is already open -- should fail. Then open it again just cause.
+BOOST_DATA_TEST_CASE(dirty_check, data::make(mapped_and_heap) * data::make(mapped_and_heap), first, second) { try {
+   fc::temp_directory tmp_code_cache;
+
+   eosvmoc::config first_eosvmoc_config = {32u*1024u*1024u, 1u, first};
+   eosvmoc::config second_eosvmoc_config = {32u*1024u*1024u, 1u, second};
+
+   {
+      eosvmoc::code_cache_sync cc(tmp_code_cache.path(), first_eosvmoc_config, get_some_wasm);
+
+      BOOST_REQUIRE_EXCEPTION(eosvmoc::code_cache_sync(tmp_code_cache.path(), second_eosvmoc_config, get_some_wasm), database_exception,
+                              eosio::testing::fc_exception_message_is("code cache is dirty") );
+   }
+
+   eosvmoc::code_cache_sync cc(tmp_code_cache.path(), first_eosvmoc_config, get_some_wasm);
+} FC_LOG_AND_RETHROW() }
+
+//test that growing the code cache behaves as expected
+BOOST_DATA_TEST_CASE(growit, data::make(mapped_and_heap) * data::make(mapped_and_heap) * data::make(mapped_and_heap), first, second, third) { try {
+   fc::temp_directory tmp_code_cache;
+
+   eosvmoc::config first_eosvmoc_config = {32u*1024u*1024u, 1u, first};
+   eosvmoc::config second_eosvmoc_config = {256u*1024u*1024u, 1u, second};
+   eosvmoc::config third_eosvmoc_config = {32u*1024u*1024u, 1u, third};
+
+   {
+      eosvmoc::code_cache_sync cc(tmp_code_cache.path(), first_eosvmoc_config, get_some_wasm);
+      BOOST_REQUIRE(cc.get_descriptor_for_code_sync(digest_type(), UINT8_C(0)));
+      BOOST_REQUIRE(cc.number_entries());
+      BOOST_REQUIRE(cc.free_bytes());
+      BOOST_REQUIRE(*cc.free_bytes() < first_eosvmoc_config.cache_size);
+      cc.free_code(digest_type(), UINT8_C(0)); //so free_bytes() can be populated next time
+   }
+
+   {
+      eosvmoc::code_cache_sync cc(tmp_code_cache.path(), second_eosvmoc_config, get_some_wasm);
+      BOOST_REQUIRE(cc.get_descriptor_for_code_sync(digest_type(), UINT8_C(0)));
+      BOOST_REQUIRE(cc.number_entries());
+      BOOST_REQUIRE(cc.free_bytes());
+      BOOST_REQUIRE(*cc.free_bytes() > first_eosvmoc_config.cache_size*2);
+      cc.free_code(digest_type(), UINT8_C(0)); //so free_bytes() can be populated next time
+   }
+
+   //eos vm oc's code cache size behaves similar to that as chainbase: reducing the config does not shrink the cache
+   {
+      eosvmoc::code_cache_sync cc(tmp_code_cache.path(), third_eosvmoc_config, get_some_wasm);
+      BOOST_REQUIRE(cc.get_descriptor_for_code_sync(digest_type(), UINT8_C(0)));
+      BOOST_REQUIRE(cc.number_entries());
+      BOOST_REQUIRE(cc.free_bytes());
+      BOOST_REQUIRE(*cc.free_bytes() > first_eosvmoc_config.cache_size*2);
+   }
+} FC_LOG_AND_RETHROW() }
+
+//try creating a code cache with a size not a multiple of page size
+BOOST_DATA_TEST_CASE(oddball_size, data::make(mapped_and_heap), mode) { try {
+   fc::temp_directory tmp_code_cache;
+
+   eosvmoc::config eosvmoc_config = {32u*1024u*1024u+708u, 1u, mode};
+
+   {
+      eosvmoc::code_cache_sync cc(tmp_code_cache.path(), eosvmoc_config, get_some_wasm);
+      BOOST_REQUIRE(cc.get_descriptor_for_code_sync(digest_type(), UINT8_C(0)));
+   }
+   BOOST_REQUIRE_EQUAL(boost::filesystem::file_size(tmp_code_cache.path() / "code_cache.bin"), eosvmoc_config.cache_size);
+
+   eosvmoc::code_cache_sync cc(tmp_code_cache.path(), eosvmoc_config, get_some_wasm);
+   BOOST_REQUIRE(cc.get_descriptor_for_code_sync(digest_type(), UINT8_C(0)));
+} FC_LOG_AND_RETHROW() }
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/eosvmoc_tests/main.cpp
+++ b/tests/eosvmoc_tests/main.cpp
@@ -1,0 +1,31 @@
+#include <cstdlib>
+#include <iostream>
+#include <boost/test/included/unit_test.hpp>
+#include <fc/log/logger.hpp>
+#include <eosio/chain/exceptions.hpp>
+
+void translate_fc_exception(const fc::exception &e) {
+   std::cerr << "\033[33m" <<  e.to_detail_string() << "\033[0m" << std::endl;
+   BOOST_TEST_FAIL("Caught Unexpected Exception");
+}
+
+boost::unit_test::test_suite* init_unit_test_suite(int argc, char* argv[]) {
+   // Turn off fc logging if no --verbose parameter
+   bool is_verbose = false;
+   std::string verbose_arg = "--verbose";
+   for (int i = 0; i < argc; i++) {
+      if (verbose_arg == argv[i]) {
+         is_verbose = true;
+         break;
+      }
+   }
+   if(!is_verbose) fc::logger::get(DEFAULT_LOGGER).set_log_level(fc::log_level::off);
+
+   // Register fc::exception translator
+   boost::unit_test::unit_test_monitor.register_exception_translator<fc::exception>(&translate_fc_exception);
+
+   std::srand(time(NULL));
+   std::cout << "Random number generator seeded to " << time(NULL) << std::endl;
+
+   return nullptr;
+}


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->
## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
2.2 backport of #10683

Add an option to control the map mode for EOS VM OC’s code cache. This new option, `eos-vm-oc-code-cache-map-mode`, functions equivalently to the `database-map-mode` option, i.e.
* `mapped`: previous behavior and still the default – directly map the on-disk code cache file in to memory
* `heap`: preload the entire code cache in to swapable memory and use hugepages if available
* `locked`: same behavior as heap but mlock() the code cache too

Some security best practices conflict with mapped mode; for example, mounting partitions intended solely for data with the noexec mount option (how one might mount nodeos’ data directory). The new heap mode can be used in such an environment. Additionally there can be a small but measurable performance boost using hugepages for the code cache due to reduced iTLB pressure.

This change also includes some refactoring to fix a race condition described in #10164. A handle to the on disk code cache is maintained for the entirety of eosvmoc::code_cache life cycle (well, at least after creation). This will ensure even if the file is removed for a code cache that is still active, upon destruction it will write out the code cache to the removed file.

Prior to creation of the PR Kevin and I discussed that given the code cache size maybe it should just always behave as heap. I would take it further and say that the on-disk code cache shouldn’t even be a boost::interprocess allocator, but rather a serialized representation of the in-memory data structures. In the future when the code cache implementation is touched in a breaking manner, such a change should be seriously considered as it probably simplifies the implementation. As is, I was reaching more for consistency with database-map-mode instead of a more through refactoring.

## Change Type
**Select *ONE*:**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [ ] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [x] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the release notes. Please include a description of the change for inclusion in the release notes. -->


## Testing Changes
**Select *ANY* that apply:**
- [x] New Tests
<!-- checked [x] = new test cases were added; unchecked [ ] = no new test cases -->
- [ ] Existing Tests
<!-- checked [x] = existing test cases were edited; unchecked [ ] = no existing tests were modified -->
- [ ] Test Framework
<!-- checked [x] = this modifies the test framework; unchecked [ ] = no test framework changes -->
- [ ] CI System
<!-- checked [x] = this changes the CI system; unchecked [ ] = no CI changes -->
- [ ] Other
<!-- checked [x] = this integrates an external test system; unchecked [ ] = no miscellaneous test-related changes -->
<!-- Please describe your test changes, or list each new test and its purpose, under each respective checkbox -->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [x] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
There is a new option to nodeos