### PR TITLE
add first_block_num for get_info command 📦

### DIFF
--- a/libraries/chain/block_log.cpp
+++ b/libraries/chain/block_log.cpp
@@ -570,6 +570,7 @@ namespace eosio { namespace chain {
 
    void block_log::set_version(uint32_t ver) { detail::block_log_impl::default_version = ver; }
    uint32_t block_log::version() const { return my->preamble.version; }
+   uint32_t block_log::get_first_block_num() const { return my->preamble.first_block_num; }
 
    detail::block_log_impl::block_log_impl(const block_log::config_type& config)
    : stride( config.stride )

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -2296,7 +2296,7 @@ const controller::config& controller::get_config()const
    return my->conf;
 }
 
-const uint32_t controller::get_first_block_num()const
+uint32_t controller::get_first_block_num()const
 {
    return my->blog.get_first_block_num();
 }

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -2296,6 +2296,11 @@ const controller::config& controller::get_config()const
    return my->conf;
 }
 
+const uint32_t controller::get_first_block_num()const
+{
+   return my->blog.get_first_block_num();
+}
+
 controller::controller( const controller::config& cfg, const chain_id_type& chain_id )
 :my( new controller_impl( cfg, *this, protocol_feature_set{}, chain_id ) )
 {

--- a/libraries/chain/include/eosio/chain/block_log.hpp
+++ b/libraries/chain/include/eosio/chain/block_log.hpp
@@ -97,6 +97,7 @@ namespace eosio { namespace chain {
          // used for unit test to generate older version blocklog
          static void set_version(uint32_t);
          uint32_t    version() const;
+         uint32_t get_first_block_num() const;
 
          /**
           * @param n Only test 1 block out of every n blocks. If n is 0, it is maximum between 1 and the ceiling of the total number blocks divided by 8.

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -206,6 +206,7 @@ namespace eosio { namespace chain {
          const protocol_feature_manager&       get_protocol_feature_manager()const;
          uint32_t                              get_max_nonprivileged_inline_action_size()const;
          const config&                         get_config()const;
+         const uint32_t get_first_block_num() const;
 
          const flat_set<account_name>&   get_actor_whitelist() const;
          const flat_set<account_name>&   get_actor_blacklist() const;

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -206,7 +206,7 @@ namespace eosio { namespace chain {
          const protocol_feature_manager&       get_protocol_feature_manager()const;
          uint32_t                              get_max_nonprivileged_inline_action_size()const;
          const config&                         get_config()const;
-         const uint32_t get_first_block_num() const;
+         uint32_t get_first_block_num() const;
 
          const flat_set<account_name>&   get_actor_whitelist() const;
          const flat_set<account_name>&   get_actor_blacklist() const;

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1485,11 +1485,13 @@ std::string itoh(I n, size_t hlen = sizeof(I)<<1) {
 }
 
 read_only::get_info_results read_only::get_info(const read_only::get_info_params&) const {
+
    const auto& rm = db.get_resource_limits_manager();
    return {
       itoh(static_cast<uint32_t>(app().version())),
       db.get_chain_id(),
       db.head_block_num(),
+      db.get_first_block_num(),
       db.last_irreversible_block_num(),
       db.last_irreversible_block_id(),
       db.head_block_id(),

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1491,7 +1491,6 @@ read_only::get_info_results read_only::get_info(const read_only::get_info_params
       itoh(static_cast<uint32_t>(app().version())),
       db.get_chain_id(),
       db.head_block_num(),
-      db.get_first_block_num(),
       db.last_irreversible_block_num(),
       db.last_irreversible_block_id(),
       db.head_block_id(),
@@ -1509,7 +1508,8 @@ read_only::get_info_results read_only::get_info(const read_only::get_info_params
       app().full_version_string(),
       db.last_irreversible_block_time(),
       rm.get_total_cpu_weight(),
-      rm.get_total_net_weight()
+      rm.get_total_net_weight(),
+      db.get_first_block_num()
    };
 }
 

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -123,7 +123,6 @@ public:
       string                               server_version;
       chain::chain_id_type                 chain_id;
       uint32_t                             head_block_num = 0;
-      uint32_t                             first_block_num = 0;
       uint32_t                             last_irreversible_block_num = 0;
       chain::block_id_type                 last_irreversible_block_id;
       chain::block_id_type                 head_block_id;
@@ -144,6 +143,7 @@ public:
       std::optional<fc::time_point>        last_irreversible_block_time;
       std::optional<uint64_t>              total_cpu_weight;
       std::optional<uint64_t>              total_net_weight;
+      std::optional<uint32_t>              first_block_num;
    };
    get_info_results get_info(const get_info_params&) const;
 
@@ -1105,11 +1105,11 @@ FC_REFLECT( eosio::chain_apis::linked_action, (account)(action) )
 FC_REFLECT( eosio::chain_apis::permission, (perm_name)(parent)(required_auth)(linked_actions) )
 FC_REFLECT(eosio::chain_apis::empty, )
 FC_REFLECT(eosio::chain_apis::read_only::get_info_results,
-           (server_version)(chain_id)(head_block_num)(first_block_num)(last_irreversible_block_num)(last_irreversible_block_id)
+           (server_version)(chain_id)(head_block_num)(last_irreversible_block_num)(last_irreversible_block_id)
            (head_block_id)(head_block_time)(head_block_producer)
            (virtual_block_cpu_limit)(virtual_block_net_limit)(block_cpu_limit)(block_net_limit)
            (server_version_string)(fork_db_head_block_num)(fork_db_head_block_id)(server_full_version_string)
-           (last_irreversible_block_time)(total_cpu_weight)(total_net_weight) )
+           (last_irreversible_block_time)(total_cpu_weight)(total_net_weight)(first_block_num) )
 FC_REFLECT(eosio::chain_apis::read_only::get_activated_protocol_features_params, (lower_bound)(upper_bound)(limit)(search_by_block_num)(reverse) )
 FC_REFLECT(eosio::chain_apis::read_only::get_activated_protocol_features_results, (activated_protocol_features)(more) )
 FC_REFLECT(eosio::chain_apis::read_only::get_block_params, (block_num_or_id))

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -123,6 +123,7 @@ public:
       string                               server_version;
       chain::chain_id_type                 chain_id;
       uint32_t                             head_block_num = 0;
+      uint32_t                             first_block_num = 0;
       uint32_t                             last_irreversible_block_num = 0;
       chain::block_id_type                 last_irreversible_block_id;
       chain::block_id_type                 head_block_id;
@@ -1104,7 +1105,7 @@ FC_REFLECT( eosio::chain_apis::linked_action, (account)(action) )
 FC_REFLECT( eosio::chain_apis::permission, (perm_name)(parent)(required_auth)(linked_actions) )
 FC_REFLECT(eosio::chain_apis::empty, )
 FC_REFLECT(eosio::chain_apis::read_only::get_info_results,
-           (server_version)(chain_id)(head_block_num)(last_irreversible_block_num)(last_irreversible_block_id)
+           (server_version)(chain_id)(head_block_num)(first_block_num)(last_irreversible_block_num)(last_irreversible_block_id)
            (head_block_id)(head_block_time)(head_block_producer)
            (virtual_block_cpu_limit)(virtual_block_net_limit)(block_cpu_limit)(block_net_limit)
            (server_version_string)(fork_db_head_block_num)(fork_db_head_block_id)(server_full_version_string)


### PR DESCRIPTION
## Change Description

EPE 737

add first_block_num to the result of get_info command, the first block num is fetched from block_log_imp object, and then fill this number to get info result.

https://github.com/EOSIO/eos/pull/10087

## Change Type
**Select ONE**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [ ] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [x] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the relase notes. Please include a description of the change for inclusion in the release notes.-->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->