### PR TITLE
EPE-1563 nodeos (amqp_trx_plugin)/cleos being able to get amqp address from an environment variable

### DIFF
--- a/libraries/amqp/util.cpp
+++ b/libraries/amqp/util.cpp
@@ -2,7 +2,7 @@
 namespace fc {
 void to_variant(const AMQP::Address& a, fc::variant& v) {
    std::string str(a.secure() ? "amqps://" : "amqp://");
-   str.append(a.login().user()).append(":********").append("@");
+   str.append("********:********").append("@");
    str.append(a.hostname().empty() ? "localhost" : a.hostname());
    if(a.port() != 5672)
       str.append(":").append(std::to_string(a.port()));

--- a/plugins/amqp_trx_plugin/amqp_trx_plugin.cpp
+++ b/plugins/amqp_trx_plugin/amqp_trx_plugin.cpp
@@ -243,9 +243,12 @@ amqp_trx_plugin::~amqp_trx_plugin() {}
 
 void amqp_trx_plugin::set_program_options(options_description& cli, options_description& cfg) {
    auto op = cfg.add_options();
-   op("amqp-trx-address", bpo::value<std::string>(),
+   op("amqp-trx-address", bpo::value<std::string>()->default_value(std::getenv(EOSIO_AMQP_ADDRESS_ENV_VAR) ? std::getenv(EOSIO_AMQP_ADDRESS_ENV_VAR) : ""),
       "AMQP address: Format: amqp://USER:PASSWORD@ADDRESS:PORT\n"
-      "Will consume from amqp-trx-queue-name (amqp-trx-queue-name) queue.");
+      "Will consume from amqp-trx-queue-name (amqp-trx-queue-name) queue.\n"
+      "If --amqp-trx-address is not specified, will use the value from the environment variable "
+      EOSIO_AMQP_ADDRESS_ENV_VAR
+      ".");
    op("amqp-trx-queue-name", bpo::value<std::string>()->default_value("trx"),
       "AMQP queue to consume transactions from, must already exist.");
    op("amqp-trx-queue-size", bpo::value<uint32_t>()->default_value(my->trx_processing_queue_size),

--- a/plugins/amqp_trx_plugin/include/eosio/amqp_trx_plugin/amqp_trx_plugin.hpp
+++ b/plugins/amqp_trx_plugin/include/eosio/amqp_trx_plugin/amqp_trx_plugin.hpp
@@ -3,6 +3,8 @@
 #include <eosio/producer_plugin/producer_plugin.hpp>
 #include <appbase/application.hpp>
 
+#define EOSIO_AMQP_ADDRESS_ENV_VAR "EOSIO_AMQP_ADDRESS"
+
 namespace eosio {
 
 // consume message types

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -2610,7 +2610,7 @@ int main( int argc, char** argv ) {
 
    app.add_option( "-u,--url", default_url, localized( "The http/https URL where ${n} is running", ("n", node_executable_name)), true );
    app.add_option( "--wallet-url", wallet_url, localized("The http/https URL where ${k} is running", ("k", key_store_executable_name)), true );
-   app.add_option( "--amqp", amqp_address, localized("The ampq URL where AMQP is running amqp://USER:PASSWORD@ADDRESS:PORT"), false );
+   app.add_option( "--amqp", amqp_address, localized("The ampq URL where AMQP is running amqp://USER:PASSWORD@ADDRESS:PORT"), false )->envname(EOSIO_AMQP_ADDRESS_ENV_VAR);
    app.add_option( "--amqp-queue-name", amqp_queue_name, localized("The ampq queue to send transaction to"), true );
    app.add_option( "--amqp-reply-to", amqp_reply_to, localized("The ampq reply to string"), false );
 


### PR DESCRIPTION
Merge changes from "EPE-1563 nodeos (amqp_trx_plugin)/cleos being able to get amqp address from an environment variable" #10829 to develop branch too.

<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->
## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->


## Change Type
**Select *ONE*:**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [ ] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [ ] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the release notes. Please include a description of the change for inclusion in the release notes. -->


## Testing Changes
**Select *ANY* that apply:**
- [ ] New Tests
<!-- checked [x] = new test cases were added; unchecked [ ] = no new test cases -->
- [ ] Existing Tests
<!-- checked [x] = existing test cases were edited; unchecked [ ] = no existing tests were modified -->
- [ ] Test Framework
<!-- checked [x] = this modifies the test framework; unchecked [ ] = no test framework changes -->
- [ ] CI System
<!-- checked [x] = this changes the CI system; unchecked [ ] = no CI changes -->
- [ ] Other
<!-- checked [x] = this integrates an external test system; unchecked [ ] = no miscellaneous test-related changes -->
<!-- Please describe your test changes, or list each new test and its purpose, under each respective checkbox -->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [x] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->


The changes here add the support to nodeos (amqp_trx_plugin) and cleos to accept the amqp address string from an environment variable.

for nodeos:

```
  --amqp-trx-address arg                AMQP address: Format:
                                        amqp://USER:PASSWORD@ADDRESS:PORT
                                        Will consume from amqp-trx-queue-name
                                        (amqp-trx-queue-name) queue.
                                        If --amqp-trx-address is not specified,
                                        will use the value from the environment
                                        variable EOSIO_AMQP_ADDRESS.
```

for cleos:

```
  --amqp TEXT (Env:EOSIO_AMQP_ADDRESS)
                              The ampq URL where AMQP is running amqp://USER:PASSWORD@ADDRESS:PORT
```

And the username for amqp connection is also masked together with the password.