### PR TITLE
Debian packaging - change Debian revision versioning 

### DIFF
--- a/scripts/generate_deb.sh
+++ b/scripts/generate_deb.sh
@@ -6,10 +6,14 @@ export SPREFIX="${PREFIX}"
 export SUBPREFIX="opt/${PROJECT}/${VERSION}"
 export SSUBPREFIX="opt\/${PROJECT}\/${VERSION}"
 RELEASE="${VERSION_SUFFIX}"
+DPKG_DEBIAN_REVISION=""
 
 # default release to "1" if there is no suffix
 if [[ -z "$RELEASE" ]]; then
     RELEASE='1'
+    DPKG_DEBIAN_REVISION='1'
+else
+    DPKG_DEBIAN_REVISION=1~${VERSION_SUFFIX}
 fi
 
 NAME="${PROJECT}_${VERSION_NO_SUFFIX}-${RELEASE}_amd64"
@@ -36,7 +40,7 @@ mkdir -p "${PROJECT}/DEBIAN"
 chmod 0755 "${PROJECT}/DEBIAN"
 echo "Writing control file to '${PROJECT}/DEBIAN/control'."
 echo "Package: ${PROJECT}
-Version: ${VERSION_NO_SUFFIX}-${RELEASE}
+Version: ${VERSION_NO_SUFFIX}-${DPKG_DEBIAN_REVISION}
 Section: devel
 Priority: optional
 Depends: libc6, libgcc1, ${RELEASE_SPECIFIC_DEPS}, libstdc++6, libtinfo5, zlib1g, libusb-1.0-0, libcurl3-gnutls, libpq5


### PR DESCRIPTION
When installing the final release over a release candidate, e.g moving from 2.1.0-rc1 to 2.1.0, using the published .deb packages, both supported ubuntu versions, will warn that the release candidate version is the newer one, and print a warning message about downgrading over the “newer” release candidate:

`root@ip-172-31-19-10:~/eos# dpkg -i eosio_2.1.0-rc2-ubuntu-18.04_amd64.deb`
`Selecting previously unselected package eosio.`
`(Reading database ... 78812 files and directories currently installed.)`
`Preparing to unpack eosio_2.1.0-rc2-ubuntu-18.04_amd64.deb ...`
`Unpacking eosio (2.1.0-rc2) ...`
`Setting up eosio (2.1.0-rc2) ...`
`root@ip-172-31-19-10:~/eos# which nodeos`
`/usr/bin/nodeos`
`root@ip-172-31-19-10:~/eos# nodeos -v`
`v2.1.0-rc2`
`root@ip-172-31-19-10:~/eos# dpkg i eosio_2.1.0`
`eosio_2.1.0-1-ubuntu-18.04_amd64.deb`
`eosio_2.1.0-rc2-ubuntu-18.04_amd64.deb`
`root@ip-172-31-19-10:~/eos# dpkg -i eosio_2.1.0-1-ubuntu-18.04_amd64.deb`
`dpkg: warning: downgrading eosio from 2.1.0-rc2 to 2.1.0-1`
`(Reading database ... 78847 files and directories currently installed.)`
`Preparing to unpack eosio_2.1.0-1-ubuntu-18.04_amd64.deb ...`
`Unpacking eosio (2.1.0-1) over (2.1.0-rc2) ...`
`Setting up eosio (2.1.0-1) ...`
`root@ip-172-31-19-10:~/eos# nodeos -v`
`v2.1.0`
`root@ip-172-31-19-10:~/eos#`

This is due to the debian package comparison algorithm as explained in: https://manpages.debian.org/wheezy/dpkg-dev/deb-version.5.en.html#Sorting_Algorithm

I propose we change the debian package version of release candidate versions to use the debian-revision section as 1~rc2 (as an example for a release candidate 2). 

As a way to test that this will evaluate i ran:

`$ dpkg --compare-versions '2.1.0-1~rc2' lt '2.1.0-1' && echo less than`
`less than`

<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->
## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->


## Change Type
**Select *ONE*:**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [ ] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [ ] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the release notes. Please include a description of the change for inclusion in the release notes. -->


## Testing Changes
**Select *ANY* that apply:**
- [ ] New Tests
<!-- checked [x] = new test cases were added; unchecked [ ] = no new test cases -->
- [ ] Existing Tests
<!-- checked [x] = existing test cases were edited; unchecked [ ] = no existing tests were modified -->
- [ ] Test Framework
<!-- checked [x] = this modifies the test framework; unchecked [ ] = no test framework changes -->
- [ ] CI System
<!-- checked [x] = this changes the CI system; unchecked [ ] = no CI changes -->
- [ ] Other
<!-- checked [x] = this integrates an external test system; unchecked [ ] = no miscellaneous test-related changes -->
<!-- Please describe your test changes, or list each new test and its purpose, under each respective checkbox -->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
