### PR TITLE
Add new loggers for dumping transaction trace 📦

### DIFF
--- a/docs/01_nodeos/06_logging/10_native_logging/index.md
+++ b/docs/01_nodeos/06_logging/10_native_logging/index.md
@@ -84,7 +84,8 @@ The logging library built into EOSIO currently supports the following loggers:
 - `state_history` - detailed logging for state history plugin.
 - `transaction_success_tracing` - detailed log that emits successful verdicts from relay nodes on the P2P network.
 - `transaction_failure_tracing` - detailed log that emits failed verdicts from relay nodes on the P2P network.
-- `transaction_trace_dump` - detailed log that emits successful and failed verdicts from relay nodes on the P2P network; enabling this logger can greatly slow down nodeos.
+- `transaction_trace_success` - fully detailed log that emits successful verdicts from relay nodes on the P2P network; enabling this logger can greatly slow down nodeos.
+- `transaction_trace_failure` - fully detailed log that emits failed verdicts from relay nodes on the P2P network; enabling this logger can greatly slow down nodeos.
 - `trace_api` - detailed logging for the trace_api plugin.
 - `blockvault_client_plugin` - detailed logging for the blockvault client plugin.
 

--- a/docs/01_nodeos/06_logging/10_native_logging/index.md
+++ b/docs/01_nodeos/06_logging/10_native_logging/index.md
@@ -84,7 +84,7 @@ The logging library built into EOSIO currently supports the following loggers:
 - `state_history` - detailed logging for state history plugin.
 - `transaction_success_tracing` - detailed log that emits successful verdicts from relay nodes on the P2P network.
 - `transaction_failure_tracing` - detailed log that emits failed verdicts from relay nodes on the P2P network.
-- `transaction_trace_dump` - detailed log that emits successful and failed verdicts from relay nodes on the P2P network.
+- `transaction_trace_dump` - detailed log that emits successful and failed verdicts from relay nodes on the P2P network; enabling this logger can greatly slow down nodeos.
 - `trace_api` - detailed logging for the trace_api plugin.
 - `blockvault_client_plugin` - detailed logging for the blockvault client plugin.
 

--- a/docs/01_nodeos/06_logging/10_native_logging/index.md
+++ b/docs/01_nodeos/06_logging/10_native_logging/index.md
@@ -84,6 +84,7 @@ The logging library built into EOSIO currently supports the following loggers:
 - `state_history` - detailed logging for state history plugin.
 - `transaction_success_tracing` - detailed log that emits successful verdicts from relay nodes on the P2P network.
 - `transaction_failure_tracing` - detailed log that emits failed verdicts from relay nodes on the P2P network.
+- `transaction_trace_dump` - detailed log that emits successful and failed verdicts from relay nodes on the P2P network.
 - `trace_api` - detailed logging for the trace_api plugin.
 - `blockvault_client_plugin` - detailed logging for the blockvault client plugin.
 

--- a/libraries/chain/include/eosio/chain/unapplied_transaction_queue.hpp
+++ b/libraries/chain/include/eosio/chain/unapplied_transaction_queue.hpp
@@ -107,7 +107,7 @@ public:
          if( deadline <= fc::time_point::now() ) {
             return false;
          }
-         callback( itr->id(), itr->trx_type );
+         callback( itr->trx_meta->packed_trx(), itr->trx_type );
          if( itr->next ) {
             itr->next( std::static_pointer_cast<fc::exception>(
                   std::make_shared<expired_tx_exception>(

--- a/plugins/amqp_trx_plugin/include/eosio/amqp_trx_plugin/fifo_trx_processing_queue.hpp
+++ b/plugins/amqp_trx_plugin/include/eosio/amqp_trx_plugin/fifo_trx_processing_queue.hpp
@@ -181,7 +181,7 @@ public:
                q_item i;
                if( self->queue_.pop_and_pause(i) ) {
                   auto exception_handler = [&i, &prod_plugin=self->prod_plugin_](fc::exception_ptr ex) {
-                     prod_plugin->log_failed_transaction(i.trx->id(), ex->what());
+                     prod_plugin->log_failed_transaction(i.trx->id(), i.trx, ex->what());
                      i.next(ex);
                   };
                   chain::transaction_metadata_ptr trx_meta;

--- a/plugins/amqp_trx_plugin/test/test_ordered.cpp
+++ b/plugins/amqp_trx_plugin/test/test_ordered.cpp
@@ -79,7 +79,7 @@ struct mock_producer_plugin {
       return true;
    }
 
-   void log_failed_transaction(const transaction_id_type& trx_id, const char* reason) const {}
+   void log_failed_transaction(const transaction_id_type& trx_id, const packed_transaction_ptr& packed_trx_ptr, const char* reason) const {}
 
    std::deque<std::pair<chain::transaction_metadata_ptr, producer_plugin::next_function<chain::transaction_trace_ptr>>> unapplied_trxs_;
    std::deque<chain::transaction_metadata_ptr> trxs_;

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -3505,16 +3505,13 @@ read_only::get_required_keys_result read_only::get_required_keys( const get_requ
 
 fc::variant read_only::get_entire_trx_trace(const std::variant<fc::exception_ptr, transaction_trace_ptr>& trace_ptr )const {
 
-   fc::variant pretty_output;
-   try {
-      abi_serializer::to_variant(trace_ptr, pretty_output,
-                                 make_resolver(this, abi_serializer::create_yield_function(abi_serializer_max_time)),
-                                 abi_serializer::create_yield_function(abi_serializer_max_time));
-   }catch(const fc::exception& e){
-      wlog("problem encountered while expanding transaction trace via the abi serializer:\n${details}",
-           ("details",e.to_detail_string()));
-   }
-   return pretty_output;
+    fc::variant pretty_output;
+    try {
+        abi_serializer::to_variant(trace_ptr, pretty_output,
+                                   make_resolver(this, abi_serializer::create_yield_function(abi_serializer_max_time)),
+                                   abi_serializer::create_yield_function(abi_serializer_max_time));
+    }EOS_RETHROW_EXCEPTIONS(chain::packed_transaction_type_exception, "Invalid packed transaction trace")
+    return pretty_output;
 }
 
 read_only::get_transaction_id_result read_only::get_transaction_id( const read_only::get_transaction_id_params& params)const {

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -2840,26 +2840,23 @@ read_only::get_producer_schedule_result read_only::get_producer_schedule( const 
    return result;
 }
 
-template<typename Api>
 struct resolver_factory {
-   static auto make(const Api* api, abi_serializer::yield_function_t yield) {
-      return [api, yield{std::move(yield)}](const account_name &name) -> std::optional<abi_serializer> {
-         const auto* accnt = api->db.db().template find<account_object, by_name>(name);
+   static auto make(const controller& control, abi_serializer::yield_function_t yield) {
+      return [&control, yield{std::move(yield)}](const account_name &name) -> std::optional<abi_serializer> {
+         const auto* accnt = control.db().template find<account_object, by_name>(name);
          if (accnt != nullptr) {
             abi_def abi;
             if (abi_serializer::to_abi(accnt->abi, abi)) {
                return abi_serializer(abi, yield);
             }
          }
-
          return std::optional<abi_serializer>();
       };
    }
 };
 
-template<typename Api>
-auto make_resolver(const Api* api, abi_serializer::yield_function_t yield) {
-   return resolver_factory<Api>::make(api, std::move( yield ));
+auto make_resolver(const controller& control, abi_serializer::yield_function_t yield) {
+   return resolver_factory::make(control, std::move( yield ));
 }
 
 
@@ -2895,7 +2892,7 @@ read_only::get_scheduled_transactions( const read_only::get_scheduled_transactio
 
    read_only::get_scheduled_transactions_result result;
 
-   auto resolver = make_resolver(this, abi_serializer::create_yield_function( abi_serializer_max_time ));
+   auto resolver = make_resolver(db, abi_serializer::create_yield_function( abi_serializer_max_time ));
 
    uint32_t remaining = p.limit;
    auto time_limit = fc::time_point::now() + fc::microseconds(1000 * 10); /// 10ms max time
@@ -2961,7 +2958,7 @@ fc::variant read_only::get_block(const read_only::get_block_params& params) cons
 
    // serializes signed_block to variant in signed_block_v0 format
    fc::variant pretty_output;
-   abi_serializer::to_variant(*block, pretty_output, make_resolver(this, abi_serializer::create_yield_function( abi_serializer_max_time )),
+   abi_serializer::to_variant(*block, pretty_output, make_resolver(db, abi_serializer::create_yield_function( abi_serializer_max_time )),
                               abi_serializer::create_yield_function( abi_serializer_max_time ));
 
    const auto id = block->calculate_id();
@@ -3039,7 +3036,7 @@ void read_write::push_block(read_write::push_block_params&& params, next_functio
 void read_write::push_transaction(const read_write::push_transaction_params& params, next_function<read_write::push_transaction_results> next) {
    try {
       packed_transaction_v0 input_trx_v0;
-      auto resolver = make_resolver(this, abi_serializer::create_yield_function( abi_serializer_max_time ));
+      auto resolver = make_resolver(db, abi_serializer::create_yield_function( abi_serializer_max_time ));
       packed_transaction_ptr input_trx;
       try {
          abi_serializer::from_variant(params, input_trx_v0, std::move( resolver ), abi_serializer::create_yield_function( abi_serializer_max_time ));
@@ -3192,7 +3189,7 @@ void read_write::send_transaction(const read_write::send_transaction_params& par
 
    try {
       packed_transaction_v0 input_trx_v0;
-      auto resolver = make_resolver(this, abi_serializer::create_yield_function( abi_serializer_max_time ));
+      auto resolver = make_resolver(db, abi_serializer::create_yield_function( abi_serializer_max_time ));
       packed_transaction_ptr input_trx;
       try {
          abi_serializer::from_variant(params, input_trx_v0, std::move( resolver ), abi_serializer::create_yield_function( abi_serializer_max_time ));
@@ -3492,7 +3489,7 @@ read_only::abi_bin_to_json_result read_only::abi_bin_to_json( const read_only::a
 
 read_only::get_required_keys_result read_only::get_required_keys( const get_required_keys_params& params )const {
    transaction pretty_input;
-   auto resolver = make_resolver(this, abi_serializer::create_yield_function( abi_serializer_max_time ));
+   auto resolver = make_resolver(db, abi_serializer::create_yield_function( abi_serializer_max_time ));
    try {
       abi_serializer::from_variant(params.transaction, pretty_input, resolver, abi_serializer::create_yield_function( abi_serializer_max_time ));
    } EOS_RETHROW_EXCEPTIONS(chain::transaction_type_exception, "Invalid transaction")
@@ -3501,17 +3498,6 @@ read_only::get_required_keys_result read_only::get_required_keys( const get_requ
    get_required_keys_result result;
    result.required_keys = required_keys_set;
    return result;
-}
-
-fc::variant read_only::get_entire_trx_trace(const std::variant<fc::exception_ptr, transaction_trace_ptr>& trace_ptr )const {
-
-    fc::variant pretty_output;
-    try {
-        abi_serializer::to_variant(trace_ptr, pretty_output,
-                                   make_resolver(this, abi_serializer::create_yield_function(abi_serializer_max_time)),
-                                   abi_serializer::create_yield_function(abi_serializer_max_time));
-    }EOS_RETHROW_EXCEPTIONS(chain::packed_transaction_type_exception, "Invalid packed transaction trace")
-    return pretty_output;
 }
 
 read_only::get_transaction_id_result read_only::get_transaction_id( const read_only::get_transaction_id_params& params)const {
@@ -3621,6 +3607,31 @@ read_only::get_all_accounts( const get_all_accounts_params& params ) const
 }
 
 } // namespace chain_apis
+
+fc::variant chain_plugin::get_entire_trx_trace(const transaction_trace_ptr& trx_trace ) const {
+   fc::variant pretty_output;
+   try {
+      abi_serializer::to_variant(trx_trace, pretty_output,
+                                 chain_apis::make_resolver(chain(), abi_serializer::create_yield_function(get_abi_serializer_max_time())),
+                                 abi_serializer::create_yield_function(get_abi_serializer_max_time()));
+   } catch (...) {
+      pretty_output = trx_trace;
+   }
+   return pretty_output;
+}
+
+fc::variant chain_plugin::get_entire_trx(const transaction& trx) const {
+   fc::variant pretty_output;
+   try {
+      abi_serializer::to_variant(trx, pretty_output,
+                                 chain_apis::make_resolver(chain(), abi_serializer::create_yield_function(get_abi_serializer_max_time())),
+                                 abi_serializer::create_yield_function(get_abi_serializer_max_time()));
+   } catch (...) {
+      pretty_output = trx;
+   }
+   return pretty_output;
+}
+
 } // namespace eosio
 
 FC_REFLECT( eosio::chain_apis::detail::ram_market_exchange_state_t, (ignore1)(ignore2)(ignore3)(core_symbol)(ignore4) )

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -3503,6 +3503,20 @@ read_only::get_required_keys_result read_only::get_required_keys( const get_requ
    return result;
 }
 
+fc::variant read_only::get_entire_trx_trace(const std::variant<fc::exception_ptr, transaction_trace_ptr>& trace_ptr )const {
+
+   fc::variant pretty_output;
+   try {
+      abi_serializer::to_variant(trace_ptr, pretty_output,
+                                 make_resolver(this, abi_serializer::create_yield_function(abi_serializer_max_time)),
+                                 abi_serializer::create_yield_function(abi_serializer_max_time));
+   }catch(const fc::exception& e){
+      wlog("problem encountered while expanding transaction trace via the abi serializer:\n${details}",
+           ("details",e.to_detail_string()));
+   }
+   return pretty_output;
+}
+
 read_only::get_transaction_id_result read_only::get_transaction_id( const read_only::get_transaction_id_params& params)const {
    return params.id();
 }

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -63,9 +63,6 @@ struct permission {
    std::optional<std::vector<linked_action>>  linked_actions;
 };
 
-template<typename>
-struct resolver_factory;
-
 // see specializations for uint64_t and double in source file
 template<typename Type>
 Type convert_to_type(const string& str, const string& desc) {
@@ -313,8 +310,6 @@ public:
    };
 
    get_required_keys_result get_required_keys( const get_required_keys_params& params)const;
-
-   fc::variant get_entire_trx_trace(const std::variant<fc::exception_ptr, transaction_trace_ptr>& trace_ptr )const;
 
    using get_transaction_id_params = transaction;
    using get_transaction_id_result = transaction_id_type;
@@ -917,7 +912,6 @@ public:
    get_accounts_by_authorizers_result get_accounts_by_authorizers( const get_accounts_by_authorizers_params& args) const;
 
    chain::symbol extract_core_symbol()const;
-   friend struct resolver_factory<read_only>;
 
    struct get_all_accounts_result {
       struct account_result {
@@ -967,8 +961,6 @@ public:
    using send_transaction_params = push_transaction_params;
    using send_transaction_results = push_transaction_results;
    void send_transaction(const send_transaction_params& params, chain::plugin_interface::next_function<send_transaction_results> next);
-
-   friend resolver_factory<read_write>;
 };
 
  //support for --key_types [sha256,ripemd160] and --encoding [dec/hex]
@@ -1096,6 +1088,10 @@ public:
    static void handle_bad_alloc();
    
    bool account_queries_enabled() const;
+
+   fc::variant get_entire_trx_trace(const transaction_trace_ptr& trx_trace) const;
+   fc::variant get_entire_trx(const transaction& trx) const;
+
 private:
    static void log_guard_exception(const chain::guard_exception& e);
 

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -314,6 +314,8 @@ public:
 
    get_required_keys_result get_required_keys( const get_required_keys_params& params)const;
 
+   fc::variant get_entire_trx_trace(const std::variant<fc::exception_ptr, transaction_trace_ptr>& trace_ptr )const;
+
    using get_transaction_id_params = transaction;
    using get_transaction_id_result = transaction_id_type;
 

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2784,10 +2784,10 @@ namespace eosio {
 
       const unsigned long trx_in_progress_sz = this->trx_in_progress_size.load();
 
-      auto report_dropping_trx = [](const transaction_id_type& trx_id, unsigned long trx_in_progress_sz) {
+      auto report_dropping_trx = [](const transaction_id_type& trx_id, const packed_transaction_ptr& packed_trx_ptr, unsigned long trx_in_progress_sz) {
          char reason[72];
          snprintf(reason, 72, "Dropping trx, too many trx in progress %lu bytes", trx_in_progress_sz);
-         my_impl->producer_plug->log_failed_transaction(trx_id, reason);
+         my_impl->producer_plug->log_failed_transaction(trx_id, packed_trx_ptr, reason);
       };
 
       bool have_trx = false;
@@ -2801,7 +2801,7 @@ namespace eosio {
          fc::raw::unpack( ds, trx_id );
          if( trx_id ) {
             if (trx_in_progress_sz > def_max_trx_in_progress_size) {
-               report_dropping_trx(*trx_id, trx_in_progress_sz);
+               report_dropping_trx(*trx_id, ptr, trx_in_progress_sz);
                return true;
             }
             have_trx = my_impl->dispatcher->add_peer_txn( *trx_id, connection_id );
@@ -2816,14 +2816,14 @@ namespace eosio {
             ptr = std::move( trx );
 
             if (ptr && trx_id && *trx_id != ptr->id()) {
-               my_impl->producer_plug->log_failed_transaction(*trx_id, "Provided trx_id does not match provided packed_transaction");
+               my_impl->producer_plug->log_failed_transaction(*trx_id, ptr, "Provided trx_id does not match provided packed_transaction");
                EOS_ASSERT(false, transaction_id_type_exception,
                         "Provided trx_id does not match provided packed_transaction" );
             }
             
             if( !trx_id ) {
                if (trx_in_progress_sz > def_max_trx_in_progress_size) {
-                  report_dropping_trx(ptr->id(), trx_in_progress_sz);
+                  report_dropping_trx(ptr->id(), ptr, trx_in_progress_sz);
                   return true;
                }
                have_trx = my_impl->dispatcher->have_txn( ptr->id() );
@@ -2836,7 +2836,7 @@ namespace eosio {
          packed_transaction_v0 pt_v0;
          fc::raw::unpack( ds, pt_v0 );
          if( trx_in_progress_sz > def_max_trx_in_progress_size) {
-            report_dropping_trx(pt_v0.id(), trx_in_progress_sz);
+            report_dropping_trx(pt_v0.id(), ptr, trx_in_progress_sz);
             return true;
          }
          have_trx = my_impl->dispatcher->have_txn( pt_v0.id() );

--- a/plugins/producer_plugin/include/eosio/producer_plugin/producer_plugin.hpp
+++ b/plugins/producer_plugin/include/eosio/producer_plugin/producer_plugin.hpp
@@ -95,7 +95,7 @@ public:
    bool                   is_producing_block() const;
    bool                   is_producer_key(const chain::public_key_type& key) const;
    chain::signature_type  sign_compact(const chain::public_key_type& key, const fc::sha256& digest) const;
-   void log_failed_transaction(const transaction_id_type& trx_id, const char* reason) const;
+   void log_failed_transaction(const transaction_id_type& trx_id, const packed_transaction_ptr& packed_trx_ptr, const char* reason) const;
 
    bool execute_incoming_transaction(const chain::transaction_metadata_ptr& trx,
                                      next_function<chain::transaction_trace_ptr> next);

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -462,10 +462,8 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
                             ("txid", trx->id())("a",trx->get_transaction().first_authorizer())("why",ex->what()));
                      next(ex);
 
-                     if (_trx_trace_failure_log.is_enabled(fc::log_level::debug)) {
-                        auto entire_trx = self->chain_plug->get_entire_trx(trx->get_transaction());
-                        fc_dlog(_trx_trace_failure_log, "[TRX_TRACE] Speculative execution is REJECTING tx: ${entire_trx}", ("entire_trx", entire_trx));
-                     }
+                     fc_dlog(_trx_trace_failure_log, "[TRX_TRACE] Speculative execution is REJECTING tx: ${entire_trx}",
+                             ("entire_trx", self->chain_plug->get_entire_trx(trx->get_transaction())));
                   };
                   try {
                      auto result = future.get();
@@ -489,13 +487,21 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
 
          return [this, &trx, &chain, &next](const std::variant<fc::exception_ptr, transaction_trace_ptr>& response) {
             next(response);
-            fc::exception_ptr except_ptr;
+            fc::exception_ptr except_ptr; // rejected
             if (std::holds_alternative<fc::exception_ptr>(response)) {
                except_ptr = std::get<fc::exception_ptr>(response);
             } else if (std::get<transaction_trace_ptr>(response)->except) {
                except_ptr = std::get<transaction_trace_ptr>(response)->except->dynamic_copy_exception();
             }
             _transaction_ack_channel.publish(priority::low, std::pair<fc::exception_ptr, transaction_metadata_ptr>(except_ptr, trx));
+
+            auto get_trace = [&](const std::variant<fc::exception_ptr, transaction_trace_ptr>& response) -> fc::variant {
+               if (std::holds_alternative<fc::exception_ptr>(response)) {
+                  return fc::variant{std::get<fc::exception_ptr>(response)};
+               } else {
+                  return chain_plug->get_entire_trx_trace( std::get<transaction_trace_ptr>(response) );
+               }
+            };
 
             if (except_ptr) {
                if (_pending_block_mode == pending_block_mode::producing) {
@@ -506,23 +512,18 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
                         ("a", trx->packed_trx()->get_transaction().first_authorizer())
                         ("why",except_ptr->what()));
 
-                  if (_trx_trace_failure_log.is_enabled(fc::log_level::debug)) {
-                     auto entire_trace = std::get<fc::exception_ptr>(response);
-                     fc_dlog(_trx_trace_failure_log, "[TRX_TRACE] Block ${block_num} for producer ${prod} is REJECTING tx: ${entire_trace} ",
-                             ("block_num", chain.head_block_num() + 1)
-                             ("prod", get_pending_block_producer())
-                             ("entire_trace", entire_trace));
-                  }
+                  fc_dlog(_trx_trace_failure_log, "[TRX_TRACE] Block ${block_num} for producer ${prod} is REJECTING tx: ${entire_trace} ",
+                          ("block_num", chain.head_block_num() + 1)
+                          ("prod", get_pending_block_producer())
+                          ("entire_trace", get_trace(response)));
                } else {
                   fc_dlog(_trx_failed_trace_log, "[TRX_TRACE] Speculative execution is REJECTING tx: ${txid}, auth: ${a} : ${why} ",
                           ("txid", trx->id())
                           ("a", trx->packed_trx()->get_transaction().first_authorizer())
                           ("why",except_ptr->what()));
 
-                  if (_trx_trace_failure_log.is_enabled(fc::log_level::debug)) {
-                     auto entire_trace = std::get<fc::exception_ptr>(response);
-                     fc_dlog(_trx_trace_failure_log, "[TRX_TRACE] Speculative execution is REJECTING tx: ${entire_trace} ", ("entire_trace", entire_trace));
-                  }
+                  fc_dlog(_trx_trace_failure_log, "[TRX_TRACE] Speculative execution is REJECTING tx: ${entire_trace} ",
+                          ("entire_trace", get_trace(response)));
                }
             } else {
                if (_pending_block_mode == pending_block_mode::producing) {
@@ -532,22 +533,17 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
                           ("txid", trx->id())
                           ("a", trx->packed_trx()->get_transaction().first_authorizer()));
 
-                  if (_trx_trace_success_log.is_enabled(fc::log_level::debug)) {
-                     auto entire_trace = chain_plug->get_entire_trx_trace(std::get<transaction_trace_ptr>(response) );
-                     fc_dlog(_trx_trace_success_log, "[TRX_TRACE] Block ${block_num} for producer ${prod} is ACCEPTING tx: ${entire_trace}",
-                             ("block_num", chain.head_block_num() + 1)
-                             ("prod", get_pending_block_producer())
-                             ("entire_trace", entire_trace));
-                  }
+                  fc_dlog(_trx_trace_success_log, "[TRX_TRACE] Block ${block_num} for producer ${prod} is ACCEPTING tx: ${entire_trace}",
+                          ("block_num", chain.head_block_num() + 1)
+                          ("prod", get_pending_block_producer())
+                          ("entire_trace", get_trace(response)));
                } else {
                   fc_dlog(_trx_successful_trace_log, "[TRX_TRACE] Speculative execution is ACCEPTING tx: ${txid}, auth: ${a}",
                           ("txid", trx->id())
                           ("a", trx->packed_trx()->get_transaction().first_authorizer()));
 
-                  if (_trx_trace_success_log.is_enabled(fc::log_level::debug)) {
-                     auto entire_trace = chain_plug->get_entire_trx_trace(std::get<transaction_trace_ptr>(response) );
-                     fc_dlog(_trx_trace_success_log, "[TRX_TRACE] Speculative execution is ACCEPTING tx: ${entire_trace}", ("entire_trace", entire_trace));
-                  }
+                  fc_dlog(_trx_trace_success_log, "[TRX_TRACE] Speculative execution is ACCEPTING tx: ${entire_trace}",
+                          ("entire_trace", get_trace(response)));
                }
             }
          };
@@ -1766,20 +1762,15 @@ bool producer_plugin_impl::remove_expired_trxs( const fc::time_point& deadline )
                            ("block_num", chain.head_block_num() + 1)("txid", packed_trx_ptr->id())
                            ("prod", chain.is_building_block() ? chain.pending_block_producer() : name()) );
 
-                  if (_trx_trace_failure_log.is_enabled(fc::log_level::debug)) {
-                     auto entire_trx = chain_plug->get_entire_trx(packed_trx_ptr->get_transaction());
-                     fc_dlog(_trx_trace_failure_log, "[TRX_TRACE] Block ${block_num} for producer ${prod} is EXPIRING PERSISTED tx: ${entire_trx}",
-                             ("block_num", chain.head_block_num() + 1)
-                             ("prod", chain.is_building_block() ? chain.pending_block_producer() : name())
-                             ("entire_trx", entire_trx));
-                  }
+                  fc_dlog(_trx_trace_failure_log, "[TRX_TRACE] Block ${block_num} for producer ${prod} is EXPIRING PERSISTED tx: ${entire_trx}",
+                          ("block_num", chain.head_block_num() + 1)
+                          ("prod", chain.is_building_block() ? chain.pending_block_producer() : name())
+                          ("entire_trx", chain_plug->get_entire_trx(packed_trx_ptr->get_transaction())));
                } else {
                   fc_dlog(_trx_failed_trace_log, "[TRX_TRACE] Speculative execution is EXPIRING PERSISTED tx: ${txid}", ("txid", packed_trx_ptr->id()));
 
-                  if (_trx_trace_failure_log.is_enabled(fc::log_level::debug)) {
-                     auto entire_trx = chain_plug->get_entire_trx(packed_trx_ptr->get_transaction());
-                     fc_dlog(_trx_trace_failure_log, "[TRX_TRACE] Speculative execution is EXPIRING PERSISTED tx: ${entire_trx}", ("entire_trx", entire_trx));
-                  }
+                  fc_dlog(_trx_trace_failure_log, "[TRX_TRACE] Speculative execution is EXPIRING PERSISTED tx: ${entire_trx}",
+                          ("entire_trx", chain_plug->get_entire_trx(packed_trx_ptr->get_transaction())));
                }
                ++num_expired_persistent;
             } else {
@@ -1788,10 +1779,8 @@ bool producer_plugin_impl::remove_expired_trxs( const fc::time_point& deadline )
                         "[TRX_TRACE] Node with producers configured is dropping an EXPIRED transaction that was PREVIOUSLY ACCEPTED : ${txid}",
                         ("txid", packed_trx_ptr->id()));
 
-                  if (_trx_trace_failure_log.is_enabled(fc::log_level::debug)) {
-                     auto entire_trx = chain_plug->get_entire_trx(packed_trx_ptr->get_transaction());
-                     fc_dlog(_trx_trace_failure_log, "[TRX_TRACE] Node with producers configured is dropping an EXPIRED transaction that was PREVIOUSLY ACCEPTED: ${entire_trx}", ("entire_trx", entire_trx));
-                  }
+                  fc_dlog(_trx_trace_failure_log, "[TRX_TRACE] Node with producers configured is dropping an EXPIRED transaction that was PREVIOUSLY ACCEPTED: ${entire_trx}",
+                          ("entire_trx", chain_plug->get_entire_trx(packed_trx_ptr->get_transaction())));
                }
                ++num_expired_other;
             }
@@ -2440,15 +2429,8 @@ void producer_plugin::log_failed_transaction(const transaction_id_type& trx_id, 
    fc_dlog(_trx_failed_trace_log, "[TRX_TRACE] Speculative execution is REJECTING tx: ${txid} : ${why}",
            ("txid", trx_id)("why", reason));
 
-   if (_trx_trace_failure_log.is_enabled(fc::log_level::debug)){
-      if (packed_trx_ptr) {
-         auto entire_trx = my->chain_plug->get_entire_trx(packed_trx_ptr->get_transaction());
-         fc_dlog(_trx_trace_failure_log, "[TRX_TRACE] Speculative execution is REJECTING tx: ${entire_trx}", ("entire_trx", entire_trx));
-      } else {
-         fc_dlog(_trx_failed_trace_log, "[TRX_TRACE] Speculative execution is REJECTING tx: ${txid} : ${why}",
-                 ("txid", trx_id)("why", reason));
-      }
-   }
+   fc_dlog(_trx_trace_failure_log, "[TRX_TRACE] Speculative execution is REJECTING tx: ${entire_trx}",
+           ("entire_trx", packed_trx_ptr ? my->chain_plug->get_entire_trx(packed_trx_ptr->get_transaction()) : fc::variant{trx_id}));
 }
 
 bool producer_plugin::execute_incoming_transaction(const chain::transaction_metadata_ptr& trx,

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -74,6 +74,9 @@ fc::logger       _trx_successful_trace_log;
 const fc::string trx_failed_trace_logger_name("transaction_failure_tracing");
 fc::logger       _trx_failed_trace_log;
 
+const fc::string trx_trace_dump_logger_name("transaction_trace_dump");
+fc::logger       _trx_trace_dump_log;
+
 namespace eosio {
 
 static appbase::abstract_plugin& _producer_plugin = app().register_plugin<producer_plugin>();
@@ -500,6 +503,11 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
                           ("a", trx->packed_trx()->get_transaction().first_authorizer())
                           ("why",except_ptr->what()));
                }
+
+               //Dump transaction trace
+               fc_dlog(_trx_trace_dump_log, "[TRX_TRACE][REJECTING tx] ${entire_trace}",
+                        ("entire_trace", fc::json::to_pretty_string(response)));
+
             } else {
                if (_pending_block_mode == pending_block_mode::producing) {
                   fc_dlog(_trx_successful_trace_log, "[TRX_TRACE] Block ${block_num} for producer ${prod} is ACCEPTING tx: ${txid}, auth: ${a}",
@@ -512,6 +520,11 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
                           ("txid", trx->id())
                           ("a", trx->packed_trx()->get_transaction().first_authorizer()));
                }
+
+               //Dump transaction trace
+               fc_dlog(_trx_trace_dump_log, "[TRX_TRACE][ACCEPTING tx] ${entire_trace}",
+                        ("entire_trace", fc::json::to_pretty_string(response)));
+
             }
          };
       }
@@ -1059,6 +1072,7 @@ void producer_plugin::handle_sighup() {
    fc::logger::update( logger_name, _log );
    fc::logger::update(trx_successful_trace_logger_name, _trx_successful_trace_log);
    fc::logger::update(trx_failed_trace_logger_name, _trx_failed_trace_log);
+   fc::logger::update(trx_trace_dump_logger_name, _trx_trace_dump_log);
 }
 
 void producer_plugin::pause() {

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -458,6 +458,14 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
                      fc_dlog(_trx_failed_trace_log, "[TRX_TRACE] Speculative execution is REJECTING tx: ${txid}, auth: ${a} : ${why} ",
                             ("txid", trx->id())("a",trx->get_transaction().first_authorizer())("why",ex->what()));
                      next(ex);
+
+                     //Dump failed transaction if logger `_trx_trace_dump_log` is enabled
+                     fc::variant entire_trx = fc::mutable_variant_object()("transaction", *trx);
+                     fc_dlog(_trx_trace_dump_log, "[TRX_TRACE] [Speculative execution is REJECTING tx: ${txid} : ${why}] \n${entire_trace} ",
+                             ("txid", trx->id())
+                             ("why",ex->what())
+                             ("entire_trace", fc::json::to_pretty_string(entire_trx)));
+
                   };
                   try {
                      auto result = future.get();
@@ -489,6 +497,7 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
             }
             _transaction_ack_channel.publish(priority::low, std::pair<fc::exception_ptr, transaction_metadata_ptr>(except_ptr, trx));
 
+            auto entire_trace = chain_plug->get_entire_trx_trace(response);
             if (except_ptr) {
                if (_pending_block_mode == pending_block_mode::producing) {
                   fc_dlog(_trx_failed_trace_log, "[TRX_TRACE] Block ${block_num} for producer ${prod} is REJECTING tx: ${txid}, auth: ${a} : ${why} ",
@@ -497,11 +506,25 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
                         ("txid", trx->id())
                         ("a", trx->packed_trx()->get_transaction().first_authorizer())
                         ("why",except_ptr->what()));
+
+                  //Dump transaction trace if logger `_trx_trace_dump_log` is enabled
+                  fc_dlog(_trx_trace_dump_log, "[TRX_TRACE] [Block ${block_num} for producer ${prod} is REJECTING tx: ${txid} : ${why}] \n${entire_trace} ",
+                          ("block_num", chain.head_block_num() + 1)
+                          ("prod", get_pending_block_producer())
+                          ("txid", trx->id())
+                          ("why",std::get<fc::exception_ptr>(response)->what())
+                          ("entire_trace", fc::json::to_pretty_string(entire_trace)));
                } else {
                   fc_dlog(_trx_failed_trace_log, "[TRX_TRACE] Speculative execution is REJECTING tx: ${txid}, auth: ${a} : ${why} ",
                           ("txid", trx->id())
                           ("a", trx->packed_trx()->get_transaction().first_authorizer())
                           ("why",except_ptr->what()));
+
+                  //Dump transaction trace if logger `_trx_trace_dump_log` is enabled
+                  fc_dlog(_trx_trace_dump_log, "[TRX_TRACE] [Speculative execution is REJECTING tx: ${txid} : ${why}] \n${entire_trace}",
+                          ("txid", trx->id())
+                          ("why",std::get<fc::exception_ptr>(response)->what())
+                          ("entire_trace", fc::json::to_pretty_string(entire_trace)));
                }
 
                //Dump transaction trace
@@ -515,16 +538,23 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
                           ("prod", get_pending_block_producer())
                           ("txid", trx->id())
                           ("a", trx->packed_trx()->get_transaction().first_authorizer()));
+
+                  //Dump transaction trace if logger `_trx_trace_dump_log` is enabled
+                  fc_dlog(_trx_trace_dump_log, "[TRX_TRACE] [Block ${block_num} for producer ${prod} is ACCEPTING tx: ${txid}] \n${entire_trace}",
+                          ("block_num", chain.head_block_num() + 1)
+                          ("prod", get_pending_block_producer())
+                          ("txid", trx->id())
+                          ("entire_trace", fc::json::to_pretty_string(entire_trace)));
                } else {
                   fc_dlog(_trx_successful_trace_log, "[TRX_TRACE] Speculative execution is ACCEPTING tx: ${txid}, auth: ${a}",
                           ("txid", trx->id())
                           ("a", trx->packed_trx()->get_transaction().first_authorizer()));
+
+                  //Dump transaction trace if logger `_trx_trace_dump_log` is enabled
+                  fc_dlog(_trx_trace_dump_log, "[TRX_TRACE] [Speculative execution is ACCEPTING tx: ${txid}] \n${entire_trace}",
+                          ("txid", trx->id())
+                           ("entire_trace", fc::json::to_pretty_string(entire_trace)));
                }
-
-               //Dump transaction trace
-               fc_dlog(_trx_trace_dump_log, "[TRX_TRACE][ACCEPTING tx] ${entire_trace}",
-                        ("entire_trace", fc::json::to_pretty_string(response)));
-
             }
          };
       }
@@ -1732,16 +1762,31 @@ bool producer_plugin_impl::remove_expired_trxs( const fc::time_point& deadline )
    size_t num_expired_other = 0;
    size_t orig_count = _unapplied_transactions.size();
    bool exhausted = !_unapplied_transactions.clear_expired( pending_block_time, deadline,
-                  [&num_expired_persistent, &num_expired_other, pbm = _pending_block_mode,
+                  [this, &num_expired_persistent, &num_expired_other, pbm = _pending_block_mode,
                    &chain, has_producers = !_producers.empty()]( const transaction_id_type& txid, trx_enum_type trx_type ) {
+            auto trx = this->_unapplied_transactions.get_trx(txid);
+            fc::variant entire_trx = fc::mutable_variant_object()("transaction", trx->packed_trx()->get_transaction());
             if( trx_type == trx_enum_type::persisted ) {
                if( pbm == pending_block_mode::producing ) {
                   fc_dlog(_trx_failed_trace_log,
                            "[TRX_TRACE] Block ${block_num} for producer ${prod} is EXPIRING PERSISTED tx: ${txid}",
                            ("block_num", chain.head_block_num() + 1)("txid", txid)
                            ("prod", chain.is_building_block() ? chain.pending_block_producer() : name()) );
+
+                  // Dump failed transaction if logger `_trx_trace_dump_log` is enabled
+                  fc_dlog(_trx_trace_dump_log,
+                          "[TRX_TRACE] [Block ${block_num} for producer ${prod} is EXPIRING PERSISTED tx: ${txid}] \n${entire_trace}",
+                          ("block_num", chain.head_block_num() + 1)
+                          ("txid", txid)
+                          ("prod", chain.is_building_block() ? chain.pending_block_producer() : name())
+                          ("entire_trace", fc::json::to_pretty_string(entire_trx)));
                } else {
                   fc_dlog(_trx_failed_trace_log, "[TRX_TRACE] Speculative execution is EXPIRING PERSISTED tx: ${txid}", ("txid", txid));
+
+                  // Dump failed transaction if logger `_trx_trace_dump_log` is enabled
+                  fc_dlog(_trx_trace_dump_log, "[TRX_TRACE] [Speculative execution is EXPIRING PERSISTED tx] \n${entire_trace}",
+                          ("entire_trace", fc::json::to_pretty_string(entire_trx)));
+
                }
                ++num_expired_persistent;
             } else {
@@ -1749,6 +1794,10 @@ bool producer_plugin_impl::remove_expired_trxs( const fc::time_point& deadline )
                   fc_dlog(_trx_failed_trace_log,
                         "[TRX_TRACE] Node with producers configured is dropping an EXPIRED transaction that was PREVIOUSLY ACCEPTED : ${txid}",
                         ("txid", txid));
+
+                  // Dump failed transaction if logger `_trx_trace_dump_log` is enabled
+                  fc_dlog(_trx_trace_dump_log, "[TRX_TRACE] [Node with producers configured is dropping an EXPIRED transaction that was PREVIOUSLY ACCEPTED] \n${entire_trace}",
+                          ("entire_trace", fc::json::to_pretty_string(entire_trx)));
                }
                ++num_expired_other;
             }
@@ -2396,6 +2445,11 @@ void producer_plugin_impl::produce_block() {
 void producer_plugin::log_failed_transaction(const transaction_id_type& trx_id, const char* reason) const {
    fc_dlog(_trx_failed_trace_log, "[TRX_TRACE] Speculative execution is REJECTING tx: ${txid} : ${why}",
            ("txid", trx_id)("why", reason));
+   auto trx = my->_unapplied_transactions.get_trx(trx_id);
+   fc::variant entire_trx = fc::mutable_variant_object()("transaction", trx->packed_trx()->get_transaction());
+   fc_dlog(_trx_trace_dump_log, "[TRX_TRACE] [Speculative execution is REJECTING tx:} : ${why}] \n${entire_trx}",
+           ("why", fc::json::to_pretty_string(reason))
+           ("entire_trx", fc::json::to_pretty_string(entire_trx)));
 }
 
 bool producer_plugin::execute_incoming_transaction(const chain::transaction_metadata_ptr& trx,

--- a/programs/nodeos/logging.json
+++ b/programs/nodeos/logging.json
@@ -121,14 +121,23 @@
         "net"
       ]
     },{
-    "name": "transaction_trace_dump",
-    "level": "info",
-    "enabled": true,
-    "additivity": false,
-    "appenders": [
-      "stderr",
-      "net"
-    ]
+      "name": "transaction_trace_success",
+      "level": "info",
+      "enabled": true,
+      "additivity": false,
+      "appenders": [
+        "stderr",
+        "net"
+      ]
+    },{
+      "name": "transaction_trace_failure",
+      "level": "info",
+      "enabled": true,
+      "additivity": false,
+      "appenders": [
+        "stderr",
+        "net"
+      ]
     },{
       "name": "state_history",
       "level": "debug",

--- a/programs/nodeos/logging.json
+++ b/programs/nodeos/logging.json
@@ -121,6 +121,15 @@
         "net"
       ]
     },{
+    "name": "transaction_trace_dump",
+    "level": "info",
+    "enabled": true,
+    "additivity": false,
+    "appenders": [
+      "stderr",
+      "net"
+    ]
+    },{
       "name": "state_history",
       "level": "debug",
       "enabled": true,


### PR DESCRIPTION
## Change Description
Current loggers `transaction_success_tracing` and `transaction_failure_tracing` in file logging.json are created for displaying brief transaction trace information. New loggers that could be used to dump entire transaction trace or entire transaction for all trxs including failed are requested. 

Everywhere we currently log REJECTING or ACCEPTING we should log to new loggers with either the trace or the transaction. We should  log to new loggers with the transaction for the case of  an invalid signature.

New added loggers `transaction_trace_success` and `transaction_trace_failure` have default logging level `info` in file logging.json. To enable them, their logging levels need to be changed to `debug`.

Two examples of log output from new trace loggers:

1. creating an account named as "bob" succeeded  

> debug 2021-02-23T20:12:22.681 thread-0  producer_plugin.cpp:553       operator()           ] [TRX_TRACE] Block 44 for producer eosio is ACCEPTING tx: {"id":"f205f092723a1e62d27846df6168905fa6e504323353138404dd9ef4bfeee365","block_num":44,"block_time":"2021-02-23T20:12:23.000","producer_block_id":null,"receipt":{"status":"executed","cpu_usage_us":657,"net_usage_words":25},"elapsed":657,"net_usage":200,"scheduled":false,"action_traces":[{"action_ordinal":1,"creator_action_ordinal":0,"closest_unnotified_ancestor_action_ordinal":0,"receipt":{"receiver":"eosio","act_digest":"1c83ef3abe3ca4905d0aac83fb5f94f5ce55e92f35f0eca5df18a5ec547d950e","global_sequence":44,"recv_sequence":44,"auth_sequence":[["eosio",44]],"code_sequence":0,"abi_sequence":0},"receiver":"eosio","act":{"account":"eosio","name":"newaccount","authorization":[{"actor":"eosio","permission":"active"}],"data":{"creator":"eosio","name":"bob","owner":{"threshold":1,"keys":[{"key":"EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV","weight":1}],"accounts":[],"waits":[]},"active":{"threshold":1,"keys":[{"key":"EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV","weight":1}],"accounts":[],"waits":[]}},"hex_data":"0000000000ea30550000000000000e3d01000000010002c0ded2bc1f1305fb0faac5e6c03ee3a1924234985427b6167ca569d13df435cf0100000001000000010002c0ded2bc1f1305fb0faac5e6c03ee3a1924234985427b6167ca569d13df435cf01000000"},"context_free":false,"elapsed":220,"console":"","trx_id":"f205f092723a1e62d27846df6168905fa6e504323353138404dd9ef4bfeee365","block_num":44,"block_time":"2021-02-23T20:12:23.000","producer_block_id":null,"account_ram_deltas":[{"account":"bob","delta":2724}],"account_disk_deltas":[],"except":null,"error_code":null,"return_value_hex_data":""}],"account_ram_delta":null,"except":null,"error_code":null}

2. creating an account named as "bob" failed

> debug 2021-02-23T20:13:28.728 thread-0  producer_plugin.cpp:528       operator()           ] [TRX_TRACE] Block 176 for producer eosio is REJECTING tx: {"code":3050001,"name":"account_name_exists_exception","message":"Account name already exists","stack":[{"context":{"level":"error","file":"eosio_contract.cpp","line":93,"method":"apply_eosio_newaccount","hostname":"","thread_name":"thread-0","timestamp":"2021-02-23T20:13:28.727"},"format":"Cannot create account named ${name}, as that name is already taken","data":{"name":"bob"}},{"context":{"level":"warn","file":"eosio_contract.cpp","line":127,"method":"apply_eosio_newaccount","hostname":"","thread_name":"thread-0","timestamp":"2021-02-23T20:13:28.727"},"format":"","data":{"create":{"creator":"eosio","name":"bob","owner":{"threshold":1,"keys":[{"key":"EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV","weight":1}],"accounts":[],"waits":[]},"active":{"threshold":1,"keys":[{"key":"EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV","weight":1}],"accounts":[],"waits":[]}}}},{"context":{"level":"warn","file":"apply_context.cpp","line":143,"method":"exec_one","hostname":"","thread_name":"thread-0","timestamp":"2021-02-23T20:13:28.727"},"format":"pending console output: ${console}","data":{"console":""}}]}

https://github.com/EOSIO/eos/pull/10051

## Change Type
**Select *ONE*:**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [ ] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [x] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the release notes. Please include a description of the change for inclusion in the release notes. -->

## Documentation Additions
- [x] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
The following trace loggers are added:
- `transaction_trace_success` - fully detailed log that emits successful verdicts from relay nodes on the P2P network; enabling this logger can greatly slow down nodeos.
- `transaction_trace_failure` - fully detailed log that emits failed verdicts from relay nodes on the P2P network; enabling this logger can greatly slow down nodeos.