### PR TITLE
Add test case for decompress zlib funciton of transaction  📦

### DIFF
--- a/unittests/chain_tests.cpp
+++ b/unittests/chain_tests.cpp
@@ -2,10 +2,12 @@
 #include <eosio/chain/global_property_object.hpp>
 #include <eosio/chain/permission_object.hpp>
 #include <eosio/chain/resource_limits.hpp>
+#include <eosio/chain/transaction.hpp>
 #include <boost/test/unit_test.hpp>
 #include <eosio/testing/tester.hpp>
 
 #include "fork_test_utilities.hpp"
+#include "test_cfd_transaction.hpp"
 
 using namespace eosio;
 using namespace eosio::chain;
@@ -73,5 +75,96 @@ BOOST_AUTO_TEST_CASE( replace_account_keys ) try {
    BOOST_REQUIRE(new_usr_auth == expected_authority);
 
 } FC_LOG_AND_RETHROW()
+
+BOOST_AUTO_TEST_CASE( decompressed_size_over_limit ) try {
+   tester chain;
+   const name usr = config::system_account_name;
+   const name active_permission = config::active_name;
+
+   // build a transaction, add cf data, sign
+   cf_action                        cfa;
+   eosio::chain::signed_transaction trx;
+   eosio::chain::action             act({}, cfa);
+   trx.context_free_actions.push_back(act); 
+   // this is a over limit size (4+4)*129*1024 = 1032*1024 > 1M
+   for(int i = 0; i < 129*1024; ++i){
+      trx.context_free_data.emplace_back(fc::raw::pack<uint32_t>(100));
+      trx.context_free_data.emplace_back(fc::raw::pack<uint32_t>(200));
+   }
+   // add a normal action along with cfa
+   dummy_action         da = {DUMMY_ACTION_DEFAULT_A, DUMMY_ACTION_DEFAULT_B, DUMMY_ACTION_DEFAULT_C};
+   eosio::chain::action act1(
+       std::vector<eosio::chain::permission_level>{{"testapi"_n, eosio::chain::config::active_name}}, da);
+   trx.actions.push_back(act1);
+   chain.set_transaction_headers(trx);
+   auto sig = trx.sign(chain.get_private_key("testapi"_n, "active"), chain.control->get_chain_id());
+
+
+   // pack
+   packed_transaction_v0 ptv0(trx, packed_transaction_v0::compression_type::zlib);
+   // try unpack and throw
+   bytes packed_txn = ptv0.get_packed_transaction();
+   bytes pcfd = ptv0.get_packed_context_free_data();
+   vector<signature_type>  sigs;
+   sigs.push_back(sig);
+   bool throwed = false;
+   bool throw_expect_string = false; 
+   try { 
+      // will call into decompress zlib 
+      packed_transaction_v0 copy( packed_txn, sigs, pcfd, packed_transaction_v0::compression_type::zlib );
+   } catch(fc::exception& er){
+     throwed = true;
+     if ( er.to_detail_string().find("Exceeded maximum decompressed transaction size") != std::string::npos){
+       throw_expect_string = true;
+     } 
+   }
+   BOOST_REQUIRE(throwed);
+   BOOST_REQUIRE(throw_expect_string); 
+} FC_LOG_AND_RETHROW()
+
+BOOST_AUTO_TEST_CASE( decompressed_size_under_limit ) try {
+   tester chain;
+
+   // build a transaction, add cf data, sign
+   cf_action                        cfa;
+   eosio::chain::signed_transaction trx;
+   eosio::chain::action             act({}, cfa);
+   trx.context_free_actions.push_back(act);
+   // this is a under limit size  (4+4)*128*1024 = 1024*1024
+   for(int i = 0; i < 100*1024; ++i){
+      trx.context_free_data.emplace_back(fc::raw::pack<uint32_t>(100));
+      trx.context_free_data.emplace_back(fc::raw::pack<uint32_t>(200));
+   }
+   // add a normal action along with cfa
+   dummy_action         da = {DUMMY_ACTION_DEFAULT_A, DUMMY_ACTION_DEFAULT_B, DUMMY_ACTION_DEFAULT_C};
+   eosio::chain::action act1(
+       std::vector<eosio::chain::permission_level>{{"testapi"_n, eosio::chain::config::active_name}}, da);
+   trx.actions.push_back(act1);
+   chain.set_transaction_headers(trx);
+   auto sig = trx.sign(chain.get_private_key("testapi"_n, "active"), chain.control->get_chain_id());
+
+   // pack
+   packed_transaction_v0 ptv0(trx, packed_transaction_v0::compression_type::zlib);
+   // try unpack and throw
+   bytes packed_txn = ptv0.get_packed_transaction();
+   bytes pcfd = ptv0.get_packed_context_free_data();
+   vector<signature_type>  sigs;
+   sigs.push_back(sig);
+   bool throwed = false;
+   bool throw_expect_string = false; 
+   try {
+      // will call into decompress zlib 
+      packed_transaction_v0 copy( packed_txn, sigs, pcfd, packed_transaction_v0::compression_type::zlib );
+   } catch(fc::exception& er){
+     throwed = true;
+     if ( er.to_detail_string().find("Exceeded maximum decompressed transaction size") != std::string::npos){
+       throw_expect_string = true;
+     } 
+   }
+   BOOST_REQUIRE(throwed == false);
+   BOOST_REQUIRE(throw_expect_string == false); 
+} FC_LOG_AND_RETHROW()
+
+
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/unittests/chain_tests.cpp
+++ b/unittests/chain_tests.cpp
@@ -78,8 +78,6 @@ BOOST_AUTO_TEST_CASE( replace_account_keys ) try {
 
 BOOST_AUTO_TEST_CASE( decompressed_size_over_limit ) try {
    tester chain;
-   const name usr = config::system_account_name;
-   const name active_permission = config::active_name;
 
    // build a transaction, add cf data, sign
    cf_action                        cfa;


### PR DESCRIPTION
## Change Description

EPE 70

Add test cases to decompress zlib funciton of transaction.cpp , see EPE-70 also. 
The test case is for this function, https://github.com/EOSIO/eos/blob/master/libraries/chain/transaction.cpp#L197 

https://github.com/EOSIO/eos/pull/10224

## Change Type
**Select ONE**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [ ] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [x] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the relase notes. Please include a description of the change for inclusion in the release notes.-->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->