### PR TITLE
Use node_id for duplicate connection resolution - 2.2

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -3200,7 +3200,9 @@ namespace eosio {
                fc_dlog( logger, "dup check ${c}, ${l} =? ${r}",
                         ("c", check->connected())("l", check->last_handshake_recv.p2p_address)("r", msg.p2p_address) );
                if(check->connected() && check->last_handshake_recv.p2p_address == msg.p2p_address) {
+                  fc_dlog( logger, "equal p2p_address");
                   if (net_version < dup_goaway_resolution || msg.network_version < dup_goaway_resolution) {
+                     fc_dlog( logger, "net_version < dup_goaway_resolution");
                      // It's possible that both peers could arrive here at relatively the same time, so
                      // we need to avoid the case where they would both tell a different connection to go away.
                      // Using the sum of the initial handshake times of the two connections, we will
@@ -3211,6 +3213,8 @@ namespace eosio {
                      if (msg.time + c_time <= check_time)
                         continue;
                   } else if (my_impl->p2p_address < msg.p2p_address) {
+                     fc_dlog( logger, "my_impl->p2p_address '${lhs}' < msg.p2p_address '${rhs}'",
+                              ("lhs", my_impl->p2p_address)("rhs", msg.p2p_address) );
                      // only the connection from lower p2p_address to higher p2p_address will be considered as a duplicate, 
                      // so there is no chance for both connections to be closed
                      continue; 
@@ -3223,6 +3227,8 @@ namespace eosio {
                   enqueue(gam);
                   no_retry = duplicate;
                   return;
+               } else {
+                  fc_dlog( logger, "not equal");
                }
             }
          } else {

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -3225,8 +3225,6 @@ namespace eosio {
                   enqueue(gam);
                   no_retry = duplicate;
                   return;
-               } else {
-                  fc_dlog( logger, "not equal");
                }
             }
          } else {

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -451,9 +451,10 @@ namespace eosio {
    constexpr uint16_t proto_block_id_notify = 2;     // reserved. feature was removed. next net_version should be 3
    constexpr uint16_t proto_pruned_types = 3;        // supports new signed_block & packed_transaction types
    constexpr uint16_t heartbeat_interval = 4;        // supports configurable heartbeat interval
-   constexpr uint16_t dup_goaway_resolution = 5;     // support node_id based duplicate connection resolution
+   constexpr uint16_t dup_goaway_resolution = 5;     // support peer address based duplicate connection resolution
+   constexpr uint16_t dup_node_id_goaway = 6;        // support peer node_id based duplicate connection resolution
 
-   constexpr uint16_t net_version = dup_goaway_resolution;
+   constexpr uint16_t net_version = dup_node_id_goaway;
 
    /**
     * Index by start_block_num
@@ -3210,6 +3211,14 @@ namespace eosio {
                      g_check_conn.unlock();
                      if (msg.time + c_time <= check_time)
                         continue;
+                  } else if (net_version < dup_node_id_goaway || msg.network_version < dup_node_id_goaway) {
+                     if (my_impl->p2p_address < msg.p2p_address) {
+                        fc_dlog( logger, "my_impl->p2p_address '${lhs}' < msg.p2p_address '${rhs}'",
+                                 ("lhs", my_impl->p2p_address)( "rhs", msg.p2p_address ) );
+                        // only the connection from lower p2p_address to higher p2p_address will be considered as a duplicate,
+                        // so there is no chance for both connections to be closed
+                        continue;
+                     }
                   } else if (my_impl->node_id < msg.node_id) {
                      fc_dlog( logger, "not duplicate, my_impl->node_id '${lhs}' < msg.node_id '${rhs}'",
                               ("lhs", my_impl->node_id)("rhs", msg.node_id) );

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -3169,6 +3169,10 @@ namespace eosio {
       peer_dlog( this, "received handshake gen ${g}, lib ${lib}, head ${head}",
                  ("g", msg.generation)("lib", msg.last_irreversible_block_num)("head", msg.head_num) );
 
+      std::unique_lock<std::mutex> g_conn( conn_mtx );
+      last_handshake_recv = msg;
+      g_conn.unlock();
+
       connecting = false;
       if (msg.generation == 1) {
          if( msg.node_id == my_impl->node_id) {
@@ -3290,9 +3294,6 @@ namespace eosio {
          }
       }
 
-      std::unique_lock<std::mutex> g_conn( conn_mtx );
-      last_handshake_recv = msg;
-      g_conn.unlock();
       my_impl->sync_master->recv_handshake( shared_from_this(), msg );
    }
 

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -3213,7 +3213,7 @@ namespace eosio {
                   } else if (my_impl->node_id < msg.node_id) {
                      fc_dlog( logger, "not duplicate, my_impl->node_id '${lhs}' < msg.node_id '${rhs}'",
                               ("lhs", my_impl->node_id)("rhs", msg.node_id) );
-                     // only the connection from lower p2p_address to higher p2p_address will be considered as a duplicate, 
+                     // only the connection from lower node_id to higher node_id will be considered as a duplicate,
                      // so there is no chance for both connections to be closed
                      continue; 
                   }

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -3198,9 +3198,9 @@ namespace eosio {
                   continue;
                std::unique_lock<std::mutex> g_check_conn( check->conn_mtx );
                fc_dlog( logger, "dup check ${c}, ${l} =? ${r}",
-                        ("c", check->connected())("l", check->last_handshake_recv.p2p_address)("r", msg.p2p_address) );
-               if(check->connected() && check->last_handshake_recv.p2p_address == msg.p2p_address) {
-                  fc_dlog( logger, "equal p2p_address");
+                        ("c", check->connected())("l", check->last_handshake_recv.node_id)("r", msg.node_id) );
+               if(check->connected() && check->last_handshake_recv.node_id == msg.node_id) {
+                  fc_dlog( logger, "equal node_id");
                   if (net_version < dup_goaway_resolution || msg.network_version < dup_goaway_resolution) {
                      fc_dlog( logger, "net_version < dup_goaway_resolution");
                      // It's possible that both peers could arrive here at relatively the same time, so
@@ -3212,9 +3212,9 @@ namespace eosio {
                      g_check_conn.unlock();
                      if (msg.time + c_time <= check_time)
                         continue;
-                  } else if (my_impl->p2p_address < msg.p2p_address) {
-                     fc_dlog( logger, "my_impl->p2p_address '${lhs}' < msg.p2p_address '${rhs}'",
-                              ("lhs", my_impl->p2p_address)("rhs", msg.p2p_address) );
+                  } else if (my_impl->node_id < msg.node_id) {
+                     fc_dlog( logger, "my_impl->node_id '${lhs}' < msg.node_id '${rhs}'",
+                              ("lhs", my_impl->node_id)("rhs", msg.node_id) );
                      // only the connection from lower p2p_address to higher p2p_address will be considered as a duplicate, 
                      // so there is no chance for both connections to be closed
                      continue; 

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -3197,8 +3197,8 @@ namespace eosio {
                if(check.get() == this)
                   continue;
                std::unique_lock<std::mutex> g_check_conn( check->conn_mtx );
-               fc_dlog( logger, "dup check ${l} =? ${r}",
-                        ("l", check->last_handshake_recv.p2p_address)("r", msg.p2p_address) );
+               fc_dlog( logger, "dup check ${c}, ${l} =? ${r}",
+                        ("c", check->connected())("l", check->last_handshake_recv.p2p_address)("r", msg.p2p_address) );
                if(check->connected() && check->last_handshake_recv.p2p_address == msg.p2p_address) {
                   if (net_version < dup_goaway_resolution || msg.network_version < dup_goaway_resolution) {
                      // It's possible that both peers could arrive here at relatively the same time, so

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -451,7 +451,7 @@ namespace eosio {
    constexpr uint16_t proto_block_id_notify = 2;     // reserved. feature was removed. next net_version should be 3
    constexpr uint16_t proto_pruned_types = 3;        // supports new signed_block & packed_transaction types
    constexpr uint16_t heartbeat_interval = 4;        // supports configurable heartbeat interval
-   constexpr uint16_t dup_goaway_resolution = 5;     // support peer address based duplicate connection resolution
+   constexpr uint16_t dup_goaway_resolution = 5;     // support node_id based duplicate connection resolution
 
    constexpr uint16_t net_version = dup_goaway_resolution;
 
@@ -3197,12 +3197,10 @@ namespace eosio {
                if(check.get() == this)
                   continue;
                std::unique_lock<std::mutex> g_check_conn( check->conn_mtx );
-               fc_dlog( logger, "dup check ${c}, ${l} =? ${r}",
+               fc_dlog( logger, "dup check: connected ${c}, ${l} =? ${r}",
                         ("c", check->connected())("l", check->last_handshake_recv.node_id)("r", msg.node_id) );
                if(check->connected() && check->last_handshake_recv.node_id == msg.node_id) {
-                  fc_dlog( logger, "equal node_id");
                   if (net_version < dup_goaway_resolution || msg.network_version < dup_goaway_resolution) {
-                     fc_dlog( logger, "net_version < dup_goaway_resolution");
                      // It's possible that both peers could arrive here at relatively the same time, so
                      // we need to avoid the case where they would both tell a different connection to go away.
                      // Using the sum of the initial handshake times of the two connections, we will
@@ -3213,7 +3211,7 @@ namespace eosio {
                      if (msg.time + c_time <= check_time)
                         continue;
                   } else if (my_impl->node_id < msg.node_id) {
-                     fc_dlog( logger, "my_impl->node_id '${lhs}' < msg.node_id '${rhs}'",
+                     fc_dlog( logger, "not duplicate, my_impl->node_id '${lhs}' < msg.node_id '${rhs}'",
                               ("lhs", my_impl->node_id)("rhs", msg.node_id) );
                      // only the connection from lower p2p_address to higher p2p_address will be considered as a duplicate, 
                      // so there is no chance for both connections to be closed


### PR DESCRIPTION
## Change Description

- Fix duplicate connection check by using `node_id` instead of `p2p_address`.
- New `net_version` `dup_node_id_goaway` created for this PR.
- Issue introduced by: https://github.com/EOSIO/eos/pull/10006
- https://github.com/EOSIO/eos/pull/10786

## Change Type
**Select *ONE*:**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [x] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [ ] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the release notes. Please include a description of the change for inclusion in the release notes. -->


## Testing Changes
**Select *ANY* that apply:**
- [ ] New Tests
<!-- checked [x] = new test cases were added; unchecked [ ] = no new test cases -->
- [ ] Existing Tests
<!-- checked [x] = existing test cases were edited; unchecked [ ] = no existing tests were modified -->
- [ ] Test Framework
<!-- checked [x] = this modifies the test framework; unchecked [ ] = no test framework changes -->
- [ ] CI System
<!-- checked [x] = this changes the CI system; unchecked [ ] = no CI changes -->
- [ ] Other
<!-- checked [x] = this integrates an external test system; unchecked [ ] = no miscellaneous test-related changes -->
<!-- Please describe your test changes, or list each new test and its purpose, under each respective checkbox -->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
