### PR TITLE
net_plugin bugfix for resetting requested range - 2.2

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -168,7 +168,10 @@ namespace eosio {
       void sync_update_expected( const connection_ptr& c, const block_id_type& blk_id, uint32_t blk_num, bool blk_applied );
       void recv_handshake( const connection_ptr& c, const handshake_message& msg );
       void sync_recv_notice( const connection_ptr& c, const notice_message& msg );
-      inline void reset_last_requested_num() {
+      inline void reset_last_requested_num(bool lock = false) {
+         std::unique_lock<std::mutex> g( sync_mtx, std::defer_lock_t{} );
+         if (lock)
+            g.lock();
          sync_last_requested_num = 0;
       }
    };
@@ -2234,14 +2237,15 @@ namespace eosio {
    // called from connection strand
    void sync_manager::rejected_block( const connection_ptr& c, uint32_t blk_num ) {
       c->block_status_monitor_.rejected();
+      std::unique_lock<std::mutex> g( sync_mtx );
+      reset_last_requested_num();
       if( c->block_status_monitor_.max_events_violated()) {
          peer_wlog( c, "block ${bn} not accepted, closing connection", ("bn", blk_num) );
-         std::unique_lock<std::mutex> g( sync_mtx );
-         reset_last_requested_num();
          sync_source.reset();
          g.unlock();
          c->close();
       } else {
+         g.unlock();
          c->send_handshake();
       }
    }
@@ -2971,7 +2975,7 @@ namespace eosio {
             peer_ilog( this, "received block ${n} less than ${which}lib ${lib}",
                        ("n", blk_num)("which", blk_num < last_sent_lib ? "sent " : "")
                        ("lib", blk_num < last_sent_lib ? last_sent_lib : lib) );
-            my_impl->sync_master->reset_last_requested_num();
+            my_impl->sync_master->reset_last_requested_num(true);
             enqueue( (sync_request_message) {0, 0} );
             send_handshake();
             cancel_wait();

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -168,10 +168,10 @@ namespace eosio {
       void sync_update_expected( const connection_ptr& c, const block_id_type& blk_id, uint32_t blk_num, bool blk_applied );
       void recv_handshake( const connection_ptr& c, const handshake_message& msg );
       void sync_recv_notice( const connection_ptr& c, const notice_message& msg );
-      inline void reset_last_requested_num(bool lock = false) {
-         std::unique_lock<std::mutex> g( sync_mtx, std::defer_lock_t{} );
-         if (lock)
-            g.lock();
+      inline std::unique_lock<std::mutex> locked_sync_mutex() {
+         return std::unique_lock<std::mutex>(sync_mtx);
+      }
+      inline void reset_last_requested_num(const std::unique_lock<std::mutex>& lock) {
          sync_last_requested_num = 0;
       }
    };
@@ -1882,7 +1882,7 @@ namespace eosio {
 
          // if closing the connection we are currently syncing from, then reset our last requested and next expected.
          if( c == sync_source ) {
-            reset_last_requested_num();
+            reset_last_requested_num(g);
             uint32_t head_blk_num = 0;
             std::tie( std::ignore, head_blk_num, std::ignore, std::ignore, std::ignore, std::ignore ) = my_impl->get_chain_info();
             sync_next_expected_num = head_blk_num + 1;
@@ -1968,7 +1968,7 @@ namespace eosio {
       if( !sync_source || !sync_source->current() || sync_source->is_transactions_only_connection() ) {
          fc_elog( logger, "Unable to continue syncing at this time");
          sync_known_lib_num = lib_block_num;
-         reset_last_requested_num();
+         reset_last_requested_num(g_sync);
          set_state( in_sync ); // probably not, but we can't do anything else
          return;
       }
@@ -2053,7 +2053,7 @@ namespace eosio {
 
       if( c == sync_source ) {
          c->cancel_sync(reason);
-         reset_last_requested_num();
+         reset_last_requested_num(g);
          request_next_chunk( std::move(g) );
       }
    }
@@ -2238,7 +2238,7 @@ namespace eosio {
    void sync_manager::rejected_block( const connection_ptr& c, uint32_t blk_num ) {
       c->block_status_monitor_.rejected();
       std::unique_lock<std::mutex> g( sync_mtx );
-      reset_last_requested_num();
+      reset_last_requested_num(g);
       if( c->block_status_monitor_.max_events_violated()) {
          peer_wlog( c, "block ${bn} not accepted, closing connection", ("bn", blk_num) );
          sync_source.reset();
@@ -2975,7 +2975,7 @@ namespace eosio {
             peer_ilog( this, "received block ${n} less than ${which}lib ${lib}",
                        ("n", blk_num)("which", blk_num < last_sent_lib ? "sent " : "")
                        ("lib", blk_num < last_sent_lib ? last_sent_lib : lib) );
-            my_impl->sync_master->reset_last_requested_num(true);
+            my_impl->sync_master->reset_last_requested_num(my_impl->sync_master->locked_sync_mutex());
             enqueue( (sync_request_message) {0, 0} );
             send_handshake();
             cancel_wait();


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->
## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
test fail example:
https://buildkite.com/EOSIO/eosio-test-stability/builds/319#b82a137d-3c4d-48d6-96cb-e48d3af9496d

investigation details:
When net_plugin sends `sync_request_message{0,0}` in response to block<lib it doesn't reset `sync_last_requested_num`. After that when node gets `notice_message` it ignores it instead of doing catchup since head is less than `sync_last_requested_num`.

backport of #10860 

## Change Type
**Select *ONE*:**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [x] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [ ] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the release notes. Please include a description of the change for inclusion in the release notes. -->


## Testing Changes
**Select *ANY* that apply:**
- [ ] New Tests
<!-- checked [x] = new test cases were added; unchecked [ ] = no new test cases -->
- [ ] Existing Tests
<!-- checked [x] = existing test cases were edited; unchecked [ ] = no existing tests were modified -->
- [ ] Test Framework
<!-- checked [x] = this modifies the test framework; unchecked [ ] = no test framework changes -->
- [ ] CI System
<!-- checked [x] = this changes the CI system; unchecked [ ] = no CI changes -->
- [ ] Other
<!-- checked [x] = this integrates an external test system; unchecked [ ] = no miscellaneous test-related changes -->
<!-- Please describe your test changes, or list each new test and its purpose, under each respective checkbox -->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
