### PR TITLE
Backport PR#9923 to release/2.1.x

### DIFF
--- a/libraries/chain/include/eosio/chain/backing_store/db_key_value_format.hpp
+++ b/libraries/chain/include/eosio/chain/backing_store/db_key_value_format.hpp
@@ -565,6 +565,7 @@ namespace chain { namespace backing_store { namespace db_key_value_format {
 
    eosio::session::shared_bytes create_full_primary_key(name code, name scope, name table, uint64_t primary_key);
    eosio::session::shared_bytes create_full_prefix_key(name code, name scope, name table, std::optional<key_type> kt = std::optional<key_type>{});
+   eosio::session::shared_bytes create_full_primary_key(const eosio::session::shared_bytes& prefix, uint64_t primary_key);
 
    template<typename Key>
    eosio::session::shared_bytes create_full_secondary_key(name code, name scope, name table, const Key& sec_key, uint64_t primary_key) {

--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -354,31 +354,6 @@ namespace eosio { namespace testing {
 
          void sync_with(base_tester& other);
 
-         const table_id_object* find_table( name code, name scope, name table );
-
-         // method treats key as a name type, if this is not appropriate in your case, pass require == false and report the correct behavior
-         template<typename Object>
-         bool get_table_entry(Object& obj, account_name code, account_name scope, account_name table, uint64_t key, bool require = true) {
-            auto* maybe_tid = find_table(code, scope, table);
-            if( maybe_tid == nullptr ) {
-               BOOST_FAIL( "table for code=\"" + code.to_string()
-                            + "\" scope=\"" + scope.to_string()
-                            + "\" table=\"" + table.to_string()
-                            + "\" does not exist"                 );
-            }
-
-            auto* o = control->db().find<key_value_object, by_scope_primary>(boost::make_tuple(maybe_tid->id, key));
-            if( o == nullptr ) {
-               if( require )
-                  BOOST_FAIL("object does not exist for primary_key=\"" + name(key).to_string() + "\"");
-
-               return false;
-            }
-
-            fc::raw::unpack(o->value.data(), o->value.size(), obj);
-            return true;
-         }
-
          const controller::config& get_config() const {
             return cfg;
          }

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -2717,23 +2717,20 @@ read_only::get_producers_result read_only::get_producers( const read_only::get_p
       }
 
       auto session = kv_database.get_kv_undo_stack()->top();
-      auto retrieve_primary_key = [&code,&scope,&producers_table,&session](uint64_t primary_key) {
-         auto full_primary_key = backing_store::db_key_value_format::create_full_primary_key(code, scope, producers_table, primary_key);
-         auto value = session.read(full_primary_key);
-         return *value;
-      };
+      auto prefix_primary_key =
+         backing_store::db_key_value_format::create_full_prefix_key(code, scope, producers_table, backing_store::db_key_value_format::key_type::primary);
 
       using done_func = decltype(done);
       using add_val_func = decltype(add_val);
-      using retrieve_prim_func = decltype(retrieve_primary_key);
+      using session_type = decltype(session);
 
       struct f64_secondary_key_receiver
       : backing_store::single_type_error_receiver<f64_secondary_key_receiver,
                                                   backing_store::secondary_index_view<float64_t>,
                                                   contract_table_query_exception> {
          f64_secondary_key_receiver(read_only::get_producers_result& result, done_func&& done,
-                                    add_val_func&& add_val, retrieve_prim_func&& retrieve_prim)
-         : result_(result), done_(done), add_val_(add_val), retrieve_primary_key_(retrieve_prim) {}
+                                    add_val_func&& add_val, eosio::session::shared_bytes&& prefix_primary_key, session_type& session)
+         : result_(result), done_(done), add_val_(add_val), prefix_primary_key_(std::move(prefix_primary_key)), session_(session) {}
 
          void add_only_row(const backing_store::secondary_index_view<float64_t>& row) {
             // needs to allow a second pass after limit is reached or time has passed, to allow "more" processing
@@ -2741,8 +2738,16 @@ read_only::get_producers_result read_only::get_producers( const read_only::get_p
                finished_ = true;
             }
             else {
-               auto value = retrieve_primary_key_(row.primary_key);
-               add_val_(backing_store::primary_index_view::create(row.primary_key, value.data(), value.size()));
+               auto full_primary_key =
+                     eosio::session::make_shared_bytes<std::string_view, 2>({std::string_view{prefix_primary_key_.data(),
+                                                                                              prefix_primary_key_.size()},
+                                                                             std::string_view{reinterpret_cast<const char*>(&row.primary_key),
+                                                                                              sizeof(row.primary_key)}});
+               auto value = session_.read(full_primary_key);
+               EOS_ASSERT(value,
+                          contract_table_query_exception,
+                          "Secondary key lookup identified primary key: ${pk}, but primary key not found in database", ("pk",row.primary_key));
+               add_val_(backing_store::primary_index_view::create(row.primary_key, value->data(), value->size()));
             }
          }
 
@@ -2759,10 +2764,11 @@ read_only::get_producers_result read_only::get_producers( const read_only::get_p
          read_only::get_producers_result& result_;
          done_func done_;
          add_val_func add_val_;
-         retrieve_prim_func retrieve_primary_key_;
+         eosio::session::shared_bytes prefix_primary_key_;
+         session_type& session_;
          bool finished_ = false;
       };
-      f64_secondary_key_receiver receiver(result, std::move(done), std::move(add_val), std::move(retrieve_primary_key));
+      f64_secondary_key_receiver receiver(result, std::move(done), std::move(add_val), std::move(prefix_primary_key), session);
       auto kpe = receiver.keep_processing_entries();
       backing_store::rocksdb_contract_db_table_writer<f64_secondary_key_receiver, std::decay_t < decltype(kpe)>>
          writer(receiver, backing_store::key_context::standalone, kpe);

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -2738,11 +2738,7 @@ read_only::get_producers_result read_only::get_producers( const read_only::get_p
                finished_ = true;
             }
             else {
-               auto full_primary_key =
-                     eosio::session::make_shared_bytes<std::string_view, 2>({std::string_view{prefix_primary_key_.data(),
-                                                                                              prefix_primary_key_.size()},
-                                                                             std::string_view{reinterpret_cast<const char*>(&row.primary_key),
-                                                                                              sizeof(row.primary_key)}});
+               auto full_primary_key = backing_store::db_key_value_format::create_full_primary_key(prefix_primary_key_, row.primary_key);
                auto value = session_.read(full_primary_key);
                EOS_ASSERT(value,
                           contract_table_query_exception,

--- a/tests/get_producers_tests.cpp
+++ b/tests/get_producers_tests.cpp
@@ -1,0 +1,50 @@
+#include <boost/test/unit_test.hpp>
+#include <boost/algorithm/string/predicate.hpp>
+
+#include <eosio/testing/tester.hpp>
+#include <eosio/chain/abi_serializer.hpp>
+#include <eosio/chain/wasm_eosio_constraints.hpp>
+#include <eosio/chain/resource_limits.hpp>
+#include <eosio/chain/exceptions.hpp>
+#include <eosio/chain/wast_to_wasm.hpp>
+#include <eosio/chain_plugin/chain_plugin.hpp>
+
+#include <contracts.hpp>
+
+#include <fc/io/fstream.hpp>
+
+#include <Runtime/Runtime.h>
+
+#include <fc/variant_object.hpp>
+#include <fc/io/json.hpp>
+
+#include <array>
+#include <utility>
+
+#include <eosio/testing/backing_store_tester_macros.hpp>
+//#include <eosio/testing/eosio_system_tester.hpp>
+
+using namespace eosio;
+using namespace eosio::chain;
+using namespace eosio::testing;
+using namespace fc;
+
+BOOST_AUTO_TEST_SUITE(get_producers_tests)
+
+//using backing_store_ts = boost::mpl::list< eosio_system::eosio_system_tester<TESTER>,eosio_system::eosio_system_tester<ROCKSDB_TESTER> >;
+using backing_store_ts = boost::mpl::list< TESTER, ROCKSDB_TESTER >;
+
+BOOST_AUTO_TEST_CASE_TEMPLATE( get_producers, TESTER_T, backing_store_ts) { try {
+   TESTER_T t;
+   // t.produce_block();
+
+   chain_apis::read_only plugin(*(t.control), {}, fc::microseconds::maximum());
+   chain_apis::read_only::get_producers_params params = { .json = true, .lower_bound = "", .limit = 21 };
+
+   auto results = plugin.get_producers(params);
+   BOOST_REQUIRE_EQUAL(results.more, "");
+   BOOST_REQUIRE_EQUAL(results.rows.size(), 1);
+
+} FC_LOG_AND_RETHROW() } /// get_table_next_key_test
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/get_producers_tests.cpp
+++ b/tests/get_producers_tests.cpp
@@ -22,7 +22,7 @@
 #include <utility>
 
 #include <eosio/testing/backing_store_tester_macros.hpp>
-//#include <eosio/testing/eosio_system_tester.hpp>
+#include <eosio/testing/eosio_system_tester.hpp>
 #include <fc/log/log_message.hpp>
 #include <fc/log/logger.hpp>
 
@@ -31,6 +31,7 @@ BOOST_AUTO_TEST_SUITE(get_producers_tests)
 using namespace eosio::testing;
 using backing_store_ts = boost::mpl::list< TESTER, ROCKSDB_TESTER >;
 
+// this test verifies the exception case of get_producer, where it is populated by the active schedule of producers
 BOOST_AUTO_TEST_CASE_TEMPLATE( get_producers, TESTER_T, backing_store_ts) { try {
    TESTER_T chain;
 
@@ -40,7 +41,12 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( get_producers, TESTER_T, backing_store_ts) { try 
    auto results = plugin.get_producers(params);
    BOOST_REQUIRE_EQUAL(results.more, "");
    BOOST_REQUIRE_EQUAL(results.rows.size(), 1);
-   BOOST_CHECK_EQUAL(results.rows[0]["owner"].as_string(), "eosio");
+   const auto& row = results.rows[0].get_object();
+   BOOST_REQUIRE(row.contains("owner"));
+   BOOST_REQUIRE_EQUAL(row["owner"].as_string(), "eosio");
+   // check for producer_authority, since it is only set when the producer schedule is used
+   BOOST_REQUIRE(row.contains("producer_authority"));
+
 
    chain.produce_blocks(2);
 
@@ -54,8 +60,32 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( get_producers, TESTER_T, backing_store_ts) { try 
    auto owners = std::vector<std::string>{"dan", "sam", "pam"};
    auto it     = owners.begin();
    for (const auto& elem : results.rows) {
-      BOOST_CHECK_EQUAL(elem["owner"].as_string(), *it++);
+      BOOST_REQUIRE_EQUAL(elem["owner"].as_string(), *it++);
    }
-} FC_LOG_AND_RETHROW() } /// get_table_next_key_test
+} FC_LOG_AND_RETHROW() }
+
+using backing_store_system_ts = boost::mpl::list< eosio_system::eosio_system_tester<TESTER>, eosio_system::eosio_system_tester<ROCKSDB_TESTER> >;
+
+// this test verifies the normal case of get_producer, where the contents of the system contract's producers table is used
+BOOST_AUTO_TEST_CASE_TEMPLATE( get_producers_from_table, TESTER_T, backing_store_system_ts) { try {
+   TESTER_T chain;
+
+   // ensure that enough voting is occurring so that producer1111 is elected as the producer
+   chain.cross_15_percent_threshold();
+
+   eosio::chain_apis::read_only plugin(*(chain.control), {}, fc::microseconds::maximum());
+   eosio::chain_apis::read_only::get_producers_params params = { .json = true, .lower_bound = "", .limit = 21 };
+
+   auto results = plugin.get_producers(params);
+   BOOST_REQUIRE_EQUAL(results.more, "");
+   BOOST_REQUIRE_EQUAL(results.rows.size(), 1);
+   const auto& row = results.rows[0].get_object();
+   BOOST_REQUIRE(row.contains("owner"));
+   BOOST_REQUIRE_EQUAL(row["owner"].as_string(), "producer1111");
+   // check for producer_authority not present, since it is only set when the producer schedule is used, this verifies producers table was used
+   BOOST_REQUIRE(!row.contains("producer_authority"));
+
+} FC_LOG_AND_RETHROW() }
+
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/get_producers_tests.cpp
+++ b/tests/get_producers_tests.cpp
@@ -23,28 +23,39 @@
 
 #include <eosio/testing/backing_store_tester_macros.hpp>
 //#include <eosio/testing/eosio_system_tester.hpp>
+#include <fc/log/log_message.hpp>
+#include <fc/log/logger.hpp>
 
-using namespace eosio;
-using namespace eosio::chain;
-using namespace eosio::testing;
-using namespace fc;
 
 BOOST_AUTO_TEST_SUITE(get_producers_tests)
-
-//using backing_store_ts = boost::mpl::list< eosio_system::eosio_system_tester<TESTER>,eosio_system::eosio_system_tester<ROCKSDB_TESTER> >;
+using namespace eosio::testing;
 using backing_store_ts = boost::mpl::list< TESTER, ROCKSDB_TESTER >;
 
 BOOST_AUTO_TEST_CASE_TEMPLATE( get_producers, TESTER_T, backing_store_ts) { try {
-   TESTER_T t;
-   // t.produce_block();
+   TESTER_T chain;
 
-   chain_apis::read_only plugin(*(t.control), {}, fc::microseconds::maximum());
-   chain_apis::read_only::get_producers_params params = { .json = true, .lower_bound = "", .limit = 21 };
+   eosio::chain_apis::read_only plugin(*(chain.control), {}, fc::microseconds::maximum());
+   eosio::chain_apis::read_only::get_producers_params params = { .json = true, .lower_bound = "", .limit = 21 };
 
    auto results = plugin.get_producers(params);
    BOOST_REQUIRE_EQUAL(results.more, "");
    BOOST_REQUIRE_EQUAL(results.rows.size(), 1);
+   BOOST_CHECK_EQUAL(results.rows[0]["owner"].as_string(), "eosio");
 
+   chain.produce_blocks(2);
+
+   chain.create_accounts( {"dan"_n,"sam"_n,"pam"_n} );
+   chain.produce_block();
+   chain.set_producers( {"dan"_n,"sam"_n,"pam"_n} );
+   chain.produce_blocks(30);
+
+   results = plugin.get_producers(params);
+   BOOST_REQUIRE_EQUAL(results.rows.size(), 3);
+   auto owners = std::vector<std::string>{"dan", "sam", "pam"};
+   auto it     = owners.begin();
+   for (const auto& elem : results.rows) {
+      BOOST_CHECK_EQUAL(elem["owner"].as_string(), *it++);
+   }
 } FC_LOG_AND_RETHROW() } /// get_table_next_key_test
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/unittests/ram_tests.cpp
+++ b/unittests/ram_tests.cpp
@@ -12,7 +12,7 @@
 
 #include <contracts.hpp>
 
-#include "eosio_system_tester.hpp"
+#include <eosio/testing/eosio_system_tester.hpp>
 
 /*
  * register test suite `ram_tests`
@@ -22,7 +22,7 @@ BOOST_AUTO_TEST_SUITE(ram_tests)
 /*************************************************************************************
  * ram_tests test case
  *************************************************************************************/
-BOOST_FIXTURE_TEST_CASE(ram_tests, eosio_system::eosio_system_tester) { try {
+BOOST_FIXTURE_TEST_CASE(ram_tests, eosio_system::eosio_system_tester<TESTER>) { try {
    auto init_request_bytes = 80000 + 7110; // `7110' is for table token row
    const auto increment_contract_bytes = 10000;
    const auto table_allocation_bytes = 12000;


### PR DESCRIPTION
## Change Description
[EPE-1930](https://blockone.atlassian.net/browse/EPE-1930)

Backporting [PR#9923](https://github.com/EOSIO/eos/pull/9923):

- fixes a problem to add table row with f64 secondary key.
- add a unit test for get_producers

## Change Type
**Select *ONE*:**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [ ] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [x] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the release notes. Please include a description of the change for inclusion in the release notes. -->


## Testing Changes
**Select *ANY* that apply:**
- [X] New Tests
<!-- checked [x] = new test cases were added; unchecked [ ] = no new test cases -->
- [ ] Existing Tests
<!-- checked [x] = existing test cases were edited; unchecked [ ] = no existing tests were modified -->
- [ ] Test Framework
<!-- checked [x] = this modifies the test framework; unchecked [ ] = no test framework changes -->
- [ ] CI System
<!-- checked [x] = this changes the CI system; unchecked [ ] = no CI changes -->
- [ ] Other
<!-- checked [x] = this integrates an external test system; unchecked [ ] = no miscellaneous test-related changes -->
<!-- Please describe your test changes, or list each new test and its purpose, under each respective checkbox -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->


