### PR TITLE
EPE-1577 rodeos getting stream addresses for queues or exchanges from environment variables 📦

### DIFF
--- a/programs/rodeos/streamer_plugin.cpp
+++ b/programs/rodeos/streamer_plugin.cpp
@@ -72,13 +72,13 @@ streamer_plugin::~streamer_plugin() {}
 void streamer_plugin::set_program_options(options_description& cli, options_description& cfg) {
    auto op = cfg.add_options();
    op("stream-rabbits", bpo::value<std::vector<string>>()->composing(),
-      "RabbitMQ Streams to queues if any; Format: amqp://USER:PASSWORD@ADDRESS:PORT/QUEUE[/STREAMING_ROUTE, ...]. Additional list of streams delimited by ::: can be specified in the environment variable "
+      "RabbitMQ Streams to queues if any; Additional list of streams delimited by ::: can be specified in the environment variable "
       EOSIO_STREAM_RABBITS_ENV_VAR
-      ".");
+      ". Format: amqp://USER:PASSWORD@ADDRESS:PORT/QUEUE[/STREAMING_ROUTE, ...].");
    op("stream-rabbits-exchange", bpo::value<std::vector<string>>()->composing(),
-      "RabbitMQ Streams to exchanges if any; Format: amqp://USER:PASSWORD@ADDRESS:PORT/EXCHANGE[::EXCHANGE_TYPE][/STREAMING_ROUTE, ...]. Additional list of streams delimited by ::: can be specified in the environment variable "
+      "RabbitMQ Streams to exchanges if any; Additional list of streams delimited by ::: can be specified in the environment variable "
       EOSIO_STREAM_RABBITS_EXCHANGE_ENV_VAR
-      ".");
+      ". Format: amqp://USER:PASSWORD@ADDRESS:PORT/EXCHANGE[::EXCHANGE_TYPE][/STREAMING_ROUTE, ...]");
    op("stream-rabbits-immediately", bpo::bool_switch(&my->publish_immediately)->default_value(false),
       "Stream to RabbitMQ immediately instead of batching per block. Disables reliable message delivery.");
    op("stream-loggers", bpo::value<std::vector<string>>()->composing(),

--- a/programs/rodeos/streamer_plugin.cpp
+++ b/programs/rodeos/streamer_plugin.cpp
@@ -11,7 +11,6 @@
 #include <fc/exception/exception.hpp>
 #include <fc/log/trace.hpp>
 #include <boost/filesystem/operations.hpp>
-#include <boost/filesystem/operations.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/classification.hpp>
 #include <memory>

--- a/programs/rodeos/streamer_plugin.hpp
+++ b/programs/rodeos/streamer_plugin.hpp
@@ -6,6 +6,9 @@
 
 #include "cloner_plugin.hpp"
 
+#define EOSIO_STREAM_RABBITS_ENV_VAR "EOSIO_STREAM_RABBITS"
+#define EOSIO_STREAM_RABBITS_EXCHANGE_ENV_VAR "EOSIO_STREAM_RABBITS_EXCHANGE"
+
 namespace b1 {
 
 struct stream_wrapper_v0 {


### PR DESCRIPTION
This change makes rodeos be able to get the rabbits stream addresses for queues or exchanges from environment variables.

```
  --stream-rabbits arg                  Addresses of RabbitMQ queues to stream
                                        to. Format: amqp://USER:PASSWORD@ADDRES
                                        S:PORT/QUEUE[/STREAMING_ROUTE, ...].
                                        Multiple queue addresses can be
                                        specified with ::: as the delimiter,
                                        such as "amqp://u1:p1@amqp1:5672/queue1
                                        :::amqp://u2:p2@amqp2:5672/queue2".If
                                        this option is not specified, the value
                                        from the environment variable
                                        EOSIO_STREAM_RABBITS will be used.
  --stream-rabbits-exchange arg         Addresses of RabbitMQ exchanges to
                                        stream to. amqp://USER:PASSWORD@ADDRESS
                                        :PORT/EXCHANGE[::EXCHANGE_TYPE][/STREAM
                                        ING_ROUTE, ...]. Multiple queue
                                        addresses can be specified with ::: as
                                        the delimiter, such as
                                        "amqp://u1:p1@amqp1:5672/exchange1:::am
                                        qp://u2:p2@amqp2:5672/exchange2".If
                                        this option is not specified, the value
                                        from the environment variable
                                        EOSIO_STREAM_RABBITS_EXCHANGE will be
                                        used.
```

This PR is done for rodeos following the changes for amqp_trx_plugin in nodeos and for cleos - #10829 .


<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->
## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->


## Change Type
**Select *ONE*:**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [ ] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [X] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the release notes. Please include a description of the change for inclusion in the release notes. -->


## Testing Changes
**Select *ANY* that apply:**
- [ ] New Tests
<!-- checked [x] = new test cases were added; unchecked [ ] = no new test cases -->
- [ ] Existing Tests
<!-- checked [x] = existing test cases were edited; unchecked [ ] = no existing tests were modified -->
- [ ] Test Framework
<!-- checked [x] = this modifies the test framework; unchecked [ ] = no test framework changes -->
- [ ] CI System
<!-- checked [x] = this changes the CI system; unchecked [ ] = no CI changes -->
- [ ] Other
<!-- checked [x] = this integrates an external test system; unchecked [ ] = no miscellaneous test-related changes -->
<!-- Please describe your test changes, or list each new test and its purpose, under each respective checkbox -->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [x] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->

