### PR TITLE
nodeos min-initial-block-num option 📦

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -620,7 +620,7 @@ struct controller_impl {
       uint32_t lib_num = (blog.head() ? blog.head()->block_num() : fork_db.root()->block_num);
 
       EOS_ASSERT( lib_num >= this->conf.min_initial_block_num, misc_exception, "Controller latest irreversible block "
-      "at block number ${lib_num}, which is smaller than the minimum required ${required}", ("block_num", lib_num)("required",this->conf.min_initial_block_num) );
+      "at block number ${lib_num}, which is smaller than the minimum required ${required}", ("lib_num", lib_num)("required",this->conf.min_initial_block_num) );
 
       auto header_itr = validate_db_version( db );
 

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -619,8 +619,8 @@ struct controller_impl {
    void init(std::function<bool()> check_shutdown, bool clean_startup) {
       uint32_t lib_num = (blog.head() ? blog.head()->block_num() : fork_db.root()->block_num);
 
-      EOS_ASSERT( lib_num >= this->conf.min_initial_block_num, misc_exception, "Controller head "
-      "at block number ${block_num}, which is smaller than the minimum required ${required}", ("block_num", fork_db.head()->block_num)("required",this->conf.min_initial_block_num) );
+      EOS_ASSERT( lib_num >= this->conf.min_initial_block_num, misc_exception, "Controller latest irreversible block "
+      "at block number ${lib_num}, which is smaller than the minimum required ${required}", ("block_num", lib_num)("required",this->conf.min_initial_block_num) );
 
       auto header_itr = validate_db_version( db );
 

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -619,6 +619,9 @@ struct controller_impl {
    void init(std::function<bool()> check_shutdown, bool clean_startup) {
       uint32_t lib_num = (blog.head() ? blog.head()->block_num() : fork_db.root()->block_num);
 
+      EOS_ASSERT( lib_num >= this->conf.min_initial_block_num, misc_exception, "Controller head "
+      "at block number ${block_num}, which is smaller than the minimum required ${required}", ("block_num", fork_db.head()->block_num)("required",this->conf.min_initial_block_num) );
+
       auto header_itr = validate_db_version( db );
 
       {

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -116,6 +116,7 @@ namespace eosio { namespace chain {
             uint32_t                 greylist_limit         = chain::config::maximum_elastic_resource_multiplier;
 
             flat_set<account_name>   profile_accounts;
+            uint32_t                 min_initial_block_num = 0;
          };
 
          enum class block_status {

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -458,6 +458,8 @@ void chain_plugin::set_program_options(options_description& cli, options_descrip
          ("export-reversible-blocks", bpo::value<bfs::path>(),
            "export reversible block database in portable format into specified file and then exit")
          ("snapshot", bpo::value<bfs::path>(), "File to read Snapshot State from")
+         ("min-initial-block-num", bpo::value<uint32_t>()->default_value(0), "minimum block number to load, "
+         "nodeos would refuse to load any state from prior to that block number")
          ;
 
 }
@@ -1222,6 +1224,7 @@ void chain_plugin::plugin_initialize(const variables_map& options) {
 #endif
 
       my->account_queries_enabled = options.at("enable-account-queries").as<bool>();
+      my->chain_config->min_initial_block_num = options["min-initial-block-num"].as<uint32_t>();
 
       my->chain.emplace( *my->chain_config, std::move(pfs), *chain_id );
 

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -458,7 +458,7 @@ void chain_plugin::set_program_options(options_description& cli, options_descrip
          ("export-reversible-blocks", bpo::value<bfs::path>(),
            "export reversible block database in portable format into specified file and then exit")
          ("snapshot", bpo::value<bfs::path>(), "File to read Snapshot State from")
-         ("min-initial-block-num", bpo::value<uint32_t>()->default_value(0), "minimum block number to load, "
+         ("min-initial-block-num", bpo::value<uint32_t>()->default_value(0), "minimum latest irreversible block number to load, "
          "nodeos would refuse to load any state from prior to that block number")
          ;
 

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -458,8 +458,8 @@ void chain_plugin::set_program_options(options_description& cli, options_descrip
          ("export-reversible-blocks", bpo::value<bfs::path>(),
            "export reversible block database in portable format into specified file and then exit")
          ("snapshot", bpo::value<bfs::path>(), "File to read Snapshot State from")
-         ("min-initial-block-num", bpo::value<uint32_t>()->default_value(0), "minimum latest irreversible block number to load, "
-         "nodeos would refuse to load any state from prior to that block number")
+         ("min-initial-block-num", bpo::value<uint32_t>()->default_value(0), 
+         "minimum last irreversible block (lib) number, fail to start if state/snapshot lib is prior to specified")
          ;
 
 }

--- a/unittests/restart_chain_tests.cpp
+++ b/unittests/restart_chain_tests.cpp
@@ -220,7 +220,7 @@ BOOST_AUTO_TEST_CASE(restart_from_existing_state_do_not_meet_min_initial_block_n
 
    // restarting chain with no block log and no genesis
    BOOST_REQUIRE_EXCEPTION({ tester other(cfg); }, misc_exception,
-                           fc_exception_message_starts_with("Controller head at block"));
+                           fc_exception_message_starts_with("Controller latest irreversible block at block"));
 }
 
 BOOST_AUTO_TEST_CASE(restart_from_blocklog_do_not_meet_min_initial_block_num) {
@@ -239,7 +239,7 @@ BOOST_AUTO_TEST_CASE(restart_from_blocklog_do_not_meet_min_initial_block_num) {
 
    // restarting chain with no block log and no genesis
    BOOST_REQUIRE_EXCEPTION({ tester other(cfg, *genesis); }, misc_exception,
-                           fc_exception_message_starts_with("Controller head at block"));
+                           fc_exception_message_starts_with("Controller latest irreversible block at block"));
 }
 
 BOOST_AUTO_TEST_CASE(test_restart_with_different_chain_id) {

--- a/unittests/restart_chain_tests.cpp
+++ b/unittests/restart_chain_tests.cpp
@@ -205,17 +205,33 @@ BOOST_AUTO_TEST_CASE(test_existing_state_without_block_log) {
    }
 }
 
+
+std::pair<controller::config, uint32_t> setup_existing_chain(tester& chain) {
+   chain.produce_block();
+   chain.produce_block();
+   auto blk = chain.produce_block();
+   auto lib_num = chain.control->last_irreversible_block_num();
+   chain.close();
+
+   return std::make_pair(chain.get_config(), lib_num);
+}
+
+BOOST_AUTO_TEST_CASE(restart_from_existing_state_exactly_meet_min_initial_block_num) {
+   tester chain;
+
+   auto [cfg, lib_num]    = setup_existing_chain(chain);
+   cfg.min_initial_block_num = lib_num;
+   remove_existing_blocks(cfg);
+
+   // restarting chain with no block log and no genesis
+   BOOST_REQUIRE_NO_THROW({ tester other(cfg); });
+}
+
 BOOST_AUTO_TEST_CASE(restart_from_existing_state_do_not_meet_min_initial_block_num) {
    tester chain;
 
-   std::vector<signed_block_ptr> blocks;
-   blocks.push_back(chain.produce_block());
-   blocks.push_back(chain.produce_block());
-   blocks.push_back(chain.produce_block());
-   chain.close();
-
-   auto cfg                  = chain.get_config();
-   cfg.min_initial_block_num = 100;
+   auto [cfg, lib_num]    = setup_existing_chain(chain);
+   cfg.min_initial_block_num = lib_num + 1;
    remove_existing_blocks(cfg);
 
    // restarting chain with no block log and no genesis
@@ -223,17 +239,23 @@ BOOST_AUTO_TEST_CASE(restart_from_existing_state_do_not_meet_min_initial_block_n
                            fc_exception_message_starts_with("Controller latest irreversible block at block"));
 }
 
+BOOST_AUTO_TEST_CASE(restart_from_blocklog_exactly_meet_min_initial_block_num) {
+   tester chain;
+
+   auto [cfg, lib_num]    = setup_existing_chain(chain);
+   cfg.min_initial_block_num = lib_num;
+   auto genesis              = chain::block_log::extract_genesis_state(cfg.blog.log_dir);
+   remove_existing_states(cfg);
+
+   // restarting chain with no block log and no genesis
+   BOOST_REQUIRE_NO_THROW({ tester other(cfg, *genesis); });
+}
+
 BOOST_AUTO_TEST_CASE(restart_from_blocklog_do_not_meet_min_initial_block_num) {
    tester chain;
 
-   std::vector<signed_block_ptr> blocks;
-   blocks.push_back(chain.produce_block());
-   blocks.push_back(chain.produce_block());
-   blocks.push_back(chain.produce_block());
-   chain.close();
-
-   auto cfg                  = chain.get_config();
-   cfg.min_initial_block_num = 100;
+   auto [cfg, lib_num]    = setup_existing_chain(chain);
+   cfg.min_initial_block_num = lib_num + 1;
    auto genesis              = chain::block_log::extract_genesis_state(cfg.blog.log_dir);
    remove_existing_states(cfg);
 

--- a/unittests/snapshot_tests.cpp
+++ b/unittests/snapshot_tests.cpp
@@ -579,6 +579,46 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_restart_with_existing_state_and_truncated_blo
    verify_integrity_hash<SNAPSHOT_SUITE>(*chain.control, *snap_chain.control);
 }
 
+BOOST_AUTO_TEST_CASE_TEMPLATE(restart_from_snapshot_do_not_meet_min_initial_block_num, SNAPSHOT_SUITE, snapshot_suites)
+{
+   tester chain;
+   const chainbase::bfs::path parent_path = chain.get_config().blog.log_dir.parent_path();
+
+   chain.create_account("snapshot"_n);
+   chain.produce_blocks(1);
+   chain.set_code("snapshot"_n, contracts::snapshot_test_wasm());
+   chain.set_abi("snapshot"_n, contracts::snapshot_test_abi().data());
+   chain.produce_blocks(1);
+   chain.control->abort_block();
+
+   static const int pre_snapshot_block_count = 12;
+
+   for (int itr = 0; itr < pre_snapshot_block_count; itr++) {
+      // increment the contract
+      chain.push_action("snapshot"_n, "increment"_n, "snapshot"_n, mutable_variant_object()
+                        ( "value", 1 )
+                        );
+
+      // produce block
+      chain.produce_block();
+   }
+
+   chain.control->abort_block();
+
+   // create a new snapshot child
+   auto writer = SNAPSHOT_SUITE::get_writer();
+   chain.control->write_snapshot(writer);
+   auto snapshot = SNAPSHOT_SUITE::finalize(writer);
+
+   auto cfg                  = chain.get_config();
+   cfg.min_initial_block_num = 100;
+
+   // create a new child at this snapshot
+   BOOST_REQUIRE_EXCEPTION(
+       { snapshotted_tester snap_chain(cfg, SNAPSHOT_SUITE::get_reader(snapshot), 1); },
+       misc_exception, fc_exception_message_starts_with("Controller head at block"));
+}
+
 // Psudo code for the following WAST:
 //    kv_get(receiver, ...)
 //    uint64_t buff[1];

--- a/unittests/snapshot_tests.cpp
+++ b/unittests/snapshot_tests.cpp
@@ -616,7 +616,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(restart_from_snapshot_do_not_meet_min_initial_bloc
    // create a new child at this snapshot
    BOOST_REQUIRE_EXCEPTION(
        { snapshotted_tester snap_chain(cfg, SNAPSHOT_SUITE::get_reader(snapshot), 1); },
-       misc_exception, fc_exception_message_starts_with("Controller head at block"));
+       misc_exception, fc_exception_message_starts_with("Controller latest irreversible block at block"));
 }
 
 // Psudo code for the following WAST:


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->
## Change Description

This PR adds `min-initial-block-num` option to chain plugin so that nodeos could refuse to load any state from prior to the specified block number


## Change Type
**Select *ONE*:**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [ ] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [x] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the release notes. Please include a description of the change for inclusion in the release notes. -->


## Testing Changes
**Select *ANY* that apply:**
- [ ] New Tests
<!-- checked [x] = new test cases were added; unchecked [ ] = no new test cases -->
- [ ] Existing Tests
<!-- checked [x] = existing test cases were edited; unchecked [ ] = no existing tests were modified -->
- [ ] Test Framework
<!-- checked [x] = this modifies the test framework; unchecked [ ] = no test framework changes -->
- [ ] CI System
<!-- checked [x] = this changes the CI system; unchecked [ ] = no CI changes -->
- [ ] Other
<!-- checked [x] = this integrates an external test system; unchecked [ ] = no miscellaneous test-related changes -->
<!-- Please describe your test changes, or list each new test and its purpose, under each respective checkbox -->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [x] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
