### PR TITLE
Add total CPU weight and total NET weight to get_info 📦

### DIFF
--- a/libraries/chain/include/eosio/chain/resource_limits.hpp
+++ b/libraries/chain/include/eosio/chain/resource_limits.hpp
@@ -90,6 +90,9 @@ namespace eosio { namespace chain { namespace resource_limits {
          void process_block_usage( uint32_t block_num );
 
          // accessors
+         uint64_t get_total_cpu_weight() const;
+         uint64_t get_total_net_weight() const;
+
          uint64_t get_virtual_block_cpu_limit() const;
          uint64_t get_virtual_block_net_limit() const;
 

--- a/libraries/chain/resource_limits.cpp
+++ b/libraries/chain/resource_limits.cpp
@@ -426,6 +426,16 @@ void resource_limits_manager::process_block_usage(uint32_t block_num) {
 
 }
 
+uint64_t resource_limits_manager::get_total_cpu_weight() const {
+   const auto& state = _db.get<resource_limits_state_object>();
+   return state.total_cpu_weight;
+}
+
+uint64_t resource_limits_manager::get_total_net_weight() const {
+   const auto& state = _db.get<resource_limits_state_object>();
+   return state.total_net_weight;
+}
+
 uint64_t resource_limits_manager::get_virtual_block_cpu_limit() const {
    const auto& state = _db.get<resource_limits_state_object>();
    return state.virtual_cpu_limit;

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1741,8 +1741,6 @@ read_only::get_info_results read_only::get_info(const read_only::get_info_params
       db.head_block_id(),
       db.head_block_time(),
       db.head_block_producer(),
-      rm.get_total_cpu_weight(),
-      rm.get_total_net_weight(),
       rm.get_virtual_block_cpu_limit(),
       rm.get_virtual_block_net_limit(),
       rm.get_block_cpu_limit(),
@@ -1753,7 +1751,9 @@ read_only::get_info_results read_only::get_info(const read_only::get_info_params
       db.fork_db_pending_head_block_num(),
       db.fork_db_pending_head_block_id(),
       app().full_version_string(),
-      db.last_irreversible_block_time()
+      db.last_irreversible_block_time(),
+      rm.get_total_cpu_weight(),
+      rm.get_total_net_weight()
    };
 }
 

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1741,6 +1741,8 @@ read_only::get_info_results read_only::get_info(const read_only::get_info_params
       db.head_block_id(),
       db.head_block_time(),
       db.head_block_producer(),
+      rm.get_total_cpu_weight(),
+      rm.get_total_net_weight(),
       rm.get_virtual_block_cpu_limit(),
       rm.get_virtual_block_net_limit(),
       rm.get_block_cpu_limit(),

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -129,6 +129,9 @@ public:
       fc::time_point                       head_block_time;
       account_name                         head_block_producer;
 
+      uint64_t                             total_cpu_weight = 0;
+      uint64_t                             total_net_weight = 0;
+
       uint64_t                             virtual_block_cpu_limit = 0;
       uint64_t                             virtual_block_net_limit = 0;
 
@@ -1119,7 +1122,7 @@ FC_REFLECT(eosio::chain_apis::empty, )
 FC_REFLECT(eosio::chain_apis::read_only::get_info_results,
            (server_version)(chain_id)(head_block_num)(last_irreversible_block_num)(last_irreversible_block_id)
            (head_block_id)(head_block_time)(head_block_producer)
-           (virtual_block_cpu_limit)(virtual_block_net_limit)(block_cpu_limit)(block_net_limit)
+           (total_cpu_weight)(total_net_weight)(virtual_block_cpu_limit)(virtual_block_net_limit)(block_cpu_limit)(block_net_limit)
            (server_version_string)(fork_db_head_block_num)(fork_db_head_block_id)(server_full_version_string)
            (last_irreversible_block_time) )
 FC_REFLECT(eosio::chain_apis::read_only::get_activated_protocol_features_params, (lower_bound)(upper_bound)(limit)(search_by_block_num)(reverse) )

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -129,9 +129,6 @@ public:
       fc::time_point                       head_block_time;
       account_name                         head_block_producer;
 
-      uint64_t                             total_cpu_weight = 0;
-      uint64_t                             total_net_weight = 0;
-
       uint64_t                             virtual_block_cpu_limit = 0;
       uint64_t                             virtual_block_net_limit = 0;
 
@@ -144,6 +141,8 @@ public:
       std::optional<chain::block_id_type>  fork_db_head_block_id;
       std::optional<string>                server_full_version_string;
       std::optional<fc::time_point>        last_irreversible_block_time;
+      std::optional<uint64_t>              total_cpu_weight;
+      std::optional<uint64_t>              total_net_weight;
    };
    get_info_results get_info(const get_info_params&) const;
 
@@ -1122,9 +1121,9 @@ FC_REFLECT(eosio::chain_apis::empty, )
 FC_REFLECT(eosio::chain_apis::read_only::get_info_results,
            (server_version)(chain_id)(head_block_num)(last_irreversible_block_num)(last_irreversible_block_id)
            (head_block_id)(head_block_time)(head_block_producer)
-           (total_cpu_weight)(total_net_weight)(virtual_block_cpu_limit)(virtual_block_net_limit)(block_cpu_limit)(block_net_limit)
+           (virtual_block_cpu_limit)(virtual_block_net_limit)(block_cpu_limit)(block_net_limit)
            (server_version_string)(fork_db_head_block_num)(fork_db_head_block_id)(server_full_version_string)
-           (last_irreversible_block_time) )
+           (last_irreversible_block_time)(total_cpu_weight)(total_net_weight) )
 FC_REFLECT(eosio::chain_apis::read_only::get_activated_protocol_features_params, (lower_bound)(upper_bound)(limit)(search_by_block_num)(reverse) )
 FC_REFLECT(eosio::chain_apis::read_only::get_activated_protocol_features_results, (activated_protocol_features)(more) )
 FC_REFLECT(eosio::chain_apis::read_only::get_block_params, (block_num_or_id))

--- a/tests/chain_plugin_tests.cpp
+++ b/tests/chain_plugin_tests.cpp
@@ -148,6 +148,8 @@ BOOST_FIXTURE_TEST_CASE( get_info, TESTER ) try {
    BOOST_TEST(info.head_block_id == control->head_block_id());
    BOOST_TEST(info.head_block_time == control->head_block_time());
    BOOST_TEST(info.head_block_producer == control->head_block_producer());
+   BOOST_TEST(info.total_cpu_weight == control->get_resource_limits_manager().get_total_cpu_weight());
+   BOOST_TEST(info.total_net_weight == control->get_resource_limits_manager().get_total_net_weight());
    BOOST_TEST(info.virtual_block_cpu_limit == control->get_resource_limits_manager().get_virtual_block_cpu_limit());
    BOOST_TEST(info.virtual_block_net_limit == control->get_resource_limits_manager().get_virtual_block_net_limit());
    BOOST_TEST(info.block_cpu_limit == control->get_resource_limits_manager().get_block_cpu_limit());

--- a/tests/chain_plugin_tests.cpp
+++ b/tests/chain_plugin_tests.cpp
@@ -148,8 +148,6 @@ BOOST_FIXTURE_TEST_CASE( get_info, TESTER ) try {
    BOOST_TEST(info.head_block_id == control->head_block_id());
    BOOST_TEST(info.head_block_time == control->head_block_time());
    BOOST_TEST(info.head_block_producer == control->head_block_producer());
-   BOOST_TEST(info.total_cpu_weight == control->get_resource_limits_manager().get_total_cpu_weight());
-   BOOST_TEST(info.total_net_weight == control->get_resource_limits_manager().get_total_net_weight());
    BOOST_TEST(info.virtual_block_cpu_limit == control->get_resource_limits_manager().get_virtual_block_cpu_limit());
    BOOST_TEST(info.virtual_block_net_limit == control->get_resource_limits_manager().get_virtual_block_net_limit());
    BOOST_TEST(info.block_cpu_limit == control->get_resource_limits_manager().get_block_cpu_limit());
@@ -159,6 +157,8 @@ BOOST_FIXTURE_TEST_CASE( get_info, TESTER ) try {
    BOOST_TEST(*info.fork_db_head_block_id == control->fork_db_pending_head_block_id());
    BOOST_TEST(*info.server_full_version_string == app().full_version_string());
    BOOST_TEST(*info.last_irreversible_block_time == control->last_irreversible_block_time());
+   BOOST_TEST(*info.total_cpu_weight == control->get_resource_limits_manager().get_total_cpu_weight());
+   BOOST_TEST(*info.total_net_weight == control->get_resource_limits_manager().get_total_net_weight());
 
    produce_blocks(1);
 


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->
## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
Total CPU and NET weights are added to `get_info` (https://blockone.atlassian.net/browse/EPE-1801). They are made as optional such that different versions of `cleos` and `nodeos` can work.

A sample run of `cleos` run against the same version of `nodeos` looks like

```
./cleos get info
{
  "server_version": "57fdf3b7",
  "chain_id": "8a34ec7df1b8cd06ff4a8abbaa7cc50300823350cadc59ab296cb00d104d2b8f",
  "head_block_num": 2204,
  "last_irreversible_block_num": 2203,
  "last_irreversible_block_id": "0000089bafe800c9dbe39819fc5e875d71d9a712bc591270835f9b2855598923",
  "head_block_id": "0000089c4ea6b4c97c80c7697721a608438959441e1bf92f6a5148c997f7c069",
  "head_block_time": "2021-12-02T18:14:48.500",
  "head_block_producer": "eosio",
  "virtual_block_cpu_limit": 1808373,
  "virtual_block_net_limit": 9498325,
  "block_cpu_limit": 199900,
  "block_net_limit": 1048576,
  "server_version_string": "v2.1.0",
  "fork_db_head_block_num": 2204,
  "fork_db_head_block_id": "0000089c4ea6b4c97c80c7697721a608438959441e1bf92f6a5148c997f7c069",
  "server_full_version_string": "v2.1.0-57fdf3b74a97b2ec7286a352e10de8c03fe6ec01-dirty",
  "last_irreversible_block_time": "2021-12-02T18:14:48.000",
  "total_cpu_weight": 0,
  "total_net_weight": 0
}
```
A sample run of `cleos` run against an older version of `nodeos` looks like
```
./cleos get info
{
  "server_version": "57fdf3b7",
  "chain_id": "8a34ec7df1b8cd06ff4a8abbaa7cc50300823350cadc59ab296cb00d104d2b8f",
  "head_block_num": 481,
  "last_irreversible_block_num": 480,
  "last_irreversible_block_id": "000001e0ac8805e57055fc6f1c05d579b5112953b623dd9ef59151f4a5f33f33",
  "head_block_id": "000001e19dbe5edbd3da930a4857303f112cda346c6c36e90e147ca52f322542",
  "head_block_time": "2021-12-03T14:30:23.000",
  "head_block_producer": "eosio",
  "virtual_block_cpu_limit": 322985,
  "virtual_block_net_limit": 1694682,
  "block_cpu_limit": 199900,
  "block_net_limit": 1048576,
  "server_version_string": "v2.1.0",
  "fork_db_head_block_num": 481,
  "fork_db_head_block_id": "000001e19dbe5edbd3da930a4857303f112cda346c6c36e90e147ca52f322542",
  "server_full_version_string": "v2.1.0-57fdf3b74a97b2ec7286a352e10de8c03fe6ec01",
  "last_irreversible_block_time": "2021-12-03T14:30:22.500"
}

```
## Change Type
**Select *ONE*:**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [ ] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [x] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the release notes. Please include a description of the change for inclusion in the release notes. -->


## Testing Changes
**Select *ANY* that apply:**
- [ ] New Tests
<!-- checked [x] = new test cases were added; unchecked [ ] = no new test cases -->
- [x] Existing Tests
<!-- checked [x] = existing test cases were edited; unchecked [ ] = no existing tests were modified -->
- [ ] Test Framework
<!-- checked [x] = this modifies the test framework; unchecked [ ] = no test framework changes -->
- [ ] CI System
<!-- checked [x] = this changes the CI system; unchecked [ ] = no CI changes -->
- [ ] Other
<!-- checked [x] = this integrates an external test system; unchecked [ ] = no miscellaneous test-related changes -->
<!-- Please describe your test changes, or list each new test and its purpose, under each respective checkbox -->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [x] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
`total_cpu_weight` and `total_net_weight` are added to get_info chain API endpoint.
