### PR TITLE
get_account: include eosio.any in linkauth, add unit test 📦

### DIFF
--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -3412,8 +3412,8 @@ read_only::get_account_results read_only::get_account( const get_account_params&
    }
 
    // add eosio.any linked authorizations
-   auto linked_actions = get_linked_actions("eosio.any"_n);
-   result.permissions.push_back( permission{"eosio.any"_n, {}, {}, std::move(linked_actions)} );
+   auto linked_actions = get_linked_actions(chain::config::eosio_any_name);
+   result.permissions.push_back( permission{chain::config::eosio_any_name, {}, {}, std::move(linked_actions)} );
 
    const auto& code_account = db.db().get<account_object,by_name>( config::system_account_name );
 

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -3412,8 +3412,7 @@ read_only::get_account_results read_only::get_account( const get_account_params&
    }
 
    // add eosio.any linked authorizations
-   auto linked_actions = get_linked_actions(chain::config::eosio_any_name);
-   result.permissions.push_back( permission{chain::config::eosio_any_name, {}, {}, std::move(linked_actions)} );
+   result.eosio_any_linked_actions = get_linked_actions(chain::config::eosio_any_name);
 
    const auto& code_account = db.db().get<account_object,by_name>( config::system_account_name );
 

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -206,6 +206,9 @@ public:
       fc::variant                refund_request;
       fc::variant                voter_info;
       fc::variant                rex_info;
+
+      // linked actions for eosio_any
+      std::vector<linked_action> eosio_any_linked_actions;
    };
 
    struct get_account_params {
@@ -1144,7 +1147,7 @@ FC_REFLECT( eosio::chain_apis::read_only::account_resource_info, (used)(availabl
 FC_REFLECT( eosio::chain_apis::read_only::get_account_results,
             (account_name)(head_block_num)(head_block_time)(privileged)(last_code_update)(created)
             (core_liquid_balance)(ram_quota)(net_weight)(cpu_weight)(net_limit)(cpu_limit)(ram_usage)(permissions)
-            (total_resources)(self_delegated_bandwidth)(refund_request)(voter_info)(rex_info) )
+            (total_resources)(self_delegated_bandwidth)(refund_request)(voter_info)(rex_info)(eosio_any_linked_actions) )
 // @swap code_hash
 FC_REFLECT( eosio::chain_apis::read_only::get_code_results, (account_name)(code_hash)(wast)(wasm)(abi) )
 FC_REFLECT( eosio::chain_apis::read_only::get_code_hash_results, (account_name)(code_hash) )

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -2295,15 +2295,9 @@ void get_account( const string& accountName, const string& coresym, bool json_fo
       }
       std::cout << std::endl;
 
-      bool header_printed = false;
+      std::cout << "permission links: " << std::endl;
       dfs_fn_t print_links = [&](const eosio::chain_apis::permission& p, int) -> void {
          if (p.linked_actions) {
-
-            if (!header_printed) {
-               std::cout << "permission links: " << std::endl;
-               header_printed = true;
-            }
-
             if (!p.linked_actions->empty()) {
                std::cout << indent << p.perm_name.to_string() + ":" << std::endl;
                for ( auto it = p.linked_actions->begin(); it != p.linked_actions->end(); ++it ) {
@@ -2318,10 +2312,15 @@ void get_account( const string& accountName, const string& coresym, bool json_fo
          dfs_exec( r, 0, print_links);
       }
 
-      if (header_printed) {
-         std::cout << std::endl;
+      // print linked actions 
+      std::cout << indent << "eosio.any: " << std::endl;
+      for (const auto& it : res.eosio_any_linked_actions) {
+         auto action_value = it.action ? it.action->to_string() : std::string("*");
+         std::cout << indent << indent << it.account << "::" << action_value << std::endl;
       }
 
+      std::cout << std::endl;
+ 
       auto to_pretty_net = []( int64_t nbytes, uint8_t width_for_units = 5 ) {
          if(nbytes == -1) {
              // special case. Treat it as unlimited

--- a/tests/chain_plugin_tests.cpp
+++ b/tests/chain_plugin_tests.cpp
@@ -424,5 +424,98 @@ BOOST_FIXTURE_TEST_CASE( get_all_accounts, TESTER ) try {
 
 } FC_LOG_AND_RETHROW() //get_all_accounts
 
+BOOST_FIXTURE_TEST_CASE( get_account, TESTER ) try {
+   produce_blocks(2);
+
+   std::vector<account_name> accs{{ "alice"_n, "bob"_n, "cindy"_n}};
+   create_accounts(accs, false, false);
+
+   produce_block();
+
+   chain_apis::read_only plugin(*(this->control), {}, fc::microseconds::maximum());
+
+   chain_apis::read_only::get_account_params p{"alice"_n};
+
+   chain_apis::read_only::get_account_results result = plugin.read_only::get_account(p);
+
+   auto check_result_basic = [](chain_apis::read_only::get_account_results result, eosio::name nm, bool isPriv) {
+      BOOST_REQUIRE_EQUAL(nm, result.account_name);
+      BOOST_REQUIRE_EQUAL(isPriv, result.privileged);
+
+      BOOST_REQUIRE_EQUAL(3, result.permissions.size());
+      if (result.permissions.size() > 2) {
+         auto perm = result.permissions[0];
+         BOOST_REQUIRE_EQUAL(name("active"_n), perm.perm_name); 
+         BOOST_REQUIRE_EQUAL(name("owner"_n), perm.parent);
+         auto auth = perm.required_auth;
+         BOOST_REQUIRE_EQUAL(1, auth.threshold);
+         BOOST_REQUIRE_EQUAL(1, auth.keys.size());
+         BOOST_REQUIRE_EQUAL(0, auth.accounts.size());
+         BOOST_REQUIRE_EQUAL(0, auth.waits.size());
+
+         perm = result.permissions[1];
+         BOOST_REQUIRE_EQUAL(name("owner"_n), perm.perm_name); 
+         BOOST_REQUIRE_EQUAL(name(""_n), perm.parent); 
+         auth = perm.required_auth;
+         BOOST_REQUIRE_EQUAL(1, auth.threshold);
+         BOOST_REQUIRE_EQUAL(1, auth.keys.size());
+         BOOST_REQUIRE_EQUAL(0, auth.accounts.size());
+         BOOST_REQUIRE_EQUAL(0, auth.waits.size());
+
+         perm = result.permissions[2];
+         BOOST_REQUIRE_EQUAL(name("eosio.any"_n), perm.perm_name); 
+         BOOST_REQUIRE_EQUAL(name(""_n), perm.parent);
+         auth = perm.required_auth;
+         BOOST_REQUIRE_EQUAL(0, auth.threshold);
+         BOOST_REQUIRE_EQUAL(0, auth.keys.size());
+         BOOST_REQUIRE_EQUAL(0, auth.accounts.size());
+         BOOST_REQUIRE_EQUAL(0, auth.waits.size());
+      }
+   };
+
+   check_result_basic(result, name("alice"_n), false);
+
+   for (auto perm : result.permissions) {
+      BOOST_REQUIRE_EQUAL(true, perm.linked_actions.has_value());
+      if (perm.linked_actions.has_value())
+         BOOST_REQUIRE_EQUAL(0, perm.linked_actions->size());
+   }
+
+   // test link authority
+   link_authority(name("alice"_n), name("bob"_n), name("active"_n), name("foo"_n));
+   produce_block();
+   result = plugin.read_only::get_account(p);
+
+   check_result_basic(result, name("alice"_n), false);
+   auto perm = result.permissions[0];
+   BOOST_REQUIRE_EQUAL(1, perm.linked_actions->size());
+   if (perm.linked_actions->size() >= 1) {
+      auto la = (*perm.linked_actions)[0];
+      BOOST_REQUIRE_EQUAL(name("bob"_n), la.account);
+      BOOST_REQUIRE_EQUAL(true, la.action.has_value());
+      if(la.action.has_value()) {
+         BOOST_REQUIRE_EQUAL(name("foo"_n), la.action.value());
+      }
+   }
+
+   // test link authority to eosio.any
+   link_authority(name("alice"_n), name("bob"_n), name("eosio.any"_n), name("foo"_n));
+   produce_block();
+   result = plugin.read_only::get_account(p);
+   check_result_basic(result, name("alice"_n), false);
+   // active permission should no longer have linked auth, as eosio.any replaces it
+   perm = result.permissions[0];
+   BOOST_REQUIRE_EQUAL(0, perm.linked_actions->size());
+   perm = result.permissions[2];
+   BOOST_REQUIRE_EQUAL(1, perm.linked_actions->size());
+   if (perm.linked_actions->size() >= 1) {
+      auto la = (*perm.linked_actions)[0];
+      BOOST_REQUIRE_EQUAL(name("bob"_n), la.account);
+      BOOST_REQUIRE_EQUAL(true, la.action.has_value());
+      if(la.action.has_value()) {
+         BOOST_REQUIRE_EQUAL(name("foo"_n), la.action.value());
+      }
+   }
+} FC_LOG_AND_RETHROW() /// get_account
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/chain_plugin_tests.cpp
+++ b/tests/chain_plugin_tests.cpp
@@ -442,8 +442,8 @@ BOOST_FIXTURE_TEST_CASE( get_account, TESTER ) try {
       BOOST_REQUIRE_EQUAL(nm, result.account_name);
       BOOST_REQUIRE_EQUAL(isPriv, result.privileged);
 
-      BOOST_REQUIRE_EQUAL(3, result.permissions.size());
-      if (result.permissions.size() > 2) {
+      BOOST_REQUIRE_EQUAL(2, result.permissions.size());
+      if (result.permissions.size() > 1) {
          auto perm = result.permissions[0];
          BOOST_REQUIRE_EQUAL(name("active"_n), perm.perm_name); 
          BOOST_REQUIRE_EQUAL(name("owner"_n), perm.parent);
@@ -461,15 +461,6 @@ BOOST_FIXTURE_TEST_CASE( get_account, TESTER ) try {
          BOOST_REQUIRE_EQUAL(1, auth.keys.size());
          BOOST_REQUIRE_EQUAL(0, auth.accounts.size());
          BOOST_REQUIRE_EQUAL(0, auth.waits.size());
-
-         perm = result.permissions[2];
-         BOOST_REQUIRE_EQUAL(name("eosio.any"_n), perm.perm_name); 
-         BOOST_REQUIRE_EQUAL(name(""_n), perm.parent);
-         auth = perm.required_auth;
-         BOOST_REQUIRE_EQUAL(0, auth.threshold);
-         BOOST_REQUIRE_EQUAL(0, auth.keys.size());
-         BOOST_REQUIRE_EQUAL(0, auth.accounts.size());
-         BOOST_REQUIRE_EQUAL(0, auth.waits.size());
       }
    };
 
@@ -480,6 +471,7 @@ BOOST_FIXTURE_TEST_CASE( get_account, TESTER ) try {
       if (perm.linked_actions.has_value())
          BOOST_REQUIRE_EQUAL(0, perm.linked_actions->size());
    }
+   BOOST_REQUIRE_EQUAL(0, result.eosio_any_linked_actions.size());
 
    // test link authority
    link_authority(name("alice"_n), name("bob"_n), name("active"_n), name("foo"_n));
@@ -497,6 +489,7 @@ BOOST_FIXTURE_TEST_CASE( get_account, TESTER ) try {
          BOOST_REQUIRE_EQUAL(name("foo"_n), la.action.value());
       }
    }
+   BOOST_REQUIRE_EQUAL(0, result.eosio_any_linked_actions.size());
 
    // test link authority to eosio.any
    link_authority(name("alice"_n), name("bob"_n), name("eosio.any"_n), name("foo"_n));
@@ -506,10 +499,11 @@ BOOST_FIXTURE_TEST_CASE( get_account, TESTER ) try {
    // active permission should no longer have linked auth, as eosio.any replaces it
    perm = result.permissions[0];
    BOOST_REQUIRE_EQUAL(0, perm.linked_actions->size());
-   perm = result.permissions[2];
-   BOOST_REQUIRE_EQUAL(1, perm.linked_actions->size());
-   if (perm.linked_actions->size() >= 1) {
-      auto la = (*perm.linked_actions)[0];
+
+   auto eosio_any_la = result.eosio_any_linked_actions;
+   BOOST_REQUIRE_EQUAL(1, eosio_any_la.size());
+   if (eosio_any_la.size() >= 1) {
+      auto la = eosio_any_la[0];
       BOOST_REQUIRE_EQUAL(name("bob"_n), la.account);
       BOOST_REQUIRE_EQUAL(true, la.action.has_value());
       if(la.action.has_value()) {


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->
## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
`get_account` RPC call https://github.com/EOSIO/eos/pull/10832 did not include linked authorizations from `eosio.any`, which is an implicit permission that exists on every account - but can only contain linked actions, never keys, accounts or waits. 

The linked actions to `eosio.any` will show up as a. new field `eosio_any_linked_actions` present in the JSON and also displayed in cleos. 

Example:
```
$ cleos push action eosio linkauth '["alice", "bob", "", "active"]' -p alice@active
$ cleos push action eosio linkauth '["alice", "bob", "bar", "active"]' -p alice@active
$ cleos push action eosio linkauth '["alice", "bob", "foo", "owner"]' -p alice@active
$ cleos push action eosio linkauth '["alice", "bob", "baz", "eosio.any"]' -p alice@active
$ cleos get account alice
created: 2021-11-05T21:46:23.000
permissions:
     owner     1:    1 EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV
        active     1:    1 EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV

permission links:
     owner:
          bob::foo
     active:
          bob::*
          bob::bar
     eosio.any:
          bob::baz
```
JSON:
```
$ ./cleos get account alice -j
{
  "account_name": "alice",
  "head_block_num": 117,
  "head_block_time": "2021-11-05T21:47:04.000",
  "privileged": false,
  ...
  "permissions": [{
      "perm_name": "active",
      "parent": "owner",
      "required_auth": {
        "threshold": 1,
        "keys": [{
            "key": "EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV",
            "weight": 1
          }
        ],
        "accounts": [],
        "waits": []
      },
      "linked_actions": [{
          "account": "bob"
        },{
          "account": "bob",
          "action": "bar"
        }
      ]
    },{
      "perm_name": "owner",
      "parent": "",
      "required_auth": {
        "threshold": 1,
        "keys": [{
            "key": "EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV",
            "weight": 1
          }
        ],
        "accounts": [],
        "waits": []
      },
      "linked_actions": [{
          "account": "bob",
          "action": "foo"
        }
      ]
    }
  ],
... 
  "eosio_any_linked_actions": [{
      "account": "bob",
      "action": "baz"
    }
  ]
}
```
Previously, `linkauth` actions with `eosio.any` permission level were not visible from `get_account` call. 

## Change Type
**Select *ONE*:**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [x] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [ ] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the release notes. Please include a description of the change for inclusion in the release notes. -->


## Testing Changes
**Select *ANY* that apply:**
- [x] New Tests
<!-- checked [x] = new test cases were added; unchecked [ ] = no new test cases -->
- [ ] Existing Tests
<!-- checked [x] = existing test cases were edited; unchecked [ ] = no existing tests were modified -->
- [ ] Test Framework
<!-- checked [x] = this modifies the test framework; unchecked [ ] = no test framework changes -->
- [ ] CI System
<!-- checked [x] = this changes the CI system; unchecked [ ] = no CI changes -->
- [ ] Other
<!-- checked [x] = this integrates an external test system; unchecked [ ] = no miscellaneous test-related changes -->
<!-- Please describe your test changes, or list each new test and its purpose, under each respective checkbox -->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [x] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->

get_account RPC will have an additional field `eosio_any_linked_actions`


## Documentation Additions
- [x] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
