### PR TITLE
support creating TPM keys at a specific persistent handle 📦

### DIFF
--- a/libraries/tpm-helpers/include/eosio/tpm-helpers/tpm-helpers.hpp
+++ b/libraries/tpm-helpers/include/eosio/tpm-helpers/tpm-helpers.hpp
@@ -3,12 +3,15 @@
 #include <fc/crypto/public_key.hpp>
 #include <fc/crypto/signature.hpp>
 #include <fc/crypto/sha256.hpp>
+#include <fc/exception/exception.hpp>
 
 #include <boost/container/flat_set.hpp>
 
 #include <set>
 
 namespace eosio::tpm {
+
+FC_DECLARE_EXCEPTION(tpm_key_exists, 9100000, "TPM key already exists");
 
 class tpm_key {
 public:

--- a/libraries/tpm-helpers/include/eosio/tpm-helpers/tpm-helpers.hpp
+++ b/libraries/tpm-helpers/include/eosio/tpm-helpers/tpm-helpers.hpp
@@ -34,8 +34,8 @@ struct attested_key {
 };
 
 boost::container::flat_set<fc::crypto::public_key> get_all_persistent_keys(const std::string& tcti);
-fc::crypto::public_key create_key(const std::string& tcti, const std::vector<unsigned>& pcrs);
-attested_key create_key_attested(const std::string& tcti, const std::vector<unsigned>& pcrs, uint32_t certifying_key_handle);
+fc::crypto::public_key create_key(const std::string& tcti, const std::vector<unsigned>& pcrs, const uint32_t at = 0);
+attested_key create_key_attested(const std::string& tcti, const std::vector<unsigned>& pcrs, const uint32_t certifying_key_handle, const uint32_t at = 0);
 fc::crypto::public_key verify_attestation(const attested_key& ak, const std::map<unsigned, fc::sha256>& pcr_policy = std::map<unsigned, fc::sha256>());
 
 class nv_data {

--- a/libraries/tpm-helpers/tpm-helpers.cpp
+++ b/libraries/tpm-helpers/tpm-helpers.cpp
@@ -451,6 +451,8 @@ attested_key create_key_attested(const std::string& tcti, const std::vector<unsi
    ESYS_TR persistent_handle;
    rc = Esys_EvictControl(esys_ctx.ctx(), ESYS_TR_RH_OWNER, created_handle, ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE,
                           persistent_handle_id, &persistent_handle);
+   if(rc == TPM2_RC_NV_DEFINED)
+      FC_THROW_EXCEPTION(tpm_key_exists, "Given TPM handle already contains a key");
    FC_ASSERT(!rc, "Failed to persist TPM key: ${m}", ("m", Tss2_RC_Decode(rc)));
    Esys_TR_Close(esys_ctx.ctx(), &persistent_handle);
 

--- a/libraries/tpm-helpers/tpm-helpers.cpp
+++ b/libraries/tpm-helpers/tpm-helpers.cpp
@@ -342,7 +342,7 @@ boost::container::flat_set<fc::crypto::public_key> get_all_persistent_keys(const
    return keys;
 }
 
-attested_key create_key_attested(const std::string& tcti, const std::vector<unsigned>& pcrs, uint32_t certifying_key_handle) {
+attested_key create_key_attested(const std::string& tcti, const std::vector<unsigned>& pcrs, const uint32_t certifying_key_handle, const uint32_t at) {
    esys_context esys_ctx(tcti);
    attested_key returned_key;
 
@@ -434,13 +434,19 @@ attested_key create_key_attested(const std::string& tcti, const std::vector<unsi
                                                                            certification_signature);
    }
 
-   std::set<TPM2_HANDLE> currrent_persistent_handles = persistent_handles(esys_ctx);
-   TPMI_DH_PERSISTENT persistent_handle_id = TPM2_PERSISTENT_FIRST;
-   const TPMI_DH_PERSISTENT past_last_owner_persistent = TPM2_PLATFORM_PERSISTENT;
-   for(; persistent_handle_id < past_last_owner_persistent; persistent_handle_id++)
-      if(currrent_persistent_handles.find(persistent_handle_id) == currrent_persistent_handles.end())
-         break;
-   FC_ASSERT(persistent_handle_id != past_last_owner_persistent, "Couldn't find unused persistent handle");
+   TPMI_DH_PERSISTENT persistent_handle_id = 0;
+   if(at) {
+      persistent_handle_id = at;
+   }
+   else {
+      std::set<TPM2_HANDLE> currrent_persistent_handles = persistent_handles(esys_ctx);
+      persistent_handle_id = TPM2_PERSISTENT_FIRST;
+      const TPMI_DH_PERSISTENT past_last_owner_persistent = TPM2_PLATFORM_PERSISTENT;
+      for(; persistent_handle_id < past_last_owner_persistent; persistent_handle_id++)
+         if(currrent_persistent_handles.find(persistent_handle_id) == currrent_persistent_handles.end())
+            break;
+      FC_ASSERT(persistent_handle_id != past_last_owner_persistent, "Couldn't find unused persistent handle");
+   }
 
    ESYS_TR persistent_handle;
    rc = Esys_EvictControl(esys_ctx.ctx(), ESYS_TR_RH_OWNER, created_handle, ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE,
@@ -451,8 +457,8 @@ attested_key create_key_attested(const std::string& tcti, const std::vector<unsi
    return returned_key;
 }
 
-fc::crypto::public_key create_key(const std::string& tcti, const std::vector<unsigned>& pcrs) {
-   return create_key_attested(tcti, pcrs, 0).pub_key;
+fc::crypto::public_key create_key(const std::string& tcti, const std::vector<unsigned>& pcrs, const uint32_t at) {
+   return create_key_attested(tcti, pcrs, 0, at).pub_key;
 }
 
 fc::crypto::public_key verify_attestation(const attested_key& ak, const std::map<unsigned, fc::sha256>& pcr_policy) {

--- a/programs/eosio-tpmtool/main.cpp
+++ b/programs/eosio-tpmtool/main.cpp
@@ -34,7 +34,7 @@ int main(int argc, char** argv) {
       ("handle", bpo::value<std::string>()->notifier([&](const std::string& a) {
          create_at_handle = strtol(a.c_str(), NULL, 0);
          FC_ASSERT(create_at_handle, "Creation handle argument is not an integer");
-      }), "Persist key at given TPM handle (by default, find first available owner handle)")
+      }), "Persist key at given TPM handle (by default, find first available owner handle). Returns error code 100 if key already exists.")
       ;
    bpo::variables_map varmap;
    try {
@@ -69,6 +69,10 @@ int main(int argc, char** argv) {
             std::cout << k.to_string() << std::endl;
 
       return 0;
+   }
+   catch(eosio::tpm::tpm_key_exists&) {
+      std::cerr << "Key already exists at given handle" << std::endl;
+      return 100;
    } FC_LOG_AND_DROP();
 
    return 1;

--- a/programs/eosio-tpmtool/main.cpp
+++ b/programs/eosio-tpmtool/main.cpp
@@ -15,6 +15,7 @@ int main(int argc, char** argv) {
    std::string tcti;
    std::vector<unsigned> pcrs;
    uint32_t attest_handle = 0;
+   uint32_t create_at_handle = 0;
 
    cli.add_options()
       ("help,h", bpo::bool_switch(&help)->default_value(false), "Print this help message and exit.")
@@ -30,6 +31,10 @@ int main(int argc, char** argv) {
          attest_handle = strtol(a.c_str(), NULL, 0);
          FC_ASSERT(attest_handle, "Attest handle argument is not an integer");
       }), "Certify creation of the new key via key with given TPM handle")
+      ("handle", bpo::value<std::string>()->notifier([&](const std::string& a) {
+         create_at_handle = strtol(a.c_str(), NULL, 0);
+         FC_ASSERT(create_at_handle, "Creation handle argument is not an integer");
+      }), "Persist key at given TPM handle (by default, find first available owner handle)")
       ;
    bpo::variables_map varmap;
    try {
@@ -55,9 +60,9 @@ int main(int argc, char** argv) {
 
    try {
       if(create && !attest_handle)
-         std::cout << eosio::tpm::create_key(tcti, pcrs).to_string() << std::endl;
+         std::cout << eosio::tpm::create_key(tcti, pcrs, create_at_handle).to_string() << std::endl;
       else if(create)
-         std::cout << fc::json::to_pretty_string(eosio::tpm::create_key_attested(tcti, pcrs, attest_handle)) << std::endl;
+         std::cout << fc::json::to_pretty_string(eosio::tpm::create_key_attested(tcti, pcrs, attest_handle, create_at_handle)) << std::endl;
 
       if(list)
          for(const auto& k : eosio::tpm::get_all_persistent_keys(tcti))

--- a/tests/tpm_tests/tpm_tests.cpp
+++ b/tests/tpm_tests/tpm_tests.cpp
@@ -441,14 +441,14 @@ BOOST_AUTO_TEST_CASE(test_specific_location) try {
 
    fc::crypto::public_key created_key = create_key(tpm.tcti(), {}, 0x8100BEEF);
    //create at same location, should be error
-   BOOST_CHECK_THROW(create_key(tpm.tcti(), {}, 0x8100BEEF), fc::exception);
+   BOOST_CHECK_THROW(create_key(tpm.tcti(), {}, 0x8100BEEF), tpm_key_exists);
    //pick first available index, should still work
    fc::crypto::public_key second_created_key = create_key(tpm.tcti(), {});
 
    //try attesting keys persisted to a specific location; attests with "created_key" a new key at 0x8100DEAD
    attested_key another_key = create_key_attested(tpm.tcti(), {}, 0x8100BEEF, 0x8100DEAD);
    //doing it again, should fail
-   BOOST_CHECK_THROW(create_key_attested(tpm.tcti(), {}, 0x8100BEEF, 0x8100DEAD), fc::exception);
+   BOOST_CHECK_THROW(create_key_attested(tpm.tcti(), {}, 0x8100BEEF, 0x8100DEAD), tpm_key_exists);
 
    BOOST_CHECK(get_all_persistent_keys(tpm.tcti()).size() == 3);
 } FC_LOG_AND_RETHROW();

--- a/tests/tpm_tests/tpm_tests.cpp
+++ b/tests/tpm_tests/tpm_tests.cpp
@@ -433,6 +433,26 @@ BOOST_AUTO_TEST_CASE(test_attest_checks) try {
    BOOST_CHECK_THROW(verify_attestation(damaged_attested_key), fc::exception);
 } FC_LOG_AND_RETHROW();
 
+BOOST_AUTO_TEST_CASE(test_specific_location) try {
+   swtpm tpm;
+
+   //not a persistent handle, so can't persist here
+   BOOST_CHECK_THROW(create_key(tpm.tcti(), {}, 0x01000000), fc::exception);
+
+   fc::crypto::public_key created_key = create_key(tpm.tcti(), {}, 0x8100BEEF);
+   //create at same location, should be error
+   BOOST_CHECK_THROW(create_key(tpm.tcti(), {}, 0x8100BEEF), fc::exception);
+   //pick first available index, should still work
+   fc::crypto::public_key second_created_key = create_key(tpm.tcti(), {});
+
+   //try attesting keys persisted to a specific location; attests with "created_key" a new key at 0x8100DEAD
+   attested_key another_key = create_key_attested(tpm.tcti(), {}, 0x8100BEEF, 0x8100DEAD);
+   //doing it again, should fail
+   BOOST_CHECK_THROW(create_key_attested(tpm.tcti(), {}, 0x8100BEEF, 0x8100DEAD), fc::exception);
+
+   BOOST_CHECK(get_all_persistent_keys(tpm.tcti()).size() == 3);
+} FC_LOG_AND_RETHROW();
+
 BOOST_AUTO_TEST_CASE(basic_nv) try {
    swtpm tpm;
 


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->
## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
Prior to this change, `eosio-tpmtool` would persist created keys at the first available owner handle in the TPM. This simplicity is nice to avoid exposing details of TPM handles to users, but sometimes it can cause deployment headaches. Consider a boot or deployment script that always wants to create a BP key if it doesn't already exist. Using something like `eosio-tpmtool --list | wc` isn't always helpful because `eosio-tpmtool --list` will report all usable TPM keys: even keys it did not create itself -- keys that may used for other purposes -- making it hard to correlate the number of existing keys with whether a BP key needs to be created.

Instead of requiring the environment to further parse the output of `eosio-tpmtool -l` to determine if it needs to create a key, add the ability for `eosio-tpmtool` to persist to a specific handle. If that handle already has an object persisted there, the command will fail with error code 100. This allows a deployment script to do something like
```bash
bp_key_handle=0x81000E05

if key=$(./eosio-tpmtool --create --handle $bp_key_handle); then
   echo created BP key: $key
   # do something more interesting here, like upload the key somewhere or modify nodeos config.ini
elif [[ $? == 100 ]]; then
   echo BP key was already created
   # no need to do interesting things here
else
   echo eosio-tpmtool failed
fi
```


## Change Type
**Select *ONE*:**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [ ] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [x] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the release notes. Please include a description of the change for inclusion in the release notes. -->


## Testing Changes
**Select *ANY* that apply:**
- [x] New Tests
<!-- checked [x] = new test cases were added; unchecked [ ] = no new test cases -->
- [ ] Existing Tests
<!-- checked [x] = existing test cases were edited; unchecked [ ] = no existing tests were modified -->
- [ ] Test Framework
<!-- checked [x] = this modifies the test framework; unchecked [ ] = no test framework changes -->
- [ ] CI System
<!-- checked [x] = this changes the CI system; unchecked [ ] = no CI changes -->
- [ ] Other
<!-- checked [x] = this integrates an external test system; unchecked [ ] = no miscellaneous test-related changes -->
<!-- Please describe your test changes, or list each new test and its purpose, under each respective checkbox -->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
