### PR TITLE
EPE-1708 cleos sorts keys/permission_levels/waits for "cleos set account permission" - release/2.2.x

### DIFF
--- a/libraries/chain/include/eosio/chain/authority.hpp
+++ b/libraries/chain/include/eosio/chain/authority.hpp
@@ -84,6 +84,10 @@ struct permission_level_weight {
    friend bool operator == ( const permission_level_weight& lhs, const permission_level_weight& rhs ) {
       return tie( lhs.permission, lhs.weight ) == tie( rhs.permission, rhs.weight );
    }
+
+   friend bool operator < ( const permission_level_weight& lhs, const permission_level_weight& rhs ) {
+      return tie( lhs.permission, lhs.weight ) < tie( rhs.permission, rhs.weight );
+   }
 };
 
 struct key_weight {
@@ -92,6 +96,10 @@ struct key_weight {
 
    friend bool operator == ( const key_weight& lhs, const key_weight& rhs ) {
       return tie( lhs.key, lhs.weight ) == tie( rhs.key, rhs.weight );
+   }
+
+   friend bool operator < ( const key_weight& lhs, const key_weight& rhs ) {
+      return tie( lhs.key, lhs.weight ) < tie( rhs.key, rhs.weight );
    }
 };
 
@@ -136,6 +144,10 @@ struct wait_weight {
 
    friend bool operator == ( const wait_weight& lhs, const wait_weight& rhs ) {
       return tie( lhs.wait_sec, lhs.weight ) == tie( rhs.wait_sec, rhs.weight );
+   }
+
+   friend bool operator < ( const wait_weight& lhs, const wait_weight& rhs ) {
+      return tie( lhs.wait_sec, lhs.weight ) < tie( rhs.wait_sec, rhs.weight );
    }
 };
 
@@ -190,6 +202,12 @@ struct authority {
 
    friend bool operator != ( const authority& lhs, const authority& rhs ) {
       return tie( lhs.threshold, lhs.keys, lhs.accounts, lhs.waits ) != tie( rhs.threshold, rhs.keys, rhs.accounts, rhs.waits );
+   }
+
+   void sort_fields () {
+      std::sort(std::begin(keys), std::end(keys));
+      std::sort(std::begin(accounts), std::end(accounts));
+      std::sort(std::begin(waits), std::end(waits));
    }
 };
 

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -833,6 +833,7 @@ authority parse_json_authority_or_key(const std::string& authorityJsonOrFile) {
       } EOS_RETHROW_EXCEPTIONS(public_key_type_exception, "Invalid public key: ${public_key}", ("public_key", authorityJsonOrFile))
    } else {
       auto result = parse_json_authority(authorityJsonOrFile);
+      result.sort_fields();
       EOS_ASSERT( eosio::chain::validate(result), authority_type_exception, "Authority failed validation! ensure that keys, accounts, and waits are sorted and that the threshold is valid and satisfiable!");
       return result;
    }


### PR DESCRIPTION
The same change to `release/2.2.x` branch for https://github.com/EOSIO/eos/pull/10903 .

The keys/permissions/waits to `eosio::updateauth` action must be ordered. The order is not simply the string order.

At current, cleos can validate the authority data structure. But when there are multiple keys or multiple permission_levels, it is hard to figure out how to order the keys/permissions/waits. There are N! number of combinations to try for N keys/permission_levels.

It will be convenient if `cleos set account permission` can automatically sort the keys, permission_levels and waits for users.

One example:

```
./bin/cleos -u https://eos.greymass.com set account permission eosio active -sdj -x 3600 '{
  "threshold": 1,
  "keys": [
    {
      "key": "EOS8YWkQM9bcwHUSjEfZVAb7cDoQNAwikYvJXrAbQya2hhdDz7KSR",
      "weight": 1
    },
    {
      "key": "EOS7QvhpiF4uWTrjCgyJz2mV13mhdCwzNLNXSGn6npK87Ymz56Mip",
      "weight": 1
    }
  ],
  "accounts": [
    {
      "permission": {
          "actor": "eosio.token",
          "permission": "owner"
        },
        "weight": 1
    },
    {
      "permission": {
          "actor": "eosio.token",
          "permission": "active"
        },
        "weight": 1
    },
    {
      "permission": {
          "actor": "eosio.saving",
          "permission": "active"
        },
        "weight": 1
    }
  ],
  "waits": [
    {
      "wait_sec": 10,
      "weight": 2
    },
    {
      "wait_sec": 5,
      "weight": 1
    }
  ]
}' -p eosio@active
{
  "expiration": "2021-11-24T10:27:24",
  "ref_block_num": 46078,
  "ref_block_prefix": 3678459831,
  "max_net_usage_words": 0,
  "max_cpu_usage_ms": 0,
  "delay_sec": 0,
  "context_free_actions": [],
  "actions": [{
      "account": "eosio",
      "name": "updateauth",
      "authorization": [{
          "actor": "eosio",
          "permission": "active"
        }
      ],
      "data": {
        "account": "eosio",
        "permission": "active",
        "parent": "owner",
        "auth": {
          "threshold": 1,
          "keys": [{
              "key": "EOS7QvhpiF4uWTrjCgyJz2mV13mhdCwzNLNXSGn6npK87Ymz56Mip",
              "weight": 1
            },{
              "key": "EOS8YWkQM9bcwHUSjEfZVAb7cDoQNAwikYvJXrAbQya2hhdDz7KSR",
              "weight": 1
            }
          ],
          "accounts": [{
              "permission": {
                "actor": "eosio.saving",
                "permission": "active"
              },
              "weight": 1
            },{
              "permission": {
                "actor": "eosio.token",
                "permission": "active"
              },
              "weight": 1
            },{
              "permission": {
                "actor": "eosio.token",
                "permission": "owner"
              },
              "weight": 1
            }
          ],
          "waits": [{
              "wait_sec": 5,
              "weight": 1
            },{
              "wait_sec": 10,
              "weight": 2
            }
          ]
        }
      },
      "hex_data": "0000000000ea305500000000a8ed32320000000080ab26a7010000000200034c80d981ee83fd82089672e361102b87f561f2f07fc51fd10bbda24471072c6d01000003e16d3374ee29cf0b794df19dd0919ee309cf4e500e1f71c4c866884a32ae9f67010003c0a6db0603ea305500000000a8ed3232010000a6823403ea305500000000a8ed3232010000a6823403ea30550000000080ab26a70100020500000001000a0000000200"
    }
  ],
  "signatures": [],
  "context_free_data": []
}
```

<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->
## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->


## Change Type
**Select *ONE*:**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [ ] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [x] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the release notes. Please include a description of the change for inclusion in the release notes. -->


## Testing Changes
**Select *ANY* that apply:**
- [ ] New Tests
<!-- checked [x] = new test cases were added; unchecked [ ] = no new test cases -->
- [ ] Existing Tests
<!-- checked [x] = existing test cases were edited; unchecked [ ] = no existing tests were modified -->
- [ ] Test Framework
<!-- checked [x] = this modifies the test framework; unchecked [ ] = no test framework changes -->
- [ ] CI System
<!-- checked [x] = this changes the CI system; unchecked [ ] = no CI changes -->
- [ ] Other
<!-- checked [x] = this integrates an external test system; unchecked [ ] = no miscellaneous test-related changes -->
<!-- Please describe your test changes, or list each new test and its purpose, under each respective checkbox -->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
