### PR TITLE
rodeos: return partial trace on send_transaction failure 📦

### DIFF
--- a/libraries/rodeos/include/b1/rodeos/wasm_ql.hpp
+++ b/libraries/rodeos/include/b1/rodeos/wasm_ql.hpp
@@ -117,9 +117,10 @@ const std::vector<char>& query_get_abi(wasm_ql::thread_state& thread_state, cons
 const std::vector<char>& query_get_raw_abi(wasm_ql::thread_state& thread_state, const std::vector<char>& contract_kv_prefix,
                                        std::string_view body);
 const std::vector<char>& query_get_required_keys(wasm_ql::thread_state& thread_state, std::string_view body);
-const std::vector<char>& query_send_transaction(wasm_ql::thread_state&   thread_state,
-                                                const std::vector<char>& contract_kv_prefix, std::string_view body,
-                                                bool return_trace_on_except);
+eosio::ship_protocol::transaction_trace_v0
+query_send_transaction(wasm_ql::thread_state& thread_state,
+                       const std::vector<char>& contract_kv_prefix,
+                       std::string_view body);
 eosio::ship_protocol::transaction_trace_v0
 query_send_transaction(wasm_ql::thread_state& thread_state, const std::vector<char>& contract_kv_prefix,
                        const eosio::ship_protocol::packed_transaction& trx, const rocksdb::Snapshot* snapshot,

--- a/libraries/rodeos/wasm_ql.cpp
+++ b/libraries/rodeos/wasm_ql.cpp
@@ -605,16 +605,9 @@ struct send_transaction_params {
 
 EOSIO_REFLECT(send_transaction_params, signatures, compression, packed_context_free_data, packed_trx)
 
-struct send_transaction_results {
-   eosio::checksum256   transaction_id; // todo: redundant with processed.id
-   transaction_trace_v0 processed;
-};
-
-EOSIO_REFLECT(send_transaction_results, transaction_id, processed)
-
-const std::vector<char>& query_send_transaction(wasm_ql::thread_state&   thread_state,
-                                                const std::vector<char>& contract_kv_prefix, std::string_view body,
-                                                bool return_trace_on_except) {
+eosio::ship_protocol::transaction_trace_v0
+query_send_transaction(wasm_ql::thread_state&   thread_state,
+                       const std::vector<char>& contract_kv_prefix, std::string_view body) {
    send_transaction_params params;
    {
       std::string              s{ body.begin(), body.end() };
@@ -635,15 +628,7 @@ const std::vector<char>& query_send_transaction(wasm_ql::thread_state&   thread_
    rocksdb::ManagedSnapshot snapshot{ thread_state.shared->db->rdb.get() };
 
    std::vector<std::vector<char>> memory;
-   send_transaction_results       results;
-   results.processed = query_send_transaction(thread_state, contract_kv_prefix, trx, snapshot.snapshot(), memory,
-                                              return_trace_on_except);
-
-   // todo: hide variants during json conversion
-   // todo: avoid the extra copy
-   auto json = eosio::convert_to_json(results);
-   thread_state.action_return_value.assign(json.begin(), json.end());
-   return thread_state.action_return_value;
+   return query_send_transaction(thread_state, contract_kv_prefix, trx, snapshot.snapshot(), memory, true);
 } // query_send_transaction
 
 bool is_signatures_empty(const ship_protocol::prunable_data_type& data) {

--- a/programs/rodeos/wasm_ql_http.cpp
+++ b/programs/rodeos/wasm_ql_http.cpp
@@ -62,6 +62,30 @@ struct error_results {
 
 EOSIO_REFLECT(error_results, code, message, error)
 
+struct send_transaction_results {
+   eosio::checksum256   transaction_id; // todo: redundant with processed.id
+   eosio::ship_protocol::transaction_trace_v0 processed;
+};
+
+EOSIO_REFLECT(send_transaction_results, transaction_id, processed)
+
+struct send_error_info {
+   int64_t                                                code = {};
+   std::string                                            name = {};
+   std::string                                            what = {};
+   std::optional<eosio::ship_protocol::transaction_trace> trace = {};
+};
+
+EOSIO_REFLECT(send_error_info, code, name, what, trace)
+
+struct send_error_results {
+   uint16_t         code = {};
+   std::string      message = {};
+   send_error_info  error = {};
+};
+
+EOSIO_REFLECT(send_error_results, code, message, error)
+
 namespace b1::rodeos::wasm_ql {
 
 // Report a failure
@@ -259,11 +283,26 @@ void handle_request(const wasm_ql::http_config& http_config, const wasm_ql::shar
             return send(
                   error(http::status::bad_request, "Unsupported HTTP-method for " + req.target().to_string() + "\n"));
          auto thread_state = state_cache.get_state();
-         send(ok(query_send_transaction(*thread_state, temp_contract_kv_prefix,
-                                        std::string_view{ req.body().data(), req.body().size() },
-                                        false // todo: switch to true when /v1/chain/send_transaction2
-                                        ),
-                 "application/json"));
+         send_transaction_results results;
+         results.processed = query_send_transaction(*thread_state, temp_contract_kv_prefix,
+                                                    std::string_view{ req.body().data(), req.body().size() });
+         if (!results.processed.except) { // todo: support /v2/chain/send_transaction option for partial trace
+            auto json = eosio::convert_to_json(results);
+            send(ok(std::vector<char>{json.begin(), json.end()}, "application/json"));
+         } else {
+            try {
+               // elog("query failed: ${s}", ("s", e.what()));
+               send_error_results err;
+               err.code       = (uint16_t)http::status::internal_server_error;
+               err.message    = "Internal Service Error";
+               err.error.name = "failed transaction";
+               err.error.what = *results.processed.except;
+               err.error.trace = std::move(results.processed);
+               return send(error(http::status::internal_server_error, eosio::convert_to_json(err), "application/json"));
+            } catch (...) { //
+               return send(error(http::status::internal_server_error, "failure reporting vm::exception failure\n"));
+            }
+         }
          return;
       } else if (req.target() == "/v1/rodeos/create_checkpoint") {
          if (!http_config.checkpoint_dir)
@@ -338,7 +377,7 @@ void handle_request(const wasm_ql::http_config& http_config, const wasm_ql::shar
          err.error.what = e.what() + std::string(": ") + e.detail();
          return send(error(http::status::internal_server_error, eosio::convert_to_json(err), "application/json"));
       } catch (...) { //
-         return send(error(http::status::internal_server_error, "failure reporting failure\n"));
+         return send(error(http::status::internal_server_error, "failure reporting vm::exception failure\n"));
       }
    } catch (const std::exception& e) {
       try {
@@ -350,7 +389,7 @@ void handle_request(const wasm_ql::http_config& http_config, const wasm_ql::shar
          err.error.what = e.what();
          return send(error(http::status::internal_server_error, eosio::convert_to_json(err), "application/json"));
       } catch (...) { //
-         return send(error(http::status::internal_server_error, "failure reporting failure\n"));
+         return send(error(http::status::internal_server_error, "failure reporting exception failure\n"));
       }
    } catch (...) {
       elog("query failed: unknown exception");


### PR DESCRIPTION
## Change Description

- In the error json returned from a rodeos wasmql `/v1/chain/send_transaction` include the partial trace of the failed transaction in a `trace` section of the error.
- Example:

```
{
  "code": 500,
  "message": "Internal Service Error",
  "error": {
    "code": "0",
    "name": "failed transaction",
    "what": "This is a test for Kevin",
    "trace": [
      "transaction_trace_v0",
      {
        "id": "0000000000000000000000000000000000000000000000000000000000000000",
        "status": 1,
        "cpu_usage_us": 0,
        "net_usage_words": 0,
        "elapsed": "0",
        "net_usage": "0",
        "scheduled": false,
        "action_traces": [
          [
            "action_trace_v1",
            {
              "action_ordinal": 1,
              "creator_action_ordinal": 0,
              "receipt": null,
              "receiver": "contract",
              "act": {
                "account": "contract",
                "name": "queryit",
                "authorization": [],
                "data": "0571756572790001056F72646572010D01086F726465724E756D0310E50700040269640000067573657269640000067374617475730000056974656D730000"
              },
              "context_free": false,
              "elapsed": "0",
              "console": "        WASMQL: eosio::anyvar contract::queryit has been called)",
              "account_ram_deltas": [],
              "account_disk_deltas": [],
              "except": "This is a test for Kevin",
              "error_code": null,
              "return_value": ""
            }
          ]
        ],
        "account_ram_delta": null,
        "except": "This is a test for Kevin",
        "error_code": null,
        "failed_dtrx_trace": null,
        "partial": null
      }
    ]
  }
}
```

## Change Type
**Select *ONE*:**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [ ] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [x] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the release notes. Please include a description of the change for inclusion in the release notes. -->


## Testing Changes
**Select *ANY* that apply:**
- [ ] New Tests
<!-- checked [x] = new test cases were added; unchecked [ ] = no new test cases -->
- [ ] Existing Tests
<!-- checked [x] = existing test cases were edited; unchecked [ ] = no existing tests were modified -->
- [ ] Test Framework
<!-- checked [x] = this modifies the test framework; unchecked [ ] = no test framework changes -->
- [ ] CI System
<!-- checked [x] = this changes the CI system; unchecked [ ] = no CI changes -->
- [ ] Other
<!-- checked [x] = this integrates an external test system; unchecked [ ] = no miscellaneous test-related changes -->
<!-- Please describe your test changes, or list each new test and its purpose, under each respective checkbox -->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
