### PR TITLE
2.0.x -- Add total CPU and NET to get_info

### DIFF
--- a/libraries/chain/include/eosio/chain/resource_limits.hpp
+++ b/libraries/chain/include/eosio/chain/resource_limits.hpp
@@ -84,6 +84,9 @@ namespace eosio { namespace chain { namespace resource_limits {
          void process_block_usage( uint32_t block_num );
 
          // accessors
+         uint64_t get_total_cpu_weight() const;
+         uint64_t get_total_net_weight() const;
+
          uint64_t get_virtual_block_cpu_limit() const;
          uint64_t get_virtual_block_net_limit() const;
 

--- a/libraries/chain/resource_limits.cpp
+++ b/libraries/chain/resource_limits.cpp
@@ -350,6 +350,16 @@ void resource_limits_manager::process_block_usage(uint32_t block_num) {
 
 }
 
+uint64_t resource_limits_manager::get_total_cpu_weight() const {
+   const auto& state = _db.get<resource_limits_state_object>();
+   return state.total_cpu_weight;
+}
+
+uint64_t resource_limits_manager::get_total_net_weight() const {
+   const auto& state = _db.get<resource_limits_state_object>();
+   return state.total_net_weight;
+}
+
 uint64_t resource_limits_manager::get_virtual_block_cpu_limit() const {
    const auto& state = _db.get<resource_limits_state_object>();
    return state.virtual_cpu_limit;

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1537,7 +1537,9 @@ read_only::get_info_results read_only::get_info(const read_only::get_info_params
       app().version_string(),
       db.fork_db_pending_head_block_num(),
       db.fork_db_pending_head_block_id(),
-      app().full_version_string()
+      app().full_version_string(),
+      rm.get_total_cpu_weight(),
+      rm.get_total_net_weight()
    };
 }
 

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -121,6 +121,8 @@ public:
       optional<uint32_t>              fork_db_head_block_num;
       optional<chain::block_id_type>  fork_db_head_block_id;
       optional<string>        server_full_version_string;
+      optional<uint64_t>      total_cpu_weight;
+      optional<uint64_t>      total_net_weight;
    };
    get_info_results get_info(const get_info_params&) const;
 
@@ -773,7 +775,7 @@ FC_REFLECT(eosio::chain_apis::read_only::get_info_results,
            (server_version)(chain_id)(head_block_num)(last_irreversible_block_num)(last_irreversible_block_id)
            (head_block_id)(head_block_time)(head_block_producer)
            (virtual_block_cpu_limit)(virtual_block_net_limit)(block_cpu_limit)(block_net_limit)
-           (server_version_string)(fork_db_head_block_num)(fork_db_head_block_id)(server_full_version_string) )
+           (server_version_string)(fork_db_head_block_num)(fork_db_head_block_id)(server_full_version_string)(total_cpu_weight)(total_net_weight) )
 FC_REFLECT(eosio::chain_apis::read_only::get_activated_protocol_features_params, (lower_bound)(upper_bound)(limit)(search_by_block_num)(reverse) )
 FC_REFLECT(eosio::chain_apis::read_only::get_activated_protocol_features_results, (activated_protocol_features)(more) )
 FC_REFLECT(eosio::chain_apis::read_only::get_block_params, (block_num_or_id))


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->
## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
This is to merge https://github.com/EOSIO/eos/pull/10923 into `rel 2.0.x`. Total CPU weight and total NET weight are added to `get_info` (https://blockone.atlassian.net/browse/EPE-1801).

A sample run of `cleos` run looks like
```
./cleos get info
{
  "server_version": "55e99c2e",
  "chain_id": "8a34ec7df1b8cd06ff4a8abbaa7cc50300823350cadc59ab296cb00d104d2b8f",
  "head_block_num": 56,
  "last_irreversible_block_num": 55,
  "last_irreversible_block_id": "000000374631fe2f1bacb8a92ff4f292055b9cd2516156f865c2118038618ef5",
  "head_block_id": "00000038433d7c997f1424a94ef0d0fc2ad9e0b3799d56cc053eab3348bc911a",
  "head_block_time": "2021-12-06T21:21:25.500",
  "head_block_producer": "eosio",
  "virtual_block_cpu_limit": 211288,
  "virtual_block_net_limit": 1107864,
  "block_cpu_limit": 199900,
  "block_net_limit": 1048576,
  "server_version_string": "v2.0.13",
  "fork_db_head_block_num": 56,
  "fork_db_head_block_id": "00000038433d7c997f1424a94ef0d0fc2ad9e0b3799d56cc053eab3348bc911a",
  "server_full_version_string": "v2.0.13-55e99c2e040a93a1d1e1bac4fa1cd94948f8288f-dirty",
  "total_cpu_weight": 0,
  "total_net_weight": 0
}
```

## Change Type
**Select *ONE*:**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [ ] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [x] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the release notes. Please include a description of the change for inclusion in the release notes. -->


## Testing Changes
**Select *ANY* that apply:**
- [ ] New Tests
<!-- checked [x] = new test cases were added; unchecked [ ] = no new test cases -->
- [ ] Existing Tests
<!-- checked [x] = existing test cases were edited; unchecked [ ] = no existing tests were modified -->
- [ ] Test Framework
<!-- checked [x] = this modifies the test framework; unchecked [ ] = no test framework changes -->
- [ ] CI System
<!-- checked [x] = this changes the CI system; unchecked [ ] = no CI changes -->
- [ ] Other
<!-- checked [x] = this integrates an external test system; unchecked [ ] = no miscellaneous test-related changes -->
<!-- Please describe your test changes, or list each new test and its purpose, under each respective checkbox -->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [x] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
`total_cpu_weight` and `total_net_weight` are added to get_info chain API endpoint.
