### PR TITLE
2.2.x -- Add total CPU weight and total NET weight to get_info

### DIFF
--- a/libraries/chain/include/eosio/chain/resource_limits.hpp
+++ b/libraries/chain/include/eosio/chain/resource_limits.hpp
@@ -90,6 +90,9 @@ namespace eosio { namespace chain { namespace resource_limits {
          void process_block_usage( uint32_t block_num );
 
          // accessors
+         uint64_t get_total_cpu_weight() const;
+         uint64_t get_total_net_weight() const;
+
          uint64_t get_virtual_block_cpu_limit() const;
          uint64_t get_virtual_block_net_limit() const;
 

--- a/libraries/chain/resource_limits.cpp
+++ b/libraries/chain/resource_limits.cpp
@@ -448,6 +448,16 @@ void resource_limits_manager::process_block_usage(uint32_t block_num) {
 
 }
 
+uint64_t resource_limits_manager::get_total_cpu_weight() const {
+   const auto& state = _db.get<resource_limits_state_object>();
+   return state.total_cpu_weight;
+}
+
+uint64_t resource_limits_manager::get_total_net_weight() const {
+   const auto& state = _db.get<resource_limits_state_object>();
+   return state.total_net_weight;
+}
+
 uint64_t resource_limits_manager::get_virtual_block_cpu_limit() const {
    const auto& state = _db.get<resource_limits_state_object>();
    return state.virtual_cpu_limit;

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1494,6 +1494,8 @@ read_only::get_info_results read_only::get_info(const read_only::get_info_params
       db.head_block_id(),
       db.head_block_time(),
       db.head_block_producer(),
+      rm.get_total_cpu_weight(),
+      rm.get_total_net_weight(),
       rm.get_virtual_block_cpu_limit(),
       rm.get_virtual_block_net_limit(),
       rm.get_block_cpu_limit(),

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1494,8 +1494,6 @@ read_only::get_info_results read_only::get_info(const read_only::get_info_params
       db.head_block_id(),
       db.head_block_time(),
       db.head_block_producer(),
-      rm.get_total_cpu_weight(),
-      rm.get_total_net_weight(),
       rm.get_virtual_block_cpu_limit(),
       rm.get_virtual_block_net_limit(),
       rm.get_block_cpu_limit(),
@@ -1507,7 +1505,9 @@ read_only::get_info_results read_only::get_info(const read_only::get_info_params
       db.fork_db_pending_head_block_id(),
       app().full_version_string(),
       db.last_irreversible_block_time(),
-      db.get_first_block_num()
+      db.get_first_block_num(),
+      rm.get_total_cpu_weight(),
+      rm.get_total_net_weight()
    };
 }
 

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -123,6 +123,9 @@ public:
       fc::time_point                       head_block_time;
       account_name                         head_block_producer;
 
+      uint64_t                             total_cpu_weight = 0;
+      uint64_t                             total_net_weight = 0;
+
       uint64_t                             virtual_block_cpu_limit = 0;
       uint64_t                             virtual_block_net_limit = 0;
 
@@ -1093,7 +1096,7 @@ FC_REFLECT(eosio::chain_apis::empty, )
 FC_REFLECT(eosio::chain_apis::read_only::get_info_results,
            (server_version)(chain_id)(head_block_num)(last_irreversible_block_num)(last_irreversible_block_id)
            (head_block_id)(head_block_time)(head_block_producer)
-           (virtual_block_cpu_limit)(virtual_block_net_limit)(block_cpu_limit)(block_net_limit)
+           (total_cpu_weight)(total_net_weight)(virtual_block_cpu_limit)(virtual_block_net_limit)(block_cpu_limit)(block_net_limit)
            (server_version_string)(fork_db_head_block_num)(fork_db_head_block_id)(server_full_version_string)
            (last_irreversible_block_time) (first_block_num) )
 FC_REFLECT(eosio::chain_apis::read_only::get_activated_protocol_features_params, (lower_bound)(upper_bound)(limit)(search_by_block_num)(reverse) )

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -123,9 +123,6 @@ public:
       fc::time_point                       head_block_time;
       account_name                         head_block_producer;
 
-      uint64_t                             total_cpu_weight = 0;
-      uint64_t                             total_net_weight = 0;
-
       uint64_t                             virtual_block_cpu_limit = 0;
       uint64_t                             virtual_block_net_limit = 0;
 
@@ -139,6 +136,8 @@ public:
       std::optional<string>                server_full_version_string;
       std::optional<fc::time_point>        last_irreversible_block_time;
       std::optional<uint32_t>              first_block_num;
+      std::optional<uint64_t>              total_cpu_weight;
+      std::optional<uint64_t>              total_net_weight;
    };
    get_info_results get_info(const get_info_params&) const;
 
@@ -1096,9 +1095,10 @@ FC_REFLECT(eosio::chain_apis::empty, )
 FC_REFLECT(eosio::chain_apis::read_only::get_info_results,
            (server_version)(chain_id)(head_block_num)(last_irreversible_block_num)(last_irreversible_block_id)
            (head_block_id)(head_block_time)(head_block_producer)
-           (total_cpu_weight)(total_net_weight)(virtual_block_cpu_limit)(virtual_block_net_limit)(block_cpu_limit)(block_net_limit)
+           (virtual_block_cpu_limit)(virtual_block_net_limit)(block_cpu_limit)(block_net_limit)
            (server_version_string)(fork_db_head_block_num)(fork_db_head_block_id)(server_full_version_string)
-           (last_irreversible_block_time) (first_block_num) )
+           (last_irreversible_block_time) (first_block_num)
+           (total_cpu_weight)(total_net_weight) )
 FC_REFLECT(eosio::chain_apis::read_only::get_activated_protocol_features_params, (lower_bound)(upper_bound)(limit)(search_by_block_num)(reverse) )
 FC_REFLECT(eosio::chain_apis::read_only::get_activated_protocol_features_results, (activated_protocol_features)(more) )
 FC_REFLECT(eosio::chain_apis::read_only::get_block_params, (block_num_or_id))

--- a/tests/chain_plugin_tests.cpp
+++ b/tests/chain_plugin_tests.cpp
@@ -148,6 +148,8 @@ BOOST_FIXTURE_TEST_CASE( get_info, TESTER ) try {
    BOOST_TEST(info.head_block_id == control->head_block_id());
    BOOST_TEST(info.head_block_time == control->head_block_time());
    BOOST_TEST(info.head_block_producer == control->head_block_producer());
+   BOOST_TEST(info.total_cpu_weight == control->get_resource_limits_manager().get_total_cpu_weight());
+   BOOST_TEST(info.total_net_weight == control->get_resource_limits_manager().get_total_net_weight());
    BOOST_TEST(info.virtual_block_cpu_limit == control->get_resource_limits_manager().get_virtual_block_cpu_limit());
    BOOST_TEST(info.virtual_block_net_limit == control->get_resource_limits_manager().get_virtual_block_net_limit());
    BOOST_TEST(info.block_cpu_limit == control->get_resource_limits_manager().get_block_cpu_limit());

--- a/tests/chain_plugin_tests.cpp
+++ b/tests/chain_plugin_tests.cpp
@@ -148,8 +148,6 @@ BOOST_FIXTURE_TEST_CASE( get_info, TESTER ) try {
    BOOST_TEST(info.head_block_id == control->head_block_id());
    BOOST_TEST(info.head_block_time == control->head_block_time());
    BOOST_TEST(info.head_block_producer == control->head_block_producer());
-   BOOST_TEST(info.total_cpu_weight == control->get_resource_limits_manager().get_total_cpu_weight());
-   BOOST_TEST(info.total_net_weight == control->get_resource_limits_manager().get_total_net_weight());
    BOOST_TEST(info.virtual_block_cpu_limit == control->get_resource_limits_manager().get_virtual_block_cpu_limit());
    BOOST_TEST(info.virtual_block_net_limit == control->get_resource_limits_manager().get_virtual_block_net_limit());
    BOOST_TEST(info.block_cpu_limit == control->get_resource_limits_manager().get_block_cpu_limit());
@@ -159,6 +157,8 @@ BOOST_FIXTURE_TEST_CASE( get_info, TESTER ) try {
    BOOST_TEST(*info.fork_db_head_block_id == control->fork_db_pending_head_block_id());
    BOOST_TEST(*info.server_full_version_string == app().full_version_string());
    BOOST_TEST(*info.last_irreversible_block_time == control->last_irreversible_block_time());
+   BOOST_TEST(*info.total_cpu_weight == control->get_resource_limits_manager().get_total_cpu_weight());
+   BOOST_TEST(*info.total_net_weight == control->get_resource_limits_manager().get_total_net_weight());
 
    produce_blocks(1);
 


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->
## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
This is to merge https://github.com/EOSIO/eos/pull/10923 into `rel 2.2.x`. Total CPU weight and total NET weight are added to `get_info` (https://blockone.atlassian.net/browse/EPE-1801).

A sample run of `cleos` run looks like
```
./cleos get info
{
  "server_version": "5ed3cf98",
  "chain_id": "8a34ec7df1b8cd06ff4a8abbaa7cc50300823350cadc59ab296cb00d104d2b8f",
  "head_block_num": 66,
  "last_irreversible_block_num": 65,
  "last_irreversible_block_id": "00000041154937d6e11f21d87bfd576bf322a7ffc79fb2f548d2b8a443882e31",
  "head_block_id": "000000425c61439ea9988098b6ea9e820b329459478c1a4be826d5108dd7b306",
  "head_block_time": "2021-12-06T21:18:07.000",
  "head_block_producer": "eosio",
  "virtual_block_cpu_limit": 213407,
  "virtual_block_net_limit": 1118998,
  "block_cpu_limit": 199900,
  "block_net_limit": 1048576,
  "server_version_string": "v2.2.0-rc1",
  "fork_db_head_block_num": 66,
  "fork_db_head_block_id": "000000425c61439ea9988098b6ea9e820b329459478c1a4be826d5108dd7b306",
  "server_full_version_string": "v2.2.0-rc1-5ed3cf981b4ac460d4acd2c59121b411a8a2afbf-dirty",
  "last_irreversible_block_time": "2021-12-06T21:18:06.500",
  "first_block_num": 1,
  "total_cpu_weight": 0,
  "total_net_weight": 0
}

```
## Change Type
**Select *ONE*:**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [ ] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [x] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the release notes. Please include a description of the change for inclusion in the release notes. -->


## Testing Changes
**Select *ANY* that apply:**
- [ ] New Tests
<!-- checked [x] = new test cases were added; unchecked [ ] = no new test cases -->
- [x] Existing Tests
<!-- checked [x] = existing test cases were edited; unchecked [ ] = no existing tests were modified -->
- [ ] Test Framework
<!-- checked [x] = this modifies the test framework; unchecked [ ] = no test framework changes -->
- [ ] CI System
<!-- checked [x] = this changes the CI system; unchecked [ ] = no CI changes -->
- [ ] Other
<!-- checked [x] = this integrates an external test system; unchecked [ ] = no miscellaneous test-related changes -->
<!-- Please describe your test changes, or list each new test and its purpose, under each respective checkbox -->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [x] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
`total_cpu_weight` and `total_net_weight` are added to get_info chain API endpoint.